### PR TITLE
fix(wizard+discover): CP361 user-reported 4 bugs in one PR

### DIFF
--- a/frontend/src/features/mandala-wizard/model/useWizard.ts
+++ b/frontend/src/features/mandala-wizard/model/useWizard.ts
@@ -316,12 +316,19 @@ export function useWizard() {
   // to a non-existent entry, fallback default mandala wins.
   const selectMandalaInStore = useMandalaStore((s) => s.selectMandala);
   const queryClient = useQueryClient();
+  // Bug #3 fix: await the refetch so the sidebar has fresh data by the time
+  // we navigate. Previously this was fire-and-forget invalidateQueries, which
+  // caused SidebarMandalaSection to render with stale list + fall back to
+  // `mandalas[0]` (= the previously first mandala, e.g. "AI/ML Expert") while
+  // the new mandala was still propagating. The refetch typically completes
+  // in < 300ms so the wait is imperceptible vs the old broken state.
   const goToUnifiedDashboard = useCallback(
-    (newMandalaId: string) => {
+    async (newMandalaId: string) => {
       selectMandalaInStore(newMandalaId);
-      // Force list refetch so the new mandala appears in sidebar + IndexPage.
-      queryClient.invalidateQueries({ queryKey: queryKeys.mandala.list() });
-      queryClient.invalidateQueries({ queryKey: queryKeys.mandala.all });
+      await Promise.all([
+        queryClient.refetchQueries({ queryKey: queryKeys.mandala.list() }),
+        queryClient.refetchQueries({ queryKey: queryKeys.mandala.quota() }),
+      ]);
       navigate('/');
     },
     [navigate, selectMandalaInStore, queryClient]

--- a/frontend/src/features/mandala-wizard/ui/WizardStepGoal.tsx
+++ b/frontend/src/features/mandala-wizard/ui/WizardStepGoal.tsx
@@ -202,17 +202,17 @@ export default function WizardStepGoal({
 
   const aiPhaseLabel =
     aiElapsedMs < AI_PHASE_ANALYSIS_MS
-      ? t('wizard.goal.ai.phase1', '목표 분석 중...')
+      ? t('wizard.goal.ai.phase1', 'Analyzing goal...')
       : aiElapsedMs < AI_PHASE_DRAFT_MS
-        ? t('wizard.goal.ai.phase2', '세부목표 8개 생성 중...')
-        : t('wizard.goal.ai.phase3', '만다라 완성 중...');
+        ? t('wizard.goal.ai.phase2', 'Generating 8 sub-goals...')
+        : t('wizard.goal.ai.phase3', 'Finalizing mandala...');
 
-  // Soft-slow inline hint text (shown below skeleton, NEVER amber).
+  // Soft-slow inline hint text (shown below skeleton, never amber).
   const searchSoftSlowHint = isSearchSoftSlow
-    ? t('wizard.goal.softSlow.search', '평소보다 조금 걸리고 있어요...')
+    ? t('wizard.goal.softSlow.search', 'Taking longer than usual...')
     : undefined;
   const generateSoftSlowHint = isGenerateSoftSlow
-    ? t('wizard.goal.softSlow.generate', '조금만 더 기다려 주세요...')
+    ? t('wizard.goal.softSlow.generate', 'Please wait a bit longer...')
     : undefined;
 
   return (

--- a/frontend/src/features/mandala-wizard/ui/WizardStepSkills.tsx
+++ b/frontend/src/features/mandala-wizard/ui/WizardStepSkills.tsx
@@ -179,6 +179,7 @@ export default function WizardStepSkills({
   const {
     isConnected: youtubeConnected,
     isConnecting: youtubeConnecting,
+    isLoading: youtubeLoading,
     connect: connectYouTube,
   } = useYouTubeAuth();
 
@@ -203,7 +204,12 @@ export default function WizardStepSkills({
         {t('wizard.skills.subtitle')}
       </p>
 
-      {showYouTubeCta && (
+      {/* Bug #2 fix: gate render on !youtubeLoading so the CTA does not
+          flash "not connected" → "connected" during the initial status
+          query. useYouTubeAuth defaults isConnected to false while the
+          query is still loading (status.data undefined), which caused a
+          visible flicker on every Step 3 mount. */}
+      {showYouTubeCta && !youtubeLoading && (
         <YouTubeConnectCta
           isConnected={youtubeConnected}
           isConnecting={youtubeConnecting}

--- a/frontend/src/pages/mandala-wizard/ui/MandalaWizardPage.tsx
+++ b/frontend/src/pages/mandala-wizard/ui/MandalaWizardPage.tsx
@@ -1,3 +1,6 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Ban } from 'lucide-react';
 import {
   useWizard,
   WizardStepper,
@@ -5,15 +8,63 @@ import {
   WizardStepPreview,
   WizardStepSkills,
 } from '@/features/mandala-wizard';
+import { useMandalaQuota } from '@/features/mandala';
 
 export default function MandalaWizardPage() {
+  const { t } = useTranslation();
   const wizard = useWizard();
+  // Bug #4 fix: gate the entire wizard on mandala quota at MOUNT time.
+  // Previously the quota error surfaced at Step 3 "시작하기" click — users
+  // completed goal entry + template preview + skill selection only to be
+  // blocked at the end with "Mandala limit reached (3/3)". Check here so
+  // the user sees the block immediately and is directed to the upgrade
+  // path before investing any effort.
+  const { data: quota, isLoading: quotaLoading } = useMandalaQuota();
+  const quotaReached =
+    !quotaLoading && quota?.limit !== null && quota?.limit !== undefined && quota.remaining === 0;
 
   // Step 1 (Goal) uses wider layout for the 4-column card grid
   const isGoalStep = wizard.currentStep === 1;
   const containerClass = isGoalStep
     ? 'mx-auto max-w-[1080px] px-6 py-10'
     : 'mx-auto max-w-[720px] px-6 py-10';
+
+  if (quotaReached) {
+    return (
+      <div className="mx-auto max-w-[720px] px-6 py-10">
+        <div className="mb-10 text-[10px] font-bold uppercase tracking-[2px] text-foreground/[0.08]">
+          /mandalas/new
+        </div>
+        <div className="rounded-xl border border-destructive/30 bg-destructive/5 px-6 py-10 text-center">
+          <Ban className="mx-auto mb-4 h-10 w-10 text-destructive/70" strokeWidth={1.6} />
+          <h1 className="mb-2 text-[22px] font-bold tracking-tight">
+            {t('wizard.quotaReached.title', 'Mandala limit reached')}
+          </h1>
+          <p className="mx-auto mb-6 max-w-[420px] text-[14px] leading-relaxed text-muted-foreground">
+            {t(
+              'wizard.quotaReached.description',
+              'You have reached the mandala limit for your plan ({{used}} / {{limit}}). Delete an existing mandala or upgrade to create more.',
+              { used: quota?.used ?? 0, limit: quota?.limit ?? 0 }
+            )}
+          </p>
+          <div className="flex items-center justify-center gap-3">
+            <Link
+              to="/"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-4 py-2 text-[13px] font-semibold text-foreground transition-colors hover:bg-foreground/[0.04]"
+            >
+              {t('wizard.quotaReached.backHome', 'Back to home')}
+            </Link>
+            <Link
+              to="/settings/subscription"
+              className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-[13px] font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              {t('wizard.quotaReached.upgrade', 'Upgrade plan')}
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={containerClass}>

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -41,8 +41,14 @@
       "hashtag": "Hashtag",
       "hashtagDesc": "Sync search results by keyword"
     },
-    "url": { "name": "URL", "desc": "Web pages, Blogs, News" },
-    "rss": { "name": "RSS", "desc": "Feed subscriptions" },
+    "url": {
+      "name": "URL",
+      "desc": "Web pages, Blogs, News"
+    },
+    "rss": {
+      "name": "RSS",
+      "desc": "Feed subscriptions"
+    },
     "assignMandala": "Assign to Mandala (optional)",
     "assignMandalaDesc": "Where should videos from this source be organized?",
     "aiAuto": "AI auto",
@@ -421,7 +427,6 @@
       "24h": "Every 24 hours"
     },
     "connect": "Connect YouTube",
-    "connected": "Connected",
     "disconnect": "Disconnect",
     "disconnectConfirm": "Disconnect YouTube?",
     "disconnectDesc": "You won't be able to access private playlists after disconnecting.",
@@ -442,7 +447,7 @@
     "playlistsSynced": "{{count}} playlists synced.",
     "playlistsDeleted": "{{count}} playlists deleted.",
     "playlists": "playlists",
-    "tabPlaylists": "Playlists",
+    "tabPlaylists": "My Playlists",
     "tabChannels": "Channels",
     "tabHashtags": "Hashtags",
     "addChannel": "Add Channel",
@@ -464,7 +469,6 @@
     "connectFirst": "Connect your YouTube account to import your library",
     "importFromLibrary": "Import from YouTube",
     "importBtn": "Import ({{count}})",
-    "tabPlaylists": "My Playlists",
     "tabSubscriptions": "Subscriptions",
     "noSubscriptions": "No subscriptions found",
     "loadMore": "Load more...",
@@ -683,7 +687,6 @@
     "multiCardMoved": "{{count}} cards moved",
     "movedToCell": "Moved to \"{{subject}}\".",
     "moveFailedDesc": "Please try again later.",
-    "cardMoved": "Card moved",
     "insightAdded": "Insight added",
     "insightAddedToCell": "Saved to \"{{subject}}\".",
     "mandalaNotReady": "Mandala is still loading. Please try again.",
@@ -774,18 +777,61 @@
     "clickToWriteNote": "Click to write a note..."
   },
   "dashboard": {
-    "focusMap": "Focus Map",
-    "focusMapSubtitle": "Where",
-    "focusMapDesc": "Distribution of my effort and interests",
-    "monthlyTrend": "Monthly Insight Accumulation Trend",
-    "monthlyTrendSubtitle": "How Fast",
-    "monthlyTrendDesc": "Growth speed and consistency of knowledge assets",
-    "qualityAnalysis": "Saved Insight Quality Analysis",
-    "qualityAnalysisSubtitle": "How Well",
-    "qualityAnalysisDesc": "Quality and engagement level of learning",
-    "totalCards": "Total Cards",
-    "withMemo": "With Memo",
-    "withoutMemo": "Without Memo"
+    "error": {
+      "title": "Failed to load dashboard",
+      "notFound": "Mandala not found."
+    },
+    "streak": {
+      "suffix": " day streak"
+    },
+    "header": {
+      "edit": "Edit",
+      "share": "Share"
+    },
+    "section": {
+      "recommendations": "Recommended Videos",
+      "skills": "Skills",
+      "stats": "Statistics"
+    },
+    "resume": {
+      "empty": {
+        "title": "Recently watched videos appear here",
+        "subtitle": "Add videos to mandala cells and watch them to activate resume"
+      },
+      "relevance": "Relevance",
+      "playButton": "Play ▶"
+    },
+    "orbital": {
+      "emptyHint": "Add some videos",
+      "cellLabel": "Area {{index}}",
+      "ctaAdd": "Add videos from main",
+      "ctaAi": "AI video recommendations",
+      "ctaAiSoon": "Coming soon"
+    },
+    "biasAlert": {
+      "title": "Bias Filtered"
+    },
+    "skills": {
+      "videoDiscover": "YouTube Discover",
+      "newsletter": "Newsletter",
+      "alerts": "Video Alerts",
+      "biasFilter": "Bias Filter",
+      "report": "Report"
+    },
+    "stats": {
+      "filledCells": "Filled Cells",
+      "videos": "Filled Items",
+      "streak": "Learning Streak",
+      "relevance": "Avg Relevance",
+      "days": "d",
+      "empty": "Learning stats will appear here when you add videos"
+    },
+    "videoShelf": {
+      "empty": {
+        "line1": "Add videos to mandala cells",
+        "line2": "to get recommendations"
+      }
+    }
   },
   "playlist": {
     "importing": "Importing playlist...",
@@ -1020,12 +1066,36 @@
     "compareTitle": "Compare Plans",
     "compareFeature": "Feature",
     "compareRows": [
-      { "feature": "Mandalas", "monthly": "3", "ltd": "Unlimited" },
-      { "feature": "AI Summaries", "monthly": "100/mo", "ltd": "500/mo" },
-      { "feature": "Playlist Sync", "monthly": "true", "ltd": "true" },
-      { "feature": "Priority Support", "monthly": "false", "ltd": "true" },
-      { "feature": "Lifetime Updates", "monthly": "false", "ltd": "true" },
-      { "feature": "Total Cost (1yr)", "monthly": "$238.80", "ltd": "$99" }
+      {
+        "feature": "Mandalas",
+        "monthly": "3",
+        "ltd": "Unlimited"
+      },
+      {
+        "feature": "AI Summaries",
+        "monthly": "100/mo",
+        "ltd": "500/mo"
+      },
+      {
+        "feature": "Playlist Sync",
+        "monthly": "true",
+        "ltd": "true"
+      },
+      {
+        "feature": "Priority Support",
+        "monthly": "false",
+        "ltd": "true"
+      },
+      {
+        "feature": "Lifetime Updates",
+        "monthly": "false",
+        "ltd": "true"
+      },
+      {
+        "feature": "Total Cost (1yr)",
+        "monthly": "$238.80",
+        "ltd": "$99"
+      }
     ],
     "faqTitle": "Frequently Asked Questions",
     "faq1q": "What does lifetime mean?",
@@ -1243,18 +1313,35 @@
     "s16P1": "For questions about these Terms, contact:"
   },
   "wizard": {
-    "steps": { "domain": "Domain", "preview": "Preview", "skills": "Skills" },
-    "navigation": { "aria": "Wizard steps" },
-    "stepStatus": { "completed": "Completed", "current": "Current", "waiting": "Waiting" },
+    "steps": {
+      "domain": "Domain",
+      "preview": "Preview",
+      "skills": "Skills"
+    },
+    "navigation": {
+      "aria": "Wizard steps"
+    },
+    "stepStatus": {
+      "completed": "Completed",
+      "current": "Current",
+      "waiting": "Waiting"
+    },
     "domain": {
       "title": "What goal would you like to achieve?",
       "subtitle": "Choose a domain and we'll recommend templates",
-      "templates": { "title": "Templates", "comingSoon": "Coming soon" },
+      "templates": {
+        "title": "Templates",
+        "comingSoon": "Coming soon"
+      },
       "separator": "or",
       "createBlank": "Start from scratch",
       "categories": {
-        "tech": "Tech/Dev", "health": "Health", "business": "Business",
-        "finance": "Finance", "creative": "Creative", "lifestyle": "Lifestyle"
+        "tech": "Tech/Dev",
+        "health": "Health",
+        "business": "Business",
+        "finance": "Finance",
+        "creative": "Creative",
+        "lifestyle": "Lifestyle"
       }
     },
     "goal": {
@@ -1276,7 +1363,10 @@
         "titleLora": "AI-crafted mandala for your goal",
         "titleFallback": "AI-crafted mandala (fallback LLM)",
         "error": "Generation is taking longer than expected. Would you like to try again?",
-        "retry": "Retry"
+        "retry": "Retry",
+        "phase1": "Analyzing goal...",
+        "phase2": "Generating 8 sub-goals...",
+        "phase3": "Finalizing mandala..."
       },
       "card": {
         "aiLoadingBadge": "AI generating...",
@@ -1294,49 +1384,123 @@
         "templateTitle": "Template search is slower than usual",
         "templateSubtitle": "Want to try again?",
         "retry": "Retry"
+      },
+      "softSlow": {
+        "search": "Taking longer than usual...",
+        "generate": "Please wait a bit longer..."
       }
     },
     "preview": {
       "centerGoal": "Core Goal · {{count}} sub-areas",
       "subject": "Area {{index}} · {{count}} action items",
       "subtitle": "Hover over cells to see detailed plans",
-      "hint": { "line1": "← Hover over", "line2": "a cell" },
+      "hint": {
+        "line1": "← Hover over",
+        "line2": "a cell"
+      },
       "startButton": "Start with this",
       "backButton": "Other templates"
     },
     "skills": {
       "title": "Which services would you like?",
       "subtitle": "Turn ON to preview how it works",
-      "button": { "creating": "Creating...", "start": "Let's go!" },
-      "card": { "preview": "Turn on to preview", "toggle": "Activate" },
-      "state": { "active": "Active", "inactive": "Inactive" }
+      "button": {
+        "creating": "Creating...",
+        "start": "Let's go!"
+      },
+      "card": {
+        "preview": "Turn on to preview",
+        "toggle": "Activate"
+      },
+      "state": {
+        "active": "Active",
+        "inactive": "Inactive"
+      }
     },
     "skill": {
-      "recommend": { "name": "AI Video Picks", "desc": "Auto-fill each cell with personalized videos" },
-      "newsletter": { "name": "Weekly Newsletter", "desc": "3 recommended videos per cell + key summaries weekly" },
-      "alert": { "name": "Activity Alerts", "desc": "Instant alerts when related new videos are found" },
-      "alerts": { "name": "New Video Alerts", "desc": "Instant alerts when related new videos are found" },
-      "biasFilter": { "name": "Bias Filter", "desc": "Auto-block clickbait/biased content" },
-      "report": { "name": "Report", "desc": "Learning progress + insight analysis" },
-      "script": { "name": "Video Script", "desc": "Auto-generate video scripts from your mandala cards" },
-      "blog": { "name": "Blog Draft", "desc": "Draft blog posts from your mandala knowledge" },
-      "videoDiscover": { "name": "YouTube Card Discovery", "desc": "Auto-discover videos based on your goal + trends", "betaHint": "Coming soon — toggle on now and it'll auto-activate at launch" },
+      "recommend": {
+        "name": "AI Video Picks",
+        "desc": "Auto-fill each cell with personalized videos"
+      },
+      "newsletter": {
+        "name": "Weekly Newsletter",
+        "desc": "3 recommended videos per cell + key summaries weekly"
+      },
+      "alert": {
+        "name": "Activity Alerts",
+        "desc": "Instant alerts when related new videos are found"
+      },
+      "alerts": {
+        "name": "New Video Alerts",
+        "desc": "Instant alerts when related new videos are found"
+      },
+      "biasFilter": {
+        "name": "Bias Filter",
+        "desc": "Auto-block clickbait/biased content"
+      },
+      "report": {
+        "name": "Report",
+        "desc": "Learning progress + insight analysis"
+      },
+      "script": {
+        "name": "Video Script",
+        "desc": "Auto-generate video scripts from your mandala cards"
+      },
+      "blog": {
+        "name": "Blog Draft",
+        "desc": "Draft blog posts from your mandala knowledge"
+      },
+      "videoDiscover": {
+        "name": "YouTube Card Discovery",
+        "desc": "Auto-discover videos based on your goal + trends",
+        "betaHint": "Coming soon — toggle on now and it'll auto-activate at launch"
+      },
       "demo": {
         "mail": "Arrives Monday 8 AM",
         "bell": "New video found!",
-        "bias": { "thumbnail": "100x guaranteed!", "stamp": "Blocked", "label": "Clickbait filtered" },
+        "bias": {
+          "thumbnail": "100x guaranteed!",
+          "stamp": "Blocked",
+          "label": "Clickbait filtered"
+        },
         "chart": "Monthly growth trend",
         "video": "3 picks for today"
       }
+    },
+    "quotaReached": {
+      "title": "Mandala limit reached",
+      "description": "You have reached the mandala limit for your plan ({{used}} / {{limit}}). Delete an existing mandala or upgrade to create more.",
+      "backHome": "Back to home",
+      "upgrade": "Upgrade plan"
     }
   },
   "editor": {
-    "header": { "title": "Edit Mandala", "back": "Go back", "save": "Save", "saving": "Saving..." },
-    "error": { "loadFailed": "Failed to load edit data. Please try again.", "backButton": "Go back" },
+    "header": {
+      "title": "Edit Mandala",
+      "back": "Go back",
+      "save": "Save",
+      "saving": "Saving..."
+    },
+    "error": {
+      "loadFailed": "Failed to load edit data. Please try again.",
+      "backButton": "Go back"
+    },
     "exploreLink": "Find templates in Explore",
-    "share": { "title": "Public Sharing", "subtitle": "Anyone with the link can view", "aria": "Toggle public sharing" },
-    "keyboard": { "nextCell": "Next cell", "switchBlock": "Switch block", "exit": "Exit editing" },
-    "navigator": { "aria": "Block navigation", "centerBlock": "Center block", "aiFill": "AI fill entire block" },
+    "share": {
+      "title": "Public Sharing",
+      "subtitle": "Anyone with the link can view",
+      "aria": "Toggle public sharing"
+    },
+    "keyboard": {
+      "nextCell": "Next cell",
+      "switchBlock": "Switch block",
+      "exit": "Exit editing"
+    },
+    "navigator": {
+      "aria": "Block navigation",
+      "centerBlock": "Center block",
+      "aiFill": "AI fill entire block"
+    },
     "grid": {
       "centerLabel": "Core Goal · 8 sub-goals",
       "subLabel": "Sub-goal · 8 action items",
@@ -1349,26 +1513,19 @@
       "aiFillLabel": "AI Fill",
       "aiBlockTooltip": "Fill empty cells in this block with AI"
     },
-    "completion": { "thisBlock": "This block", "total": "Total" },
-    "ghostSuggestions": ["Storybook docs", "API gateway", "Design system", "Performance benchmark", "E2E testing", "Code review guide", "Tech blog", "Demo video"]
-  },
-  "dashboard": {
-    "error": { "title": "Failed to load dashboard", "notFound": "Mandala not found." },
-    "streak": { "suffix": " day streak" },
-    "header": { "edit": "Edit", "share": "Share" },
-    "section": { "recommendations": "Recommended Videos", "skills": "Skills", "stats": "Statistics" },
-    "resume": {
-      "empty": { "title": "Recently watched videos appear here", "subtitle": "Add videos to mandala cells and watch them to activate resume" },
-      "relevance": "Relevance",
-      "playButton": "Play ▶"
+    "completion": {
+      "thisBlock": "This block",
+      "total": "Total"
     },
-    "orbital": { "emptyHint": "Add some videos", "cellLabel": "Area {{index}}", "ctaAdd": "Add videos from main", "ctaAi": "AI video recommendations", "ctaAiSoon": "Coming soon" },
-    "biasAlert": { "title": "Bias Filtered" },
-    "skills": { "videoDiscover": "YouTube Discover", "newsletter": "Newsletter", "alerts": "Video Alerts", "biasFilter": "Bias Filter", "report": "Report" },
-    "stats": {
-      "filledCells": "Filled Cells", "videos": "Filled Items", "streak": "Learning Streak", "relevance": "Avg Relevance",
-      "days": "d", "empty": "Learning stats will appear here when you add videos"
-    },
-    "videoShelf": { "empty": { "line1": "Add videos to mandala cells", "line2": "to get recommendations" } }
+    "ghostSuggestions": [
+      "Storybook docs",
+      "API gateway",
+      "Design system",
+      "Performance benchmark",
+      "E2E testing",
+      "Code review guide",
+      "Tech blog",
+      "Demo video"
+    ]
   }
 }

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -41,8 +41,14 @@
       "hashtag": "해시태그",
       "hashtagDesc": "키워드 기반 검색 결과 동기화"
     },
-    "url": { "name": "URL", "desc": "웹페이지 · 블로그 · 뉴스" },
-    "rss": { "name": "RSS", "desc": "피드 구독" },
+    "url": {
+      "name": "URL",
+      "desc": "웹페이지 · 블로그 · 뉴스"
+    },
+    "rss": {
+      "name": "RSS",
+      "desc": "피드 구독"
+    },
     "assignMandala": "만다라 연결 (선택사항)",
     "assignMandalaDesc": "이 소스의 영상을 어디에 정리할까요?",
     "aiAuto": "AI 자동",
@@ -422,7 +428,6 @@
       "24h": "24시간마다"
     },
     "connect": "YouTube 연결",
-    "connected": "연결됨",
     "disconnect": "연결 해제",
     "disconnectConfirm": "YouTube 연결을 해제하시겠습니까?",
     "disconnectDesc": "연결을 해제하면 비공개 플레이리스트에 접근할 수 없습니다.",
@@ -443,7 +448,7 @@
     "playlistsSynced": "{{count}}개 재생목록이 동기화되었습니다.",
     "playlistsDeleted": "{{count}}개 재생목록이 삭제되었습니다.",
     "playlists": "재생목록",
-    "tabPlaylists": "재생목록",
+    "tabPlaylists": "내 플레이리스트",
     "tabChannels": "채널",
     "tabHashtags": "해시태그",
     "addChannel": "채널 추가",
@@ -465,7 +470,6 @@
     "connectFirst": "YouTube 라이브러리를 가져오려면 Google 계정을 연결하세요",
     "importFromLibrary": "YouTube에서 가져오기",
     "importBtn": "가져오기 ({{count}})",
-    "tabPlaylists": "내 플레이리스트",
     "tabSubscriptions": "구독 채널",
     "noSubscriptions": "구독 채널이 없습니다",
     "loadMore": "더 보기...",
@@ -649,7 +653,7 @@
     "limitExceeded": "카드 제한 초과",
     "cardAdded": "카드가 추가되었습니다",
     "cardDeleted": "카드가 삭제되었습니다",
-    "cardMoved": "카드가 이동되었습니다",
+    "cardMoved": "카드 이동됨",
     "moveFailed": "이동 실패",
     "deleteFailed": "삭제 실패",
     "loginRequired": "로그인이 필요합니다",
@@ -684,7 +688,6 @@
     "multiCardMoved": "{{count}}개 카드 이동됨",
     "movedToCell": "\"{{subject}}\"로 이동했습니다.",
     "moveFailedDesc": "잠시 후 다시 시도해 주세요.",
-    "cardMoved": "카드 이동됨",
     "insightAdded": "인사이트 추가됨",
     "insightAddedToCell": "\"{{subject}}\"에 저장되었습니다.",
     "mandalaNotReady": "만다라가 아직 로딩 중입니다. 잠시 후 다시 시도해주세요.",
@@ -775,18 +778,61 @@
     "clickToWriteNote": "클릭하여 메모 작성..."
   },
   "dashboard": {
-    "focusMap": "Focus Map",
-    "focusMapSubtitle": "어디에 (Where)",
-    "focusMapDesc": "나의 노력과 관심사 분포",
-    "monthlyTrend": "월별 인사이트 축적 트렌드",
-    "monthlyTrendSubtitle": "얼마나 (How Fast)",
-    "monthlyTrendDesc": "지식 자산의 성장 속도와 꾸준함",
-    "qualityAnalysis": "저장된 인사이트 품질 분석",
-    "qualityAnalysisSubtitle": "어떻게 (How Well)",
-    "qualityAnalysisDesc": "학습의 질과 참여 수준",
-    "totalCards": "총 카드",
-    "withMemo": "메모 있음",
-    "withoutMemo": "메모 없음"
+    "error": {
+      "title": "대시보드를 불러올 수 없습니다",
+      "notFound": "만다라를 찾을 수 없습니다."
+    },
+    "streak": {
+      "suffix": "일 연속"
+    },
+    "header": {
+      "edit": "편집",
+      "share": "공유"
+    },
+    "section": {
+      "recommendations": "추천 영상",
+      "skills": "스킬",
+      "stats": "통계"
+    },
+    "resume": {
+      "empty": {
+        "title": "최근 시청한 영상이 여기에 표시됩니다",
+        "subtitle": "만다라 셀에 영상을 추가하고 시청하면 이어보기가 활성화돼요"
+      },
+      "relevance": "관련도",
+      "playButton": "재생 ▶"
+    },
+    "orbital": {
+      "emptyHint": "영상을 추가해보세요",
+      "cellLabel": "영역 {{index}}",
+      "ctaAdd": "메인에서 영상 추가하기",
+      "ctaAi": "AI 영상 추천 받기",
+      "ctaAiSoon": "준비 중"
+    },
+    "biasAlert": {
+      "title": "편향 필터링됨"
+    },
+    "skills": {
+      "videoDiscover": "유튜브 카드 추천",
+      "newsletter": "뉴스레터",
+      "alerts": "영상 알림",
+      "biasFilter": "편향 필터",
+      "report": "리포트"
+    },
+    "stats": {
+      "filledCells": "채움 셀",
+      "videos": "채운 항목",
+      "streak": "연속 학습",
+      "relevance": "평균 관련도",
+      "days": "일",
+      "empty": "영상을 추가하면 학습 통계가 여기에 표시됩니다"
+    },
+    "videoShelf": {
+      "empty": {
+        "line1": "만다라 셀에 영상을 추가하면",
+        "line2": "관련 영상을 추천해드려요"
+      }
+    }
   },
   "playlist": {
     "importing": "플레이리스트 가져오는 중...",
@@ -1010,18 +1056,47 @@
     "monthlyPrice": "$19.90",
     "monthlyPeriod": "월",
     "monthlyAnnual": "연 $238.80",
-    "monthlyFeatures": ["만다라트 3개", "AI 요약 (월 100회)", "플레이리스트 동기화", "일반 지원"],
+    "monthlyFeatures": [
+      "만다라트 3개",
+      "AI 요약 (월 100회)",
+      "플레이리스트 동기화",
+      "일반 지원"
+    ],
     "monthlyTrial": "14일 무료 체험",
     "monthlyCtaDisabled": "곧 출시 예정",
     "compareTitle": "플랜 비교",
     "compareFeature": "기능",
     "compareRows": [
-      { "feature": "만다라트", "monthly": "3개", "ltd": "무제한" },
-      { "feature": "AI 요약", "monthly": "월 100회", "ltd": "월 500회" },
-      { "feature": "플레이리스트 동기화", "monthly": "true", "ltd": "true" },
-      { "feature": "우선 지원", "monthly": "false", "ltd": "true" },
-      { "feature": "평생 업데이트", "monthly": "false", "ltd": "true" },
-      { "feature": "1년 총 비용", "monthly": "$238.80", "ltd": "$99" }
+      {
+        "feature": "만다라트",
+        "monthly": "3개",
+        "ltd": "무제한"
+      },
+      {
+        "feature": "AI 요약",
+        "monthly": "월 100회",
+        "ltd": "월 500회"
+      },
+      {
+        "feature": "플레이리스트 동기화",
+        "monthly": "true",
+        "ltd": "true"
+      },
+      {
+        "feature": "우선 지원",
+        "monthly": "false",
+        "ltd": "true"
+      },
+      {
+        "feature": "평생 업데이트",
+        "monthly": "false",
+        "ltd": "true"
+      },
+      {
+        "feature": "1년 총 비용",
+        "monthly": "$238.80",
+        "ltd": "$99"
+      }
     ],
     "faqTitle": "자주 묻는 질문",
     "faq1q": "평생이란 정말 평생인가요?",
@@ -1239,18 +1314,35 @@
     "s16P1": "본 약관에 대한 질문은 다음으로 연락해 주세요:"
   },
   "wizard": {
-    "steps": { "domain": "도메인", "preview": "미리보기", "skills": "스킬" },
-    "navigation": { "aria": "위저드 단계" },
-    "stepStatus": { "completed": "완료", "current": "현재", "waiting": "대기" },
+    "steps": {
+      "domain": "도메인",
+      "preview": "미리보기",
+      "skills": "스킬"
+    },
+    "navigation": {
+      "aria": "위저드 단계"
+    },
+    "stepStatus": {
+      "completed": "완료",
+      "current": "현재",
+      "waiting": "대기"
+    },
     "domain": {
       "title": "어떤 목표를 이루고 싶으세요?",
       "subtitle": "분야를 선택하면 맞춤 템플릿을 추천해드려요",
-      "templates": { "title": "템플릿", "comingSoon": "준비 중" },
+      "templates": {
+        "title": "템플릿",
+        "comingSoon": "준비 중"
+      },
       "separator": "또는",
       "createBlank": "처음부터 직접 만들기",
       "categories": {
-        "tech": "기술/개발", "health": "건강", "business": "비즈니스",
-        "finance": "재테크", "creative": "창작", "lifestyle": "라이프"
+        "tech": "기술/개발",
+        "health": "건강",
+        "business": "비즈니스",
+        "finance": "재테크",
+        "creative": "창작",
+        "lifestyle": "라이프"
       }
     },
     "goal": {
@@ -1272,7 +1364,10 @@
         "titleLora": "AI가 목표에 맞춰 만든 맞춤 만다라",
         "titleFallback": "AI 맞춤 만다라 (보조 LLM)",
         "error": "처리가 지연되고 있습니다. 다시 시도하시겠습니까?",
-        "retry": "다시 시도"
+        "retry": "다시 시도",
+        "phase1": "목표 분석 중...",
+        "phase2": "세부목표 8개 생성 중...",
+        "phase3": "만다라 완성 중..."
       },
       "card": {
         "aiLoadingBadge": "AI 생성 중...",
@@ -1290,49 +1385,123 @@
         "templateTitle": "템플릿 검색이 오래 걸리고 있어요",
         "templateSubtitle": "다시 시도해볼까요?",
         "retry": "다시 시도"
+      },
+      "softSlow": {
+        "search": "평소보다 조금 걸리고 있어요...",
+        "generate": "조금만 더 기다려 주세요..."
       }
     },
     "preview": {
       "centerGoal": "중심 목표 · {{count}}개 하위 영역",
       "subject": "영역 {{index}} · {{count}}개 실행 항목",
       "subtitle": "셀 위에 마우스를 올리면 세부 계획을 확인할 수 있어요",
-      "hint": { "line1": "← 셀 위에 마우스를", "line2": "올려보세요" },
+      "hint": {
+        "line1": "← 셀 위에 마우스를",
+        "line2": "올려보세요"
+      },
       "startButton": "이대로 시작하기",
       "backButton": "다른 템플릿"
     },
     "skills": {
       "title": "어떤 서비스를 받으시겠어요?",
       "subtitle": "ON으로 켜면 실제 동작을 미리 볼 수 있어요",
-      "button": { "creating": "생성 중...", "start": "시작하기!" },
-      "card": { "preview": "켜서 미리보기", "toggle": "활성화" },
-      "state": { "active": "활성", "inactive": "비활성" }
+      "button": {
+        "creating": "생성 중...",
+        "start": "시작하기!"
+      },
+      "card": {
+        "preview": "켜서 미리보기",
+        "toggle": "활성화"
+      },
+      "state": {
+        "active": "활성",
+        "inactive": "비활성"
+      }
     },
     "skill": {
-      "recommend": { "name": "AI 영상 추천", "desc": "셀별 맞춤 영상을 자동으로 찾아 채워줘요" },
-      "newsletter": { "name": "주간 뉴스레터", "desc": "매주 셀별 추천 영상 3개 + 핵심 요약" },
-      "alert": { "name": "활동 알림", "desc": "관련 신규 영상 발견 시 즉시 알림" },
-      "alerts": { "name": "신규 영상 알림", "desc": "관련 신규 영상 발견 시 즉시 알림" },
-      "biasFilter": { "name": "편향 필터", "desc": "과대광고/편향 콘텐츠 자동 차단" },
-      "report": { "name": "리포트", "desc": "학습 진행도 + 인사이트 분석" },
-      "script": { "name": "영상 스크립트", "desc": "만다라 카드로 영상 스크립트 자동 생성" },
-      "blog": { "name": "블로그 초안", "desc": "만다라 지식으로 블로그 포스트 초안 작성" },
-      "videoDiscover": { "name": "유튜브 카드 추천", "desc": "목표 + 트렌드 기반 영상 자동 발굴", "betaHint": "곧 출시 예정 — 지금 켜두면 출시 즉시 자동 활성화돼요" },
+      "recommend": {
+        "name": "AI 영상 추천",
+        "desc": "셀별 맞춤 영상을 자동으로 찾아 채워줘요"
+      },
+      "newsletter": {
+        "name": "주간 뉴스레터",
+        "desc": "매주 셀별 추천 영상 3개 + 핵심 요약"
+      },
+      "alert": {
+        "name": "활동 알림",
+        "desc": "관련 신규 영상 발견 시 즉시 알림"
+      },
+      "alerts": {
+        "name": "신규 영상 알림",
+        "desc": "관련 신규 영상 발견 시 즉시 알림"
+      },
+      "biasFilter": {
+        "name": "편향 필터",
+        "desc": "과대광고/편향 콘텐츠 자동 차단"
+      },
+      "report": {
+        "name": "리포트",
+        "desc": "학습 진행도 + 인사이트 분석"
+      },
+      "script": {
+        "name": "영상 스크립트",
+        "desc": "만다라 카드로 영상 스크립트 자동 생성"
+      },
+      "blog": {
+        "name": "블로그 초안",
+        "desc": "만다라 지식으로 블로그 포스트 초안 작성"
+      },
+      "videoDiscover": {
+        "name": "유튜브 카드 추천",
+        "desc": "목표 + 트렌드 기반 영상 자동 발굴",
+        "betaHint": "곧 출시 예정 — 지금 켜두면 출시 즉시 자동 활성화돼요"
+      },
       "demo": {
         "mail": "월요일 오전 8시 도착",
         "bell": "새 영상 발견!",
-        "bias": { "thumbnail": "100배 확정!", "stamp": "차단됨", "label": "과대광고 필터링" },
+        "bias": {
+          "thumbnail": "100배 확정!",
+          "stamp": "차단됨",
+          "label": "과대광고 필터링"
+        },
         "chart": "월별 성장 추이",
         "video": "오늘의 추천 3편"
       }
+    },
+    "quotaReached": {
+      "title": "만다라 생성 한도에 도달했습니다",
+      "description": "플랜의 만다라 한도에 도달했습니다 ({{used}} / {{limit}}). 기존 만다라를 삭제하거나 플랜을 업그레이드하세요.",
+      "backHome": "홈으로",
+      "upgrade": "플랜 업그레이드"
     }
   },
   "editor": {
-    "header": { "title": "만다라 편집", "back": "뒤로 가기", "save": "저장", "saving": "저장 중..." },
-    "error": { "loadFailed": "편집 데이터를 불러올 수 없습니다. 다시 시도해 주세요.", "backButton": "돌아가기" },
+    "header": {
+      "title": "만다라 편집",
+      "back": "뒤로 가기",
+      "save": "저장",
+      "saving": "저장 중..."
+    },
+    "error": {
+      "loadFailed": "편집 데이터를 불러올 수 없습니다. 다시 시도해 주세요.",
+      "backButton": "돌아가기"
+    },
     "exploreLink": "Explore에서 템플릿 찾기",
-    "share": { "title": "공개 공유", "subtitle": "링크가 있는 누구나 볼 수 있습니다", "aria": "공개 공유 토글" },
-    "keyboard": { "nextCell": "다음 셀", "switchBlock": "블록 전환", "exit": "편집 종료" },
-    "navigator": { "aria": "블록 탐색", "centerBlock": "중심 블록", "aiFill": "블록 전체 AI 채우기" },
+    "share": {
+      "title": "공개 공유",
+      "subtitle": "링크가 있는 누구나 볼 수 있습니다",
+      "aria": "공개 공유 토글"
+    },
+    "keyboard": {
+      "nextCell": "다음 셀",
+      "switchBlock": "블록 전환",
+      "exit": "편집 종료"
+    },
+    "navigator": {
+      "aria": "블록 탐색",
+      "centerBlock": "중심 블록",
+      "aiFill": "블록 전체 AI 채우기"
+    },
     "grid": {
       "centerLabel": "중심 목표 · 8개 서브목표",
       "subLabel": "서브목표 · 8개 실행 항목",
@@ -1345,26 +1514,19 @@
       "aiFillLabel": "AI 채우기",
       "aiBlockTooltip": "이 블록의 빈 셀을 AI로 채웁니다"
     },
-    "completion": { "thisBlock": "이 블록", "total": "전체" },
-    "ghostSuggestions": ["Storybook 문서화", "API 게이트웨이", "디자인 시스템", "성능 벤치마크", "E2E 테스트", "코드 리뷰 가이드", "기술 블로그", "데모 영상 제작"]
-  },
-  "dashboard": {
-    "error": { "title": "대시보드를 불러올 수 없습니다", "notFound": "만다라를 찾을 수 없습니다." },
-    "streak": { "suffix": "일 연속" },
-    "header": { "edit": "편집", "share": "공유" },
-    "section": { "recommendations": "추천 영상", "skills": "스킬", "stats": "통계" },
-    "resume": {
-      "empty": { "title": "최근 시청한 영상이 여기에 표시됩니다", "subtitle": "만다라 셀에 영상을 추가하고 시청하면 이어보기가 활성화돼요" },
-      "relevance": "관련도",
-      "playButton": "재생 ▶"
+    "completion": {
+      "thisBlock": "이 블록",
+      "total": "전체"
     },
-    "orbital": { "emptyHint": "영상을 추가해보세요", "cellLabel": "영역 {{index}}", "ctaAdd": "메인에서 영상 추가하기", "ctaAi": "AI 영상 추천 받기", "ctaAiSoon": "준비 중" },
-    "biasAlert": { "title": "편향 필터링됨" },
-    "skills": { "videoDiscover": "유튜브 카드 추천", "newsletter": "뉴스레터", "alerts": "영상 알림", "biasFilter": "편향 필터", "report": "리포트" },
-    "stats": {
-      "filledCells": "채움 셀", "videos": "채운 항목", "streak": "연속 학습", "relevance": "평균 관련도",
-      "days": "일", "empty": "영상을 추가하면 학습 통계가 여기에 표시됩니다"
-    },
-    "videoShelf": { "empty": { "line1": "만다라 셀에 영상을 추가하면", "line2": "관련 영상을 추천해드려요" } }
+    "ghostSuggestions": [
+      "Storybook 문서화",
+      "API 게이트웨이",
+      "디자인 시스템",
+      "성능 벤치마크",
+      "E2E 테스트",
+      "코드 리뷰 가이드",
+      "기술 블로그",
+      "데모 영상 제작"
+    ]
   }
 }

--- a/frontend/src/widgets/app-shell/ui/SidebarMandalaSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarMandalaSection.tsx
@@ -183,7 +183,15 @@ export function SidebarMandalaSection({ collapsed, minimapData }: SidebarMandala
   );
 
   const currentMandala = mandalas.find((m) => m.id === selectedMandalaId);
-  const currentTitle = currentMandala?.title ?? mandalas[0]?.title ?? '—';
+  // Bug #3 fix: when selectedMandalaId is set but the mandala isn't in the
+  // list yet (fresh creation, list refetch in flight), show a placeholder
+  // instead of falling back to mandals[0] — the previous fallback cascaded
+  // to the OLD first mandala (e.g. "AI/ML Expert") and looked like a
+  // cross-mandala UI leak. The mandals[0] fallback only applies when there
+  // is no selection at all (first-time user path).
+  const currentTitle = selectedMandalaId
+    ? (currentMandala?.title ?? '…')
+    : (mandalas[0]?.title ?? '—');
 
   return (
     <div className="px-2 flex flex-col">

--- a/src/skills/plugins/video-discover/executor.ts
+++ b/src/skills/plugins/video-discover/executor.ts
@@ -139,6 +139,10 @@ const CACHE_LOOKBACK_MS = CACHE_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
 const MIN_CACHE_HITS_PER_CELL = 3;
 /** How many rows to read per cell-cache lookup (avoids loading everything). */
 const CACHE_LOOKUP_LIMIT = 20;
+/** Min cell↔keyword cosine required to reuse cache.
+ *  Below this, the cached keyword is topically wrong for the cell
+ *  (basketball-mandala 2026-04-09: weak keyword → running videos). */
+const CACHE_REUSE_MIN_RELEVANCE = 0.5;
 
 interface SubGoalCell {
   cellIndex: number;
@@ -670,6 +674,15 @@ export const executor: SkillExecutor = {
       perMandalaRelevance: number;
     }): Promise<boolean> {
       if (state.cacheReuseDisabled) return false;
+
+      // Semantic gate — weak keyword cosine means cached videos are off-topic.
+      if (sel.perMandalaRelevance < CACHE_REUSE_MIN_RELEVANCE) {
+        log.info(
+          `cache skip: cell=${sel.cell.cellIndex} keyword="${sel.keyword.keyword}" relevance=${sel.perMandalaRelevance.toFixed(3)} < threshold ${CACHE_REUSE_MIN_RELEVANCE} — fallback to search`
+        );
+        return false;
+      }
+
       try {
         const cached = await db.recommendation_cache.findMany({
           where: {
@@ -704,8 +717,8 @@ export const executor: SkillExecutor = {
             videoId: r.video_id,
             title: r.title,
             channel: r.channel ?? '',
-            // No channel_id in cache — use channel title as dedup surrogate
-            channelId: r.channel ?? '',
+            // Fallback to video_id so null-channel rows don't collide in dedup.
+            channelId: r.channel ?? r.video_id,
             publishedAt: r.published_at?.toISOString() ?? new Date().toISOString(),
             thumbnail: r.thumbnail ?? '',
             viewCount: r.view_count,
@@ -717,7 +730,7 @@ export const executor: SkillExecutor = {
         cellsServedFromCache += 1;
         quotaSavedUnits += VIDEO_DISCOVER_QUERIES_PER_CELL * 100;
         log.info(
-          `cache hit: cell=${sel.cell.cellIndex} keyword="${sel.keyword.keyword}" ${unique.size} videos from ${cached.length} rows — skipping YouTube search`
+          `cache hit: cell=${sel.cell.cellIndex} keyword="${sel.keyword.keyword}" relevance=${sel.perMandalaRelevance.toFixed(3)} ${unique.size} videos from ${cached.length} rows — skipping YouTube search`
         );
         return true;
       } catch (err) {


### PR DESCRIPTION
## Summary

End-to-end guest-account (jamie24kim) demo test on 2026-04-09 surfaced four defects simultaneously. Fixing all four in a single PR so the post-merge rerun validates the whole path.

## Bugs fixed

### Bug #1 — Basketball mandala produced 0 cards
Cache reuse served topically wrong videos (running content for basketball cells) because it matched only on keyword string, not semantic fit. `keyword_scores` has no basketball entries, so cosine forced each cell onto a weakly-related keyword, cache lookup returned off-topic rows, rerank correctly rejected all 9 → **0 cards upserted**.

**Fix A (semantic gate)**: `tryCellCache` bails out when `sel.perMandalaRelevance < CACHE_REUSE_MIN_RELEVANCE` (0.5). Weak-keyword cells fall through to the YouTube search path which uses `sub_goal` text directly and is topically correct.

**Fix B (channelId fallback)**: original code used `r.channel ?? ''` as the dedup key, collapsing all null-channel rows onto `''` and starving cells via the channel-dedup loop. Fall back to `r.video_id` to guarantee per-video unique keys.

### Bug #2 — YouTube OAuth CTA flicker on wizard Step 3
`useYouTubeAuth` defaults `isConnected: false` while the status query is loading (`status.data` is `undefined`). Step 3 mounted with "Connect YouTube" CTA, then switched to "Connected" ~200ms later once the query resolved — a visible flash.

**Fix**: gate CTA render on `!isLoading` in `WizardStepSkills.tsx`. No CTA during the initial status query, proper state after.

### Bug #3 — Sidebar navigator showed the old mandala after creation
`goToUnifiedDashboard` in `useWizard` was fire-and-forget `invalidateQueries`, then `navigate('/')`. `SidebarMandalaSection` re-rendered with stale list → `mandalas.find(m => m.id === selectedMandalaId)` returned `undefined` → fallback `mandalas[0]?.title` cascaded to the **previously-first** mandala (e.g. "AI/ML Expert"), creating a fake cross-mandala UI leak.

**Fix (two layers)**:
- `useWizard`: `await Promise.all([refetchQueries(list), refetchQueries(quota)])` BEFORE `navigate`. Sidebar mounts on the new route with fresh data already in cache.
- `SidebarMandalaSection`: when `selectedMandalaId` is set but not in the list, show an ellipsis placeholder instead of cascading to `mandalas[0]`. The `mandalas[0]` fallback is retained only for the first-time-user path (no selection).

### Bug #4 — Quota check surfaced only at Step 3
Free-tier users hit the mandala limit error at the final "Start" button, AFTER completing goal input + template preview + skill selection. High frustration path.

**Fix**: `MandalaWizardPage` calls `useMandalaQuota()` at mount and renders a quota-reached overlay BEFORE the wizard steps when `quota.remaining === 0`. Upgrade + back-home CTAs shown directly.

i18n keys added:
- `wizard.quotaReached.{title,description,backHome,upgrade}` (en + ko)

## Test plan

- [x] `npx tsc --noEmit` clean (frontend + backend)
- [x] `npx vitest run` → **212/212 frontend pass**
- [x] `npx jest --no-coverage` → **572/572 backend pass**
- [ ] Post-merge manual validation on jamie24kim account:
  - Create basketball mandala → cards SHOULD populate (semantic gate lets search fallback handle weak keywords)
  - Step 3 mount → NO CTA flicker
  - After creation → sidebar shows the new mandala immediately, no "AI/ML Expert" cascade
  - If quota reached, `/mandalas/new` shows block screen immediately, not Step 3

## Related

- PR #373 (Phase 1 cache reuse) — introduced the cache code path this PR hardens with the semantic gate + channelId fix
- Issue #374 (rerank Qwen3 stability) — still open, independent concern
- Earlier session: CP359 P1 "sidebar dropdown stale" carry-over — now closed by Bug #3 fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
