### PR TITLE
fix: resolve 5 production card UX bugs

### DIFF
--- a/frontend/src/features/card-management/model/useLocalCards.ts
+++ b/frontend/src/features/card-management/model/useLocalCards.ts
@@ -62,6 +62,7 @@ export function useLocalCardsList() {
     },
     staleTime: 30 * 1000, // 30 seconds
     placeholderData: keepPreviousData,
+    refetchOnWindowFocus: false,
   });
 }
 
@@ -103,6 +104,46 @@ export function useAddLocalCard() {
 
       const data = await response.json();
       return data.card;
+    },
+    onMutate: async (payload: AddLocalCardPayload) => {
+      await queryClient.cancelQueries({ queryKey: localCardsKeys.list() });
+      const previous = queryClient.getQueryData<LocalCardsResponse>(localCardsKeys.list());
+
+      if (previous) {
+        const tempCard: LocalCard = {
+          id: `temp-${Date.now()}`,
+          user_id: '',
+          url: payload.url,
+          title: payload.title || null,
+          thumbnail: payload.thumbnail || null,
+          link_type: payload.link_type,
+          user_note: payload.user_note || '',
+          metadata_title: payload.metadata_title || null,
+          metadata_description: payload.metadata_description || null,
+          metadata_image: payload.metadata_image || null,
+          cell_index: payload.cell_index ?? -1,
+          level_id: payload.level_id || 'scratchpad',
+          sort_order: payload.sort_order ?? null,
+          mandala_id: payload.mandala_id || null,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        };
+        queryClient.setQueryData<LocalCardsResponse>(localCardsKeys.list(), {
+          ...previous,
+          cards: [...previous.cards, tempCard],
+          subscription: {
+            ...previous.subscription,
+            used: previous.subscription.used + 1,
+          },
+        });
+      }
+
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(localCardsKeys.list(), context.previous);
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: localCardsKeys.list() });

--- a/frontend/src/features/youtube-sync/model/useYouTubeAuth.ts
+++ b/frontend/src/features/youtube-sync/model/useYouTubeAuth.ts
@@ -65,7 +65,6 @@ export function useYouTubeAuthStatus() {
       return response.json();
     },
     staleTime: 60 * 1000, // 1 minute
-    refetchOnWindowFocus: true,
   });
 }
 

--- a/frontend/src/pages/index/model/useCardOrchestrator.ts
+++ b/frontend/src/pages/index/model/useCardOrchestrator.ts
@@ -488,7 +488,7 @@ export function useCardOrchestrator(
         });
 
         // Invalidate local cards query to refresh UI
