### PR TITLE
fix(infra): frontend healthcheck localhost → 127.0.0.1 (IPv6 refused)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -59,7 +59,7 @@ services:
       api:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8081/"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8081/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -77,7 +77,7 @@ EXPOSE 8081
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget -q --spider http://localhost:8081/ || exit 1
+    CMD wget -q --spider http://127.0.0.1:8081/ || exit 1
 
 # Start nginx with environment variable substitution
 CMD ["/bin/sh", "-c", "envsubst '${API_URL}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]


### PR DESCRIPTION
Resubmit of #405 (closed due to conflict file contamination). Clean 2-file change only. See #405 for full context.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
