### PR TITLE
fix(wizard+card-list): default sort to relevance + parallelize post-creation writes + timing log

### DIFF
--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -507,6 +507,7 @@
     "all": "All",
     "clearAll": "Clear all",
     "noFilterResults": "No cards match the selected filters",
+    "sortRelevance": "Relevance",
     "sortLatest": "Latest",
     "sortOldest": "Oldest",
     "sortTitleAZ": "Title A-Z",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -508,6 +508,7 @@
     "all": "전체",
     "clearAll": "모두 해제",
     "noFilterResults": "선택한 필터에 맞는 카드가 없습니다",
+    "sortRelevance": "관련성 순",
     "sortLatest": "최신순",
     "sortOldest": "오래된순",
     "sortTitleAZ": "제목 A-Z",

--- a/frontend/src/widgets/card-list-view/ui/CardListView.tsx
+++ b/frontend/src/widgets/card-list-view/ui/CardListView.tsx
@@ -158,7 +158,7 @@ export function CardListView({
   const [activeCard, setActiveCard] = useState<InsightCard | null>(null);
   const [isMobile, setIsMobile] = useState(false);
   const [selectedCardIds, setSelectedCardIds] = useState<string[]>([]);
-  const [sortMode, setSortMode] = useState<SortMode>('latest');
+  const [sortMode, setSortMode] = useState<SortMode>('relevance');
   const [isExternalDragOver, setIsExternalDragOver] = useState(false);
 
   // Native HTML5 external drag handlers (YouTube URL from browser etc.)
@@ -212,10 +212,16 @@ export function CardListView({
 
   const effectiveViewMode = viewMode === 'list-detail' && isMobile ? 'list' : viewMode;
 
-  // Sort cards based on sortMode
+  // Sort cards based on sortMode. 'relevance' is the default: it preserves
+  // server-side order (cell_index ASC, rec_score DESC from the API) so the
+  // caller sees the mandala filter's ranking instead of being overwritten
+  // by a client-side createdAt sort. The other modes are explicit user
+  // choices from the sort dropdown.
   const sortedCards = useMemo(() => {
     const arr = [...cards];
     switch (sortMode) {
+      case 'relevance':
+        return arr;
       case 'latest':
         return arr.sort((a, b) => {
           if (a.sortOrder !== undefined && b.sortOrder !== undefined)

--- a/frontend/src/widgets/card-list-view/ui/ContextHeader.tsx
+++ b/frontend/src/widgets/card-list-view/ui/ContextHeader.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuRadioItem,
 } from '@/shared/ui/dropdown-menu';
 
-export type SortMode = 'latest' | 'oldest' | 'title-asc' | 'title-desc';
+export type SortMode = 'relevance' | 'latest' | 'oldest' | 'title-asc' | 'title-desc';
 
 interface ContextHeaderProps {
   title: string;
@@ -25,6 +25,7 @@ interface ContextHeaderProps {
 }
 
 const SORT_OPTIONS: { value: SortMode; labelKey: string }[] = [
+  { value: 'relevance', labelKey: 'contextHeader.sortRelevance' },
   { value: 'latest', labelKey: 'contextHeader.sortLatest' },
   { value: 'oldest', labelKey: 'contextHeader.sortOldest' },
   { value: 'title-asc', labelKey: 'contextHeader.sortTitleAZ' },

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -790,18 +790,41 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         });
       }
 
-      const result = await getMandalaManager().createMandala(userId, title, levels);
+      // CP362 2026-04-17: prod wizard "Go → dashboard" hangs ~20s even after
+      // Prisma pool uplift (PR #402). Per-stage timing log emitted here so the
+      // next prod occurrence can be traced directly from docker logs instead
+      // of guessing. Dev is always near-0 because the DB is localhost.
+      const t0 = Date.now();
+      const tLog: Record<string, number> = {};
 
-      // Save focus_tags and target_level if provided
-      if (focusTags?.length || targetLevel) {
-        const updateData: { focus_tags?: string[]; target_level?: string } = {};
-        if (focusTags?.length) updateData.focus_tags = focusTags;
-        if (targetLevel) updateData.target_level = targetLevel;
-        await getPrismaClient().user_mandalas.update({
-          where: { id: result.id, user_id: userId },
-          data: updateData,
-        });
-      }
+      const result = await getMandalaManager().createMandala(userId, title, levels);
+      tLog['createMandala'] = Date.now() - t0;
+
+      // Run the two follow-up writes in parallel — they are independent.
+      // Previously sequential: update() THEN createMany(). On a us-west-2
+      // connection the round-trips stack and the user waits. With pool>=2
+      // they can fly in parallel.
+      const t1 = Date.now();
+      const updateTask: Promise<unknown> =
+        focusTags?.length || targetLevel
+          ? getPrismaClient().user_mandalas.update({
+              where: { id: result.id, user_id: userId },
+              data: {
+                ...(focusTags?.length ? { focus_tags: focusTags } : {}),
+                ...(targetLevel ? { target_level: targetLevel } : {}),
+              },
+            })
+          : Promise.resolve();
+      const skillTask: Promise<unknown> = getPrismaClient().user_skill_config.createMany({
+        data: buildSkillConfigRows(
+          userId,
+          result.id,
+          (skills as Record<string, unknown> | null | undefined) ?? null
+        ),
+        skipDuplicates: true,
+      });
+      await Promise.all([updateTask, skillTask]);
+      tLog['parallelWrites'] = Date.now() - t1;
 
       // Skip label generation if FE already provided labels (e.g., from AI generation).
       // Otherwise fire-and-forget to generate them asynchronously.
@@ -828,17 +851,6 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         });
       }
 
-      // Create skill config rows (CP357: video_discover defaults ON with auto_add=true)
-      const prisma = getPrismaClient();
-      await prisma.user_skill_config.createMany({
-        data: buildSkillConfigRows(
-          userId,
-          result.id,
-          (skills as Record<string, unknown> | null | undefined) ?? null
-        ),
-        skipDuplicates: true,
-      });
-
       // Phase 2 revert: actions are now generated one-shot in generateMandalaWithHaiku
       // (not fire-and-forget). FE receives mandala with 64 actions already populated
       // and sends them via subDetails. No background actions generation needed.
@@ -847,6 +859,9 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       // Fire-and-forget post-creation pipeline for the new mandala.
       // Opt-in via user_skill_config; safe if not enabled.
       triggerMandalaPostCreationAsync(userId, result.id);
+
+      tLog['total'] = Date.now() - t0;
+      request.log.info({ mandalaId: result.id, timing_ms: tLog }, 'create-with-data timing');
 
       return reply.send({ status: 200, data: { mandalaId: result.id } });
     } catch (err) {


### PR DESCRIPTION
## Issues addressed

### 1. Card list ordering looks \"latest\" / \"엉망진창\"

API returns `recommendation_cache` ordered by `cell_index ASC, rec_score DESC`. Frontend `CardListView` **then re-sorted** by `createdAt` desc (default `sortMode = 'latest'`) — overwriting the relevance ranking. All cards from one wizard run share nearly the same `createdAt`, so the user sees a near-random order.

**Fix**: introduce `'relevance'` sort mode (pass-through — preserves server order) and make it the default. Existing 'latest' / 'oldest' / title sorts stay available.

Files:
- `ContextHeader.tsx`: `SortMode` union + `SORT_OPTIONS` entry
- `CardListView.tsx`: `useState<SortMode>('relevance')` + `case 'relevance': return arr`
- `shared/i18n/locales/{en,ko}.json`: `contextHeader.sortRelevance` (\"Relevance\" / \"관련성 순\")

### 2. Wizard \"Go → dashboard\" still ~20s on prod, ~0s on dev

PR #402 raised Prisma pool 1→5. `P2024` stopped, but the ~20s tail remains. Re-reading `manager.ts`: `createLevels` **already** uses `createMany` (1 round-trip — the CP358 hotfix comment is historical), so the 73-INSERTs hypothesis is wrong. The 20s lives elsewhere — and I don't know where yet.

This PR takes two cautious steps:

1. **Parallelize the two post-`createMandala` writes.** `user_mandalas.update` (focusTags/targetLevel) and `user_skill_config.createMany` are order-independent. They ran sequentially; now `Promise.all`. On a us-west-2 connection with RTT 80-200ms this halves that stretch. Won't explain 20s by itself, but a real win with zero behavior change.

2. **Add per-stage timing log.** `request.log.info({ mandalaId, timing_ms: { createMandala, parallelWrites, total } })`. Next prod occurrence will surface the actual slow stage in `docker logs`. The follow-up PR can then target the right code instead of guessing.

**Not in this PR**: any change to `createMandala` internals (already batched) or to `authenticate` / setImmediate / Prisma bootstrap code — because the timing log hasn't fingered any of them yet.

## Not in this PR (explicit)

- **Filter threshold tuning** (`MIN_SUB_RELEVANCE`). The two marginal recs on the sample mandala are within acceptable filter drift at 29-row scale. No change without more evidence.
- **Optimistic wizard navigation** (client navigates before server responds). Still lower priority than finding the actual ~20s cause.

## Tests

- `npx tsc --noEmit` passes root + frontend.
- No new unit tests: sort mode change is declarative, timing log is observability-only, Promise.all preserves semantics of the two independent writes.

## Post-deploy

1. Confirm image sha live.
2. Create a new mandala, check `docker logs insighta-api --since 5m | grep 'create-with-data timing'` for the stage-level breakdown.
3. UI: new cards appear in `rec_score` desc order by default. Sort dropdown shows \"관련성 순 / Relevance\" as the first option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
