### PR TITLE
feat: deploy API documentation to production

### DIFF
--- a/frontend/nginx/nginx.conf.template
+++ b/frontend/nginx/nginx.conf.template
@@ -40,6 +40,26 @@ server {
         proxy_connect_timeout 90s;
     }
 
+    # API documentation proxy - Swagger UI
+    location /documentation {
+        proxy_pass ${API_URL}/documentation;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # API documentation proxy - Scalar API Reference
+    location /api-reference {
+        proxy_pass ${API_URL}/api-reference;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Health endpoint proxy
     location /health {
         proxy_pass ${API_URL}/health;

--- a/src/api/plugins/scalar.ts
+++ b/src/api/plugins/scalar.ts
@@ -39,18 +39,18 @@ export async function registerScalar(fastify: FastifyInstance) {
         ogDescription:
           'REST API for personal knowledge management with YouTube playlist synchronization',
         ogTitle: 'Insighta API',
-        ogImage: 'https://example.com/og-image.png',
+        ogImage: 'https://insighta.one/og-image.png',
         twitterCard: 'summary_large_image',
       },
       searchHotKey: 'k',
       servers: [
         {
-          url: 'http://localhost:3000',
-          description: 'Development',
+          url: 'https://insighta.one',
+          description: 'Production',
         },
         {
-          url: 'https://api.yourdomain.com',
-          description: 'Production',
+          url: 'http://localhost:3000',
+          description: 'Development',
         },
       ],
       defaultOpenAllTags: false,

--- a/src/api/plugins/swagger.ts
+++ b/src/api/plugins/swagger.ts
@@ -20,8 +20,8 @@ export async function registerSwagger(fastify: FastifyInstance) {
           'REST API for personal knowledge management with YouTube playlist synchronization',
         version: '1.0.0',
         contact: {
-          name: 'API Support',
-          email: 'support@example.com',
+          name: 'Insighta Support',
+          email: 'jamesjk4242@gmail.com',
         },
         license: {
           name: 'MIT',
@@ -30,12 +30,12 @@ export async function registerSwagger(fastify: FastifyInstance) {
       },
       servers: [
         {
-          url: 'http://localhost:3000',
-          description: 'Development server',
+          url: 'https://insighta.one',
+          description: 'Production server',
         },
         {
-          url: 'https://api.yourdomain.com',
-          description: 'Production server',
+          url: 'http://localhost:3000',
+          description: 'Development server',
         },
       ],
       tags: [
@@ -64,8 +64,8 @@ export async function registerSwagger(fastify: FastifyInstance) {
         },
       },
       externalDocs: {
-        url: 'https://docs.yourdomain.com',
-        description: 'Full documentation',
+        url: 'https://insighta.one/api-reference',
+        description: 'Interactive API Reference (Scalar)',
       },
     },
   });


### PR DESCRIPTION
## Summary
- Add Nginx proxy rules for `/documentation` (Swagger UI) and `/api-reference` (Scalar) endpoints
- Update OpenAPI server URLs from placeholder `api.yourdomain.com` to `https://insighta.one`
- Fix contact info and externalDocs references in Swagger/Scalar configs

Closes #21

## Changes
| File | Change |
|------|--------|
| `frontend/nginx/nginx.conf.template` | Add proxy rules for doc endpoints |
| `src/api/plugins/swagger.ts` | Production URL, contact, externalDocs |
| `src/api/plugins/scalar.ts` | Production URL, ogImage URL |

## How it works
```
https://insighta.one/api-reference
  → EC2 Host Nginx (SSL termination)
  → Frontend Nginx (port 8081) — new proxy rules
  → API Container (port 3000) — serves Scalar/Swagger UI
```

## Test plan
- [ ] Verify `/api-reference` loads Scalar UI on production
- [ ] Verify `/documentation` loads Swagger UI on production
- [ ] Confirm OpenAPI spec shows `https://insighta.one` as default server
- [ ] Test "Try it out" functionality works through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)