### PR TITLE
fix(llm): disable Qwen3 thinking + Nginx timeout increase

### DIFF
--- a/src/modules/llm/openrouter.ts
+++ b/src/modules/llm/openrouter.ts
@@ -27,6 +27,8 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
       messages: [{ role: 'user', content: prompt }],
       temperature: options?.temperature ?? 0.3,
       max_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
+      // Disable thinking/reasoning for Qwen3 models (consumes max_tokens budget)
+      reasoning: { effort: 'none' },
     };
 
     const response = await fetch(OPENROUTER_API_URL, {


### PR DESCRIPTION
## Summary
- Disable Qwen3 reasoning/thinking mode (consumes max_tokens → empty response)
- Nginx proxy_read_timeout 60s → 180s (enrichment takes >60s for long transcripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)