### PR TITLE
fix(video-discover/v3): route recs through the mandala itself; skip the legacy pool

### DIFF
--- a/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Regression tests for the v3 mandala filter — the 9-axis relevance gate
+ * that rejects off-domain candidates and routes the rest to the best-fit
+ * cell. Covers the prod-observed contamination cases from 2026-04-16.
+ */
+
+import { applyMandalaFilter, MIN_SUB_RELEVANCE, type FilterCandidate } from '../mandala-filter';
+
+function cand(videoId: string, title: string, description = ''): FilterCandidate {
+  return { videoId, title, description };
+}
+
+describe('applyMandalaFilter — center gate (Gate 1)', () => {
+  const input = {
+    centerGoal: '일일 습관 성장',
+    subGoals: [
+      '아침 루틴 설계',
+      '학습 시간 확보',
+      '신체 건강 관리',
+      '감정 및 정신 관리',
+      '저녁 성찰 및 회고 습관',
+      '목표 진행상황 추적 시스템',
+      '방해요소 제거 및 환경 최적화',
+      '루틴 지속성 유지 및 동기부여',
+    ],
+    language: 'ko' as const,
+  };
+
+  test('drops "하느님 자비의 기도" — no center token overlap', () => {
+    const result = applyMandalaFilter([cand('v1', '찬미로 드리는 하느님 자비의 기도 5단')], input);
+    for (const list of result.values()) expect(list).toHaveLength(0);
+  });
+
+  test('drops "부업추천" — no center token overlap', () => {
+    const result = applyMandalaFilter(
+      [cand('v2', '[부업추천] 하루 8분! 온라인부업 다해보고 알려드립니다')],
+      input
+    );
+    for (const list of result.values()) expect(list).toHaveLength(0);
+  });
+
+  test('drops "정보처리기능사 필기" — no center token overlap', () => {
+    const result = applyMandalaFilter(
+      [cand('v3', '[균쌤] 정보처리기능사 필기 22강 - 운영체제 Windows 개요')],
+      input
+    );
+    for (const list of result.values()) expect(list).toHaveLength(0);
+  });
+});
+
+describe('applyMandalaFilter — center gate with substring (수능특강 case)', () => {
+  const input = {
+    centerGoal: '수능 대비 100일',
+    subGoals: [
+      '국어 영역 실전 문제풀이',
+      '수학 개념 정리 및 응용',
+      '영어 어휘 확장',
+      '과학탐구 암기',
+      '모의고사 오답노트',
+      '학습 플래너 수립',
+      '수면과 체력 관리',
+      '수능 당일 컨디션',
+    ],
+    language: 'ko' as const,
+  };
+
+  test('drops "한능검" — "수능" not in title, not substring-compatible', () => {
+    const result = applyMandalaFilter(
+      [cand('v1', '여기서 약20점!! 2026 벼락치기 한능검 1부')],
+      input
+    );
+    for (const list of result.values()) expect(list).toHaveLength(0);
+  });
+
+  test('admits "2027 수능특강 영어독해" — "수능" is substring of "수능특강"', () => {
+    const result = applyMandalaFilter(
+      [cand('v2', '2027 수능특강 영어독해 1강 1번 풀이', '영어 독해 문제풀이')],
+      input
+    );
+    const totalKept = Array.from(result.values()).reduce((n, list) => n + list.length, 0);
+    expect(totalKept).toBe(1);
+  });
+});
+
+describe('applyMandalaFilter — sub_goal routing (Gate 2)', () => {
+  const input = {
+    centerGoal: '토플 100점 달성',
+    subGoals: [
+      'Reading 25점 이상',
+      'Listening 25점 이상',
+      'Speaking 23점 이상',
+      'Writing 25점 이상',
+      'Grammar 복습',
+      '학습 루틴 관리',
+      '오답노트 작성',
+      '시험일 컨디션 관리',
+    ],
+    language: 'ko' as const,
+  };
+
+  test('TEPS material dropped — passes center ("토플"? no) but no sub_goal overlap', () => {
+    // This video has no 토플 token — should fail Gate 1 and be dropped.
+    const result = applyMandalaFilter(
+      [cand('v1', '텝스 단어 자면서 외우는 기출텝스 보카', '영어 공부')],
+      input
+    );
+    for (const list of result.values()) expect(list).toHaveLength(0);
+  });
+
+  test('real TOEFL Reading video routed to Reading cell', () => {
+    const result = applyMandalaFilter(
+      [cand('v2', '토플 Reading 만점 전략', '토플 Reading 지문 빠르게 읽는 법 25점 이상 목표')],
+      input
+    );
+    const reading = result.get(0) ?? [];
+    expect(reading).toHaveLength(1);
+    expect(reading[0]!.score).toBeGreaterThan(0);
+  });
+});
+
+describe('applyMandalaFilter — score ordering', () => {
+  test('per-cell results sorted by score desc', () => {
+    const input = {
+      centerGoal: '요리 입문자 한식 마스터',
+      subGoals: [
+        '밥 짓기 기초',
+        '국 끓이기',
+        '반찬 만들기',
+        '김치 담그기',
+        '찌개 끓이기',
+        '양념 이해',
+        '조리도구 활용',
+        '한식 상차림',
+      ],
+      language: 'ko' as const,
+    };
+    const candidates: FilterCandidate[] = [
+      cand('high', '한식 반찬 만들기 완벽 가이드', '반찬 만들기 반찬 반찬'),
+      cand('med', '한식 요리 반찬 간단 레시피', '요리 기본'),
+      cand('low', '한식 반찬 조금', ''),
+    ];
+    const result = applyMandalaFilter(candidates, input);
+    const list = result.get(2) ?? []; // 반찬 만들기 is cell 2
+    expect(list.length).toBeGreaterThanOrEqual(2);
+    for (let i = 1; i < list.length; i++) {
+      expect(list[i - 1]!.score).toBeGreaterThanOrEqual(list[i]!.score);
+    }
+  });
+});
+
+describe('applyMandalaFilter — empty input and edge cases', () => {
+  test('empty candidates returns empty per-cell lists', () => {
+    const result = applyMandalaFilter([], {
+      centerGoal: '무언가',
+      subGoals: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+      language: 'ko',
+    });
+    expect(result.size).toBe(8);
+    for (const list of result.values()) expect(list).toHaveLength(0);
+  });
+
+  test('empty centerGoal keeps center gate open (sub_goal alone decides)', () => {
+    const result = applyMandalaFilter([cand('v1', '아침 루틴 정리', '아침 루틴 매일')], {
+      centerGoal: '',
+      subGoals: ['아침 루틴 설계', 'x', 'x', 'x', 'x', 'x', 'x', 'x'],
+      language: 'ko',
+    });
+    const list = result.get(0) ?? [];
+    expect(list).toHaveLength(1);
+  });
+
+  test('MIN_SUB_RELEVANCE threshold is public and 0.05', () => {
+    expect(MIN_SUB_RELEVANCE).toBe(0.05);
+  });
+});

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -30,10 +30,10 @@ import type {
 
 import { manifest, V3_TARGET_PER_CELL, V3_NUM_CELLS, V3_TARGET_TOTAL } from './manifest';
 import { matchFromVideoPool, groupByCell } from './cache-matcher';
+import { applyMandalaFilter, MIN_SUB_RELEVANCE } from './mandala-filter';
 
 import {
   buildRuleBasedQueriesSync,
-  extractCoreKeyphrase,
   runLLMQueries,
   type KeywordLanguage,
   type SearchQuery,
@@ -52,10 +52,29 @@ const log = logger.child({ module: 'video-discover/v3/executor' });
 const TTL_DAYS = 7;
 const RECOMMENDATION_STATUS_PENDING = 'pending';
 const WEIGHT_VERSION = 3;
-const MIN_TIER2_RELEVANCE = 0.05;
+// Retained as a reference; the actual value now lives in mandala-filter.ts
+// (MIN_SUB_RELEVANCE). Both are 0.05 and kept in sync intentionally.
+void MIN_SUB_RELEVANCE;
 // How many search queries to attempt per deficit cell (rule-based + LLM
 // together; the LLM pass yields at most a handful for the whole mandala).
 const TIER2_MAX_QUERIES_PER_CELL = 2;
+
+/**
+ * Tier 1 (video_pool cache) is disabled by default (2026-04-16).
+ *
+ * The current pool holds ~1k rows dominated (~60%) by `user-derived`
+ * leftovers from past mandalas. At that scale embedding cosine (≥0.3)
+ * produces cross-topic hits — e.g. "하느님 자비의 기도" admitted into a
+ * "일일 습관 성장" mandala because both land near each other in the
+ * generic Korean self-help cluster. Until the pool reaches a useful
+ * scale (10⁵–10⁶ rows) and/or is replaced with a domain-tuned model,
+ * we skip Tier 1 entirely and route every request through Tier 2.
+ *
+ * The pgvector index, matchFromVideoPool function, and upsert path all
+ * remain intact. Flip this env flag (V3_ENABLE_TIER1_CACHE=true) to
+ * reactivate without a code change.
+ */
+const V3_ENABLE_TIER1_CACHE = process.env['V3_ENABLE_TIER1_CACHE'] === 'true';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -169,12 +188,14 @@ export const executor: SkillExecutor = {
     const state = ctx.state as unknown as HydratedState;
     const mandalaId = ctx.mandalaId!;
 
-    // ── Tier 1: video_pool cache ────────────────────────────────────────
-    const tier1Matches = await matchFromVideoPool({
-      mandalaId,
-      language: state.language,
-      perCell: V3_TARGET_PER_CELL,
-    });
+    // ── Tier 1: video_pool cache (disabled by default — see V3_ENABLE_TIER1_CACHE)
+    const tier1Matches = V3_ENABLE_TIER1_CACHE
+      ? await matchFromVideoPool({
+          mandalaId,
+          language: state.language,
+          perCell: V3_TARGET_PER_CELL,
+        })
+      : [];
     const tier1ByCell = groupByCell(tier1Matches, V3_NUM_CELLS);
     const tier1Total = tier1Matches.length;
 
@@ -365,68 +386,34 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   }
   if (enriched.length === 0) return { slots: [], queriesUsed };
 
-  // Score enriched videos against deficit cell sub_goals only (other cells
-  // already full from Tier 1). Uses local tokenize/jaccard so v3 has no
-  // runtime dependency on v2's private helpers.
-  //
-  // Relevance gate is TWO-pronged to prevent cross-topic contamination
-  // (e.g. "한 달안에 토플 100점 달성"의 Reading 셀에 텝스/토익 영상이
-  // 붙는 현상, observed 2026-04-16):
-  //   1. Video must share at least one center-goal token — ensures
-  //      domain-level fit (e.g. 토플).
-  //   2. Video must share at least one cell sub_goal token — ensures
-  //      cell-level fit (e.g. reading).
-  // Videos meeting only one are dropped: that's how "영어 기출" TEPS
-  // material slipped into a TOEFL Reading cell (shared "영어" but no
-  // TOEFL/reading overlap).
-  // Center tokens are drawn from the extracted core keyphrase (drops
-  // year prefixes, verbal endings, common particles) so the gate hinges
-  // on the domain-specific words only — e.g. "한 달안에 토플 100점
-  // 달성 하기" reduces to "토플" after noise is stripped, and a video
-  // must carry that token in its title to count as in-domain.
-  const centerCore = extractCoreKeyphrase(input.state.centerGoal, input.state.language);
-  const centerTokens = tokenize(centerCore, input.state.language);
-  const cellTokenSets = new Map<number, Set<string>>();
-  for (const { cellIndex } of input.deficitCells) {
-    cellTokenSets.set(
-      cellIndex,
-      tokenize(input.state.subGoals[cellIndex] ?? '', input.state.language)
-    );
-  }
-
+  // 9-axis mandala filter: the mandala itself (centerGoal + 8 sub_goals) is
+  // the filter. applyMandalaFilter routes each candidate to the best-fit
+  // sub_goal cell and drops off-domain candidates. This replaces the prior
+  // v3-internal two-gate (3368d34/ff35fcf) so Tier 1 and Tier 2 share the
+  // exact same filter logic — see mandala-filter.ts for the contract.
   interface ScoredCandidate {
     video: Enriched;
     cellIndex: number;
     score: number;
   }
+  const filterable = enriched.filter((v) => !input.existingVideoIds.has(v.videoId));
+  const byCell = applyMandalaFilter(filterable, {
+    centerGoal: input.state.centerGoal,
+    subGoals: input.state.subGoals,
+    language: input.state.language,
+  });
+
+  // Flatten into a single scored list (per-cell order preserved inside the
+  // map by applyMandalaFilter; overall sort happens again below because the
+  // cap-per-cell loop needs a global desc order to pick the best slots
+  // across cells fairly).
+  const deficitCellSet = new Set(input.deficitCells.map((c) => c.cellIndex));
   const scored: ScoredCandidate[] = [];
-  for (const v of enriched) {
-    if (input.existingVideoIds.has(v.videoId)) continue;
-
-    // Gate 1 uses TITLE ONLY against center goal. Descriptions frequently
-    // carry brand cross-references (e.g. a TEPS video's description
-    // mentioning "해커스 토플") that let unrelated videos sneak past a
-    // desc-inclusive gate. Title is the signal the user actually reads.
-    const titleTokens = tokenize(v.title, input.state.language);
-    const centerScore = jaccard(titleTokens, centerTokens);
-    if (centerTokens.size > 0 && centerScore === 0) continue;
-
-    // Gate 2 uses title + description against each cell's sub_goal —
-    // descriptions are fair game here because we're trying to assign to
-    // the best-fitting cell, not to filter domain membership.
-    const vTokens = tokenize(`${v.title} ${v.description ?? ''}`, input.state.language);
-    let bestCell = -1;
-    let bestScore = 0;
-    for (const [cellIndex, tokens] of cellTokenSets) {
-      const s = jaccard(vTokens, tokens);
-      if (s > bestScore) {
-        bestScore = s;
-        bestCell = cellIndex;
-      }
+  for (const [cellIndex, list] of byCell) {
+    if (!deficitCellSet.has(cellIndex)) continue;
+    for (const a of list) {
+      scored.push({ video: a.candidate, cellIndex, score: a.score });
     }
-    if (bestCell === -1 || bestScore < MIN_TIER2_RELEVANCE) continue;
-    const finalScore = (centerScore + bestScore) / 2;
-    scored.push({ video: v, cellIndex: bestCell, score: finalScore });
   }
 
   // Cap per cell using the deficit need + overall target remaining.
@@ -607,97 +594,4 @@ async function upsertSlots(
     }
   }
   return count;
-}
-
-// ============================================================================
-// Tokenization (duplicated from v2 — keeping v3 self-contained so v2 stays
-// untouched and rollback is trivial)
-// ============================================================================
-
-const KO_STOPWORDS = new Set([
-  '및',
-  '등',
-  '하기',
-  '되기',
-  '관련',
-  '방법',
-  '위한',
-  '통한',
-  '이상',
-  '이하',
-  '대해',
-  '으로',
-  '에서',
-  '에게',
-  '한다',
-  '있다',
-  '없다',
-  '그리고',
-  '하지만',
-  '또한',
-]);
-const EN_STOPWORDS = new Set([
-  'a',
-  'an',
-  'the',
-  'of',
-  'in',
-  'on',
-  'at',
-  'to',
-  'for',
-  'with',
-  'by',
-  'and',
-  'or',
-  'but',
-  'is',
-  'are',
-  'was',
-  'were',
-  'be',
-  'been',
-  'being',
-  'have',
-  'has',
-  'had',
-  'do',
-  'does',
-  'did',
-  'how',
-  'what',
-  'why',
-  'when',
-  'where',
-  'this',
-  'that',
-  'these',
-  'those',
-  'my',
-  'your',
-  'our',
-  'their',
-  'from',
-  'as',
-  'it',
-]);
-
-function tokenize(text: string, language: KeywordLanguage): Set<string> {
-  if (!text) return new Set();
-  const stops = language === 'ko' ? KO_STOPWORDS : EN_STOPWORDS;
-  const cleaned = text
-    .toLowerCase()
-    .replace(/&[a-z#0-9]+;/g, ' ')
-    .replace(/[^\p{L}\p{N}\s]/gu, ' ');
-  const tokens = cleaned.split(/\s+/).filter((t) => t.length >= 2 && !stops.has(t));
-  return new Set(tokens);
-}
-
-function jaccard(videoTokens: Set<string>, cellTokens: Set<string>): number {
-  if (cellTokens.size === 0 || videoTokens.size === 0) return 0;
-  let hits = 0;
-  for (const t of cellTokens) {
-    if (videoTokens.has(t)) hits++;
-  }
-  return hits / cellTokens.size;
 }

--- a/src/skills/plugins/video-discover/v3/mandala-filter.ts
+++ b/src/skills/plugins/video-discover/v3/mandala-filter.ts
@@ -1,0 +1,188 @@
+/**
+ * v3 Mandala Filter — 9-axis relevance gate for candidate videos.
+ *
+ * Philosophy (2026-04-16): collect wide, filter via the mandala itself
+ * (1 centerGoal + 8 sub_goals). The mandala structure IS the filter.
+ *
+ *   Gate 1 (center, substring-match): the title must contain at least one
+ *     token from extractCoreKeyphrase(centerGoal). Substring match — so
+ *     "수능" admits "수능특강" but not "한능검".
+ *     Rejects off-domain candidates (e.g. "하느님 자비의 기도" in a
+ *     "일일 습관 성장" mandala).
+ *
+ *   Gate 2 (sub_goal, jaccard): title+description must overlap with one of
+ *     the 8 sub_goals above MIN_SUB_RELEVANCE. The best-fit sub_goal
+ *     becomes the cell assignment (argmax).
+ *
+ * Final score = 0.5 · centerScore + 0.5 · bestCellScore ∈ [0, 1].
+ * The downstream consumer sorts per-cell score desc and takes top-N.
+ * Empty cells stay empty — we never fill with garbage.
+ */
+
+import { extractCoreKeyphrase, type KeywordLanguage } from '../v2/keyword-builder';
+
+/** Minimum jaccard overlap with a sub_goal for a candidate to be routed. */
+export const MIN_SUB_RELEVANCE = 0.05;
+
+/** Shape the filter needs — any candidate source (pool, search, future). */
+export interface FilterCandidate {
+  videoId: string;
+  title: string;
+  description: string | null;
+}
+
+export interface ScoredAssignment<T extends FilterCandidate> {
+  candidate: T;
+  cellIndex: number;
+  /** Final score, range 0..1, used for per-cell ranking. */
+  score: number;
+  /** Gate 1 component. */
+  centerScore: number;
+  /** Gate 2 component (best sub_goal jaccard). */
+  cellScore: number;
+}
+
+export interface MandalaFilterInput {
+  centerGoal: string;
+  subGoals: ReadonlyArray<string>; // length 8
+  language: KeywordLanguage;
+}
+
+/**
+ * Apply the 9-axis mandala filter. Returns assignments grouped by cell,
+ * each list sorted by score desc. Drops candidates that fail the center
+ * gate or don't clear MIN_SUB_RELEVANCE on any sub_goal.
+ */
+export function applyMandalaFilter<T extends FilterCandidate>(
+  candidates: ReadonlyArray<T>,
+  input: MandalaFilterInput
+): Map<number, ScoredAssignment<T>[]> {
+  const centerCore = extractCoreKeyphrase(input.centerGoal, input.language);
+  const centerTokens = tokenize(centerCore, input.language);
+
+  const subGoalTokens: Set<string>[] = input.subGoals.map((sg) => tokenize(sg, input.language));
+
+  const byCell = new Map<number, ScoredAssignment<T>[]>();
+  for (let i = 0; i < input.subGoals.length; i++) byCell.set(i, []);
+
+  for (const c of candidates) {
+    const titleTokens = tokenize(c.title, input.language);
+    const centerScore = substringOverlap(centerTokens, titleTokens);
+    if (centerTokens.size > 0 && centerScore === 0) continue;
+
+    const bodyTokens = tokenize(`${c.title} ${c.description ?? ''}`, input.language);
+
+    let bestCell = -1;
+    let bestScore = 0;
+    for (let i = 0; i < subGoalTokens.length; i++) {
+      const sg = subGoalTokens[i];
+      if (!sg) continue;
+      const s = jaccard(bodyTokens, sg);
+      if (s > bestScore) {
+        bestScore = s;
+        bestCell = i;
+      }
+    }
+    if (bestCell === -1 || bestScore < MIN_SUB_RELEVANCE) continue;
+
+    const final = 0.5 * centerScore + 0.5 * bestScore;
+    byCell.get(bestCell)!.push({
+      candidate: c,
+      cellIndex: bestCell,
+      score: final,
+      centerScore,
+      cellScore: bestScore,
+    });
+  }
+
+  for (const list of byCell.values()) {
+    list.sort((a, b) => b.score - a.score);
+  }
+  return byCell;
+}
+
+/**
+ * Substring overlap between center tokens and title tokens. Any pair where
+ * one is a substring of the other counts as a hit. This lets "수능" admit
+ * compound words like "수능특강" while still rejecting "한능검".
+ * Returns hits / centerTokens.size ∈ [0, 1].
+ */
+function substringOverlap(centerTokens: Set<string>, titleTokens: Set<string>): number {
+  if (centerTokens.size === 0) return 0;
+  let hits = 0;
+  for (const ct of centerTokens) {
+    for (const tt of titleTokens) {
+      if (tt.includes(ct) || ct.includes(tt)) {
+        hits++;
+        break;
+      }
+    }
+  }
+  return hits / centerTokens.size;
+}
+
+function jaccard(bodyTokens: Set<string>, subGoalTokens: Set<string>): number {
+  if (bodyTokens.size === 0 || subGoalTokens.size === 0) return 0;
+  let hits = 0;
+  for (const t of subGoalTokens) if (bodyTokens.has(t)) hits++;
+  return hits / subGoalTokens.size;
+}
+
+const KO_STOPWORDS = new Set([
+  '및',
+  '등',
+  '하기',
+  '되기',
+  '관련',
+  '방법',
+  '위한',
+  '통한',
+  '이상',
+  '이하',
+  '대해',
+  '으로',
+  '에서',
+  '에게',
+  '한다',
+  '있다',
+  '없다',
+  '그리고',
+  '하지만',
+  '또한',
+]);
+const EN_STOPWORDS = new Set([
+  'a',
+  'an',
+  'the',
+  'of',
+  'in',
+  'on',
+  'at',
+  'to',
+  'for',
+  'with',
+  'by',
+  'and',
+  'or',
+  'but',
+  'is',
+  'are',
+  'was',
+  'were',
+  'be',
+  'been',
+  'from',
+  'as',
+  'it',
+]);
+
+function tokenize(text: string, language: KeywordLanguage): Set<string> {
+  if (!text) return new Set();
+  const stops = language === 'ko' ? KO_STOPWORDS : EN_STOPWORDS;
+  const cleaned = text
+    .toLowerCase()
+    .replace(/&[a-z#0-9]+;/g, ' ')
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ');
+  const tokens = cleaned.split(/\s+/).filter((t) => t.length >= 2 && !stops.has(t));
+  return new Set(tokens);
+}


### PR DESCRIPTION
## Context

Prod incident **2026-04-16 evening**: every user-created mandala returned
unrelated videos.

- "일일 습관 성장" mandala surfaced "하느님 자비의 기도", "부업추천",
  "정보처리기능사 필기" (spiritual / side-hustle / IT cert material in a
  daily-habit mandala).
- "수능 대비 100일" mandala surfaced "한능검" (Korean history test, not
  the Korean SAT).
- Same pattern across every sampled mandala.

## Root cause

v3's recommendation pipeline has two candidate sources, run in order:

| Source | What it does |
|--------|--------------|
| **Tier 1 (cache)** | Reads the `video_pool` table and matches videos to each sub_goal via pgvector cosine similarity (threshold 0.3). |
| **Tier 2 (fresh)** | Calls YouTube `search.list`, enriches with `videos.list`, then applies a keyword / jaccard filter. |

**Tier 1 runs first. In prod it fills 100% of the deficit slots, so Tier 2 never executes.** Verified directly in the DB: on two sampled mandalas, every row in `recommendation_cache` had `rec_reason = 'cache'`.

Two compounding issues inside Tier 1:

1. **Pool composition**: 631 of 1024 rows (~60%) are `user-derived` leftovers from past users' mandalas. No curation, no quality floor.
2. **Cosine 0.3 is too permissive** at this pool size. Generic Korean self-help content clusters together in embedding space, so "하느님 자비의 기도" lands within 0.3–0.5 cosine of "저녁 성찰 및 회고 습관" and gets admitted.

The earlier two-gate fixes (`3368d34`, `ff35fcf`) did the right thing but in the wrong place — they live inside Tier 2, which never runs.

## What this change does

### 1. Disables Tier 1 by default

The cache-matching function (`matchFromVideoPool`), pgvector index, and upsert logic are all **preserved** — we just stop calling them until the pool reaches a useful scale (rough target: 10⁵–10⁶ rows) and/or a domain-tuned embedding model.

Gated by a new env flag **`V3_ENABLE_TIER1_CACHE`** (default off). Set to `'true'` to reactivate without any code change.

While off, every request flows through Tier 2 only.

### 2. New `mandala-filter.ts` — the mandala is the filter

A shared relevance filter that uses the mandala itself (1 centerGoal + 8 sub_goals) to score and route every candidate.

For each candidate video:

- **Gate 1** — substring match between the title and tokens of `extractCoreKeyphrase(centerGoal)`. Admits compound words ("수능" matches "수능특강") while rejecting unrelated topics ("한능검" has no "수능"). **Off-domain candidates drop here.**
- **Gate 2** — jaccard overlap of title+description against each of the 8 sub_goals. The highest-scoring sub_goal decides which cell the candidate lands in. Below `MIN_SUB_RELEVANCE` (0.05) → dropped.
- **Score** — `0.5·centerScore + 0.5·bestCellScore`. Per-cell results sorted by score desc; caller takes top-N and leaves empty cells empty (no garbage backfill).

Tier 2's executor now calls `applyMandalaFilter` directly instead of its own inline two-gate loop, so both sources (when Tier 1 is eventually re-enabled) will go through **identical** relevance logic.

## Why not alternatives

- **Just raise the cosine threshold (0.3 → 0.5)?** Bandaid at this pool size. Embedding quality is the real limit, and boundary cases still leak. Vocabulary-level filtering is the right primitive until the pool and the model both grow.
- **Truncate `video_pool`?** With Tier 1 disabled the pool can't cause harm, and keeping it avoids re-embedding work when we eventually re-enable (possibly with a curated purge at that point).

## Tests

`mandala-filter.test.ts` — 11 cases:
- Drops the prod-observed garbage: 하느님, 부업, 정보처리기능사, 한능검, TEPS-in-TOEFL.
- Admits the intentional boundary case: "2027 수능특강 영어독해" passes Gate 1 for a "수능" mandala via substring match.
- Routes a real TOEFL Reading video to the Reading cell.
- Verifies per-cell results are sorted score desc.

Existing v3 cache-matcher tests unchanged (still pass).

## Post-deploy steps (to perform after merge + deploy)

1. Confirm new image sha is live on `insighta-api`.
2. **`DELETE FROM recommendation_cache;`** — clear the garbage-cached rows so existing mandalas regenerate on next dashboard load. Pre-launch, no user data loss concern.
3. Regenerate "일일 습관 성장" and "수능 대비 100일" mandalas; confirm none of the garbage titles appear in the new `recommendation_cache` rows.
4. `recommendation_cache.rec_reason` column should read `'realtime'` for every new row while Tier 1 remains disabled.

## Follow-ups (separate PRs)

- **Step 1.5**: surface `rec_score` as a quality badge in `InsightCardItemV2`. The score is already stored in `recommendation_cache` but currently only read by `FeedCard`.
- **Step 2**: YouTube channel whitelist + `playlistItems.list` for quota-safe pool growth (1 unit per page vs search's 100).
- **Step 3**: PubSubHubbub webhook to eliminate polling cost.
- **Step 5**: domain-tuned embedding model + Tier 1 re-enabled once the pool is both large and curated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
