### PR TITLE
feat(video-discover): stage-level observability for dev/prod diagnostic

### DIFF
--- a/frontend/src/features/mandala-wizard/model/useWizard.ts
+++ b/frontend/src/features/mandala-wizard/model/useWizard.ts
@@ -446,7 +446,7 @@ export function useWizard() {
 
   // Create with full data mutation (for search results + AI generated)
   const createWithDataMutation = useMutation({
-    mutationFn: (params: {
+    mutationFn: async (params: {
       title: string;
       centerGoal: string;
       subjects: string[];
@@ -456,8 +456,30 @@ export function useWizard() {
       subLabels?: string[];
       focusTags?: string[];
       targetLevel?: string;
-    }) => apiClient.createMandalaWithData(params),
+    }) => {
+      // Observability (2026-04-17): per-stage FE timing for dev/prod diagnostic.
+      // No behavior change — measurement-only.
+      const tSubmit = performance.now();
+      const result = await apiClient.createMandalaWithData(params);
+      const tResponse = performance.now();
+      // eslint-disable-next-line no-console
+      console.info('[wizard-timing]', {
+        event: 'createMandalaWithData',
+        submit_to_response_ms: Math.round(tResponse - tSubmit),
+        mandalaId: result.mandalaId,
+        title: params.title,
+      });
+      return { ...result, _tSubmit: tSubmit, _tResponse: tResponse };
+    },
     onSuccess: (data) => {
+      const tNavigateStart = performance.now();
+      // eslint-disable-next-line no-console
+      console.info('[wizard-timing]', {
+        event: 'navigate_start',
+        response_to_navigate_ms: Math.round(tNavigateStart - data._tResponse),
+        total_submit_to_navigate_ms: Math.round(tNavigateStart - data._tSubmit),
+        mandalaId: data.mandalaId,
+      });
       goToUnifiedDashboard(data.mandalaId);
     },
   });

--- a/scripts/video-discover-tc/run-tc.ts
+++ b/scripts/video-discover-tc/run-tc.ts
@@ -1,0 +1,351 @@
+/**
+ * Video-Discover TC Runner
+ * ------------------------
+ * Runs a fixed 10-mandala test set (ko5 + en5) via ai-custom generation,
+ * measures per-stage timings (BE Server-Timing-equivalent log fields + pipeline
+ * step_result.debug), and emits a structured JSON report.
+ *
+ * Target env is chosen by DATABASE_URL / DIRECT_URL (inline env, CP358).
+ *   Dev:  DIRECT_URL=postgresql://...@127.0.0.1:5432/postgres
+ *         YOUTUBE_API_KEY_SEARCH=<dev key>
+ *         OPENROUTER_API_KEY=<dev key>
+ *   Prod: DIRECT_URL=<prod> YOUTUBE_API_KEY_SEARCH=<prod> etc. (when invoked
+ *         against prod, every step is SELECT-first; the only write is
+ *         mandala creation + pipeline trigger — same as normal wizard flow.)
+ *
+ * Writes:
+ *   - reports/video-discover-tc/<timestamp>-<env_label>.json
+ *   - reports/video-discover-tc/<timestamp>-<env_label>.md (human-readable)
+ *
+ * Usage:
+ *   DIRECT_URL="..." \
+ *   YOUTUBE_API_KEY_SEARCH="..." \
+ *   YOUTUBE_API_KEY_SEARCH_2="..." \
+ *   OPENROUTER_API_KEY="..." OPENROUTER_MODEL="..." \
+ *   USER_EMAIL=jamesjk4242@gmail.com \
+ *   ENV_LABEL=dev|prod \
+ *   npx tsx scripts/video-discover-tc/run-tc.ts
+ */
+
+import { Client } from 'pg';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { getMandalaManager } from '@/modules/mandala/manager';
+import { generateMandalaWithHaiku } from '@/modules/mandala/generator';
+import {
+  createPipelineRun,
+  executePipelineRun,
+} from '@/modules/mandala/pipeline-runner';
+import { getPrismaClient } from '@/modules/database/client';
+
+// Minimal mirror of buildSkillConfigRows in src/api/routes/mandalas.ts:87
+// (CP357 default: video_discover ON with auto_add). Kept in sync manually.
+function buildSkillConfigRows(userId: string, mandalaId: string) {
+  return [
+    {
+      user_id: userId,
+      mandala_id: mandalaId,
+      skill_type: 'video_discover',
+      enabled: true,
+      config: { auto_add: true },
+    },
+  ];
+}
+
+interface TestCase {
+  title: string;
+  goal: string;
+  language: 'ko' | 'en';
+}
+
+const TEST_SET: TestCase[] = [
+  // Korean
+  { title: '3개월 내 토익 900 달성', goal: '3개월 내 토익 900 달성', language: 'ko' },
+  { title: '6개월 내 개발자 취업', goal: '6개월 내 개발자 취업', language: 'ko' },
+  { title: '100일 수능 마무리 1등급', goal: '100일 수능 마무리 1등급', language: 'ko' },
+  { title: '3개월 내 10kg 감량 바디프로필', goal: '3개월 내 10kg 감량 바디프로필', language: 'ko' },
+  { title: '6개월 내 사이드 프로젝트 월 100만원 수익화', goal: '6개월 내 사이드 프로젝트 월 100만원 수익화', language: 'ko' },
+  // English
+  { title: '90-Day AI Agent SaaS Launch with $5K MRR', goal: '90-Day AI Agent SaaS Launch with $5K MRR', language: 'en' },
+  { title: '6-Month Full-Stack Bootcamp to FAANG Offer', goal: '6-Month Full-Stack Bootcamp to FAANG Offer', language: 'en' },
+  { title: '12-Week Half Marathon Sub-2 Hour Finish', goal: '12-Week Half Marathon Sub-2 Hour Finish', language: 'en' },
+  { title: '90-Day Solopreneur Newsletter to 10K Subscribers', goal: '90-Day Solopreneur Newsletter to 10K Subscribers', language: 'en' },
+  { title: '6-Month Passive Income Portfolio Yielding $2K Monthly', goal: '6-Month Passive Income Portfolio Yielding $2K Monthly', language: 'en' },
+];
+
+interface TrialResult {
+  caseIdx: number;
+  title: string;
+  language: 'ko' | 'en';
+  mandalaId: string | null;
+  timings: {
+    aiGenerateMs: number;
+    createMandalaMs: number;
+    pipelineTotalMs: number;
+    step1Ms: number | null;
+    step2Ms: number | null;
+    step3Ms: number | null;
+  };
+  pipeline: {
+    status: string | null;
+    step1Status: string | null;
+    step1Result: unknown;
+    step2Status: string | null;
+    step2Result: unknown;
+    step2Error: string | null;
+    step3Status: string | null;
+    step3Result: unknown;
+    step3Error: string | null;
+  };
+  recCount: number;
+  error?: string;
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  const userEmail = process.env.USER_EMAIL ?? 'jamesjk4242@gmail.com';
+  const envLabel = process.env.ENV_LABEL ?? 'unknown';
+  const dbUrl = process.env.DIRECT_URL ?? process.env.DATABASE_URL;
+  if (!dbUrl) {
+    console.error('[fatal] DIRECT_URL (or DATABASE_URL) required');
+    process.exit(2);
+  }
+  if (!/:5432/.test(dbUrl)) {
+    console.error('[fatal] must run against port 5432 (session mode), not pgbouncer :6543.');
+    process.exit(2);
+  }
+  if (!process.env.YOUTUBE_API_KEY_SEARCH) {
+    console.error('[fatal] YOUTUBE_API_KEY_SEARCH env required');
+    process.exit(2);
+  }
+
+  const pg = new Client({ connectionString: dbUrl });
+  await pg.connect();
+
+  const userRow = await pg.query<{ id: string }>(
+    `SELECT id FROM auth.users WHERE email = $1 LIMIT 1`,
+    [userEmail]
+  );
+  if (userRow.rowCount === 0) {
+    console.error(`[fatal] user not found: ${userEmail}`);
+    await pg.end();
+    process.exit(2);
+  }
+  const userId = userRow.rows[0]!.id;
+  console.log(`[user] ${userEmail} → ${userId}`);
+  console.log(`[env]  ${envLabel}`);
+  console.log(`[set]  ${TEST_SET.length} mandalas\n`);
+
+  const results: TrialResult[] = [];
+
+  for (let i = 0; i < TEST_SET.length; i++) {
+    const tc = TEST_SET[i]!;
+    console.log(`[${i + 1}/${TEST_SET.length}] "${tc.title}" (${tc.language})`);
+    const result: TrialResult = {
+      caseIdx: i,
+      title: tc.title,
+      language: tc.language,
+      mandalaId: null,
+      timings: {
+        aiGenerateMs: 0,
+        createMandalaMs: 0,
+        pipelineTotalMs: 0,
+        step1Ms: null,
+        step2Ms: null,
+        step3Ms: null,
+      },
+      pipeline: {
+        status: null,
+        step1Status: null,
+        step1Result: null,
+        step2Status: null,
+        step2Result: null,
+        step2Error: null,
+        step3Status: null,
+        step3Result: null,
+        step3Error: null,
+      },
+      recCount: 0,
+    };
+
+    try {
+      const tAi = Date.now();
+      const ai = await generateMandalaWithHaiku({
+        goal: tc.goal,
+        language: tc.language,
+      });
+      result.timings.aiGenerateMs = Date.now() - tAi;
+
+      const subjects = ai.sub_goals ?? [];
+      if (subjects.length !== 8) throw new Error(`ai returned ${subjects.length} sub_goals`);
+
+      // Build levels mirror create-with-data route
+      const levels = [
+        {
+          levelKey: 'root',
+          centerGoal: ai.center_goal ?? tc.goal,
+          centerLabel: ai.center_label,
+          subjects,
+          subjectLabels: ai.sub_labels,
+          position: 0,
+          depth: 0,
+          parentLevelKey: null,
+        },
+        ...subjects.map((sg, idx) => {
+          const actions = ai.actions?.[sg] ?? [];
+          const padded = [...actions];
+          while (padded.length < 8) padded.push('');
+          return {
+            levelKey: `sub_${idx}`,
+            centerGoal: sg,
+            subjects: padded.slice(0, 8),
+            position: idx,
+            depth: 1,
+            parentLevelKey: 'root',
+          };
+        }),
+      ];
+
+      const titleWithSuffix = `${tc.title} [tc-${envLabel}-${Date.now()}]`;
+      const tCreate = Date.now();
+      const mandala = await getMandalaManager().createMandala(userId, titleWithSuffix, levels);
+      result.timings.createMandalaMs = Date.now() - tCreate;
+      result.mandalaId = mandala.id;
+
+      // Skill config (video_discover ON default)
+      await getPrismaClient().user_skill_config.createMany({
+        data: buildSkillConfigRows(userId, mandala.id),
+        skipDuplicates: true,
+      });
+
+      // Execute pipeline synchronously via runner (not fire-and-forget).
+      const tPipe = Date.now();
+      const runId = await createPipelineRun(mandala.id, userId, 'tc');
+      await executePipelineRun(runId);
+      result.timings.pipelineTotalMs = Date.now() - tPipe;
+
+      const runRow = await pg.query<{
+        status: string | null;
+        step1_status: string | null;
+        step1_result: unknown;
+        step1_started_at: Date | null;
+        step1_ended_at: Date | null;
+        step2_status: string | null;
+        step2_result: unknown;
+        step2_error: string | null;
+        step2_started_at: Date | null;
+        step2_ended_at: Date | null;
+        step3_status: string | null;
+        step3_result: unknown;
+        step3_error: string | null;
+        step3_started_at: Date | null;
+        step3_ended_at: Date | null;
+      }>(
+        `SELECT status, step1_status, step1_result, step1_started_at, step1_ended_at,
+                step2_status, step2_result, step2_error, step2_started_at, step2_ended_at,
+                step3_status, step3_result, step3_error, step3_started_at, step3_ended_at
+         FROM public.mandala_pipeline_runs WHERE id = $1`,
+        [runId]
+      );
+      const r = runRow.rows[0];
+      if (r) {
+        result.pipeline.status = r.status;
+        result.pipeline.step1Status = r.step1_status;
+        result.pipeline.step1Result = r.step1_result;
+        result.pipeline.step2Status = r.step2_status;
+        result.pipeline.step2Result = r.step2_result;
+        result.pipeline.step2Error = r.step2_error;
+        result.pipeline.step3Status = r.step3_status;
+        result.pipeline.step3Result = r.step3_result;
+        result.pipeline.step3Error = r.step3_error;
+        if (r.step1_started_at && r.step1_ended_at) {
+          result.timings.step1Ms = r.step1_ended_at.getTime() - r.step1_started_at.getTime();
+        }
+        if (r.step2_started_at && r.step2_ended_at) {
+          result.timings.step2Ms = r.step2_ended_at.getTime() - r.step2_started_at.getTime();
+        }
+        if (r.step3_started_at && r.step3_ended_at) {
+          result.timings.step3Ms = r.step3_ended_at.getTime() - r.step3_started_at.getTime();
+        }
+      }
+
+      const recRow = await pg.query<{ count: string }>(
+        `SELECT COUNT(*)::text AS count FROM public.recommendation_cache WHERE mandala_id = $1`,
+        [mandala.id]
+      );
+      result.recCount = parseInt(recRow.rows[0]?.count ?? '0', 10);
+
+      console.log(
+        `  ok mandala=${mandala.id.slice(0, 8)} status=${r?.status} rec=${result.recCount} pipe=${result.timings.pipelineTotalMs}ms`
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      result.error = msg;
+      console.error(`  fail: ${msg}`);
+    }
+    results.push(result);
+
+    // Rate limit breathing room (5min dedup gate applies to same mandala only
+    // so a 2s gap between fresh mandalas is safe; keeps YouTube search
+    // behaviour realistic without hammering).
+    await sleep(2000);
+  }
+
+  await pg.end();
+
+  // Write outputs
+  const outDir = path.resolve(__dirname, '../../reports/video-discover-tc');
+  fs.mkdirSync(outDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const base = `${ts}-${envLabel}`;
+  const jsonFp = path.join(outDir, `${base}.json`);
+  fs.writeFileSync(jsonFp, JSON.stringify({ envLabel, userEmail, results }, null, 2));
+  console.log(`\n[written] ${jsonFp}`);
+
+  const mdFp = path.join(outDir, `${base}.md`);
+  const md = formatMarkdown(envLabel, userEmail, results);
+  fs.writeFileSync(mdFp, md);
+  console.log(`[written] ${mdFp}`);
+}
+
+function formatMarkdown(envLabel: string, userEmail: string, results: TrialResult[]): string {
+  const lines: string[] = [];
+  lines.push(`# Video-Discover TC — ${envLabel}`);
+  lines.push('');
+  lines.push(`- Generated: ${new Date().toISOString()}`);
+  lines.push(`- User: ${userEmail}`);
+  lines.push(`- Cases: ${results.length}`);
+  const ok = results.filter((r) => r.recCount > 0).length;
+  lines.push(`- Success (rec > 0): ${ok}/${results.length}`);
+  lines.push('');
+  lines.push('| # | title | lang | rec | pipe ms | step1 | step2 | step3 | status |');
+  lines.push('|---|---|---|---|---|---|---|---|---|');
+  for (const r of results) {
+    lines.push(
+      `| ${r.caseIdx + 1} | ${r.title.slice(0, 40)} | ${r.language} | ${r.recCount} | ${r.timings.pipelineTotalMs} | ${r.timings.step1Ms ?? '?'} | ${r.timings.step2Ms ?? '?'} | ${r.timings.step3Ms ?? '?'} | ${r.pipeline.status ?? r.error ?? '?'} |`
+    );
+  }
+  lines.push('');
+  lines.push('## Detail');
+  for (const r of results) {
+    lines.push(`### [${r.caseIdx + 1}] ${r.title}`);
+    lines.push('```json');
+    lines.push(
+      JSON.stringify(
+        { timings: r.timings, pipeline: r.pipeline, recCount: r.recCount, error: r.error },
+        null,
+        2
+      )
+    );
+    lines.push('```');
+  }
+  return lines.join('\n');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -713,6 +713,12 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       config: { rateLimit: { max: 3, timeWindow: '10 seconds' } },
     },
     async (request, reply) => {
+      // Observability: per-stage timing for dev/prod diagnostic comparison.
+      // Added 2026-04-17. No behavior change; emits Server-Timing header.
+      const t0 = Date.now();
+      const stages: Array<{ name: string; ms: number }> = [];
+      const stage = (name: string) => stages.push({ name, ms: Date.now() - t0 });
+
       const userId = getUserId(request, reply);
       if (!userId) return;
 
@@ -740,6 +746,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           message: 'subjects must be an array of 8 items',
         });
       }
+      stage('validation');
 
       // Daily mandala creation limit (Phase 0-5) — admins bypass
       const DAILY_MANDALA_LIMIT = 5;
@@ -763,6 +770,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           });
         }
       }
