### PR TITLE
fix: empty body on playlist sync request

### DIFF
--- a/frontend/src/hooks/useYouTubeSync.ts
+++ b/frontend/src/hooks/useYouTubeSync.ts
@@ -113,6 +113,7 @@ export function useSyncPlaylist() {
       const response = await fetch(`/api/v1/playlists/${playlistId}/sync`, {
         method: 'POST',
         headers,
+        body: JSON.stringify({}),
       });
 
       if (!response.ok) {


### PR DESCRIPTION
Fastify rejects POST with Content-Type: application/json but no body.