### PR TITLE
fix(video-discover): null-guard shorts filter + #shorts title check

### DIFF
--- a/src/skills/plugins/video-discover/__tests__/v2-youtube-client.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v2-youtube-client.test.ts
@@ -10,6 +10,7 @@ import {
   videosBatch,
   parseIsoDuration,
   isShortsByDuration,
+  titleIndicatesShorts,
   titleHitsBlocklist,
 } from '../v2/youtube-client';
 
@@ -100,11 +101,35 @@ describe('parseIsoDuration', () => {
 });
 
 describe('filters', () => {
-  test('isShortsByDuration', () => {
+  test('isShortsByDuration — duration-based', () => {
     expect(isShortsByDuration(30)).toBe(true);
     expect(isShortsByDuration(60)).toBe(true);
     expect(isShortsByDuration(61)).toBe(false);
-    expect(isShortsByDuration(null)).toBe(false);
+  });
+
+  test('isShortsByDuration — null defensively treated as shorts', () => {
+    // Prod bug 2026-04-16: `videos.list` sometimes returns an item
+    // without contentDetails.duration, so `parseIsoDuration` yields
+    // null. Previously this returned false (= "not shorts") and let
+    // a shorts video surface in a habit-building mandala. The safe
+    // answer when we cannot confirm long-form is to drop.
+    expect(isShortsByDuration(null)).toBe(true);
+  });
+
+  test('titleIndicatesShorts — hashtag markers only', () => {
+    expect(titleIndicatesShorts('더 이상 구입하지 않는 물건 3가지 #shorts')).toBe(true);
+    expect(titleIndicatesShorts('Study routine #Shorts #미니멀라이프')).toBe(true);
+    expect(titleIndicatesShorts('【shorts】 1분 스트레칭')).toBe(true);
+    expect(titleIndicatesShorts('「shorts」 tips')).toBe(true);
+  });
+
+  test('titleIndicatesShorts — does NOT match the plain word "short"', () => {
+    // Avoid false-positives on normal titles that happen to contain
+    // "short" as a word (e.g. "short book review"). Only true shorts
+    // hashtags/brackets count.
+    expect(titleIndicatesShorts('A short book review')).toBe(false);
+    expect(titleIndicatesShorts('short film director interview')).toBe(false);
+    expect(titleIndicatesShorts('')).toBe(false);
   });
 
   test('titleHitsBlocklist case-insensitive', () => {

--- a/src/skills/plugins/video-discover/v2/executor.ts
+++ b/src/skills/plugins/video-discover/v2/executor.ts
@@ -39,6 +39,7 @@ import {
   videosBatch,
   parseIsoDuration,
   isShortsByDuration,
+  titleIndicatesShorts,
   titleHitsBlocklist,
   type YouTubeVideoStatsItem,
 } from './youtube-client';
@@ -234,9 +235,12 @@ export const executor: SkillExecutor = {
     }
     const candidates = enrichWithStats(pool, stats);
 
-    // 4. Pre-filter (shorts + blocklist)
+    // 4. Pre-filter (shorts duration + shorts title markers + blocklist)
     const filtered = candidates.filter(
-      (c) => !isShortsByDuration(c.durationSec) && !titleHitsBlocklist(c.title)
+      (c) =>
+        !isShortsByDuration(c.durationSec) &&
+        !titleIndicatesShorts(c.title) &&
+        !titleHitsBlocklist(c.title)
     );
 
     if (filtered.length === 0) {

--- a/src/skills/plugins/video-discover/v2/youtube-client.ts
+++ b/src/skills/plugins/video-discover/v2/youtube-client.ts
@@ -170,8 +170,31 @@ export const V2_TITLE_BLOCKLIST: ReadonlyArray<string> = [
   '광고',
 ];
 
+/**
+ * Shorts are excluded from AI recommendations — users can add them
+ * manually, but the discovery pipeline recommends long-form only.
+ *
+ * Null duration is treated as shorts (defensive drop). The prior
+ * `durationSec !== null && durationSec <= 60` variant returned false
+ * for null, letting videos past whenever `videos.list` enrichment
+ * failed to populate contentDetails.duration. Observed in prod
+ * 2026-04-16: a "더 이상 구입하지 않는 물건 3가지 #미니멀라이프"
+ * shorts survived this hole and surfaced in a habit-building mandala.
+ */
 export function isShortsByDuration(durationSec: number | null): boolean {
-  return durationSec !== null && durationSec <= 60;
+  return durationSec === null || durationSec <= 60;
+}
+
+/**
+ * Secondary shorts signal based on title markers. Catches cases where
+ * duration is present and > 60s (unusual edit) but the title still
+ * carries #shorts-style tags. Scoped to literal hashtags / brackets
+ * so normal titles containing the word "short" (e.g. "short book
+ * review") are not affected.
+ */
+export function titleIndicatesShorts(title: string): boolean {
+  if (!title) return false;
+  return /#shorts\b|【\s*shorts?\s*】|「\s*shorts?\s*」/i.test(title);
 }
 
 export function titleHitsBlocklist(title: string): boolean {

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -43,6 +43,7 @@ import {
   videosBatch,
   parseIsoDuration,
   isShortsByDuration,
+  titleIndicatesShorts,
   titleHitsBlocklist,
   type YouTubeVideoStatsItem,
 } from '../v2/youtube-client';
@@ -375,6 +376,7 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     const likeCount = s?.statistics?.likeCount ? parseInt(s.statistics.likeCount, 10) : null;
     const durationSec = parseIsoDuration(s?.contentDetails?.duration);
     if (isShortsByDuration(durationSec)) continue;
+    if (titleIndicatesShorts(p.title)) continue;
     if (titleHitsBlocklist(p.title)) continue;
     enriched.push({
       ...p,


### PR DESCRIPTION
## Context

Prod incident **2026-04-16 evening** — shorts leaking into AI recommendations despite the existing shorts filter. Example surfaced to user: \"더 이상 구입하지 않는 물건 3가지 #미니멀라이프\" inside a \"한 달 데일리루틴\" mandala.

Policy: shorts are for **manual user addition** only. The AI discovery pipeline recommends long-form videos only.

## Root cause

Two holes in the existing filter:

### 1. `isShortsByDuration(null)` returned `false`

```ts
// before
return durationSec !== null && durationSec <= 60;
```

`videos.list` sometimes returns an item without `contentDetails.duration` — API timing, shorts-specific payload shape, or transient missing field. In those cases `parseIsoDuration` yields `null`, and the old check said \"not shorts\" and let the video through.

### 2. Duration > 60s but tagged #shorts

Some shorts are filmed as 70–90s clips. Duration alone passes them, but YouTube (and the user) still treats them as shorts. The title is the secondary reliable signal.

## What this change does

### `isShortsByDuration` — null means drop

```ts
return durationSec === null || durationSec <= 60;
```

If we cannot confirm the video is long-form, we drop. The old smoke test that pinned this as `false` for null is flipped and commented with the reason so the intent can't regress silently again.

### `titleIndicatesShorts` (new)

Matches `#shorts` hashtag markers and `【shorts】` / `「shorts」` bracket conventions. Intentionally scoped so normal titles containing the word \"short\" (e.g. \"a short book review\") are not false-positives.

Applied in both `v2/executor.ts` and `v3/executor.ts` at the same pre-filter stage that already runs `isShortsByDuration` + `titleHitsBlocklist`.

## Tests

`v2-youtube-client.test.ts`:
- `isShortsByDuration` — duration-based cases kept; **null now returns true** (regression lock on the fix).
- `titleIndicatesShorts` — positive: `#shorts`, `#Shorts`, `【shorts】`, `「shorts」`. Negative: \"A short book review\", \"short film director interview\", empty string.

14/14 pass (backend jest).

## Scope note

The Tier 1 cache matcher (`video_pool`) is currently disabled via `V3_ENABLE_TIER1_CACHE`; its SQL query does not apply a duration filter either. When the cache is eventually re-enabled (pool scale + curated model), adding `duration_seconds > 60` to the match query will be part of that change — tracked in the follow-up design.

## Post-deploy verification

1. Confirm new image sha live on `insighta-api`.
2. Generate a new mandala (or let existing ones refresh after cache expiry) — no shorts should appear in the recommendation cells.
3. Verify `recommendation_cache.rec_reason = 'realtime'` rows do not contain entries with duration ≤ 60s or `#shorts`-tagged titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/399" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
