### PR TITLE
feat(video-discover/v3): semantic rerank consumer behind feature flag (CP406)

### DIFF
--- a/src/modules/video-dictionary/constants.ts
+++ b/src/modules/video-dictionary/constants.ts
@@ -1,0 +1,21 @@
+/**
+ * video-dictionary — constants
+ *
+ * Named constants for semantic rerank. Source: synthesis spec §4.2
+ * (/cursor/video-dictionary/docs/design/discovery-strategy.md).
+ */
+
+/** Per-cell cap for the pre-filter → rerank candidate set (§4.2). */
+export const SEMANTIC_RERANK_TOP_N_PER_CELL = 50;
+
+/** Blend weight on the linear pre-filter `rec_score` (§4.2 starting point). */
+export const DEFAULT_SEMANTIC_ALPHA = 0.6;
+
+/** Blend weight on the pgvector cosine term (§4.2 starting point). */
+export const DEFAULT_SEMANTIC_BETA = 0.4;
+
+/** Minimum cosine similarity admitted into the rerank (below = treat as null). */
+export const SEMANTIC_COSINE_FLOOR = 0;
+
+/** pgvector cosine distance operator → cosine similarity via `1 - dist`. */
+export const COSINE_SIMILARITY_MAX = 1;

--- a/src/modules/video-dictionary/index.ts
+++ b/src/modules/video-dictionary/index.ts
@@ -1,0 +1,23 @@
+/**
+ * video-dictionary — module barrel
+ *
+ * Consumer module for the external video-dictionary collector's
+ * `video_chunk_embeddings` table (populated on mac mini via A1→A4 pipeline,
+ * shipped as raw vectors only — no code dependency on that repo).
+ *
+ * Synthesis spec: /cursor/video-dictionary/docs/design/discovery-strategy.md
+ */
+
+export { getSemanticRank } from './semantic-rank';
+export { applySemanticRerank } from './rerank';
+export type { SemanticRankOptions, SemanticRankResult, RerankableSlot } from './types';
+export type {
+  ApplySemanticRerankOptions,
+  SemanticRerankOutput,
+  SemanticRerankTrace,
+} from './rerank';
+export {
+  SEMANTIC_RERANK_TOP_N_PER_CELL,
+  DEFAULT_SEMANTIC_ALPHA,
+  DEFAULT_SEMANTIC_BETA,
+} from './constants';

--- a/src/modules/video-dictionary/rerank.ts
+++ b/src/modules/video-dictionary/rerank.ts
@@ -1,0 +1,81 @@
+/**
+ * video-dictionary — semantic rerank blend
+ *
+ * Applies α·rec_score + β·cosine to slots using a SemanticRankResult map.
+ *
+ * Contract (synthesis spec §4.2, §4.3):
+ *   - When cosine is `null` (no embedding rows): pass through unchanged
+ *   - When α=1, β=0: identity (emergency rollback path)
+ *   - Scores stay clamped to [0, 1]
+ *
+ * Pure function: no I/O, no mutation of input array. Re-sorts descending.
+ */
+
+import type { RerankableSlot, SemanticRankResult } from './types';
+
+export interface ApplySemanticRerankOptions {
+  alpha: number;
+  beta: number;
+}
+
+export interface SemanticRerankTrace {
+  /** Input slot count. */
+  candidatesIn: number;
+  /** Slots that had a non-null cosine and were blended. */
+  candidatesScored: number;
+  /** Mean cosine of scored slots, or 0 if none. */
+  avgCosine: number;
+}
+
+export interface SemanticRerankOutput<S extends RerankableSlot> {
+  slots: S[];
+  trace: SemanticRerankTrace;
+}
+
+/**
+ * Blend linear pre-filter score with pgvector cosine.
+ *   blended = α·score + β·cosine    (when cosine present)
+ *   blended = score                  (when cosine null)
+ *
+ * Returns a new array sorted by blended score desc. Input not mutated.
+ */
+export function applySemanticRerank<S extends RerankableSlot>(
+  slots: ReadonlyArray<S>,
+  ranks: SemanticRankResult,
+  opts: ApplySemanticRerankOptions
+): SemanticRerankOutput<S> {
+  const { alpha, beta } = opts;
+  const out: S[] = [];
+  let scored = 0;
+  let cosineSum = 0;
+
+  for (const slot of slots) {
+    const cosine = ranks.get(slot.videoId);
+    if (cosine == null) {
+      out.push(slot);
+      continue;
+    }
+    const blended = clampUnit(alpha * slot.score + beta * cosine);
+    scored += 1;
+    cosineSum += cosine;
+    out.push({ ...slot, score: blended });
+  }
+
+  out.sort((a, b) => b.score - a.score);
+
+  return {
+    slots: out,
+    trace: {
+      candidatesIn: slots.length,
+      candidatesScored: scored,
+      avgCosine: scored > 0 ? cosineSum / scored : 0,
+    },
+  };
+}
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}