+      stage('quota_check');
 
       try {
         // Build levels: depth=0 root with 8 subjects, depth=1 for each subject with actions
@@ -808,6 +816,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         }
 
         const result = await getMandalaManager().createMandala(userId, title, levels);
+        stage('create_mandala');
 
         // Save focus_tags and target_level if provided
         if (focusTags?.length || targetLevel) {
@@ -818,6 +827,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             where: { id: result.id, user_id: userId },
             data: updateData,
           });
+          stage('focus_update');
         }
 
         // Skip label generation if FE already provided labels (e.g., from AI generation).
@@ -855,6 +865,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           ),
           skipDuplicates: true,
         });
+        stage('skill_config');
 
         // Phase 2 revert: actions are now generated one-shot in generateMandalaWithHaiku
         // (not fire-and-forget). FE receives mandala with 64 actions already populated
@@ -864,7 +875,13 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         // Fire-and-forget post-creation pipeline for the new mandala.
         // Opt-in via user_skill_config; safe if not enabled.
         triggerMandalaPostCreationAsync(userId, result.id);
+        stage('trigger_pipeline');
 
+        void reply.header('Server-Timing', stages.map((s) => `${s.name};dur=${s.ms}`).join(', '));
+        request.log.info(
+          { mandalaId: result.id, userId, stages, totalMs: Date.now() - t0 },
+          'create-with-data timing'
+        );
         return reply.send({ status: 200, data: { mandalaId: result.id } });
       } catch (err) {
         const anyErr = err as Error & { quota?: number; current?: number };

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -30,7 +30,7 @@ import type {
 
 import { manifest, V3_TARGET_PER_CELL, V3_NUM_CELLS, V3_TARGET_TOTAL } from './manifest';
 import { matchFromVideoPool, groupByCell } from './cache-matcher';
-import { applyMandalaFilter, MIN_SUB_RELEVANCE } from './mandala-filter';
+import { applyMandalaFilterWithStats, MIN_SUB_RELEVANCE } from './mandala-filter';
 
 import {
   buildRuleBasedQueriesSync,
@@ -46,6 +46,7 @@ import {
   titleIndicatesShorts,
   titleHitsBlocklist,
   type YouTubeVideoStatsItem,
+  type YouTubeSearchItem,
 } from '../v2/youtube-client';
 
 const log = logger.child({ module: 'video-discover/v3/executor' });
@@ -224,6 +225,7 @@ export const executor: SkillExecutor = {
     // ── Tier 2: realtime fallback for deficit cells ────────────────────
     let tier2Count = 0;
     let tier2QueriesUsed = 0;
+    let tier2Debug: Tier2Debug | null = null;
     if (tier1Total < V3_TARGET_TOTAL) {
       const deficitCells: Array<{ cellIndex: number; need: number }> = [];
       for (let i = 0; i < V3_NUM_CELLS; i++) {
@@ -243,12 +245,17 @@ export const executor: SkillExecutor = {
       slots.push(...tier2Fill.slots);
       tier2Count = tier2Fill.slots.length;
       tier2QueriesUsed = tier2Fill.queriesUsed;
+      tier2Debug = tier2Fill.debug;
     }
 
     if (slots.length === 0) {
       return {
         status: 'failed',
-        data: { tier1_matches: 0, tier2_matches: 0 },
+        data: {
+          tier1_matches: 0,
+          tier2_matches: 0,
+          ...(tier2Debug ? { debug: tier2Debug } : {}),
+        },
         error: 'No recommendations from cache or realtime fallback',
         metrics: { duration_ms: Date.now() - t0 },
       };
@@ -270,6 +277,7 @@ export const executor: SkillExecutor = {
         cells_filled: new Set(slots.map((s) => s.cellIndex)).size,
         rows_upserted: upserts,
         target_met: finalTotal >= V3_TARGET_TOTAL,
+        ...(tier2Debug ? { debug: tier2Debug } : {}),
       },
       metrics: {
         duration_ms: wallMs,
@@ -292,13 +300,96 @@ interface Tier2Input {
   existingVideoIds: ReadonlySet<string>;
 }
 
+interface Tier2Debug {
+  timing: {
+    keywordRuleMs: number;
+    keywordLlmMs: number;
+    ruleSearchMs: number;
+    llmSearchMs: number;
+    videosBatchMs: number;
+    filterMs: number;
+    mandalaFilterMs: number;
+    scoringMs: number;
+    totalMs: number;
+  };
+  queries: Array<{ query: string; source: 'rule' | 'llm'; cellIndex: number | null }>;
+  perQueryCounts: Array<{ query: string; source: 'rule' | 'llm'; count: number; error?: string }>;
+  poolAfterDedupe: number;
+  droppedShortsDuration: number;
+  droppedShortsTitle: number;
+  droppedBlocklist: number;
+  afterFilter: number;
+  existingExcluded: number;
+  mandalaFilterInput: number;
+  mandalaFilterOutput: number;
+  mandalaFilterDroppedCenterGate: number;
+  mandalaFilterDroppedJaccard: number;
+  mandalaFilterCenterTokens: string[];
+  mandalaFilterSubGoalTokenCounts: number[];
+  perCellAssigned: Record<number, number>;
+  scoredCandidates: number;
+  finalSlots: number;
+  centerGoal: string;
+  subGoalsSample: string[];
+  llmQuotaHit: boolean;
+  ytSearchErrors: string[];
+}
+
 interface Tier2Output {
   slots: AssembledSlot[];
   queriesUsed: number;
+  /**
+   * Observability-only trace. Added 2026-04-17 to diagnose dev vs prod
+   * tier2_matches divergence. No behavior change. Serialized into
+   * step2_result.debug for read-side comparison.
+   */
+  debug: Tier2Debug;
+}
+
+function makeEmptyDebug(input: Tier2Input): Tier2Debug {
+  return {
+    timing: {
+      keywordRuleMs: 0,
+      keywordLlmMs: 0,
+      ruleSearchMs: 0,
+      llmSearchMs: 0,
+      videosBatchMs: 0,
+      filterMs: 0,
+      mandalaFilterMs: 0,
+      scoringMs: 0,
+      totalMs: 0,
+    },
+    queries: [],
+    perQueryCounts: [],
+    poolAfterDedupe: 0,
+    droppedShortsDuration: 0,
+    droppedShortsTitle: 0,
+    droppedBlocklist: 0,
+    afterFilter: 0,
+    existingExcluded: 0,
+    mandalaFilterInput: 0,
+    mandalaFilterOutput: 0,
+    mandalaFilterDroppedCenterGate: 0,
+    mandalaFilterDroppedJaccard: 0,
+    mandalaFilterCenterTokens: [],
+    mandalaFilterSubGoalTokenCounts: [],
+    perCellAssigned: {},
+    scoredCandidates: 0,
+    finalSlots: 0,
+    centerGoal: input.state.centerGoal,
+    subGoalsSample: [...input.state.subGoals],
+    llmQuotaHit: false,
+    ytSearchErrors: [],
+  };
 }
 
 async function runTier2(input: Tier2Input): Promise<Tier2Output> {
-  if (input.deficitCells.length === 0) return { slots: [], queriesUsed: 0 };
+  const t0 = Date.now();
+  const debug = makeEmptyDebug(input);
+  if (input.deficitCells.length === 0) {
+    debug.timing.totalMs = Date.now() - t0;
+    return { slots: [], queriesUsed: 0, debug };
+  }
 
   // Build queries targeting the deficit cells specifically. keyword-builder
   // already supports tagging by sub_goal index; here we narrow the
@@ -308,6 +399,7 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     deficitSubGoals[cellIndex] = input.state.subGoals[cellIndex] ?? '';
   }
 
+  const tKwRuleStart = Date.now();
   const ruleQueries = buildRuleBasedQueriesSync({
     centerGoal: input.state.centerGoal,
     subGoals: deficitSubGoals,
@@ -315,7 +407,9 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     targetLevel: input.state.targetLevel,
     language: input.state.language,
   });
+  debug.timing.keywordRuleMs = Date.now() - tKwRuleStart;
 
+  const tKwLlmStart = Date.now();
   const llmPromise = runLLMQueries(
     {
       centerGoal: input.state.centerGoal,
@@ -330,19 +424,49 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     }
   );
 
-  const rulePool = await runSearch(ruleQueries, input.apiKey, input.state.language);
+  const tRuleSearchStart = Date.now();
+  const ruleSearch = await runSearchTraced(ruleQueries, input.apiKey, input.state.language);
+  debug.timing.ruleSearchMs = Date.now() - tRuleSearchStart;
+  const rulePool = ruleSearch.pool;
+  for (const t of ruleSearch.perQuery) {
+    debug.perQueryCounts.push({ ...t, source: 'rule' });
+  }
+  for (const q of ruleQueries) {
+    debug.queries.push({ query: q.query, source: 'rule', cellIndex: q.cellIndex ?? null });
+  }
+  debug.ytSearchErrors.push(...ruleSearch.perQuery.filter((p) => p.error).map((p) => p.error!));
 
   const llmQueries = await llmPromise;
+  debug.timing.keywordLlmMs = Date.now() - tKwLlmStart;
+  debug.llmQuotaHit = llmQueries.length === 0 && Boolean(input.openRouterApiKey);
   const usedQueryTexts = new Set(ruleQueries.map((q) => q.query.toLowerCase()));
   const extraLLM = llmQueries.filter((q) => !usedQueryTexts.has(q.query.toLowerCase()));
-  const llmPool =
-    extraLLM.length > 0 ? await runSearch(extraLLM, input.apiKey, input.state.language) : [];
+  for (const q of extraLLM) {
+    debug.queries.push({ query: q.query, source: 'llm', cellIndex: q.cellIndex ?? null });
+  }
+
+  let llmPool: PoolItem[] = [];
+  if (extraLLM.length > 0) {
+    const tLlmSearchStart = Date.now();
+    const llmSearch = await runSearchTraced(extraLLM, input.apiKey, input.state.language);
+    debug.timing.llmSearchMs = Date.now() - tLlmSearchStart;
+    llmPool = llmSearch.pool;
+    for (const t of llmSearch.perQuery) {
+      debug.perQueryCounts.push({ ...t, source: 'llm' });
+    }
+    debug.ytSearchErrors.push(...llmSearch.perQuery.filter((p) => p.error).map((p) => p.error!));
+  }
 
   const queriesUsed = ruleQueries.length + extraLLM.length;
   const combined = dedupePool([...rulePool, ...llmPool]);
-  if (combined.length === 0) return { slots: [], queriesUsed };
+  debug.poolAfterDedupe = combined.length;
+  if (combined.length === 0) {
+    debug.timing.totalMs = Date.now() - t0;
+    return { slots: [], queriesUsed, debug };
+  }
 
   // videos.list batch for duration + viewCount
+  const tVideosBatchStart = Date.now();
   let stats: YouTubeVideoStatsItem[] = [];
   try {
     stats = await videosBatch({
@@ -350,12 +474,11 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
       apiKey: input.apiKey,
     });
   } catch (err) {
-    log.warn(
-      `videos.list failed (continuing w/o stats): ${
-        err instanceof Error ? err.message : String(err)
-      }`
-    );
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`videos.list failed (continuing w/o stats): ${msg}`);
+    debug.ytSearchErrors.push(`videos.list: ${msg}`);
   }
+  debug.timing.videosBatchMs = Date.now() - tVideosBatchStart;
   const statsById = new Map<string, YouTubeVideoStatsItem>();
   for (const s of stats) if (s.id) statsById.set(s.id, s);
 
@@ -369,15 +492,25 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     durationSec: number | null;
     publishedDate: Date | null;
   };
+  const tFilterStart = Date.now();
   const enriched: Enriched[] = [];
   for (const p of combined) {
     const s = statsById.get(p.videoId);
     const viewCount = s?.statistics?.viewCount ? parseInt(s.statistics.viewCount, 10) : null;
     const likeCount = s?.statistics?.likeCount ? parseInt(s.statistics.likeCount, 10) : null;
     const durationSec = parseIsoDuration(s?.contentDetails?.duration);
-    if (isShortsByDuration(durationSec)) continue;
-    if (titleIndicatesShorts(p.title)) continue;
-    if (titleHitsBlocklist(p.title)) continue;
+    if (isShortsByDuration(durationSec)) {
+      debug.droppedShortsDuration++;
+      continue;
+    }
+    if (titleIndicatesShorts(p.title)) {
+      debug.droppedShortsTitle++;
+      continue;
+    }
+    if (titleHitsBlocklist(p.title)) {
+      debug.droppedBlocklist++;
+      continue;
+    }
     enriched.push({
       ...p,
       viewCount: Number.isFinite(viewCount) ? viewCount : null,
@@ -386,7 +519,12 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
       publishedDate: p.publishedAt ? new Date(p.publishedAt) : null,
     });
   }
-  if (enriched.length === 0) return { slots: [], queriesUsed };
+  debug.timing.filterMs = Date.now() - tFilterStart;
+  debug.afterFilter = enriched.length;
+  if (enriched.length === 0) {
+    debug.timing.totalMs = Date.now() - t0;
+    return { slots: [], queriesUsed, debug };
+  }
 
   // 9-axis mandala filter: the mandala itself (centerGoal + 8 sub_goals) is
   // the filter. applyMandalaFilter routes each candidate to the best-fit
@@ -399,16 +537,28 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     score: number;
   }
   const filterable = enriched.filter((v) => !input.existingVideoIds.has(v.videoId));
-  const byCell = applyMandalaFilter(filterable, {
+  debug.existingExcluded = enriched.length - filterable.length;
+  debug.mandalaFilterInput = filterable.length;
+
+  const tMandalaFilterStart = Date.now();
+  const { byCell, stats: mfStats } = applyMandalaFilterWithStats(filterable, {
     centerGoal: input.state.centerGoal,
     subGoals: input.state.subGoals,
     language: input.state.language,
   });
+  debug.timing.mandalaFilterMs = Date.now() - tMandalaFilterStart;
+
+  debug.mandalaFilterOutput = mfStats.output;
+  debug.mandalaFilterDroppedCenterGate = mfStats.droppedByCenterGate;
+  debug.mandalaFilterDroppedJaccard = mfStats.droppedByJaccardBelowThreshold;
+  debug.mandalaFilterCenterTokens = mfStats.centerTokens;
+  debug.mandalaFilterSubGoalTokenCounts = mfStats.subGoalTokenCounts;
 
   // Flatten into a single scored list (per-cell order preserved inside the
   // map by applyMandalaFilter; overall sort happens again below because the
   // cap-per-cell loop needs a global desc order to pick the best slots
   // across cells fairly).
+  const tScoringStart = Date.now();
   const deficitCellSet = new Set(input.deficitCells.map((c) => c.cellIndex));
   const scored: ScoredCandidate[] = [];
   for (const [cellIndex, list] of byCell) {
@@ -417,6 +567,7 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
       scored.push({ video: a.candidate, cellIndex, score: a.score });
     }
   }
+  debug.scoredCandidates = scored.length;
 
   // Cap per cell using the deficit need + overall target remaining.
   const cellFilled = new Map<number, number>();
@@ -446,9 +597,15 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
       tier: 'realtime',
     });
   }
+  debug.timing.scoringMs = Date.now() - tScoringStart;
+  debug.finalSlots = slots.length;
+  for (const [cellIndex, n] of cellFilled) {
+    debug.perCellAssigned[cellIndex] = n;
+  }
+  debug.timing.totalMs = Date.now() - t0;
   void TIER2_MAX_QUERIES_PER_CELL; // referenced in docs; retained for future tuning
 
-  return { slots, queriesUsed };
+  return { slots, queriesUsed, debug };
 }
 
 // ============================================================================
@@ -465,12 +622,17 @@ interface PoolItem {
   cellIndexHint: number | null;
 }
 
-async function runSearch(
+interface SearchTrace {
+  pool: PoolItem[];
+  perQuery: Array<{ query: string; count: number; error?: string }>;
+}
+
+async function runSearchTraced(
   queries: ReadonlyArray<SearchQuery>,
   apiKey: string,
   language: KeywordLanguage
-): Promise<PoolItem[]> {
-  if (queries.length === 0) return [];
+): Promise<SearchTrace> {
+  if (queries.length === 0) return { pool: [], perQuery: [] };
   const regionCode = language === 'ko' ? 'KR' : 'US';
   const results = await Promise.all(
     queries.map(async (q) => {
@@ -481,21 +643,26 @@ async function runSearch(
           relevanceLanguage: language,
           regionCode,
         });
-        return { q, items };
+        return { q, items, error: undefined as string | undefined };
       } catch (err) {
-        log.warn(
-          `search.list failed for "${q.query}": ${err instanceof Error ? err.message : String(err)}`
-        );
-        return { q, items: [] };
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn(`search.list failed for "${q.query}": ${msg}`);
+        return { q, items: [] as YouTubeSearchItem[], error: msg };
       }
     })
   );
-  const out: PoolItem[] = [];
-  for (const { q, items } of results) {
+  const pool: PoolItem[] = [];
+  const perQuery: SearchTrace['perQuery'] = [];
+  for (const { q, items, error } of results) {
+    perQuery.push({
+      query: q.query,
+      count: items.length,
+      ...(error ? { error } : {}),
+    });
     for (const item of items) {
       const id = item.id?.videoId;
       if (!id) continue;
-      out.push({
+      pool.push({
         videoId: id,
         title: item.snippet?.title ?? '',
         description: item.snippet?.description ?? '',
@@ -506,7 +673,7 @@ async function runSearch(
       });
     }
   }
-  return out;
+  return { pool, perQuery };
 }
 
 function dedupePool(items: ReadonlyArray<PoolItem>): PoolItem[] {

--- a/src/skills/plugins/video-discover/v3/mandala-filter.ts
+++ b/src/skills/plugins/video-discover/v3/mandala-filter.ts
@@ -53,10 +53,31 @@ export interface MandalaFilterInput {
  * each list sorted by score desc. Drops candidates that fail the center
  * gate or don't clear MIN_SUB_RELEVANCE on any sub_goal.
  */
+/**
+ * Diagnostic stats from a single applyMandalaFilter run. No behavior impact.
+ * Mutated by `applyMandalaFilterWithStats`. Added 2026-04-17 for dev/prod
+ * divergence analysis.
+ */
+export interface MandalaFilterStats {
+  input: number;
+  output: number;
+  droppedByCenterGate: number;
+  droppedByJaccardBelowThreshold: number;
+  centerTokens: string[];
+  subGoalTokenCounts: number[];
+}
+
 export function applyMandalaFilter<T extends FilterCandidate>(
   candidates: ReadonlyArray<T>,
   input: MandalaFilterInput
 ): Map<number, ScoredAssignment<T>[]> {
+  return applyMandalaFilterWithStats(candidates, input).byCell;
+}
+
+export function applyMandalaFilterWithStats<T extends FilterCandidate>(
+  candidates: ReadonlyArray<T>,
+  input: MandalaFilterInput
+): { byCell: Map<number, ScoredAssignment<T>[]>; stats: MandalaFilterStats } {
   const centerCore = extractCoreKeyphrase(input.centerGoal, input.language);
   const centerTokens = tokenize(centerCore, input.language);
 
@@ -65,10 +86,22 @@ export function applyMandalaFilter<T extends FilterCandidate>(
   const byCell = new Map<number, ScoredAssignment<T>[]>();
   for (let i = 0; i < input.subGoals.length; i++) byCell.set(i, []);
 
+  const stats: MandalaFilterStats = {
+    input: candidates.length,
+    output: 0,
+    droppedByCenterGate: 0,
+    droppedByJaccardBelowThreshold: 0,
+    centerTokens: [...centerTokens],
+    subGoalTokenCounts: subGoalTokens.map((s) => s.size),
+  };
+
   for (const c of candidates) {
     const titleTokens = tokenize(c.title, input.language);
     const centerScore = substringOverlap(centerTokens, titleTokens);
-    if (centerTokens.size > 0 && centerScore === 0) continue;
+    if (centerTokens.size > 0 && centerScore === 0) {
+      stats.droppedByCenterGate++;
+      continue;
+    }
 
     const bodyTokens = tokenize(`${c.title} ${c.description ?? ''}`, input.language);
 
@@ -83,7 +116,10 @@ export function applyMandalaFilter<T extends FilterCandidate>(
         bestCell = i;
       }
     }
-    if (bestCell === -1 || bestScore < MIN_SUB_RELEVANCE) continue;
+    if (bestCell === -1 || bestScore < MIN_SUB_RELEVANCE) {
+      stats.droppedByJaccardBelowThreshold++;
+      continue;
+    }
 
     const final = 0.5 * centerScore + 0.5 * bestScore;
     byCell.get(bestCell)!.push({
@@ -93,12 +129,13 @@ export function applyMandalaFilter<T extends FilterCandidate>(
       centerScore,
       cellScore: bestScore,
     });
+    stats.output++;
   }
 
   for (const list of byCell.values()) {
     list.sort((a, b) => b.score - a.score);
   }
-  return byCell;
+  return { byCell, stats };
 }
 
 /**


### PR DESCRIPTION
## Why

2026-04-17 — dev/prod tier2_matches divergence reported. Same code, same mandala ("창업 프로그램 지원"), dev yields 40 matches, prod yields 0. Without per-stage instrumentation we cannot tell whether the drop-off is in keyword generation, YouTube search, shorts filter, mandala-filter, or scoring.

This PR adds **measurement-only** observability so the next run on each environment writes enough into \`mandala_pipeline_runs.step2_result\` + API response headers + FE console logs to compare side-by-side.

## What

Observability-only. No behavior change in any production code path.

**BE**
- \`src/skills/plugins/video-discover/v3/executor.ts\`: \`runTier2\` returns a \`debug\` object with per-stage ms, query list, per-query YouTube result counts, drop counts by reason (shorts duration / shorts title / blocklist / center gate / jaccard below threshold), mandala-filter center tokens + subgoal token sizes, and final per-cell assignment. Serialized into \`step2_result.debug\`.
- \`src/skills/plugins/video-discover/v3/mandala-filter.ts\`: new \`applyMandalaFilterWithStats\` export (legacy \`applyMandalaFilter\` preserved).
- \`src/api/routes/mandalas.ts\` (/create-with-data only): \`Server-Timing\` header + structured \`request.log\` timing breakdown.

**FE**
- \`frontend/src/features/mandala-wizard/model/useWizard.ts\`: \`[wizard-timing]\` \`console.info\` at submit→response and response→navigate transitions, to locate the prod 30s dashboard delay.

**Scripts**
- \`scripts/video-discover-tc/run-tc.ts\`: 10-mandala test harness (ko5 + en5) that calls \`generateMandalaWithHaiku → createMandala → executePipelineRun\` end-to-end and dumps \`step_result\` rows (including the new \`debug\`) to \`reports/video-discover-tc/<ts>-<ENV_LABEL>.{json,md}\`.

## Verification (\`/verify\` PASS)

| Check | Result |
|---|---|
| \`tsc --noEmit\` (BE) | clean |
| \`tsc --noEmit\` (FE) | clean |
| \`vitest run\` | 217/217 PASS |
| frontend \`npm run build\` | ok (4.5s) |
| browser smoke (\`/\`, \`/mandalas/new\`, \`/mandalas\`) | 3/3 → 200 |
| \`jest\` | 28 pre-existing failures on \`main\` remain identical (mandala-post-creation, v1 executor; not touched here); **0 new failures** |

## How it's going to be used

After merge + prod deploy:

1. Run \`scripts/video-discover-tc/run-tc.ts\` on **dev** (10 mandala, ko5+en5) — collect full \`debug\` per run.
2. Run the same harness on **prod** (identical 10 mandala, same user) — collect full \`debug\`.
3. Compare stage-by-stage (queries sent, per-query YouTube counts, drop funnel, mandala-filter drops by reason) to pinpoint the single stage where dev succeeds and prod fails.

Quota-aware: 10 × 1200 units/env = 12k; prod now has a secondary \`YOUTUBE_API_KEY_SEARCH_2\` secret available as needed (key rotation not wired in this PR — separate change).

## Not in this PR

- Any tuning of thresholds (\`MIN_SUB_RELEVANCE\`, \`MAX_QUERIES\`, etc.). Measurement first, tuning later.
- Key rotation between \`YOUTUBE_API_KEY_SEARCH\` / \`_2\` (needs its own PR once the diagnostic says it's needed).
- mandala-filter v2 redesign (embedding / hybrid search / reranker) discussed in \`docs/design/semantic-search-reference.md\` — deferred until diagnostic pinpoints the actual bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
