### PR TITLE
fix: UI/UX accessibility, touch targets, dark mode (#17)

### DIFF
--- a/frontend/src/components/DraggableCard.tsx
+++ b/frontend/src/components/DraggableCard.tsx
@@ -83,7 +83,7 @@ export function DraggableCard({ card, onClick, onDragStart, compact = false }: D
         <h3
           className={cn(
             'absolute bottom-1 left-1 right-1 font-medium text-primary-foreground line-clamp-2',
-            compact ? 'text-[10px] leading-tight' : 'text-xs'
+            compact ? 'text-xs leading-tight' : 'text-xs'
           )}
         >
           {card.title}
@@ -92,7 +92,7 @@ export function DraggableCard({ card, onClick, onDragStart, compact = false }: D
 
       {!compact && card.userNote && (
         <div className="p-2">
-          <p className="text-[10px] text-muted-foreground line-clamp-1">{card.userNote}</p>
+          <p className="text-xs text-muted-foreground line-clamp-1">{card.userNote}</p>
         </div>
       )}
 
@@ -101,7 +101,7 @@ export function DraggableCard({ card, onClick, onDragStart, compact = false }: D
         {/* Share to X */}
         <button
           onClick={handleShareToX}
-          className="bg-background/80 backdrop-blur-sm rounded p-1 text-muted-foreground hover:text-foreground transition-colors"
+          className="bg-background/80 backdrop-blur-sm rounded p-2 min-w-[44px] min-h-[44px] flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
           title={t('draggableCard.shareOnX')}
         >
           <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
@@ -114,7 +114,7 @@ export function DraggableCard({ card, onClick, onDragStart, compact = false }: D
           target="_blank"
           rel="noopener noreferrer"
           onClick={(e) => e.stopPropagation()}
-          className="bg-background/80 backdrop-blur-sm rounded p-1 text-primary hover:text-primary/80"
+          className="bg-background/80 backdrop-blur-sm rounded p-2 min-w-[44px] min-h-[44px] flex items-center justify-center text-primary hover:text-primary/80"
           title={t('draggableCard.viewOnYouTube')}
         >
           <ExternalLink className="w-3 h-3" />

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -6,7 +6,7 @@ export function Footer() {
   const { t } = useTranslation();
 
   return (
-    <footer className="py-6 text-center text-sm text-muted-foreground">
+    <footer className="py-6 text-center text-sm text-muted-foreground border-t border-border/50 bg-surface-mid/50">
       <div className="container mx-auto px-4 flex flex-col sm:flex-row items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <Archive className="w-4 h-4 text-primary" aria-hidden="true" />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -84,7 +84,7 @@ export function Header({ onNavigateHome }: HeaderProps) {
         }}
       />
       <div className="container mx-auto px-4 py-3 flex items-center justify-between relative">
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2 sm:gap-4">
           <button
             onClick={onNavigateHome}
             aria-label={t('header.goHome')}
@@ -133,7 +133,7 @@ export function Header({ onNavigateHome }: HeaderProps) {
           </Button>
         </div>
 
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 sm:gap-3">
           {isLoading ? (
             <>
               <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />

--- a/frontend/src/components/InsightCardItem.tsx
+++ b/frontend/src/components/InsightCardItem.tsx
@@ -409,7 +409,7 @@ export function InsightCardItem({
                   {t('insightCard.memoEdit')}
                 </span>
               </div>
-              <span className="text-[10px] text-muted-foreground flex items-center gap-1 bg-surface-sunken px-1.5 py-0.5 rounded-full whitespace-nowrap flex-shrink-0">
+              <span className="text-xs text-muted-foreground flex items-center gap-1 bg-surface-sunken px-1.5 py-0.5 rounded-full whitespace-nowrap flex-shrink-0">
                 <Clock className="w-2.5 h-2.5" />
                 {new Date(card.createdAt).toLocaleDateString('ko-KR')}
               </span>
@@ -532,7 +532,7 @@ export function InsightCardItem({
                   window.open(twitterUrl, '_blank', 'noopener,noreferrer,width=550,height=420');
                   toast.success(t('videoPlayer.xShareOpened'));
                 }}
-                className="h-7 w-7 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-surface-mid transition-colors"
+                className="h-11 w-11 flex items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-surface-mid transition-colors"
                 title={t('videoPlayer.shareOnX')}
               >
                 <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
@@ -542,7 +542,7 @@ export function InsightCardItem({
               <Button
                 size="sm"
                 onClick={handleSave}
-                className="h-7 w-7 p-0 rounded-lg"
+                className="h-11 w-11 p-0 rounded-lg"
                 style={{ boxShadow: 'var(--shadow-md)' }}
               >
                 <Save className="w-3.5 h-3.5" />

--- a/frontend/src/components/MandalaCell.tsx
+++ b/frontend/src/components/MandalaCell.tsx
@@ -274,7 +274,7 @@ export const MandalaCell = memo(
                 setIsExpanded(!isExpanded);
               }}
               className={cn(
-                'mt-1 flex items-center gap-0.5 text-[9px] text-primary font-bold',
+                'mt-1 flex items-center gap-0.5 text-xs text-primary font-bold',
                 'hover:underline transition-all duration-200',
                 !isExpanded && 'animate-[pulse_3s_ease-in-out_infinite]'
               )}
@@ -295,10 +295,24 @@ export const MandalaCell = memo(
       );
     };
 
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick();
+      }
+    };
+
     return (
       <div
+        role="button"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        aria-label={
+          isCenter ? label : `${label} (${cardCount} ${cardCount === 1 ? 'card' : 'cards'})`
+        }
         className={cn(
           'relative flex flex-col items-center justify-start p-2 md:p-3 rounded-xl cursor-pointer group/cell',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
           'border bg-surface-light',
           'transition-all duration-200 ease-out',
           // Swap animation
@@ -369,7 +383,7 @@ export const MandalaCell = memo(
           <div
             className={cn(
               'absolute bottom-1.5 right-1.5 flex items-center justify-center',
-              'min-w-[20px] h-5 px-1.5 rounded-full text-[10px] font-bold',
+              'min-w-[20px] h-5 px-1.5 rounded-full text-xs font-bold',
               'bg-primary text-primary-foreground shadow-md',
               'transition-transform hover:scale-110'
             )}
@@ -386,7 +400,7 @@ export const MandalaCell = memo(
                 <div key={i} className="w-2 h-2 rounded-[1px] bg-muted-foreground/30" />
               ))}
             </div>
-            <span className="text-[9px]">{t('mandala.dragToAdd')}</span>
+            <span className="text-xs">{t('mandala.dragToAdd')}</span>
           </div>
         )}
 

--- a/frontend/src/components/MandalaGrid.tsx
+++ b/frontend/src/components/MandalaGrid.tsx
@@ -382,6 +382,7 @@ export const MandalaGrid = memo(function MandalaGrid({
                       e.stopPropagation();
                       handleNavigateToSubLevel(gridIndex);
                     }}
+                    aria-label={`${t('mandala.navigateToSub', { subject: cellData.label })}`}
                     className={cn(
                       'absolute z-40 group transition-all duration-300',
                       'hover:scale-110 active:scale-95',
@@ -415,6 +416,7 @@ export const MandalaGrid = memo(function MandalaGrid({
                   e.stopPropagation();
                   handleNavigateBack();
                 }}
+                aria-label={t('mandala.back')}
                 className={cn(
                   'absolute z-40 group transition-all duration-300',
                   'hover:scale-110 active:scale-95',
@@ -500,7 +502,7 @@ export const MandalaGrid = memo(function MandalaGrid({
 
       {/* Hint */}
       {showHint && (
-        <p className="text-[10px] text-center text-muted-foreground/60">
+        <p className="text-xs text-center text-muted-foreground/60">
           {isFlipped ? t('mandala.hintFlipped') : t('mandala.hintDefault')}
         </p>
       )}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -18,7 +18,8 @@
     "home": "Home",
     "items": "{{count}}",
     "cards": "{{count}} cards",
-    "selected": "{{count}} selected"
+    "selected": "{{count}} selected",
+    "backToTop": "Back to top"
   },
   "header": {
     "subtitle": "Mandala-based YouTube Archive",
@@ -254,7 +255,8 @@
     "titleLoading": "Loading title...",
     "collapse": "Collapse",
     "switchToFloating": "Switch to floating",
-    "switchToDock": "Dock"
+    "switchToDock": "Dock",
+    "navigateToSub": "Navigate to {{subject}}"
   },
   "scratchPad": {
     "title": "Scratch Pad",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -18,7 +18,8 @@
     "home": "홈",
     "items": "{{count}}개",
     "cards": "{{count}}카드",
-    "selected": "{{count}}개 선택됨"
+    "selected": "{{count}}개 선택됨",
+    "backToTop": "맨 위로"
   },
   "header": {
     "subtitle": "만다라트 기반 YouTube 아카이브",
@@ -254,7 +255,8 @@
     "titleLoading": "제목 로딩중...",
     "collapse": "접기",
     "switchToFloating": "플로팅으로 전환",
-    "switchToDock": "도킹하기"
+    "switchToDock": "도킹하기",
+    "navigateToSub": "{{subject}}로 이동"
   },
   "scratchPad": {
     "title": "스크래치패드",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -486,6 +486,26 @@
   }
 }
 
+@layer components {
+  /* Legal page prose styling for dark mode contrast */
+  .legal-prose h2 {
+    @apply text-foreground;
+  }
+
+  .legal-prose p,
+  .legal-prose li {
+    @apply text-foreground/85;
+  }
+
+  .legal-prose a {
+    @apply text-primary hover:text-primary/80 underline-offset-2;
+  }
+
+  .legal-prose code {
+    @apply bg-muted text-foreground/80 px-1 py-0.5 rounded text-sm font-mono;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/frontend/src/pages/Privacy.tsx
+++ b/frontend/src/pages/Privacy.tsx
@@ -1,11 +1,15 @@
+import { ArrowUp } from 'lucide-react';
 import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
+import { useTranslation } from 'react-i18next';
 
 const Privacy = () => {
+  const { t } = useTranslation();
+
   return (
     <div className="min-h-screen bg-background text-foreground flex flex-col">
       <Header />
-      <div className="flex-1 p-4 sm:p-8 max-w-3xl mx-auto w-full">
+      <div className="flex-1 p-4 sm:p-8 max-w-3xl mx-auto w-full legal-prose">
         <h1 className="text-3xl font-bold mb-6">Privacy Policy</h1>
         <p className="text-muted-foreground mb-4">Last updated: March 5, 2026</p>
 
@@ -28,7 +32,7 @@ const Privacy = () => {
             <li>
               <strong>YouTube Data</strong>: Playlist metadata, video titles, descriptions, and
               thumbnails from your YouTube playlists (read-only access via{' '}
-              <code className="bg-muted text-muted-foreground px-1 py-0.5 rounded text-sm font-mono">
+              <code className="bg-muted text-foreground/80 px-1 py-0.5 rounded text-sm font-mono">
                 youtube.readonly
               </code>{' '}
               scope).
@@ -81,7 +85,7 @@ const Privacy = () => {
           </p>
           <p className="mt-2">
             We request{' '}
-            <code className="bg-muted text-muted-foreground px-1 py-0.5 rounded text-sm font-mono">
+            <code className="bg-muted text-foreground/80 px-1 py-0.5 rounded text-sm font-mono">
               youtube.readonly
             </code>{' '}
             access to read your playlist and video metadata. We never modify or delete any YouTube
@@ -139,6 +143,15 @@ const Privacy = () => {
             </a>
           </p>
         </section>
+        <div className="flex justify-center mt-8">
+          <button
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            className="inline-flex items-center gap-1.5 px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors rounded-lg hover:bg-surface-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+          >
+            <ArrowUp className="w-4 h-4" aria-hidden="true" />
+            {t('common.backToTop')}
+          </button>
+        </div>
       </div>
       <Footer />
     </div>

--- a/frontend/src/pages/Terms.tsx
+++ b/frontend/src/pages/Terms.tsx
@@ -1,11 +1,15 @@
+import { ArrowUp } from 'lucide-react';
 import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
+import { useTranslation } from 'react-i18next';
 
 const Terms = () => {
+  const { t } = useTranslation();
+
   return (
     <div className="min-h-screen bg-background text-foreground flex flex-col">
       <Header />
-      <div className="flex-1 p-4 sm:p-8 max-w-3xl mx-auto w-full">
+      <div className="flex-1 p-4 sm:p-8 max-w-3xl mx-auto w-full legal-prose">
         <h1 className="text-3xl font-bold mb-6">Terms of Service</h1>
         <p className="text-muted-foreground mb-4">Last updated: March 5, 2026</p>
 
@@ -108,6 +112,15 @@ const Terms = () => {
             </a>
           </p>
         </section>
+        <div className="flex justify-center mt-8">
+          <button
+            onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            className="inline-flex items-center gap-1.5 px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors rounded-lg hover:bg-surface-light focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+          >
+            <ArrowUp className="w-4 h-4" aria-hidden="true" />
+            {t('common.backToTop')}
+          </button>
+        </div>
       </div>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- **Footer**: border-t + subtle bg for visual separation from content
- **Back-to-Top**: ArrowUp button on Privacy/Terms pages with i18n (en/ko)
- **Dark mode**: `legal-prose` CSS class for consistent heading/link/code contrast
- **Header**: responsive gap spacing (`gap-2 sm:gap-4`) for mobile
- **MandalaCell keyboard a11y**: `role="button"`, `tabIndex={0}`, Enter/Space handlers, `focus-visible` ring, descriptive `aria-label`
- **MandalaGrid**: `aria-label` on navigation arrows
- **Touch targets**: 44px minimum on DraggableCard & InsightCardItem action buttons
- **Font sizes**: `text-[9px]`/`text-[10px]` → `text-xs` across MandalaCell, DraggableCard, InsightCardItem, MandalaGrid

Closes #17

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Dark/light mode: verify Privacy & Terms page contrast
- [ ] Keyboard: Tab through MandalaGrid cells, Enter/Space to select
- [ ] Mobile viewport (375px): Header spacing, touch targets
- [ ] Back-to-top button works on Privacy & Terms pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)