--- a/src/modules/video-dictionary/semantic-rank.ts
+++ b/src/modules/video-dictionary/semantic-rank.ts
@@ -1,0 +1,157 @@
+/**
+ * video-dictionary — semantic rank (consumer module for video_chunk_embeddings)
+ *
+ * pgvector cosine similarity between mandala cell embeddings (level=1,
+ * 4096-dim) and video transcript chunk embeddings (4096-dim, same
+ * qwen3-embedding:8b space — directly comparable).
+ *
+ * Signature per synthesis spec §6.2:
+ *   getSemanticRank(mandalaId, videoIds[]) → Map<videoId, cosine | null>
+ *
+ * Fallback contract (§6.2, §4.3): a videoId with zero embedding rows returns
+ * `null` — caller keeps the pre-filter `rec_score` with no penalty.
+ *
+ * Query: sequential scan inside `WHERE video_id = ANY($ids)` predicate.
+ * Migration comment in 001_create_table.sql documents the chosen trade-off —
+ * no HNSW/IVFFlat index is possible on 4096-dim `vector` today (pgvector
+ * 0.8.0 caps both at 2000 dims). At Phase 0 scale (~6000 chunks per query)
+ * the scan is <100ms.
+ */
+
+import { Prisma } from '@prisma/client';
+
+import { getPrismaClient } from '@/modules/database';
+import { logger } from '@/utils/logger';
+
+import type { SemanticRankOptions, SemanticRankResult } from './types';
+
+const log = logger.child({ module: 'video-dictionary/semantic-rank' });
+
+interface RankRow {
+  video_id: string;
+  cosine: number;
+}
+
+/**
+ * Compute per-video cosine similarity for semantic rerank.
+ *
+ * When `cellAssignments` is provided, cosine is taken against the assigned
+ * cell's embedding only (§4.2). When omitted, cosine is max-pooled across
+ * all cells — gives upper-bound similarity but may reward cross-cell matches.
+ */
+export async function getSemanticRank(opts: SemanticRankOptions): Promise<SemanticRankResult> {
+  const result: SemanticRankResult = new Map();
+  if (opts.videoIds.length === 0) return result;
+
+  // Seed result with nulls so callers can rely on map-has for every input id
+  // (tests + callers expect this invariant).
+  for (const id of opts.videoIds) result.set(id, null);
+
+  const db = getPrismaClient();
+  const videoIds = Array.from(new Set(opts.videoIds));
+  const assignments = opts.cellAssignments;
+
+  try {
+    const rows =
+      assignments && assignments.size > 0
+        ? await queryCellTargeted(db, opts.mandalaId, videoIds, assignments)
+        : await queryMaxAcrossCells(db, opts.mandalaId, videoIds);
+
+    for (const row of rows) {
+      const raw = row.cosine;
+      const clamped = Number.isFinite(raw) ? Math.max(0, Math.min(1, raw)) : null;
+      result.set(row.video_id, clamped);
+    }
+
+    log.debug(
+      `semantic rank: mandala=${opts.mandalaId} in=${videoIds.length} matched=${rows.length} targeted=${Boolean(assignments)}`
+    );
+    return result;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`semantic rank query failed: ${msg}`);
+    // Fallback contract: on query error, return all-null map (callers use
+    // pre-filter rec_score, no penalty).
+    return result;
+  }
+}
+
+/**
+ * Cell-targeted cosine: join video chunks to the specific cell the caller
+ * pre-assigned. Max-pools cosine across chunks (§4.2 "video_chunk_embedding_max").
+ */
+async function queryCellTargeted(
+  db: ReturnType<typeof getPrismaClient>,
+  mandalaId: string,
+  videoIds: string[],
+  assignments: ReadonlyMap<string, number>
+): Promise<RankRow[]> {
+  // Build (video_id, cell_index) pairs the caller cares about. Postgres
+  // `unnest(array, array)` paired with a join on both columns keeps the
+  // query single-pass.
+  const pairs: Array<[string, number]> = [];
+  for (const id of videoIds) {
+    const cell = assignments.get(id);
+    if (cell == null) continue;
+    pairs.push([id, cell]);
+  }
+  if (pairs.length === 0) return [];
+
+  const vidArr = pairs.map((p) => p[0]);
+  const cellArr = pairs.map((p) => p[1]);
+
+  return db.$queryRaw<RankRow[]>(Prisma.sql`
+    WITH targets AS (
+      SELECT v.video_id, v.cell_index
+      FROM unnest(${vidArr}::text[], ${cellArr}::int[]) AS v(video_id, cell_index)
+    ),
+    mandala_cells AS (
+      SELECT sub_goal_index AS cell_index, embedding
+      FROM public.mandala_embeddings
+      WHERE mandala_id = ${mandalaId}
+        AND level = 1
+        AND embedding IS NOT NULL
+    ),
+    scored AS (
+      SELECT
+        vce.video_id,
+        MAX(1 - (vce.embedding <=> mc.embedding)) AS cosine
+      FROM public.video_chunk_embeddings vce
+      JOIN targets t ON t.video_id = vce.video_id
+      JOIN mandala_cells mc ON mc.cell_index = t.cell_index
+      GROUP BY vce.video_id
+    )
+    SELECT video_id, cosine FROM scored
+  `);
+}
+
+/**
+ * Max-across-cells cosine: no caller-provided cell assignment. For each
+ * video, take max cosine across (all chunks × all 8 cells). Simpler but
+ * looser than cell-targeted (§4.2 is cell-targeted; this is the fallback).
+ */
+async function queryMaxAcrossCells(
+  db: ReturnType<typeof getPrismaClient>,
+  mandalaId: string,
+  videoIds: string[]
+): Promise<RankRow[]> {
+  return db.$queryRaw<RankRow[]>(Prisma.sql`
+    WITH mandala_cells AS (
+      SELECT embedding
+      FROM public.mandala_embeddings
+      WHERE mandala_id = ${mandalaId}
+        AND level = 1
+        AND embedding IS NOT NULL
+    ),
+    scored AS (
+      SELECT
+        vce.video_id,
+        MAX(1 - (vce.embedding <=> mc.embedding)) AS cosine
+      FROM public.video_chunk_embeddings vce
+      CROSS JOIN mandala_cells mc
+      WHERE vce.video_id = ANY(${videoIds}::text[])
+      GROUP BY vce.video_id
+    )
+    SELECT video_id, cosine FROM scored
+  `);
+}

