### PR TITLE
fix(sync+ui): place synced videos into mapped mandala + sync polish (#389)

### DIFF
--- a/frontend/src/__tests__/smoke/newly-synced-cards.test.ts
+++ b/frontend/src/__tests__/smoke/newly-synced-cards.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Issue #389 — "Newly Synced" card predicate + per-mandala aggregation.
+ *
+ * Pins the filter logic that drives:
+ *   - the mandala-level "Newly Synced" tab (LabelFilterPillsV2)
+ *   - the sidebar dot+count indicator (SidebarMandalaSection)
+ *
+ * Predicate (isNewlySyncedCard):
+ *   - isInIdeation === false
+ *   - cellIndex < 0 (or missing)
+ *   - mandalaId is set
+ *   - (optional) filter to a specific mandala
+ *
+ * Aggregation (countNewlySyncedByMandala):
+ *   - groups by mandalaId; mandalas with 0 newly-synced are omitted
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  isNewlySyncedCard,
+  countNewlySyncedByMandala,
+} from '@/features/card-management/lib/cardUtils';
+import type { InsightCard } from '@/entities/card/model/types';
+
+const MANDALA_A = 'mandala-a';
+const MANDALA_B = 'mandala-b';
+
+function makeCard(partial: Partial<InsightCard>): InsightCard {
+  // Fill required InsightCard fields with benign defaults; the predicate
+  // only reads isInIdeation / cellIndex / mandalaId, so the rest are
+  // stubbed to satisfy the type without affecting behavior.
+  return {
+    id: partial.id ?? 'card-1',
+    title: partial.title ?? 'Sample',
+    videoUrl: partial.videoUrl ?? 'https://example.com/v',
+    thumbnail: partial.thumbnail ?? '',
+    linkType: partial.linkType ?? 'youtube',
+    cellIndex: partial.cellIndex ?? -1,
+    levelId: partial.levelId ?? 'scratchpad',
+    mandalaId: partial.mandalaId ?? null,
+    isInIdeation: partial.isInIdeation ?? true,
+    createdAt: partial.createdAt ?? new Date(),
+    ...partial,
+  } as InsightCard;
+}
+
+describe('isNewlySyncedCard', () => {
+  it('returns true for a mapped-but-unplaced card', () => {
+    const card = makeCard({
+      isInIdeation: false,
+      cellIndex: -1,
+      mandalaId: MANDALA_A,
+    });
+    expect(isNewlySyncedCard(card)).toBe(true);
+  });
+
+  it('returns false when still in global Ideation (is_in_ideation=true)', () => {
+    const card = makeCard({
+      isInIdeation: true,
+      cellIndex: -1,
+      mandalaId: MANDALA_A,
+    });
+    expect(isNewlySyncedCard(card)).toBe(false);
+  });
+
+  it('returns false when already placed into a cell (cellIndex >= 0)', () => {
+    const card = makeCard({
+      isInIdeation: false,
+      cellIndex: 3,
+      mandalaId: MANDALA_A,
+    });
+    expect(isNewlySyncedCard(card)).toBe(false);
+  });
+
+  it('returns false when mandalaId is null (unmapped sync)', () => {
+    const card = makeCard({
+      isInIdeation: false,
+      cellIndex: -1,
+      mandalaId: null,
+    });
+    expect(isNewlySyncedCard(card)).toBe(false);
+  });
+
+  it('filters to a specific mandala when mandalaId arg is provided', () => {
+    const cardInA = makeCard({
+      id: 'a',
+      isInIdeation: false,
+      cellIndex: -1,
+      mandalaId: MANDALA_A,
+    });
+    const cardInB = makeCard({
+      id: 'b',
+      isInIdeation: false,
+      cellIndex: -1,
+      mandalaId: MANDALA_B,
+    });
+    expect(isNewlySyncedCard(cardInA, MANDALA_A)).toBe(true);
+    expect(isNewlySyncedCard(cardInB, MANDALA_A)).toBe(false);
+  });
+
+  it('treats missing cellIndex (non-number) as unplaced', () => {
+    const card = makeCard({
+      isInIdeation: false,
+      mandalaId: MANDALA_A,
+    });
+    // typescript enforces cellIndex as number; simulate undefined via cast.
+    (card as unknown as { cellIndex: unknown }).cellIndex = undefined;
+    expect(isNewlySyncedCard(card)).toBe(true);
+  });
+});
+
+describe('countNewlySyncedByMandala', () => {
+  it('aggregates counts per mandala, excluding non-newly-synced cards', () => {
+    const cards: InsightCard[] = [
+      makeCard({ id: '1', isInIdeation: false, cellIndex: -1, mandalaId: MANDALA_A }),
+      makeCard({ id: '2', isInIdeation: false, cellIndex: -1, mandalaId: MANDALA_A }),
+      makeCard({ id: '3', isInIdeation: false, cellIndex: -1, mandalaId: MANDALA_B }),
+      // placed card — ignored
+      makeCard({ id: '4', isInIdeation: false, cellIndex: 0, mandalaId: MANDALA_A }),
+      // still-in-ideation — ignored
+      makeCard({ id: '5', isInIdeation: true, cellIndex: -1, mandalaId: MANDALA_A }),
+      // unmapped — ignored
+      makeCard({ id: '6', isInIdeation: false, cellIndex: -1, mandalaId: null }),
+    ];
+
+    const counts = countNewlySyncedByMandala(cards);
+    expect(counts).toEqual({
+      [MANDALA_A]: 2,
+      [MANDALA_B]: 1,
+    });
+  });
+
+  it('omits mandalas with 0 newly-synced from the result (missing key ≡ 0)', () => {
+    const cards: InsightCard[] = [
+      makeCard({ id: '1', isInIdeation: false, cellIndex: 0, mandalaId: MANDALA_A }),
+    ];
+    const counts = countNewlySyncedByMandala(cards);
+    expect(counts).not.toHaveProperty(MANDALA_A);
+    expect(Object.keys(counts)).toHaveLength(0);
+  });
+
+  it('returns empty object for empty input (no mandalas)', () => {
+    expect(countNewlySyncedByMandala([])).toEqual({});
+  });
+});

--- a/frontend/src/__tests__/smoke/sync-reauth-error.test.ts
+++ b/frontend/src/__tests__/smoke/sync-reauth-error.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Issue #389-adjacent — YouTube OAuth re-auth detection.
+ *
+ * Pins the `isYouTubeReauthError` classifier so the sync-failure toast
+ * flow in SourceManagementTab(V2) surfaces the reconnect CTA for the
+ * exact error messages the BE emits:
+ *
+ *   - `src/modules/auth/token-manager.ts:268` → InvalidCredentialsError
+ *     with reason "Refresh token expired or revoked"
+ *   - `src/api/routes/youtube.ts:50,96` → "YouTube account not connected
+ *     or token expired. Please reconnect via Settings."
+ *   - Raw `invalid_grant` from Google's OAuth error body
+ *
+ * Generic sync failures (network, server 500) must NOT classify as
+ * re-auth so the reconnect CTA doesn't spam when the fix is a retry.
+ */
+import { describe, expect, it } from 'vitest';
+import { isYouTubeReauthError } from '@/features/youtube-sync/model/useYouTubeSync';
+
+describe('isYouTubeReauthError', () => {
+  it('matches the BE InvalidCredentialsError reason string', () => {
+    expect(isYouTubeReauthError(new Error('Refresh token expired or revoked'))).toBe(true);
+    expect(isYouTubeReauthError(new Error('Token refresh failed'))).toBe(true);
+  });
+
+  it('matches raw Google OAuth invalid_grant payload', () => {
+    expect(isYouTubeReauthError(new Error('invalid_grant'))).toBe(true);
+    expect(isYouTubeReauthError(new Error('OAuth2 request failed: invalid_grant'))).toBe(true);
+  });
+
+  it('matches the routes/youtube.ts user-facing copy', () => {
+    expect(
+      isYouTubeReauthError(
+        new Error('YouTube account not connected or token expired. Please reconnect via Settings.')
+      )
+    ).toBe(true);
+  });
+
+  it('is case-insensitive (normalizes to lowercase before matching)', () => {
+    expect(isYouTubeReauthError(new Error('INVALID_GRANT'))).toBe(true);
+    expect(isYouTubeReauthError(new Error('Refresh Token Expired'))).toBe(true);
+  });
+
+  it('does NOT classify generic sync failures as re-auth', () => {
+    expect(isYouTubeReauthError(new Error('Network error'))).toBe(false);
+    expect(isYouTubeReauthError(new Error('Failed to sync playlist'))).toBe(false);
+    expect(isYouTubeReauthError(new Error('Quota exceeded'))).toBe(false);
+    expect(isYouTubeReauthError(new Error('Sync failed with status: failed'))).toBe(false);
+  });
+
+  it('returns false for non-Error inputs (plain string, null, undefined, object)', () => {
+    expect(isYouTubeReauthError('invalid_grant')).toBe(false);
+    expect(isYouTubeReauthError(null)).toBe(false);
+    expect(isYouTubeReauthError(undefined)).toBe(false);
+    expect(isYouTubeReauthError({ message: 'invalid_grant' })).toBe(false);
+  });
+});

--- a/frontend/src/features/card-management/lib/cardUtils.ts
+++ b/frontend/src/features/card-management/lib/cardUtils.ts
@@ -138,3 +138,39 @@ export function isCardInMandala(card: InsightCard): boolean {
     card.levelId !== 'scratchpad'
   );
 }
