### PR TITLE
chore(redis): wire REDIS_HOST into api container + SMEMBERS smoke (20d follow-up)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -330,7 +330,15 @@ jobs:
               ss -tlnp | grep ":6379 " || echo "(no 6379 listener)"
               exit 1
             fi
-            echo "Redis smoke test OK — 4 users authenticate, bound to Tailscale iface."
+            # CP411 follow-up (20d) — verify end-to-end consumer path: the
+            # insighta ACL user must be able to SMEMBERS the whitelist key.
+            # Catches regressions in `docker/redis/redis.acl.template` keys
+            # pattern or command grant list. Empty set is a valid PASS.
+            if ! docker exec insighta-redis redis-cli --user insighta -a "$REDIS_SMOKE_READ_PW" --no-auth-warning SMEMBERS whitelist:channels > /dev/null 2>&1; then
+              echo "Redis insighta user cannot SMEMBERS whitelist:channels — check ACL keys pattern"
+              exit 1
+            fi
+            echo "Redis smoke test OK — 4 users authenticate, bound to Tailscale iface, insighta→whitelist SMEMBERS OK."
 
             # Cleanup old images
             docker image prune -f

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,6 +23,13 @@ services:
       - NODE_ENV=production
       - API_HOST=0.0.0.0
       - API_PORT=3000
+      # CP411 follow-up (PR #426 / BACKLOG 20d) — serving-side Redis read for
+      # dual-whitelist consumer. Host is the EC2 Tailscale IP (same value as
+      # the redis service port bind); port/user are static and non-secret.
+      # REDIS_INSIGHTA_PASSWORD is supplied via env_file .env.
+      - REDIS_HOST=${INSIGHTA_TAILSCALE_IP}
+      - REDIS_PORT=6379
+      - REDIS_USER=insighta
     volumes:
       - cache_data:/app/cache
       - logs_data:/app/logs


### PR DESCRIPTION
## Summary

Follow-up to PR #426 (dual whitelist gate consumer). #426 shipped the consumer code path but not the runtime wiring — `insighta-api` container has no `REDIS_HOST` env so `getInsightaRedisClient()` returns null even after `V3_ENABLE_WHITELIST_GATE` is flipped on. This PR closes that gap with two minimal, flag-off safe changes.

## Changes

**`docker-compose.prod.yml`** (`api` service `environment:` block, +7 lines with comment):
- `REDIS_HOST=${INSIGHTA_TAILSCALE_IP}` — compose already interpolates this variable for the redis service port bind; non-secret per CP392 Hard Rule.
- `REDIS_PORT=6379`, `REDIS_USER=insighta` — static, non-secret.
- `REDIS_INSIGHTA_PASSWORD` continues to flow via `env_file: .env` (unchanged).

**`.github/workflows/deploy.yml`** (Redis ACL smoke block, +6 lines):
- After the existing 4-user PING block, add one `SMEMBERS whitelist:channels` call as the insighta ACL user.
- Empty set is a valid PASS; any `NOPERM` / `WRONGPASS` fails the deploy step.
- Catches regressions in `docker/redis/redis.acl.template` keys pattern or command grant list.
- Follow-up acknowledged in PR #426 commit message footer.

## Risk

Flag `V3_ENABLE_WHITELIST_GATE` remains off by default. Zero user-facing impact; this only adds wiring + a deploy-time assertion.

## Test plan

- [ ] CI 6/6 green (lint, type-check, test FE/BE, build, hardcode audit)
- [ ] Deploy workflow smoke line reads: `Redis smoke test OK — 4 users authenticate, bound to Tailscale iface, insighta→whitelist SMEMBERS OK.`
- [ ] Post-deploy: `ssh insighta-ec2 "docker exec insighta-api printenv | grep ^REDIS_"` must include `REDIS_HOST`, `REDIS_PORT`, `REDIS_USER`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)