--- a/src/modules/video-dictionary/types.ts
+++ b/src/modules/video-dictionary/types.ts
@@ -1,0 +1,30 @@
+/**
+ * video-dictionary — types
+ *
+ * Public contracts for the semantic rerank consumer.
+ * Source: synthesis spec §6.2.
+ */
+
+export interface SemanticRankOptions {
+  mandalaId: string;
+  videoIds: ReadonlyArray<string>;
+  /**
+   * Optional per-video cell assignment. When provided, cosine is computed
+   * against the specified cell's embedding only (spec-accurate per §4.2).
+   * When omitted, cosine is max-pooled across all 8 sub_goal cells.
+   */
+  cellAssignments?: ReadonlyMap<string, number>;
+}
+
+/**
+ * Per-video rank result. `null` means "no embedding row for this video" —
+ * caller should fall back to pre-filter `rec_score` with no penalty (§4.3).
+ */
+export type SemanticRankResult = Map<string, number | null>;
+
+/** Minimal slot shape consumed by `applySemanticRerank`. */
+export interface RerankableSlot {
+  videoId: string;
+  cellIndex: number;
+  score: number;
+}

--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -1,13 +1,18 @@
+import { DEFAULT_SEMANTIC_ALPHA, DEFAULT_SEMANTIC_BETA } from '@/modules/video-dictionary';
+
 import { DEFAULT_PUBLISHED_AFTER_DAYS, loadV3Config } from '../config';
 import { DEFAULT_RECENCY_HALF_LIFE_MONTHS, DEFAULT_RECENCY_WEIGHT } from '../mandala-filter';
 
 describe('loadV3Config', () => {
-  test('empty env → activated defaults (Tier 1 off, recency on, 3yr cutoff)', () => {
+  test('empty env → activated defaults (Tier 1 off, recency on, 3yr cutoff, semantic off)', () => {
     expect(loadV3Config({})).toEqual({
       enableTier1Cache: false,
       recencyWeight: DEFAULT_RECENCY_WEIGHT,
       recencyHalfLifeMonths: DEFAULT_RECENCY_HALF_LIFE_MONTHS,
       publishedAfterDays: DEFAULT_PUBLISHED_AFTER_DAYS,
+      enableSemanticRerank: false,
+      semanticAlpha: DEFAULT_SEMANTIC_ALPHA,
+      semanticBeta: DEFAULT_SEMANTIC_BETA,
     });
   });
 
@@ -66,6 +71,29 @@ describe('loadV3Config', () => {
       recencyWeight: 0.15,
       recencyHalfLifeMonths: 18,
       publishedAfterDays: 1095,
+      enableSemanticRerank: false,
+      semanticAlpha: DEFAULT_SEMANTIC_ALPHA,
+      semanticBeta: DEFAULT_SEMANTIC_BETA,
     });
+  });
+
+  test('V3_ENABLE_SEMANTIC_RERANK parses boolean flag', () => {
+    expect(loadV3Config({ V3_ENABLE_SEMANTIC_RERANK: 'true' }).enableSemanticRerank).toBe(true);
+    expect(loadV3Config({ V3_ENABLE_SEMANTIC_RERANK: '  TRUE  ' }).enableSemanticRerank).toBe(true);
+    expect(loadV3Config({ V3_ENABLE_SEMANTIC_RERANK: 'false' }).enableSemanticRerank).toBe(false);
+    expect(loadV3Config({ V3_ENABLE_SEMANTIC_RERANK: '' }).enableSemanticRerank).toBe(false);
+  });
+
+  test('V3_SEMANTIC_ALPHA / _BETA parse valid [0,1] values', () => {
+    expect(loadV3Config({ V3_SEMANTIC_ALPHA: '0.75' }).semanticAlpha).toBeCloseTo(0.75, 6);
+    expect(loadV3Config({ V3_SEMANTIC_BETA: '0.25' }).semanticBeta).toBeCloseTo(0.25, 6);
+    expect(loadV3Config({ V3_SEMANTIC_ALPHA: '0' }).semanticAlpha).toBe(0);
+    expect(loadV3Config({ V3_SEMANTIC_BETA: '1' }).semanticBeta).toBe(1);
+  });
+
+  test('invalid V3_SEMANTIC_ALPHA → baseline (entire config falls back)', () => {
+    expect(loadV3Config({ V3_SEMANTIC_ALPHA: '1.5' }).semanticAlpha).toBe(DEFAULT_SEMANTIC_ALPHA);
+    expect(loadV3Config({ V3_SEMANTIC_ALPHA: '-0.1' }).semanticAlpha).toBe(DEFAULT_SEMANTIC_ALPHA);
+    expect(loadV3Config({ V3_SEMANTIC_BETA: 'NaN' }).semanticBeta).toBe(DEFAULT_SEMANTIC_BETA);
   });
 });