-        queryClient.invalidateQueries({ queryKey: localCardsKeys.all });
+        queryClient.invalidateQueries({ queryKey: localCardsKeys.list() });
       } catch (error) {
         toast({
           title: t('common.error'),

--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -8,6 +8,9 @@ import { cn } from '@/shared/lib/utils';
 import { useDragSelect } from '@/features/drag-select/model/useDragSelect';
 import { cardSlotDropId } from '@/shared/lib/dnd';
 import { CardSkeleton } from './CardSkeleton';
+import { useQueryClient } from '@tanstack/react-query';
+import { localCardsKeys } from '@/features/card-management/model/useLocalCards';
+import type { LocalCardsResponse } from '@/entities/card/model/local-cards';
 
 interface CardListProps {
   cards: InsightCard[];
@@ -53,6 +56,8 @@ function CardSlot({
 
 export function CardList({ cards, isLoading, onCardClick, onSaveNote, onSelectionChange }: CardListProps) {
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const cachedCardCount = queryClient.getQueryData<LocalCardsResponse>(localCardsKeys.list())?.cards.length;
   const containerRef = useRef<HTMLDivElement | null>(null);
   const gridRef = useRef<HTMLDivElement | null>(null);
   const [selectedCardIds, setSelectedCardIds] = useState<Set<string>>(new Set());
@@ -187,7 +192,7 @@ export function CardList({ cards, isLoading, onCardClick, onSaveNote, onSelectio
   );
 
   if (isLoading && cards.length === 0) {
-    return <CardSkeleton />;
+    return <CardSkeleton count={cachedCardCount ?? 6} />;
   }
 
   if (cards.length === 0) {

--- a/frontend/src/widgets/card-list/ui/CardSkeleton.tsx
+++ b/frontend/src/widgets/card-list/ui/CardSkeleton.tsx
@@ -2,12 +2,20 @@ export function CardSkeleton({ count = 6 }: { count?: number }) {
   return (
     <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 p-3">
       {Array.from({ length: count }).map((_, i) => (
-        <div key={i} className="rounded-2xl overflow-hidden animate-pulse">
+        <div key={i} className="rounded-2xl overflow-hidden relative">
           <div className="aspect-video bg-muted" />
           <div className="p-3 space-y-2">
             <div className="h-4 bg-muted rounded w-3/4" />
             <div className="h-3 bg-muted rounded w-1/2" />
           </div>
+          {/* Shimmer sweep overlay */}
+          <div
+            className="absolute inset-0 -translate-x-full"
+            style={{
+              background: 'linear-gradient(90deg, transparent, hsl(var(--foreground) / 0.04), transparent)',
+              animation: `shimmer 1.5s ease-in-out infinite ${i * 100}ms`,
+            }}
+          />
         </div>
       ))}
     </div>

--- a/frontend/src/widgets/mandala-grid/ui/MandalaCell.tsx
+++ b/frontend/src/widgets/mandala-grid/ui/MandalaCell.tsx
@@ -383,8 +383,8 @@ export const MandalaCell = memo(
 
     const handleExternalDragOver = useCallback(
       (e: React.DragEvent) => {
+        e.preventDefault();
         if (!isCenter) {
-          e.preventDefault();
           setIsExternalDragOver(true);
         }
       },
@@ -399,20 +399,19 @@ export const MandalaCell = memo(
     }, []);
 
     const handleExternalDrop = (e: React.DragEvent) => {
-      if (isCenter) return;
+      e.preventDefault();
       setIsExternalDragOver(false);
+      if (isCenter) return;
       // NOTE: Do NOT call stopPropagation() here — the document-level drop
       // handler (useCardDragDrop) must fire to reset isDraggingOver state.
       // Without this, external drags (YouTube etc.) leave the overlay stuck
       // because dragend only fires in the source window.
       if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-        e.preventDefault();
         onDrop(index, undefined, undefined, undefined, e.dataTransfer.files);
         return;
       }
       const cardId = e.dataTransfer.getData('application/card-id');
       if (cardId) {
-        e.preventDefault();
         const multiCardIdsStr = e.dataTransfer.getData('application/multi-card-ids');
         if (multiCardIdsStr) {
           try {
@@ -434,7 +433,6 @@ export const MandalaCell = memo(
         if (html) url = extractUrlFromHtml(html);
       }
       if (url) {
-        e.preventDefault();
         onDrop(index, url);
       }
     };

--- a/supabase/functions/local-cards/index.ts
+++ b/supabase/functions/local-cards/index.ts
@@ -193,9 +193,9 @@ Deno.serve(async (req) => {
           );
         }
 
-        const { data: card, error: insertError } = await supabase
+        const { data: card, error: upsertError } = await supabase
           .from('user_local_cards')
-          .insert({
+          .upsert({
             user_id: user.id,
             url: body.url,
             title: body.title || null,
@@ -209,18 +209,12 @@ Deno.serve(async (req) => {
             level_id: body.level_id || 'scratchpad',
             sort_order: body.sort_order ?? null,
             mandala_id: body.mandala_id || null,
-          })
+          }, { onConflict: 'user_id,url' })
           .select()
           .single();
 
-        if (insertError) {
-          if (insertError.code === '23505') {
-            return new Response(
-              JSON.stringify({ error: 'Card with this URL already exists' }),
-              { status: 409, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-            );
-          }
-          throw insertError;
+        if (upsertError) {
+          throw upsertError;
         }
 
         return new Response(


### PR DESCRIPTION
## Summary
- **#1** Remove `refetchOnWindowFocus` from YouTube auth query — iframe click no longer clears cards
- **#2** Add optimistic update to `useAddLocalCard` — new cards appear instantly without flicker
- **#3** Change Edge Function `add` action from INSERT to UPSERT — prevents 409 on re-add after delete
- **#4** Move `e.preventDefault()` before `isCenter` check in MandalaCell — blocks Chrome multi-panel on URL drag
- **#5** Replace `animate-pulse` with shimmer gradient + dynamic skeleton count from cache

## Test plan
- [ ] Video player repeated clicks → cards remain visible (#1)
- [ ] Add card → appears instantly without flicker (#2)
- [ ] Delete card → re-add same URL → success (#3) — Edge Function manual deploy required
- [ ] YouTube URL D&D to center cell → no Chrome multi-panel (#4)
- [ ] Page refresh → skeleton shows shimmer + matches previous card count (#5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)