### PR TITLE
fix: SCP docker-compose.prod.yml to EC2 during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,6 +138,8 @@ jobs:
           aws-secret-access-key: ${{ secrets.TF_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
+      - uses: actions/checkout@v4
+
       - name: Open SSH for runner IP
         run: |
           RUNNER_IP=$(curl -s ifconfig.me)
@@ -148,6 +150,16 @@ jobs:
             --cidr "$RUNNER_IP/32" \
             --tag-specifications "ResourceType=security-group-rule,Tags=[{Key=Purpose,Value=github-actions-deploy}]"
           echo "Opened SSH for $RUNNER_IP"
+
+      - name: Copy docker-compose.prod.yml to EC2
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: "docker-compose.prod.yml"
+          target: "/opt/tubearchive/"
+          overwrite: true
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1


### PR DESCRIPTION
## Summary
- Add `actions/checkout@v4` to deploy job (needed to access compose file)
- Add SCP step using `appleboy/scp-action@v1` to copy `docker-compose.prod.yml` to EC2 `/opt/tubearchive/` before deployment
- Ensures new services (e.g., frontend-v2) are automatically picked up without manual SCP

Closes #87

## Test plan
- [ ] CI passes
- [ ] After merge, deploy workflow shows successful SCP step
- [ ] Verify EC2 `/opt/tubearchive/docker-compose.prod.yml` matches repo version

🤖 Generated with [Claude Code](https://claude.com/claude-code)