### PR TITLE
feat(enrichment): video_summaries table + enrichVideo + auto-summary guard (#285)

### DIFF
--- a/frontend/src/entities/card/model/index.ts
+++ b/frontend/src/entities/card/model/index.ts
@@ -1,4 +1,4 @@
-export type { LinkType, UrlMetadata, InsightCard, MandalaLevel, MandalaPath } from './types';
+export type { LinkType, UrlMetadata, InsightCard, MandalaLevel, MandalaPath, VideoSummary } from './types';
 
 export type {
   SubscriptionTier,

--- a/frontend/src/entities/card/model/local-cards.ts
+++ b/frontend/src/entities/card/model/local-cards.ts
@@ -5,7 +5,7 @@
  * stored in Supabase separately from YouTube synced videos.
  */
 
-import type { LinkType, InsightCard } from './types';
+import type { LinkType, InsightCard, VideoSummary } from './types';
 
 /**
  * Subscription tier types
@@ -42,6 +42,7 @@ export interface LocalCard {
   sort_order: number | null;
   created_at: string;
   updated_at: string;
+  video_summary?: VideoSummary;
 }
 
 /**
@@ -121,6 +122,7 @@ export function localCardToInsightCard(card: LocalCard): InsightCard {
           url: card.url,
         }
       : undefined,
+    videoSummary: card.video_summary,
   };
 }
 

--- a/frontend/src/entities/card/model/types.ts
+++ b/frontend/src/entities/card/model/types.ts
@@ -19,6 +19,13 @@ export interface UrlMetadata {
   url: string;
 }
 
+export interface VideoSummary {
+  summary_en: string;
+  summary_ko: string;
+  tags: string[];
+  model: string;
+}
+
 /** @deprecated Use ContentEntity from '@/entities/content' instead. Will be removed after migration. */
 export interface InsightCard {
   id: string;
@@ -35,6 +42,7 @@ export interface InsightCard {
   metadata?: UrlMetadata; // OG metadata for external links
   lastWatchPosition?: number; // Last playback position in seconds (for YouTube videos)
   isInIdeation?: boolean; // Whether the card is in ideation (scratchpad) or mandala grid
+  videoSummary?: VideoSummary; // Central video summary from video_summaries table
 }
 
 export interface MandalaLevel {

--- a/frontend/src/entities/content/ui/ContentCard.tsx
+++ b/frontend/src/entities/content/ui/ContentCard.tsx
@@ -175,8 +175,8 @@ export const ContentCard = memo(function ContentCard({
       {/* Meta area */}
       <div className="p-2 space-y-1">
         {Renderer && <Renderer card={rendererCard} view={view} />}
-        {card.userNote && (
-          <CompactNotePreview note={card.userNote} maxLines={1} />
+        {(card.userNote || card.videoSummary) && (
+          <CompactNotePreview note={card.userNote} maxLines={1} videoSummary={card.videoSummary} />
         )}
       </div>
     </div>

--- a/frontend/src/pages/index/model/useCardOrchestrator.ts
+++ b/frontend/src/pages/index/model/useCardOrchestrator.ts
@@ -13,6 +13,7 @@ import {
   useAllVideoStates,
   useUpdateVideoState,
 } from '@/features/youtube-sync/model/useYouTubeSync';
+import { useYouTubeAuth } from '@/features/youtube-sync/model/useYouTubeAuth';
 import { convertToInsightCards } from '@/features/card-management/lib/youtubeToInsightCard';
 import { detectCardSource, getCardById } from '@/features/card-management/lib/cardUtils';
 import {
@@ -99,6 +100,7 @@ export function useCardOrchestrator(
   // YouTube sync
   const { data: allVideoStates } = useAllVideoStates();
   const updateVideoState = useUpdateVideoState();
+  const { autoSummaryEnabled } = useYouTubeAuth();
 
   // Local cards
   const {
@@ -117,9 +119,10 @@ export function useCardOrchestrator(
   // Track cards currently being enriched (for spinner UI)
   const [enrichingCardIds, setEnrichingCardIds] = useState<Set<string>>(new Set());
 
-  // Auto-enrichment for YouTube cards — tracks enriching state
+  // Auto-enrichment for YouTube cards — respects autoSummaryEnabled setting
   const triggerAutoEnrich = useCallback(
     async (cardId: string, videoUrl?: string) => {
+      if (!autoSummaryEnabled) return;
       setEnrichingCardIds((prev) => new Set(prev).add(cardId));
       try {
         // Step 1: Try to fetch transcript via Edge Function (Deno Deploy, not EC2)
@@ -165,7 +168,7 @@ export function useCardOrchestrator(
         });
       }
     },
-    [queryClient],
+    [queryClient, autoSummaryEnabled],
   );
 
   // Convert video states to InsightCards
@@ -594,6 +597,12 @@ export function useCardOrchestrator(
 
         // Invalidate local cards query to refresh UI
         queryClient.invalidateQueries({ queryKey: localCardsKeys.list() });
+
+        // Fire-and-forget: trigger AI enrichment for each imported YouTube card
+        const importedCards: Array<{ id: string; url: string }> = data.cards || [];
+        for (const card of importedCards) {
+          triggerAutoEnrich(card.id, card.url).catch(() => {/* non-critical */});
+        }
       } catch (error) {
         toast({
           title: t('common.error'),
@@ -602,7 +611,7 @@ export function useCardOrchestrator(
         });
       }
     },
-    [toast, t, queryClient, mandalaId]
+    [toast, t, queryClient, mandalaId, triggerAutoEnrich]
   );
 
   // Card drop on mandala cell

--- a/frontend/src/shared/ui/CompactNotePreview.tsx
+++ b/frontend/src/shared/ui/CompactNotePreview.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/shared/lib/utils';
 import { parseNoteMarkdown, type ParsedSegment } from '@/shared/lib/note-markdown';
 import { useTranslation } from 'react-i18next';
 import type { SummaryRating } from '@/features/card-management/model/useSummaryRating';
+import type { VideoSummary } from '@/entities/card/model/types';
 
 const AI_SUMMARY_PREFIX_EN = '🤖 AI Summary:\n';
 const AI_SUMMARY_PREFIX_KO = '🤖 AI 요약:\n';
@@ -18,6 +19,8 @@ interface CompactNotePreviewProps {
   summaryRating?: SummaryRating;
   /** Callback when user rates the summary */
   onRate?: (cardId: string, rating: SummaryRating) => void;
+  /** Central video summary from video_summaries table (preferred over parsing user_note) */
+  videoSummary?: VideoSummary;
 }
 
 function SegmentRenderer({ segment }: { segment: ParsedSegment }) {
@@ -172,11 +175,60 @@ function extractLocaleSummary(note: string, locale: string): { body: string; lab
   return null;
 }
 
-export function CompactNotePreview({ note, maxLines, className, cardId, summaryRating, onRate }: CompactNotePreviewProps) {
+function UserNotePreview({ note, maxLines, className }: { note: string; maxLines?: number; className?: string }) {
+  const parsedLines = parseNoteMarkdown(note);
+  const clampClass = maxLines === 1 ? 'line-clamp-1' : maxLines === 2 ? 'line-clamp-2' : undefined;
+
+  return (
+    <div className={cn('text-xs text-muted-foreground mt-1', clampClass, className)}>
+      {parsedLines.map((line, lineIdx) =>
+        line.segments.length > 0 ? (
+          <div key={lineIdx} className="whitespace-pre-wrap">
+            {line.segments.map((seg, segIdx) => (
+              <SegmentRenderer key={`${lineIdx}-${segIdx}`} segment={seg} />
+            ))}
+          </div>
+        ) : (
+          <div key={lineIdx}>&nbsp;</div>
+        )
+      )}
+    </div>
+  );
+}
+
+export function CompactNotePreview({ note, maxLines, className, cardId, summaryRating, onRate, videoSummary }: CompactNotePreviewProps) {
   const { i18n } = useTranslation();
+
+  // Priority 1: Use central video_summaries data if available
+  if (videoSummary?.summary_en) {
+    const isKo = i18n.language === 'ko';
+    const body = isKo && videoSummary.summary_ko ? videoSummary.summary_ko : videoSummary.summary_en;
+    const label = isKo ? 'AI 요약' : 'AI Summary';
+
+    // Show AI summary + user note below if exists
+    const userNote = note && !note.startsWith(AI_SUMMARY_PREFIX_EN) ? note : null;
+
+    return (
+      <>
+        <AiSummaryPreview
+          body={body}
+          label={label}
+          maxLines={userNote ? 2 : maxLines}
+          className={className}
+          cardId={cardId}
+          summaryRating={summaryRating}
+          onRate={onRate}
+        />
+        {userNote && (
+          <UserNotePreview note={userNote} maxLines={1} className={className} />
+        )}
+      </>
+    );
+  }
+
   if (!note) return null;
 
-  // Detect bilingual or single AI Summary and render locale-appropriate version
+  // Priority 2: Legacy — detect bilingual AI Summary embedded in user_note
   const localeSummary = extractLocaleSummary(note, i18n.language);
   if (localeSummary) {
     return (

--- a/frontend/src/widgets/card-list/ui/InsightCardItem.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItem.tsx
@@ -189,7 +189,7 @@ export function InsightCardItem({
               />
             ) : (
               <div onDoubleClick={handleNoteDoubleClick}>
-                {card.userNote ? (
+                {card.userNote || card.videoSummary ? (
                   <div className="flex items-start gap-1">
                     <StickyNote
                       className="w-3 h-3 mt-0.5 shrink-0 text-primary/60"
@@ -201,6 +201,7 @@ export function InsightCardItem({
                       cardId={card.id}
                       summaryRating={summaryRating}
                       onRate={onRate}
+                      videoSummary={card.videoSummary}
                     />
                   </div>
                 ) : (
@@ -247,12 +248,13 @@ export function InsightCardItem({
                 className="w-full h-full text-xs bg-muted/50 border border-input rounded px-1.5 py-1 resize-none focus:outline-none focus:ring-1 focus:ring-ring"
                 placeholder={t('cards.addNote')}
               />
-            ) : card.userNote ? (
+            ) : card.userNote || card.videoSummary ? (
               <CompactNotePreview
                 note={card.userNote}
                 cardId={card.id}
                 summaryRating={summaryRating}
                 onRate={onRate}
+                videoSummary={card.videoSummary}
               />
             ) : (
               <p className="text-xs text-muted-foreground/50 italic">

--- a/frontend/src/widgets/list-view/ui/ListViewItem.tsx
+++ b/frontend/src/widgets/list-view/ui/ListViewItem.tsx
@@ -67,8 +67,8 @@ export const ListViewItem = memo(function ListViewItem({
       {/* Title + Note preview */}
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium truncate">{card.title || t('cards.untitled')}</p>
-        {card.userNote ? (
-          <CompactNotePreview note={card.userNote} maxLines={1} className="truncate" />
+        {card.userNote || card.videoSummary ? (
+          <CompactNotePreview note={card.userNote} maxLines={1} className="truncate" videoSummary={card.videoSummary} />
         ) : (
           <p className="text-xs text-muted-foreground truncate">{t('insightCard.noMemo')}</p>
         )}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -491,6 +491,21 @@ model user_local_cards {
   @@schema("public")
 }
 
+model video_summaries {
+  video_id            String   @id
+  url                 String
+  title               String?
+  summary_en          String?
+  summary_ko          String?
+  tags                String[]
+  model               String?
+  transcript_segments Int      @default(0)
+  created_at          DateTime @default(now()) @db.Timestamptz(6)
+  updated_at          DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+
+  @@schema("public")
+}
+
 model content_entities {
   id          String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   user_id     String         @db.Uuid

--- a/src/api/routes/admin/enrichment.ts
+++ b/src/api/routes/admin/enrichment.ts
@@ -1,0 +1,23 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { systemBatchEnrich } from '../../../modules/ontology/enrichment';
+import { createSuccessResponse } from '../../schemas/common.schema';
+
+const BatchAllBodySchema = z.object({
+  limit: z.number().int().min(1).max(500).default(100),
+  delay_ms: z.number().int().min(0).max(10000).default(2000),
+});
+
+export async function adminEnrichmentRoutes(fastify: FastifyInstance) {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  // POST /api/v1/admin/enrichment/batch-all — enrich all unsummarized YouTube videos
+  fastify.post('/batch-all', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
+    const body = BatchAllBodySchema.parse(request.body);
+    const result = await systemBatchEnrich({
+      limit: body.limit,
+      delayMs: body.delay_ms,
+    });
+    return reply.send(createSuccessResponse(result));
+  });
+}

--- a/src/api/routes/admin/index.ts
+++ b/src/api/routes/admin/index.ts
@@ -12,6 +12,7 @@ import { adminContentRoutes } from './content';
 import { adminReportRoutes } from './reports';
 import { adminHealthRoutes } from './health';
 import { adminLlmRoutes } from './llm';
+import { adminEnrichmentRoutes } from './enrichment';
 
 /**
  * Admin routes plugin.
@@ -35,5 +36,6 @@ export async function adminRoutes(fastify: FastifyInstance) {
   await fastify.register(adminPaymentRoutes, { prefix: '/payments' });
   await fastify.register(adminHealthRoutes, { prefix: '/health' });
   await fastify.register(adminLlmRoutes, { prefix: '/llm' });
+  await fastify.register(adminEnrichmentRoutes, { prefix: '/enrichment' });
   await fastify.register(stripeWebhookRoutes, { prefix: '/webhooks/stripe' });
 }

--- a/src/modules/ontology/enrichment.ts
+++ b/src/modules/ontology/enrichment.ts
@@ -5,17 +5,28 @@ import { embedNode } from './embedding';
 import { logger } from '../../utils/logger';
 
 // ============================================================================
-// Resource Node Enrichment — YouTube transcript → LLM summary → re-embed
+// Video Enrichment — YouTube transcript → LLM summary → video_summaries table
 // ============================================================================
 
 const MAX_TRANSCRIPT_CHARS = 10000;
-const AI_SUMMARY_PREFIX = '🤖 AI Summary:\n';
-const AI_SUMMARY_PREFIX_KO = '🤖 AI 요약:\n';
 
 // Chunked summarization constants (qwen3.5:9b limitation: >500 chars → empty response)
 const CHUNK_THRESHOLD = 500;
 const MAX_CHUNK_SIZE = 300;
 const MAX_MERGE_INPUT = 400;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface VideoSummaryResult {
+  videoId: string;
+  summaryEn: string;
+  summaryKo: string;
+  tags: string[];
+  model: string;
+  cached: boolean;
+}
 
 interface EnrichResult {
   nodeId: string;
@@ -28,10 +39,19 @@ interface BatchEnrichResult {
   total: number;
   enriched: number;
   skipped: number;
-  errors: { nodeId: string; error: string }[];
+  errors: { videoId: string; error: string }[];
 }
 
-function extractYouTubeVideoId(url: string): string | null {
+interface SummaryResponse {
+  summary: string;
+  tags: string[];
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+export function extractYouTubeVideoId(url: string): string | null {
   try {
     const parsed = new URL(url);
     if (parsed.hostname === 'youtu.be') {
@@ -50,13 +70,7 @@ function extractYouTubeVideoId(url: string): string | null {
   }
 }
 
-interface SummaryResponse {
-  summary: string;
-  tags: string[];
-}
-
 function parseSummaryResponse(raw: string): SummaryResponse {
-  // Try to extract JSON from the response (may have markdown fences)
   const jsonMatch = raw.match(/\{[\s\S]*\}/);
   if (!jsonMatch) {
     throw new Error('No JSON found in LLM response');
@@ -75,9 +89,6 @@ function parseSummaryResponse(raw: string): SummaryResponse {
 // Chunked Summarization — split long transcripts for small LLMs
 // ============================================================================
 
-/**
- * Split text into paragraphs by double newlines or consecutive newlines.
- */
 function splitIntoParagraphs(text: string): string[] {
   return text
     .split(/\n{2,}/)
@@ -85,9 +96,6 @@ function splitIntoParagraphs(text: string): string[] {
     .filter((p) => p.length > 0);
 }
 
-/**
- * Split a single long paragraph by sentence boundaries (. ! ?).
- */
 function splitBySentences(text: string, maxSize: number): string[] {
   const sentences = text.match(/[^.!?]+[.!?]+/g) || [text];
   const chunks: string[] = [];
@@ -109,22 +117,16 @@ function splitBySentences(text: string, maxSize: number): string[] {
   return chunks;
 }
 
-/**
- * Pack paragraphs into chunks of maxSize characters, preserving paragraph boundaries.
- * If a single paragraph exceeds maxSize, split it by sentence boundaries.
- */
 function packChunks(paragraphs: string[], maxSize: number): string[] {
   const chunks: string[] = [];
   let current = '';
 
   for (const para of paragraphs) {
     if (para.length > maxSize) {
-      // Flush current buffer first
       if (current.trim()) {
         chunks.push(current.trim());
         current = '';
       }
-      // Split oversized paragraph by sentences
       chunks.push(...splitBySentences(para, maxSize));
       continue;
     }
@@ -154,11 +156,6 @@ function buildMergePrompt(partials: string[], title: string): string {
 
 const MAX_REDUCE_DEPTH = 5;
 
-/**
- * Hierarchically reduce partial summaries if they exceed merge budget.
- * Groups partials into batches that fit within MAX_MERGE_INPUT,
- * summarizes each batch, then recurses if needed (up to MAX_REDUCE_DEPTH).
- */
 async function reducePartials(
   partials: string[],
   generate: (prompt: string) => Promise<string>,
@@ -169,7 +166,6 @@ async function reducePartials(
     return partials;
   }
 
-  // Safety: if max depth reached, force-truncate to fit
   if (depth >= MAX_REDUCE_DEPTH) {
     logger.warn('reducePartials max depth reached, truncating', { depth, partials: partials.length });
     const truncated: string[] = [];
@@ -183,18 +179,15 @@ async function reducePartials(
     return truncated.length > 0 ? truncated : [partials[0]!.slice(0, 100)];
   }
 
-  // Group partials into batches of 3-5 items each (not by size alone)
   const BATCH_SIZE = 4;
   const batches: string[][] = [];
   for (let i = 0; i < partials.length; i += BATCH_SIZE) {
     batches.push(partials.slice(i, i + BATCH_SIZE));
   }
 
-  // Summarize each batch into 1 sentence
   const reduced: string[] = [];
   for (const group of batches) {
     if (group.length === 1) {
-      // Single item: shorten it via LLM
       const prompt = `Shorten to 1 sentence:\n${group[0]}`;
       const result = await generate(prompt);
       reduced.push(result.trim().slice(0, 120));
@@ -205,7 +198,6 @@ async function reducePartials(
     reduced.push(result.trim().slice(0, 120));
   }
 
-  // Recurse if still too large
   const reducedSize = reduced.reduce((sum, p) => sum + p.length + 3, 0);
   if (reducedSize > MAX_MERGE_INPUT && reduced.length > 1) {
     return reducePartials(reduced, generate, depth + 1);
@@ -214,10 +206,6 @@ async function reducePartials(
   return reduced;
 }
 
-/**
- * Chunked summarization strategy for long transcripts.
- * Splits transcript → chunk summaries (plain text) → merge (JSON).
- */
 async function chunkedSummarize(
   title: string,
   transcript: string,
@@ -229,7 +217,6 @@ async function chunkedSummarize(
 
   logger.info('Chunked summarization', { chunks: chunks.length, totalChars: truncated.length });
 
-  // Phase 1: Summarize each chunk (plain text, no JSON)
   const partials: string[] = [];
   for (const chunk of chunks) {
     const prompt = buildChunkSummaryPrompt(chunk);
@@ -244,11 +231,9 @@ async function chunkedSummarize(
     throw new Error('All chunk summaries returned empty');
   }
 
-  // Phase 2: Reduce partials if too many for merge prompt
   const plainGenerate = (p: string) => generate(p, { temperature: 0.3 });
   const reducedPartials = await reducePartials(partials, plainGenerate);
 
-  // Phase 3: Merge into final JSON response
   const mergePrompt = buildMergePrompt(reducedPartials, title);
   logger.info('Merge prompt size', { chars: mergePrompt.length, partials: reducedPartials.length });
 
@@ -269,6 +254,130 @@ Respond in JSON: {"summary": "...", "tags": ["...", ...]}
 Important: Respond in English. Do NOT start summary with "This video" or "The video".`;
 }
 
+// ============================================================================
+// Core: enrichVideo — video_id based, UPSERT to video_summaries
+// ============================================================================
+
+/**
+ * Generate or retrieve summary for a YouTube video.
+ * Results are stored in video_summaries table (1 row per video_id).
+ * No user_note writes. No user_id dependency.
+ */
+export async function enrichVideo(
+  videoId: string,
+  options?: { transcript?: string; force?: boolean; title?: string; url?: string }
+): Promise<VideoSummaryResult> {
+  const prisma = getPrismaClient();
+
+  // 1. Check if summary already exists (skip unless force)
+  if (!options?.force) {
+    const existing = await prisma.$queryRaw<
+      { video_id: string; summary_en: string | null; summary_ko: string | null; tags: string[]; model: string | null }[]
+    >`
+      SELECT video_id, summary_en, summary_ko, tags, model
+      FROM public.video_summaries
+      WHERE video_id = ${videoId}
+    `;
+
+    if (existing.length > 0 && existing[0]!.summary_en) {
+      logger.info('Video summary cache hit', { videoId });
+      return {
+        videoId,
+        summaryEn: existing[0]!.summary_en!,
+        summaryKo: existing[0]!.summary_ko || existing[0]!.summary_en!,
+        tags: existing[0]!.tags || [],
+        model: existing[0]!.model || '',
+        cached: true,
+      };
+    }
+  }
+
+  // 2. Get transcript
+  let transcript: string;
+  let transcriptSegments = 0;
+
+  if (options?.transcript) {
+    transcript = options.transcript;
+    logger.info('Using client-provided transcript', { videoId, length: transcript.length });
+  } else {
+    const captionExtractor = getCaptionExtractor();
+    const captionResult = await captionExtractor.extractCaptions(videoId);
+    if (!captionResult.success || !captionResult.caption) {
+      throw new Error(`CAPTION_FAILED: ${captionResult.error || 'unknown'}`);
+    }
+    transcript = captionResult.caption.fullText;
+    transcriptSegments = captionResult.caption.segments?.length ?? 0;
+  }
+
+  // 3. Generate bilingual summary
+  const title = options?.title || videoId;
+  const generationProvider = await createGenerationProvider();
+  const generate = (prompt: string, opts?: { format?: 'json' | 'text'; temperature?: number }) =>
+    generationProvider.generate(prompt, opts);
+
+  let primarySummary: SummaryResponse;
+  if (transcript.length > CHUNK_THRESHOLD) {
+    logger.info('Using chunked summarization', { videoId, transcriptLength: transcript.length });
+    primarySummary = await chunkedSummarize(title, transcript, generate);
+  } else {
+    const rawResponse = await generate(
+      buildSummaryPrompt(title, transcript),
+      { format: 'json', temperature: 0.3 }
+    );
+    primarySummary = parseSummaryResponse(rawResponse);
+  }
+
+  const summaryEn = primarySummary.summary;
+  let summaryKo: string;
+
+  try {
+    const translated = await generate(
+      `Translate to natural Korean in 2-3 sentences:\n${summaryEn}`,
+      { temperature: 0.3 }
+    );
+    summaryKo = translated.trim();
+  } catch {
+    summaryKo = summaryEn;
+  }
+
+  const tags = primarySummary.tags;
+  const modelName = generationProvider.model;
+
+  logger.info('Bilingual summary generated', { videoId, en: summaryEn.length, ko: summaryKo.length });
+
+  // 4. UPSERT to video_summaries
+  const url = options?.url || `https://www.youtube.com/watch?v=${videoId}`;
+  const tagsArray = `{${tags.map((t) => `"${t.replace(/"/g, '\\"')}"`).join(',')}}`;
+
+  await prisma.$executeRaw`
+    INSERT INTO public.video_summaries (video_id, url, title, summary_en, summary_ko, tags, model, transcript_segments, created_at, updated_at)
+    VALUES (${videoId}, ${url}, ${title}, ${summaryEn}, ${summaryKo}, ${tagsArray}::text[], ${modelName}, ${transcriptSegments}, now(), now())
+    ON CONFLICT (video_id) DO UPDATE SET
+      summary_en = EXCLUDED.summary_en,
+      summary_ko = EXCLUDED.summary_ko,
+      tags = EXCLUDED.tags,
+      model = EXCLUDED.model,
+      transcript_segments = EXCLUDED.transcript_segments,
+      title = COALESCE(EXCLUDED.title, public.video_summaries.title),
+      updated_at = now()
+  `;
+
+  logger.info('Video summary saved', { videoId, tagsCount: tags.length, model: modelName });
+
+  return {
+    videoId,
+    summaryEn,
+    summaryKo,
+    tags,
+    model: modelName,
+    cached: false,
+  };
+}
+
+// ============================================================================
+// Legacy adapter: enrichResourceNode — wraps enrichVideo + updates ontology.nodes
+// ============================================================================
+
 export async function enrichResourceNode(
   nodeId: string,
   userId: string,
@@ -278,12 +387,11 @@ export async function enrichResourceNode(
 
   // 1. Get resource node
   const nodes = await prisma.$queryRaw<
-    { id: string; title: string; properties: Record<string, unknown>; source_ref: { table?: string; id?: string } | null }[]
+    { id: string; title: string; properties: Record<string, unknown> }[]
   >`
-    SELECT id, title, properties, source_ref
+    SELECT id, title, properties
     FROM ontology.nodes
     WHERE id = ${nodeId}::uuid AND user_id = ${userId}::uuid
-      -- TODO: add "AND domain = 'service'" after domain column migration
   `;
 
   if (nodes.length === 0) {
@@ -301,69 +409,21 @@ export async function enrichResourceNode(
     throw new Error('NOT_YOUTUBE_URL');
   }
 
-  // 3. Get transcript: use client-provided transcript if available, else server-side extraction
-  let transcript: string;
-  let transcriptLang = 'en';
+  // 3. Delegate to enrichVideo (central summary)
+  const result = await enrichVideo(videoId, {
+    transcript: options?.transcript,
+    title: node.title,
+    url,
+  });
 
-  if (options?.transcript) {
-    transcript = options.transcript;
-    logger.info('Using client-provided transcript', { nodeId, length: transcript.length });
-  } else {
-    const captionExtractor = getCaptionExtractor();
-    const captionResult = await captionExtractor.extractCaptions(videoId);
-    if (!captionResult.success || !captionResult.caption) {
-      throw new Error(`CAPTION_FAILED: ${captionResult.error || 'unknown'}`);
-    }
-    transcript = captionResult.caption.fullText;
-    transcriptLang = captionResult.caption.language;
-  }
-
-  // 4. Generate bilingual summary (en + ko)
-  const generationProvider = await createGenerationProvider();
-  const generate = (prompt: string, opts?: { format?: 'json' | 'text'; temperature?: number }) =>
-    generationProvider.generate(prompt, opts);
-
-  // 4a. Generate primary summary (in transcript's language)
-  let primarySummary: SummaryResponse;
-  if (transcript.length > CHUNK_THRESHOLD) {
-    logger.info('Using chunked summarization', { transcriptLength: transcript.length, lang: transcriptLang });
-    primarySummary = await chunkedSummarize(node.title, transcript, generate);
-  } else {
-    const rawResponse = await generate(
-      buildSummaryPrompt(node.title, transcript),
-      { format: 'json', temperature: 0.3 }
-    );
-    primarySummary = parseSummaryResponse(rawResponse);
-  }
-
-  // 4b. EN-first strategy: primary summary is always English → translate to Korean
-  const summaryEn = primarySummary.summary;
-  let summaryKo: string;
-
-  try {
-    const translated = await generate(
-      `Translate to natural Korean in 2-3 sentences:\n${summaryEn}`,
-      { temperature: 0.3 }
-    );
-    summaryKo = translated.trim();
-  } catch {
-    summaryKo = summaryEn; // fallback: same as en
-  }
-
-  const tags = primarySummary.tags;
-  // Default summary for backward compatibility (English)
-  const summary = summaryEn;
-
-  logger.info('Bilingual summary generated', { nodeId, en: summaryEn.length, ko: summaryKo.length });
-
-  // 5. Update node properties (bilingual summary + tags + provenance)
+  // 4. Update ontology.nodes properties (graph usage)
   const updatedProperties = {
     ...node.properties,
-    summary,
-    summary_en: summaryEn,
-    summary_ko: summaryKo,
-    summary_tags: tags,
-    summary_model: generationProvider.model,
+    summary: result.summaryEn,
+    summary_en: result.summaryEn,
+    summary_ko: result.summaryKo,
+    summary_tags: result.tags,
+    summary_model: result.model,
     summary_created_at: new Date().toISOString(),
   };
 
@@ -374,46 +434,7 @@ export async function enrichResourceNode(
     WHERE id = ${nodeId}::uuid AND user_id = ${userId}::uuid
   `;
 
-  // 5b. Write bilingual AI Summary to user_local_cards.user_note
-  const sourceRef = node.source_ref as { table?: string; id?: string } | null;
-  if (sourceRef?.table === 'user_local_cards' && sourceRef?.id) {
-    const bilingualNote = `${AI_SUMMARY_PREFIX}${summaryEn}\n\n${AI_SUMMARY_PREFIX_KO}${summaryKo}`;
-
-    // Get existing note to prepend/replace
-    const existingRows = await prisma.$queryRaw<{ user_note: string | null }[]>`
-      SELECT user_note FROM public.user_local_cards
-      WHERE id = ${sourceRef.id}::uuid
-    `;
-    const existingNote = existingRows[0]?.user_note ?? '';
-
-    let newNote: string;
-    if (!existingNote) {
-      newNote = bilingualNote;
-    } else if (existingNote.startsWith(AI_SUMMARY_PREFIX)) {
-      // Already has AI Summary: replace everything before user content
-      // Find user content after the last AI Summary block
-      const lastPrefixIdx = existingNote.lastIndexOf(AI_SUMMARY_PREFIX_KO);
-      let userContent = '';
-      if (lastPrefixIdx >= 0) {
-        const afterKo = existingNote.indexOf('\n\n', lastPrefixIdx + AI_SUMMARY_PREFIX_KO.length);
-        userContent = afterKo >= 0 ? existingNote.slice(afterKo) : '';
-      } else {
-        const afterEn = existingNote.indexOf('\n\n', AI_SUMMARY_PREFIX.length);
-        userContent = afterEn >= 0 ? existingNote.slice(afterEn) : '';
-      }
-      newNote = bilingualNote + userContent;
-    } else {
-      newNote = bilingualNote + '\n\n' + existingNote;
-    }
-
-    await prisma.$executeRaw`
-      UPDATE public.user_local_cards
-      SET user_note = ${newNote}, updated_at = now()
-      WHERE id = ${sourceRef.id}::uuid
-    `;
-  }
-
-  // 6. Re-embed with enriched content (non-fatal: summary already saved in step 5)
+  // 5. Re-embed (non-fatal)
   let embedded = false;
   try {
     embedded = await embedNode(nodeId, node.title, updatedProperties);
@@ -424,16 +445,15 @@ export async function enrichResourceNode(
     });
   }
 
-  logger.info('Resource node enriched', { nodeId, videoId, tagsCount: tags.length, embedded });
+  logger.info('Resource node enriched', { nodeId, videoId, tagsCount: result.tags.length, embedded });
 
-  return { nodeId, summary, tags, embedded };
+  return { nodeId, summary: result.summaryEn, tags: result.tags, embedded };
 }
 
-/**
- * Find resource node by source_ref (e.g., local_card ID) and enrich it.
- * If no resource node exists, auto-create one from the card data, then enrich.
- * Used for auto-enrichment after card creation.
- */
+// ============================================================================
+// enrichBySourceRef — find/create resource node, then enrich
+// ============================================================================
+
 export async function enrichBySourceRef(
   userId: string,
   sourceTable: string,
@@ -467,7 +487,6 @@ export async function enrichBySourceRef(
     }
     const card = cards[0]!;
 
-    // Only create resource nodes for YouTube cards
     if (card.link_type !== 'youtube' && card.link_type !== 'youtube-shorts') {
       return null;
     }
@@ -490,7 +509,7 @@ export async function enrichBySourceRef(
 
   const nodeId = nodes[0]!.id;
 
-  // Check summary_dismissed flag (skip auto-enrich, allow manual re-generation)
+  // Check summary_dismissed flag
   if (!options?.force) {
     const nodeData = await prisma.$queryRaw<{ properties: Record<string, unknown> }[]>`
       SELECT properties FROM ontology.nodes WHERE id = ${nodeId}::uuid AND user_id = ${userId}::uuid
@@ -499,7 +518,6 @@ export async function enrichBySourceRef(
       return null;
     }
   } else {
-    // Manual re-generation: clear dismissed flag
     await prisma.$executeRaw`
       UPDATE ontology.nodes
       SET properties = properties - 'summary_dismissed', updated_at = now()
@@ -530,17 +548,12 @@ export interface BackfillResult {
   errors: { cardId: string; error: string }[];
 }
 
-/**
- * Create ontology resource nodes for existing user_local_cards that don't have one.
- * This bridges the gap: cards → resource nodes → enrichment → user_note.
- */
 export async function backfillResourceNodes(
   userId: string,
   options: { onProgress?: (event: BackfillProgressEvent) => void } = {}
 ): Promise<BackfillResult> {
   const prisma = getPrismaClient();
 
-  // Find YouTube cards that have no corresponding ontology resource node
   const cards = await prisma.$queryRaw<
     { id: string; url: string; title: string; link_type: string }[]
   >`
@@ -594,6 +607,10 @@ export async function backfillResourceNodes(
   return result;
 }
 
+// ============================================================================
+// Batch Enrich — legacy (user-scoped, uses ontology.nodes)
+// ============================================================================
+
 const MAX_BATCH_LIMIT = 500;
 
 export interface EnrichProgressEvent {
@@ -611,16 +628,13 @@ export async function batchEnrichResources(
   options: { limit?: number; delayMs?: number; onProgress?: (event: EnrichProgressEvent) => void } = {}
 ): Promise<BatchEnrichResult> {
   const prisma = getPrismaClient();
-  // limit=0 means "all" (capped at MAX_BATCH_LIMIT for safety)
   const rawLimit = options.limit ?? 10;
   const limit = rawLimit === 0 ? MAX_BATCH_LIMIT : Math.min(rawLimit, MAX_BATCH_LIMIT);
   const delayMs = options.delayMs ?? 2000;
 
-  // Find resource nodes without summary, YouTube link_type
   const nodes = await prisma.$queryRaw<{ id: string; title: string }[]>`
     SELECT id, title FROM ontology.nodes
     WHERE user_id = ${userId}::uuid
-      -- TODO: add "AND domain = 'service'" after domain column migration
       AND type = 'resource'
       AND (properties->>'link_type' = 'youtube' OR properties->>'url' LIKE '%youtube.com%' OR properties->>'url' LIKE '%youtu.be%')
       AND (properties->>'summary' IS NULL OR properties->>'summary' = '')
@@ -646,7 +660,7 @@ export async function batchEnrichResources(
       onProgress?.({ current: i + 1, total: nodes.length, nodeId: node.id, title: node.title, status: 'success', summary: enrichResult.summary });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      result.errors.push({ nodeId: node.id, error: msg });
+      result.errors.push({ videoId: node.id, error: msg });
       logger.warn('Batch enrich skipped node', { nodeId: node.id, error: msg });
       onProgress?.({ current: i + 1, total: nodes.length, nodeId: node.id, title: node.title, status: 'error', error: msg });
     }
@@ -660,6 +674,87 @@ export async function batchEnrichResources(
     userId,
     total: result.total,
     enriched: result.enriched,
+    errors: result.errors.length,
+  });
+
+  return result;
+}
+
+// ============================================================================
+// System Batch Enrich — no user auth, scans all cards for unsummarized videos
+// ============================================================================
+
+export interface SystemBatchResult {
+  total: number;
+  enriched: number;
+  skipped: number;
+  errors: { videoId: string; error: string }[];
+}
+
+const SYSTEM_BATCH_DELAY_MS = 2000;
+
+/**
+ * Scan all user_local_cards for YouTube URLs, extract unique video_ids,
+ * and enrich any that don't have a video_summaries entry.
+ * No user authentication required — this is a system/admin operation.
+ */
+export async function systemBatchEnrich(
+  options: { limit?: number; delayMs?: number } = {}
+): Promise<SystemBatchResult> {
+  const prisma = getPrismaClient();
+  const limit = Math.min(options.limit ?? 100, MAX_BATCH_LIMIT);
+  const delayMs = options.delayMs ?? SYSTEM_BATCH_DELAY_MS;
+
+  // Find YouTube cards whose video_id is NOT yet in video_summaries
+  const cards = await prisma.$queryRaw<
+    { url: string; title: string }[]
+  >`
+    SELECT DISTINCT ON (c.url) c.url, COALESCE(c.title, c.metadata_title, 'Untitled') as title
+    FROM public.user_local_cards c
+    WHERE c.link_type IN ('youtube', 'youtube-shorts')
+      AND NOT EXISTS (
+        SELECT 1 FROM public.video_summaries vs
+        WHERE vs.url = c.url
+      )
+    ORDER BY c.url, c.created_at ASC
+    LIMIT ${limit}
+  `;
+
+  const result: SystemBatchResult = {
+    total: cards.length,
+    enriched: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  for (let i = 0; i < cards.length; i++) {
+    const card = cards[i]!;
+    const videoId = extractYouTubeVideoId(card.url);
+
+    if (!videoId) {
+      result.skipped++;
+      continue;
+    }
+
+    try {
+      await enrichVideo(videoId, { title: card.title, url: card.url });
+      result.enriched++;
+      logger.info('System batch enriched', { videoId, progress: `${i + 1}/${cards.length}` });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      result.errors.push({ videoId, error: msg });
+      logger.warn('System batch enrich failed', { videoId, error: msg });
+    }
+
+    if (delayMs > 0 && i < cards.length - 1) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  logger.info('System batch enrichment complete', {
+    total: result.total,
+    enriched: result.enriched,
+    skipped: result.skipped,
     errors: result.errors.length,
   });
 

--- a/supabase/functions/local-cards/index.ts
+++ b/supabase/functions/local-cards/index.ts
@@ -214,7 +214,7 @@ Deno.serve(async (req) => {
       case 'list': {
         const mandalaId = url.searchParams.get('mandala_id');
 
-        // Parallel fetch: subscription + cards (was 3 sequential queries, now 2 parallel)
+        // Parallel fetch: subscription + cards
         let cardsQuery = supabase
           .from('user_local_cards')
           .select('*')
@@ -234,9 +234,35 @@ Deno.serve(async (req) => {
 
         const cards = cardsResult.data || [];
 
+        // Enrich YouTube cards with video_summaries (LEFT JOIN equivalent)
+        const youtubeUrls = cards
+          .filter((c: Record<string, unknown>) => c.link_type === 'youtube' || c.link_type === 'youtube-shorts')
+          .map((c: Record<string, unknown>) => c.url as string);
+
+        let summaryMap = new Map<string, Record<string, unknown>>();
+        if (youtubeUrls.length > 0) {
+          const { data: summaries } = await supabase
+            .from('video_summaries')
+            .select('url, summary_en, summary_ko, tags, model')
+            .in('url', youtubeUrls);
+
+          if (summaries) {
+            for (const s of summaries) {
+              summaryMap.set(s.url, s);
+            }
+          }
+        }
+
+        const enrichedCards = cards.map((card: Record<string, unknown>) => {
+          const summary = summaryMap.get(card.url as string);
+          return summary
+            ? { ...card, video_summary: summary }
+            : card;
+        });
+
         return new Response(
           JSON.stringify({
-            cards,
+            cards: enrichedCards,
             subscription: {
               tier: subscription.tier,
               limit: subscription.local_cards_limit,
@@ -713,6 +739,7 @@ Deno.serve(async (req) => {
           .filter(Boolean);
 
         let cardsCreated = 0;
+        const createdCards: Array<{ id: string; url: string }> = [];
         if (cardRows.length > 0) {
           // Insert in batches to avoid hitting payload limits
           for (let i = 0; i < cardRows.length; i += 50) {
@@ -720,12 +747,15 @@ Deno.serve(async (req) => {
             const { data: inserted, error: insertError } = await supabase
               .from('user_local_cards')
               .upsert(batch as Record<string, unknown>[], { onConflict: 'user_id,url' })
-              .select('id');
+              .select('id, url');
 
             if (insertError) {
               console.error('[local-cards] import-playlist insert error:', insertError);
             } else {
               cardsCreated += (inserted?.length || 0);
+              for (const card of inserted || []) {
+                createdCards.push({ id: card.id, url: card.url });
+              }
             }
           }
         }
@@ -751,6 +781,7 @@ Deno.serve(async (req) => {
             success: true,
             playlist: { id: playlistId, title: playlistTitle, itemCount: playlistItemCount },
             cardsCreated,
+            cards: createdCards,
             quotaUsed,
             limitInfo: {
               tier: limitInfo.tier,


### PR DESCRIPTION
## Summary
- Add `video_summaries` table for centralized video summary storage (video_id PK)
- Refactor enrichment: `enrichVideo()` with UPSERT to video_summaries, `enrichResourceNode` as legacy adapter
- Add `admin/enrichment/batch-all` API for system-wide batch enrichment (no user JWT)
- Fix playlist import missing AI summary trigger
- Fix auto-summary settings toggle not disabling enrichment
- Edge Function `list` action: LEFT JOIN video_summaries for summary data
- Frontend: `VideoSummary` type + `CompactNotePreview` priority display across 4 components

## Pre-flight
- tsc (backend): ✅ pass
- tsc (frontend): ✅ pass
- build: ✅ pass (3.56s)
- files changed: 13

## Test plan
- [ ] CI pass
- [ ] Deploy health check
- [ ] Add single YouTube card → verify AI summary generation
- [ ] Add playlist → verify enrichment triggers for each card
- [ ] Disable auto-summary toggle → verify no enrichment on card add

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)