### PR TITLE
feat(v3): YouTube search per-call timeout + allSettled (Phase 1 slice 1)

### DIFF
--- a/src/skills/plugins/video-discover/__tests__/v2-youtube-client.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v2-youtube-client.test.ts
@@ -245,3 +245,81 @@ describe('searchVideos — key rotation on 403 quota', () => {
     );
   });
 });
+
+describe('searchVideos — timeout (Phase 1 slice 1)', () => {
+  test('aborts when fetch exceeds timeoutMs → throws "search.list timeout"', async () => {
+    // Slow fetch that respects AbortSignal — simulates a genuine
+    // network tail. When the controller aborts, reject with the
+    // DOMException-shaped error that `fetch` surfaces in real code.
+    const fetchFn = ((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        if (signal) {
+          const onAbort = () => {
+            const err = new Error('The operation was aborted.');
+            (err as Error & { name: string }).name = 'AbortError';
+            reject(err);
+          };
+          if (signal.aborted) onAbort();
+          else signal.addEventListener('abort', onAbort, { once: true });
+        }
+        // Never resolves on its own — only abort finishes this promise.
+      });
+    }) as unknown as typeof fetch;
+
+    const start = Date.now();
+    await expect(searchVideos({ query: 'x', apiKey: 'K', fetchFn, timeoutMs: 50 })).rejects.toThrow(
+      /search\.list timeout after 50ms/
+    );
+    const elapsed = Date.now() - start;
+    // Generous upper bound — CI runners can jitter. Main assertion is
+    // "didn't hang forever".
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  test('omitting timeoutMs → legacy behavior (no AbortController created)', async () => {
+    let sawSignal = false;
+    const fetchFn = (async (_url: string, init?: RequestInit) => {
+      if (init?.signal) sawSignal = true;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ items: [] }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    await searchVideos({ query: 'x', apiKey: 'K', fetchFn });
+    expect(sawSignal).toBe(false);
+  });
+
+  test('timeoutMs=0 → treated as no-timeout (falsy branch)', async () => {
+    let sawSignal = false;
+    const fetchFn = (async (_url: string, init?: RequestInit) => {
+      if (init?.signal) sawSignal = true;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ items: [] }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    await searchVideos({ query: 'x', apiKey: 'K', fetchFn, timeoutMs: 0 });
+    expect(sawSignal).toBe(false);
+  });
+
+  test('fast fetch before timeout → resolves normally, no timeout error', async () => {
+    const fetchFn = (async () => {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ items: [{ id: { videoId: 'abc' } }] }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    const items = await searchVideos({
+      query: 'x',
+      apiKey: 'K',
+      fetchFn,
+      timeoutMs: 5000,
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]?.id?.videoId).toBe('abc');
+  });
+});

--- a/src/skills/plugins/video-discover/v2/youtube-client.ts
+++ b/src/skills/plugins/video-discover/v2/youtube-client.ts
@@ -59,6 +59,15 @@ export interface SearchOpts {
   /** ISO timestamp; results limited to videos published after. Optional. */
   publishedAfter?: string;
   fetchFn?: typeof fetch;
+  /**
+   * Per-call timeout in milliseconds. When set, the underlying fetch is
+   * aborted once the timeout elapses and an Error with message starting
+   * with "search.list timeout" is thrown. Callers using
+   * `Promise.allSettled` treat this as a partial-result signal (empty
+   * items for the timed-out query) rather than a pipeline failure.
+   * Unset / 0 → no timeout (legacy behavior).
+   */
+  timeoutMs?: number;
 }
 
 /**
@@ -112,7 +121,26 @@ async function searchVideosOne(
   url.searchParams.set('safeSearch', 'moderate');
 
   const fetchFn = opts.fetchFn ?? fetch;
-  const res = await fetchFn(url.toString());
+  const timeoutMs = opts.timeoutMs;
+  const controller = typeof timeoutMs === 'number' && timeoutMs > 0 ? new AbortController() : null;
+  const timer =
+    controller && typeof timeoutMs === 'number' && timeoutMs > 0
+      ? setTimeout(() => controller.abort(), timeoutMs)
+      : null;
+  let res: Response;
+  try {
+    res = await fetchFn(url.toString(), controller ? { signal: controller.signal } : {});
+  } catch (err) {
+    if (
+      controller?.signal.aborted ||
+      (err instanceof Error && (err.name === 'AbortError' || /aborted|abort/i.test(err.message)))
+    ) {
+      throw new Error(`search.list timeout after ${timeoutMs}ms`);
+    }
+    throw err;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
   if (!res.ok) {
     let msg = '';
     try {

--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -1,10 +1,14 @@
 import { DEFAULT_SEMANTIC_ALPHA, DEFAULT_SEMANTIC_BETA } from '@/modules/video-dictionary';
 
-import { DEFAULT_PUBLISHED_AFTER_DAYS, loadV3Config } from '../config';
+import {
+  DEFAULT_PUBLISHED_AFTER_DAYS,
+  DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
+  loadV3Config,
+} from '../config';
 import { DEFAULT_RECENCY_HALF_LIFE_MONTHS, DEFAULT_RECENCY_WEIGHT } from '../mandala-filter';
 
 describe('loadV3Config', () => {
-  test('empty env → activated defaults (Tier 1 off, recency on, 3yr cutoff, semantic off)', () => {
+  test('empty env → activated defaults (Tier 1 off, recency on, 3yr cutoff, semantic off, yt timeout 1s)', () => {
     expect(loadV3Config({})).toEqual({
       enableTier1Cache: false,
       recencyWeight: DEFAULT_RECENCY_WEIGHT,
@@ -14,6 +18,7 @@ describe('loadV3Config', () => {
       semanticAlpha: DEFAULT_SEMANTIC_ALPHA,
       semanticBeta: DEFAULT_SEMANTIC_BETA,
       enableWhitelistGate: false,
+      youtubeSearchTimeoutMs: DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
     });
   });
 
@@ -76,7 +81,28 @@ describe('loadV3Config', () => {
       semanticAlpha: DEFAULT_SEMANTIC_ALPHA,
       semanticBeta: DEFAULT_SEMANTIC_BETA,
       enableWhitelistGate: false,
+      youtubeSearchTimeoutMs: DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
     });
+  });
+
+  test('V3_YOUTUBE_SEARCH_TIMEOUT_MS parses positive integer', () => {
+    expect(loadV3Config({ V3_YOUTUBE_SEARCH_TIMEOUT_MS: '500' }).youtubeSearchTimeoutMs).toBe(500);
+    expect(loadV3Config({ V3_YOUTUBE_SEARCH_TIMEOUT_MS: '2000' }).youtubeSearchTimeoutMs).toBe(
+      2000
+    );
+  });
+
+  test('invalid V3_YOUTUBE_SEARCH_TIMEOUT_MS → baseline (entire config falls back)', () => {
+    // zero / negative / non-int / garbage → entire schema fails → fallback
+    expect(loadV3Config({ V3_YOUTUBE_SEARCH_TIMEOUT_MS: '0' }).youtubeSearchTimeoutMs).toBe(
+      DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS
+    );
+    expect(loadV3Config({ V3_YOUTUBE_SEARCH_TIMEOUT_MS: '-500' }).youtubeSearchTimeoutMs).toBe(
+      DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS
+    );
+    expect(loadV3Config({ V3_YOUTUBE_SEARCH_TIMEOUT_MS: 'garbage' }).youtubeSearchTimeoutMs).toBe(
+      DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS
+    );
   });
 
   test('V3_ENABLE_SEMANTIC_RERANK parses boolean flag', () => {

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -6,6 +6,18 @@ import { DEFAULT_RECENCY_HALF_LIFE_MONTHS, DEFAULT_RECENCY_WEIGHT } from './mand
 
 export const DEFAULT_PUBLISHED_AFTER_DAYS = 1095;
 
+/**
+ * Per-call timeout for YouTube search.list in v3 discovery.
+ *
+ * 1000ms is empirically below the p95 of normal YouTube Data API
+ * latency from our EC2 region → any call exceeding this is on the
+ * tail and would otherwise bottleneck the entire Promise.allSettled
+ * fan-out (`v3/executor.ts:755`). Tail calls are cut and treated as
+ * `partial` results (missing items, not a pipeline failure). See
+ * Phase 1 slice 1 rationale in the PR description.
+ */
+export const DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS = 1000;
+
 export type V3EnvInput = Record<string, string | undefined>;
 
 const booleanFlag = z.preprocess(
@@ -48,6 +60,13 @@ const semanticBeta = z
   )
   .transform((v) => v ?? DEFAULT_SEMANTIC_BETA);
 
+const youtubeSearchTimeoutMs = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().int().positive().optional()
+  )
+  .transform((v) => v ?? DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS);
+
 export const v3EnvSchema = z.object({
   V3_ENABLE_TIER1_CACHE: booleanFlag.optional().default(false as unknown as string),
   V3_RECENCY_WEIGHT: clampedUnit,
@@ -57,6 +76,7 @@ export const v3EnvSchema = z.object({
   V3_SEMANTIC_ALPHA: semanticAlpha,
   V3_SEMANTIC_BETA: semanticBeta,
   V3_ENABLE_WHITELIST_GATE: booleanFlag.optional().default(false as unknown as string),
+  V3_YOUTUBE_SEARCH_TIMEOUT_MS: youtubeSearchTimeoutMs,
 });
 
 export interface V3Config {
@@ -68,6 +88,7 @@ export interface V3Config {
   semanticAlpha: number;
   semanticBeta: number;
   enableWhitelistGate: boolean;
+  youtubeSearchTimeoutMs: number;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -80,6 +101,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_SEMANTIC_ALPHA: env['V3_SEMANTIC_ALPHA'],
     V3_SEMANTIC_BETA: env['V3_SEMANTIC_BETA'],
     V3_ENABLE_WHITELIST_GATE: env['V3_ENABLE_WHITELIST_GATE'],
+    V3_YOUTUBE_SEARCH_TIMEOUT_MS: env['V3_YOUTUBE_SEARCH_TIMEOUT_MS'],
   });
   if (!parsed.success) {
     return {
@@ -91,6 +113,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       semanticAlpha: DEFAULT_SEMANTIC_ALPHA,
       semanticBeta: DEFAULT_SEMANTIC_BETA,
       enableWhitelistGate: false,
+      youtubeSearchTimeoutMs: DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
     };
   }
   return {
@@ -102,6 +125,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     semanticAlpha: parsed.data.V3_SEMANTIC_ALPHA,
     semanticBeta: parsed.data.V3_SEMANTIC_BETA,
     enableWhitelistGate: parsed.data.V3_ENABLE_WHITELIST_GATE,
+    youtubeSearchTimeoutMs: parsed.data.V3_YOUTUBE_SEARCH_TIMEOUT_MS,
   };
 }
 

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -752,7 +752,16 @@ async function runSearchTraced(
     v3Config.publishedAfterDays > 0
       ? new Date(Date.now() - v3Config.publishedAfterDays * MS_PER_DAY).toISOString()
       : undefined;
-  const results = await Promise.all(
+  // Phase 1 slice 1 (post-SGNL-parity audit): Promise.allSettled instead
+  // of Promise.all, combined with a per-call timeout passed into the
+  // YouTube client (`timeoutMs`). Rationale: before this change the
+  // entire fan-out blocked on the slowest YouTube API response (p95
+  // tail). Now each call has a hard cutoff; slow calls abort and
+  // surface as `{ items: [], error: 'timeout ...' }`, matching the
+  // existing error-handling contract so downstream pool assembly and
+  // perQuery tracing are unaffected. Tail latency no longer dominates
+  // wall clock.
+  const settled = await Promise.allSettled(
     queries.map(async (q) => {
       try {
         const items = await searchVideos({
@@ -760,6 +769,7 @@ async function runSearchTraced(
           apiKey: apiKeys,
           relevanceLanguage: language,
           regionCode,
+          timeoutMs: v3Config.youtubeSearchTimeoutMs,
           ...(publishedAfter ? { publishedAfter } : {}),
         });
         return { q, items, error: undefined as string | undefined };
@@ -770,6 +780,20 @@ async function runSearchTraced(
       }
     })
   );
+  const results = settled.map((r, idx) => {
+    if (r.status === 'fulfilled') return r.value;
+    // Defensive: the inner try/catch already converts errors to the
+    // fulfilled shape, so a rejected settle result would indicate a
+    // bug in the inner map fn (sync throw before the try). Surface it
+    // as an empty-items entry so the outer pipeline still completes.
+    const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
+    log.warn(`search.list settled=rejected for "${queries[idx]?.query ?? '?'}": ${reason}`);
+    return {
+      q: queries[idx]!,
+      items: [] as YouTubeSearchItem[],
+      error: reason,
+    };
+  });
   const pool: PoolItem[] = [];
   const perQuery: SearchTrace['perQuery'] = [];
   for (const { q, items, error } of results) {


### PR DESCRIPTION
## Summary

Tail-latency mitigation for v3 executor's YouTube search fan-out.
First slice of the post-SGNL-parity performance audit (2026-04-21).

- **Problem**: `Promise.all` on 10-30 parallel `search.list` calls blocks on the slowest response. With no timeout in `v2/youtube-client.ts`, a single p99 outlier stalls the entire fan-out. At 20 parallel calls with ~5% tail per call, ~64% of user queries are tail-bottlenecked.
- **Fix**: Per-call timeout + `Promise.allSettled` with partial-result tolerance. Default 1000ms via new `V3_YOUTUBE_SEARCH_TIMEOUT_MS` env. Slow calls surface as `{ items: [], error: 'timeout ...' }`, matching the existing `perQuery` trace contract — no downstream code change needed.
- **Effect**: Wall-clock converges to `p50 + 1s` (capped tail) instead of `max(p99 of fan-out)`.

## Changes

**`src/skills/plugins/video-discover/v3/config.ts`**
- New env `V3_YOUTUBE_SEARCH_TIMEOUT_MS`, default `DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS = 1000`.
- Validated as positive int via zod; invalid → config falls back per `loadV3Config` contract.

**`src/skills/plugins/video-discover/v2/youtube-client.ts`**
- `SearchOpts` gains optional `timeoutMs`.
- `searchVideosOne` creates `AbortController` + `setTimeout` when `timeoutMs > 0`, passes `signal` into `fetch`, clears timer in `finally`, converts aborted fetches into `Error('search.list timeout after Nms')`.
- `timeoutMs` unset or `0` → legacy behavior (no controller created).

**`src/skills/plugins/video-discover/v3/executor.ts`**
- `Promise.all` → `Promise.allSettled` on the per-query fan-out.
- Inner try/catch preserved — converts errors to `{ items: [], error: msg }`. Settled loop normally yields only fulfilled entries; rejected branch is defensive coverage for sync throws.
- Every call receives `timeoutMs: v3Config.youtubeSearchTimeoutMs`.

## Tests

- **v3 config**: 10/10 pass (3 new — parse + invalid → fallback + default included in empty-env test).
- **v2 youtube-client**: 27/27 pass (4 new — abort-during-fetch / `timeoutMs` unset / `timeoutMs=0` / fast fetch beats timeout).
- **video-discover full suite**: 243 pass / 11 fail. Stash A/B confirmed all 11 failures pre-exist on `main` (v1 legacy `executor.test.ts`, unrelated to this change). **Zero new regressions**.
- `tsc --noEmit`: clean.

## Test plan

- [ ] CI green (type check / lint / tests / build).
- [ ] Post-merge: prod health check after deploy (`curl -sf https://insighta.one/health`).
- [ ] Smoke: trigger one discover query in prod, verify `[TIMING]` logs show no call > ~1100ms (the 100ms buffer is jitter tolerance).
- [ ] Optional: set `V3_YOUTUBE_SEARCH_TIMEOUT_MS=500` in dev to tighten and observe degraded-tail behavior.

## Rollback

- Feature flag-free, but the 1000ms default is generous. If tail-cutting surfaces unexpected pass-rate drops, set `V3_YOUTUBE_SEARCH_TIMEOUT_MS=5000` (effectively disables) without code revert.
- Full revert: `git revert bb346da`.

## Follow-up slices (separate PRs)

- **Slice 2**: SSE endpoint for streaming card append.
- **Slice 3**: mandala structure+labels → single LLM call.
- **Slice 4**: frontend SSE consumer + append-style render.
- **Slice 5**: Tier 1 cache degraded-root-cause investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)