### PR TITLE
fix(video-discover): widen candidate pool (12 queries, 8/8 sub_goal coverage); per-cell cap not floor

### DIFF
--- a/src/skills/plugins/video-discover/v2/keyword-builder.ts
+++ b/src/skills/plugins/video-discover/v2/keyword-builder.ts
@@ -77,11 +77,14 @@ export interface SearchQuery {
   cellIndex?: number | null;
 }
 
-// Bumped 5 → 8 (2026-04-15) so Tier 2 has a deeper YouTube pool to draw
-// from when the local cache is empty and topics like "해외 리모트" return
-// few results per query. 8 × search.list (100 units) = 800 quota/mandala
-// — still well under the 10k/day budget for typical usage (≥12 mandalas).
-export const MAX_QUERIES = 8;
+// Bumped 8 → 12 (2026-04-16) so the candidate pool is large enough for the
+// mandala filter to produce a natural per-cell distribution (rather than
+// mechanically 5-each). With 8 sub_goals each covered by a rule query +
+// core/focus/level heads, ~12 queries land the floor; the LLM pass adds
+// a few more on top up to the cap. 12 × search.list (100 units) = 1200
+// quota/mandala — still inside the 10k/day budget at ~8 mandalas/day.
+// Further growth is gated on the Step 2 seed dictionary + API quota uplift.
+export const MAX_QUERIES = 12;
 export const MAX_QUERY_LENGTH = 100;
 
 const TARGET_LEVEL_KEYWORDS: Record<string, Record<KeywordLanguage, string>> = {
@@ -210,10 +213,13 @@ function buildRuleBasedQueries(input: KeywordBuilderInput, center: string): Sear
       out.push({ query: clip(`${center} ${map[input.language]}`), source: 'level' });
     }
   }
