### PR TITLE
feat(ux): DEV badge for dev/prod distinction

### DIFF
--- a/frontend/src/pages/admin/ui/AdminLayout.tsx
+++ b/frontend/src/pages/admin/ui/AdminLayout.tsx
@@ -19,7 +19,14 @@ export function AdminLayout() {
       {/* Sidebar */}
       <aside className="w-56 border-r border-border bg-card flex flex-col">
         <div className="p-4 border-b border-border">
-          <h1 className="text-lg font-semibold text-foreground">Admin</h1>
+          <div className="flex items-center gap-2">
+            <h1 className="text-lg font-semibold text-foreground">Admin</h1>
+            {import.meta.env.DEV && (
+              <span className="px-1.5 py-0.5 rounded text-[10px] font-bold leading-none bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
+                DEV
+              </span>
+            )}
+          </div>
           <p className="text-xs text-muted-foreground mt-0.5">Insighta Backoffice</p>
         </div>
 

--- a/frontend/src/widgets/app-shell/ui/AppHeader.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppHeader.tsx
@@ -58,6 +58,11 @@ export function AppHeader({ onMobileMenuOpen, searchBarElement }: AppHeaderProps
             <span className="text-lg font-bold text-foreground tracking-tight hidden sm:inline">
               Insighta
             </span>
+            {import.meta.env.DEV && (
+              <span className="hidden sm:inline-flex items-center px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider bg-yellow-500/20 text-yellow-400 border border-yellow-500/30 rounded-md">
+                DEV
+              </span>
+            )}
             <span className="hidden sm:inline-flex items-center px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-primary/10 text-primary border border-primary/30 rounded-md">
               {t('common.beta')}
             </span>


### PR DESCRIPTION
## Summary
- Yellow "DEV" badge on admin sidebar title and app header logo
- Only visible in local dev (`import.meta.env.DEV`), automatically hidden in prod builds

## Test plan
- [ ] Verify DEV badge shows on localhost:8081
- [ ] Verify DEV badge does NOT show on insighta.one (prod build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)