+
+/**
+ * Issue #389: a card is "newly synced" when a `source_mandala_mappings`
+ * entry caused the sync engine to stamp `mandala_id` on it, but no cell
+ * placement has happened yet. These cards live in the target mandala's
+ * "Newly Synced" tab until the user drops them into a cell.
+ *
+ * Predicate:
+ *   - `isInIdeation === false` (out of the global Ideation palette)
+ *   - `cellIndex < 0` or missing (unplaced)
+ *   - `mandalaId` is truthy (has a mapped home mandala)
+ *   - if `mandalaId` is supplied, filters to that mandala only
+ */
+export function isNewlySyncedCard(card: InsightCard, mandalaId?: string | null): boolean {
+  if (card.isInIdeation !== false) return false;
+  if (typeof card.cellIndex === 'number' && card.cellIndex >= 0) return false;
+  if (!card.mandalaId) return false;
+  if (mandalaId && card.mandalaId !== mandalaId) return false;
+  return true;
+}
+
+/**
+ * Count newly-synced cards per mandala. Cards without a `mandalaId` or
+ * that fail {@link isNewlySyncedCard} are ignored. Mandalas with count 0
+ * are omitted from the result — consumers can treat a missing key as 0.
+ */
+export function countNewlySyncedByMandala(cards: InsightCard[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const c of cards) {
+    if (!isNewlySyncedCard(c)) continue;
+    const key = c.mandalaId;
+    if (!key) continue;
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}

--- a/frontend/src/features/card-management/lib/index.ts
+++ b/frontend/src/features/card-management/lib/index.ts
@@ -5,6 +5,8 @@ export {
   getCardById,
   isCardInIdeation,
   isCardInMandala,
+  isNewlySyncedCard,
+  countNewlySyncedByMandala,
 } from './cardUtils';
 export type { CardSource } from './cardUtils';
 

--- a/frontend/src/features/youtube-sync/model/index.ts
+++ b/frontend/src/features/youtube-sync/model/index.ts
@@ -10,6 +10,7 @@ export {
   useUpdateVideoState,
   useSyncAllPlaylists,
   useYouTubeSync,
+  isYouTubeReauthError,
 } from './useYouTubeSync';
 
 export {

--- a/frontend/src/features/youtube-sync/model/useYouTubeSync.ts
+++ b/frontend/src/features/youtube-sync/model/useYouTubeSync.ts
@@ -258,7 +258,14 @@ export function useResumePlaylist() {
 }
 
 /**
- * Hook to update sync settings (still via Edge Function -- no Backend API equivalent yet)
+ * Hook to update sync settings.
+ *
+ * Plan 2: migrated from the `update-settings` Edge Function to the new
+ * `POST /api/v1/sync/settings` BE route. The EF only wrote
+ * `youtube_sync_settings`; the BE route additionally propagates the
+ * change to `sync_schedules.interval_ms` and re-registers cron jobs
+ * via `SchedulerManager.updateSchedule` so the UI dropdown is no
+ * longer cosmetic.
  */
 export function useUpdateSyncSettings() {
   const queryClient = useQueryClient();
@@ -269,14 +276,20 @@ export function useUpdateSyncSettings() {
     autoSummaryEnabled?: boolean;
   };
 
+  type UpdateSettingsResult = {
+    schedulesUpdated: number;
+    appliedInterval: SyncInterval | null;
+    autoSyncEnabled: boolean;
+  };
+
   return useMutation({
     mutationFn: async ({
       syncInterval,
       autoSyncEnabled,
       autoSummaryEnabled,
-    }: UpdateSettingsVars): Promise<void> => {
+    }: UpdateSettingsVars): Promise<UpdateSettingsResult> => {
       const headers = await getAuthHeaders();
-      const response = await fetch(ytSyncUrl('update-settings'), {
+      const response = await fetch('/api/v1/sync/settings', {
         method: 'POST',
         headers,
         body: JSON.stringify({ syncInterval, autoSyncEnabled, autoSummaryEnabled }),
@@ -284,8 +297,14 @@ export function useUpdateSyncSettings() {
 
       if (!response.ok) {
         const error = await response.json();
-        throw new Error(error.error || 'Failed to update settings');
+        throw new Error(error?.error?.message || error?.error || 'Failed to update settings');
       }
+      const data = await response.json();
+      return {
+        schedulesUpdated: data.schedulesUpdated ?? 0,
+        appliedInterval: (data.appliedInterval ?? null) as SyncInterval | null,
+        autoSyncEnabled: data.autoSyncEnabled ?? false,
+      };
     },
     onMutate: async (vars: UpdateSettingsVars) => {
       await queryClient.cancelQueries({ queryKey: ['youtube', 'auth', 'status'] });
@@ -508,6 +527,33 @@ export function useYouTubeSearch() {
       return data.videos ?? [];
     },
   });
+}
+
+/**
+ * Classifier for sync errors that signal the user's YouTube OAuth
+ * refresh_token is no longer accepted by Google (invalid_grant) or the
+ * credentials row is missing. Callers should respond by prompting the
+ * user to reconnect YouTube in Settings instead of showing a generic
+ * "sync failed" toast.
+ *
+ * Matches the known failure messages surfaced by the BE layer:
+ *   - `src/modules/auth/token-manager.ts:268` → InvalidCredentialsError
+ *     with reason "Refresh token expired or revoked" or
+ *     "Token refresh failed".
+ *   - `src/api/routes/youtube.ts:50,96` → "YouTube account not connected
+ *     or token expired. Please reconnect via Settings."
+ *   - Raw `invalid_grant` string from the Google OAuth response.
+ */
+export function isYouTubeReauthError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const msg = error.message.toLowerCase();
+  return (
+    msg.includes('invalid_grant') ||
+    msg.includes('refresh token expired') ||
+    msg.includes('token refresh failed') ||
+    msg.includes('youtube account not connected') ||
+    msg.includes('token expired')
+  );
 }
 
 /**

--- a/frontend/src/pages/index/model/useCardOrchestrator.ts
+++ b/frontend/src/pages/index/model/useCardOrchestrator.ts
@@ -16,7 +16,12 @@ import {
 } from '@/features/youtube-sync/model/useYouTubeSync';
 import { useYouTubeAuth } from '@/features/youtube-sync/model/useYouTubeAuth';
 import { convertToInsightCards } from '@/features/card-management/lib/youtubeToInsightCard';
-import { detectCardSource, getCardById } from '@/features/card-management/lib/cardUtils';
+import {
+  detectCardSource,
+  getCardById,
+  isNewlySyncedCard,
+  countNewlySyncedByMandala,
+} from '@/features/card-management/lib/cardUtils';
 import {
   createMockCards,
   createCardFromUrl,
@@ -47,6 +52,9 @@ export interface UseCardOrchestratorReturn {
   totalCards: number;
   displayCards: InsightCard[];
   displayTitle: string;
+  // Issue #389: mapping-synced, not yet placed into a cell.
+  newlySyncedCards: InsightCard[];
+  newlySyncedCountByMandala: Record<string, number>;
   // Derived arrays (needed by external hooks)
   syncedCards: InsightCard[];
   persistedLocalCards: InsightCard[];
@@ -131,7 +139,7 @@ export function useCardOrchestrator(
     async (
       cardId: string,
       videoUrl?: string,
-      sourceTable: 'user_local_cards' | 'user_video_states' = 'user_local_cards',
+      sourceTable: 'user_local_cards' | 'user_video_states' = 'user_local_cards'
     ): Promise<boolean> => {
       try {
         // Step 1: Try to fetch transcript via Edge Function (Deno Deploy, not EC2)
@@ -141,7 +149,7 @@ export function useCardOrchestrator(
             const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
             const transcriptRes = await fetch(
               `${supabaseUrl}/functions/v1/fetch-transcript?video_id=${encodeURIComponent(videoUrl)}`,
-              { headers: await getAuthHeaders() },
+              { headers: await getAuthHeaders() }
             );
             if (transcriptRes.ok) {
               const data = await transcriptRes.json();
@@ -174,7 +182,7 @@ export function useCardOrchestrator(
         return false;
       }
     },
-    [queryClient],
+    [queryClient]
   );
 
   // Auto-enrichment for YouTube cards — respects autoSummaryEnabled setting
@@ -183,7 +191,7 @@ export function useCardOrchestrator(
     async (
       cardId: string,
       videoUrl?: string,
-      sourceTable: 'user_local_cards' | 'user_video_states' = 'user_local_cards',
+      sourceTable: 'user_local_cards' | 'user_video_states' = 'user_local_cards'
     ) => {
       if (!autoSummaryEnabled) return;
       setEnrichingCardIds((prev) => new Set(prev).add(cardId));
@@ -211,15 +219,21 @@ export function useCardOrchestrator(
         return next;
       });
     },
-    [autoSummaryEnabled, executeEnrich],
+    [autoSummaryEnabled, executeEnrich]
   );
 
   // Manual retry for failed enrichment
   const retryEnrich = useCallback(
-    (cardId: string, videoUrl?: string, sourceTable: 'user_local_cards' | 'user_video_states' = 'user_local_cards') => {
-      triggerAutoEnrich(cardId, videoUrl, sourceTable).catch(() => {/* handled internally */});
+    (
+      cardId: string,
+      videoUrl?: string,
+      sourceTable: 'user_local_cards' | 'user_video_states' = 'user_local_cards'
+    ) => {
+      triggerAutoEnrich(cardId, videoUrl, sourceTable).catch(() => {
+        /* handled internally */
+      });
     },
-    [triggerAutoEnrich],
+    [triggerAutoEnrich]
   );
 
   // Convert video states to InsightCards
@@ -281,10 +295,28 @@ export function useCardOrchestrator(
     [syncedCards]
   );
 
+  // Issue #389: "Newly Synced" cards — mapped to a mandala via
+  // source_mandala_mappings but not yet placed into a specific cell.
+  // Predicate centralized in cardUtils.isNewlySyncedCard.
+  const newlySyncedCards = useMemo(
+    () => syncedCards.filter((c) => isNewlySyncedCard(c, mandalaId)),
+    [syncedCards, mandalaId]
+  );
+
+  // Global per-mandala counts — drives sidebar dot+count indicator.
+  // Not scoped to the current mandala so every mandala item can display
+  // its own count without extra queries.
+  const newlySyncedCountByMandala = useMemo(
+    () => countNewlySyncedByMandala(syncedCards),
+    [syncedCards]
+  );
+
   // Merged scratchpad (deduplicate by normalized URL)
   const scratchPadCards = useMemo(() => {
     const persistedUrls = new Set(persistedLocalCards.map((c) => normalizeUrl(c.videoUrl)));
-    const filteredPending = pendingLocalCards.filter((c) => !persistedUrls.has(normalizeUrl(c.videoUrl)));
+    const filteredPending = pendingLocalCards.filter(
+      (c) => !persistedUrls.has(normalizeUrl(c.videoUrl))
+    );
     const merged = [...ideationVideoCards, ...scratchpadLocalCards, ...filteredPending];
     const seen = new Set<string>();
     return merged.filter((card) => {
@@ -456,7 +488,16 @@ export function useCardOrchestrator(
         }
       }
     },
-    [handleFileUpload, currentLevelId, currentLevel.subjects, toast, addLocalCard, queryClient, t, mandalaId]
+    [
+      handleFileUpload,
+      currentLevelId,
+      currentLevel.subjects,
+      toast,
+      addLocalCard,
+      queryClient,
+      t,
+      mandalaId,
+    ]
   );
 
   // File drop for scratchpad
@@ -547,13 +588,18 @@ export function useCardOrchestrator(
         if ('_isUpdate' in result && result._isUpdate) {
           toast({
             title: t('index.cardUpdated', 'Card updated'),
-            description: t('index.cardUpdatedDesc', 'This URL already existed. Card position updated.'),
+            description: t(
+              'index.cardUpdatedDesc',
+              'This URL already existed. Card position updated.'
+            ),
           });
         }
 
         // Fire-and-forget: trigger AI enrichment for YouTube cards
         if (linkType === 'youtube' || linkType === 'youtube-shorts') {
-          triggerAutoEnrich(result.id, url).catch(() => {/* non-critical */});
+          triggerAutoEnrich(result.id, url).catch(() => {
+            /* non-critical */
+          });
         }
       } catch (error) {
         setPendingLocalCards((prev) => prev.filter((c) => c.id !== tempCard.id));
@@ -652,7 +698,9 @@ export function useCardOrchestrator(
         // Fire-and-forget: trigger AI enrichment for each imported YouTube card
         const importedCards: Array<{ id: string; url: string }> = data.cards || [];
         for (const card of importedCards) {
-          triggerAutoEnrich(card.id, card.url).catch(() => {/* non-critical */});
+          triggerAutoEnrich(card.id, card.url).catch(() => {
+            /* non-critical */
+          });
         }
       } catch (error) {
         toast({
@@ -683,7 +731,9 @@ export function useCardOrchestrator(
       // Multi-card drop
       if (multiCardIds && multiCardIds.length > 0) {
         if (!mandalaId) {
-          console.warn('[CardOrchestrator] mandalaId is null during multi-card drop — waiting for mandala selection');
+          console.warn(
+            '[CardOrchestrator] mandalaId is null during multi-card drop — waiting for mandala selection'
+          );
           toast({
             title: t('common.error'),
             description: t('index.mandalaNotReady'),
@@ -742,7 +792,9 @@ export function useCardOrchestrator(
       // Single card drop
       if (cardId) {
         if (!mandalaId) {
-          console.warn('[CardOrchestrator] mandalaId is null during single card drop — waiting for mandala selection');
+          console.warn(
+            '[CardOrchestrator] mandalaId is null during single card drop — waiting for mandala selection'
+          );
           toast({
             title: t('common.error'),
             description: t('index.mandalaNotReady'),
@@ -835,7 +887,9 @@ export function useCardOrchestrator(
 
         // Guard: mandalaId must be set before adding cards to mandala cells
         if (!mandalaId) {
-          console.warn('[CardOrchestrator] mandalaId is null during card drop — waiting for mandala selection');
+          console.warn(
+            '[CardOrchestrator] mandalaId is null during card drop — waiting for mandala selection'
+          );
           toast({
             title: t('common.error'),
             description: t('index.mandalaNotReady'),
@@ -868,7 +922,11 @@ export function useCardOrchestrator(
 
           const newCard = createCardFromUrl(url, cellIndex, currentLevelId);
           if (!newCard) {
-            toast({ title: t('index.invalidUrl'), description: 'This URL cannot be saved as a card.', variant: 'destructive' });
+            toast({
+              title: t('index.invalidUrl'),
+              description: 'This URL cannot be saved as a card.',
+              variant: 'destructive',
+            });
             return;
           }
           setPendingLocalCards((prev) => [...prev, newCard]);
@@ -967,7 +1025,11 @@ export function useCardOrchestrator(
 
         const newCard = createCardFromUrl(url, -1, 'scratchpad');
         if (!newCard) {
-          toast({ title: t('index.invalidUrl'), description: 'This URL cannot be saved as a card.', variant: 'destructive' });
+          toast({
+            title: t('index.invalidUrl'),
+            description: 'This URL cannot be saved as a card.',
+            variant: 'destructive',
+          });
           return;
         }
         setPendingLocalCards((prev) => [...prev, newCard]);
@@ -984,7 +1046,18 @@ export function useCardOrchestrator(
         });
       }
     },
-    [isLoggedIn, navigate, toast, canAddCard, subscription, t, persistUrlCard, handlePlaylistDrop, persistedLocalCards, pendingLocalCards]
+    [
+      isLoggedIn,
+      navigate,
+      toast,
+      canAddCard,
+      subscription,
+      t,
+      persistUrlCard,
+      handlePlaylistDrop,
+      persistedLocalCards,
+      pendingLocalCards,
+    ]
   );
 
   // Move card from mandala back to scratchpad
@@ -1291,6 +1364,8 @@ export function useCardOrchestrator(
     displayTitle,
     isLoading: isLocalCardsLoading,
     syncedCards,
+    newlySyncedCards,
+    newlySyncedCountByMandala,
     persistedLocalCards,
     pendingLocalCards,
     addPendingCard: (card: InsightCard) => setPendingLocalCards((prev) => [...prev, card]),
@@ -1313,6 +1388,11 @@ export function useCardOrchestrator(
     failedEnrichCardIds,
     retryEnrich,
     markEnrichStart: (cardId: string) => setEnrichingCardIds((prev) => new Set(prev).add(cardId)),
-    markEnrichEnd: (cardId: string) => setEnrichingCardIds((prev) => { const next = new Set(prev); next.delete(cardId); return next; }),
+    markEnrichEnd: (cardId: string) =>
+      setEnrichingCardIds((prev) => {
+        const next = new Set(prev);
+        next.delete(cardId);
+        return next;
+      }),
   };
 }

--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -651,6 +651,7 @@ function AuthenticatedApp() {
   const setMinimapData = useShellStore((s) => s.setMinimapData);
   const setSearchBarElement = useShellStore((s) => s.setSearchBarElement);
   const setOnNavigateHome = useShellStore((s) => s.setOnNavigateHome);
+  const setNewlySyncedCountByMandala = useShellStore((s) => s.setNewlySyncedCountByMandala);
   const clearShell = useShellStore((s) => s.clearShell);
 
   // cleanup on unmount only
@@ -700,6 +701,12 @@ function AuthenticatedApp() {
     selectedMandalaId,
     setMinimapData,
   ]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Issue #389: push per-mandala "Newly Synced" counts to the shell store
+  // so the sidebar mandala list can render the dot+count indicator.
+  useEffect(() => {
+    setNewlySyncedCountByMandala(cards.newlySyncedCountByMandala);
+  }, [cards.newlySyncedCountByMandala, setNewlySyncedCountByMandala]);
 
   // searchBar — useMemo with primitive deps only
   const searchBarMemo = useMemo(
@@ -899,6 +906,7 @@ function AuthenticatedApp() {
                       totalCardCount={cards.totalCards}
                       cardsByCell={cards.cardsByCell}
                       isExternalCardDragActive={activeDragData?.type === 'card'}
+                      newlySyncedCards={cards.newlySyncedCards}
                     />
                   </>
                 )}

--- a/frontend/src/pages/settings/ui/ConnectedServicesTab.tsx
+++ b/frontend/src/pages/settings/ui/ConnectedServicesTab.tsx
@@ -5,21 +5,69 @@ import { Switch } from '@/shared/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
 import { useYouTubeAuth } from '@/features/youtube-sync/model/useYouTubeAuth';
 import { useUpdateSyncSettings } from '@/features/youtube-sync/model/useYouTubeSync';
+import { useToast } from '@/shared/lib/use-toast';
 import { YouTubeConnectionCard } from './YouTubeConnectionCard';
 import { LlmKeysSettingsTab } from './LlmKeysSettingsTab';
 import type { SyncInterval } from '@/entities/youtube/model/types';
 
 export function ConnectedServicesTab() {
   const { t } = useTranslation();
+  const { toast } = useToast();
   const ytAuth = useYouTubeAuth();
   const updateSettings = useUpdateSyncSettings();
 
+  // UX guard (Plan 2): surface the propagation result so the user knows
+  // the dropdown is no longer cosmetic. For interval changes we report
+  // the new interval + how many cron schedules were re-registered.
   const handleSyncIntervalChange = (value: string) => {
-    updateSettings.mutate({ syncInterval: value as SyncInterval });
+    updateSettings.mutate(
+      { syncInterval: value as SyncInterval },
+      {
+        onSuccess: (result) => {
+          const intervalLabel = value === 'manual' ? t('youtube.syncManual', 'Manual') : value;
+          toast({
+            title: t('settings.syncIntervalUpdated', 'Sync interval updated'),
+            description: t(
+              'settings.syncIntervalUpdatedDesc',
+              'Interval: {{interval}}. Applied to {{count}} playlist(s) immediately.',
+              { interval: intervalLabel, count: result.schedulesUpdated }
+            ),
+          });
+        },
+        onError: (err) => {
+          toast({
+            title: t('settings.syncSettingsFailed', 'Failed to update sync settings'),
+            description: err instanceof Error ? err.message : String(err),
+            variant: 'destructive',
+          });
+        },
+      }
+    );
   };
 
   const handleAutoSyncToggle = (checked: boolean) => {
-    updateSettings.mutate({ autoSyncEnabled: checked });
+    updateSettings.mutate(
+      { autoSyncEnabled: checked },
+      {
+        onSuccess: (result) => {
+          toast({
+            title: checked
+              ? t('settings.autoSyncOn', 'Background sync enabled')
+              : t('settings.autoSyncOff', 'Background sync disabled'),
+            description: t('settings.autoSyncToggleDesc', 'Applied to {{count}} playlist(s).', {
+              count: result.schedulesUpdated,
+            }),
+          });
+        },
+        onError: (err) => {
+          toast({
+            title: t('settings.syncSettingsFailed', 'Failed to update sync settings'),
+            description: err instanceof Error ? err.message : String(err),
+            variant: 'destructive',
+          });
+        },
+      }
+    );
   };
 
   const handleAutoSummaryToggle = (checked: boolean) => {

--- a/frontend/src/pages/settings/ui/SourceManagementTab.tsx
+++ b/frontend/src/pages/settings/ui/SourceManagementTab.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/shared/ui/button';
 import { Plus, RefreshCw, Loader2, Search, ChevronDown } from 'lucide-react';
-import { useYouTubeSync } from '@/features/youtube-sync/model/useYouTubeSync';
+import { useYouTubeSync, isYouTubeReauthError } from '@/features/youtube-sync/model/useYouTubeSync';
 import {
   useMandalaList,
   useSourceMappings,
@@ -10,6 +11,8 @@ import {
   useDeleteSourceMapping,
 } from '@/features/mandala';
 import { apiClient } from '@/shared/lib/api-client';
+import { useToast } from '@/shared/lib/use-toast';
+import { ToastAction } from '@/shared/ui/toast';
 import { SourceCard } from './SourceCard';
 import { AddSourceModal } from './AddSourceModal';
 import { cn } from '@/shared/lib/utils';
@@ -19,7 +22,46 @@ type SortType = 'name' | 'date' | 'videos';
 
 export function SourceManagementTab() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [, setSearchParams] = useSearchParams();
+  const { toast } = useToast();
   const ytSync = useYouTubeSync();
+
+  // Same error-surfacing helper as SourceManagementTabV2. Keeps V1/V2 in
+  // lockstep until one of them is retired.
+  const openConnectedServicesTab = () => {
+    setSearchParams({ tab: 'services' });
+    navigate('/settings?tab=services');
+  };
+  const surfaceSyncError = (err: unknown, reason: string) => {
+    const message = err instanceof Error ? err.message : String(err);
+    if (isYouTubeReauthError(err)) {
+      toast({
+        title: t('sources.reconnectNeeded', 'YouTube reconnection required'),
+        description: t(
+          'sources.reconnectNeededDesc',
+          'Your YouTube credentials have expired. Please reconnect in Settings > Connected Services.'
+        ),
+        variant: 'destructive',
+        action: (
+          <ToastAction
+            altText={t('sources.openSettings', 'Open Settings')}
+            onClick={openConnectedServicesTab}
+          >
+            {t('sources.openSettings', 'Open Settings')}
+          </ToastAction>
+        ),
+      });
+      return;
+    }
+    toast({
+      title: t('sources.syncFailed', 'Sync failed'),
+      description: t('sources.syncFailedDesc', 'An error occurred during sync: {{reason}}', {
+        reason: message || reason,
+      }),
+      variant: 'destructive',
+    });
+  };
   const [filter, setFilter] = useState<FilterType>('all');
   const [mandalaFilter, setMandalaFilter] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -135,10 +177,14 @@ export function SourceManagementTab() {
     });
   };
 
-  const handleSync = async (id: string) => {
+  const handleSync = async (id: string): Promise<{ ok: boolean; error?: unknown }> => {
     setSyncingIds((prev) => new Set(prev).add(id));
     try {
       await ytSync.syncPlaylist(id);
+      return { ok: true };
+    } catch (err) {
+      surfaceSyncError(err, 'syncPlaylist');
+      return { ok: false, error: err };
     } finally {
       setSyncingIds((prev) => {
         const next = new Set(prev);
@@ -239,8 +285,31 @@ export function SourceManagementTab() {
 
   const handleSyncAll = async () => {
     const activeSources = filtered.filter((s) => !s.isPaused);
+    let failed = 0;
+    let reauthHit = false;
     for (const source of activeSources) {
-      await handleSync(source.id);
+      const res = await handleSync(source.id);
+      if (!res.ok) {
+        failed += 1;
+        if (isYouTubeReauthError(res.error)) {
+          reauthHit = true;
+          break;
+        }
+      }
+    }
+    if (!reauthHit && failed > 0) {
+      toast({
+        title: t('sources.syncFailed', 'Sync failed'),
+        description: t(
+          'sources.syncAllFailedDesc',
+          '{{failed}} of {{total}} sources failed to sync',
+          {
+            failed,
+            total: activeSources.length,
+          }
+        ),
+        variant: 'destructive',
+      });
     }
   };
 

--- a/frontend/src/pages/settings/ui/SourceManagementTabV2.tsx
+++ b/frontend/src/pages/settings/ui/SourceManagementTabV2.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { RefreshCw, Loader2 } from 'lucide-react';
-import { useYouTubeSync } from '@/features/youtube-sync/model/useYouTubeSync';
+import { useYouTubeSync, isYouTubeReauthError } from '@/features/youtube-sync/model/useYouTubeSync';
 import {
   useMandalaList,
   useSourceMappings,
   useCreateSourceMappings,
   useDeleteSourceMapping,
 } from '@/features/mandala';
+import { useToast } from '@/shared/lib/use-toast';
+import { ToastAction } from '@/shared/ui/toast';
 import { SourceCardV2 } from './SourceCardV2';
 import { AddSourceModalV2 } from './AddSourceModalV2';
 import { BulkActionBar } from './BulkActionBar';
@@ -20,7 +23,50 @@ type SortId = 'name' | 'videos' | 'date';
 
 export function SourceManagementTabV2() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [, setSearchParams] = useSearchParams();
+  const { toast } = useToast();
   const ytSync = useYouTubeSync();
+
+  // Open Settings → Connected Services tab (scoped query param).
+  const openConnectedServicesTab = () => {
+    setSearchParams({ tab: 'services' });
+    navigate('/settings?tab=services');
+  };
+
+  // Emit a regression-aware error toast for sync failures. OAuth
+  // refresh_token rejection (invalid_grant / token expired) gets a
+  // dedicated reconnect CTA; everything else falls back to a generic
+  // toast that surfaces the server message.
+  const surfaceSyncError = (err: unknown, reason: string) => {
+    const message = err instanceof Error ? err.message : String(err);
+    if (isYouTubeReauthError(err)) {
+      toast({
+        title: t('sources.reconnectNeeded', 'YouTube reconnection required'),
+        description: t(
+          'sources.reconnectNeededDesc',
+          'Your YouTube credentials have expired. Please reconnect in Settings > Connected Services.'
+        ),
+        variant: 'destructive',
+        action: (
+          <ToastAction
+            altText={t('sources.openSettings', 'Open Settings')}
+            onClick={openConnectedServicesTab}
+          >
+            {t('sources.openSettings', 'Open Settings')}
+          </ToastAction>
+        ),
+      });
+      return;
+    }
+    toast({
+      title: t('sources.syncFailed', 'Sync failed'),
+      description: t('sources.syncFailedDesc', 'An error occurred during sync: {{reason}}', {
+        reason: message || reason,
+      }),
+      variant: 'destructive',
+    });
+  };
 
   const [typeFilter, setTypeFilter] = useState<FilterType>('all');
   const [mandalaFilter, setMandalaFilter] = useState<string | null>(null);
@@ -141,10 +187,17 @@ export function SourceManagementTabV2() {
   };
 
   // Handlers
-  const handleSync = async (id: string) => {
+  const handleSync = async (id: string): Promise<{ ok: boolean; error?: unknown }> => {
     setSyncingIds((prev) => new Set(prev).add(id));
     try {
       await ytSync.syncPlaylist(id);
+      return { ok: true };
+    } catch (err) {
+      // Reauth errors propagate so handleSyncAll can bail out early
+      // (rather than retrying each playlist against the same dead token).
+      // Individual-button callers surface the toast here directly.
+      surfaceSyncError(err, 'syncPlaylist');
+      return { ok: false, error: err };
     } finally {
       setSyncingIds((prev) => {
         const n = new Set(prev);
@@ -247,10 +300,38 @@ export function SourceManagementTabV2() {
   const handleSyncAll = async () => {
     setIsSyncingAll(true);
     const active = filtered.filter((s) => !s.isPaused);
-    for (const s of active) {
-      await handleSync(s.id);
+    let failed = 0;
+    let reauthHit = false;
+    try {
+      for (const s of active) {
+        const res = await handleSync(s.id);
+        if (!res.ok) {
+          failed += 1;
+          // If the refresh_token is rejected, every subsequent playlist
+          // will fail the same way — stop the loop and rely on the
+          // reconnect toast surfaced inside handleSync.
+          if (isYouTubeReauthError(res.error)) {
+            reauthHit = true;
+            break;
+          }
+        }
+      }
+      // Summary toast for mixed-outcome bulk runs (skip when reauth hit
+      // since that toast already dominates).
+      if (!reauthHit && failed > 0) {
+        toast({
+          title: t('sources.syncFailed', 'Sync failed'),
+          description: t(
+            'sources.syncAllFailedDesc',
+            '{{failed}} of {{total}} sources failed to sync',
+            { failed, total: active.length }
+          ),
+          variant: 'destructive',
+        });
+      }
+    } finally {
+      setIsSyncingAll(false);
     }
-    setIsSyncingAll(false);
   };
 
   const FILTER_OPTIONS = [

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -59,7 +59,13 @@
     "lastSync": "Last sync",
     "selectedCount": "{{count}} selected",
     "bulkAssign": "Assign Mandala",
-    "mandalaApplyNote": "Applies to all sources added in this session. For individual mapping, use the mandala pills on each source card."
+    "mandalaApplyNote": "Applies to all sources added in this session. For individual mapping, use the mandala pills on each source card.",
+    "syncFailed": "Sync failed",
+    "syncFailedDesc": "An error occurred during sync: {{reason}}",
+    "syncAllFailedDesc": "{{failed}} of {{total}} sources failed to sync",
+    "reconnectNeeded": "YouTube reconnection required",
+    "reconnectNeededDesc": "Your YouTube credentials have expired. Please reconnect in Settings > Connected Services.",
+    "openSettings": "Open Settings"
   },
   "explore": {
     "title": "Explore Mandalas",
@@ -273,6 +279,12 @@
     "syncCompletionDesc": "Notify when YouTube sync completes",
     "aiInsightReady": "AI insight ready",
     "aiInsightReadyDesc": "Notify when AI summary is available",
+    "syncIntervalUpdated": "Sync interval updated",
+    "syncIntervalUpdatedDesc": "Interval: {{interval}}. Applied to {{count}} playlist(s) immediately.",
+    "autoSyncOn": "Background sync enabled",
+    "autoSyncOff": "Background sync disabled",
+    "autoSyncToggleDesc": "Applied to {{count}} playlist(s).",
+    "syncSettingsFailed": "Failed to update sync settings",
     "exportData": "Export Data",
     "exportDataDesc": "Download all your data as JSON",
     "exportBtn": "Export JSON",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -59,7 +59,13 @@
     "lastSync": "마지막 동기화",
     "selectedCount": "{{count}}개 선택",
     "bulkAssign": "만다라 일괄 지정",
-    "mandalaApplyNote": "이 세션에서 추가하는 모든 소스에 적용됩니다. 개별 매핑은 소스 카드의 만다라 pill에서 변경하세요."
+    "mandalaApplyNote": "이 세션에서 추가하는 모든 소스에 적용됩니다. 개별 매핑은 소스 카드의 만다라 pill에서 변경하세요.",
+    "syncFailed": "동기화 실패",
+    "syncFailedDesc": "동기화 중 오류가 발생했습니다: {{reason}}",
+    "syncAllFailedDesc": "{{failed}}개 소스 동기화 실패 ({{total}}개 시도)",
+    "reconnectNeeded": "YouTube 재연결 필요",
+    "reconnectNeededDesc": "YouTube 인증이 만료되었습니다. 설정 > 연결된 서비스에서 다시 연결해 주세요.",
+    "openSettings": "설정으로 이동"
   },
   "explore": {
     "title": "만다라트 탐색",
@@ -274,6 +280,12 @@
     "syncCompletionDesc": "YouTube 동기화 완료 시 알림",
     "aiInsightReady": "AI 인사이트 준비 완료",
     "aiInsightReadyDesc": "AI 요약이 준비되면 알림",
+    "syncIntervalUpdated": "동기화 간격이 변경되었습니다",
+    "syncIntervalUpdatedDesc": "간격: {{interval}}. {{count}}개 플레이리스트에 즉시 반영됨.",
+    "autoSyncOn": "백그라운드 동기화 켜짐",
+    "autoSyncOff": "백그라운드 동기화 꺼짐",
+    "autoSyncToggleDesc": "{{count}}개 플레이리스트에 반영됨.",
+    "syncSettingsFailed": "동기화 설정 업데이트 실패",
     "exportData": "데이터 내보내기",
     "exportDataDesc": "모든 데이터를 JSON으로 다운로드",
     "exportBtn": "JSON 내보내기",

--- a/frontend/src/stores/shellStore.ts
+++ b/frontend/src/stores/shellStore.ts
@@ -20,9 +20,16 @@ interface ShellStore {
   minimapData: MinimapData | null;
   searchBarElement: React.ReactNode | null;
   onNavigateHome: (() => void) | null;
+  /**
+   * Issue #389: per-mandala "Newly Synced" card count. Drives the sidebar
+   * dot+count indicator. Empty record when no mandala has mapping-synced
+   * unplaced cards.
+   */
+  newlySyncedCountByMandala: Record<string, number>;
   setMinimapData: (data: MinimapData | null) => void;
   setSearchBarElement: (el: React.ReactNode | null) => void;
   setOnNavigateHome: (fn: (() => void) | null) => void;
+  setNewlySyncedCountByMandala: (counts: Record<string, number>) => void;
   clearShell: () => void;
 }
 
@@ -30,8 +37,16 @@ export const useShellStore = create<ShellStore>((set) => ({
   minimapData: null,
   searchBarElement: null,
   onNavigateHome: null,
+  newlySyncedCountByMandala: {},
   setMinimapData: (data) => set({ minimapData: data }),
   setSearchBarElement: (el) => set({ searchBarElement: el }),
   setOnNavigateHome: (fn) => set({ onNavigateHome: fn }),
-  clearShell: () => set({ minimapData: null, searchBarElement: null, onNavigateHome: null }),
+  setNewlySyncedCountByMandala: (counts) => set({ newlySyncedCountByMandala: counts }),
+  clearShell: () =>
+    set({
+      minimapData: null,
+      searchBarElement: null,
+      onNavigateHome: null,
+      newlySyncedCountByMandala: {},
+    }),
 }));

--- a/frontend/src/widgets/app-shell/ui/AppShell.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppShell.tsx
@@ -35,6 +35,7 @@ export function AppShell({ children }: AppShellProps) {
   const minimapData = useShellStore((s) => s.minimapData);
   const searchBarElement = useShellStore((s) => s.searchBarElement);
   const onNavigateHome = useShellStore((s) => s.onNavigateHome);
+  const newlySyncedCountByMandala = useShellStore((s) => s.newlySyncedCountByMandala);
   const { isLoggedIn } = useAuth();
   const { t } = useTranslation();
   const sensors = useDndSensors();
@@ -120,6 +121,7 @@ export function AppShell({ children }: AppShellProps) {
               onToggleCollapse={handleToggleCollapse}
               onNavigateHome={onNavigateHome ?? undefined}
               minimapData={minimapData ?? undefined}
+              newlySyncedCountByMandala={newlySyncedCountByMandala}
               settingsMode={isSettingsRoute}
             />
           )}

--- a/frontend/src/widgets/app-shell/ui/Sidebar.tsx
+++ b/frontend/src/widgets/app-shell/ui/Sidebar.tsx
@@ -112,6 +112,8 @@ interface SidebarProps {
   onToggleCollapse: () => void;
   onNavigateHome?: () => void;
   minimapData?: MinimapData;
+  /** Issue #389: per-mandala "Newly Synced" card count for the sidebar dot+count indicator. */
+  newlySyncedCountByMandala?: Record<string, number>;
   settingsMode?: boolean;
 }
 
@@ -129,6 +131,7 @@ export function Sidebar({
   onToggleCollapse,
   onNavigateHome,
   minimapData,
+  newlySyncedCountByMandala,
   settingsMode = false,
 }: SidebarProps) {
   const { t } = useTranslation();
@@ -289,7 +292,11 @@ export function Sidebar({
               </div>
             )}
           >
-            <SidebarMandalaSection collapsed={collapsed} minimapData={minimapData} />
+            <SidebarMandalaSection
+              collapsed={collapsed}
+              minimapData={minimapData}
+              newlySyncedCountByMandala={newlySyncedCountByMandala}
+            />
           </ErrorBoundary>
         </nav>
 

--- a/frontend/src/widgets/app-shell/ui/SidebarMandalaSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarMandalaSection.tsx
@@ -29,9 +29,20 @@ const SWITCH_DEBOUNCE_MS = 300;
 interface SidebarMandalaSectionProps {
   collapsed: boolean;
   minimapData?: MinimapData;
+  /**
+   * Issue #389: per-mandala "Newly Synced" card count (videos synced from a
+   * mapped source but not yet placed into a cell). Rendered as `● N`
+   * next to each mandala row in the popover. Entries with count 0 are
+   * omitted entirely — no indicator shown.
+   */
+  newlySyncedCountByMandala?: Record<string, number>;
 }
 
-export function SidebarMandalaSection({ collapsed, minimapData }: SidebarMandalaSectionProps) {
+export function SidebarMandalaSection({
+  collapsed,
+  minimapData,
+  newlySyncedCountByMandala,
+}: SidebarMandalaSectionProps) {
   const selectedMandalaId = useMandalaStore((s) => s.selectedMandalaId);
   const selectMandala = useMandalaStore((s) => s.selectMandala);
   const pendingMandala = useMandalaStore((s) => s.pendingMandala);
@@ -223,6 +234,7 @@ export function SidebarMandalaSection({ collapsed, minimapData }: SidebarMandala
           <div className="max-h-[240px] overflow-y-auto">
             {sortedMandalas.map((mandala) => {
               const isSelected = mandala.id === selectedMandalaId;
+              const newlySyncedCount = newlySyncedCountByMandala?.[mandala.id] ?? 0;
               return (
                 <button
                   key={mandala.id}
@@ -237,7 +249,20 @@ export function SidebarMandalaSection({ collapsed, minimapData }: SidebarMandala
                   )}
                 >
                   <span className="truncate">{getCenterLabel(mandala)}</span>
-                  {isSelected && <Check className="w-3.5 h-3.5 text-primary shrink-0 ml-2" />}
+                  <span className="flex items-center gap-2 shrink-0 ml-2">
+                    {newlySyncedCount > 0 && (
+                      <span
+                        className="flex items-center gap-1 text-[11px] text-primary font-medium"
+                        aria-label={t('sidebar.newlySyncedAria', '{{count}} newly synced', {
+                          count: newlySyncedCount,
+                        })}
+                      >
+                        <span className="w-1.5 h-1.5 rounded-full bg-primary" aria-hidden="true" />
+                        {newlySyncedCount}
+                      </span>
+                    )}
+                    {isSelected && <Check className="w-3.5 h-3.5 text-primary" />}
+                  </span>
                 </button>
               );
             })}

--- a/frontend/src/widgets/card-list-view/ui/CardListView.tsx
+++ b/frontend/src/widgets/card-list-view/ui/CardListView.tsx
@@ -107,6 +107,12 @@ interface CardListViewProps {
   gridColumns?: number;
   /** Grid column change handler */
   onGridColumnsChange?: (columns: number) => void;
+  /**
+   * Issue #389: cards synced from a mapped source but not yet placed into
+   * a cell (mandala_id set, cell_index<0, is_in_ideation=false). The
+   * "Newly Synced" pill is hidden when this list is empty.
+   */
+  newlySyncedCards?: InsightCard[];
 }
 
 export function CardListView({
@@ -141,6 +147,7 @@ export function CardListView({
   gridColumns: gridColumnsProp,
   onGridColumnsChange,
   compactMode = false,
+  newlySyncedCards,
 }: CardListViewProps) {
   const { t } = useTranslation();
   // Auto-responsive columns by CONTAINER width (reacts to side panel open/close).
@@ -160,6 +167,28 @@ export function CardListView({
   const [selectedCardIds, setSelectedCardIds] = useState<string[]>([]);
   const [sortMode, setSortMode] = useState<SortMode>('latest');
   const [isExternalDragOver, setIsExternalDragOver] = useState(false);
+  // Issue #389: Newly Synced pill is mutually exclusive with All/sector pills.
+  // Kept as local state (rather than lifting to parent) because the filter is
+  // a pure view concern that doesn't persist across navigations — the pill
+  // only appears when the current mandala has mapping-synced unplaced cards.
+  const [isNewlySyncedActive, setIsNewlySyncedActive] = useState(false);
+  const newlySyncedCount = newlySyncedCards?.length ?? 0;
+
+  // Auto-exit the Newly Synced view when the source list drains to 0 (user
+  // placed the last card via D&D). Prevents an empty-with-no-exit state.
+  useEffect(() => {
+    if (isNewlySyncedActive && newlySyncedCount === 0) {
+      setIsNewlySyncedActive(false);
+    }
+  }, [isNewlySyncedActive, newlySyncedCount]);
+
+  // Exit Newly Synced whenever a sector pill (or a cell-click elsewhere in
+  // the app) selects a real cell — keeps the two views mutually exclusive.
+  useEffect(() => {
+    if (selectedCellIndex !== null && selectedCellIndex >= 0 && isNewlySyncedActive) {
+      setIsNewlySyncedActive(false);
+    }
+  }, [selectedCellIndex, isNewlySyncedActive]);
 
   // Native HTML5 external drag handlers (YouTube URL from browser etc.)
   const handleExternalDragOver = useCallback(
@@ -212,12 +241,17 @@ export function CardListView({
 
   const effectiveViewMode = viewMode === 'list-detail' && isMobile ? 'list' : viewMode;
 
+  // Issue #389: when the Newly Synced pill is active, swap the card source
+  // to the unplaced mapping-synced cards. Otherwise keep the parent-filtered
+  // `cards` flow (All / sector pills / search) intact.
+  const effectiveCards = isNewlySyncedActive && newlySyncedCards ? newlySyncedCards : cards;
+
   // "latest"/"oldest" rank by source publish date (YouTube upload) ONLY.
   // Cards without a publish date sort to the end instead of inheriting
   // `createdAt` — otherwise newly-cached items inherit "today" and leak
   // into the "Latest" band above genuinely-recent uploads.
   const sortedCards = useMemo(() => {
-    const arr = [...cards];
+    const arr = [...effectiveCards];
     const getPublishedMs = (c: (typeof cards)[number]): number => {
       const fromField = c.publishedAt ? new Date(c.publishedAt).getTime() : NaN;
       if (Number.isFinite(fromField)) return fromField;
@@ -260,7 +294,7 @@ export function CardListView({
       default:
         return arr;
     }
-  }, [cards, sortMode]);
+  }, [effectiveCards, sortMode]);
 
   // Sector card counts (0-7)
   const sectorCounts = useMemo(() => {
@@ -290,6 +324,12 @@ export function CardListView({
   }, [selectedCardIds, onDeleteCards]);
 
   const handleAllClick = useCallback(() => {
+    setIsNewlySyncedActive(false);
+    onCellClick?.(-1, '');
+  }, [onCellClick]);
+
+  const handleNewlySyncedClick = useCallback(() => {
+    setIsNewlySyncedActive(true);
     onCellClick?.(-1, '');
   }, [onCellClick]);
 
@@ -312,11 +352,12 @@ export function CardListView({
       </div>
     ) : null;
 
-  // Context header
+  // Context header — count reflects whatever list the view is rendering,
+  // so it tracks the Newly Synced pill too.
   const contextHeaderElement = (
     <ContextHeader
       title={title}
-      totalCardCount={cards.length}
+      totalCardCount={effectiveCards.length}
       viewMode={effectiveViewMode}
       onViewModeChange={onViewModeChange}
       selectedCardIds={selectedCardIds}
@@ -336,6 +377,9 @@ export function CardListView({
       sectorCounts={sectorCounts}
       onSectorClick={(idx, subject) => onCellClick?.(idx, subject)}
       onAllClick={handleAllClick}
+      newlySyncedCount={newlySyncedCount}
+      isNewlySyncedSelected={isNewlySyncedActive}
+      onNewlySyncedClick={handleNewlySyncedClick}
     />
   );
 

--- a/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
+++ b/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
@@ -14,6 +14,15 @@ interface LabelFilterPillsV2Props {
   onSectorClick: (cellIndex: number, subject: string) => void;
   /** Called when All pill is clicked (deselect sector) */
   onAllClick: () => void;
+  /**
+   * Issue #389: count of synced videos mapped to this mandala but not yet
+   * placed into a cell. Pill is hidden entirely when 0.
+   */
+  newlySyncedCount?: number;
+  /** True when the "Newly Synced" pill is the active filter. */
+  isNewlySyncedSelected?: boolean;
+  /** Called when the "Newly Synced" pill is clicked. */
+  onNewlySyncedClick?: () => void;
 }
 
 export function LabelFilterPillsV2({
@@ -23,9 +32,13 @@ export function LabelFilterPillsV2({
   sectorCounts,
   onSectorClick,
   onAllClick,
+  newlySyncedCount = 0,
+  isNewlySyncedSelected = false,
+  onNewlySyncedClick,
 }: LabelFilterPillsV2Props) {
   const { t } = useTranslation();
-  const isAllSelected = selectedIndex === null;
+  const isAllSelected = selectedIndex === null && !isNewlySyncedSelected;
+  const showNewlySynced = newlySyncedCount > 0 && typeof onNewlySyncedClick === 'function';
 
   return (
     <div
@@ -53,7 +66,7 @@ export function LabelFilterPillsV2({
 
       {/* 8 sector tabs */}
       {sectors.map((sector, idx) => {
-        const isActive = selectedIndex === idx;
+        const isActive = selectedIndex === idx && !isNewlySyncedSelected;
         const count = sectorCounts[idx] ?? 0;
         return (
           <button
@@ -76,6 +89,34 @@ export function LabelFilterPillsV2({
           </button>
         );
       })}
+
+      {/* Issue #389: "Newly Synced" tab — appended at the end, hidden when 0.
+          Visually distinguished from the All/sector pills with the primary
+          accent (leading dot + tinted text) so it echoes the sidebar
+          dot+count indicator that surfaces the same per-mandala count. */}
+      {showNewlySynced && (
+        <button
+          onClick={onNewlySyncedClick}
+          className={cn(
+            'relative shrink-0 mr-3 pb-1 text-[11px] font-medium transition-colors bg-transparent border-none cursor-pointer inline-flex items-center gap-1',
+            isNewlySyncedSelected
+              ? 'text-[var(--ind,#818cf8)] font-bold'
+              : 'text-[var(--ind,#818cf8)]/80 hover:text-[var(--ind,#818cf8)]'
+          )}
+        >
+          <span
+            className="w-1.5 h-1.5 rounded-full bg-[var(--ind,#818cf8)] shrink-0"
+            aria-hidden="true"
+          />
+          {t('labelFilter.newlySynced', 'Newly Synced')}
+          <span className="ml-[2px] text-[10px] font-medium text-[var(--ind,#818cf8)]/70">
+            {newlySyncedCount}
+          </span>
+          {isNewlySyncedSelected && (
+            <span className="absolute bottom-[-2px] left-0 right-0 h-[2px] bg-[var(--ind,#818cf8)] rounded-full" />
+          )}
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/widgets/scratch-pad/ui/FloatingScratchPad.tsx
+++ b/frontend/src/widgets/scratch-pad/ui/FloatingScratchPad.tsx
@@ -6,7 +6,11 @@ import { CSS } from '@dnd-kit/utilities';
 import { InsightCard } from '@/entities/card/model/types';
 import { type DragData, type DropData, cardDragId } from '@/shared/lib/dnd';
 import { extractUrlFromDragData, extractUrlFromHtml } from '@/shared/data/mockData';
-import { handleThumbnailError, handleThumbnailLoad } from '@/shared/lib/image-utils';
+import {
+  handleThumbnailError,
+  handleThumbnailLoad,
+  upgradeYouTubeThumbnail,
+} from '@/shared/lib/image-utils';
 import {
   Lightbulb,
   Plus,
@@ -866,7 +870,7 @@ export const FloatingScratchPad = forwardRef<HTMLDivElement, FloatingScratchPadP
                   style={{ boxShadow: 'var(--shadow-sm)' }}
                 >
                   <img
-                    src={card.thumbnail}
+                    src={upgradeYouTubeThumbnail(card.thumbnail) ?? card.thumbnail}
                     alt={card.title}
                     draggable={false}
                     className="w-full h-full object-cover transition-transform duration-200 group-hover:scale-105"
@@ -1172,7 +1176,7 @@ export const FloatingScratchPad = forwardRef<HTMLDivElement, FloatingScratchPadP
                                   style={{ boxShadow: 'var(--shadow-xs)' }}
                                 >
                                   <img
-                                    src={card.thumbnail}
+                                    src={upgradeYouTubeThumbnail(card.thumbnail) ?? card.thumbnail}
                                     alt={card.title}
                                     draggable={false}
                                     className="w-full h-full object-cover transition-transform duration-200 group-hover:scale-105"

--- a/frontend/src/widgets/scratch-pad/ui/ScratchPad.tsx
+++ b/frontend/src/widgets/scratch-pad/ui/ScratchPad.tsx
@@ -4,7 +4,11 @@ import { type DragData, cardDragId } from '@/shared/lib/dnd';
 import { extractUrlFromDragData, extractUrlFromHtml } from '@/shared/data/mockData';
 import { Lightbulb, Plus, ExternalLink } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
-import { handleThumbnailError, handleThumbnailLoad } from '@/shared/lib/image-utils';
+import {
+  handleThumbnailError,
+  handleThumbnailLoad,
+  upgradeYouTubeThumbnail,
+} from '@/shared/lib/image-utils';
 import {
   format,
   differenceInHours,
@@ -268,7 +272,7 @@ export function ScratchPad({
                         style={{ boxShadow: 'var(--shadow-sm)' }}
                       >
                         <img
-                          src={card.thumbnail}
+                          src={upgradeYouTubeThumbnail(card.thumbnail) ?? card.thumbnail}
                           alt={card.title}
                           className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
                           onError={handleThumbnailError}

--- a/src/api/routes/playlists.ts
+++ b/src/api/routes/playlists.ts
@@ -242,6 +242,72 @@ export const playlistRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
   );
 
   /**
+   * POST /api/v1/playlists/sync-all - Sync every playlist owned by the
+   * authenticated user. Sequential execution (respects per-user write
+   * rate limit). Failures per playlist are captured in the result row
+   * and do NOT abort the remaining syncs.
+   *
+   * Response shape matches the FE contract in
+   * `frontend/src/features/youtube-sync/model/useYouTubeSync.ts:useSyncAllPlaylists`
+   * — `data.results: Array<{ playlistId, status, itemsAdded }>`, where
+   * `status ∈ { 'completed', 'failed' }`.
+   */
+  fastify.post<{
+    Reply: {
+      results: Array<{
+        playlistId: string;
+        status: 'completed' | 'failed';
+        itemsAdded: number;
+        error?: string;
+      }>;
+    };
+  }>('/sync-all', { onRequest: [fastify.authenticate] }, async (request, reply) => {
+    if (!request.user || !('userId' in request.user)) {
+      throw new Error('Unauthorized');
+    }
+    const userId = request.user.userId;
+
+    const { playlists } = await getManager().listPlaylists({ userId });
+
+    logger.info('Syncing all playlists for user', {
+      userId,
+      count: playlists.length,
+    });
+
+    const results: Array<{
+      playlistId: string;
+      status: 'completed' | 'failed';
+      itemsAdded: number;
+      error?: string;
+    }> = [];
+
+    for (const playlist of playlists) {
+      try {
+        const result = await getSync().syncPlaylist(playlist.id);
+        results.push({
+          playlistId: playlist.id,
+          status: 'completed',
+          itemsAdded: result.itemsAdded,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn('Playlist sync failed during sync-all', {
+          playlistId: playlist.id,
+          error: message,
+        });
+        results.push({
+          playlistId: playlist.id,
+          status: 'failed',
+          itemsAdded: 0,
+          error: message,
+        });
+      }
+    }
+
+    return reply.code(200).send({ results });
+  });
+
+  /**
    * POST /api/v1/playlists/:id/sync - Sync playlist
    */
   fastify.post<{ Params: SyncPlaylistParams; Reply: { result: SyncResultResponse } }>(

--- a/src/api/routes/sync.ts
+++ b/src/api/routes/sync.ts
@@ -8,6 +8,7 @@ import { FastifyPluginCallback } from 'fastify';
 import { getPlaylistManager } from '../../modules/playlist';
 import { getSchedulerManager } from '../../modules/scheduler';
 import { getPrismaClient } from '../../modules/database';
+import { MS_PER_HOUR } from '../../utils/time-constants';
 import {
   GetSyncStatusParamsSchema,
   GetSyncHistoryQuerySchema,
@@ -37,6 +38,17 @@ import {
   type ScheduleResponse,
 } from '../schemas/sync.schema';
 import { logger } from '../../utils/logger';
+
+// Plan 2 — canonical sync_interval string → interval_ms mapping.
+// 'manual' has no numeric interval; callers should treat it as
+// "disable all schedules" and not push it into `interval_ms`.
+const INTERVAL_STRING_TO_MS: Record<string, number | undefined> = {
+  '1h': 1 * MS_PER_HOUR,
+  '6h': 6 * MS_PER_HOUR,
+  '12h': 12 * MS_PER_HOUR,
+  '24h': 24 * MS_PER_HOUR,
+  manual: undefined,
+};
 
 /**
  * Sync routes plugin
@@ -245,6 +257,142 @@ export const syncRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       return reply.code(200).send({ sync: response });
     }
   );
+
+  /**
+   * POST /api/v1/sync/settings (Plan 2) — update user-level sync settings
+   * AND propagate the change to per-playlist cron schedules in one call.
+   *
+   * Fixes two pre-existing gaps:
+   *   - Bug A: the Edge Function that previously handled update-settings
+   *     only wrote `youtube_sync_settings`, leaving `sync_schedules.interval_ms`
+   *     at its hardcoded 6h default. The UI dropdown was purely cosmetic.
+   *   - Bug B: `auto_sync_enabled` was never respected by the scheduler.
+   *     Now this route flips every schedule's `enabled` flag for the user
+   *     when the toggle changes, and the cron callback also checks the
+   *     flag at execution time (defense-in-depth).
+   *
+   * `syncInterval='manual'` disables every schedule but preserves the
+   * last interval for the eventual re-enable.
+   */
+  fastify.post<{
+    Body: {
+      syncInterval?: '1h' | '6h' | '12h' | '24h' | 'manual';
+      autoSyncEnabled?: boolean;
+      autoSummaryEnabled?: boolean;
+    };
+    Reply: {
+      success: true;
+      schedulesUpdated: number;
+      appliedInterval: string | null;
+      autoSyncEnabled: boolean;
+    };
+  }>('/settings', { onRequest: [fastify.authenticate] }, async (request, reply) => {
+    if (!request.user || !('userId' in request.user)) {
+      throw new Error('Unauthorized');
+    }
+    const userId = request.user.userId;
+    const { syncInterval, autoSyncEnabled, autoSummaryEnabled } = request.body ?? {};
+
+    const VALID_INTERVALS = ['1h', '6h', '12h', '24h', 'manual'] as const;
+    if (syncInterval !== undefined && !VALID_INTERVALS.includes(syncInterval)) {
+      return reply.code(400).send({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: `syncInterval must be one of: ${VALID_INTERVALS.join(', ')}`,
+          timestamp: new Date().toISOString(),
+          path: request.url,
+        },
+        // cast to satisfy Reply type; error path doesn't use success shape
+      } as never);
+    }
+
+    const db = getDb();
+
+    // 1) Upsert settings. Only write fields that were supplied so
+    //    partial updates from either toggle don't clobber siblings.
+    const updates: Record<string, unknown> = { updated_at: new Date() };
+    if (syncInterval !== undefined) updates['sync_interval'] = syncInterval;
+    if (autoSyncEnabled !== undefined) updates['auto_sync_enabled'] = autoSyncEnabled;
+    if (autoSummaryEnabled !== undefined) updates['auto_summary_enabled'] = autoSummaryEnabled;
+
+    const existing = await db.youtube_sync_settings.findUnique({ where: { user_id: userId } });
+    if (existing) {
+      await db.youtube_sync_settings.update({
+        where: { user_id: userId },
+        data: updates,
+      });
+    } else {
+      await db.youtube_sync_settings.create({
+        data: {
+          user_id: userId,
+          sync_interval: syncInterval ?? 'manual',
+          auto_sync_enabled: autoSyncEnabled ?? false,
+          auto_summary_enabled: autoSummaryEnabled ?? true,
+        },
+      });
+    }
+
+    // 2) Determine the effective interval + enabled pair to push into
+    //    sync_schedules. If the caller only toggled autoSyncEnabled we
+    //    keep the previously-stored interval.
+    const settingsAfter = await db.youtube_sync_settings.findUnique({
+      where: { user_id: userId },
+      select: { sync_interval: true, auto_sync_enabled: true },
+    });
+    const effectiveInterval = settingsAfter?.sync_interval ?? 'manual';
+    const effectiveAutoSync = settingsAfter?.auto_sync_enabled ?? false;
+    const intervalMs = INTERVAL_STRING_TO_MS[effectiveInterval];
+    const scheduleEnabled = effectiveAutoSync && effectiveInterval !== 'manual';
+
+    // 3) Propagate to every user playlist schedule. Only touch schedules
+    //    that actually need changing to minimize cron churn.
+    const playlists = await db.youtube_playlists.findMany({
+      where: { user_id: userId },
+      select: { id: true },
+    });
+
+    let schedulesUpdated = 0;
+    if (playlists.length > 0) {
+      const scheduler = getScheduler();
+      for (const pl of playlists) {
+        try {
+          const existingSchedule = await scheduler.getSchedule(pl.id);
+          if (!existingSchedule) continue;
+
+          const needsIntervalUpdate =
+            intervalMs !== undefined && existingSchedule.interval !== intervalMs;
+          const needsEnabledUpdate = existingSchedule.enabled !== scheduleEnabled;
+          if (!needsIntervalUpdate && !needsEnabledUpdate) continue;
+
+          await scheduler.updateSchedule(pl.id, {
+            ...(needsIntervalUpdate && intervalMs !== undefined ? { interval: intervalMs } : {}),
+            ...(needsEnabledUpdate ? { enabled: scheduleEnabled } : {}),
+          });
+          schedulesUpdated++;
+        } catch (err) {
+          logger.warn('Failed to propagate sync settings to schedule (continuing)', {
+            playlistId: pl.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
+
+    logger.info('Sync settings updated', {
+      userId,
+      syncInterval: syncInterval ?? null,
+      autoSyncEnabled: autoSyncEnabled ?? null,
+      autoSummaryEnabled: autoSummaryEnabled ?? null,
+      schedulesUpdated,
+    });
+
+    return reply.code(200).send({
+      success: true as const,
+      schedulesUpdated,
+      appliedInterval: effectiveInterval,
+      autoSyncEnabled: effectiveAutoSync,
+    });
+  });
 
   /**
    * GET /api/v1/sync/schedule - List schedules

--- a/src/modules/scheduler/auto-sync.ts
+++ b/src/modules/scheduler/auto-sync.ts
@@ -349,6 +349,29 @@ export class AutoSyncScheduler {
     try {
       logger.info('Starting scheduled sync job', { playlistId });
 
+      // Bug B (Plan 2): respect the user-level auto_sync_enabled toggle.
+      // sync_schedules.enabled is per-playlist; auto_sync_enabled is
+      // per-user and wasn't previously consulted at execution time. Skip
+      // cleanly when the user has globally opted out.
+      const db = getPrismaClient();
+      const playlistRow = await db.youtube_playlists.findUnique({
+        where: { id: playlistId },
+        select: { user_id: true },
+      });
+      if (playlistRow) {
+        const settings = await db.youtube_sync_settings.findUnique({
+          where: { user_id: playlistRow.user_id },
+          select: { auto_sync_enabled: true },
+        });
+        if (settings && settings.auto_sync_enabled === false) {
+          logger.debug('Skipping scheduled sync — user opted out of auto-sync', {
+            playlistId,
+            userId: playlistRow.user_id,
+          });
+          return;
+        }
+      }
+
       // Check quota availability before syncing
       const { remaining } = await this.quotaManager.getTodayUsage();
 

--- a/src/modules/sync/engine.ts
+++ b/src/modules/sync/engine.ts
@@ -20,6 +20,96 @@ import { logger, logSyncOperation } from '../../utils/logger';
 import { executeTransaction } from '../database/client';
 import { getErrorRecoveryManager, RecoveryStrategy } from '../../utils/error-recovery';
 
+// Issue #389: constants used by the source_mandala_mappings propagation path.
+// Matches the VALID_SOURCE_TYPES contract in src/api/routes/mandalas.ts.
+const SOURCE_TYPE_PLAYLIST = 'playlist' as const;
+const NEWLY_SYNCED_IS_IN_IDEATION = false;
+
+/**
+ * Transaction-scoped subset of the Prisma client needed by
+ * {@link propagateSourceMandalaMapping}. Declared as a minimal interface so
+ * unit tests can pass in a focused mock instead of the full TransactionClient.
+ */
+export interface SourceMandalaMappingTx {
+  source_mandala_mappings: {
+    findFirst(args: {
+      where: { user_id: string; source_type: string; source_id: string };
+      orderBy?: { created_at: 'asc' | 'desc' };
+    }): Promise<{ mandala_id: string } | null>;
+  };
+  userVideoState: {
+    updateMany(args: {
+      where: { user_id: string; videoId: { in: string[] } };
+      data: { mandala_id: string; is_in_ideation: boolean };
+    }): Promise<{ count: number }>;
+  };
+}
+
+/**
+ * Issue #389: propagate source_mandala_mappings → user_video_states after
+ * a sync has inserted new rows. If a mapping exists for
+ * (user, source_type='playlist', source_id=youtubePlaylistId), stamp
+ * `mandala_id` onto the newly created rows and set `is_in_ideation=false`
+ * so they leave the global Ideation palette and appear in the target
+ * mandala's "Newly Synced" tab. No mapping → legacy behavior preserved
+ * (rows stay in Ideation with mandala_id=NULL).
+ *
+ * Multi-mapping note: the source_mandala_mappings table's uniqueness
+ * constraint (user_id, source_type, source_id, mandala_id) allows a
+ * single source to map to multiple mandalas, but UserVideoState's
+ * (user_id, videoId) uniqueness limits us to one mandala per row.
+ * Phase 1 picks the oldest mapping (deterministic first-wins). A true
+ * multi-mandala fanout is deferred to a future iteration.
+ *
+ * Skips cleanly when {@link newVideoIds} is empty.
+ */
+export async function propagateSourceMandalaMapping(
+  tx: SourceMandalaMappingTx,
+  opts: {
+    userId: string;
+    playlistId: string;
+    youtubePlaylistId: string;
+    newVideoIds: string[];
+  }
+): Promise<{ mapped: boolean; mandalaId: string | null; videosMapped: number }> {
+  if (opts.newVideoIds.length === 0) {
+    return { mapped: false, mandalaId: null, videosMapped: 0 };
+  }
+
+  const mapping = await tx.source_mandala_mappings.findFirst({
+    where: {
+      user_id: opts.userId,
+      source_type: SOURCE_TYPE_PLAYLIST,
+      source_id: opts.youtubePlaylistId,
+    },
+    orderBy: { created_at: 'asc' },
+  });
+
+  if (!mapping) {
+    return { mapped: false, mandalaId: null, videosMapped: 0 };
+  }
+
+  const { count: videosMapped } = await tx.userVideoState.updateMany({
+    where: {
+      user_id: opts.userId,
+      videoId: { in: opts.newVideoIds },
+    },
+    data: {
+      mandala_id: mapping.mandala_id,
+      is_in_ideation: NEWLY_SYNCED_IS_IN_IDEATION,
+    },
+  });
+
+  logger.info('Applied source→mandala mapping to synced videos', {
+    playlistId: opts.playlistId,
+    youtubePlaylistId: opts.youtubePlaylistId,
+    mandalaId: mapping.mandala_id,
+    videosMapped,
+  });
+
+  return { mapped: true, mandalaId: mapping.mandala_id, videosMapped };
+}
+
 /**
  * Sync result
  */
@@ -248,6 +338,13 @@ export class SyncEngine {
               logger.info('Created user_video_states', {
                 playlistId: playlist.id,
                 count: newStates.length,
+              });
+
+              await propagateSourceMandalaMapping(tx, {
+                userId: playlist.user_id,
+                playlistId: playlist.id,
+                youtubePlaylistId: playlist.youtube_playlist_id,
+                newVideoIds: newStates.map((s) => s.videoId),
               });
             }
           }

--- a/tests/unit/api/sync-settings-route.test.ts
+++ b/tests/unit/api/sync-settings-route.test.ts
@@ -1,0 +1,167 @@
+/**
+ * POST /api/v1/sync/settings (Plan 2) — unit pin.
+ *
+ * Verifies the two behavioral guarantees we introduced:
+ *   1. The route mirrors `syncInterval` into both `youtube_sync_settings`
+ *      AND every `sync_schedules` row for the user, converting the string
+ *      ('1h'/'6h'/'12h'/'24h'/'manual') to the correct `interval_ms`.
+ *   2. 'manual' disables every schedule (enabled=false) while preserving
+ *      the previously stored numeric interval.
+ *
+ * Also guards the Bug B invariant by exercising the autoSyncEnabled=false
+ * branch, which should flip every schedule's `enabled` flag even when
+ * `syncInterval` is not supplied.
+ *
+ * Mocks Prisma + SchedulerManager at module load so the route can run
+ * without a live DB or cron runtime. The route's `getSchedulerManager`
+ * returns the same stub on every call because we replace the module
+ * export before importing the route file.
+ */
+import Fastify from 'fastify';
+
+const mockFindUnique = jest.fn();
+const mockUpdate = jest.fn();
+const mockCreate = jest.fn();
+const mockPlaylistFindMany = jest.fn();
+const mockSchedulerGet = jest.fn();
+const mockSchedulerUpdate = jest.fn();
+
+jest.mock('@/modules/database', () => ({
+  getPrismaClient: () => ({
+    youtube_sync_settings: {
+      findUnique: mockFindUnique,
+      update: mockUpdate,
+      create: mockCreate,
+    },
+    youtube_playlists: { findMany: mockPlaylistFindMany },
+  }),
+}));
+
+jest.mock('../../../src/modules/scheduler', () => ({
+  getSchedulerManager: () => ({
+    getSchedule: mockSchedulerGet,
+    updateSchedule: mockSchedulerUpdate,
+  }),
+}));
+
+jest.mock('../../../src/modules/playlist', () => ({
+  getPlaylistManager: () => ({}),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { syncRoutes } from '../../../src/api/routes/sync';
+
+const USER_ID = '00000000-0000-0000-0000-000000000042';
+const PL1 = '00000000-0000-0000-0000-000000000101';
+const PL2 = '00000000-0000-0000-0000-000000000102';
+
+// Stand up a minimal fastify app with the auth decorator stubbed to inject
+// a predictable userId. We only register the /settings route to keep the
+// test surface tight.
+async function makeApp() {
+  const app = Fastify();
+  app.decorate('authenticate', async (req: any) => {
+    req.user = { userId: USER_ID };
+  });
+  await app.register(syncRoutes);
+  return app;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /api/v1/sync/settings (Plan 2)', () => {
+  it('propagates syncInterval="24h" to every user schedule with the correct interval_ms', async () => {
+    mockFindUnique
+      .mockResolvedValueOnce({ user_id: USER_ID, sync_interval: '6h', auto_sync_enabled: true })
+      .mockResolvedValueOnce({ sync_interval: '24h', auto_sync_enabled: true });
+    mockPlaylistFindMany.mockResolvedValueOnce([{ id: PL1 }, { id: PL2 }]);
+    mockSchedulerGet
+      .mockResolvedValueOnce({ interval: 6 * 3600_000, enabled: true })
+      .mockResolvedValueOnce({ interval: 6 * 3600_000, enabled: true });
+    mockSchedulerUpdate.mockResolvedValue(undefined);
+
+    const app = await makeApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/settings',
+      payload: { syncInterval: '24h' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.success).toBe(true);
+    expect(body.appliedInterval).toBe('24h');
+    expect(body.schedulesUpdated).toBe(2);
+
+    expect(mockSchedulerUpdate).toHaveBeenCalledTimes(2);
+    const intervalArgs = mockSchedulerUpdate.mock.calls.map((c) => c[1].interval);
+    expect(intervalArgs).toEqual([24 * 3600_000, 24 * 3600_000]);
+    await app.close();
+  });
+
+  it('syncInterval="manual" disables every schedule without touching interval_ms', async () => {
+    mockFindUnique
+      .mockResolvedValueOnce({ user_id: USER_ID, sync_interval: '6h', auto_sync_enabled: true })
+      .mockResolvedValueOnce({ sync_interval: 'manual', auto_sync_enabled: true });
+    mockPlaylistFindMany.mockResolvedValueOnce([{ id: PL1 }]);
+    mockSchedulerGet.mockResolvedValueOnce({ interval: 6 * 3600_000, enabled: true });
+    mockSchedulerUpdate.mockResolvedValue(undefined);
+
+    const app = await makeApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/settings',
+      payload: { syncInterval: 'manual' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const update = mockSchedulerUpdate.mock.calls[0]?.[1];
+    expect(update).toMatchObject({ enabled: false });
+    // manual → no interval key should be passed
+    expect(update).not.toHaveProperty('interval');
+    await app.close();
+  });
+
+  it('autoSyncEnabled=false flips every schedule to enabled=false (Bug B guard)', async () => {
+    mockFindUnique
+      .mockResolvedValueOnce({ user_id: USER_ID, sync_interval: '6h', auto_sync_enabled: true })
+      .mockResolvedValueOnce({ sync_interval: '6h', auto_sync_enabled: false });
+    mockPlaylistFindMany.mockResolvedValueOnce([{ id: PL1 }, { id: PL2 }]);
+    mockSchedulerGet
+      .mockResolvedValueOnce({ interval: 6 * 3600_000, enabled: true })
+      .mockResolvedValueOnce({ interval: 6 * 3600_000, enabled: true });
+    mockSchedulerUpdate.mockResolvedValue(undefined);
+
+    const app = await makeApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/settings',
+      payload: { autoSyncEnabled: false },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.autoSyncEnabled).toBe(false);
+    expect(mockSchedulerUpdate).toHaveBeenCalledTimes(2);
+    mockSchedulerUpdate.mock.calls.forEach((c) => {
+      expect(c[1]).toMatchObject({ enabled: false });
+    });
+    await app.close();
+  });
+
+  it('rejects invalid syncInterval with 400', async () => {
+    const app = await makeApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/settings',
+      payload: { syncInterval: 'bogus' },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+});

--- a/tests/unit/modules/sync-engine-mapping-propagation.test.ts
+++ b/tests/unit/modules/sync-engine-mapping-propagation.test.ts
@@ -1,0 +1,157 @@
+/**
+ * sync engine — source_mandala_mappings propagation (Issue #389)
+ *
+ * Pins the behavior of {@link propagateSourceMandalaMapping}:
+ *   - mapping found       → updateMany stamps mandala_id + is_in_ideation=false
+ *   - no mapping          → legacy behavior preserved (no updateMany call)
+ *   - empty newVideoIds   → no DB work at all
+ *   - multiple mappings   → oldest-wins (findFirst orderBy created_at asc)
+ *   - source_type + source_id filter uses 'playlist' + youtubePlaylistId
+ *
+ * Unit test against a hand-rolled tx mock; no Prisma, no database.
+ */
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+  logSyncOperation: jest.fn(),
+}));
+
+import {
+  propagateSourceMandalaMapping,
+  type SourceMandalaMappingTx,
+} from '../../../src/modules/sync/engine';
+
+const USER_ID = '00000000-0000-0000-0000-000000000010';
+const PLAYLIST_ROW_ID = '00000000-0000-0000-0000-000000000011';
+const YT_PLAYLIST_ID = 'PLabcdef123456';
+const MANDALA_A = '00000000-0000-0000-0000-000000000020';
+const VIDEO_1 = '00000000-0000-0000-0000-000000000030';
+const VIDEO_2 = '00000000-0000-0000-0000-000000000031';
+const VIDEO_3 = '00000000-0000-0000-0000-000000000032';
+
+function makeTxMock(): {
+  tx: SourceMandalaMappingTx;
+  findFirst: jest.Mock;
+  updateMany: jest.Mock;
+} {
+  const findFirst = jest.fn();
+  const updateMany = jest.fn();
+  return {
+    tx: {
+      source_mandala_mappings: { findFirst },
+      userVideoState: { updateMany },
+    },
+    findFirst,
+    updateMany,
+  };
+}
+
+describe('propagateSourceMandalaMapping (Issue #389)', () => {
+  it('stamps mandala_id and is_in_ideation=false when a mapping exists', async () => {
+    const { tx, findFirst, updateMany } = makeTxMock();
+    findFirst.mockResolvedValueOnce({ mandala_id: MANDALA_A });
+    updateMany.mockResolvedValueOnce({ count: 3 });
+
+    const result = await propagateSourceMandalaMapping(tx, {
+      userId: USER_ID,
+      playlistId: PLAYLIST_ROW_ID,
+      youtubePlaylistId: YT_PLAYLIST_ID,
+      newVideoIds: [VIDEO_1, VIDEO_2, VIDEO_3],
+    });
+
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        user_id: USER_ID,
+        source_type: 'playlist',
+        source_id: YT_PLAYLIST_ID,
+      },
+      orderBy: { created_at: 'asc' },
+    });
+    expect(updateMany).toHaveBeenCalledWith({
+      where: {
+        user_id: USER_ID,
+        videoId: { in: [VIDEO_1, VIDEO_2, VIDEO_3] },
+      },
+      data: {
+        mandala_id: MANDALA_A,
+        is_in_ideation: false,
+      },
+    });
+    expect(result).toEqual({ mapped: true, mandalaId: MANDALA_A, videosMapped: 3 });
+  });
+
+  it('is a no-op when no mapping exists — legacy behavior preserved', async () => {
+    const { tx, findFirst, updateMany } = makeTxMock();
+    findFirst.mockResolvedValueOnce(null);
+
+    const result = await propagateSourceMandalaMapping(tx, {
+      userId: USER_ID,
+      playlistId: PLAYLIST_ROW_ID,
+      youtubePlaylistId: YT_PLAYLIST_ID,
+      newVideoIds: [VIDEO_1, VIDEO_2],
+    });
+
+    expect(findFirst).toHaveBeenCalledTimes(1);
+    expect(updateMany).not.toHaveBeenCalled();
+    expect(result).toEqual({ mapped: false, mandalaId: null, videosMapped: 0 });
+  });
+
+  it('skips all DB calls when newVideoIds is empty (no-op idempotency guard)', async () => {
+    const { tx, findFirst, updateMany } = makeTxMock();
+
+    const result = await propagateSourceMandalaMapping(tx, {
+      userId: USER_ID,
+      playlistId: PLAYLIST_ROW_ID,
+      youtubePlaylistId: YT_PLAYLIST_ID,
+      newVideoIds: [],
+    });
+
+    expect(findFirst).not.toHaveBeenCalled();
+    expect(updateMany).not.toHaveBeenCalled();
+    expect(result).toEqual({ mapped: false, mandalaId: null, videosMapped: 0 });
+  });
+
+  it('queries with source_type="playlist" + youtubePlaylistId (external YouTube ID, not internal UUID)', async () => {
+    const { tx, findFirst, updateMany } = makeTxMock();
+    findFirst.mockResolvedValueOnce(null);
+
+    await propagateSourceMandalaMapping(tx, {
+      userId: USER_ID,
+      playlistId: PLAYLIST_ROW_ID, // internal UUID — must NOT be used in where
+      youtubePlaylistId: YT_PLAYLIST_ID, // external — must be used
+      newVideoIds: [VIDEO_1],
+    });
+
+    const call = findFirst.mock.calls[0]?.[0] as {
+      where: { source_id: string; source_type: string };
+    };
+    expect(call.where.source_id).toBe(YT_PLAYLIST_ID);
+    expect(call.where.source_id).not.toBe(PLAYLIST_ROW_ID);
+    expect(call.where.source_type).toBe('playlist');
+    expect(updateMany).not.toHaveBeenCalled();
+  });
+
+  it('oldest mapping wins when multiple mappings exist (orderBy created_at asc)', async () => {
+    const { tx, findFirst, updateMany } = makeTxMock();
+    // findFirst + orderBy asc ≡ oldest. The mock returns only what we program,
+    // but we can assert the call's orderBy clause.
+    findFirst.mockResolvedValueOnce({ mandala_id: MANDALA_A });
+    updateMany.mockResolvedValueOnce({ count: 1 });
+
+    await propagateSourceMandalaMapping(tx, {
+      userId: USER_ID,
+      playlistId: PLAYLIST_ROW_ID,
+      youtubePlaylistId: YT_PLAYLIST_ID,
+      newVideoIds: [VIDEO_1],
+    });
+
+    const findFirstCall = findFirst.mock.calls[0]?.[0] as {
+      orderBy?: { created_at: string };
+    };
+    expect(findFirstCall.orderBy).toEqual({ created_at: 'asc' });
+  });
+});


### PR DESCRIPTION
## Summary

Issue #389: mapped playlist/channel videos now land in the target mandala's **Newly Synced** tab instead of disappearing into global Ideation. Includes 4 concomitant pre-existing sync fixes discovered during scope work.

### Core fix (#389)
- BE `src/modules/sync/engine.ts` — exported `propagateSourceMandalaMapping(tx, opts)` helper called after `userVideoState.createMany` inside the sync transaction. Stamps `mandala_id` + `is_in_ideation=false` when a `source_mandala_mappings` row matches `(user_id, source_type='playlist', source_id=youtube_playlist_id)`. Oldest-mapping-wins for the edge case of multiple mandalas per source.
- FE — `isNewlySyncedCard` / `countNewlySyncedByMandala` predicate helpers + `useCardOrchestrator` returns `newlySyncedCards` + per-mandala counts. `CardListView` gains a **"Newly Synced"** pill at the end of `LabelFilterPillsV2` (primary accent + leading dot), hidden when count=0, mutex with All/sector pills. `SidebarMandalaSection` renders `● N` dot+count next to each mandala name, driven by a new `shellStore.newlySyncedCountByMandala` slice.
- D&D from the new tab into any sub-goal cell completes placement via the existing `batch-update-video-state` Edge Function — no new D&D wiring.

### Concomitant pre-existing fixes (scope expanded with explicit user approval)

- **`POST /api/v1/playlists/sync-all`** — FE hook was calling a dead URL (404). Route added with per-playlist failure isolation. Currently dead code on the UI side (Settings "전체 동기화" loops individual sync); preserved for future UI migration.
- **Ideation palette thumbnails (엑박)** — 933 of 1530 rows in `youtube_videos` have `default.jpg` URLs (120×90). `handleThumbnailLoad` was misclassifying them as grey placeholders and replacing with `/placeholder.svg`. Fix: `FloatingScratchPad` (2 sites) + `ScratchPad` (1 site) now wrap `<img src>` with `upgradeYouTubeThumbnail(url) ?? url` — matching the existing pattern used by mandala-cell components.
- **Sync reauth UX** — `handleSync` in `SourceManagementTab(V2)` now classifies errors via `isYouTubeReauthError` helper (matches `invalid_grant` / `Refresh token expired` / `Token refresh failed` / `YouTube account not connected`). Reauth errors surface a destructive toast with "Open Settings" CTA linking to `/settings?tab=services`; generic errors get plain toast with server message. `handleSyncAll` short-circuits on reauth hit.
- **`POST /api/v1/sync/settings` + Bug A/B fixes** — the old `update-settings` Edge Function only wrote `youtube_sync_settings`, leaving `sync_schedules.interval_ms` at its hardcoded 6h default (Bug A: UI interval dropdown was cosmetic). Scheduler also never consulted `auto_sync_enabled` (Bug B). New route propagates UI interval → `sync_schedules.interval_ms` + re-registers cron jobs via `SchedulerManager.updateSchedule` + flips `enabled` per toggle. Cron callback also checks `auto_sync_enabled` as defense-in-depth.

### Pre-flight
- tsc (backend): ✅ pass
- tsc (frontend): ✅ pass
- build (frontend): ✅ pass (4.53s)
- Vitest: ✅ **247/247** (+15 new: 9 newly-synced + 6 reauth)
- Jest: ✅ **722/833** (+9 new: 5 engine helper + 4 route). Baseline 28-fail parity verified via stash A/B — all failing suites (mandala-*, video-discover/executor) are pre-existing on main.
- files changed: 27 (23 M + 4 new test files)

## Test plan
- [ ] CI pass (6 jobs)
- [ ] Deploy success + health check 200
- [ ] Post-deploy prod smoke: pick one user with an existing `source_mandala_mappings` row → next scheduled sync (or manual sync) → assert `user_video_states` row appears with `mandala_id != NULL AND cell_index < 0 AND is_in_ideation = false` + UI "Newly Synced" tab shows it + sidebar dot+count renders

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jk42jj/insighta/pull/425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