--- a/src/skills/plugins/video-discover/v3/__tests__/executor-semantic-rerank.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/executor-semantic-rerank.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Integration test for Slice B executor wiring.
+ *
+ * Verifies maybeApplySemanticRerank:
+ *   - flag off   → slots byte-identical, trace null, no getSemanticRank call
+ *   - flag on    → getSemanticRank called with cell-targeted assignments,
+ *                  slots re-sorted with blended scores, trace populated
+ *   - all-null   → passthrough with re-sort (applySemanticRerank semantics)
+ */
+
+const mockGetSemanticRank = jest.fn();
+
+jest.mock('@/modules/video-dictionary', () => {
+  // Real applySemanticRerank + mocked getSemanticRank — tests the wiring
+  // while keeping the blend formula under test coverage too.
+  const actual = jest.requireActual('@/modules/video-dictionary');
+  return {
+    ...actual,
+    getSemanticRank: mockGetSemanticRank,
+  };
+});
+
+jest.mock('@/modules/database', () => ({
+  getPrismaClient: () => ({ $queryRaw: jest.fn() }),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({
+      debug: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+// Config module mocked so we can toggle the flag without touching process.env.
+jest.mock('../config', () => ({
+  v3Config: {
+    enableTier1Cache: false,
+    recencyWeight: 0.15,
+    recencyHalfLifeMonths: 18,
+    publishedAfterDays: 1095,
+    enableSemanticRerank: false, // overridden per-test via the helper below
+    semanticAlpha: 0.6,
+    semanticBeta: 0.4,
+  },
+  DEFAULT_PUBLISHED_AFTER_DAYS: 1095,
+}));
+
+import { maybeApplySemanticRerank, type AssembledSlot } from '../executor';
+import { v3Config } from '../config';
+
+function setFlag(enabled: boolean): void {
+  (v3Config as { enableSemanticRerank: boolean }).enableSemanticRerank = enabled;
+}
+
+function makeSlots(): AssembledSlot[] {
+  return [makeSlot('v-a', 0, 0.4), makeSlot('v-b', 0, 0.8), makeSlot('v-c', 1, 0.5)];
+}
+
+function makeSlot(videoId: string, cellIndex: number, score: number): AssembledSlot {
+  return {
+    videoId,
+    title: `title ${videoId}`,
+    description: null,
+    channelName: null,
+    thumbnail: null,
+    viewCount: null,
+    likeCount: null,
+    durationSec: null,
+    publishedAt: null,
+    cellIndex,
+    score,
+    tier: 'realtime',
+  };
+}
+
+describe('maybeApplySemanticRerank', () => {
+  beforeEach(() => {
+    mockGetSemanticRank.mockReset();
+  });
+
+  test('flag off — slots byte-identical, trace null, getSemanticRank NOT called', async () => {
+    setFlag(false);
+    const inputSlots = makeSlots();
+    const snapshot = JSON.stringify(inputSlots);
+
+    const out = await maybeApplySemanticRerank(inputSlots, 'm1');
+
+    expect(out.slots).toBe(inputSlots); // same reference
+    expect(out.trace).toBeNull();
+    expect(mockGetSemanticRank).not.toHaveBeenCalled();
+    expect(JSON.stringify(inputSlots)).toBe(snapshot);
+  });
+
+  test('flag on + ranks present — getSemanticRank called with cell assignments, slots re-sorted with blend', async () => {
+    setFlag(true);
+    mockGetSemanticRank.mockResolvedValue(
+      new Map([
+        ['v-a', 0.9], // blended = 0.6*0.4 + 0.4*0.9 = 0.60
+        ['v-b', 0.2], // blended = 0.6*0.8 + 0.4*0.2 = 0.56
+        ['v-c', 0.5], // blended = 0.6*0.5 + 0.4*0.5 = 0.50
+      ])
+    );
+
+    const out = await maybeApplySemanticRerank(makeSlots(), 'm1');
+
+    expect(mockGetSemanticRank).toHaveBeenCalledTimes(1);
+    const arg = mockGetSemanticRank.mock.calls[0]![0] as {
+      mandalaId: string;
+      videoIds: string[];
+      cellAssignments: Map<string, number>;
+    };
+    expect(arg.mandalaId).toBe('m1');
+    expect(arg.videoIds).toEqual(['v-a', 'v-b', 'v-c']);
+    expect(arg.cellAssignments.get('v-a')).toBe(0);
+    expect(arg.cellAssignments.get('v-b')).toBe(0);
+    expect(arg.cellAssignments.get('v-c')).toBe(1);
+
+    expect(out.slots.map((s) => s.videoId)).toEqual(['v-a', 'v-b', 'v-c']);
+    expect(out.trace).not.toBeNull();
+    expect(out.trace!.candidatesIn).toBe(3);
+    expect(out.trace!.candidatesScored).toBe(3);
+    expect(out.trace!.avgCosine).toBeCloseTo((0.9 + 0.2 + 0.5) / 3, 4);
+  });
+
+  test('flag on + all null ranks — slots re-sorted by original score, trace scored=0', async () => {
+    setFlag(true);
+    mockGetSemanticRank.mockResolvedValue(
+      new Map([
+        ['v-a', null],
+        ['v-b', null],
+        ['v-c', null],
+      ])
+    );
+
+    const out = await maybeApplySemanticRerank(makeSlots(), 'm1');
+
+    // applySemanticRerank always re-sorts (by blended-or-passthrough score desc)
+    expect(out.slots.map((s) => s.videoId)).toEqual(['v-b', 'v-c', 'v-a']);
+    expect(out.trace).not.toBeNull();
+    expect(out.trace!.candidatesScored).toBe(0);
+    expect(out.trace!.avgCosine).toBe(0);
+  });
+
+  test('flag on + empty slots — returns empty, trace null, no getSemanticRank call', async () => {
+    setFlag(true);
+    const out = await maybeApplySemanticRerank([], 'm1');
+    expect(out.slots).toEqual([]);
+    expect(out.trace).toBeNull();
+    expect(mockGetSemanticRank).not.toHaveBeenCalled();
+  });
+});

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { DEFAULT_SEMANTIC_ALPHA, DEFAULT_SEMANTIC_BETA } from '@/modules/video-dictionary';
+
 import { DEFAULT_RECENCY_HALF_LIFE_MONTHS, DEFAULT_RECENCY_WEIGHT } from './mandala-filter';
 
 export const DEFAULT_PUBLISHED_AFTER_DAYS = 1095;
@@ -32,11 +34,28 @@ const nonNegativeInt = z
   )
   .transform((v) => v ?? DEFAULT_PUBLISHED_AFTER_DAYS);
 
+const semanticAlpha = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().min(0).max(1).optional()
+  )
+  .transform((v) => v ?? DEFAULT_SEMANTIC_ALPHA);
+
+const semanticBeta = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().min(0).max(1).optional()
+  )
+  .transform((v) => v ?? DEFAULT_SEMANTIC_BETA);
+
 export const v3EnvSchema = z.object({
   V3_ENABLE_TIER1_CACHE: booleanFlag.optional().default(false as unknown as string),
   V3_RECENCY_WEIGHT: clampedUnit,
   V3_RECENCY_HALF_LIFE_MONTHS: positiveInt,
   V3_PUBLISHED_AFTER_DAYS: nonNegativeInt,
+  V3_ENABLE_SEMANTIC_RERANK: booleanFlag.optional().default(false as unknown as string),
+  V3_SEMANTIC_ALPHA: semanticAlpha,
+  V3_SEMANTIC_BETA: semanticBeta,
 });
 
 export interface V3Config {
@@ -44,6 +63,9 @@ export interface V3Config {
   recencyWeight: number;
   recencyHalfLifeMonths: number;
   publishedAfterDays: number;
+  enableSemanticRerank: boolean;
+  semanticAlpha: number;
+  semanticBeta: number;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -52,6 +74,9 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_RECENCY_WEIGHT: env['V3_RECENCY_WEIGHT'],
     V3_RECENCY_HALF_LIFE_MONTHS: env['V3_RECENCY_HALF_LIFE_MONTHS'],
     V3_PUBLISHED_AFTER_DAYS: env['V3_PUBLISHED_AFTER_DAYS'],
+    V3_ENABLE_SEMANTIC_RERANK: env['V3_ENABLE_SEMANTIC_RERANK'],
+    V3_SEMANTIC_ALPHA: env['V3_SEMANTIC_ALPHA'],
+    V3_SEMANTIC_BETA: env['V3_SEMANTIC_BETA'],
   });
   if (!parsed.success) {
     return {
@@ -59,6 +84,9 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       recencyWeight: DEFAULT_RECENCY_WEIGHT,
       recencyHalfLifeMonths: DEFAULT_RECENCY_HALF_LIFE_MONTHS,
       publishedAfterDays: DEFAULT_PUBLISHED_AFTER_DAYS,
+      enableSemanticRerank: false,
+      semanticAlpha: DEFAULT_SEMANTIC_ALPHA,
+      semanticBeta: DEFAULT_SEMANTIC_BETA,
     };
   }
   return {
@@ -66,6 +94,9 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     recencyWeight: parsed.data.V3_RECENCY_WEIGHT,
     recencyHalfLifeMonths: parsed.data.V3_RECENCY_HALF_LIFE_MONTHS,
     publishedAfterDays: parsed.data.V3_PUBLISHED_AFTER_DAYS,
+    enableSemanticRerank: parsed.data.V3_ENABLE_SEMANTIC_RERANK,
+    semanticAlpha: parsed.data.V3_SEMANTIC_ALPHA,
+    semanticBeta: parsed.data.V3_SEMANTIC_BETA,
   };
 }
 

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -28,6 +28,11 @@ import type {
   ExecuteResult,
 } from '@/skills/_shared/types';
 
+import {
+  applySemanticRerank,
+  getSemanticRank,
+  type SemanticRerankTrace,
+} from '@/modules/video-dictionary';
 import { MS_PER_DAY } from '@/utils/time-constants';
 import { manifest, V3_TARGET_PER_CELL, V3_NUM_CELLS, V3_TARGET_TOTAL } from './manifest';
 import { matchFromVideoPool, groupByCell } from './cache-matcher';
@@ -80,7 +85,7 @@ interface HydratedState {
   targetLevel: string;
 }
 
-interface AssembledSlot {
+export interface AssembledSlot {
   videoId: string;
   title: string;
   description: string | null;
@@ -251,10 +256,14 @@ export const executor: SkillExecutor = {
       };
     }
 
-    // ── Upsert recommendation_cache ────────────────────────────────────
-    const upserts = await upsertSlots(ctx.userId, mandalaId, slots, state.subGoals);
+    // ── Semantic rerank (D36, synthesis spec §4.2 — off by default) ────
+    const rerankedSlots = await maybeApplySemanticRerank(slots, mandalaId);
+    const semanticTrace: SemanticRerankTrace | null = rerankedSlots.trace;
 
-    const finalTotal = slots.length;
+    // ── Upsert recommendation_cache ────────────────────────────────────
+    const upserts = await upsertSlots(ctx.userId, mandalaId, rerankedSlots.slots, state.subGoals);
+
+    const finalTotal = rerankedSlots.slots.length;
     const wallMs = Date.now() - t0;
 
     return {
@@ -264,10 +273,11 @@ export const executor: SkillExecutor = {
         tier2_matches: tier2Count,
         tier2_queries: tier2QueriesUsed,
         total_recommendations: finalTotal,
-        cells_filled: new Set(slots.map((s) => s.cellIndex)).size,
+        cells_filled: new Set(rerankedSlots.slots.map((s) => s.cellIndex)).size,
         rows_upserted: upserts,
         target_met: finalTotal >= V3_TARGET_TOTAL,
         ...(tier2Debug ? { debug: tier2Debug } : {}),
+        ...(semanticTrace ? { semantic_rerank: semanticTrace } : {}),
       },
       metrics: {
         duration_ms: wallMs,
@@ -276,6 +286,47 @@ export const executor: SkillExecutor = {
     };
   },
 };
+
+// ============================================================================
+// Semantic rerank — D36 per synthesis spec §4.2 (off unless V3_ENABLE_SEMANTIC_RERANK=true)
+// ============================================================================
+
+interface MaybeRerankOutput {
+  slots: AssembledSlot[];
+  trace: SemanticRerankTrace | null;
+}
+
+/**
+ * If the feature flag is on, blend pre-filter `score` with pgvector cosine
+ * against `video_chunk_embeddings`. Cell-targeted per §4.2. Missing embeddings
+ * pass through unchanged — no penalty.
+ */
+export async function maybeApplySemanticRerank(
+  slots: AssembledSlot[],
+  mandalaId: string
+): Promise<MaybeRerankOutput> {
+  if (!v3Config.enableSemanticRerank || slots.length === 0) {
+    return { slots, trace: null };
+  }
+
+  const cellAssignments = new Map(slots.map((s) => [s.videoId, s.cellIndex]));
+  const ranks = await getSemanticRank({
+    mandalaId,
+    videoIds: slots.map((s) => s.videoId),
+    cellAssignments,
+  });
+
+  const { slots: reranked, trace } = applySemanticRerank(slots, ranks, {
+    alpha: v3Config.semanticAlpha,
+    beta: v3Config.semanticBeta,
+  });
+
+  log.info(
+    `semantic rerank: mandala=${mandalaId} in=${trace.candidatesIn} scored=${trace.candidatesScored} avgCos=${trace.avgCosine.toFixed(3)}`
+  );
+
+  return { slots: reranked, trace };
+}
 
 // ============================================================================
 // Tier 2: deficit-cell realtime fill

--- a/tests/unit/modules/video-dictionary-rerank.test.ts
+++ b/tests/unit/modules/video-dictionary-rerank.test.ts
@@ -1,0 +1,99 @@
+import { applySemanticRerank } from '../../../src/modules/video-dictionary/rerank';
+import type {
+  RerankableSlot,
+  SemanticRankResult,
+} from '../../../src/modules/video-dictionary/types';
+
+type Slot = RerankableSlot & { videoId: string; cellIndex: number; score: number };
+
+function makeSlots(): Slot[] {
+  return [
+    { videoId: 'a', cellIndex: 0, score: 0.4 },
+    { videoId: 'b', cellIndex: 0, score: 0.8 },
+    { videoId: 'c', cellIndex: 1, score: 0.5 },
+  ];
+}
+
+describe('applySemanticRerank', () => {
+  test('null cosines — passthrough, no score mutation, re-sorts by original score', () => {
+    const ranks: SemanticRankResult = new Map([
+      ['a', null],
+      ['b', null],
+      ['c', null],
+    ]);
+    const { slots, trace } = applySemanticRerank(makeSlots(), ranks, { alpha: 0.6, beta: 0.4 });
+
+    expect(slots.map((s) => s.videoId)).toEqual(['b', 'c', 'a']);
+    expect(slots.map((s) => s.score)).toEqual([0.8, 0.5, 0.4]);
+    expect(trace).toEqual({ candidatesIn: 3, candidatesScored: 0, avgCosine: 0 });
+  });
+
+  test('all cosines present — α·score + β·cosine blended and re-sorted', () => {
+    const ranks: SemanticRankResult = new Map([
+      ['a', 0.9], // blended = 0.6*0.4 + 0.4*0.9 = 0.60
+      ['b', 0.2], // blended = 0.6*0.8 + 0.4*0.2 = 0.56
+      ['c', 0.5], // blended = 0.6*0.5 + 0.4*0.5 = 0.50
+    ]);
+    const { slots, trace } = applySemanticRerank(makeSlots(), ranks, { alpha: 0.6, beta: 0.4 });
+
+    expect(slots.map((s) => s.videoId)).toEqual(['a', 'b', 'c']);
+    expect(slots.map((s) => s.score)[0]).toBeCloseTo(0.6, 4);
+    expect(slots.map((s) => s.score)[1]).toBeCloseTo(0.56, 4);
+    expect(slots.map((s) => s.score)[2]).toBeCloseTo(0.5, 4);
+    expect(trace.candidatesScored).toBe(3);
+    expect(trace.avgCosine).toBeCloseTo((0.9 + 0.2 + 0.5) / 3, 4);
+  });
+
+  test('partial nulls — blended where present, passthrough where null', () => {
+    const ranks: SemanticRankResult = new Map([
+      ['a', 1.0], // blended = 0.6*0.4 + 0.4*1.0 = 0.64
+      ['b', null], // passthrough 0.8
+      ['c', 0.1], // blended = 0.6*0.5 + 0.4*0.1 = 0.34
+    ]);
+    const { slots, trace } = applySemanticRerank(makeSlots(), ranks, { alpha: 0.6, beta: 0.4 });
+
+    expect(slots.map((s) => s.videoId)).toEqual(['b', 'a', 'c']);
+    const scores = slots.map((s) => s.score);
+    expect(scores[0]).toBe(0.8);
+    expect(scores[1]).toBeCloseTo(0.64, 4);
+    expect(scores[2]).toBeCloseTo(0.34, 4);
+    expect(trace.candidatesScored).toBe(2);
+    expect(trace.avgCosine).toBeCloseTo((1.0 + 0.1) / 2, 4);
+  });
+
+  test('α=1, β=0 — emergency rollback: identical to passthrough for blended slots', () => {
+    const ranks: SemanticRankResult = new Map([
+      ['a', 0.9],
+      ['b', 0.2],
+      ['c', 0.5],
+    ]);
+    const { slots } = applySemanticRerank(makeSlots(), ranks, { alpha: 1, beta: 0 });
+
+    // blended = 1·score + 0·cosine = score, so order matches pre-filter
+    expect(slots.map((s) => s.videoId)).toEqual(['b', 'c', 'a']);
+    expect(slots.map((s) => s.score)).toEqual([0.8, 0.5, 0.4]);
+  });
+
+  test('scores stay clamped to [0, 1] even if blend overflows', () => {
+    const slots: Slot[] = [{ videoId: 'x', cellIndex: 0, score: 0.9 }];
+    const ranks: SemanticRankResult = new Map([['x', 0.9]]);
+    // alpha + beta > 1 would produce ~1.8 pre-clamp
+    const { slots: out } = applySemanticRerank(slots, ranks, { alpha: 1, beta: 1 });
+    const outScore = out.map((s) => s.score)[0];
+    expect(outScore).toBe(1);
+  });
+
+  test('empty input — empty output, zero trace', () => {
+    const { slots, trace } = applySemanticRerank([], new Map(), { alpha: 0.6, beta: 0.4 });
+    expect(slots).toEqual([]);
+    expect(trace).toEqual({ candidatesIn: 0, candidatesScored: 0, avgCosine: 0 });
+  });
+
+  test('input array is not mutated', () => {
+    const input = makeSlots();
+    const snapshot = JSON.stringify(input);
+    const ranks: SemanticRankResult = new Map([['a', 0.9]]);
+    applySemanticRerank(input, ranks, { alpha: 0.6, beta: 0.4 });
+    expect(JSON.stringify(input)).toBe(snapshot);
+  });
+});

--- a/tests/unit/modules/video-dictionary-semantic-rank.test.ts
+++ b/tests/unit/modules/video-dictionary-semantic-rank.test.ts
@@ -1,0 +1,130 @@
+const mockQueryRaw = jest.fn();
+
+jest.mock('@/modules/database', () => ({
+  getPrismaClient: () => ({ $queryRaw: mockQueryRaw }),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({
+      debug: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+import { getSemanticRank } from '../../../src/modules/video-dictionary/semantic-rank';
+
+describe('getSemanticRank', () => {
+  beforeEach(() => {
+    mockQueryRaw.mockReset();
+  });
+
+  test('empty videoIds — returns empty map, no DB query', async () => {
+    const result = await getSemanticRank({ mandalaId: 'm1', videoIds: [] });
+    expect(result.size).toBe(0);
+    expect(mockQueryRaw).not.toHaveBeenCalled();
+  });
+
+  test('happy path — max-across-cells: returns cosine map, missing ids stay null', async () => {
+    mockQueryRaw.mockResolvedValue([
+      { video_id: 'v1', cosine: 0.82 },
+      { video_id: 'v2', cosine: 0.41 },
+    ]);
+
+    const result = await getSemanticRank({
+      mandalaId: 'm1',
+      videoIds: ['v1', 'v2', 'v3'],
+    });
+
+    expect(result.get('v1')).toBeCloseTo(0.82, 4);
+    expect(result.get('v2')).toBeCloseTo(0.41, 4);
+    // v3 had no embedding row — must stay null (fallback contract)
+    expect(result.get('v3')).toBeNull();
+    expect(result.size).toBe(3);
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  test('cell-targeted — when cellAssignments provided, uses targeted query path', async () => {
+    mockQueryRaw.mockResolvedValue([{ video_id: 'v1', cosine: 0.75 }]);
+
+    const result = await getSemanticRank({
+      mandalaId: 'm1',
+      videoIds: ['v1'],
+      cellAssignments: new Map([['v1', 3]]),
+    });
+
+    expect(result.get('v1')).toBeCloseTo(0.75, 4);
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  test('cell-targeted — videoId without assignment is excluded from query but stays null in result', async () => {
+    mockQueryRaw.mockResolvedValue([{ video_id: 'v1', cosine: 0.6 }]);
+
+    const result = await getSemanticRank({
+      mandalaId: 'm1',
+      videoIds: ['v1', 'v2'],
+      cellAssignments: new Map([['v1', 0]]),
+    });
+
+    expect(result.get('v1')).toBeCloseTo(0.6, 4);
+    expect(result.get('v2')).toBeNull();
+  });
+
+  test('cosine out-of-range — clamped to [0, 1]', async () => {
+    mockQueryRaw.mockResolvedValue([
+      { video_id: 'v1', cosine: 1.5 },
+      { video_id: 'v2', cosine: -0.3 },
+      { video_id: 'v3', cosine: Number.NaN },
+    ]);
+
+    const result = await getSemanticRank({
+      mandalaId: 'm1',
+      videoIds: ['v1', 'v2', 'v3'],
+    });
+
+    expect(result.get('v1')).toBe(1);
+    expect(result.get('v2')).toBe(0);
+    // NaN is non-finite → returns null per fallback contract
+    expect(result.get('v3')).toBeNull();
+  });
+
+  test('DB error — returns all-null map, does not throw', async () => {
+    mockQueryRaw.mockRejectedValue(new Error('connection refused'));
+
+    const result = await getSemanticRank({
+      mandalaId: 'm1',
+      videoIds: ['v1', 'v2'],
+    });
+
+    expect(result.get('v1')).toBeNull();
+    expect(result.get('v2')).toBeNull();
+  });
+
+  test('duplicate videoIds — deduped before query', async () => {
+    mockQueryRaw.mockResolvedValue([{ video_id: 'v1', cosine: 0.5 }]);
+
+    const result = await getSemanticRank({
+      mandalaId: 'm1',
+      videoIds: ['v1', 'v1', 'v1'],
+    });
+
+    // Map uses videoId as key → only 1 entry regardless of input dups
+    expect(result.size).toBe(1);
+    expect(result.get('v1')).toBeCloseTo(0.5, 4);
+  });
+
+  test('cell-targeted — empty assignments map falls back to max-across-cells path', async () => {
+    mockQueryRaw.mockResolvedValue([{ video_id: 'v1', cosine: 0.3 }]);
+
+    const result = await getSemanticRank({
+      mandalaId: 'm1',
+      videoIds: ['v1'],
+      cellAssignments: new Map(),
+    });
+
+    expect(result.get('v1')).toBeCloseTo(0.3, 4);
+  });
+});


### PR DESCRIPTION
## Summary

Lands **BACKLOG item 10 Slice A+B** — pgvector-based semantic rerank consumer module per synthesis spec §6.2 (`/cursor/video-dictionary/docs/design/discovery-strategy.md`).

**Prod behavior is unchanged**: `V3_ENABLE_SEMANTIC_RERANK` defaults to `false`, so `getSemanticRank()` is never invoked until the flag is explicitly flipped. Phase B activation = flag flip via admin UI (Issue #421).

### Slice A — `src/modules/video-dictionary/`
- `getSemanticRank(mandalaId, videoIds[], cellAssignments?)` → `Map<videoId, cosine | null>`
  - Cell-targeted path (per §4.2) using `mandala_embeddings` × `video_chunk_embeddings` cosine via pgvector `<=>` operator
  - Max-across-cells fallback path when cell assignments unavailable
  - Null fallback preserves pre-filter `rec_score` with no penalty (§4.3 null-tolerant contract)
- `applySemanticRerank(slots, ranks, {alpha, beta})` — pure α·score + β·cosine blend with re-sort; clamps to [0, 1]; emits `candidatesIn/Scored/avgCosine` trace
- `v3/config.ts`: 3 new env vars on zod schema with safe defaults — `V3_ENABLE_SEMANTIC_RERANK` (`false`), `V3_SEMANTIC_ALPHA` (`0.6`), `V3_SEMANTIC_BETA` (`0.4`)
- **15 unit tests** (rerank + semantic-rank) + 3 new config tests

### Slice B — `v3/executor.ts`
- New `maybeApplySemanticRerank()` helper inserted between slot assembly and `upsertSlots()` — flag-guarded, early-returns to no-op when disabled
- `ExecuteResult.data.semantic_rerank` trace emitted when rerank ran (conditional spread, mirrors existing `debug` field pattern)
- Exported `maybeApplySemanticRerank` + `AssembledSlot` type for testability
- **4 integration tests**: flag off = byte-identical / flag on = blend+sort / all-null = passthrough / empty slots = no-op

## Pre-flight

- [x] `tsc --noEmit` (backend) — clean
- [x] `tsc --noEmit` (frontend) — clean
- [x] `npm run build` (frontend) — clean (4.69s)
- [x] `jest --testPathPattern='video-discover/v3|video-dictionary'` — **56/56 passing**
- [x] Full jest — 28 failures match baseline (pre-existing in `mandala-manager` / `mandala-routes` / `mandala-post-creation` / v1 legacy `executor`), **zero new regressions**
- [x] Prod-verify `VIDEO_DISCOVER_V3=1` confirmed via `ssh insighta-ec2 "docker exec insighta-api printenv"` before any code edit (read-only)
- [x] Plan → Approve → Execute honored per slice (15th consecutive session)

## Rollback strategy

1. **Single-knob disable**: set `V3_ENABLE_SEMANTIC_RERANK=false` (the default). Flag-off = byte-identical prod behavior.
2. **Code revert**: remove 3-line wiring block in `v3/executor.ts::execute()` — module itself is additive and touches nothing else.
3. **No DB schema change**: `video_chunk_embeddings` table already exists (CP397 commit `352ad1f`), populated externally by mac mini A1→A4 pipeline. This PR only reads from it.
4. **No FE contract change**: `recommendation_cache.rec_reason` values unchanged (`'cache' | 'realtime'`).

## Cross-repo companion

Synthesis spec follow-ups (IKS audit §4.2–§4.5) applied separately in `video-dictionary` repo commit `0ad2c4f` — local-only per CP395 repo boundary rule. See `docs/audit/iks-integration-2026-04-20.md` + `docs/design/discovery-strategy.md` §6.4 for audit resolution.

## Test plan

- [ ] CI passes (backend + frontend + build)
- [ ] Deploy health check (`https://insighta.one/health`)
- [ ] Post-deploy: confirm `rec_reason` distribution in `recommendation_cache` unchanged (flag off = no new code path exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
