### PR TITLE
fix(ux): infinite scroll, sidebar toggle, design regressions, i18n summary

### DIFF
--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -563,7 +563,7 @@ function AuthenticatedApp() {
               </div>
             )}
 
-            <div className="flex-1 h-full overflow-y-auto px-4 py-4">
+            <div className={`flex-1 h-full px-4 py-4 ${modal.isModalOpen ? 'overflow-hidden' : 'overflow-y-auto'}`}>
               {/* Mobile search bar (hidden on md+, shown in header instead) */}
               <div className="md:hidden mb-3">
                 <SearchBar

--- a/frontend/src/shared/ui/CompactNotePreview.tsx
+++ b/frontend/src/shared/ui/CompactNotePreview.tsx
@@ -79,7 +79,7 @@ function AiSummaryPreview({ body, label, maxLines, className, cardId, summaryRat
     [cardId, summaryRating, onRate]
   );
 
-  const clampClass = maxLines === 1
+  const bodyClampClass = maxLines === 1
     ? 'line-clamp-1'
     : maxLines === 2
       ? 'line-clamp-2'
@@ -91,7 +91,6 @@ function AiSummaryPreview({ body, label, maxLines, className, cardId, summaryRat
     <div
       className={cn(
         'border-l-2 border-blue-400 pl-2 pr-1 py-1 bg-blue-50/50 dark:bg-blue-950/30 rounded-r text-xs text-muted-foreground',
-        clampClass,
         className,
       )}
     >
@@ -127,17 +126,19 @@ function AiSummaryPreview({ body, label, maxLines, className, cardId, summaryRat
           </span>
         )}
       </div>
-      {parsedLines.map((line, lineIdx) =>
-        line.segments.length > 0 ? (
-          <div key={lineIdx} className="whitespace-pre-wrap">
-            {line.segments.map((seg, segIdx) => (
-              <SegmentRenderer key={`${lineIdx}-${segIdx}`} segment={seg} />
-            ))}
-          </div>
-        ) : (
-          <div key={lineIdx}>&nbsp;</div>
-        ),
-      )}
+      <div className={bodyClampClass}>
+        {parsedLines.map((line, lineIdx) =>
+          line.segments.length > 0 ? (
+            <div key={lineIdx} className="whitespace-pre-wrap">
+              {line.segments.map((seg, segIdx) => (
+                <SegmentRenderer key={`${lineIdx}-${segIdx}`} segment={seg} />
+              ))}
+            </div>
+          ) : (
+            <div key={lineIdx}>&nbsp;</div>
+          ),
+        )}
+      </div>
     </div>
   );
 }
@@ -213,14 +214,14 @@ export function CompactNotePreview({ note, maxLines, className, cardId, summaryR
         <AiSummaryPreview
           body={body}
           label={label}
-          maxLines={userNote ? 2 : maxLines}
+          maxLines={maxLines !== undefined ? (userNote ? 2 : maxLines) : undefined}
           className={className}
           cardId={cardId}
           summaryRating={summaryRating}
           onRate={onRate}
         />
         {userNote && (
-          <UserNotePreview note={userNote} maxLines={1} className={className} />
+          <UserNotePreview note={userNote} maxLines={maxLines !== undefined ? 1 : undefined} className={className} />
         )}
       </>
     );

--- a/frontend/src/widgets/app-shell/ui/AppShell.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppShell.tsx
@@ -13,6 +13,7 @@ interface AppShellProps {
 }
 
 const SIDEBAR_COLLAPSED_KEY = 'insighta-sidebar-collapsed';
+const SIDEBAR_SIZE_KEY = 'insighta-sidebar-size';
 
 function getInitialCollapsed(): boolean {
   try {
@@ -20,6 +21,16 @@ function getInitialCollapsed(): boolean {
   } catch {
     return false;
   }
+}
+
+function getInitialSize(): 'compact' | 'wide' {
+  try {
+    const stored = localStorage.getItem(SIDEBAR_SIZE_KEY);
+    if (stored === 'wide') return 'wide';
+  } catch {
+    // ignore
+  }
+  return 'compact';
 }
 
 export function AppShell({
@@ -31,6 +42,7 @@ export function AppShell({
   searchBarElement,
 }: AppShellProps) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(getInitialCollapsed);
+  const [sidebarSize, setSidebarSize] = useState<'compact' | 'wide'>(getInitialSize);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
 
   const handleToggleCollapse = useCallback(() => {
@@ -45,6 +57,18 @@ export function AppShell({
     });
   }, []);
 
+  const handleToggleSize = useCallback(() => {
+    setSidebarSize((prev) => {
+      const next = prev === 'compact' ? 'wide' : 'compact';
+      try {
+        localStorage.setItem(SIDEBAR_SIZE_KEY, next);
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }, []);
+
   return (
     <div className="h-screen flex flex-col bg-surface-base overflow-hidden">
       <AppHeader onMobileMenuOpen={() => setMobileDrawerOpen(true)} searchBarElement={searchBarElement} />
@@ -52,7 +76,9 @@ export function AppShell({
       <div className="flex-1 flex overflow-hidden">
         <Sidebar
           collapsed={sidebarCollapsed}
+          sidebarSize={sidebarCollapsed ? 'compact' : sidebarSize}
           onToggleCollapse={handleToggleCollapse}
+          onToggleSize={sidebarCollapsed ? undefined : handleToggleSize}
           onNavigateHome={onNavigateHome}
           mandalaGridElement={mandalaGridElement}
           selectedMandalaId={selectedMandalaId}

--- a/frontend/src/widgets/app-shell/ui/Sidebar.tsx
+++ b/frontend/src/widgets/app-shell/ui/Sidebar.tsx
@@ -11,6 +11,8 @@ import {
   Loader2,
   ChevronLeft,
   ChevronRight,
+  Maximize2,
+  Minimize2,
 } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { useAuth } from '@/features/auth/model/useAuth';
@@ -21,7 +23,9 @@ import { RefreshCw } from 'lucide-react';
 
 interface SidebarProps {
   collapsed: boolean;
+  sidebarSize: 'compact' | 'wide';
   onToggleCollapse: () => void;
+  onToggleSize?: () => void;
   onNavigateHome?: () => void;
   mandalaGridElement?: React.ReactNode;
   selectedMandalaId: string | null;
@@ -46,9 +50,16 @@ const SECONDARY_NAV: NavItem[] = [
 
 const BOTTOM_NAV: NavItem[] = [{ to: '/settings', icon: Settings, labelKey: 'sidebar.settings' }];
 
+const SIDEBAR_WIDTH = {
+  compact: '22rem',   // 352px
+  wide: '30rem',      // 480px
+} as const;
+
 export function Sidebar({
   collapsed,
+  sidebarSize,
   onToggleCollapse,
+  onToggleSize,
   onNavigateHome,
   mandalaGridElement,
   selectedMandalaId,
@@ -113,9 +124,10 @@ export function Sidebar({
   return (
     <aside
       className={cn(
-        'hidden md:flex flex-col h-full bg-sidebar border-r border-sidebar-border transition-[width] duration-200 ease-in-out',
-        collapsed ? 'w-16' : 'w-[var(--sidebar-width)]'
+        'hidden md:flex flex-col h-full bg-sidebar border-r border-sidebar-border shrink-0 transition-[width] duration-200 ease-in-out',
+        collapsed && 'w-16',
       )}
+      style={!collapsed ? { width: SIDEBAR_WIDTH[sidebarSize] } : undefined}
       aria-label={t('sidebar.navigation')}
     >
       {/* Main navigation */}
@@ -209,19 +221,37 @@ export function Sidebar({
           {!collapsed && <span>{t('common.logout')}</span>}
         </button>
 
-        {/* Collapse toggle */}
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onToggleCollapse}
-          className={cn(
-            'w-full mt-1 text-sidebar-foreground/50 hover:text-sidebar-foreground hover:bg-sidebar-accent',
-            collapsed ? 'justify-center px-2' : 'justify-end'
+        {/* Bottom controls: size toggle + collapse toggle */}
+        <div className={cn('flex items-center mt-1', collapsed ? 'justify-center' : 'justify-end gap-1')}>
+          {!collapsed && onToggleSize && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onToggleSize}
+              className="text-sidebar-foreground/50 hover:text-sidebar-foreground hover:bg-sidebar-accent px-2"
+              aria-label={sidebarSize === 'compact' ? 'Expand sidebar' : 'Shrink sidebar'}
+              title={sidebarSize === 'compact' ? 'Expand sidebar' : 'Shrink sidebar'}
+            >
+              {sidebarSize === 'compact' ? (
+                <Maximize2 className="w-3.5 h-3.5" />
+              ) : (
+                <Minimize2 className="w-3.5 h-3.5" />
+              )}
+            </Button>
           )}
-          aria-label={collapsed ? t('sidebar.expand') : t('sidebar.collapse')}
-        >
-          {collapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
-        </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onToggleCollapse}
+            className={cn(
+              'text-sidebar-foreground/50 hover:text-sidebar-foreground hover:bg-sidebar-accent',
+              collapsed ? 'justify-center px-2' : 'px-2'
+            )}
+            aria-label={collapsed ? t('sidebar.expand') : t('sidebar.collapse')}
+          >
+            {collapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
+          </Button>
+        </div>
       </div>
     </aside>
   );

--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -60,6 +60,8 @@ function CardSlot({
   );
 }
 
+const PAGE_SIZE = 24;
+
 export function CardList({ cards, isLoading, onCardClick, onSaveNote, onSelectionChange, enrichingCardIds, failedEnrichCardIds, onRetryEnrich }: CardListProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -75,8 +77,10 @@ export function CardList({ cards, isLoading, onCardClick, onSaveNote, onSelectio
   const cachedCardCount = queryClient.getQueryData<LocalCardsResponse>(localCardsKeys.list())?.cards.length;
   const containerRef = useRef<HTMLDivElement | null>(null);
   const gridRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
   const [selectedCardIds, setSelectedCardIds] = useState<Set<string>>(new Set());
   const [lastSelectedIndex, setLastSelectedIndex] = useState<number | null>(null);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   // Sort cards: by sortOrder if available, otherwise by createdAt (newest first)
   const sortedCards = useMemo(() => {
@@ -89,6 +93,35 @@ export function CardList({ cards, isLoading, onCardClick, onSaveNote, onSelectio
       return dateB - dateA;
     });
   }, [cards]);
+
+  // Reset visible count when card list changes (e.g., cell switch)
+  const cardListKey = useMemo(() => cards.map((c) => c.id).join(','), [cards]);
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [cardListKey]);
+
+  // Infinite scroll: observe sentinel at bottom of grid
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setVisibleCount((prev) => Math.min(prev + PAGE_SIZE, sortedCards.length));
+        }
+      },
+      { rootMargin: '200px' }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [sortedCards.length]);
+
+  const visibleCards = useMemo(
+    () => sortedCards.slice(0, visibleCount),
+    [sortedCards, visibleCount]
+  );
+  const hasMore = visibleCount < sortedCards.length;
 
   // Filter out selection IDs that no longer exist in cards (e.g., after moving cards)
   useEffect(() => {
@@ -228,7 +261,7 @@ export function CardList({ cards, isLoading, onCardClick, onSaveNote, onSelectio
         style={{ minHeight: 'calc(100vh - 200px)' }}
       >
         {selectionStyle && <div style={selectionStyle} />}
-        {sortedCards.map((card, idx) => {
+        {visibleCards.map((card, idx) => {
           const isSelected = selectedCardIds.has(card.id);
           return (
             <CardSlot key={card.id} card={card} isOver={false}>
@@ -267,6 +300,16 @@ export function CardList({ cards, isLoading, onCardClick, onSaveNote, onSelectio
           );
         })}
       </div>
+
+      {/* Infinite scroll sentinel */}
+      {hasMore && (
+        <div ref={sentinelRef} className="flex justify-center py-6">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <div className="w-4 h-4 border-2 border-muted-foreground/30 border-t-muted-foreground rounded-full animate-spin" />
+            {t('cards.loadingMore', { loaded: visibleCount, total: sortedCards.length })}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/widgets/video-player/ui/MemoEditor.tsx
+++ b/frontend/src/widgets/video-player/ui/MemoEditor.tsx
@@ -130,7 +130,7 @@ export function MemoEditor({
   onEnrichStart,
   onEnrichEnd,
 }: MemoEditorProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
   const [note, setNote] = useState(initialNote);
   const [isEditing, setIsEditing] = useState(!initialNote);
@@ -465,14 +465,19 @@ export function MemoEditor({
         <div className="px-3 pb-2 flex-1 min-h-0 overflow-y-auto scrollbar-thin">
           {/* AI Summary — always visible (read-only, not part of user note) */}
           {isGeneratingSummary && <GeneratingIndicator />}
-          {videoSummary?.summary_en && !isGeneratingSummary && (
-            <div className="border-l-2 border-blue-400 pl-2 mb-2 bg-blue-50/50 dark:bg-blue-950/30 rounded-r text-sm text-muted-foreground">
-              <div className="flex items-center gap-1 text-[10px] font-medium text-blue-600 dark:text-blue-400 mb-0.5">
-                <span>🤖</span> AI Summary:
+          {videoSummary?.summary_en && !isGeneratingSummary && (() => {
+            const isKo = i18n.language === 'ko';
+            const summaryText = isKo && videoSummary.summary_ko ? videoSummary.summary_ko : videoSummary.summary_en;
+            const summaryLabel = isKo ? 'AI 요약' : 'AI Summary';
+            return (
+              <div className="border-l-2 border-blue-400 pl-2 mb-2 bg-blue-50/50 dark:bg-blue-950/30 rounded-r text-sm text-muted-foreground">
+                <div className="flex items-center gap-1 text-[10px] font-medium text-blue-600 dark:text-blue-400 mb-0.5">
+                  <span>🤖</span> {summaryLabel}:
+                </div>
+                <p className="whitespace-pre-wrap">{summaryText}</p>
               </div>
-              <p className="whitespace-pre-wrap">{videoSummary.summary_en}</p>
-            </div>
-          )}
+            );
+          })()}
 
           {/* User note — edit or preview mode */}
           {isEditing ? (


### PR DESCRIPTION
## Summary
- **Infinite Scroll**: CardList renders 24 cards initially, loads 24 more on scroll via IntersectionObserver. Fixes severe UX performance degradation from rendering hundreds of cards at once.
- **Sidebar Toggle**: Replace drag resize (3 attempts, all had performance issues) with compact(22rem)/wide(30rem) toggle button with CSS transition animation.
- **Modal Scroll Lock**: Disable background scroll when VideoPlayerModal is open (dual scrollbar fix).
- **AI Summary Truncate**: Apply line-clamp to summary body only (not header), show full text on card back face.
- **i18n Summary**: MemoEditor AI Summary now respects i18n.language for ko/en locale selection.

## Test plan
- [ ] Scroll down card grid — verify cards load incrementally (24 at a time)
- [ ] Click sidebar expand/shrink button — verify smooth transition
- [ ] Open video modal — verify no dual scrollbar
- [ ] Check AI Summary on card front (truncated) and back (full text)
- [ ] Switch language to KO — verify DetailPanel AI Summary shows Korean

🤖 Generated with [Claude Code](https://claude.com/claude-code)