### PR TITLE
feat: Frontend V2 feature parity — widgets + YouTube hooks

### DIFF
--- a/frontend-v2/src/pages/index/model/useCardOrchestrator.ts
+++ b/frontend-v2/src/pages/index/model/useCardOrchestrator.ts
@@ -54,6 +54,9 @@ export interface UseCardOrchestratorReturn {
   handleSaveWatchPosition: (id: string, positionSeconds: number) => void;
   handleCardsReorder: (reorderedCards: InsightCard[]) => void;
   handleDeleteCards: (cardIds: string[]) => void;
+  // Pending card management (exposed for useGlobalPaste)
+  addPendingCard: (card: InsightCard) => void;
+  removePendingCard: (id: string) => void;
   // Card move helpers (exposed for navigation hooks)
   moveCardsForSubLevel: (
     fromLevelId: string,
@@ -898,6 +901,8 @@ export function useCardOrchestrator(
     syncedCards,
     persistedLocalCards,
     pendingLocalCards,
+    addPendingCard: (card: InsightCard) => setPendingLocalCards(prev => [...prev, card]),
+    removePendingCard: (id: string) => setPendingLocalCards(prev => prev.filter(c => c.id !== id)),
     handleCardClick,
     handleCardDrop,
     handleScratchPadDrop,

--- a/frontend-v2/src/pages/index/ui/IndexPage.tsx
+++ b/frontend-v2/src/pages/index/ui/IndexPage.tsx
@@ -1,8 +1,11 @@
-import { cn } from '@/shared/lib/utils';
+import { useRef, useEffect } from 'react';
 import { Header } from '@/widgets/header/ui/Header';
 import { DropZoneOverlay } from '@/widgets/header/ui/DropZoneOverlay';
 import { CardList } from '@/widgets/card-list/ui/CardList';
 import { VideoPlayerModal } from '@/widgets/video-player/ui/VideoPlayerModal';
+import { FloatingScratchPad } from '@/widgets/scratch-pad/ui/FloatingScratchPad';
+import { FloatingMandala } from '@/widgets/floating-mandala/ui/FloatingMandala';
+import { MandalaGrid } from '@/widgets/mandala-grid/ui/MandalaGrid';
 
 import { useMandalaNavigation } from '../model/useMandalaNavigation';
 import { useLayoutPreferences } from '../model/useLayoutPreferences';
@@ -22,31 +25,32 @@ const IndexPage = () => {
   // 2. Layout preferences
   const layout = useLayoutPreferences();
 
-  // 3. Mandala navigation (needs card orchestrator callbacks, wired below)
+  // 3. Refs to break circular dependency: navigation <-> card orchestrator
+  const moveCardsRef = useRef<(...args: any[]) => void>(() => {});
+  const swapCardsRef = useRef<(...args: any[]) => void>(() => {});
+
+  // 4. Mandala navigation (wired to card orchestrator via refs)
   const navigation = useMandalaNavigation({
+    onMoveCardsForSubLevel: (from, to, idx) => moveCardsRef.current(from, to, idx),
+    onSwapCardsForReorder: (swapped, levelId) => swapCardsRef.current(swapped, levelId),
     toast: (opts) => toast(opts),
     t: (key, opts) => t(key, opts as Record<string, string>),
   });
 
-  // 4. Card orchestrator (needs navigation state)
+  // 5. Card orchestrator (needs navigation state)
   const cards = useCardOrchestrator(
     {
       currentLevelId: navigation.currentLevelId,
       currentLevel: navigation.currentLevel,
     },
     navigation.selectedCellIndex,
-    // onCardClick -> opens modal
-    undefined, // will be wired after modal hook
   );
 
-  // Wire navigation callbacks to card orchestrator
-  // (useMandalaNavigation accepts these as deps)
-  navigation.handleNavigateToSubLevel;
-  // Note: The actual wiring happens via the onMoveCardsForSubLevel / onSwapCardsForReorder
-  // callbacks that are passed to useMandalaNavigation. Since hooks can't be conditionally
-  // created, we initialize navigation first then pass card methods as event handlers to JSX.
+  // Patch refs after orchestrator init
+  useEffect(() => { moveCardsRef.current = cards.moveCardsForSubLevel; }, [cards.moveCardsForSubLevel]);
+  useEffect(() => { swapCardsRef.current = cards.swapCardsForReorder; }, [cards.swapCardsForReorder]);
 
-  // 5. Video modal
+  // 6. Video modal
   const modal = useVideoModal(cards.allMandalaCards, cards.scratchPadCards);
 
   // Wire card click to open modal
@@ -54,9 +58,54 @@ const IndexPage = () => {
     modal.openModal(card);
   };
 
-  // 6. Global paste handler (side-effect only)
-  // Note: This is a simplified placeholder. The full paste logic is in useCardOrchestrator.
-  // useGlobalPaste is available for standalone use if needed.
+  // 7. Global paste handler
+  useGlobalPaste({
+    addPendingCard: cards.addPendingCard,
+    removePendingCard: cards.removePendingCard,
+  });
+
+  // Shared ScratchPad props factory
+  const scratchPadProps = (isFloating: boolean) => ({
+    cards: cards.scratchPadCards,
+    isDropTarget: dragDrop.isScratchPadDropTarget,
+    onDrop: cards.handleScratchPadDrop,
+    onCardDrop: cards.handleScratchPadCardDrop,
+    onMultiCardDrop: cards.handleScratchPadMultiCardDrop,
+    onCardClick: handleCardClick,
+    onDragOver: () => dragDrop.setIsScratchPadDropTarget(true),
+    onDragLeave: () => dragDrop.setIsScratchPadDropTarget(false),
+    onCardDragStart: dragDrop.handleCardDragStart,
+    onDeleteCards: cards.handleDeleteCards,
+    onFileDrop: cards.handleScratchPadFileDrop,
+    isFloating,
+    onToggleFloating: () => layout.handleSetScratchPadFloating(!layout.isScratchPadFloating),
+    dockPosition: layout.scratchPadDockPosition,
+    onDockPositionChange: layout.handleSetScratchPadDockPosition,
+  });
+
+  // Shared MandalaGrid element
+  const mandalaGridElement = (isCompact?: boolean) => (
+    <MandalaGrid
+      level={navigation.currentLevel}
+      cardsByCell={cards.cardsByCell}
+      selectedCellIndex={navigation.selectedCellIndex}
+      onCellClick={navigation.handleCellClick}
+      onCardDrop={cards.handleCardDrop}
+      onCardClick={handleCardClick}
+      onCardDragStart={dragDrop.handleCardDragStart}
+      onSubjectsReorder={navigation.handleSubjectsReorder}
+      onCellDragging={dragDrop.setIsDraggingCell}
+      isGridDropZone={dragDrop.isDraggingOver && !dragDrop.draggingCard && !dragDrop.isDraggingCell}
+      hasSubLevel={navigation.hasSubLevel}
+      onNavigateToSubLevel={navigation.handleNavigateToSubLevel}
+      onNavigateBack={navigation.handleNavigateBack}
+      canGoBack={navigation.path.length > 0}
+      entryGridIndex={navigation.entryGridIndex}
+      showHint={false}
+      hideHeader={true}
+      isCompact={isCompact}
+    />
+  );
 
   return (
     <div className="h-screen flex flex-col bg-surface-base overflow-hidden">
@@ -66,20 +115,72 @@ const IndexPage = () => {
         isVisible={dragDrop.isDraggingOver && !dragDrop.draggingCard && !dragDrop.isDraggingCell}
       />
 
-      {/* TODO: Render FloatingScratchPad in different dock positions */}
-      {/* Top docked */}
-      {/* {!layout.isScratchPadFloating && layout.scratchPadDockPosition === 'top' && (...)} */}
+      {/* Top docked ScratchPad */}
+      {!layout.isScratchPadFloating && layout.scratchPadDockPosition === 'top' && (
+        <div className="flex-shrink-0 relative z-30">
+          <FloatingScratchPad {...scratchPadProps(false)} />
+        </div>
+      )}
 
       {/* Floating ScratchPad */}
-      {/* {layout.isScratchPadFloating && (...)} */}
+      {layout.isScratchPadFloating && (
+        <FloatingScratchPad
+          {...scratchPadProps(true)}
+          initialPosition={
+            layout.prefScratchpadPosX !== undefined && layout.prefScratchpadPosY !== undefined
+              ? { x: layout.prefScratchpadPosX, y: layout.prefScratchpadPosY }
+              : undefined
+          }
+          onPositionChange={layout.setScratchPadPosition}
+        />
+      )}
 
       {/* Floating Mandala */}
-      {/* {(layout.isMandalaFloating || layout.isMandalaFloatingMode) && (...)} */}
+      {(layout.isMandalaFloating || layout.isMandalaFloatingMode) && (
+        <FloatingMandala
+          centerGoal={navigation.currentLevel.centerGoal}
+          totalCards={cards.totalCards}
+          isMinimized={layout.isMandalaMinimized}
+          onToggleMinimized={() => layout.handleSetMandalaMinimized(!layout.isMandalaMinimized)}
+          isFloating={true}
+          onToggleFloating={() => layout.handleSetMandalaFloating(false)}
+          dockPosition={layout.mandalaDockPosition}
+          onDockPositionChange={layout.handleSetMandalaDockPosition}
+          initialPosition={
+            layout.prefMandalaPosX !== undefined && layout.prefMandalaPosY !== undefined
+              ? { x: layout.prefMandalaPosX, y: layout.prefMandalaPosY }
+              : undefined
+          }
+          onPositionChange={layout.setMandalaPosition}
+        >
+          {mandalaGridElement(true)}
+        </FloatingMandala>
+      )}
 
       {/* Main Content Area */}
       <main className="flex-1 overflow-hidden flex">
-        {/* Left docked scratch pad */}
-        {/* Left docked mandala */}
+        {/* Left docked ScratchPad */}
+        {!layout.isScratchPadFloating && layout.scratchPadDockPosition === 'left' && (
+          <div className="flex-shrink-0 bg-surface-mid/90 backdrop-blur-sm border-r border-border/30 relative z-30 h-full">
+            <FloatingScratchPad {...scratchPadProps(false)} />
+          </div>
+        )}
+
+        {/* Left docked Mandala */}
+        {!layout.isMandalaFloating && !layout.isMandalaFloatingMode && layout.mandalaDockPosition === 'left' && (
+          <FloatingMandala
+            centerGoal={navigation.currentLevel.centerGoal}
+            totalCards={cards.totalCards}
+            isMinimized={layout.isMandalaMinimized}
+            onToggleMinimized={() => layout.handleSetMandalaMinimized(!layout.isMandalaMinimized)}
+            isFloating={false}
+            onToggleFloating={() => layout.handleSetMandalaFloating(true)}
+            dockPosition={layout.mandalaDockPosition}
+            onDockPositionChange={layout.handleSetMandalaDockPosition}
+          >
+            {mandalaGridElement()}
+          </FloatingMandala>
+        )}
 
         <div className="flex-1 overflow-hidden">
           <div className="container mx-auto px-4 py-4 h-full">
@@ -101,11 +202,36 @@ const IndexPage = () => {
           </div>
         </div>
 
-        {/* Right docked mandala */}
-        {/* Right docked scratch pad */}
+        {/* Right docked Mandala */}
+        {!layout.isMandalaFloating && !layout.isMandalaFloatingMode && layout.mandalaDockPosition === 'right' && (
+          <FloatingMandala
+            centerGoal={navigation.currentLevel.centerGoal}
+            totalCards={cards.totalCards}
+            isMinimized={layout.isMandalaMinimized}
+            onToggleMinimized={() => layout.handleSetMandalaMinimized(!layout.isMandalaMinimized)}
+            isFloating={false}
+            onToggleFloating={() => layout.handleSetMandalaFloating(true)}
+            dockPosition={layout.mandalaDockPosition}
+            onDockPositionChange={layout.handleSetMandalaDockPosition}
+          >
+            {mandalaGridElement()}
+          </FloatingMandala>
+        )}
+
+        {/* Right docked ScratchPad */}
+        {!layout.isScratchPadFloating && layout.scratchPadDockPosition === 'right' && (
+          <div className="flex-shrink-0 bg-surface-mid/90 backdrop-blur-sm border-l border-border/30 relative z-30 h-full">
+            <FloatingScratchPad {...scratchPadProps(false)} />
+          </div>
+        )}
       </main>
 
-      {/* Bottom docked scratch pad */}
+      {/* Bottom docked ScratchPad */}
+      {!layout.isScratchPadFloating && layout.scratchPadDockPosition === 'bottom' && (
+        <div className="flex-shrink-0 bg-surface-mid/90 backdrop-blur-sm border-t border-border/30 relative z-30">
+          <FloatingScratchPad {...scratchPadProps(false)} />
+        </div>
+      )}
 
       <VideoPlayerModal
         card={modal.currentModalCard}

--- a/frontend-v2/src/pages/settings/ui/YouTubeConnectButton.tsx
+++ b/frontend-v2/src/pages/settings/ui/YouTubeConnectButton.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/shared/ui/button';
-// TODO: Migrate useYouTubeAuth to @/features/youtube/model/useYouTubeAuth
-// import { useYouTubeAuth } from '@/features/youtube/model/useYouTubeAuth';
+import { useYouTubeAuth } from '@/features/youtube-sync/model/useYouTubeAuth';
 import { Loader2, Youtube, Check, X, AlertCircle, RefreshCw } from 'lucide-react';
 import {
   AlertDialog,
@@ -44,20 +43,18 @@ function useErrorMessage(error: unknown): { message: string; isAuthError: boolea
   return { message: rawMessage, isAuthError: false };
 }
 
-// TODO: This component requires useYouTubeAuth hook migration.
-// Temporarily rendering a placeholder until the YouTube feature layer is built.
 export function YouTubeConnectButton() {
   const { t } = useTranslation();
-
-  // Placeholder state until useYouTubeAuth is migrated
-  const isConnected = false;
-  const isLoading = false;
-  const isConnecting = false;
-  const isDisconnecting = false;
-  const connect = () => {};
-  const disconnect = () => {};
-  const refetch = () => {};
-  const error: unknown = null;
+  const {
+    isConnected,
+    isLoading,
+    isConnecting,
+    isDisconnecting,
+    connect,
+    disconnect,
+    refetch,
+    error,
+  } = useYouTubeAuth();
 
   const { message: errorMessage, isAuthError } = useErrorMessage(error);
 

--- a/frontend-v2/src/pages/settings/ui/YouTubeSyncCard.tsx
+++ b/frontend-v2/src/pages/settings/ui/YouTubeSyncCard.tsx
@@ -16,20 +16,14 @@ import { Separator } from '@/shared/ui/separator';
 import { ScrollArea } from '@/shared/ui/scroll-area';
 import { useToast } from '@/shared/lib/use-toast';
 import { useAuth } from '@/features/auth/model/useAuth';
-// TODO: Migrate YouTube hooks to @/features/youtube/model/
-// import { useYouTubeAuth } from '@/features/youtube/model/useYouTubeAuth';
-// import { useYouTubeSync, useUpdateSyncSettings } from '@/features/youtube/model/useYouTubeSync';
+import { useYouTubeAuth } from '@/features/youtube-sync/model/useYouTubeAuth';
+import { useYouTubeSync, useUpdateSyncSettings } from '@/features/youtube-sync/model/useYouTubeSync';
 import { PlaylistItem } from './PlaylistItem';
 import { Loader2, Plus, RefreshCw, Youtube, LogIn } from 'lucide-react';
-// TODO: Move SyncInterval type to @/shared/types/youtube when YouTube feature is migrated
-// import type { SyncInterval } from '@/shared/types/youtube';
-
-type SyncInterval = 'manual' | '1h' | '6h' | '12h' | '24h';
+import type { SyncInterval } from '@/entities/youtube/model/types';
 
 const SYNC_INTERVAL_KEYS: SyncInterval[] = ['manual', '1h', '6h', '12h', '24h'];
 
-// TODO: This component requires YouTube hooks migration (useYouTubeAuth, useYouTubeSync, useUpdateSyncSettings).
-// Currently using placeholder state. Wire up real hooks when YouTube feature layer is built.
 export function YouTubeSyncCard() {
   const { toast } = useToast();
   const { t } = useTranslation();
@@ -37,13 +31,16 @@ export function YouTubeSyncCard() {
   const [playlistUrl, setPlaylistUrl] = useState('');
   const [isSigningIn, setIsSigningIn] = useState(false);
 
-  // Placeholder state until YouTube hooks are migrated
-  const syncInterval: SyncInterval = 'manual';
-  const autoSyncEnabled = false;
-  const playlists: never[] = [];
-  const isLoading = false;
-  const isAdding = false;
-  const isSyncingAll = false;
+  const youtubeAuth = useYouTubeAuth();
+  const ytSync = useYouTubeSync();
+  const updateSettings = useUpdateSyncSettings();
+
+  const syncInterval = (youtubeAuth.syncInterval as SyncInterval) || 'manual';
+  const autoSyncEnabled = youtubeAuth.autoSyncEnabled;
+  const playlists = ytSync.playlists;
+  const isLoading = ytSync.isLoading;
+  const isAdding = ytSync.isAdding;
+  const isSyncingAll = ytSync.isSyncingAll;
   const [syncingPlaylistId, setSyncingPlaylistId] = useState<string | null>(null);
   const [deletingPlaylistId, setDeletingPlaylistId] = useState<string | null>(null);
 
@@ -72,27 +69,104 @@ export function YouTubeSyncCard() {
       });
       return;
     }
-    // TODO: Wire up addPlaylist from useYouTubeSync
-    toast({
-      title: 'Not implemented',
-      description: 'YouTube sync hooks not yet migrated.',
-    });
+    try {
+      await ytSync.addPlaylist(playlistUrl.trim());
+      setPlaylistUrl('');
+      toast({
+        title: t('youtube.playlistAdded'),
+        description: t('youtube.playlistAddedDesc'),
+      });
+    } catch (error) {
+      toast({
+        title: t('common.error'),
+        description: error instanceof Error ? error.message : t('youtube.addPlaylistFailed'),
+        variant: 'destructive',
+      });
+    }
   };
 
-  const handleSyncPlaylist = async (_playlistId: string) => {
-    // TODO: Wire up syncPlaylist from useYouTubeSync
+  const handleSyncPlaylist = async (playlistId: string) => {
+    setSyncingPlaylistId(playlistId);
+    try {
+      const result = await ytSync.syncPlaylist(playlistId);
+      toast({
+        title: t('youtube.syncComplete'),
+        description: t('youtube.syncCompleteDesc', {
+          added: String(result.itemsAdded),
+          removed: String(result.itemsRemoved),
+        }),
+      });
+    } catch (error) {
+      toast({
+        title: t('youtube.syncFailed'),
+        description: error instanceof Error ? error.message : t('youtube.syncFailedDesc'),
+        variant: 'destructive',
+      });
+    } finally {
+      setSyncingPlaylistId(null);
+    }
   };
 
-  const handleDeletePlaylist = async (_playlistId: string) => {
-    // TODO: Wire up deletePlaylist from useYouTubeSync
+  const handleDeletePlaylist = async (playlistId: string) => {
+    setDeletingPlaylistId(playlistId);
+    try {
+      await ytSync.deletePlaylist(playlistId);
+      toast({
+        title: t('youtube.playlistDeleted'),
+        description: t('youtube.playlistDeletedDesc'),
+      });
+    } catch (error) {
+      toast({
+        title: t('common.error'),
+        description: error instanceof Error ? error.message : t('youtube.deletePlaylistFailed'),
+        variant: 'destructive',
+      });
+    } finally {
+      setDeletingPlaylistId(null);
+    }
   };
 
   const handleSyncAll = async () => {
-    // TODO: Wire up syncAll from useYouTubeSync
+    try {
+      const result = await ytSync.syncAll();
+      toast({
+        title: t('youtube.syncAllComplete'),
+        description: t('youtube.syncAllCompleteDesc', {
+          synced: String(result.synced),
+          failed: String(result.failed),
+        }),
+      });
+    } catch (error) {
+      toast({
+        title: t('youtube.syncFailed'),
+        description: error instanceof Error ? error.message : t('youtube.syncFailedDesc'),
+        variant: 'destructive',
+      });
+    }
   };
 
-  const handleSyncIntervalChange = async (_value: SyncInterval) => {
-    // TODO: Wire up updateSettings from useUpdateSyncSettings
+  const handleSyncIntervalChange = async (value: SyncInterval) => {
+    try {
+      await updateSettings.mutateAsync({ syncInterval: value });
+    } catch (error) {
+      toast({
+        title: t('common.error'),
+        description: error instanceof Error ? error.message : t('youtube.settingsUpdateFailed'),
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleAutoSyncToggle = async (checked: boolean) => {
+    try {
+      await updateSettings.mutateAsync({ autoSyncEnabled: checked });
+    } catch (error) {
+      toast({
+        title: t('common.error'),
+        description: error instanceof Error ? error.message : t('youtube.settingsUpdateFailed'),
+        variant: 'destructive',
+      });
+    }
   };
 
   if (isAuthLoading) {
@@ -220,14 +294,14 @@ export function YouTubeSyncCard() {
           ) : (
             <ScrollArea className="h-[300px]">
               <div className="space-y-2 pr-4">
-                {playlists.map((playlist: never) => (
+                {playlists.map((playlist) => (
                   <PlaylistItem
-                    key={(playlist as { id: string }).id}
+                    key={playlist.id}
                     playlist={playlist}
                     onSync={handleSyncPlaylist}
                     onDelete={handleDeletePlaylist}
-                    isSyncing={syncingPlaylistId === (playlist as { id: string }).id}
-                    isDeleting={deletingPlaylistId === (playlist as { id: string }).id}
+                    isSyncing={syncingPlaylistId === playlist.id}
+                    isDeleting={deletingPlaylistId === playlist.id}
                   />
                 ))}
               </div>
@@ -275,9 +349,7 @@ export function YouTubeSyncCard() {
             <Switch
               id="auto-sync"
               checked={autoSyncEnabled}
-              onCheckedChange={(_checked) => {
-                // TODO: Wire up updateSettings.mutate when YouTube hooks are migrated
-              }}
+              onCheckedChange={handleAutoSyncToggle}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Wire FloatingScratchPad, FloatingMandala, MandalaGrid into V2 IndexPage with all dock positions (top/bottom/left/right + floating)
- Replace placeholder YouTube state in Settings with real `useYouTubeAuth` + `useYouTubeSync` hooks
- Expose `addPendingCard`/`removePendingCard` from useCardOrchestrator and wire `useGlobalPaste`

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run build` — success (1.80s)
- [x] Browser test at localhost:8082/v2/ — widgets render, dock positions work
- [ ] CI passes
- [ ] Production deploy via merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)