### PR TITLE
fix(video-discover): raise shorts threshold 60s → 180s (YouTube 2024 policy)

### DIFF
--- a/src/skills/plugins/video-discover/__tests__/v2-youtube-client.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v2-youtube-client.test.ts
@@ -101,10 +101,16 @@ describe('parseIsoDuration', () => {
 });
 
 describe('filters', () => {
-  test('isShortsByDuration — duration-based', () => {
+  test('isShortsByDuration — duration-based (180s threshold per 2024 YouTube policy)', () => {
     expect(isShortsByDuration(30)).toBe(true);
     expect(isShortsByDuration(60)).toBe(true);
-    expect(isShortsByDuration(61)).toBe(false);
+    // Prod bug 2026-04-17: 110s video "한의대수석으로 만들어준 공부법
+    // #공부" slipped past the old 60s gate because YouTube widened Shorts
+    // from 60s to 180s in October 2024. Now caught.
+    expect(isShortsByDuration(110)).toBe(true);
+    expect(isShortsByDuration(180)).toBe(true);
+    expect(isShortsByDuration(181)).toBe(false);
+    expect(isShortsByDuration(600)).toBe(false);
   });
 
   test('isShortsByDuration — null defensively treated as shorts', () => {

--- a/src/skills/plugins/video-discover/v2/youtube-client.ts
+++ b/src/skills/plugins/video-discover/v2/youtube-client.ts
@@ -174,15 +174,19 @@ export const V2_TITLE_BLOCKLIST: ReadonlyArray<string> = [
  * Shorts are excluded from AI recommendations — users can add them
  * manually, but the discovery pipeline recommends long-form only.
  *
- * Null duration is treated as shorts (defensive drop). The prior
- * `durationSec !== null && durationSec <= 60` variant returned false
- * for null, letting videos past whenever `videos.list` enrichment
- * failed to populate contentDetails.duration. Observed in prod
- * 2026-04-16: a "더 이상 구입하지 않는 물건 3가지 #미니멀라이프"
- * shorts survived this hole and surfaced in a habit-building mandala.
+ * Threshold is 180 seconds (YouTube extended Shorts from 60s to 180s
+ * in October 2024). Prod 2026-04-17: a 110-second shorts titled
+ * "한의대수석으로 만들어준 공부법 #공부 #공부잘하는방법" surfaced in
+ * a "효율적인 학습법 탐색" mandala — duration passed the old 60s gate
+ * even though the video is clearly a short. The hashtag pattern also
+ * missed it because the title tagged `#공부` rather than `#shorts`.
+ *
+ * Null duration is treated as shorts (defensive drop). Videos.list
+ * occasionally omits `contentDetails.duration` for shorts specifically,
+ * so null → drop prevents that hole.
  */
 export function isShortsByDuration(durationSec: number | null): boolean {
-  return durationSec === null || durationSec <= 60;
+  return durationSec === null || durationSec <= 180;
 }
 
 /**


### PR DESCRIPTION
## Context

Prod 2026-04-17: a 110-second shorts titled \"한의대수석으로 만들어준 공부법 ... **#공부 #공부잘하는방법**\" surfaced inside a \"효율적인 학습법 탐색\" mandala (DB confirmed: `duration_sec=110`, cell_index=0).

- `duration_sec=110` **> 60** → old `isShortsByDuration ≤ 60` gate passed.
- Title used `#공부` (domain hashtag), not `#shorts` → `titleIndicatesShorts` missed.

## Root cause

**YouTube widened the Shorts format from 60s to 180s in October 2024.** The filter still encoded the pre-2024 rule. Any shorts filmed between 61s and 180s passed through duration unchallenged — and creators today routinely hit the 90–150s range rather than 60s.

## Fix

```ts
// isShortsByDuration
return durationSec === null || durationSec <= 180;  // 60 → 180
```

`titleIndicatesShorts` unchanged — still catches the rare >180s edits YouTube still classifies as shorts via explicit `#shorts` / `【shorts】` markers.

## Tests

`isShortsByDuration` boundary table:

| duration | classified as shorts? | notes |
|---------:|:----------------------|:------|
| 30       | ✅ yes                | existing |
| 60       | ✅ yes                | existing |
| **110**  | ✅ yes                | **this PR — prod regression lock** |
| 180      | ✅ yes                | new cap boundary, inclusive |
| 181      | ❌ no                 | first long-form duration |
| 600      | ❌ no                 | obvious long-form |

14/14 tests pass.

## Not in this PR

The wizard \"Go → dashboard\" 10-second delay the user also reported is **a separate issue**. Traced to `connection_limit=1` on the Supabase transaction pooler — the same `P2024` pattern we already know about. Optimistic UI is not the right fix until the pool bottleneck is resolved. That work lives in a follow-up PR.

## Post-deploy verification

1. Confirm new image sha live on `insighta-api`.
2. Regenerate a mandala and inspect `recommendation_cache` — no rows with `duration_sec <= 180`.
3. Previous prod offender (`duration_sec=110, #공부 hashtag`) should never re-appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
