### PR TITLE
fix: resolve double /api prefix in playlist import

### DIFF
--- a/frontend/src/hooks/useYouTubeSync.ts
+++ b/frontend/src/hooks/useYouTubeSync.ts
@@ -52,8 +52,7 @@ export function useAddPlaylist() {
   return useMutation({
     mutationFn: async (playlistUrl: string): Promise<YouTubePlaylist> => {
       const headers = await getAuthHeaders();
-      const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
-      const response = await fetch(`${apiUrl}/api/v1/playlists/import`, {
+      const response = await fetch(`/api/v1/playlists/import`, {
         method: 'POST',
         headers,
         body: JSON.stringify({ playlistUrl }),

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -8,7 +8,10 @@
 
 import { supabase } from '../integrations/supabase/client';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+// In production VITE_API_URL="/api", in dev "http://localhost:3000"
+const VITE_API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+// Normalize: if base already ends with /api, don't double it in request()
+const API_BASE_URL = VITE_API_URL.endsWith('/api') ? VITE_API_URL.slice(0, -4) : VITE_API_URL;
 
 interface ApiError {
   message: string;


### PR DESCRIPTION
## Summary
- Fix double `/api` prefix bug: `VITE_API_URL=/api` + `/api/v1/...` = `/api/api/v1/...`
- `useYouTubeSync.ts`: use relative path `/api/v1/playlists/import`
- `api-client.ts`: normalize `API_BASE_URL` to strip trailing `/api` before `request()` appends `/api/v1`

## Test plan
- [ ] Verify playlist add works on production with public YouTube playlist URL
- [ ] Verify existing API calls (playlists list, auth/me) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)