### PR TITLE
fix(llm): correct Qwen3 reasoning param + default model qwen3.5-9b

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -62,7 +62,7 @@ const envSchema = z.object({
 
   // OpenRouter
   OPENROUTER_API_KEY: z.string().optional(),
-  OPENROUTER_MODEL: z.string().default('qwen/qwen3-30b-a3b'),
+  OPENROUTER_MODEL: z.string().default('qwen/qwen3.5-9b'),
 });
 
 type Env = z.infer<typeof envSchema>;

--- a/src/modules/llm/openrouter.ts
+++ b/src/modules/llm/openrouter.ts
@@ -28,7 +28,8 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
       temperature: options?.temperature ?? 0.3,
       max_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
       // Disable thinking/reasoning for Qwen3 models (consumes max_tokens budget)
-      reasoning: { effort: 'none' },
+      // OpenRouter unified param for non-OpenAI models
+      reasoning: { enabled: false },
     };
 
     const response = await fetch(OPENROUTER_API_URL, {
@@ -48,10 +49,11 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
     }
 
     const data = (await response.json()) as {
-      choices?: Array<{ message?: { content: string } }>;
+      choices?: Array<{ message?: { content: string; reasoning?: string } }>;
     };
 
-    const content = data.choices?.[0]?.message?.content;
+    const message = data.choices?.[0]?.message;
+    const content = message?.content || message?.reasoning;
     if (!content) {
       throw new Error('OpenRouter returned empty response');
     }


### PR DESCRIPTION
## Fix
- `reasoning: { enabled: false }` (not `effort: 'none'` which is OpenAI o-series only)
- Fallback: extract from `reasoning` field if `content` is empty
- Default model changed: `qwen/qwen3-30b-a3b` → `qwen/qwen3.5-9b` ($0.05/M vs $0.20/M)

🤖 Generated with [Claude Code](https://claude.com/claude-code)