### PR TITLE
fix(video-discover): P0 recommendation quality — language filter + LLM query gen + content filters

### DIFF
--- a/src/skills/plugins/video-discover/__tests__/executor.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/executor.test.ts
@@ -42,7 +42,7 @@ jest.mock('@/utils/logger', () => ({
   },
 }));
 
-import { executor } from '../executor';
+import { executor, parseIsoDuration, titleContainsBlocked } from '../executor';
 import type { PreflightContext, ExecuteContext } from '@/skills/_shared/types';
 
 // ============================================================================
@@ -199,8 +199,32 @@ describe('video-discover execute', () => {
     }>;
     statsItems?: Array<{ videoId: string; viewCount: number; likeCount: number | null }>;
     searchShouldFail?: boolean;
+    /**
+     * Fix 2 (CP358): mock Ollama LLM responses. Default returns 3 valid queries
+     * so existing tests get the same per-cell coverage. Set `llmShouldFail`
+     * to exercise the fallback path.
+     */
+    llmQueries?: string[];
+    llmShouldFail?: boolean;
   }): typeof fetch {
     return jest.fn().mockImplementation(async (url: string) => {
+      // Fix 2: route Ollama LLM calls (Mac Mini Tailscale IP or test override)
+      if (url.includes('/api/chat')) {
+        if (opts.llmShouldFail) {
+          return {
+            ok: false,
+            status: 500,
+            json: async () => ({ error: 'llm down' }),
+            text: async () => 'llm down',
+          };
+        }
+        const queries = opts.llmQueries ?? ['llm-q1', 'llm-q2', 'llm-q3'];
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ message: { content: JSON.stringify(queries) } }),
+        };
+      }
       if (url.includes('/youtube/v3/search')) {
         if (opts.searchShouldFail) {
           return {
@@ -267,6 +291,14 @@ describe('video-discover execute', () => {
           { keyword: 'kw1', iksTotal: 80, embedding: buildVec(1), domain: null },
           { keyword: 'kw2', iksTotal: 70, embedding: buildVec(2), domain: null },
         ],
+        // Fix 1 (CP358): defaults so existing tests stay green; per-test
+        // overrides drive the new language/region branches.
+        mandalaLanguage: 'ko',
+        centerGoal: 'test center goal',
+        // Fix 2 (CP358): llmUrl is forwarded to generateSearchQueries via
+        // executor; tests use the in-process URL string and rely on the
+        // fetch router to short-circuit /api/chat to canned responses.
+        llmUrl: 'http://test-ollama:11434',
         fetchImpl,
         ...customState,
       },
@@ -290,7 +322,10 @@ describe('video-discover execute', () => {
     expect(result.status).toBe('success');
     expect(result.data['cells']).toBe(2);
     expect(result.data['cell_keyword_pairs']).toBe(2); // 2 cells × 1 kw
-    expect(result.data['search_calls']).toBe(2);
+    // Fix 2 (CP358): 2 cells × 3 LLM queries = 6 search.list calls
+    expect(result.data['search_calls']).toBe(6);
+    expect(result.data['llm_query_gen_success']).toBe(2);
+    expect(result.data['llm_query_gen_failures']).toBe(0);
     expect(result.data['recommendations_upserted']).toBeGreaterThan(0);
     expect(result.metrics?.rows_written?.['recommendation_cache']).toBeGreaterThan(0);
   });
@@ -400,6 +435,289 @@ describe('video-discover execute', () => {
     expect(mockRecCacheUpsert).toHaveBeenCalled();
   });
 
+  // ─────────────────────────────────────────────────────────────────────
+  // Fix 1 (CP358): YouTube Search params are dynamic per mandala language
+  // ─────────────────────────────────────────────────────────────────────
+
+  it('Fix 1: passes dynamic relevanceLanguage + regionCode + videoDuration=medium', async () => {
+    const calls: string[] = [];
+    const fetchImpl = jest.fn().mockImplementation(async (url: string) => {
+      calls.push(url);
+      if (url.includes('/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: [
+              {
+                id: { videoId: 'v1' },
+                snippet: {
+                  title: 'V1',
+                  channelTitle: 'C',
+                  channelId: 'c',
+                  publishedAt: '2026-04-01T00:00:00Z',
+                  thumbnails: { high: { url: 't' } },
+                },
+              },
+            ],
+          }),
+        };
+      }
+      if (url.includes('/videos')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: [{ id: 'v1', statistics: { viewCount: '100', likeCount: '5' } }],
+          }),
+        };
+      }
+      throw new Error(`Unmocked: ${url}`);
+    }) as unknown as typeof fetch;
+
+    await executor.execute(
+      buildExeCtx(fetchImpl, {
+        mandalaLanguage: 'en',
+        subGoals: [{ cellIndex: 0, text: 'cell-0', embedding: buildVec(1) }],
+      })
+    );
+
+    const searchCall = calls.find((u) => u.includes('/search'));
+    expect(searchCall).toBeDefined();
+    expect(searchCall).toContain('relevanceLanguage=en');
+    expect(searchCall).toContain('regionCode=US');
+    expect(searchCall).toContain('videoDuration=medium');
+    expect(searchCall).not.toContain('relevanceLanguage=ko');
+    expect(searchCall).not.toContain('regionCode=KR');
+  });
+
+  it('Fix 1: omits regionCode when language is not in LANG_TO_REGION map', async () => {
+    const calls: string[] = [];
+    const fetchImpl = jest.fn().mockImplementation(async (url: string) => {
+      calls.push(url);
+      if (url.includes('/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: [
+              {
+                id: { videoId: 'v1' },
+                snippet: {
+                  title: 'V1',
+                  channelTitle: 'C',
+                  channelId: 'c',
+                  publishedAt: '2026-04-01T00:00:00Z',
+                  thumbnails: { high: { url: 't' } },
+                },
+              },
+            ],
+          }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          items: [{ id: 'v1', statistics: { viewCount: '100', likeCount: '5' } }],
+        }),
+      };
+    }) as unknown as typeof fetch;
+
+    await executor.execute(
+      buildExeCtx(fetchImpl, {
+        mandalaLanguage: 'xx', // unknown language → no region
+        subGoals: [{ cellIndex: 0, text: 'cell-0', embedding: buildVec(1) }],
+      })
+    );
+
+    const searchCall = calls.find((u) => u.includes('/search'));
+    expect(searchCall).toContain('relevanceLanguage=xx');
+    expect(searchCall).not.toContain('regionCode=');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Fix 2 (CP358): LLM-driven multi-query search per cell + fallback path
+  // ─────────────────────────────────────────────────────────────────────
+
+  it('Fix 2: makes 3 search.list calls per cell using LLM-generated queries', async () => {
+    const queriesSeen: string[] = [];
+    const fetchImpl = jest.fn().mockImplementation(async (url: string) => {
+      if (url.includes('/api/chat')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            message: { content: '["llm-q-A", "llm-q-B", "llm-q-C"]' },
+          }),
+        };
+      }
+      if (url.includes('/youtube/v3/search')) {
+        const m = url.match(/[?&]q=([^&]+)/);
+        if (m) queriesSeen.push(decodeURIComponent(m[1] ?? ''));
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: [
+              {
+                id: { videoId: `v-${queriesSeen.length}` },
+                snippet: {
+                  title: `Video ${queriesSeen.length}`,
+                  channelTitle: `Ch${queriesSeen.length}`,
+                  channelId: `c${queriesSeen.length}`,
+                  publishedAt: '2026-04-01T00:00:00Z',
+                  thumbnails: { high: { url: 't' } },
+                },
+              },
+            ],
+          }),
+        };
+      }
+      if (url.includes('/youtube/v3/videos')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: queriesSeen.map((_, i) => ({
+              id: `v-${i + 1}`,
+              statistics: { viewCount: '100', likeCount: '5' },
+            })),
+          }),
+        };
+      }
+      throw new Error(`Unmocked: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const result = await executor.execute(
+      buildExeCtx(fetchImpl, {
+        subGoals: [{ cellIndex: 0, text: 'cell-0', embedding: buildVec(1) }],
+      })
+    );
+
+    // 1 cell × 3 LLM queries = 3 search calls, all using the LLM-generated text
+    expect(result.data['search_calls']).toBe(3);
+    expect(queriesSeen).toEqual(['llm-q-A', 'llm-q-B', 'llm-q-C']);
+    expect(result.data['llm_query_gen_success']).toBe(1);
+    expect(result.data['llm_query_gen_failures']).toBe(0);
+  });
+
+  it('Fix 2: falls back to keyword-concat when LLM throws LlmQueryGenError', async () => {
+    const queriesSeen: string[] = [];
+    const fetchImpl = jest.fn().mockImplementation(async (url: string) => {
+      if (url.includes('/api/chat')) {
+        // Simulate Ollama HTTP failure → LlmQueryGenError → fallback path
+        return {
+          ok: false,
+          status: 503,
+          text: async () => 'service unavailable',
+          json: async () => ({}),
+        };
+      }
+      if (url.includes('/youtube/v3/search')) {
+        const m = url.match(/[?&]q=([^&]+)/);
+        if (m) queriesSeen.push(decodeURIComponent(m[1] ?? ''));
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: [
+              {
+                id: { videoId: 'fallback-vid' },
+                snippet: {
+                  title: 'Fallback Video',
+                  channelTitle: 'Ch',
+                  channelId: 'c',
+                  publishedAt: '2026-04-01T00:00:00Z',
+                  thumbnails: { high: { url: 't' } },
+                },
+              },
+            ],
+          }),
+        };
+      }
+      if (url.includes('/youtube/v3/videos')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: [{ id: 'fallback-vid', statistics: { viewCount: '100', likeCount: '5' } }],
+          }),
+        };
+      }
+      throw new Error(`Unmocked: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const result = await executor.execute(
+      buildExeCtx(fetchImpl, {
+        subGoals: [{ cellIndex: 0, text: 'cell-0-text', embedding: buildVec(1) }],
+      })
+    );
+
+    // 1 cell × 1 fallback concat query = 1 search call
+    expect(result.data['search_calls']).toBe(1);
+    expect(result.data['llm_query_gen_success']).toBe(0);
+    expect(result.data['llm_query_gen_failures']).toBe(1);
+    // Fallback uses `${cell.text} ${keyword}` format. URL search params encode
+    // spaces as `+` (URLSearchParams default), so the assertion sees `+`.
+    expect(queriesSeen).toEqual(['cell-0-text+kw1']);
+  });
+
+  it('Fix 2: dedups same video across multiple LLM queries within one cell', async () => {
+    const fetchImpl = jest.fn().mockImplementation(async (url: string) => {
+      if (url.includes('/api/chat')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            message: { content: '["q1", "q2", "q3"]' },
+          }),
+        };
+      }
+      if (url.includes('/youtube/v3/search')) {
+        // Every query returns the SAME video — without dedup we'd get 3 candidates
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: [
+              {
+                id: { videoId: 'same-vid' },
+                snippet: {
+                  title: 'Same Video',
+                  channelTitle: 'Ch',
+                  channelId: 'c',
+                  publishedAt: '2026-04-01T00:00:00Z',
+                  thumbnails: { high: { url: 't' } },
+                },
+              },
+            ],
+          }),
+        };
+      }
+      if (url.includes('/youtube/v3/videos')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: [{ id: 'same-vid', statistics: { viewCount: '100', likeCount: '5' } }],
+          }),
+        };
+      }
+      throw new Error(`Unmocked: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const result = await executor.execute(
+      buildExeCtx(fetchImpl, {
+        subGoals: [{ cellIndex: 0, text: 'cell-0', embedding: buildVec(1) }],
+      })
+    );
+
+    // 3 search calls but only 1 unique candidate (per-cell dedup)
+    expect(result.data['search_calls']).toBe(3);
+    expect(result.data['candidates_total']).toBe(1);
+  });
+
   it('reports search_calls + candidates + duration in result data', async () => {
     const fetchImpl = makeFetchRouter({
       searchItems: [{ videoId: 'v1', title: 'V1', channel: 'C', channelId: 'c' }],
@@ -409,5 +727,278 @@ describe('video-discover execute', () => {
     expect(typeof result.data['search_calls']).toBe('number');
     expect(typeof result.data['candidates_total']).toBe('number');
     expect(typeof result.metrics?.duration_ms).toBe('number');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Fix 3 (CP358): Shorts filter, title blocklist, global channel cap
+  // ─────────────────────────────────────────────────────────────────────
+
+  function makeFetchRouterWithDuration(opts: {
+    searchItems: Array<{
+      videoId: string;
+      title: string;
+      channel: string;
+      channelId: string;
+    }>;
+    statsItems: Array<{
+      videoId: string;
+      viewCount: number;
+      likeCount: number | null;
+      durationIso: string; // PT5M, PT45S, etc.
+    }>;
+  }): typeof fetch {
+    return jest.fn().mockImplementation(async (url: string) => {
+      if (url.includes('/api/chat')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ message: { content: '["q1", "q2", "q3"]' } }),
+        };
+      }
+      if (url.includes('/youtube/v3/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: opts.searchItems.map((it) => ({
+              id: { videoId: it.videoId },
+              snippet: {
+                title: it.title,
+                channelTitle: it.channel,
+                channelId: it.channelId,
+                publishedAt: '2026-04-01T00:00:00Z',
+                thumbnails: { high: { url: `thumb-${it.videoId}` } },
+              },
+            })),
+          }),
+        };
+      }
+      if (url.includes('/youtube/v3/videos')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: opts.statsItems.map((s) => ({
+              id: s.videoId,
+              statistics: {
+                viewCount: String(s.viewCount),
+                likeCount: s.likeCount === null ? undefined : String(s.likeCount),
+              },
+              contentDetails: { duration: s.durationIso },
+            })),
+          }),
+        };
+      }
+      throw new Error(`Unmocked: ${url}`);
+    }) as unknown as typeof fetch;
+  }
+
+  it('Fix 3: drops candidates with durationSec < 60 (Shorts)', async () => {
+    const fetchImpl = makeFetchRouterWithDuration({
+      searchItems: [
+        { videoId: 'short', title: 'Quick Short', channel: 'A', channelId: 'a' },
+        { videoId: 'medium', title: 'Real Tutorial', channel: 'B', channelId: 'b' },
+      ],
+      statsItems: [
+        { videoId: 'short', viewCount: 1000, likeCount: 50, durationIso: 'PT45S' },
+        { videoId: 'medium', viewCount: 1000, likeCount: 50, durationIso: 'PT5M' },
+      ],
+    });
+
+    await executor.execute(
+      buildExeCtx(fetchImpl, {
+        subGoals: [{ cellIndex: 0, text: 'cell-0', embedding: buildVec(1) }],
+      })
+    );
+
+    const upsertedVideoIds = mockRecCacheUpsert.mock.calls.map(
+      (c) => c[0].where.user_id_mandala_id_video_id.video_id
+    );
+    expect(upsertedVideoIds).toContain('medium');
+    expect(upsertedVideoIds).not.toContain('short');
+  });
+
+  it('Fix 3: keeps candidates with durationSec >= 60', async () => {
+    const fetchImpl = makeFetchRouterWithDuration({
+      searchItems: [{ videoId: 'exactly60', title: 'Tutorial', channel: 'A', channelId: 'a' }],
+      statsItems: [{ videoId: 'exactly60', viewCount: 1000, likeCount: 50, durationIso: 'PT1M' }],
+    });
+
+    await executor.execute(
+      buildExeCtx(fetchImpl, {
+        subGoals: [{ cellIndex: 0, text: 'cell-0', embedding: buildVec(1) }],
+      })
+    );
+
+    const upsertedVideoIds = mockRecCacheUpsert.mock.calls.map(
+      (c) => c[0].where.user_id_mandala_id_video_id.video_id
+    );
+    expect(upsertedVideoIds).toEqual(['exactly60']);
+  });
+
+  it('Fix 3: drops candidates whose title matches TITLE_BLOCKLIST', async () => {
+    const fetchImpl = makeFetchRouterWithDuration({
+      searchItems: [
+        { videoId: 'drama', title: '드라마 추천 TOP 10', channel: 'A', channelId: 'a' },
+        { videoId: 'edu', title: '집중력 키우는 법', channel: 'B', channelId: 'b' },
+        { videoId: 'vlog', title: 'My Daily Vlog', channel: 'C', channelId: 'c' },
+        { videoId: 'good', title: '학습 동기 부여 강의', channel: 'D', channelId: 'd' },
+      ],
+      statsItems: [
+        { videoId: 'drama', viewCount: 1000, likeCount: 50, durationIso: 'PT5M' },
+        { videoId: 'edu', viewCount: 1000, likeCount: 50, durationIso: 'PT5M' },
+        { videoId: 'vlog', viewCount: 1000, likeCount: 50, durationIso: 'PT5M' },
+        { videoId: 'good', viewCount: 1000, likeCount: 50, durationIso: 'PT5M' },
+      ],
+    });
+
+    await executor.execute(
+      buildExeCtx(fetchImpl, {
+        subGoals: [{ cellIndex: 0, text: 'cell-0', embedding: buildVec(1) }],
+      })
+    );
+
+    const upsertedVideoIds = mockRecCacheUpsert.mock.calls.map(
+      (c) => c[0].where.user_id_mandala_id_video_id.video_id
+    );
+    expect(upsertedVideoIds).toContain('edu');
+    expect(upsertedVideoIds).toContain('good');
+    expect(upsertedVideoIds).not.toContain('drama');
+    expect(upsertedVideoIds).not.toContain('vlog');
+  });
+
+  it('Fix 3: global channel cap collapses 3+ same-channel videos to highest-scored 1', async () => {
+    // Create 8 cells where 3 different cells return videos from the same channel `noisy`
+    // Per-cell dedup keeps at most 1 noisy video per cell, but the noisy
+    // channel ends up in 3 cells = 3 finalRecommendations → channel cap fires.
+    const fetchImpl = jest.fn().mockImplementation(async (url: string) => {
+      if (url.includes('/api/chat')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ message: { content: '["q1", "q2", "q3"]' } }),
+        };
+      }
+      if (url.includes('/youtube/v3/search')) {
+        // Each cell receives the same noisy channel video plus a unique alt
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: [
+              {
+                id: { videoId: 'noisy-vid' },
+                snippet: {
+                  title: 'Noisy Video',
+                  channelTitle: 'NoisyChannel',
+                  channelId: 'noisy',
+                  publishedAt: '2026-04-01T00:00:00Z',
+                  thumbnails: { high: { url: 't' } },
+                },
+              },
+              {
+                id: { videoId: `alt-${Math.random()}` },
+                snippet: {
+                  title: 'Alt Video',
+                  channelTitle: 'AltChannel',
+                  channelId: `alt-${Math.random()}`,
+                  publishedAt: '2026-04-01T00:00:00Z',
+                  thumbnails: { high: { url: 't' } },
+                },
+              },
+            ],
+          }),
+        };
+      }
+      if (url.includes('/youtube/v3/videos')) {
+        // Stub: return PT5M for any id requested
+        const idsParam = new URL(url).searchParams.get('id') ?? '';
+        const ids = idsParam.split(',').filter(Boolean);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            items: ids.map((id) => ({
+              id,
+              statistics: { viewCount: '1000', likeCount: '50' },
+              contentDetails: { duration: 'PT5M' },
+            })),
+          }),
+        };
+      }
+      throw new Error(`Unmocked: ${url}`);
+    }) as unknown as typeof fetch;
+
+    await executor.execute(
+      buildExeCtx(fetchImpl, {
+        subGoals: [
+          { cellIndex: 0, text: 'cell-0', embedding: buildVec(1) },
+          { cellIndex: 1, text: 'cell-1', embedding: buildVec(2) },
+          { cellIndex: 2, text: 'cell-2', embedding: buildVec(3) },
+          { cellIndex: 3, text: 'cell-3', embedding: buildVec(4) },
+        ],
+      })
+    );
+
+    const upsertedVideoIds = mockRecCacheUpsert.mock.calls.map(
+      (c) => c[0].where.user_id_mandala_id_video_id.video_id
+    );
+    // After global channel cap, the noisy channel should have at most 1 video kept
+    const noisyCount = upsertedVideoIds.filter((id) => id === 'noisy-vid').length;
+    expect(noisyCount).toBeLessThanOrEqual(1);
+  });
+});
+
+// ============================================================================
+// Fix 3 (CP358) — helper unit tests
+// ============================================================================
+
+describe('parseIsoDuration', () => {
+  it('parses PT30S → 30', () => {
+    expect(parseIsoDuration('PT30S')).toBe(30);
+  });
+  it('parses PT5M → 300', () => {
+    expect(parseIsoDuration('PT5M')).toBe(300);
+  });
+  it('parses PT1H2M3S → 3723', () => {
+    expect(parseIsoDuration('PT1H2M3S')).toBe(3723);
+  });
+  it('parses PT1H → 3600', () => {
+    expect(parseIsoDuration('PT1H')).toBe(3600);
+  });
+  it('returns null for null input', () => {
+    expect(parseIsoDuration(null)).toBeNull();
+  });
+  it('returns null for undefined input', () => {
+    expect(parseIsoDuration(undefined)).toBeNull();
+  });
+  it('returns null for empty string', () => {
+    expect(parseIsoDuration('')).toBeNull();
+  });
+  it('returns null for malformed input', () => {
+    expect(parseIsoDuration('not-iso')).toBeNull();
+    expect(parseIsoDuration('5M')).toBeNull();
+  });
+});
+
+describe('titleContainsBlocked', () => {
+  it('matches Korean blocklist tokens', () => {
+    expect(titleContainsBlocked('드라마 추천 TOP 10')).toBe(true);
+    expect(titleContainsBlocked('웹소설 베스트')).toBe(true);
+    expect(titleContainsBlocked('애니 OP 모음')).toBe(true);
+  });
+  it('matches English blocklist tokens (case-insensitive)', () => {
+    expect(titleContainsBlocked('My Daily Vlog')).toBe(true);
+    expect(titleContainsBlocked('VLOG: Morning Routine')).toBe(true);
+    expect(titleContainsBlocked('Best Anime Openings')).toBe(true);
+  });
+  it('passes legitimate education titles', () => {
+    expect(titleContainsBlocked('학습 동기 부여 강의')).toBe(false);
+    expect(titleContainsBlocked('How to focus better')).toBe(false);
+    expect(titleContainsBlocked('집중력 키우는 법')).toBe(false);
+  });
+  it('returns false for empty/null titles', () => {
+    expect(titleContainsBlocked('')).toBe(false);
+    expect(titleContainsBlocked(null as unknown as string)).toBe(false);
   });
 });

--- a/src/skills/plugins/video-discover/__tests__/llm-query-generator.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/llm-query-generator.test.ts
@@ -1,0 +1,277 @@
+/**
+ * llm-query-generator — unit tests (Fix 2, CP358)
+ *
+ * Pins the contract that matters for the executor:
+ *   - parseQueriesResponse handles raw JSON, markdown-fenced JSON, object wrappers
+ *   - parseQueriesResponse rejects empty / unparseable / non-string entries
+ *   - parseQueriesResponse caps at MAX_QUERIES (3) and filters short noise
+ *   - generateSearchQueries throws LlmQueryGenError on transport failure
+ *   - generateSearchQueries throws LlmQueryGenError on Ollama HTTP error
+ *   - generateSearchQueries throws LlmQueryGenError on empty content
+ *   - happy path returns up to 3 cleaned queries
+ *
+ * The Ollama URL/model are NEVER hit — fetchImpl is mocked per test.
+ */
+
+import {
+  generateSearchQueries,
+  LlmQueryGenError,
+  parseQueriesResponse,
+} from '../sources/llm-query-generator';
+
+// ============================================================================
+// parseQueriesResponse — defensive JSON shapes
+// ============================================================================
+
+describe('parseQueriesResponse', () => {
+  it('parses a raw JSON array of strings', () => {
+    const out = parseQueriesResponse('["q1", "q2", "q3"]');
+    expect(out).toEqual(['q1', 'q2', 'q3']);
+  });
+
+  it('parses a markdown-fenced JSON array (```json ... ```)', () => {
+    const fenced = '```json\n["query 1", "query 2", "query 3"]\n```';
+    const out = parseQueriesResponse(fenced);
+    expect(out).toEqual(['query 1', 'query 2', 'query 3']);
+  });
+
+  it('parses a markdown-fenced JSON array (``` ... ``` without language tag)', () => {
+    const fenced = '```\n["alpha", "beta"]\n```';
+    const out = parseQueriesResponse(fenced);
+    expect(out).toEqual(['alpha', 'beta']);
+  });
+
+  it('accepts an object wrapper with `queries` key', () => {
+    const out = parseQueriesResponse('{"queries": ["q1", "q2"]}');
+    expect(out).toEqual(['q1', 'q2']);
+  });
+
+  it('accepts an object wrapper with `results` key', () => {
+    const out = parseQueriesResponse('{"results": ["q1", "q2"]}');
+    expect(out).toEqual(['q1', 'q2']);
+  });
+
+  it('accepts an object wrapper with `items` key', () => {
+    const out = parseQueriesResponse('{"items": ["q1", "q2"]}');
+    expect(out).toEqual(['q1', 'q2']);
+  });
+
+  it('truncates to MAX_QUERIES (3) when the model returns more', () => {
+    const out = parseQueriesResponse('["q1", "q2", "q3", "q4", "q5"]');
+    expect(out).toHaveLength(3);
+    expect(out).toEqual(['q1', 'q2', 'q3']);
+  });
+
+  it('filters out entries shorter than MIN_QUERY_LENGTH (2)', () => {
+    const out = parseQueriesResponse('["a", "ok", "x", "longer"]');
+    expect(out).toEqual(['ok', 'longer']);
+  });
+
+  it('filters out non-string entries', () => {
+    const out = parseQueriesResponse('["valid", 42, null, "also valid"]');
+    expect(out).toEqual(['valid', 'also valid']);
+  });
+
+  it('strips surrounding quotes the model sometimes leaves in', () => {
+    const out = parseQueriesResponse('["\\"quoted\\"", "normal"]');
+    expect(out).toEqual(['quoted', 'normal']);
+  });
+
+  it('throws LlmQueryGenError on completely unparseable input', () => {
+    expect(() => parseQueriesResponse('not json at all {{{')).toThrow(LlmQueryGenError);
+  });
+
+  it('throws LlmQueryGenError when JSON parses but yields zero usable queries', () => {
+    expect(() => parseQueriesResponse('[]')).toThrow(LlmQueryGenError);
+    expect(() => parseQueriesResponse('["a", ""]')).toThrow(LlmQueryGenError);
+  });
+
+  it('throws LlmQueryGenError when JSON shape has no recognized array key', () => {
+    expect(() => parseQueriesResponse('{"foo": "bar"}')).toThrow(LlmQueryGenError);
+  });
+
+  it('handles trimmed whitespace and BOMs gracefully', () => {
+    const out = parseQueriesResponse('  \n["q1", "q2"]\n  ');
+    expect(out).toEqual(['q1', 'q2']);
+  });
+});
+
+// ============================================================================
+// generateSearchQueries — fetch contract
+// ============================================================================
+
+describe('generateSearchQueries', () => {
+  function makeFetch(response: {
+    ok?: boolean;
+    status?: number;
+    body?: unknown;
+    bodyText?: string;
+    throws?: Error;
+  }): typeof fetch {
+    return jest.fn().mockImplementation(async () => {
+      if (response.throws) throw response.throws;
+      return {
+        ok: response.ok ?? true,
+        status: response.status ?? 200,
+        json: async () => response.body ?? {},
+        text: async () => response.bodyText ?? '',
+      };
+    }) as unknown as typeof fetch;
+  }
+
+  it('returns parsed queries on a successful Ollama response', async () => {
+    const fetchImpl = makeFetch({
+      body: { message: { content: '["query one", "query two", "query three"]' } },
+    });
+    const result = await generateSearchQueries({
+      subGoal: '조카의 학습 동기 부여',
+      centerGoal: '조카 교육',
+      language: 'ko',
+      fetchImpl,
+    });
+    expect(result).toEqual(['query one', 'query two', 'query three']);
+  });
+
+  it('throws LlmQueryGenError on transport failure', async () => {
+    const fetchImpl = makeFetch({ throws: new Error('connection refused') });
+    await expect(
+      generateSearchQueries({
+        subGoal: 'goal',
+        centerGoal: 'center',
+        language: 'ko',
+        fetchImpl,
+      })
+    ).rejects.toThrow(LlmQueryGenError);
+  });
+
+  it('throws LlmQueryGenError on Ollama HTTP error (500)', async () => {
+    const fetchImpl = makeFetch({ ok: false, status: 500, bodyText: 'internal error' });
+    await expect(
+      generateSearchQueries({
+        subGoal: 'goal',
+        centerGoal: 'center',
+        language: 'ko',
+        fetchImpl,
+      })
+    ).rejects.toThrow(LlmQueryGenError);
+  });
+
+  it('throws LlmQueryGenError when Ollama returns an error field', async () => {
+    const fetchImpl = makeFetch({ body: { error: 'model not loaded' } });
+    await expect(
+      generateSearchQueries({
+        subGoal: 'goal',
+        centerGoal: 'center',
+        language: 'ko',
+        fetchImpl,
+      })
+    ).rejects.toThrow(LlmQueryGenError);
+  });
+
+  it('throws LlmQueryGenError when message.content is empty', async () => {
+    const fetchImpl = makeFetch({ body: { message: { content: '' } } });
+    await expect(
+      generateSearchQueries({
+        subGoal: 'goal',
+        centerGoal: 'center',
+        language: 'ko',
+        fetchImpl,
+      })
+    ).rejects.toThrow(LlmQueryGenError);
+  });
+
+  it('uses Korean prompt for ko language (system + user content)', async () => {
+    const captured: string[] = [];
+    const fetchImpl = jest.fn().mockImplementation(async (_url, init) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      for (const msg of body.messages ?? []) captured.push(String(msg.content ?? ''));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ message: { content: '["q1", "q2", "q3"]' } }),
+      };
+    }) as unknown as typeof fetch;
+
+    await generateSearchQueries({
+      subGoal: '조카의 학습 동기 부여',
+      centerGoal: '조카 교육',
+      language: 'ko',
+      fetchImpl,
+    });
+
+    const joined = captured.join(' ');
+    expect(joined).toMatch(/JSON 배열|YouTube/);
+    expect(joined).toContain('조카의 학습 동기 부여');
+    expect(joined).toContain('조카 교육');
+  });
+
+  it('uses English prompt for en language', async () => {
+    const captured: string[] = [];
+    const fetchImpl = jest.fn().mockImplementation(async (_url, init) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      for (const msg of body.messages ?? []) captured.push(String(msg.content ?? ''));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ message: { content: '["q1", "q2", "q3"]' } }),
+      };
+    }) as unknown as typeof fetch;
+
+    await generateSearchQueries({
+      subGoal: 'Build healthy habits',
+      centerGoal: 'Personal growth',
+      language: 'en',
+      fetchImpl,
+    });
+
+    const joined = captured.join(' ');
+    expect(joined).toMatch(/JSON array|search queries/i);
+    expect(joined).toContain('Build healthy habits');
+    expect(joined).toContain('Personal growth');
+  });
+
+  it('respects baseUrl override', async () => {
+    let capturedUrl = '';
+    const fetchImpl = jest.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ message: { content: '["q1", "q2", "q3"]' } }),
+      };
+    }) as unknown as typeof fetch;
+
+    await generateSearchQueries({
+      subGoal: 'goal',
+      centerGoal: 'center',
+      language: 'ko',
+      baseUrl: 'http://test-host:9999',
+      fetchImpl,
+    });
+
+    expect(capturedUrl).toBe('http://test-host:9999/api/chat');
+  });
+
+  it('respects model override in the request body', async () => {
+    let capturedModel = '';
+    const fetchImpl = jest.fn().mockImplementation(async (_url, init) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      capturedModel = body.model ?? '';
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ message: { content: '["q1", "q2", "q3"]' } }),
+      };
+    }) as unknown as typeof fetch;
+
+    await generateSearchQueries({
+      subGoal: 'goal',
+      centerGoal: 'center',
+      language: 'ko',
+      model: 'qwen2.5:7b',
+      fetchImpl,
+    });
+
+    expect(capturedModel).toBe('qwen2.5:7b');
+  });
+});

--- a/src/skills/plugins/video-discover/executor.ts
+++ b/src/skills/plugins/video-discover/executor.ts
@@ -36,11 +36,29 @@ import {
   VIDEO_DISCOVER_SEARCH_RESULTS_PER_CELL,
   VIDEO_DISCOVER_TTL_DAYS,
   VIDEO_DISCOVER_KEYWORD_POOL_SIZE,
+  VIDEO_DISCOVER_QUERIES_PER_CELL,
 } from './manifest';
+import { generateSearchQueries, LlmQueryGenError } from './sources/llm-query-generator';
 
 const log = logger.child({ module: 'video-discover' });
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const YOUTUBE_API_BASE = 'https://www.googleapis.com/youtube/v3';
+
+/**
+ * Map mandala language → YouTube `regionCode` (ISO 3166-1 alpha-2).
+ * Used by Fix 1 (CP358) to bias YouTube search results to the user's locale
+ * instead of hardcoding KR. Languages not in this map fall back to no
+ * `regionCode` (relevanceLanguage alone).
+ */
+const LANG_TO_REGION: Record<string, string> = {
+  ko: 'KR',
+  en: 'US',
+  ja: 'JP',
+  zh: 'TW',
+  es: 'ES',
+  fr: 'FR',
+  de: 'DE',
+};
 
 // Rec Score weights (CP353 P1 — tuned after view_count fix surfaced
 // freshness over-weighting + LLM noise keyword infiltration).
@@ -97,6 +115,24 @@ interface HydratedState {
   oauthToken: string;
   subGoals: SubGoalCell[];
   keywords: KeywordRow[];
+  /**
+   * Mandala language (ISO 639-1, e.g. 'ko', 'en'). Sourced from
+   * `mandala_embeddings.language` (level=1) — same value across all 8
+   * sub_goals so we read it once. Defaults to 'ko' if missing. (Fix 1, CP358)
+   */
+  mandalaLanguage: string;
+  /**
+   * Mandala center goal (root level center text). Used by Fix 2 LLM query
+   * generator to ground the prompt. Sourced from `mandala_embeddings.center_goal`
+   * (level=1, same value across rows). Empty string if missing. (Fix 1+2, CP358)
+   */
+  centerGoal: string;
+  /**
+   * Ollama base URL for the LLM query generator. Sourced from
+   * `ctx.env.OLLAMA_URL` with the Mac Mini Tailscale IP as the default.
+   * Same convention as trend-collector. (Fix 2, CP358)
+   */
+  llmUrl: string;
   fetchImpl?: typeof fetch;
 }
 
@@ -144,11 +180,53 @@ interface RecommendationCandidate {
   // Filled in after batch videos.list
   viewCount: number | null;
   likeCount: number | null;
+  /**
+   * Video duration in seconds, parsed from `contentDetails.duration` (ISO 8601).
+   * Fix 3 (CP358) — used to drop Shorts (<60s) post-hoc; the YouTube Search
+   * `videoDuration=medium` filter (Fix 1) is not 100% accurate.
+   */
+  durationSec: number | null;
   // Computed Rec Score components
   recScore?: number;
   videoQuality?: number;
   freshness?: number;
 }
+
+/**
+ * Fix 3 (CP358) — Title blocklist. Drops candidates whose titles contain
+ * drama / webnovel / vlog / reaction noise that pollutes education-intent
+ * queries. Tokens are matched case-insensitively as substrings; expand
+ * cautiously since false positives hurt diverse content.
+ */
+const TITLE_BLOCKLIST: readonly string[] = [
+  // Korean drama / webnovel / anime
+  '드라마',
+  '웹소설',
+  '웹툰',
+  '애니',
+  '만화',
+  // English
+  'drama',
+  'webtoon',
+  'anime',
+  'manga',
+  // Reaction / vlog / mukbang noise
+  '리액션',
+  '브이로그',
+  '먹방',
+  'vlog',
+  'mukbang',
+  'reaction',
+];
+
+/** Minimum duration in seconds (Fix 3, CP358) — anything shorter is a Short. */
+const MIN_DURATION_SEC = 60;
+/**
+ * Channel diversity cap (Fix 3, CP358). If a single channel contributes
+ * `>= GLOBAL_CHANNEL_CAP_THRESHOLD` videos to the final 24, collapse it to
+ * the highest-scored one only.
+ */
+const GLOBAL_CHANNEL_CAP_THRESHOLD = 3;
 
 export const executor: SkillExecutor = {
   manifest,
@@ -195,11 +273,22 @@ export const executor: SkillExecutor = {
       };
     }
 
-    // 3. Load 8 sub_goal embeddings for this mandala (level=1, 4096d)
+    // 3. Load 8 sub_goal embeddings for this mandala (level=1, 4096d).
+    // Fix 1 (CP358): also pull `language` + `center_goal` so the executor can
+    // pass relevanceLanguage/regionCode to YouTube Search and so the LLM
+    // query generator (Fix 2) has the center context.
     const subGoalRows = await db.$queryRaw<
-      { sub_goal_index: number; sub_goal: string | null; text: string | null; embedding: string }[]
+      {
+        sub_goal_index: number;
+        sub_goal: string | null;
+        text: string | null;
+        language: string | null;
+        center_goal: string | null;
+        embedding: string;
+      }[]
     >(
-      Prisma.sql`SELECT sub_goal_index, sub_goal, text, embedding::text AS embedding
+      Prisma.sql`SELECT sub_goal_index, sub_goal, text, language, center_goal,
+                        embedding::text AS embedding
                  FROM mandala_embeddings
                  WHERE mandala_id = ${mandalaId} AND level = 1 AND embedding IS NOT NULL
                  ORDER BY sub_goal_index NULLS LAST`
@@ -258,12 +347,26 @@ export const executor: SkillExecutor = {
       })
       .filter((k): k is KeywordRow => k !== null);
 
