### PR TITLE
fix(cards,wizard): recency-aware ranking + sidebar fallback + hardcode audit gate

### DIFF
--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,0 +1,168 @@
+---
+name: check
+description: "Agent-Native standard verification — quality gate before /ship"
+allowed-tools: Bash(npm:*), Bash(npx:*), Bash(git:*), Bash(curl:*), Bash(cd:*), Read, Grep, Glob
+---
+
+Quality gate before `/ship`. Checks 5 categories: code quality, API standards, tests, backend verification, documentation.
+
+Usage: `/check [scope?]`
+- Omitted: full verification (all 5 categories)
+- `--quick`: Hard Gate only (typecheck + lint + build)
+- `--api`: API/Edge Function standards only
+- `--test`: Test standards only
+
+## Core Principles
+
+> "ran without errors" ≠ "correct" — do NOT assume correctness from build pass alone.
+> Hard Gate failure blocks `/ship`. Soft Gate warnings are displayed only.
+
+## Gate Rules
+
+| Type | On failure | Applies to |
+|------|------------|------------|
+| **Hard Gate** | Blocks /ship, MUST fix and re-run | Category 1 (code quality) |
+| **Soft Gate** | /ship allowed, warning list displayed | Categories 2-5 |
+
+## Verification Categories
+
+### 1. Code Quality (Hard Gate — ANY failure blocks /ship)
+
+```bash
+# 1a. Backend type check
+npx tsc --noEmit
+
+# 1b. Frontend type check
+cd frontend && npx tsc --noEmit
+
+# 1c. ESLint
+npm run lint
+
+# 1d. Unit tests (if configured)
+npm test 2>/dev/null || echo "no tests configured"
+
+# 1e. Vite build
+cd frontend && npm run build
+
+# 1f. Hardcode/fragmentation audit
+npx tsx scripts/audit/hardcode-audit.ts
+```
+
+ALL items MUST pass for Hard Gate PASS. Audit baseline at `reports/hardcode-audit/baseline.json` ratchets down only.
+
+### 2. API/Edge Function Standards (Soft Gate)
+
+Detect API routes or Edge Functions among changed files:
+```bash
+git diff --name-only HEAD~1 | grep -E '(src/api/|supabase/functions/)'
+```
+
+For detected files, check:
+- Error responses are structured (`{ status, code, message }` pattern)
+- Success responses follow standard format (`{ status, data }` pattern)
+- **[G6] Fail Loudly**: business errors (LIMIT_EXCEEDED, NOT_FOUND, ALREADY_EXISTS, etc.) return explicit error codes
+- try-catch blocks do NOT silently swallow errors
+
+### 3. Test Standards (Soft Gate)
+
+- Tests exist for changed code (same directory or under `tests/`)
+- **[G8] E2E verification**: Playwright tests cover the changed UI
+- If `tests/TEST.md` exists, it reflects latest results
+
+### 4. Backend Verification (Soft Gate)
+
+**[G1] Real Backend + [G3] Output Verification**:
+- DB schema changes: `npx prisma generate` success + local `npx prisma db push` success confirmed
+- Edge Function changes: verify via curl with actual call (dev environment)
+- **[G5] Idempotency**: same API call twice produces no side effects
+- **[G2] Rendering Gap**: changed fields propagated across full L0-L6 path
+  - DB schema (L0) → Edge Function (L1) → Type definition (L2) → Converter (L3) → Hook (L4) → UI (L6)
+
+### 5. Documentation Standards (Soft Gate)
+
+- Whether CLAUDE.md needs updating (if core rules changed)
+- Whether commit messages can include related Issue numbers
+- Documentation exists for changed Edge Functions/APIs
+
+### 6. Runtime Risk Patterns (Soft Gate — promoted from troubleshooting.md LEVEL-2)
+
+Known repeat-offense patterns. Check changed files for these risks. If any match, require explicit ack before /ship.
+
+**[6a] tsc pass ≠ runtime safe**
+- Trigger: any FE change touching navigate/mutation lifecycle, or BE plugin loading.
+- Check: `/verify` must include browser smoke (npm run dev + curl / UI click path). tsc alone is insufficient.
+- Reference: troubleshooting.md "tsc pass ≠ runtime safe" (PR #403/#404 reverts).
+
+**[6b] Fastify plugin version constraint**
+- Trigger: `src/api/plugins/*.ts` changed, or new fp() wrapper added.
+- Check: fp() `fastify` constraint matches `package.json` installed version (grep fastify version).
+- Reference: troubleshooting.md "fp() fastify version must match" (PR #408 revert).
+
+**[6c] navigate() before mutate()**
+- Trigger: `useMutation` + `navigate()` in same handler (FE).
+- Check: navigate runs in onSuccess/after await, NOT before mutation dispatch. Unmount kills onSuccess silently.
+- Reference: troubleshooting.md "navigate() before mutate() = unmount kills onSuccess" (PR #404 revert).
+
+**[6d] Global rate limit bucket**
+- Trigger: changes to `src/api/plugins/rate-limit*`, `server.ts` rate config, or any endpoint with user-facing write.
+- Check: method/endpoint scope separated (GET vs POST distinct buckets). Write bucket sized for burst (≥ expected max concurrent click count).
+- Reference: troubleshooting.md "Global rate limit bucket = service death" (15min outage PR #408 → #407/#409 fix).
+
+**[6e] Dead code before write**
+- Trigger: NEW file under `src/api/plugins/`, `src/modules/*/`, or FE `frontend/src/features/*/`.
+- Check: Grep for existing implementation of same concept before writing new.
+- Reference: troubleshooting.md "Dead code in codebase" (rate-limit.ts 7일 dead code).
+
+**[6f] Docker healthcheck localhost**
+- Trigger: `Dockerfile` or `docker-compose*.yml` changes adding/editing healthcheck.
+- Check: healthcheck URL uses `127.0.0.1` not `localhost` (IPv6 resolution on Alpine).
+- Reference: troubleshooting.md "Alpine wget resolves localhost to IPv6 first".
+
+Promotion policy: an item is added here when it appears in troubleshooting.md at LEVEL-2 or higher (2+ recurrences). Items retired when counter drops or pattern becomes impossible by design.
+
+## Output Format
+
+```
+## /check Results
+
+### Gate Summary
+| # | Category | Gate | Result | Details |
+|---|----------|------|--------|---------|
+| 1 | Code Quality | Hard | {PASS/FAIL} | tsc: {ok/fail}, lint: {ok/fail}, test: {ok/fail/N/A}, build: {ok/fail} |
+| 2 | API Standards | Soft | {PASS/WARN/N/A} | {N} endpoints checked, {M} warnings |
+| 3 | Tests | Soft | {PASS/WARN/N/A} | coverage: {if available %}, E2E: {if available status} |
+| 4 | Backend | Soft | {PASS/WARN/N/A} | prisma: {ok/N/A}, edge fn: {ok/N/A} |
+| 5 | Documentation | Soft | {PASS/WARN/N/A} | CLAUDE.md: {ok/needs update} |
+| 6 | Runtime Risk | Soft | {PASS/WARN/N/A} | {N} LEVEL-2 patterns matched, {M} acked |
+
+### Hard Gate: {PASS / FAIL}
+{if FAIL: detailed failure items + fix suggestions}
+
+### Soft Gate Warnings ({count})
+{if warnings exist: list by item + fix suggestions}
+{if none: "No warnings"}
+
+### /ship Readiness
+{if Hard Gate PASS: "Ready for /ship"}
+{if Hard Gate FAIL: "Blocked — fix {N} Hard Gate failures first"}
+```
+
+## Behavior by $ARGUMENTS
+
+| Argument | Categories run | Use case |
+|----------|---------------|----------|
+| (none) | All 1-5 | Full verification |
+| `--quick` | 1 only | Quick build check |
+| `--api` | 2, 4 | API standards after changes |
+| `--test` | 3 | Test coverage check |
+
+## CLI-Anything Framework Mapping
+
+| Principle | Application |
+|-----------|-------------|
+| [G1] Real Backend | Category 4 — verify with actual DB/Edge Function, not mocks |
+| [G2] Rendering Gap | Category 4 — check L0-L6 propagation path |
+| [G3] Output Verification | Category 4 — exit 0 ≠ correct |
+| [G5] Idempotency | Category 4 — same request twice safety |
+| [G6] Fail Loudly | Category 2 — structured error responses |
+| [G8] E2E Verification | Category 3 — Playwright coverage |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         with:
           node-version: 20
           cache: npm
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep
       - run: npm ci
       - run: npx tsx scripts/audit/hardcode-audit.ts
       - name: Upload audit report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,25 @@ jobs:
         run: cd frontend && npm install --no-package-lock --no-audit
       - run: cd frontend && npx vitest run
 
+  hardcode-audit:
+    name: Hardcode Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx tsx scripts/audit/hardcode-audit.ts
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hardcode-audit-report
+          path: reports/hardcode-audit/latest.json
+          retention-days: 30
+
   # Combined: test-backend + build-api (saves 1 npm ci)
   test-and-build-api:
     name: Test Backend & Build API

--- a/.github/workflows/hardcode-audit-weekly.yml
+++ b/.github/workflows/hardcode-audit-weekly.yml
@@ -1,0 +1,45 @@
+name: Hardcode Audit (Weekly)
+
+# Weekly trend report complementing the per-PR gate in ci.yml.
+
+on:
+  schedule:
+    - cron: '0 18 * * 1' # Mon 18:00 UTC = Tue 03:00 KST
+  workflow_dispatch: {}
+
+jobs:
+  audit:
+    name: Hardcode Audit (trend)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Run audit (non-blocking)
+        id: audit
+        continue-on-error: true
+        run: npx tsx scripts/audit/hardcode-audit.ts
+      - name: Summarize
+        if: always()
+        run: |
+          echo "## Hardcode audit — $(date -u +%Y-%m-%d)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat reports/hardcode-audit/latest.json >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '### Baseline' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat reports/hardcode-audit/baseline.json >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload trend artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hardcode-audit-weekly-${{ github.run_id }}
+          path: reports/hardcode-audit/
+          retention-days: 180

--- a/.github/workflows/hardcode-audit-weekly.yml
+++ b/.github/workflows/hardcode-audit-weekly.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           node-version: 20
           cache: npm
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep
       - run: npm ci
       - name: Run audit (non-blocking)
         id: audit

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,7 @@ openclaw/memory/
 .claude/commands/_deprecated/
 .env.bak
 .env.bak2
+
+# Hardcode audit — keep baseline.json, ignore per-run reports
+reports/hardcode-audit/report-*.json
+reports/hardcode-audit/latest.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,17 @@
 - 3단계+ 상대 경로 import 금지 -> `@/` alias 사용
 - `docs/CODING_CONVENTIONS.md` 준수. Phase 1 즉시 적용.
 
+### 하드코딩 + 단편 조치 금지 (절대 규칙, LEVEL-3)
+- 업무 로직에 `process.env[...]` 직접 읽기, 파일별 `MS_PER_DAY` 재선언, 인라인 env 파서 금지 → `src/config/**` · `<plugin>/config.ts` (zod) · `src/utils/time-constants.ts` 사용.
+- 수정 전 `Grep` 으로 동일 패턴 전수 검색 → 발견한 중복은 **같은 PR 에서 일괄 정리**. 단일 파일 부분 조치 금지.
+- 신규 env default = "기존 동작" (unset = no-op). code revert 없이 flag off 로 롤백 가능해야.
+- 측정: `scripts/audit/hardcode-audit.ts` (5 룰). CI job `hardcode-audit` 가 PR 마다 baseline 초과 시 FAIL. baseline 은 **감소 방향으로만** 수정.
+
+**근거 (CP391 2026-04-18):**
+- v3 recency fix 중 `executor.ts` 에 `V3_RECENCY_WEIGHT`, `V3_PUBLISHED_AFTER_DAYS` env 를 `parseFloatEnv / parseIntEnv` inline helper + `MS_PER_DAY` 재선언으로 처리.
+- 당시 프로젝트엔 이미 `src/config/index.ts` 의 zod schema 존재 + `MS_PER_DAY` 는 **6개 파일 중복 선언** (admin/stats, video-discover/executor, iks-scorer, trend-collector, v3/executor 등).
+- 사용자 지적: "죄다 하드코딩", "전체 코드베이스 차원의 분석이 아닌 부분적 단편 조치". → 전 파일 일괄 정리 + config 모듈 + 중앙 상수로 재작업.
+
 ### Coding Conventions -> [상세: docs/CODING_CONVENTIONS.md]
 - 기존 코드 수정 시 해당 파일 Phase 1 위반도 함께 수정 (점진적 개선)
 

--- a/frontend/src/__tests__/smoke/sidebar-mandala-fallback.test.ts
+++ b/frontend/src/__tests__/smoke/sidebar-mandala-fallback.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest';
+import type { PendingMandalaInputs } from '@/stores/mandalaStore';
+
+// Mirror of SidebarMandalaSection's fallback chain — keep in sync.
+function derivePendingTitle(inputs: PendingMandalaInputs | undefined): string | null {
+  if (!inputs) return null;
+  return inputs.centerLabel?.trim() || inputs.title?.trim() || inputs.centerGoal?.trim() || null;
+}
+
+describe('sidebar pendingMandala title fallback', () => {
+  test('centerLabel is preferred when present', () => {
+    expect(
+      derivePendingTitle({
+        title: 'Long form title that would get truncated',
+        centerGoal: '턱걸이 20개 달성하기 마스터 플랜',
+        subjects: [],
+        centerLabel: '턱걸이 20',
+      })
+    ).toBe('턱걸이 20');
+  });
+
+  test('falls back to title when centerLabel is missing', () => {
+    expect(
+      derivePendingTitle({
+        title: '턱걸이 20개',
+        centerGoal: '턱걸이 20개 달성 플랜',
+        subjects: [],
+      })
+    ).toBe('턱걸이 20개');
+  });
+
+  test('falls back to centerGoal when title is missing or blank', () => {
+    expect(
+      derivePendingTitle({
+        title: '   ',
+        centerGoal: '턱걸이 20개 달성',
+        subjects: [],
+      })
+    ).toBe('턱걸이 20개 달성');
+  });
+
+  test('returns null for undefined pending state (caller shows loading copy)', () => {
+    expect(derivePendingTitle(undefined)).toBeNull();
+  });
+
+  test('returns null when every candidate is blank', () => {
+    expect(
+      derivePendingTitle({
+        title: '',
+        centerGoal: '',
+        centerLabel: '   ',
+        subjects: [],
+      })
+    ).toBeNull();
+  });
+});

--- a/frontend/src/entities/card/model/types.ts
+++ b/frontend/src/entities/card/model/types.ts
@@ -35,6 +35,8 @@ export interface InsightCard {
   userNote: string;
   createdAt: Date;
   updatedAt?: Date;
+  /** Source-material publish date (YouTube upload, article date), NOT createdAt. */
+  publishedAt?: Date | null;
   cellIndex: number;
   levelId: string; // Which mandala level this card belongs to
   mandalaId?: string | null; // Which mandala this card belongs to

--- a/frontend/src/features/card-management/lib/youtubeToInsightCard.ts
+++ b/frontend/src/features/card-management/lib/youtubeToInsightCard.ts
@@ -27,6 +27,7 @@ export function convertToInsightCard(data: UserVideoStateWithVideo): InsightCard
     userNote: data.user_note || '',
     createdAt: new Date(data.added_to_ideation_at),
     updatedAt: new Date(data.updated_at),
+    publishedAt: video.published_at ? new Date(video.published_at) : null,
     cellIndex: data.cell_index,
     levelId: data.level_id,
     mandalaId: data.mandala_id,

--- a/frontend/src/features/mandala-wizard/model/useWizard.ts
+++ b/frontend/src/features/mandala-wizard/model/useWizard.ts
@@ -95,6 +95,10 @@ interface CreateFromTemplateResponse {
 // linked system skill (video_discover) is also ON via setSkill linkage
 // when "recommend" lands. trend_collector + iks_scorer are cron-only
 // system plugins; they have no per-mandala row, so they're omitted.
+// Covers the DB → list-endpoint propagation window so the refetch doesn't
+// race with the optimistic stub.
+const WIZARD_LIST_INVALIDATE_DELAY_MS = 3_000;
+
 const DEFAULT_SKILLS: Record<SkillType, boolean> = {
   newsletter: true,
   report: true,
@@ -392,24 +396,14 @@ export function useWizard() {
       // longer calls trackMandalaCreated because the AI-custom path invokes
       // it with a client-generated tempId, which would poison analytics.
 
-      // 3. Fire-and-forget cache invalidation. Do NOT await —
-      //    - await blocks navigate for however long the refetch takes
-      //      (seen in prod at 20s+ when dependent queries pile on).
-      //    - the refetch result can also overwrite the optimistic stub
-      //      with a stale server list (the new mandala's DB transaction
-      //      hasn't propagated to the list endpoint yet), which then
-      //      makes SidebarMandalaSection render '…' because find() fails.
-      //
-      //    By skipping await we let navigate run immediately — the
-      //    sidebar mounts reading the optimistic stub and shows the title
-      //    right away. Background refetch updates the cache naturally,
-      //    and the sidebar's defensive retry (see SidebarMandalaSection)
-      //    handles the propagation lag window.
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.mandala.list(),
-        refetchType: 'all',
-      });
-      queryClient.invalidateQueries({ queryKey: queryKeys.mandala.quota() });
+      // Deferred so the list refetch doesn't race with the DB propagation window.
+      setTimeout(() => {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.mandala.list(),
+          refetchType: 'all',
+        });
+        queryClient.invalidateQueries({ queryKey: queryKeys.mandala.quota() });
+      }, WIZARD_LIST_INVALIDATE_DELAY_MS);
       navigate('/');
     },
     [navigate, selectMandalaInStore, setJustCreated, queryClient, state.selectedTemplate, user]

--- a/frontend/src/widgets/app-shell/ui/SidebarMandalaSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarMandalaSection.tsx
@@ -34,6 +34,7 @@ interface SidebarMandalaSectionProps {
 export function SidebarMandalaSection({ collapsed, minimapData }: SidebarMandalaSectionProps) {
   const selectedMandalaId = useMandalaStore((s) => s.selectedMandalaId);
   const selectMandala = useMandalaStore((s) => s.selectMandala);
+  const pendingMandala = useMandalaStore((s) => s.pendingMandala);
   const { t } = useTranslation();
   const { data: listData, isLoading, isError, error, refetch } = useMandalaList();
 
@@ -171,10 +172,16 @@ export function SidebarMandalaSection({ collapsed, minimapData }: SidebarMandala
     const label = (rootLevel as { centerLabel?: string | null } | undefined)?.centerLabel;
     return label || m?.title || '—';
   };
+  // Fallback for the list-cache propagation window; avoids rendering a bare "…".
+  const pendingTitle =
+    pendingMandala?.originalInputs?.centerLabel?.trim() ||
+    pendingMandala?.originalInputs?.title?.trim() ||
+    pendingMandala?.originalInputs?.centerGoal?.trim() ||
+    null;
   const currentTitle = selectedMandalaId
     ? currentMandala
       ? getCenterLabel(currentMandala)
-      : '…'
+      : (pendingTitle ?? t('sidebar.mandalaLoading', 'Finishing setup…'))
     : getCenterLabel(mandalas[0]);
 
   return (

--- a/frontend/src/widgets/card-list-view/ui/CardListView.tsx
+++ b/frontend/src/widgets/card-list-view/ui/CardListView.tsx
@@ -212,20 +212,45 @@ export function CardListView({
 
   const effectiveViewMode = viewMode === 'list-detail' && isMobile ? 'list' : viewMode;
 
-  // Sort cards based on sortMode
+  // "latest"/"oldest" rank by source publish date (YouTube upload), not createdAt.
   const sortedCards = useMemo(() => {
     const arr = [...cards];
+    const getPublishedMs = (c: (typeof cards)[number]): number => {
+      const fromField = c.publishedAt ? new Date(c.publishedAt).getTime() : NaN;
+      if (Number.isFinite(fromField)) return fromField;
+      const metaPublished = (c.metadata as unknown as Record<string, unknown> | undefined)?.[
+        'published_at'
+      ];
+      if (typeof metaPublished === 'string') {
+        const t = new Date(metaPublished).getTime();
+        if (Number.isFinite(t)) return t;
+      }
+      const createdMs = new Date(c.createdAt).getTime();
+      return Number.isFinite(createdMs) ? createdMs : NaN;
+    };
     switch (sortMode) {
       case 'latest':
         return arr.sort((a, b) => {
-          if (a.sortOrder !== undefined && b.sortOrder !== undefined)
-            return a.sortOrder - b.sortOrder;
-          return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+          const ma = getPublishedMs(a);
+          const mb = getPublishedMs(b);
+          const aHas = Number.isFinite(ma);
+          const bHas = Number.isFinite(mb);
+          if (aHas && !bHas) return -1;
+          if (!aHas && bHas) return 1;
+          if (!aHas && !bHas) return 0;
+          return mb - ma;
         });
       case 'oldest':
-        return arr.sort(
-          (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-        );
+        return arr.sort((a, b) => {
+          const ma = getPublishedMs(a);
+          const mb = getPublishedMs(b);
+          const aHas = Number.isFinite(ma);
+          const bHas = Number.isFinite(mb);
+          if (aHas && !bHas) return -1;
+          if (!aHas && bHas) return 1;
+          if (!aHas && !bHas) return 0;
+          return ma - mb;
+        });
       case 'title-asc':
         return arr.sort((a, b) => (a.title || '').localeCompare(b.title || ''));
       case 'title-desc':

--- a/reports/hardcode-audit/baseline.json
+++ b/reports/hardcode-audit/baseline.json
@@ -1,5 +1,5 @@
 {
-  "ms-per-day-reseclared": 0,
+  "ms-per-day-redeclared": 0,
   "process-env-direct-read": 35,
   "inline-env-parser": 0,
   "raw-ms-per-day-literal": 0,

--- a/reports/hardcode-audit/baseline.json
+++ b/reports/hardcode-audit/baseline.json
@@ -1,0 +1,7 @@
+{
+  "ms-per-day-reseclared": 0,
+  "process-env-direct-read": 35,
+  "inline-env-parser": 0,
+  "raw-ms-per-day-literal": 0,
+  "raw-ms-per-hour-literal": 0
+}

--- a/scripts/audit/hardcode-audit.ts
+++ b/scripts/audit/hardcode-audit.ts
@@ -1,0 +1,230 @@
+#!/usr/bin/env tsx
+// Enforces CLAUDE.md "하드코딩 + 단편 조치 금지" — fails when any rule
+// exceeds its baseline in reports/hardcode-audit/baseline.json.
+import { execSync } from 'node:child_process';
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+interface RuleDef {
+  id: string;
+  description: string;
+  pattern: string;
+  allowedFileGlobs: string[];
+  searchGlobs?: string[];
+  multiline?: boolean;
+}
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const REPORT_DIR = resolve(REPO_ROOT, 'reports', 'hardcode-audit');
+const BASELINE_PATH = resolve(REPORT_DIR, 'baseline.json');
+
+const RULES: RuleDef[] = [
+  {
+    id: 'ms-per-day-reseclared',
+    description: 'MS_PER_DAY / MS_PER_HOUR / MS_PER_MINUTE redeclared outside time-constants',
+    pattern: String.raw`^\s*(?:export\s+)?const\s+MS_PER_(?:DAY|HOUR|MINUTE|SECOND)\s*=`,
+    allowedFileGlobs: ['src/utils/time-constants.ts'],
+  },
+  {
+    id: 'process-env-direct-read',
+    description: 'process.env[...] or process.env.FOO read outside config modules',
+    pattern: String.raw`process\.env(?:\[|\.)`,
+    allowedFileGlobs: [
+      'src/config/**',
+      '**/config.ts',
+      // Bootstrap files that must read env before config loads
+      'src/index.ts',
+      'src/server.ts',
+      // Scripts and tests legitimately touch process.env
+      'scripts/**',
+      'src/**/__tests__/**',
+      'src/**/*.test.ts',
+      'tests/**',
+    ],
+  },
+  {
+    id: 'inline-env-parser',
+    description: 'Inline env-parser helper declared outside config modules',
+    pattern: String.raw`function\s+parse(?:Int|Float|Bool)Env\b`,
+    allowedFileGlobs: ['src/config/**', '**/config.ts', 'scripts/**'],
+  },
+  {
+    id: 'raw-ms-per-day-literal',
+    description: 'Raw "24 * 60 * 60 * 1000" style literal (use MS_PER_DAY)',
+    pattern: String.raw`24\s*\*\s*60\s*\*\s*60\s*\*\s*1000`,
+    allowedFileGlobs: ['src/utils/time-constants.ts'],
+  },
+  {
+    id: 'raw-ms-per-hour-literal',
+    description: 'Raw "60 * 60 * 1000" style literal (use MS_PER_HOUR)',
+    pattern: String.raw`\b60\s*\*\s*60\s*\*\s*1000\b`,
+    allowedFileGlobs: ['src/utils/time-constants.ts'],
+  },
+];
+
+interface RuleResult {
+  id: string;
+  description: string;
+  violationCount: number;
+  violations: Array<{ file: string; line: number; text: string }>;
+}
+
+function runRg(pattern: string, searchGlobs: string[]): string {
+  const globArgs = searchGlobs.map((g) => `--glob '${g}'`).join(' ');
+  try {
+    const out = execSync(
+      `rg --json --line-number -e '${pattern}' ${globArgs} src`,
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        maxBuffer: 32 * 1024 * 1024,
+      }
+    );
+    return out;
+  } catch (err) {
+    // rg exits 1 when zero matches.
+    const execErr = err as { stdout?: Buffer | string; status?: number | null };
+    if (execErr.status === 1) return typeof execErr.stdout === 'string' ? execErr.stdout : '';
+    throw err;
+  }
+}
+
+function matchesAnyGlob(file: string, globs: string[]): boolean {
+  for (const glob of globs) {
+    const re = new RegExp(
+      '^' +
+        glob
+          .replace(/\./g, '\\.')
+          .replace(/\*\*/g, '§§')
+          .replace(/\*/g, '[^/]*')
+          .replace(/§§/g, '.*') +
+        '$'
+    );
+    if (re.test(file)) return true;
+  }
+  return false;
+}
+
+function auditRule(rule: RuleDef): RuleResult {
+  const searchGlobs = rule.searchGlobs ?? [
+    '!**/__tests__/**',
+    '!**/*.test.ts',
+    '!**/*.spec.ts',
+  ];
+  const raw = runRg(rule.pattern, searchGlobs);
+  const violations: RuleResult['violations'] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const event = JSON.parse(line);
+      if (event.type !== 'match') continue;
+      const filePath = event.data.path.text as string;
+      if (matchesAnyGlob(filePath, rule.allowedFileGlobs)) continue;
+      const text = (event.data.lines.text as string).trim();
+      // Skip hour-literal hits that are part of the day literal (counted separately).
+      if (rule.id === 'raw-ms-per-hour-literal' && /\b24\s*\*\s*60\s*\*\s*60\s*\*\s*1000\b/.test(text)) {
+        continue;
+      }
+      violations.push({
+        file: filePath,
+        line: event.data.line_number as number,
+        text,
+      });
+    } catch {
+      // skip non-JSON lines
+    }
+  }
+  return {
+    id: rule.id,
+    description: rule.description,
+    violationCount: violations.length,
+    violations,
+  };
+}
+
+interface AuditReport {
+  generatedAt: string;
+  gitCommit: string | null;
+  rules: RuleResult[];
+  totalViolations: number;
+}
+
+function currentCommit(): string | null {
+  try {
+    return execSync('git rev-parse HEAD', { cwd: REPO_ROOT, encoding: 'utf8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function loadBaseline(): Record<string, number> | null {
+  if (!existsSync(BASELINE_PATH)) return null;
+  try {
+    return JSON.parse(readFileSync(BASELINE_PATH, 'utf8')) as Record<string, number>;
+  } catch {
+    return null;
+  }
+}
+
+function main(): void {
+  const results = RULES.map(auditRule);
+  const totalViolations = results.reduce((sum, r) => sum + r.violationCount, 0);
+  const report: AuditReport = {
+    generatedAt: new Date().toISOString(),
+    gitCommit: currentCommit(),
+    rules: results,
+    totalViolations,
+  };
+
+  mkdirSync(REPORT_DIR, { recursive: true });
+  const stampedPath = resolve(
+    REPORT_DIR,
+    `report-${report.generatedAt.replace(/[:]/g, '-')}.json`
+  );
+  writeFileSync(stampedPath, JSON.stringify(report, null, 2));
+  const latestPath = resolve(REPORT_DIR, 'latest.json');
+  writeFileSync(latestPath, JSON.stringify(report, null, 2));
+
+  // eslint-disable-next-line no-console
+  console.log(`[hardcode-audit] report: ${stampedPath}`);
+  for (const r of results) {
+    // eslint-disable-next-line no-console
+    console.log(`  ${r.id}: ${r.violationCount} violation(s) — ${r.description}`);
+  }
+  // eslint-disable-next-line no-console
+  console.log(`[hardcode-audit] total: ${totalViolations}`);
+
+  const baseline = loadBaseline();
+  let failed = false;
+  if (baseline) {
+    for (const r of results) {
+      const allowed = baseline[r.id] ?? 0;
+      if (r.violationCount > allowed) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[hardcode-audit] FAIL: ${r.id} — ${r.violationCount} > baseline ${allowed}`
+        );
+        for (const v of r.violations.slice(0, 10)) {
+          // eslint-disable-next-line no-console
+          console.error(`    ${v.file}:${v.line}  ${v.text}`);
+        }
+        failed = true;
+      }
+    }
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[hardcode-audit] no baseline at ${BASELINE_PATH} — current counts will be used to seed one`
+    );
+    const seeded: Record<string, number> = {};
+    for (const r of results) seeded[r.id] = r.violationCount;
+    mkdirSync(dirname(BASELINE_PATH), { recursive: true });
+    writeFileSync(BASELINE_PATH, JSON.stringify(seeded, null, 2));
+    // eslint-disable-next-line no-console
+    console.log(`[hardcode-audit] baseline seeded at ${BASELINE_PATH}`);
+  }
+
+  process.exit(failed ? 1 : 0);
+}
+
+main();

--- a/scripts/audit/hardcode-audit.ts
+++ b/scripts/audit/hardcode-audit.ts
@@ -20,7 +20,7 @@ const BASELINE_PATH = resolve(REPORT_DIR, 'baseline.json');
 
 const RULES: RuleDef[] = [
   {
-    id: 'ms-per-day-reseclared',
+    id: 'ms-per-day-redeclared',
     description: 'MS_PER_DAY / MS_PER_HOUR / MS_PER_MINUTE redeclared outside time-constants',
     pattern: String.raw`^\s*(?:export\s+)?const\s+MS_PER_(?:DAY|HOUR|MINUTE|SECOND)\s*=`,
     allowedFileGlobs: ['src/utils/time-constants.ts'],

--- a/src/api/routes/admin/stats.ts
+++ b/src/api/routes/admin/stats.ts
@@ -2,9 +2,9 @@ import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { Prisma } from '@prisma/client';
 import { db } from '@/modules/database/client';
 import { createSuccessResponse } from '../../schemas/common.schema';
+import { MS_PER_DAY } from '@/utils/time-constants';
 
 const DEFAULT_ACTIVITY_RANGE_DAYS = 6;
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export async function adminStatsRoutes(fastify: FastifyInstance) {
   const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };

--- a/src/api/routes/analytics.ts
+++ b/src/api/routes/analytics.ts
@@ -25,6 +25,7 @@ import {
 import { logger } from '../../utils/logger';
 import { getPrismaClient } from '../../modules/database';
 import { getMood } from '../../modules/mandala/mood';
+import { MS_PER_DAY } from '@/utils/time-constants';
 
 /**
  * Analytics routes plugin
@@ -263,7 +264,7 @@ export const analyticsRoutes: FastifyPluginCallback = (fastify, _opts, done) => 
     }
     const userId = request.user.userId;
     const prisma = getPrismaClient();
-    const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const oneWeekAgo = new Date(Date.now() - 7 * MS_PER_DAY);
 
     const userMandalas = await prisma.user_mandalas.findMany({
       where: { user_id: userId },

--- a/src/api/routes/snapshots.ts
+++ b/src/api/routes/snapshots.ts
@@ -11,6 +11,7 @@ import { FastifyPluginCallback } from 'fastify';
 import { Prisma } from '@prisma/client';
 import { getPrismaClient } from '../../modules/database';
 import { createErrorResponse, ErrorCode } from '../schemas/common.schema';
+import { MS_PER_HOUR } from '@/utils/time-constants';
 
 const SNAPSHOT_EXPIRY_HOURS = 24;
 
@@ -159,7 +160,7 @@ export const snapshotRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     const userId = request.user.userId;
     const prisma = getPrismaClient();
 
-    const expiryThreshold = new Date(Date.now() - SNAPSHOT_EXPIRY_HOURS * 60 * 60 * 1000);
+    const expiryThreshold = new Date(Date.now() - SNAPSHOT_EXPIRY_HOURS * MS_PER_HOUR);
 
     const snapshots = await prisma.card_snapshots.findMany({
       where: {

--- a/src/api/routes/subscriptions.ts
+++ b/src/api/routes/subscriptions.ts
@@ -7,6 +7,7 @@
 
 import { FastifyPluginCallback } from 'fastify';
 import { getPrismaClient } from '../../modules/database';
+import { MS_PER_DAY } from '@/utils/time-constants';
 
 const RECENT_UPDATES_DAYS = 7;
 
@@ -20,7 +21,7 @@ export const subscriptionRoutes: FastifyPluginCallback = (fastify, _opts, done) 
     }
     const userId = request.user.userId;
     const prisma = getPrismaClient();
-    const since = new Date(Date.now() - RECENT_UPDATES_DAYS * 24 * 60 * 60 * 1000);
+    const since = new Date(Date.now() - RECENT_UPDATES_DAYS * MS_PER_DAY);
 
     const subscriptions = await prisma.mandala_subscriptions.findMany({
       where: { subscriber_id: userId },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,7 @@ import { registerAuthCommands } from './commands/auth';
 import { registerPlaylistCommands } from './commands/playlists';
 import { registerSchedulerCommands } from './commands/scheduler';
 import { registerEnrichCommands } from './commands/enrich';
+import { MS_PER_HOUR, MS_PER_DAY } from '@/utils/time-constants';
 
 const program = new Command();
 
@@ -658,9 +659,9 @@ function parseInterval(interval: string): number {
     case 'm':
       return value * 60 * 1000; // minutes to ms
     case 'h':
-      return value * 60 * 60 * 1000; // hours to ms
+      return value * MS_PER_HOUR; // hours to ms
     case 'd':
-      return value * 24 * 60 * 60 * 1000; // days to ms
+      return value * MS_PER_DAY; // days to ms
     default:
       throw new Error('Invalid interval unit. Use m (minutes), h (hours), or d (days)');
   }

--- a/src/config/explore.ts
+++ b/src/config/explore.ts
@@ -5,6 +5,8 @@
  * Do NOT hardcode explore values elsewhere — import from this module.
  */
 
+import { MS_PER_HOUR } from '@/utils/time-constants';
+
 export const EXPLORE_SOURCES = ['all', 'template', 'community'] as const;
 export type ExploreSource = (typeof EXPLORE_SOURCES)[number];
 
@@ -24,4 +26,4 @@ export const EXPLORE_DEFAULT_PAGE_SIZE = 24;
 export const MAX_PAGINATION_LIMIT = 100;
 
 /** Cache TTL for explore results in milliseconds (1 hour — templates are near-immutable) */
-export const EXPLORE_CACHE_TTL_MS = 60 * 60 * 1000;
+export const EXPLORE_CACHE_TTL_MS = MS_PER_HOUR;

--- a/src/modules/mandala/generator.ts
+++ b/src/modules/mandala/generator.ts
@@ -26,6 +26,7 @@ import {
   ACTIONS_TEMPERATURE,
   ACTIONS_MAX_TOKENS as PROMPT_ACTIONS_MAX_TOKENS,
 } from '@/prompts/actions-generator';
+import { MS_PER_DAY } from '@/utils/time-constants';
 
 // ─── Types ───
 
@@ -60,7 +61,7 @@ const TEMPERATURE = 0.7;
 // Cache key: `${language}:${normalizedGoal}` — exact match only.
 // (Future: embedding-based cosine ≥ 0.9 hit — issue tracked separately.)
 
-const GENERATE_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const GENERATE_CACHE_TTL_MS = MS_PER_DAY; // 24h
 const GENERATE_CACHE_MAX = 200;
 
 interface CachedGeneration {

--- a/src/modules/mandala/mood.ts
+++ b/src/modules/mandala/mood.ts
@@ -1,5 +1,6 @@
 import { getPrismaClient } from '../database/client';
 import { logger } from '../../utils/logger';
+import { MS_PER_DAY } from '@/utils/time-constants';
 
 interface MoodSignals {
   weeklySessionCount: number;
@@ -42,8 +43,8 @@ export async function getMood(
 ): Promise<{ state: MoodState; signals: MoodSignals; updatedAt: string }> {
   const prisma = getPrismaClient();
   const now = new Date();
-  const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-  const twoWeeksAgo = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000);
+  const oneWeekAgo = new Date(now.getTime() - 7 * MS_PER_DAY);
+  const twoWeeksAgo = new Date(now.getTime() - 14 * MS_PER_DAY);
 
   try {
     const [activityLogs, totalCardsResult, recentCards] = await Promise.all([
@@ -96,7 +97,7 @@ export async function getMood(
     // Days since last activity
     const lastActivity = activityLogs[0]?.created_at;
     const daysSinceLastActivity = lastActivity
-      ? Math.floor((now.getTime() - new Date(lastActivity).getTime()) / (24 * 60 * 60 * 1000))
+      ? Math.floor((now.getTime() - new Date(lastActivity).getTime()) / MS_PER_DAY)
       : 999;
 
     const signals: MoodSignals = {

--- a/src/modules/scheduler/auto-sync.ts
+++ b/src/modules/scheduler/auto-sync.ts
@@ -17,6 +17,7 @@ import { getSchedulerManager, ScheduleInfo } from './manager';
 import { getPrismaClient } from '../database';
 import { logger } from '../../utils/logger';
 import { SyncStatus } from '../../types/enums';
+import { MS_PER_HOUR, MS_PER_DAY } from '@/utils/time-constants';
 
 /**
  * Scheduler status information
@@ -401,7 +402,7 @@ export class AutoSyncScheduler {
     // Parse common cron patterns
     const parts = cronExpression.trim().split(/\s+/);
 
-    const DEFAULT_SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+    const DEFAULT_SYNC_INTERVAL_MS = 6 * MS_PER_HOUR; // 6 hours
     const MIN_SYNC_INTERVAL_MS = 60 * 1000; // 1 minute
 
     if (parts.length !== 5) {
@@ -424,27 +425,27 @@ export class AutoSyncScheduler {
     // Every N hours: 0 */N * * *
     if (minute === '0' && hour?.startsWith('*/')) {
       const hours = parseInt(hour.substring(2), 10);
-      return hours * 60 * 60 * 1000;
+      return hours * MS_PER_HOUR;
     }
 
     // Every N days: 0 0 */N * *
     if (minute === '0' && hour === '0' && dayOfMonth?.startsWith('*/')) {
       const days = parseInt(dayOfMonth.substring(2), 10);
-      return days * 24 * 60 * 60 * 1000;
+      return days * MS_PER_DAY;
     }
 
     // Weekly: M H * * N (check before daily to avoid matching weekly as daily)
     if (!minute?.includes('*') && !hour?.includes('*') && dayOfWeek !== '*') {
-      return 7 * 24 * 60 * 60 * 1000;
+      return 7 * MS_PER_DAY;
     }
 
     // Daily at specific time: M H * * *
     if (!minute?.includes('*') && !hour?.includes('*') && dayOfMonth === '*') {
-      return 24 * 60 * 60 * 1000;
+      return MS_PER_DAY;
     }
 
     // Default to 6 hours for complex patterns
-    return 6 * 60 * 60 * 1000;
+    return 6 * MS_PER_HOUR;
   }
 
   /**

--- a/src/modules/sharing/manager.ts
+++ b/src/modules/sharing/manager.ts
@@ -6,6 +6,7 @@
 
 import { getPrismaClient } from '../database';
 import crypto from 'crypto';
+import { MS_PER_DAY } from '@/utils/time-constants';
 
 const SHARE_CODE_LENGTH = 8;
 
@@ -53,9 +54,7 @@ export async function createShareLink(
   }
 
   const shareCode = generateShareCode();
-  const expiresAt = expiresInDays
-    ? new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000)
-    : null;
+  const expiresAt = expiresInDays ? new Date(Date.now() + expiresInDays * MS_PER_DAY) : null;
 
   const share = await prisma.mandala_shares.create({
     data: {

--- a/src/modules/skills/newsletter.ts
+++ b/src/modules/skills/newsletter.ts
@@ -21,6 +21,7 @@ import { config } from '@/config/index';
 import { TIER_LIMITS, type Tier } from '@/config/quota';
 import { queryMandalaCards, type SkillCard } from './card-query';
 import { transporter } from './mailer';
+import { MS_PER_DAY } from '@/utils/time-constants';
 import type { InsightaSkill, SkillContext, SkillResult, SkillPreview } from './types';
 
 const log = logger.child({ module: 'NewsletterSkill' });
@@ -169,7 +170,7 @@ export class NewsletterSkill implements InsightaSkill {
   // ============================================================================
 
   private async curate(userId: string, mandalaId: string, topN: number): Promise<SkillCard[]> {
-    const since = new Date(Date.now() - CURATION_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+    const since = new Date(Date.now() - CURATION_WINDOW_DAYS * MS_PER_DAY);
 
     // Unified card query — local + synced from shared module
     const allCards = await queryMandalaCards({

--- a/src/modules/youtube/api.ts
+++ b/src/modules/youtube/api.ts
@@ -6,6 +6,7 @@
  */
 
 import { getPrismaClient } from '../database';
+import { MS_PER_HOUR } from '@/utils/time-constants';
 
 const YOUTUBE_API_BASE = 'https://www.googleapis.com/youtube/v3';
 const MAX_RESULTS = 50;
@@ -18,7 +19,7 @@ const MAX_RESULTS = 50;
  * maybe once a week). 6-hour TTL protects YouTube quota (100 units/call for
  * subscriptions) while keeping data reasonably fresh.
  */
-const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+const CACHE_TTL_MS = 6 * MS_PER_HOUR; // 6 hours
 const responseCache = new Map<string, { data: unknown; expiry: number }>();
 
 function getCached<T>(key: string): T | null {

--- a/src/skills/plugins/iks-scorer/executor.ts
+++ b/src/skills/plugins/iks-scorer/executor.ts
@@ -25,6 +25,7 @@ import { getPrismaClient } from '@/modules/database';
 import { Prisma } from '@prisma/client';
 import { logger } from '@/utils/logger';
 import { manifest, IKS_SCORER_DEFAULT_SOURCES, IKS_SCORER_TTL_DAYS } from './manifest';
+import { MS_PER_DAY } from '@/utils/time-constants';
 import { computeIksResult, type SignalForScoring, type IksWeights } from './scoring';
 import {
   embedBatch,
@@ -35,7 +36,6 @@ import {
 } from './embedding';
 
 const log = logger.child({ module: 'iks-scorer' });
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 interface HydratedState {
   sources: readonly string[];

--- a/src/skills/plugins/trend-collector/executor.ts
+++ b/src/skills/plugins/trend-collector/executor.ts
@@ -58,11 +58,11 @@ import {
 } from './sources/suggest';
 import { LEARNING_SEED_TERMS, type LearningSeed } from './seed-terms';
 import { loadDynamicSeedsFromMandalas, mergeSeeds } from './dynamic-seeds';
+import { MS_PER_DAY } from '@/utils/time-constants';
 
 const log = logger.child({ module: 'trend-collector' });
 
 const KEYWORD_MAX_LENGTH = 255;
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const DEFAULT_OLLAMA_URL = 'http://100.91.173.17:11434';
 const SUGGEST_PARALLELISM = 3; // be polite to the unofficial endpoint
 

--- a/src/skills/plugins/video-discover/executor.ts
+++ b/src/skills/plugins/video-discover/executor.ts
@@ -48,9 +48,9 @@ import {
   type SearchQueryPromptInput,
 } from '@/prompts/search-query-generator';
 import { rerankBatch, type RerankCandidate } from './sources/llm-reranker';
+import { MS_PER_DAY } from '@/utils/time-constants';
 
 const log = logger.child({ module: 'video-discover' });
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const YOUTUBE_API_BASE = 'https://www.googleapis.com/youtube/v3';
 
 /**
@@ -164,7 +164,7 @@ const MIN_VIEW_COUNT_RELAX_FRESH = 1_000;
  * Kill switch: VIDEO_DISCOVER_DISABLE_CACHE_REUSE=1
  */
 const CACHE_LOOKBACK_DAYS = 7;
-const CACHE_LOOKBACK_MS = CACHE_LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+const CACHE_LOOKBACK_MS = CACHE_LOOKBACK_DAYS * MS_PER_DAY;
 const MIN_CACHE_HITS_PER_CELL = 3;
 /** How many rows to read per cell-cache lookup (avoids loading everything). */
 const CACHE_LOOKUP_LIMIT = 20;

--- a/src/skills/plugins/video-discover/v2/executor.ts
+++ b/src/skills/plugins/video-discover/v2/executor.ts
@@ -27,6 +27,7 @@ import type {
 } from '@/skills/_shared/types';
 
 import { manifest, V2_TARGET_TOTAL, V2_TARGET_PER_CELL, V2_NUM_CELLS } from './manifest';
+import { MS_PER_DAY } from '@/utils/time-constants';
 import {
   buildRuleBasedQueriesSync,
   runLLMQueries,
@@ -619,7 +620,7 @@ async function upsertRecommendations(
   scoreByVideoId: Map<string, number>
 ): Promise<number> {
   const db = getPrismaClient();
-  const expiresAt = new Date(Date.now() + TTL_DAYS * 24 * 60 * 60 * 1000);
+  const expiresAt = new Date(Date.now() + TTL_DAYS * MS_PER_DAY);
   let count = 0;
 
   for (const a of assignments) {

--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -1,0 +1,66 @@
+import { loadV3Config } from '../config';
+import { DEFAULT_RECENCY_HALF_LIFE_MONTHS, DEFAULT_RECENCY_WEIGHT } from '../mandala-filter';
+
+describe('loadV3Config', () => {
+  test('empty env → baseline (Tier 1 off, recency weight 0, no publishedAfter)', () => {
+    expect(loadV3Config({})).toEqual({
+      enableTier1Cache: false,
+      recencyWeight: DEFAULT_RECENCY_WEIGHT,
+      recencyHalfLifeMonths: DEFAULT_RECENCY_HALF_LIFE_MONTHS,
+      publishedAfterDays: 0,
+    });
+  });
+
+  test('V3_ENABLE_TIER1_CACHE="true" → enabled (case-insensitive, trimmed)', () => {
+    expect(loadV3Config({ V3_ENABLE_TIER1_CACHE: 'true' }).enableTier1Cache).toBe(true);
+    expect(loadV3Config({ V3_ENABLE_TIER1_CACHE: '  TRUE  ' }).enableTier1Cache).toBe(true);
+    expect(loadV3Config({ V3_ENABLE_TIER1_CACHE: 'false' }).enableTier1Cache).toBe(false);
+    expect(loadV3Config({ V3_ENABLE_TIER1_CACHE: '' }).enableTier1Cache).toBe(false);
+  });
+
+  test('V3_RECENCY_WEIGHT parses valid [0,1] values', () => {
+    expect(loadV3Config({ V3_RECENCY_WEIGHT: '0.15' }).recencyWeight).toBeCloseTo(0.15, 6);
+    expect(loadV3Config({ V3_RECENCY_WEIGHT: '0' }).recencyWeight).toBe(0);
+    expect(loadV3Config({ V3_RECENCY_WEIGHT: '1' }).recencyWeight).toBe(1);
+  });
+
+  test('invalid V3_RECENCY_WEIGHT → baseline (entire config falls back)', () => {
+    // Out of range: zod rejects, loadV3Config returns baseline
+    expect(loadV3Config({ V3_RECENCY_WEIGHT: '1.5' }).recencyWeight).toBe(DEFAULT_RECENCY_WEIGHT);
+    expect(loadV3Config({ V3_RECENCY_WEIGHT: '-0.1' }).recencyWeight).toBe(DEFAULT_RECENCY_WEIGHT);
+    expect(loadV3Config({ V3_RECENCY_WEIGHT: 'NaN' }).recencyWeight).toBe(DEFAULT_RECENCY_WEIGHT);
+  });
+
+  test('V3_RECENCY_HALF_LIFE_MONTHS requires positive integer', () => {
+    expect(loadV3Config({ V3_RECENCY_HALF_LIFE_MONTHS: '24' }).recencyHalfLifeMonths).toBe(24);
+    // negative / zero / non-int → baseline
+    expect(loadV3Config({ V3_RECENCY_HALF_LIFE_MONTHS: '0' }).recencyHalfLifeMonths).toBe(
+      DEFAULT_RECENCY_HALF_LIFE_MONTHS
+    );
+    expect(loadV3Config({ V3_RECENCY_HALF_LIFE_MONTHS: '-3' }).recencyHalfLifeMonths).toBe(
+      DEFAULT_RECENCY_HALF_LIFE_MONTHS
+    );
+  });
+
+  test('V3_PUBLISHED_AFTER_DAYS accepts non-negative integer', () => {
+    expect(loadV3Config({ V3_PUBLISHED_AFTER_DAYS: '1095' }).publishedAfterDays).toBe(1095);
+    expect(loadV3Config({ V3_PUBLISHED_AFTER_DAYS: '0' }).publishedAfterDays).toBe(0);
+    expect(loadV3Config({ V3_PUBLISHED_AFTER_DAYS: '-5' }).publishedAfterDays).toBe(0);
+    expect(loadV3Config({ V3_PUBLISHED_AFTER_DAYS: 'garbage' }).publishedAfterDays).toBe(0);
+  });
+
+  test('combined: realistic CP391 rollout config', () => {
+    expect(
+      loadV3Config({
+        V3_RECENCY_WEIGHT: '0.15',
+        V3_RECENCY_HALF_LIFE_MONTHS: '18',
+        V3_PUBLISHED_AFTER_DAYS: '1095',
+      })
+    ).toEqual({
+      enableTier1Cache: false,
+      recencyWeight: 0.15,
+      recencyHalfLifeMonths: 18,
+      publishedAfterDays: 1095,
+    });
+  });
+});

--- a/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
@@ -4,10 +4,23 @@
  * cell. Covers the prod-observed contamination cases from 2026-04-16.
  */
 
-import { applyMandalaFilter, MIN_SUB_RELEVANCE, type FilterCandidate } from '../mandala-filter';
+import {
+  applyMandalaFilter,
+  applyMandalaFilterWithStats,
+  buildScoreWeights,
+  computeRecencyScore,
+  DEFAULT_RECENCY_HALF_LIFE_MONTHS,
+  MIN_SUB_RELEVANCE,
+  type FilterCandidate,
+} from '../mandala-filter';
 
-function cand(videoId: string, title: string, description = ''): FilterCandidate {
-  return { videoId, title, description };
+function cand(
+  videoId: string,
+  title: string,
+  description = '',
+  publishedAt: Date | null = null
+): FilterCandidate {
+  return { videoId, title, description, publishedAt };
 }
 
 describe('applyMandalaFilter — center gate (Gate 1)', () => {
@@ -281,5 +294,122 @@ describe('applyMandalaFilter — empty input and edge cases', () => {
 
   test('MIN_SUB_RELEVANCE threshold is public and 0.05', () => {
     expect(MIN_SUB_RELEVANCE).toBe(0.05);
+  });
+});
+
+describe('recency weighting (2026-04-18, env-gated)', () => {
+  const BASE_INPUT = {
+    centerGoal: '턱걸이 20개',
+    subGoals: [
+      '기초체력 점검',
+      '등근육 강화',
+      '팔이두근 발달',
+      '어깨안정성',
+      '코어안정화',
+      '점진적 과부하',
+      '영양체중관리',
+      '회복 부상 예방',
+    ],
+    language: 'ko' as const,
+  };
+
+  const NOW = new Date('2026-04-18T00:00:00Z');
+
+  test('recencyWeight=0 keeps legacy 0.5/0.5 weights (baseline invariant)', () => {
+    const weights = buildScoreWeights(0);
+    expect(weights).toEqual({ wCenter: 0.5, wCell: 0.5, wRecency: 0 });
+  });
+
+  test('recencyWeight>0 scales center+cell down proportionally, sums to 1', () => {
+    const w = buildScoreWeights(0.2);
+    expect(w.wRecency).toBe(0.2);
+    expect(w.wCenter).toBeCloseTo(0.4, 6);
+    expect(w.wCell).toBeCloseTo(0.4, 6);
+    expect(w.wCenter + w.wCell + w.wRecency).toBeCloseTo(1, 6);
+  });
+
+  test('computeRecencyScore: 0 when publishedAt null; 1 for future; halves at halfLife', () => {
+    expect(computeRecencyScore(null, NOW, 18)).toBe(0);
+    expect(computeRecencyScore(undefined, NOW, 18)).toBe(0);
+    // future date
+    const future = new Date(NOW.getTime() + 1000 * 60 * 60 * 24);
+    expect(computeRecencyScore(future, NOW, 18)).toBe(1);
+    // exactly one half-life (18 months ≈ 540 days)
+    const oneHalfLife = new Date(NOW.getTime() - 18 * 30 * 24 * 60 * 60 * 1000);
+    expect(computeRecencyScore(oneHalfLife, NOW, 18)).toBeCloseTo(0.5, 3);
+  });
+
+  test('with recencyWeight=0 → old video matching lexically still wins (baseline preserved)', () => {
+    // Both candidates have identical lexical match. Old has zero recency
+    // advantage in baseline mode.
+    const oldVid = cand(
+      'old',
+      '턱걸이 등근육 강화 루틴',
+      '턱걸이 등근육 팔이두근 발달',
+      new Date('2018-04-18T00:00:00Z')
+    );
+    const newVid = cand(
+      'new',
+      '턱걸이 등근육 강화 루틴',
+      '턱걸이 등근육 팔이두근 발달',
+      new Date('2025-10-18T00:00:00Z')
+    );
+    const { byCell } = applyMandalaFilterWithStats([oldVid, newVid], {
+      ...BASE_INPUT,
+      recencyWeight: 0,
+      now: NOW,
+    });
+    // All cells combined: both should be present with equal score.
+    const flat = Array.from(byCell.values()).flat();
+    expect(flat).toHaveLength(2);
+    expect(flat[0]!.score).toBeCloseTo(flat[1]!.score, 6);
+  });
+
+  test('with recencyWeight=0.15 → new video outranks equal-lexical old video', () => {
+    const oldVid = cand(
+      'old',
+      '턱걸이 등근육 강화 루틴',
+      '턱걸이 등근육 팔이두근 발달',
+      new Date('2018-04-18T00:00:00Z')
+    );
+    const newVid = cand(
+      'new',
+      '턱걸이 등근육 강화 루틴',
+      '턱걸이 등근육 팔이두근 발달',
+      new Date('2025-10-18T00:00:00Z')
+    );
+    const { byCell } = applyMandalaFilterWithStats([oldVid, newVid], {
+      ...BASE_INPUT,
+      recencyWeight: 0.15,
+      now: NOW,
+    });
+    // Both land in the same cell, sorted by score desc
+    const allCells = Array.from(byCell.values()).filter((list) => list.length > 0);
+    expect(allCells).toHaveLength(1);
+    const [list] = allCells;
+    expect(list!.length).toBeGreaterThanOrEqual(2);
+    expect(list![0]!.candidate.videoId).toBe('new');
+    expect(list![1]!.candidate.videoId).toBe('old');
+    // Observability: recencyScore stored on every assignment
+    expect(list![0]!.recencyScore).toBeGreaterThan(list![1]!.recencyScore);
+  });
+
+  test('stats.recency captures weight, halfLife, and missingPublishedAt count', () => {
+    const withDate = cand('withDate', '턱걸이 등근육 강화', '', new Date('2024-04-18T00:00:00Z'));
+    const noDate = cand('noDate', '턱걸이 등근육 강화', '', null);
+    const { stats } = applyMandalaFilterWithStats([withDate, noDate], {
+      ...BASE_INPUT,
+      recencyWeight: 0.15,
+      recencyHalfLifeMonths: 24,
+      now: NOW,
+    });
+    expect(stats.recency).toBeDefined();
+    expect(stats.recency!.weight).toBe(0.15);
+    expect(stats.recency!.halfLifeMonths).toBe(24);
+    expect(stats.recency!.missingPublishedAt).toBe(1);
+  });
+
+  test('DEFAULT_RECENCY_HALF_LIFE_MONTHS is 18', () => {
+    expect(DEFAULT_RECENCY_HALF_LIFE_MONTHS).toBe(18);
   });
 });

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+
+import { DEFAULT_RECENCY_HALF_LIFE_MONTHS, DEFAULT_RECENCY_WEIGHT } from './mandala-filter';
+
+export type V3EnvInput = Record<string, string | undefined>;
+
+const booleanFlag = z.preprocess(
+  (v) => (typeof v === 'string' ? v.trim().toLowerCase() === 'true' : Boolean(v)),
+  z.boolean()
+);
+
+const clampedUnit = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().min(0).max(1).optional()
+  )
+  .transform((v) => v ?? DEFAULT_RECENCY_WEIGHT);
+
+const positiveInt = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().int().positive().optional()
+  )
+  .transform((v) => v ?? DEFAULT_RECENCY_HALF_LIFE_MONTHS);
+
+const nonNegativeInt = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().int().nonnegative().optional()
+  )
+  .transform((v) => v ?? 0);
+
+export const v3EnvSchema = z.object({
+  V3_ENABLE_TIER1_CACHE: booleanFlag.optional().default(false as unknown as string),
+  V3_RECENCY_WEIGHT: clampedUnit,
+  V3_RECENCY_HALF_LIFE_MONTHS: positiveInt,
+  V3_PUBLISHED_AFTER_DAYS: nonNegativeInt,
+});
+
+export interface V3Config {
+  enableTier1Cache: boolean;
+  recencyWeight: number;
+  recencyHalfLifeMonths: number;
+  publishedAfterDays: number;
+}
+
+export function loadV3Config(env: V3EnvInput = process.env): V3Config {
+  const parsed = v3EnvSchema.safeParse({
+    V3_ENABLE_TIER1_CACHE: env['V3_ENABLE_TIER1_CACHE'],
+    V3_RECENCY_WEIGHT: env['V3_RECENCY_WEIGHT'],
+    V3_RECENCY_HALF_LIFE_MONTHS: env['V3_RECENCY_HALF_LIFE_MONTHS'],
+    V3_PUBLISHED_AFTER_DAYS: env['V3_PUBLISHED_AFTER_DAYS'],
+  });
+  if (!parsed.success) {
+    return {
+      enableTier1Cache: false,
+      recencyWeight: DEFAULT_RECENCY_WEIGHT,
+      recencyHalfLifeMonths: DEFAULT_RECENCY_HALF_LIFE_MONTHS,
+      publishedAfterDays: 0,
+    };
+  }
+  return {
+    enableTier1Cache: parsed.data.V3_ENABLE_TIER1_CACHE,
+    recencyWeight: parsed.data.V3_RECENCY_WEIGHT,
+    recencyHalfLifeMonths: parsed.data.V3_RECENCY_HALF_LIFE_MONTHS,
+    publishedAfterDays: parsed.data.V3_PUBLISHED_AFTER_DAYS,
+  };
+}
+
+export const v3Config: V3Config = loadV3Config();

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -28,9 +28,15 @@ import type {
   ExecuteResult,
 } from '@/skills/_shared/types';
 
+import { MS_PER_DAY } from '@/utils/time-constants';
 import { manifest, V3_TARGET_PER_CELL, V3_NUM_CELLS, V3_TARGET_TOTAL } from './manifest';
 import { matchFromVideoPool, groupByCell } from './cache-matcher';
-import { applyMandalaFilterWithStats, MIN_SUB_RELEVANCE } from './mandala-filter';
+import {
+  applyMandalaFilterWithStats,
+  MIN_SUB_RELEVANCE,
+  type FilterCandidate,
+} from './mandala-filter';
+import { v3Config } from './config';
 
 import {
   buildRuleBasedQueriesSync,
@@ -61,23 +67,6 @@ void MIN_SUB_RELEVANCE;
 // How many search queries to attempt per deficit cell (rule-based + LLM
 // together; the LLM pass yields at most a handful for the whole mandala).
 const TIER2_MAX_QUERIES_PER_CELL = 2;
-
-/**
- * Tier 1 (video_pool cache) is disabled by default (2026-04-16).
- *
- * The current pool holds ~1k rows dominated (~60%) by `user-derived`
- * leftovers from past mandalas. At that scale embedding cosine (≥0.3)
- * produces cross-topic hits — e.g. "하느님 자비의 기도" admitted into a
- * "일일 습관 성장" mandala because both land near each other in the
- * generic Korean self-help cluster. Until the pool reaches a useful
- * scale (10⁵–10⁶ rows) and/or is replaced with a domain-tuned model,
- * we skip Tier 1 entirely and route every request through Tier 2.
- *
- * The pgvector index, matchFromVideoPool function, and upsert path all
- * remain intact. Flip this env flag (V3_ENABLE_TIER1_CACHE=true) to
- * reactivate without a code change.
- */
-const V3_ENABLE_TIER1_CACHE = process.env['V3_ENABLE_TIER1_CACHE'] === 'true';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -191,8 +180,8 @@ export const executor: SkillExecutor = {
     const state = ctx.state as unknown as HydratedState;
     const mandalaId = ctx.mandalaId!;
 
-    // ── Tier 1: video_pool cache (disabled by default — see V3_ENABLE_TIER1_CACHE)
-    const tier1Matches = V3_ENABLE_TIER1_CACHE
+    // ── Tier 1: video_pool cache (disabled by default — see v3Config.enableTier1Cache)
+    const tier1Matches = v3Config.enableTier1Cache
       ? await matchFromVideoPool({
           mandalaId,
           language: state.language,
@@ -542,16 +531,24 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   debug.existingExcluded = enriched.length - filterable.length;
   debug.mandalaFilterInput = filterable.length;
 
+  type FilterInput = FilterCandidate & { videoId: string };
+  const filterInputs: FilterInput[] = filterable.map((v) => ({
+    videoId: v.videoId,
+    title: v.title,
+    description: v.description ?? null,
+    publishedAt: v.publishedDate,
+  }));
+  const enrichedById = new Map<string, Enriched>();
+  for (const v of filterable) enrichedById.set(v.videoId, v);
+
   const tMandalaFilterStart = Date.now();
-  const { byCell, stats: mfStats } = applyMandalaFilterWithStats(filterable, {
+  const { byCell, stats: mfStats } = applyMandalaFilterWithStats(filterInputs, {
     centerGoal: input.state.centerGoal,
     subGoals: input.state.subGoals,
     language: input.state.language,
-    // 2026-04-18 bug #414 fix — propagate user's focusTags so "박문호 강연"
-    // videos bypass the center-substring gate. Without this, wizard focus
-    // tags were silently dropped at the filter even though the search
-    // query layer correctly used them to fetch the pool.
     focusTags: input.state.focusTags,
+    recencyWeight: v3Config.recencyWeight,
+    recencyHalfLifeMonths: v3Config.recencyHalfLifeMonths,
   });
   debug.timing.mandalaFilterMs = Date.now() - tMandalaFilterStart;
 
@@ -571,7 +568,9 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   for (const [cellIndex, list] of byCell) {
     if (!deficitCellSet.has(cellIndex)) continue;
     for (const a of list) {
-      scored.push({ video: a.candidate, cellIndex, score: a.score });
+      const enrichedVideo = enrichedById.get(a.candidate.videoId);
+      if (!enrichedVideo) continue;
+      scored.push({ video: enrichedVideo, cellIndex, score: a.score });
     }
   }
   debug.scoredCandidates = scored.length;
@@ -641,6 +640,10 @@ async function runSearchTraced(
 ): Promise<SearchTrace> {
   if (queries.length === 0) return { pool: [], perQuery: [] };
   const regionCode = language === 'ko' ? 'KR' : 'US';
+  const publishedAfter =
+    v3Config.publishedAfterDays > 0
+      ? new Date(Date.now() - v3Config.publishedAfterDays * MS_PER_DAY).toISOString()
+      : undefined;
   const results = await Promise.all(
     queries.map(async (q) => {
       try {
@@ -649,6 +652,7 @@ async function runSearchTraced(
           apiKey: apiKeys,
           relevanceLanguage: language,
           regionCode,
+          ...(publishedAfter ? { publishedAfter } : {}),
         });
         return { q, items, error: undefined as string | undefined };
       } catch (err) {
@@ -705,7 +709,7 @@ async function upsertSlots(
   subGoals: ReadonlyArray<string>
 ): Promise<number> {
   const db = getPrismaClient();
-  const expiresAt = new Date(Date.now() + TTL_DAYS * 24 * 60 * 60 * 1000);
+  const expiresAt = new Date(Date.now() + TTL_DAYS * MS_PER_DAY);
   let count = 0;
 
   for (const slot of slots) {

--- a/src/skills/plugins/video-discover/v3/mandala-filter.ts
+++ b/src/skills/plugins/video-discover/v3/mandala-filter.ts
@@ -36,39 +36,64 @@
  */
 
 import { extractCoreKeyphrase, type KeywordLanguage } from '../v2/keyword-builder';
+import { MS_PER_MONTH_AVG } from '@/utils/time-constants';
 
-/** Minimum jaccard overlap with a sub_goal for a candidate to be routed. */
 export const MIN_SUB_RELEVANCE = 0.05;
 
-/** Shape the filter needs — any candidate source (pool, search, future). */
+export const DEFAULT_RECENCY_WEIGHT = 0;
+
+// 18mo half-life: 1y → 0.63, 3y → 0.25, 6y → 0.06.
+export const DEFAULT_RECENCY_HALF_LIFE_MONTHS = 18;
+
 export interface FilterCandidate {
   videoId: string;
   title: string;
   description: string | null;
+  publishedAt?: Date | null;
 }
 
 export interface ScoredAssignment<T extends FilterCandidate> {
   candidate: T;
   cellIndex: number;
-  /** Final score, range 0..1, used for per-cell ranking. */
   score: number;
-  /** Gate 1 component. */
   centerScore: number;
-  /** Gate 2 component (best sub_goal jaccard). */
   cellScore: number;
+  recencyScore: number;
 }
 
 export interface MandalaFilterInput {
   centerGoal: string;
   subGoals: ReadonlyArray<string>; // length 8
   language: KeywordLanguage;
-  /**
-   * User-declared focus tags from the wizard (e.g. "박문호", "뇌과학").
-   * When present, any candidate whose title lexically contains at least one
-   * focus tag bypasses the center-substring gate. Optional so callers that
-   * don't have access to the user's tags (e.g. cache-matcher) keep working.
-   */
   focusTags?: ReadonlyArray<string>;
+  recencyWeight?: number;
+  recencyHalfLifeMonths?: number;
+  now?: Date;
+}
+
+export interface ScoreWeights {
+  wCenter: number;
+  wCell: number;
+  wRecency: number;
+}
+
+export function buildScoreWeights(recencyWeight: number): ScoreWeights {
+  if (!(recencyWeight > 0)) return { wCenter: 0.5, wCell: 0.5, wRecency: 0 };
+  const clamped = Math.min(recencyWeight, 1);
+  const remaining = 1 - clamped;
+  return { wCenter: 0.5 * remaining, wCell: 0.5 * remaining, wRecency: clamped };
+}
+
+export function computeRecencyScore(
+  publishedAt: Date | null | undefined,
+  now: Date,
+  halfLifeMonths: number
+): number {
+  if (!publishedAt) return 0;
+  const ageMs = now.getTime() - publishedAt.getTime();
+  if (ageMs <= 0) return 1;
+  const ageMonths = ageMs / MS_PER_MONTH_AVG;
+  return Math.pow(0.5, ageMonths / halfLifeMonths);
 }
 
 /**
@@ -90,8 +115,12 @@ export interface MandalaFilterStats {
   subGoalTokenCounts: number[];
   /** How many candidates passed the gate via focusTag match (2026-04-18). */
   passedByFocusTag?: number;
-  /** Effective focus tokens fed into the OR gate (for diagnostic). */
   focusTokens?: string[];
+  recency?: {
+    weight: number;
+    halfLifeMonths: number;
+    missingPublishedAt: number;
+  };
 }
 
 export function applyMandalaFilter<T extends FilterCandidate>(
@@ -117,6 +146,17 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
     for (const t of tokenize(raw, input.language)) focusTokens.add(t);
   }
 
+  const recencyWeightRaw = input.recencyWeight ?? DEFAULT_RECENCY_WEIGHT;
+  const recencyWeight = Number.isFinite(recencyWeightRaw)
+    ? Math.max(0, Math.min(1, recencyWeightRaw))
+    : 0;
+  const halfLifeMonths = Math.max(
+    1,
+    input.recencyHalfLifeMonths ?? DEFAULT_RECENCY_HALF_LIFE_MONTHS
+  );
+  const weights = buildScoreWeights(recencyWeight);
+  const now = input.now ?? new Date();
+
   const byCell = new Map<number, ScoredAssignment<T>[]>();
   for (let i = 0; i < input.subGoals.length; i++) byCell.set(i, []);
 
@@ -129,6 +169,11 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
     subGoalTokenCounts: subGoalTokens.map((s) => s.size),
     passedByFocusTag: 0,
     focusTokens: [...focusTokens],
+    recency: {
+      weight: recencyWeight,
+      halfLifeMonths,
+      missingPublishedAt: 0,
+    },
   };
 
   for (const c of candidates) {
@@ -168,13 +213,21 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
       continue;
     }
 
-    const final = 0.5 * centerScore + 0.5 * bestScore;
+    const recencyScore =
+      weights.wRecency > 0 ? computeRecencyScore(c.publishedAt, now, halfLifeMonths) : 0;
+    if (weights.wRecency > 0 && !c.publishedAt && stats.recency) {
+      stats.recency.missingPublishedAt++;
+    }
+
+    const final =
+      weights.wCenter * centerScore + weights.wCell * bestScore + weights.wRecency * recencyScore;
     byCell.get(bestCell)!.push({
       candidate: c,
       cellIndex: bestCell,
       score: final,
       centerScore,
       cellScore: bestScore,
+      recencyScore,
     });
     stats.output++;
   }

--- a/src/utils/time-constants.ts
+++ b/src/utils/time-constants.ts
@@ -1,0 +1,15 @@
+export const MS_PER_SECOND = 1_000;
+export const SECONDS_PER_MINUTE = 60;
+export const MINUTES_PER_HOUR = 60;
+export const HOURS_PER_DAY = 24;
+
+export const MS_PER_MINUTE = MS_PER_SECOND * SECONDS_PER_MINUTE;
+export const MS_PER_HOUR = MS_PER_MINUTE * MINUTES_PER_HOUR;
+export const MS_PER_DAY = MS_PER_HOUR * HOURS_PER_DAY;
+
+export const DAYS_PER_MONTH_AVG = 30;
+export const MS_PER_MONTH_AVG = MS_PER_DAY * DAYS_PER_MONTH_AVG;
+
+export function daysToMs(days: number): number {
+  return days * MS_PER_DAY;
+}


### PR DESCRIPTION
## Summary

Fixes two chronic P0 issues reported from the user's dashboard and introduces a quantitative enforcement loop for the hardcoding rule that caused mid-session rework.

### User-visible fixes
- **Card feed dominated by 6-year-old uploads** — the 9-axis mandala filter scored purely lexically, and the YouTube search had no `publishedAfter` cutoff, so freshly-uploaded videos were buried. Added an env-gated recency term (exp decay over `publishedAt`, 18-month half-life by default) and an optional `publishedAfter=N days` cutoff. Defaults reproduce the prior score bit-identically; rollback = unset env flag.
- **"Latest" sort chip ranking by `createdAt`** — users read "최신순" as "most recently uploaded," not "most recently cached in our DB." Switched FE sort to `publishedAt` (falls through metadata, then `createdAt`). Missing-date cards sort last.
- **Sidebar "…" after wizard → dashboard** — the eager list invalidate raced with the DB propagation window (>15s observed) and overwrote the optimistic stub. Deferred the invalidate by 3s and added a `pendingMandala` fallback in `SidebarMandalaSection` so the title never falls through to "…".

### Platform hardening
- Centralised time-unit constants (`MS_PER_DAY`, `MS_PER_HOUR`, `MS_PER_MONTH_AVG`) in `src/utils/time-constants.ts`. Swept 16 files that redeclared them.
- `src/skills/plugins/video-discover/v3/config.ts`: zod-parsed singleton for all v3 env knobs. Executor no longer reaches into `process.env` directly.
- `scripts/audit/hardcode-audit.ts` + `reports/hardcode-audit/baseline.json`: 5-rule audit (MS_PER_DAY re-declarations, `process.env` direct reads, inline env parsers, raw time literals) with a ratchet-only baseline. Wired into `ci.yml` (per-PR gate) and a weekly trend workflow.
- CLAUDE.md: added a LEVEL-3 "하드코딩 + 단편 조치 금지" Hard Rule, cross-referenced in `/check` Category 1.

### Rollback safety
- BE behavioural changes are **disabled by default** — v3 flags unset = prior score math. Roll back by removing the env vars, no code change needed.
- FE changes (sort, sidebar fallback, wizard delay) are immediate and split across independent commits so a single `git revert <sha>` reverses any one axis.

## Commits (5)

1. `chore(audit): add hardcode audit gate + central time constants`
2. `refactor(time): replace file-local MS_PER_DAY/HOUR with central imports`
3. `feat(video-discover/v3): env-gated recency score + publishedAfter cutoff`
4. `feat(frontend): sort by source publish date, sidebar pending fallback, deferred wizard invalidate`
5. `docs(CLAUDE.md): forbid hardcoding + single-file partial fixes`

## Test plan

- [x] `npx tsc --noEmit` (BE + FE) — 0 errors
- [x] `npx jest src/skills/plugins/video-discover/v3/__tests__/` — 34/34 pass (27 existing + 7 new recency + config)
- [x] `npx vitest run src/__tests__/smoke/sidebar-mandala-fallback.test.ts` — 5/5 pass
- [x] `npm run build` (BE) / `cd frontend && npm run build` — both pass
- [x] `npx tsx scripts/audit/hardcode-audit.ts` — 35 total, each at baseline → PASS
- [ ] After merge + deploy: create a fresh mandala on prod; verify sidebar shows the title immediately (no "…"), and cards sort by upload date (newest first)
- [ ] Optional: set `V3_RECENCY_WEIGHT=0.15` and `V3_PUBLISHED_AFTER_DAYS=1095` on prod to activate recency ranking; re-run `/tc-tune --env prod` to compare against baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
