### PR TITLE
feat(admin): LLM provider settings + yt-dlp caption fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,9 @@ RUN npm ci --omit=dev --ignore-scripts
 # =============================================================================
 FROM node:20-alpine AS runner
 
-# Install runtime dependencies including OpenSSL 3.x
-RUN apk add --no-cache libc6-compat curl openssl
+# Install runtime dependencies including OpenSSL 3.x + yt-dlp (caption fallback)
+RUN apk add --no-cache libc6-compat curl openssl python3 py3-pip && \
+    pip3 install --no-cache-dir --break-system-packages yt-dlp
 
 # Security: Create non-root user
 RUN addgroup --system --gid 1001 nodejs && \

--- a/frontend/src/pages/admin/ui/AdminHealth.tsx
+++ b/frontend/src/pages/admin/ui/AdminHealth.tsx
@@ -1,6 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@/shared/lib/api-client';
-import { Activity, Database, Server } from 'lucide-react';
+import { Activity, Database, Server, Bot, Check, Loader2 } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 
 const STATUS_STYLES: Record<string, string> = {
@@ -8,6 +9,155 @@ const STATUS_STYLES: Record<string, string> = {
   degraded: 'bg-yellow-500/20 text-yellow-400',
   down: 'bg-red-500/20 text-red-400',
 };
+
+const PROVIDER_OPTIONS = [
+  { value: 'auto', label: 'Auto', desc: 'Ollama → OpenRouter → Gemini' },
+  { value: 'openrouter', label: 'OpenRouter', desc: 'Cloud LLM via OpenRouter API' },
+  { value: 'ollama', label: 'Ollama', desc: 'Local inference (requires GPU)' },
+  { value: 'gemini', label: 'Gemini', desc: 'Google Gemini API' },
+] as const;
+
+function LlmSettingsCard() {
+  const queryClient = useQueryClient();
+  const { data: llmData, isLoading } = useQuery({
+    queryKey: ['admin', 'llm'],
+    queryFn: () => apiClient.getAdminLlm(),
+    staleTime: 10_000,
+  });
+
+  const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
+  const [modelInput, setModelInput] = useState('');
+
+  const llm = llmData?.data;
+  const currentProvider = selectedProvider ?? llm?.config.provider ?? 'auto';
+
+  const updateMutation = useMutation({
+    mutationFn: (body: { provider: string; openrouter_model?: string }) =>
+      apiClient.updateAdminLlm(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'llm'] });
+      setSelectedProvider(null);
+      setModelInput('');
+    },
+  });
+
+  const handleSave = () => {
+    const body: { provider: string; openrouter_model?: string } = { provider: currentProvider };
+    if (currentProvider === 'openrouter' && modelInput.trim()) {
+      body.openrouter_model = modelInput.trim();
+    }
+    updateMutation.mutate(body);
+  };
+
+  const hasChanges = selectedProvider !== null && selectedProvider !== llm?.config.provider;
+
+  if (isLoading) {
+    return (
+      <div className="bg-card border border-border rounded-lg p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <Bot className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-medium">LLM Provider</span>
+        </div>
+        <div className="text-xs text-muted-foreground">Loading...</div>
+      </div>
+    );
+  }
+
+  if (!llm) return null;
+
+  return (
+    <div className="bg-card border border-border rounded-lg p-4 col-span-3">
+      <div className="flex items-center gap-2 mb-4">
+        <Bot className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-medium">LLM Provider Settings</span>
+        <span className="ml-auto text-xs text-muted-foreground">
+          Active: {llm.active.generation.provider} ({llm.active.generation.model})
+        </span>
+      </div>
+
+      {/* Provider Health Indicators */}
+      <div className="flex gap-3 mb-4">
+        {(['ollama', 'openrouter', 'gemini'] as const).map((p) => (
+          <div key={p} className="flex items-center gap-1.5 text-xs">
+            <div className={cn('w-2 h-2 rounded-full', llm.health[p] ? 'bg-green-500' : 'bg-red-500')} />
+            <span className="text-muted-foreground capitalize">{p}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Provider Selection */}
+      <div className="grid grid-cols-4 gap-2 mb-4">
+        {PROVIDER_OPTIONS.map((opt) => {
+          const isActive = currentProvider === opt.value;
+          const isAvailable = opt.value === 'auto' || llm.health[opt.value as 'ollama' | 'openrouter' | 'gemini'];
+          return (
+            <button
+              key={opt.value}
+              onClick={() => setSelectedProvider(opt.value)}
+              disabled={!isAvailable}
+              className={cn(
+                'flex flex-col items-start gap-1 p-3 rounded-md border text-left transition-colors',
+                isActive
+                  ? 'border-primary bg-primary/10 text-foreground'
+                  : isAvailable
+                    ? 'border-border hover:border-muted-foreground/50 text-muted-foreground hover:text-foreground'
+                    : 'border-border/50 text-muted-foreground/50 cursor-not-allowed'
+              )}
+            >
+              <div className="flex items-center gap-1.5 w-full">
+                <span className="text-sm font-medium">{opt.label}</span>
+                {llm.config.provider === opt.value && (
+                  <Check className="h-3 w-3 text-green-500 ml-auto" />
+                )}
+              </div>
+              <span className="text-[10px] leading-tight">{opt.desc}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* OpenRouter Model Override */}
+      {currentProvider === 'openrouter' && (
+        <div className="mb-4">
+          <label className="block text-xs text-muted-foreground mb-1">OpenRouter Model</label>
+          <input
+            type="text"
+            value={modelInput || llm.config.openrouter_model}
+            onChange={(e) => setModelInput(e.target.value)}
+            placeholder={llm.config.openrouter_model}
+            className="w-full px-3 py-1.5 rounded-md border border-border bg-background text-sm font-mono text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+          <p className="text-[10px] text-muted-foreground mt-1">
+            e.g. qwen/qwen3-30b-a3b, mistralai/mistral-small-3.1-24b-instruct, google/gemini-2.0-flash-001
+          </p>
+        </div>
+      )}
+
+      {/* Current Config Summary */}
+      <div className="grid grid-cols-2 gap-x-8 gap-y-1 text-xs text-muted-foreground mb-4">
+        <div className="flex justify-between"><span>Embedding</span><span className="font-mono">{llm.active.embedding.provider} ({llm.active.embedding.dimension}d)</span></div>
+        <div className="flex justify-between"><span>Generation</span><span className="font-mono">{llm.active.generation.provider}</span></div>
+        <div className="flex justify-between"><span>Ollama URL</span><span className="font-mono">{llm.config.ollama_url}</span></div>
+        <div className="flex justify-between"><span>Ollama Model</span><span className="font-mono">{llm.config.ollama_generate_model}</span></div>
+      </div>
+
+      {/* Save Button */}
+      {hasChanges && (
+        <button
+          onClick={handleSave}
+          disabled={updateMutation.isPending}
+          className="flex items-center gap-2 px-4 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+        >
+          {updateMutation.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
+          Apply Provider Change
+        </button>
+      )}
+      {updateMutation.isError && (
+        <p className="text-xs text-red-400 mt-2">Failed to update: {(updateMutation.error as Error).message}</p>
+      )}
+    </div>
+  );
+}
 
 export function AdminHealth() {
   const { data, isLoading, dataUpdatedAt } = useQuery({
@@ -87,6 +237,9 @@ export function AdminHealth() {
               </div>
             </div>
           </div>
+
+          {/* LLM Settings */}
+          <LlmSettingsCard />
 
           {/* Table Sizes */}
           <div className="bg-card border border-border rounded-lg overflow-hidden">

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -862,6 +862,29 @@ class ApiClient {
   }
 
   // ========================================
+  // Admin LLM
+  // ========================================
+
+  async getAdminLlm(): Promise<{
+    success: boolean;
+    data: {
+      config: { provider: string; openrouter_model: string; ollama_url: string; ollama_generate_model: string; ollama_embed_model: string };
+      active: { embedding: { provider: string; dimension: number }; generation: { provider: string; model: string } };
+      health: { ollama: boolean; gemini: boolean; openrouter: boolean };
+      auto_priority: string[];
+    };
+  }> {
+    return this.request('/admin/llm');
+  }
+
+  async updateAdminLlm(body: { provider: string; openrouter_model?: string }): Promise<{
+    success: boolean;
+    data: { provider: string; active: { embedding: { provider: string }; generation: { provider: string; model: string } } };
+  }> {
+    return this.request('/admin/llm', { method: 'PUT', body: JSON.stringify(body) });
+  }
+
+  // ========================================
   // Admin Analytics
   // ========================================
 

--- a/src/api/routes/admin/index.ts
+++ b/src/api/routes/admin/index.ts
@@ -11,6 +11,7 @@ import { adminAnalyticsRoutes } from './analytics';
 import { adminContentRoutes } from './content';
 import { adminReportRoutes } from './reports';
 import { adminHealthRoutes } from './health';
+import { adminLlmRoutes } from './llm';
 
 /**
  * Admin routes plugin.
@@ -33,5 +34,6 @@ export async function adminRoutes(fastify: FastifyInstance) {
   await fastify.register(adminReportRoutes, { prefix: '/reports' });
   await fastify.register(adminPaymentRoutes, { prefix: '/payments' });
   await fastify.register(adminHealthRoutes, { prefix: '/health' });
+  await fastify.register(adminLlmRoutes, { prefix: '/llm' });
   await fastify.register(stripeWebhookRoutes, { prefix: '/webhooks/stripe' });
 }

--- a/src/api/routes/admin/llm.ts
+++ b/src/api/routes/admin/llm.ts
@@ -1,0 +1,74 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { createEmbeddingProvider, createGenerationProvider, resetProviders } from '../../../modules/llm';
+import { isOllamaAvailable } from '../../../modules/llm/ollama';
+import { config } from '../../../config';
+import { createSuccessResponse } from '../../schemas/common.schema';
+
+const UpdateLlmBodySchema = z.object({
+  provider: z.enum(['auto', 'gemini', 'ollama', 'openrouter']),
+  openrouter_model: z.string().optional(),
+});
+
+export async function adminLlmRoutes(fastify: FastifyInstance) {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  // GET /api/v1/admin/llm — Current LLM config + provider status
+  fastify.get('/', adminAuth, async (_request: FastifyRequest, reply: FastifyReply) => {
+    const ollamaUp = await isOllamaAvailable();
+
+    const [embeddingProvider, generationProvider] = await Promise.all([
+      createEmbeddingProvider(),
+      createGenerationProvider(),
+    ]);
+
+    return reply.send(createSuccessResponse({
+      config: {
+        provider: config.llm.provider,
+        openrouter_model: config.openrouter.model,
+        ollama_url: config.ollama.url,
+        ollama_generate_model: config.ollama.generateModel,
+        ollama_embed_model: config.ollama.embedModel,
+      },
+      active: {
+        embedding: { provider: embeddingProvider.name, dimension: embeddingProvider.dimension },
+        generation: { provider: generationProvider.name, model: generationProvider.model },
+      },
+      health: {
+        ollama: ollamaUp,
+        gemini: !!process.env['GEMINI_API_KEY'],
+        openrouter: !!config.openrouter.apiKey,
+      },
+      // Auto-mode resolution order (for display)
+      auto_priority: ['ollama', 'openrouter', 'gemini'],
+    }));
+  });
+
+  // PUT /api/v1/admin/llm — Change LLM provider at runtime
+  fastify.put('/', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
+    const body = UpdateLlmBodySchema.parse(request.body);
+
+    // Update runtime config (survives until container restart)
+    (config.llm as { provider: string }).provider = body.provider;
+    if (body.openrouter_model) {
+      (config.openrouter as { model: string }).model = body.openrouter_model;
+    }
+
+    // Reset cached providers so next call picks up new config
+    resetProviders();
+
+    // Re-resolve to verify the new config works
+    const [embeddingProvider, generationProvider] = await Promise.all([
+      createEmbeddingProvider(),
+      createGenerationProvider(),
+    ]);
+
+    return reply.send(createSuccessResponse({
+      provider: body.provider,
+      active: {
+        embedding: { provider: embeddingProvider.name },
+        generation: { provider: generationProvider.name, model: generationProvider.model },
+      },
+    }));
+  });
+}


### PR DESCRIPTION
## Summary
- Add yt-dlp to Docker image for caption extraction fallback (youtube-transcript blocked on EC2)
- Admin LLM API: GET/PUT `/api/v1/admin/llm` for runtime provider switching
- AdminHealth page: LLM settings card with provider selection + OpenRouter model override

## Test plan
- [ ] Verify Docker build includes yt-dlp
- [ ] Test `/admin/health` page shows LLM settings card
- [ ] Test provider switching via Admin UI
- [ ] Test YouTube summary after deploy (caption extraction via yt-dlp fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)