### PR TITLE
fix: security ownership checks + playlist import bug fix

### DIFF
--- a/frontend/src/hooks/useYouTubeSync.ts
+++ b/frontend/src/hooks/useYouTubeSync.ts
@@ -44,7 +44,7 @@ export function useYouTubePlaylists() {
 }
 
 /**
- * Hook to add a new playlist
+ * Hook to add a new playlist via Backend API (uses YouTube API Key, no OAuth required)
  */
 export function useAddPlaylist() {
   const queryClient = useQueryClient();
@@ -52,7 +52,8 @@ export function useAddPlaylist() {
   return useMutation({
     mutationFn: async (playlistUrl: string): Promise<YouTubePlaylist> => {
       const headers = await getAuthHeaders();
-      const response = await fetch(ytSyncUrl('add-playlist'), {
+      const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+      const response = await fetch(`${apiUrl}/api/v1/playlists/import`, {
         method: 'POST',
         headers,
         body: JSON.stringify({ playlistUrl }),
@@ -60,11 +61,28 @@ export function useAddPlaylist() {
 
       if (!response.ok) {
         const error = await response.json();
-        throw new Error(error.error || 'Failed to add playlist');
+        throw new Error(error.error?.message || 'Failed to add playlist');
       }
 
       const data = await response.json();
-      return data.playlist;
+      const p = data.playlist;
+      // Map Backend API camelCase response to snake_case YouTubePlaylist
+      return {
+        id: p.id,
+        user_id: '',
+        youtube_playlist_id: p.youtubeId,
+        youtube_playlist_url: `https://www.youtube.com/playlist?list=${p.youtubeId}`,
+        title: p.title,
+        description: p.description ?? null,
+        thumbnail_url: p.thumbnailUrl ?? null,
+        channel_title: p.channelTitle ?? null,
+        item_count: p.itemCount ?? 0,
+        last_synced_at: p.lastSyncedAt ?? null,
+        sync_status: p.syncStatus ?? 'PENDING',
+        sync_error: null,
+        created_at: p.createdAt,
+        updated_at: p.updatedAt,
+      } as YouTubePlaylist;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: youtubeSyncKeys.playlists });

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -111,7 +111,9 @@ class ApiClient {
    */
   private async getFreshToken(): Promise<string | null> {
     try {
-      const { data: { session } } = await supabase.auth.getSession();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
       if (session?.access_token) {
         this.accessToken = session.access_token;
         return session.access_token;
@@ -126,10 +128,7 @@ class ApiClient {
   // HTTP Request Wrapper
   // ========================================
 
-  private async request<T>(
-    endpoint: string,
-    options: RequestInit = {}
-  ): Promise<T> {
+  private async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
     const url = `${this.baseUrl}/api/v1${endpoint}`;
     const token = await this.getFreshToken();
 
@@ -146,7 +145,9 @@ class ApiClient {
 
     // On 401, try refreshing session once
     if (response.status === 401) {
-      const { data: { session } } = await supabase.auth.refreshSession();
+      const {
+        data: { session },
+      } = await supabase.auth.refreshSession();
       if (session?.access_token) {
         this.accessToken = session.access_token;
         (headers as Record<string, string>)['Authorization'] = `Bearer ${session.access_token}`;
@@ -275,7 +276,7 @@ class ApiClient {
   async importPlaylist(youtubeUrl: string): Promise<Playlist> {
     return this.request<Playlist>('/playlists/import', {
       method: 'POST',
-      body: JSON.stringify({ url: youtubeUrl }),
+      body: JSON.stringify({ playlistUrl: youtubeUrl }),
     });
   }
 
@@ -377,11 +378,4 @@ export const apiClient = new ApiClient(API_BASE_URL);
 export default apiClient;
 
 // Export types for use in components
-export type {
-  User,
-  Playlist,
-  Video,
-  Note,
-  SyncStatus,
-  ApiError,
-};
+export type { User, Playlist, Video, Note, SyncStatus, ApiError };


### PR DESCRIPTION
## Summary
- **Security**: Enforce userId ownership on all playlist/sync API endpoints (prevent cross-user data access)
- **Bug fix**: Switch playlist import from Edge Function (requires OAuth) to Backend API (uses YouTube API Key)
- **Bug fix**: Correct `{ url }` → `{ playlistUrl }` field name in api-client.ts
- **Infra**: Resolve PgBouncer prepared statement conflict causing 500 errors

## Changes
- `src/api/routes/playlists.ts` — ownership checks on get/sync/delete
- `src/api/routes/sync.ts` — userId filtering on all 6 sync endpoints
- `src/modules/playlist/manager.ts` — optional userId param on getPlaylist
- `frontend/src/hooks/useYouTubeSync.ts` — use Backend API for playlist add
- `frontend/src/lib/api-client.ts` — fix field name mismatch

## Test plan
- [x] Backend unit tests pass (sync-routes, playlists)
- [x] Frontend typecheck passes
- [ ] Verify playlist add works on production (public playlist URL)
- [ ] Verify /playlists and /videos return user-scoped data

🤖 Generated with [Claude Code](https://claude.com/claude-code)