-  // 2 → 4 sub_goals (2026-04-15). Specific topics (e.g. "해외 리모트")
-  // produce few YouTube hits per query — broader sub_goal coverage gives
-  // Tier 2 a deeper pool to fill cells with.
-  for (const { s, i } of pickDistinctiveSubGoalsWithIndex(input.subGoals, 4)) {
+  // 4 → 8 sub_goals (2026-04-16). With the 9-axis mandala filter, the
+  // candidate distribution across cells is only as balanced as the query
+  // coverage. Covering all 8 sub_goals guarantees every cell has at least
+  // one query seeded specifically for it. Niche cells can still come up
+  // empty if no relevant video exists — that is the intended honest
+  // behavior, not a symptom of missing queries.
+  for (const { s, i } of pickDistinctiveSubGoalsWithIndex(input.subGoals, 8)) {
     out.push({ query: clip(`${center} ${s}`), source: 'subgoal', cellIndex: i });
   }
   return out;

--- a/src/skills/plugins/video-discover/v3/manifest.ts
+++ b/src/skills/plugins/video-discover/v3/manifest.ts
@@ -13,9 +13,24 @@
 import type { SkillManifest } from '@/skills/_shared/types';
 import { defineManifest } from '@/skills/_shared/runtime';
 
-export const V3_TARGET_PER_CELL = 5;
+/**
+ * Per-cell cap (not a target floor). With the 9-axis mandala filter,
+ * the per-cell distribution is determined by how many relevant videos
+ * actually exist for that sub_goal — it is not forced equal across
+ * cells. Some cells may come up empty (niche sub_goal), others may
+ * fill to this cap (mainstream sub_goal). 5 → 8 (2026-04-16): a larger
+ * cap gives the filter room to reflect the natural distribution
+ * instead of truncating popular cells.
+ */
+export const V3_TARGET_PER_CELL = 8;
 export const V3_NUM_CELLS = 8;
-export const V3_TARGET_TOTAL = V3_TARGET_PER_CELL * V3_NUM_CELLS; // 40
+/**
+ * Upper bound on total slots across the mandala. Used by the executor
+ * to decide when to skip Tier 2 (if Tier 1 alone hit this count). With
+ * Tier 1 disabled, total filling is driven entirely by what the filter
+ * admits from Tier 2, bounded per-cell by V3_TARGET_PER_CELL.
+ */
+export const V3_TARGET_TOTAL = V3_TARGET_PER_CELL * V3_NUM_CELLS; // 64
 
 export const manifest: SkillManifest = defineManifest({
   id: 'video-discover-v3',


### PR DESCRIPTION
## Context

After PR #398 (9-axis mandala filter) shipped, prod showed uneven per-cell fill — e.g. "우리아이 공부 습관 형성하기" with cells `{0:5, 1:4, 2:1, 3:4, 4:5, 5:1, 6:0, 7:5}` (total 25/40 expected min). Mechanical "5-each" is not the product goal anyway; the filter should reflect the **actual distribution** of relevant videos.

Observation: the uneven fill was not caused by the filter being too strict — it was caused by the **candidate pool being too small** for the filter to produce a meaningful distribution. Niche sub_goals (e.g. "학습 성과 추적 및 피드백") received no queries at all, so no candidates were fetched for them to begin with.

## What this change does

### `v2/keyword-builder.ts`

| constant | before | after |
|----------|--------|-------|
| `MAX_QUERIES` | 8 | **12** |
| rule-based sub_goal coverage | 4 | **8** (all) |

Covering all 8 sub_goals guarantees every cell is seeded by one rule-based query. Niche cells can still come up empty after filtering — that is the **intended honest behavior**, not a symptom of missing queries.

### `v3/manifest.ts`

| constant | before | after | meaning |
|----------|--------|-------|---------|
| `V3_TARGET_PER_CELL` | 5 | **8** | per-cell **cap**, not a floor |
| `V3_TARGET_TOTAL`    | 40 | **64** | upper bound on total slots |

Name retained to avoid ripple across imports; doc comments rewritten to say "cap" explicitly so a future reader does not re-interpret this as a mechanical distribution target.

## Quota

Per mandala: 12 × search.list (100 units each) + ~5 × videos.list batches ≈ **1,200–1,250 units**. 10k/day budget supports ~8 mandalas/day — enough for the pre-launch window.

The long-term plan is Step 2 (seed dictionary + playlistItems.list channel collection) paired with a Google API quota uplift. That is explicitly out of scope here.

## Not changed

- `mandala-filter.ts` (`MIN_SUB_RELEVANCE = 0.05`) unchanged.
- Tier 1 video_pool cache still disabled by `V3_ENABLE_TIER1_CACHE`.
- No new round of YouTube search for deficit cells. Forced backfill violates the "don't mechanically fill 5 per cell" principle — empty cells stay empty.
- Per-video mandala routing is still argmax on sub_goal jaccard (single cell per video).

## Tests

34/34 pass across:
- `v2-keyword-builder.test.ts`
- `v3/__tests__/cache-matcher.test.ts`
- `v3/__tests__/mandala-filter.test.ts`

## Post-deploy verification

1. Confirm new image sha live on `insighta-api`.
2. Regenerate a test mandala and inspect `recommendation_cache`:
   - Total slots should trend higher than 25 (pre-change baseline).
   - Natural per-cell distribution expected — some cells at 5–8, some lower, some possibly 0 (niche sub_goals). **This is correct.**
3. Log watch: `tier2_queries` metric in the skill execution output should read 12 (up from ~8).

## Related PRs

- #397 wizard UX + Tier 2 C+ prompt (landed)
- #398 9-axis mandala filter + Tier 1 disable (landed)
- #399 shorts null-guard + #shorts title check (landed, this branch rebased on it)
- **#400 (this)** candidate pool widening

## Follow-ups (separate)

- Step 2 design: seed dictionary (macmini weekly batch → S3 → Redis import), channel whitelist + `playlistItems.list` collection path, Google Data API quota uplift application using the design as justification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
