### PR TITLE
fix: create ideation cards after playlist sync

### DIFF
--- a/src/modules/sync/engine.ts
+++ b/src/modules/sync/engine.ts
@@ -194,6 +194,41 @@ export class SyncEngine {
               last_synced_at: new Date(),
             },
           });
+
+          // Create user_video_states for all playlist videos (ideation cards)
+          const allPlaylistItems = await tx.youtube_playlist_items.findMany({
+            where: { playlist_id: playlist.id, removed_at: null },
+            select: { video_id: true },
+          });
+          const allVideoIds = allPlaylistItems.map((item) => item.video_id);
+
+          if (allVideoIds.length > 0) {
+            const existingStates = await tx.userVideoState.findMany({
+              where: {
+                user_id: playlist.user_id,
+                videoId: { in: allVideoIds },
+              },
+              select: { videoId: true },
+            });
+            const existingVideoIds = new Set(existingStates.map((s) => s.videoId));
+
+            const newStates = allVideoIds
+              .filter((vid) => !existingVideoIds.has(vid))
+              .map((vid, idx) => ({
+                user_id: playlist.user_id,
+                videoId: vid,
+                is_in_ideation: true,
+                sort_order: idx,
+              }));
+
+            if (newStates.length > 0) {
+              await tx.userVideoState.createMany({ data: newStates });
+              logger.info('Created user_video_states', {
+                playlistId: playlist.id,
+                count: newStates.length,
+              });
+            }
+          }
         });
 
         // Update sync history


### PR DESCRIPTION
## Summary
Backend SyncEngine was missing `user_video_states` creation after syncing playlist items.
Edge Function had this logic but Backend API didn't — causing synced videos to not appear as cards.

Now creates `user_video_states` with `is_in_ideation=true` for all new videos during sync.

## Test plan
- [ ] Sync playlist → verify cards appear in Mandala Design
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)