### PR TITLE
fix(wizard): navigate to dashboard immediately — don't block on server response

### DIFF
--- a/frontend/src/features/mandala-wizard/model/useWizard.ts
+++ b/frontend/src/features/mandala-wizard/model/useWizard.ts
@@ -661,6 +661,14 @@ export function useWizard() {
 
       // If template has rich data (actions) OR is not a real DB UUID, use create-with-data
       if (hasRichData || !isUuid) {
+        // Navigate to dashboard IMMEDIATELY — don't block the UI while the
+        // server spends 10-20s creating mandala rows + embedding generation.
+        // The user sees the existing dashboard; when the mutation succeeds
+        // onSuccess calls goToUnifiedDashboard which injects the new mandala
+        // into the cache + store and selects it. Second navigate('/') is a
+        // no-op since we're already there.
+        navigate('/');
+
         const subDetailsKeyed: Record<string, string[]> = {};
         for (const [k, v] of Object.entries(template.subDetails ?? {})) {
           subDetailsKeyed[String(k)] = v;
@@ -677,7 +685,10 @@ export function useWizard() {
           targetLevel: state.targetLevel !== 'standard' ? state.targetLevel : undefined,
         });
       } else {
-        // DB template clone (keeps source_template_id linkage)
+        // DB template clone — also navigate first for consistency, even
+        // though clone is typically fast (1-2s). On prod with pgbouncer RTT
+        // it can still add perceivable delay.
+        navigate('/');
         createMutateRef.current({
           templateId: template.id,
           skills: state.skills,


### PR DESCRIPTION
## Problem

Wizard \"Go\" click → **20 second blank wait** → sudden dashboard jump.

The mutation's `onSuccess` callback calls `goToUnifiedDashboard(data.mandalaId)` → `navigate('/')`. Since `onSuccess` only fires after the server responds (~20s on prod: 73 rows through pgbouncer us-west-2 RTT), the user stares at the wizard screen the entire time.

## Fix (2 lines)

Move `navigate('/')` **before** `mutate()`. Server request runs in background.

```
Before: click → mutate() → 20s server wait → onSuccess → navigate('/')
After:  click → navigate('/') → mutate() → 20s background → onSuccess → cache inject
```

When `onSuccess` fires, `goToUnifiedDashboard` injects the new mandala into React Query cache + Zustand store, selects it in the sidebar, and calls `navigate('/')` again — which is a no-op since we're already there.

Applied to both code paths in `complete()`:
- `createWithDataMutation.mutate(...)` (AI-generated + search results)
- `createMutateRef.current(...)` (DB template clone)

## User experience

| | Before | After |
|---|--------|-------|
| Click → dashboard | ~20s | **instant** |
| New mandala visible | immediately on arrival | ~20s after arrival (sidebar updates) |
| Error case | 20s wait then error toast | instant dashboard, error toast ~20s later |

## What is NOT changed

- `goToUnifiedDashboard` itself — its optimistic cache injection, store selection, tracking, and invalidation all remain intact and fire from `onSuccess` as before.
- Server-side `create-with-data` handler — no backend change.
- No sort mode / i18n / timing log changes (those are deferred from PR #403 revert).

## Tests

- `tsc --noEmit` pass (frontend)
- vitest 181/181 pass (smoke tests)

## Post-deploy

User creates mandala → should navigate to dashboard **instantly**. New mandala appears in sidebar ~20s later when server responds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