+    // Fix 1 (CP358): mandalaLanguage + centerGoal are stored per row but are
+    // identical across the 8 sub_goals (set once in ensure-mandala-embeddings).
+    // Read from the first row, default to safe values when missing.
+    const firstRow = subGoalRows[0];
+    const mandalaLanguage = (firstRow?.language ?? 'ko').toLowerCase();
+    const centerGoal = firstRow?.center_goal ?? '';
+
+    // Fix 2 (CP358): pull Ollama URL from env, default to Mac Mini Tailscale.
+    // Same convention as trend-collector executor.
+    const llmUrl = ctx.env?.['OLLAMA_URL'] ?? 'http://100.91.173.17:11434';
+
     const hydrated: HydratedState = {
       mandalaId,
       userId: ctx.userId,
       oauthToken: oauth.youtube_access_token,
       subGoals,
       keywords,
+      mandalaLanguage,
+      centerGoal,
+      llmUrl,
     };
     return { ok: true, hydrated: hydrated as unknown as Record<string, unknown> };
   },
@@ -300,44 +403,112 @@ export const executor: SkillExecutor = {
 
     log.info(`Selected ${cellSelections.length} (cell × keyword) pairs to search`);
 
-    // ── Step 2: YouTube search.list per cell × keyword (user OAuth) ────
+    // ── Step 2: LLM-driven multi-query YouTube search per cell ─────────
+    // Fix 2 (CP358): replace the previous `${sub_goal} ${top_keyword}` single-
+    // query call with VIDEO_DISCOVER_QUERIES_PER_CELL natural-language queries
+    // generated by Mac Mini Ollama (llama3.1). On any LLM failure for a cell,
+    // fall back to the legacy concat path so the skill never blocks on a
+    // hiccup. Quota: 8 cells × 3 queries × 100 = 2,400 units (24% of daily 10k).
     const allCandidates: RecommendationCandidate[] = [];
     let searchCalls = 0;
     let searchFailures = 0;
-    for (const sel of cellSelections) {
+    let llmQueryGenSuccess = 0;
+    let llmQueryGenFailures = 0;
+    const regionCode = LANG_TO_REGION[state.mandalaLanguage];
+    // Per-cell dedup so the same video doesn't enter the candidate pool twice
+    // when two LLM queries surface it.
+    const seenPerCell = new Set<string>();
+
+    function pushCandidate(
+      sel: { cell: SubGoalCell; keyword: KeywordRow; perMandalaRelevance: number },
+      item: YouTubeSearchItem
+    ): void {
+      const videoId = item.id?.videoId;
+      if (!videoId) return;
+      const key = `${sel.cell.cellIndex}:${videoId}`;
+      if (seenPerCell.has(key)) return;
+      seenPerCell.add(key);
+      allCandidates.push({
+        cellIndex: sel.cell.cellIndex,
+        keyword: sel.keyword.keyword,
+        iksTotal: sel.keyword.iksTotal,
+        perMandalaRelevance: sel.perMandalaRelevance,
+        videoId,
+        title: item.snippet?.title ?? '(untitled)',
+        channel: item.snippet?.channelTitle ?? '',
+        channelId: item.snippet?.channelId ?? '',
+        publishedAt: item.snippet?.publishedAt ?? new Date().toISOString(),
+        thumbnail: item.snippet?.thumbnails?.high?.url ?? '',
+        viewCount: null,
+        likeCount: null,
+        durationSec: null,
+      });
+    }
+
+    async function runSearch(
+      sel: { cell: SubGoalCell; keyword: KeywordRow; perMandalaRelevance: number },
+      query: string
+    ): Promise<void> {
       try {
         const items = await youtubeSearch({
-          query: `${sel.cell.text} ${sel.keyword.keyword}`,
+          query,
           oauthToken: state.oauthToken,
           maxResults: VIDEO_DISCOVER_SEARCH_RESULTS_PER_CELL,
           fetchFn,
+          relevanceLanguage: state.mandalaLanguage,
+          regionCode,
         });
         searchCalls += 1;
-        for (const item of items) {
-          const videoId = item.id?.videoId;
-          if (!videoId) continue;
-          allCandidates.push({
-            cellIndex: sel.cell.cellIndex,
-            keyword: sel.keyword.keyword,
-            iksTotal: sel.keyword.iksTotal,
-            perMandalaRelevance: sel.perMandalaRelevance,
-            videoId,
-            title: item.snippet?.title ?? '(untitled)',
-            channel: item.snippet?.channelTitle ?? '',
-            channelId: item.snippet?.channelId ?? '',
-            publishedAt: item.snippet?.publishedAt ?? new Date().toISOString(),
-            thumbnail: item.snippet?.thumbnails?.high?.url ?? '',
-            viewCount: null,
-            likeCount: null,
-          });
-        }
+        for (const item of items) pushCandidate(sel, item);
       } catch (err) {
         searchFailures += 1;
         log.warn(
-          `YouTube search failed for cell ${sel.cell.cellIndex} kw="${sel.keyword.keyword}": ${err instanceof Error ? err.message : String(err)}`
+          `YouTube search failed for cell ${sel.cell.cellIndex} q="${query}": ${err instanceof Error ? err.message : String(err)}`
         );
       }
     }
+
+    for (const sel of cellSelections) {
+      let queries: string[] | null = null;
+      try {
+        queries = await generateSearchQueries({
+          subGoal: sel.cell.text,
+          centerGoal: state.centerGoal,
+          language: state.mandalaLanguage,
+          baseUrl: state.llmUrl,
+          fetchImpl: fetchFn,
+        });
+        // Hard cap defensively even though the parser already limits.
+        if (queries.length > VIDEO_DISCOVER_QUERIES_PER_CELL) {
+          queries = queries.slice(0, VIDEO_DISCOVER_QUERIES_PER_CELL);
+        }
+        llmQueryGenSuccess += 1;
+      } catch (err) {
+        llmQueryGenFailures += 1;
+        if (err instanceof LlmQueryGenError) {
+          log.warn(
+            `LLM query gen failed for cell ${sel.cell.cellIndex} (falling back to concat): ${err.message}`
+          );
+        } else {
+          log.warn(
+            `LLM query gen unexpected error for cell ${sel.cell.cellIndex}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+        queries = null;
+      }
+
+      if (queries && queries.length > 0) {
+        for (const q of queries) {
+          await runSearch(sel, q);
+        }
+      } else {
+        // Fallback: legacy single concat query
+        await runSearch(sel, `${sel.cell.text} ${sel.keyword.keyword}`);
+      }
+    }
+    log.info(
+      `LLM query gen: success=${llmQueryGenSuccess}, failures=${llmQueryGenFailures}, search_calls=${searchCalls}`
+    );
 
     if (allCandidates.length === 0) {
       return {
@@ -409,6 +580,10 @@ export const executor: SkillExecutor = {
             cand.likeCount = Number.isNaN(lc) ? null : lc;
           }
         }
+        // Fix 3 (CP358): parse contentDetails.duration into seconds for the
+        // Shorts filter applied after Step 3.5. videos.list already requests
+        // contentDetails (line ~613) so this is free quota-wise.
+        cand.durationSec = parseIsoDuration(stat?.contentDetails?.duration);
       }
       log.info(
         `videos.list mapping: candidates=${allCandidates.length}, mapped=${mappedCount}, view_count populated=${viewCountPopulated}`
@@ -419,22 +594,42 @@ export const executor: SkillExecutor = {
       );
     }
 
+    // ── Step 3.5: Fix 3 (CP358) — Shorts + title blocklist filters ────
+    // Drop videos shorter than MIN_DURATION_SEC (Shorts) or whose titles
+    // contain entries from TITLE_BLOCKLIST (drama / vlog / reaction noise).
+    // The YouTube Search `videoDuration=medium` param (Fix 1) already filters
+    // most Shorts at the API boundary, but it's not 100% accurate so this is
+    // a defense-in-depth pass. Candidates with `durationSec === null` are
+    // kept (no signal == benefit of doubt).
+    const beforeFilter = allCandidates.length;
+    const filteredAllCandidates = allCandidates.filter((c) => {
+      if (c.durationSec !== null && c.durationSec < MIN_DURATION_SEC) return false;
+      if (titleContainsBlocked(c.title)) return false;
+      return true;
+    });
+    const droppedShortsBlocklist = beforeFilter - filteredAllCandidates.length;
+    if (droppedShortsBlocklist > 0) {
+      log.info(
+        `Fix 3 filter: dropped ${droppedShortsBlocklist} candidates (Shorts + blocklist), ${filteredAllCandidates.length} remain`
+      );
+    }
+
     // ── Step 4: Compute Rec Score + pick top RECS_PER_CELL per cell ────
     const now = Date.now();
-    for (const cand of allCandidates) {
+    for (const cand of filteredAllCandidates) {
       cand.videoQuality = computeVideoQuality(cand);
       cand.freshness = computeFreshness(cand.publishedAt, now);
       cand.recScore = computeRecScore(cand);
     }
 
     const byCell = new Map<number, RecommendationCandidate[]>();
-    for (const cand of allCandidates) {
+    for (const cand of filteredAllCandidates) {
       const arr = byCell.get(cand.cellIndex);
       if (arr) arr.push(cand);
       else byCell.set(cand.cellIndex, [cand]);
     }
 
-    const finalRecommendations: RecommendationCandidate[] = [];
+    let finalRecommendations: RecommendationCandidate[] = [];
     for (const [, cands] of byCell) {
       cands.sort((a, b) => (b.recScore ?? 0) - (a.recScore ?? 0));
       // Apply diversity: drop duplicate channels within the same cell
@@ -447,6 +642,44 @@ export const executor: SkillExecutor = {
         cellTop.push(c);
       }
       finalRecommendations.push(...cellTop);
+    }
+
+    // ── Step 4.5: Fix 3 (CP358) — Global channel diversity cap ────────
+    // Per-cell dedup runs above, but a noisy channel can still surface in
+    // 3+ different cells. If any channel contributes >= GLOBAL_CHANNEL_CAP_THRESHOLD
+    // recommendations, collapse it to its highest-scored video only. We
+    // accept the resulting drop in total recommendation count (quality > quantity).
+    const channelCounts = new Map<string, number>();
+    for (const r of finalRecommendations) {
+      if (!r.channelId) continue;
+      channelCounts.set(r.channelId, (channelCounts.get(r.channelId) ?? 0) + 1);
+    }
+    const overusedChannels = new Set<string>();
+    for (const [ch, count] of channelCounts) {
+      if (count >= GLOBAL_CHANNEL_CAP_THRESHOLD) overusedChannels.add(ch);
+    }
+    let droppedByChannelCap = 0;
+    if (overusedChannels.size > 0) {
+      // Sort globally so the highest-scored video for each overused channel wins
+      const sorted = [...finalRecommendations].sort(
+        (a, b) => (b.recScore ?? 0) - (a.recScore ?? 0)
+      );
+      const keptChannels = new Set<string>();
+      const kept: RecommendationCandidate[] = [];
+      for (const r of sorted) {
+        if (overusedChannels.has(r.channelId)) {
+          if (keptChannels.has(r.channelId)) {
+            droppedByChannelCap += 1;
+            continue;
+          }
+          keptChannels.add(r.channelId);
+        }
+        kept.push(r);
+      }
+      finalRecommendations = kept;
+      log.info(
+        `Fix 3 channel cap: ${overusedChannels.size} overused channel(s), dropped ${droppedByChannelCap} duplicates`
+      );
     }
 
     // ── Step 5: Upsert to recommendation_cache ─────────────────────────
@@ -535,6 +768,8 @@ export const executor: SkillExecutor = {
         cells: state.subGoals.length,
         keyword_pool_size: state.keywords.length,
         cell_keyword_pairs: cellSelections.length,
+        llm_query_gen_success: llmQueryGenSuccess,
+        llm_query_gen_failures: llmQueryGenFailures,
         search_calls: searchCalls,
         search_failures: searchFailures,
         candidates_total: allCandidates.length,
@@ -566,6 +801,17 @@ interface YouTubeSearchOpts {
   oauthToken: string;
   maxResults: number;
   fetchFn: typeof fetch;
+  /**
+   * ISO 639-1 language code (e.g. 'ko', 'en'). Passed to YouTube as
+   * `relevanceLanguage`. Fix 1 (CP358) — was hardcoded 'ko' before.
+   */
+  relevanceLanguage: string;
+  /**
+   * Optional ISO 3166-1 alpha-2 region code (e.g. 'KR', 'US'). Passed to
+   * YouTube as `regionCode`. Skipped when caller cannot map the language
+   * to a region. Fix 1 (CP358) — was hardcoded 'KR' before.
+   */
+  regionCode?: string;
 }
 
 async function youtubeSearch(opts: YouTubeSearchOpts): Promise<YouTubeSearchItem[]> {
@@ -574,8 +820,14 @@ async function youtubeSearch(opts: YouTubeSearchOpts): Promise<YouTubeSearchItem
   url.searchParams.set('type', 'video');
   url.searchParams.set('q', opts.query);
   url.searchParams.set('maxResults', String(opts.maxResults));
-  url.searchParams.set('relevanceLanguage', 'ko');
-  url.searchParams.set('regionCode', 'KR');
+  url.searchParams.set('relevanceLanguage', opts.relevanceLanguage);
+  if (opts.regionCode) {
+    url.searchParams.set('regionCode', opts.regionCode);
+  }
+  // Fix 1 (CP358): drop Shorts (<60s) and the long-form bucket (>20min) at
+  // the search-API level. The API filter is not 100% accurate, so Fix 3 also
+  // post-filters by parsed duration after videos.list returns.
+  url.searchParams.set('videoDuration', 'medium');
   url.searchParams.set('safeSearch', 'moderate');
 
   const res = await opts.fetchFn(url.toString(), {
@@ -720,4 +972,41 @@ function parseVectorLiteral(literal: string): number[] {
     out[i] = parseFloat(parts[i] ?? '0');
   }
   return out;
+}
+
+// ============================================================================
+// Fix 3 (CP358) — Filter helpers
+// ============================================================================
+
+/**
+ * Parse an ISO 8601 duration string (`PT1H2M3S`) into total seconds.
+ * Returns `null` for missing/unparseable input. Implementation duplicated
+ * from YouTubeAdapter.parseDuration to comply with the plugin cross-import
+ * rule (CLAUDE.md §plugin cross-import). Exported for unit tests.
+ */
+export function parseIsoDuration(iso?: string | null): number | null {
+  if (!iso) return null;
+  const m = iso.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/);
+  if (!m) return null;
+  const h = parseInt(m[1] ?? '0', 10);
+  const mi = parseInt(m[2] ?? '0', 10);
+  const s = parseInt(m[3] ?? '0', 10);
+  if (Number.isNaN(h) || Number.isNaN(mi) || Number.isNaN(s)) return null;
+  // Reject the empty `PT` case (no hours/minutes/seconds groups matched)
+  if (h === 0 && mi === 0 && s === 0 && iso === 'PT') return null;
+  return h * 3600 + mi * 60 + s;
+}
+
+/**
+ * Returns `true` if the title contains any TITLE_BLOCKLIST entry as a
+ * case-insensitive substring. Empty/null titles return `false`.
+ * Exported for unit tests.
+ */
+export function titleContainsBlocked(title: string): boolean {
+  if (!title) return false;
+  const lower = title.toLowerCase();
+  for (const t of TITLE_BLOCKLIST) {
+    if (lower.includes(t.toLowerCase())) return true;
+  }
+  return false;
 }

--- a/src/skills/plugins/video-discover/manifest.ts
+++ b/src/skills/plugins/video-discover/manifest.ts
@@ -43,6 +43,14 @@ export const VIDEO_DISCOVER_SEARCH_RESULTS_PER_CELL = 10;
 export const VIDEO_DISCOVER_TTL_DAYS = 7;
 /** How many top keyword_scores rows to load into memory for cosine matching. */
 export const VIDEO_DISCOVER_KEYWORD_POOL_SIZE = 200;
+/**
+ * Number of LLM-generated search queries per cell. Fix 2 (CP358) — replaces
+ * the previous single sub_goal+keyword string. Quota math: 8 cells × 3 queries
+ * × 100 units = 2,400 units per execute() = 24% of the user's daily 10k.
+ * 3 is the safe upper bound; bumping to 5 would push a 4-mandala/day power
+ * user over the daily limit.
+ */
+export const VIDEO_DISCOVER_QUERIES_PER_CELL = 3;
 
 export const manifest: SkillManifest = defineManifest({
   id: 'video-discover',

--- a/src/skills/plugins/video-discover/sources/llm-query-generator.ts
+++ b/src/skills/plugins/video-discover/sources/llm-query-generator.ts
@@ -1,0 +1,249 @@
+/**
+ * llm-query-generator — Fix 2 (CP358, video-discover quality experiment 01)
+ *
+ * Calls Mac Mini Ollama (llama3.1) to turn a single (sub_goal, center_goal,
+ * language) tuple into a small set of natural-language YouTube search queries.
+ *
+ * Why: the previous executor concatenated `${sub_goal} ${top_keyword}` into
+ * one string ("조카의 학습 동기 부여 공부") which YouTube's relevance ranker
+ * scored badly — surfacing English/Chinese education content above Korean
+ * results despite the Korean cell text. Generating 3 natural query phrases
+ * ("조카 학습 동기 키우는 법", "초등학생 공부 동기부여", "아이 학습 의욕")
+ * fixes the relevance signal at the API boundary.
+ *
+ * Pattern intentionally mirrors trend-collector/sources/llm-extract.ts for
+ * consistency: same Ollama base URL, same defensive JSON parsing, same
+ * markdown-fence stripping, same fetchImpl override hook for tests.
+ */
+
+const DEFAULT_OLLAMA_URL = 'http://100.91.173.17:11434';
+const DEFAULT_MODEL = 'llama3.1:latest'; // verified installed on Mac Mini 2026-04-07
+const REQUEST_TIMEOUT_MS = 30_000;
+/** Hard cap on the number of queries returned to the caller. */
+const MAX_QUERIES = 3;
+/** Minimum length of a usable query (filters single-character noise). */
+const MIN_QUERY_LENGTH = 2;
+
+export class LlmQueryGenError extends Error {
+  status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'LlmQueryGenError';
+    this.status = status;
+  }
+}
+
+export interface GenerateQueriesOpts {
+  /** The cell's sub_goal text (e.g. "조카의 학습 동기 부여"). */
+  subGoal: string;
+  /** The mandala's root center goal (e.g. "조카 교육"). Used to anchor scope. */
+  centerGoal: string;
+  /** ISO 639-1 language code. Selects the prompt language. Defaults handled in caller. */
+  language: string;
+  /** Override Ollama URL (test injection). */
+  baseUrl?: string;
+  /** Override model name (test injection). */
+  model?: string;
+  /** Override fetch (test injection). */
+  fetchImpl?: typeof fetch;
+}
+
+interface OllamaChatResponse {
+  message?: { content?: string };
+  error?: string;
+}
+
+/**
+ * Generate up to {@link MAX_QUERIES} YouTube search queries for one
+ * (subGoal, centerGoal, language) tuple. Throws {@link LlmQueryGenError}
+ * on transport failure, model error, empty response, or unparseable JSON.
+ *
+ * Caller is expected to catch and fall back to the legacy keyword-concat
+ * path so a single Ollama hiccup doesn't take down the whole skill.
+ */
+export async function generateSearchQueries(opts: GenerateQueriesOpts): Promise<string[]> {
+  const baseUrl = opts.baseUrl ?? DEFAULT_OLLAMA_URL;
+  const model = opts.model ?? DEFAULT_MODEL;
+  const fetchFn = opts.fetchImpl ?? fetch;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  let res: Response;
+  try {
+    res = await fetchFn(`${baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: buildSystemPrompt(opts.language) },
+          {
+            role: 'user',
+            content: buildUserPrompt(opts.subGoal, opts.centerGoal, opts.language),
+          },
+        ],
+        stream: false,
+        think: false,
+        format: 'json',
+        options: { temperature: 0.4 },
+      }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    throw new LlmQueryGenError(
+      `Ollama chat failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  clearTimeout(timer);
+
+  if (!res.ok) {
+    let body = '';
+    try {
+      body = (await res.text()).slice(0, 200);
+    } catch {
+      // ignore
+    }
+    throw new LlmQueryGenError(`Ollama chat HTTP ${res.status}: ${body}`, res.status);
+  }
+
+  const data = (await res.json()) as OllamaChatResponse;
+  if (data.error) {
+    throw new LlmQueryGenError(`Ollama chat error: ${data.error}`);
+  }
+  const content = data.message?.content;
+  if (!content) {
+    throw new LlmQueryGenError('Ollama chat returned empty content');
+  }
+
+  return parseQueriesResponse(content);
+}
+
+// ============================================================================
+// Prompt construction
+// ============================================================================
+
+function buildSystemPrompt(language: string): string {
+  if (language.startsWith('ko')) {
+    return [
+      '당신은 학습 목표를 YouTube 검색어로 변환하는 도우미입니다.',
+      '응답은 반드시 JSON 배열 한 개만 출력하세요.',
+      '설명, 마크다운, 코드 펜스, 다른 텍스트를 절대 포함하지 마세요.',
+    ].join(' ');
+  }
+  return [
+    'You are an assistant that turns learning goals into YouTube search queries.',
+    'Respond with ONE JSON array only.',
+    'Never include explanations, markdown, code fences, or any other text.',
+  ].join(' ');
+}
+
+function buildUserPrompt(subGoal: string, centerGoal: string, language: string): string {
+  if (language.startsWith('ko')) {
+    return [
+      `다음 학습 목표에 대해 YouTube에서 검색할 한국어 검색어 ${MAX_QUERIES}개를 생성하세요.`,
+      '목표를 달성하려는 사람이 실제로 검색할 법한 자연스러운 한국어 검색어로 만드세요.',
+      '',
+      `만다라 중심 주제: ${centerGoal || '(미지정)'}`,
+      `세부 목표: ${subGoal}`,
+      '',
+      '규칙:',
+      `- ${MAX_QUERIES}개 모두 서로 다른 각도`,
+      '- 각 검색어는 2~6 단어',
+      '- 한국어로만 작성',
+      '- 이모지, 해시태그, 따옴표 금지',
+      '',
+      `JSON 배열로만 응답: ["검색어1", "검색어2", "검색어3"]`,
+      '다른 텍스트, 설명, markdown 금지.',
+    ].join('\n');
+  }
+  return [
+    `Generate ${MAX_QUERIES} YouTube search queries (in ${language}) for the goal below.`,
+    'The queries should be the kind of phrases a real learner would type into YouTube.',
+    '',
+    `Mandala center goal: ${centerGoal || '(unspecified)'}`,
+    `Sub goal: ${subGoal}`,
+    '',
+    'Rules:',
+    `- ${MAX_QUERIES} queries, each from a different angle`,
+    '- 2-6 words per query',
+    `- Written only in ${language}`,
+    '- No emoji, hashtags, or quotation marks',
+    '',
+    `Respond with a JSON array only: ["query 1", "query 2", "query 3"]`,
+    'No other text, explanations, or markdown.',
+  ].join('\n');
+}
+
+// ============================================================================
+// Response parsing — defensive against the various shapes Ollama emits
+// ============================================================================
+
+/**
+ * Parse the model's response into a normalized list of search queries.
+ *
+ * Defensive against (in priority order):
+ *  - Raw JSON array of strings (the happy path)
+ *  - Markdown-fenced JSON array (`\`\`\`json [...]\`\`\``)
+ *  - Object wrappers with `queries` / `results` / `items` keys
+ *  - Trailing whitespace, leading newlines, BOMs
+ *  - Empty / 1-character / quoted-empty queries (filtered out)
+ *  - More than MAX_QUERIES results (truncated)
+ *
+ * Throws {@link LlmQueryGenError} only when nothing usable could be extracted.
+ */
+export function parseQueriesResponse(content: string): string[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    const stripped = stripMarkdownFence(content);
+    try {
+      parsed = JSON.parse(stripped);
+    } catch {
+      throw new LlmQueryGenError(`Could not parse LLM JSON: ${content.slice(0, 200)}`);
+    }
+  }
+
+  // Accept several shapes
+  let candidates: unknown[] = [];
+  if (Array.isArray(parsed)) {
+    candidates = parsed;
+  } else if (parsed && typeof parsed === 'object') {
+    const obj = parsed as Record<string, unknown>;
+    if (Array.isArray(obj['queries'])) candidates = obj['queries'];
+    else if (Array.isArray(obj['results'])) candidates = obj['results'];
+    else if (Array.isArray(obj['items'])) candidates = obj['items'];
+  }
+
+  const cleaned: string[] = [];
+  for (const c of candidates) {
+    if (typeof c !== 'string') continue;
+    const trimmed = c
+      .trim()
+      .replace(/^["']|["']$/g, '')
+      .trim();
+    if (trimmed.length < MIN_QUERY_LENGTH) continue;
+    cleaned.push(trimmed);
+    if (cleaned.length >= MAX_QUERIES) break;
+  }
+
+  if (cleaned.length === 0) {
+    throw new LlmQueryGenError(`LLM returned no usable queries: ${content.slice(0, 200)}`);
+  }
+  return cleaned;
+}
+
+function stripMarkdownFence(s: string): string {
+  // Strip ```json ... ``` or ``` ... ``` wrappers (mirrors llm-extract.ts)
+  const trimmed = s.trim();
+  if (trimmed.startsWith('```')) {
+    const firstNewline = trimmed.indexOf('\n');
+    const lastFence = trimmed.lastIndexOf('```');
+    if (firstNewline > 0 && lastFence > firstNewline) {
+      return trimmed.slice(firstNewline + 1, lastFence).trim();
+    }
+  }
+  return s;
+}


### PR DESCRIPTION
## Summary

"조카 교육" 만다라 실험(`video-discover-quality-experiment-01.md`) 결과 24개 추천 카드 중 한국어가 33%에 불과(중국어 42%, 영어 25%). 한국어 만다라에 대해 한국어 결과가 과반이 안 됨. 3가지 원인을 단일 PR로 fix.

## Fix 1 — YouTube Search params dynamic

- Pull `language` + `center_goal` from `mandala_embeddings` (level=1) in preflight, hydrate on `HydratedState`
- Replace hardcoded `ko`/`KR` with `state.mandalaLanguage` + `LANG_TO_REGION` map (ko→KR, en→US, ja→JP, zh→TW, es/fr/de)
- Add `videoDuration=medium` to drop Shorts and the long-form bucket at the API boundary
- Unknown languages omit `regionCode` (relevanceLanguage alone)

## Fix 2 — LLM-driven multi-query search

- New module `sources/llm-query-generator.ts`: Mac Mini Ollama (llama3.1) prompt → 3 natural search queries per cell
- Defensive JSON parsing mirrors `trend-collector/llm-extract` (markdown-fence stripping, object-wrapper fallback, length filter, query cap)
- `LlmQueryGenError` forces fallback to legacy `\${cell.text} \${keyword}` concat — single Ollama hiccup never blocks the skill
- Per-cell `videoId` dedup so the same video doesn't enter the candidate pool 3x across the queries
- Ollama URL from `ctx.env.OLLAMA_URL` with Mac Mini Tailscale default (same convention as trend-collector)
- **Quota math**: 8 cells × 3 queries × 100 = 2,400 units = 24% of user's 10k daily YouTube quota. 3 is the safe ceiling — bumping to 5 would push a 4-mandala/day power user over the daily limit

## Fix 3 — Shorts / blocklist / global channel cap

- `parseIsoDuration` helper, populated from `videos.list` `contentDetails.duration` (already requested → zero added quota)
- Drop `durationSec < 60` (Shorts) as defense-in-depth against Search API filter imperfections
- Drop titles containing TITLE_BLOCKLIST entries: 드라마/웹소설/웹툰/애니/만화/리액션/브이로그/먹방 + drama/webtoon/anime/manga/vlog/mukbang/reaction
- **Global channel cap**: after per-cell dedup, scan finalRecommendations for channels contributing ≥3 videos. Collapse each overused channel to its highest-scored video only (quality > quantity)

## Tests (74/74 green)

| Category | Count |
|----------|-------|
| Existing executor tests adapted | 32 |
| Fix 1 URL-param assertions | 2 |
| llm-query-generator parser/transport unit tests | 21 |
| Fix 2 executor integration tests (3-query path, fallback, dedup) | 3 |
| `parseIsoDuration` unit tests | 8 |
| `titleContainsBlocked` unit tests | 4 |
| Fix 3 executor integration tests (Shorts, blocklist, channel cap) | 4 |
| **Total** | **74** |

## Verification

- [x] \`npx jest src/skills/plugins/video-discover --no-coverage\` → 74/74 pass
- [x] \`npx tsc --noEmit\` → exit 0
- [x] Pre-commit hook (prettier + eslint) clean
- [ ] Post-merge: prod 배포 후 "조카 교육" 만다라 video-discover 재실행 → 한국어 비율 ≥90%, 교육 관련성 ≥80%, Shorts 0건, 드라마/웹소설 0건, 동일 채널 3개+ 0건 (별도 검증 단위)

## Quota impact

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| YouTube search.list calls per execute | 8 | 24 | 8 cells × 3 queries |
| YouTube quota units per execute | 800 | 2,400 | +1,600 (+200%) |
| Daily quota share (10k/day) | 8% | 24% | +16pp |
| Daily mandala-creation ceiling | 12 | 4 | -8 |

The 4/day ceiling is acceptable for the current user base. If we hit it in practice, `VIDEO_DISCOVER_QUERIES_PER_CELL` is exposed in `manifest.ts` as a single tunable.

## Files

- ✏️ `src/skills/plugins/video-discover/executor.ts` — Fix 1+2+3 wiring
- ✏️ `src/skills/plugins/video-discover/manifest.ts` — `VIDEO_DISCOVER_QUERIES_PER_CELL=3` constant
- 🆕 `src/skills/plugins/video-discover/sources/llm-query-generator.ts` — Fix 2 module
- 🆕 `src/skills/plugins/video-discover/__tests__/llm-query-generator.test.ts` — 21 unit tests
- ✏️ `src/skills/plugins/video-discover/__tests__/executor.test.ts` — Fix 1+2+3 integration tests + 8/4 helper tests

## Out of scope (carry-over)

- Manual end-to-end with real OAuth/Mac Mini → next session, after deploy
- `recommendation_cache.duration_sec` column population (currently always null in upsert) — separate refactor
- Rec Score weight retuning based on Fix 3's narrower candidate pool — observe first then tune

Refs: \`video-discover-quality-experiment-01.md\`, CP358

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
