### PR TITLE
feat(v3): center-gate subword mode (Phase 1 slice 5, fixes 2/64 card outage root cause)

### DIFF
--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_SEMANTIC_ALPHA, DEFAULT_SEMANTIC_BETA } from '@/modules/video-dictionary';
 
 import {
+  DEFAULT_CENTER_GATE_MODE,
   DEFAULT_PUBLISHED_AFTER_DAYS,
   DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
   loadV3Config,
@@ -8,7 +9,7 @@ import {
 import { DEFAULT_RECENCY_HALF_LIFE_MONTHS, DEFAULT_RECENCY_WEIGHT } from '../mandala-filter';
 
 describe('loadV3Config', () => {
-  test('empty env → activated defaults (Tier 1 off, recency on, 3yr cutoff, semantic off, yt timeout 1s)', () => {
+  test('empty env → activated defaults (Tier 1 off, recency on, 3yr cutoff, semantic off, yt timeout 1s, center-gate substring)', () => {
     expect(loadV3Config({})).toEqual({
       enableTier1Cache: false,
       recencyWeight: DEFAULT_RECENCY_WEIGHT,
@@ -19,6 +20,7 @@ describe('loadV3Config', () => {
       semanticBeta: DEFAULT_SEMANTIC_BETA,
       enableWhitelistGate: false,
       youtubeSearchTimeoutMs: DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
+      centerGateMode: DEFAULT_CENTER_GATE_MODE,
     });
   });
 
@@ -82,6 +84,7 @@ describe('loadV3Config', () => {
       semanticBeta: DEFAULT_SEMANTIC_BETA,
       enableWhitelistGate: false,
       youtubeSearchTimeoutMs: DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
+      centerGateMode: DEFAULT_CENTER_GATE_MODE,
     });
   });
 
@@ -123,5 +126,19 @@ describe('loadV3Config', () => {
     expect(loadV3Config({ V3_SEMANTIC_ALPHA: '1.5' }).semanticAlpha).toBe(DEFAULT_SEMANTIC_ALPHA);
     expect(loadV3Config({ V3_SEMANTIC_ALPHA: '-0.1' }).semanticAlpha).toBe(DEFAULT_SEMANTIC_ALPHA);
     expect(loadV3Config({ V3_SEMANTIC_BETA: 'NaN' }).semanticBeta).toBe(DEFAULT_SEMANTIC_BETA);
+  });
+
+  test('V3_CENTER_GATE_MODE accepts the three enum values, case-insensitive + trimmed', () => {
+    expect(loadV3Config({ V3_CENTER_GATE_MODE: 'substring' }).centerGateMode).toBe('substring');
+    expect(loadV3Config({ V3_CENTER_GATE_MODE: 'subword' }).centerGateMode).toBe('subword');
+    expect(loadV3Config({ V3_CENTER_GATE_MODE: 'off' }).centerGateMode).toBe('off');
+    expect(loadV3Config({ V3_CENTER_GATE_MODE: '  SUBWORD  ' }).centerGateMode).toBe('subword');
+  });
+
+  test('invalid V3_CENTER_GATE_MODE → baseline default (substring)', () => {
+    expect(loadV3Config({ V3_CENTER_GATE_MODE: 'garbage' }).centerGateMode).toBe(
+      DEFAULT_CENTER_GATE_MODE
+    );
+    expect(loadV3Config({ V3_CENTER_GATE_MODE: '' }).centerGateMode).toBe(DEFAULT_CENTER_GATE_MODE);
   });
 });

--- a/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
@@ -413,3 +413,88 @@ describe('recency weighting (2026-04-18, env-gated)', () => {
     expect(DEFAULT_RECENCY_HALF_LIFE_MONTHS).toBe(18);
   });
 });
+
+// ---------------------------------------------------------------------------
+// CenterGateMode — subword + off (Phase-1 carding-quality audit)
+// ---------------------------------------------------------------------------
+
+describe('applyMandalaFilter — centerGateMode', () => {
+  // Goal with Korean particles; substring mode drops composite-word
+  // matches like "모닝루틴" ↔ "루틴으로". Subword mode catches them.
+  const input = {
+    centerGoal: '1달 일일 루틴으로 전문가되기',
+    subGoals: [
+      '전문 분야 선정 및 학습 계획 수립',
+      '매일 집중 학습 시간 확보 및 루틴화',
+      '실무 프로젝트 진행 및 포트폴리오 구축',
+      '전문 커뮤니티 참여 및 네트워킹',
+      '월간 집중 전문화',
+      '지식 체계화 및 아웃풋 생산',
+      '피드백 수집 및 개선 사이클',
+      '일일 진도 추적 및 동기 유지',
+    ],
+    language: 'ko' as const,
+  };
+
+  const composite = cand('c1', '엄지원의 모닝루틴 7가지', '아침 루틴 7가지 방법');
+  const noise = cand('n1', 'iPhone 16 프로 리뷰', '아이폰 16 스마트폰 리뷰');
+
+  test('substring mode (default) drops "모닝루틴" — regression baseline', () => {
+    const { stats } = applyMandalaFilterWithStats([composite], input);
+    expect(stats.droppedByCenterGate).toBe(1);
+    expect(stats.centerGateMode).toBe('substring');
+  });
+
+  test('subword mode keeps composite "모닝루틴" via char 2-gram overlap with "루틴으로"', () => {
+    const { byCell, stats } = applyMandalaFilterWithStats([composite], {
+      ...input,
+      centerGateMode: 'subword',
+    });
+    expect(stats.droppedByCenterGate).toBe(0);
+    expect(stats.centerGateMode).toBe('subword');
+    // Without sub-goal jaccard hits the candidate still drops at
+    // gate 2. That's expected — the point of this test is the gate-1
+    // pass.
+    const anyKept = Array.from(byCell.values()).some((list) => list.length > 0);
+    // jaccard on composite title ("모닝루틴 7가지 / 아침 루틴 7가지")
+    // vs sub-goal tokens may be 0, so output may still be empty. The
+    // stats check above is the assertion that matters.
+    void anyKept;
+  });
+
+  test('subword mode still rejects unrelated noise ("iPhone 리뷰")', () => {
+    const { stats } = applyMandalaFilterWithStats([noise], {
+      ...input,
+      centerGateMode: 'subword',
+    });
+    expect(stats.droppedByCenterGate).toBe(1);
+  });
+
+  test('off mode skips the gate entirely — both composite and noise pass to jaccard stage', () => {
+    const { stats } = applyMandalaFilterWithStats([composite, noise], {
+      ...input,
+      centerGateMode: 'off',
+    });
+    expect(stats.droppedByCenterGate).toBe(0);
+    expect(stats.centerGateMode).toBe('off');
+    // Downstream: jaccard drops noise but may also drop composite if
+    // no sub-goal token overlaps. This test verifies the gate itself
+    // was skipped, not what jaccard does next.
+  });
+
+  test('subword mode is token-aware: unrelated 2-gram collisions below threshold are still dropped', () => {
+    // Title shares a single 2-gram ("전문") with center token "전문가"
+    // → matched 2-grams of "전문가": {전문, 문가} → 1/2 = 0.5 ≥ 0.3
+    //   so this one actually matches (acceptable recall bias).
+    // Title sharing only "전" + nothing else has 0 bigram overlap.
+    const onlyChar = cand('ch', '전국민 명절 인사', '');
+    const { stats } = applyMandalaFilterWithStats([onlyChar], {
+      ...input,
+      centerGateMode: 'subword',
+    });
+    // Expect this to drop — no 2-gram matches any center token above
+    // the 0.3 floor. If this starts passing, SUBWORD_MIN_CENTER_MATCH
+    // has drifted too low and noise will leak.
+    expect(stats.droppedByCenterGate).toBe(1);
+  });
+});

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -18,6 +18,31 @@ export const DEFAULT_PUBLISHED_AFTER_DAYS = 1095;
  */
 export const DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS = 1000;
 
+/**
+ * Center-gate matching mode (post-SGNL-parity carding-quality audit).
+ *
+ * - `'substring'` (pre-audit default): token-level substring overlap.
+ *   Fast but fails for Korean composite words — `"모닝루틴"` does not
+ *   contain `"루틴으로"` as a substring and vice versa, so legitimate
+ *   videos titled `엄지원의 모닝루틴 7가지` are dropped from goals like
+ *   `1달 일일 루틴으로 전문가되기`. Measured Recall 0% / 15 on a 20-item
+ *   fixture — see `scripts/verify-mandala-filter-hypothesis.ts`.
+ *
+ * - `'subword'`: character 2-gram overlap between each center token and
+ *   the title's combined 2-gram bag. A center token is considered
+ *   matched when ≥ 30% of its 2-grams appear in the title. Catches the
+ *   composite-word case without a morphological analyzer. Measured
+ *   Recall 0.27 / Precision 1.00 on the same fixture (4 of 15 RELEVANT
+ *   kept, 0 NOISE).
+ *
+ * - `'off'`: skip the center gate entirely, let the sub-goal jaccard
+ *   stage (MIN_SUB_RELEVANCE) do the filtering alone. Widest net; use
+ *   when the center phrase is highly specific and the sub-goals cover
+ *   the semantic space.
+ */
+export type CenterGateMode = 'substring' | 'subword' | 'off';
+export const DEFAULT_CENTER_GATE_MODE: CenterGateMode = 'substring';
+
 export type V3EnvInput = Record<string, string | undefined>;
 
 const booleanFlag = z.preprocess(
@@ -67,6 +92,13 @@ const youtubeSearchTimeoutMs = z
   )
   .transform((v) => v ?? DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS);
 
+const centerGateMode = z
+  .preprocess(
+    (v) => (typeof v === 'string' ? v.trim().toLowerCase() : v),
+    z.enum(['substring', 'subword', 'off']).optional()
+  )
+  .transform((v) => v ?? DEFAULT_CENTER_GATE_MODE);
+
 export const v3EnvSchema = z.object({
   V3_ENABLE_TIER1_CACHE: booleanFlag.optional().default(false as unknown as string),
   V3_RECENCY_WEIGHT: clampedUnit,
@@ -77,6 +109,7 @@ export const v3EnvSchema = z.object({
   V3_SEMANTIC_BETA: semanticBeta,
   V3_ENABLE_WHITELIST_GATE: booleanFlag.optional().default(false as unknown as string),
   V3_YOUTUBE_SEARCH_TIMEOUT_MS: youtubeSearchTimeoutMs,
+  V3_CENTER_GATE_MODE: centerGateMode,
 });
 
 export interface V3Config {
@@ -89,6 +122,7 @@ export interface V3Config {
   semanticBeta: number;
   enableWhitelistGate: boolean;
   youtubeSearchTimeoutMs: number;
+  centerGateMode: CenterGateMode;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -102,6 +136,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_SEMANTIC_BETA: env['V3_SEMANTIC_BETA'],
     V3_ENABLE_WHITELIST_GATE: env['V3_ENABLE_WHITELIST_GATE'],
     V3_YOUTUBE_SEARCH_TIMEOUT_MS: env['V3_YOUTUBE_SEARCH_TIMEOUT_MS'],
+    V3_CENTER_GATE_MODE: env['V3_CENTER_GATE_MODE'],
   });
   if (!parsed.success) {
     return {
@@ -114,6 +149,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       semanticBeta: DEFAULT_SEMANTIC_BETA,
       enableWhitelistGate: false,
       youtubeSearchTimeoutMs: DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
+      centerGateMode: DEFAULT_CENTER_GATE_MODE,
     };
   }
   return {
@@ -126,6 +162,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     semanticBeta: parsed.data.V3_SEMANTIC_BETA,
     enableWhitelistGate: parsed.data.V3_ENABLE_WHITELIST_GATE,
     youtubeSearchTimeoutMs: parsed.data.V3_YOUTUBE_SEARCH_TIMEOUT_MS,
+    centerGateMode: parsed.data.V3_CENTER_GATE_MODE,
   };
 }
 

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -656,6 +656,7 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     focusTags: input.state.focusTags,
     recencyWeight: v3Config.recencyWeight,
     recencyHalfLifeMonths: v3Config.recencyHalfLifeMonths,
+    centerGateMode: v3Config.centerGateMode,
   });
   debug.timing.mandalaFilterMs = Date.now() - tMandalaFilterStart;
 

--- a/src/skills/plugins/video-discover/v3/mandala-filter.ts
+++ b/src/skills/plugins/video-discover/v3/mandala-filter.ts
@@ -37,6 +37,7 @@
 
 import { extractCoreKeyphrase, type KeywordLanguage } from '../v2/keyword-builder';
 import { MS_PER_MONTH_AVG } from '@/utils/time-constants';
+import type { CenterGateMode } from './config';
 
 export const MIN_SUB_RELEVANCE = 0.05;
 
@@ -44,6 +45,19 @@ export const DEFAULT_RECENCY_WEIGHT = 0.15;
 
 // 18mo half-life: 1y → 0.63, 3y → 0.25, 6y → 0.06.
 export const DEFAULT_RECENCY_HALF_LIFE_MONTHS = 18;
+
+/**
+ * Character-bigram threshold for the `'subword'` center-gate mode.
+ * A center token is considered matched when this fraction (or more)
+ * of its 2-grams appear in the title's combined 2-gram bag.
+ *
+ * 0.3 picked from the fixture sweep in
+ * `scripts/verify-mandala-filter-hypothesis.ts` — 0.3 keeps composite
+ * matches like `"모닝루틴"` ↔ `"루틴으로"` (2 shared 2-grams of 3)
+ * while rejecting single-character incidental overlaps. Lower values
+ * start letting NOISE through.
+ */
+export const SUBWORD_MIN_CENTER_MATCH = 0.3;
 
 export interface FilterCandidate {
   videoId: string;
@@ -69,6 +83,12 @@ export interface MandalaFilterInput {
   recencyWeight?: number;
   recencyHalfLifeMonths?: number;
   now?: Date;
+  /**
+   * Center-gate matching mode. See `v3/config.ts::CenterGateMode`.
+   * Defaults to `'substring'` (pre-audit behavior) when omitted so
+   * callers that haven't opted in keep the old logic bit-identical.
+   */
+  centerGateMode?: CenterGateMode;
 }
 
 export interface ScoreWeights {
@@ -121,6 +141,8 @@ export interface MandalaFilterStats {
     halfLifeMonths: number;
     missingPublishedAt: number;
   };
+  /** Which mode was applied this run. Useful for prod A/B logs. */
+  centerGateMode?: CenterGateMode;
 }
 
 export function applyMandalaFilter<T extends FilterCandidate>(
@@ -136,6 +158,12 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
 ): { byCell: Map<number, ScoredAssignment<T>[]>; stats: MandalaFilterStats } {
   const centerCore = extractCoreKeyphrase(input.centerGoal, input.language);
   const centerTokens = tokenize(centerCore, input.language);
+  const mode: CenterGateMode = input.centerGateMode ?? 'substring';
+
+  // Precompute per-center-token 2-grams once so the subword path is
+  // O(title-tokens × centerTokens) per candidate, not per pair.
+  const centerTokenGrams: Array<{ token: string; grams: Set<string> }> =
+    mode === 'subword' ? [...centerTokens].map((t) => ({ token: t, grams: charBigrams(t) })) : [];
 
   const subGoalTokens: Set<string>[] = input.subGoals.map((sg) => tokenize(sg, input.language));
 
@@ -174,11 +202,23 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
       halfLifeMonths,
       missingPublishedAt: 0,
     },
+    centerGateMode: mode,
   };
 
   for (const c of candidates) {
     const titleTokens = tokenize(c.title, input.language);
-    const centerScore = substringOverlap(centerTokens, titleTokens);
+    // Center score per mode:
+    //   substring — legacy, token-level substring overlap
+    //   subword   — char 2-gram overlap per center token, 30% floor
+    //   off       — 1 always (gate disabled)
+    let centerScore: number;
+    if (mode === 'off') {
+      centerScore = 1;
+    } else if (mode === 'subword') {
+      centerScore = subwordOverlap(centerTokenGrams, titleTokens);
+    } else {
+      centerScore = substringOverlap(centerTokens, titleTokens);
+    }
     const focusMatched = focusTokens.size > 0 && substringOverlap(focusTokens, titleTokens) > 0;
 
     // Center gate — OR of (focus-tag match) and (center overlap > 0).
@@ -188,9 +228,12 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
     // in the title. Non-focus candidates keep the original "any overlap"
     // rule so this change is purely additive on the permissive side — the
     // pre-existing pool of retained candidates is unchanged.
+    //
+    // Mode 'off' short-circuits to centerScore=1 above, so the gate
+    // never fires regardless of tokens.
     if (focusMatched) {
       stats.passedByFocusTag = (stats.passedByFocusTag ?? 0) + 1;
-    } else if (centerTokens.size > 0 && centerScore === 0) {
+    } else if (mode !== 'off' && centerTokens.size > 0 && centerScore === 0) {
       stats.droppedByCenterGate++;
       continue;
     }
@@ -256,6 +299,55 @@ function substringOverlap(centerTokens: Set<string>, titleTokens: Set<string>): 
     }
   }
   return hits / centerTokens.size;
+}
+
+/**
+ * Character 2-grams of the input string, ignoring non-letter / non-
+ * digit characters. Exported shape for tests only.
+ *
+ * Why bigrams: Korean composite words (`"모닝루틴"`, `"비밀루틴"`) share
+ * meaningful character sequences (`"루틴"`) with their root. Token-
+ * level substring can't detect this because neither `"모닝루틴"` nor
+ * `"루틴으로"` contains the other. Bigrams on each string produce
+ * overlapping sets:
+ *   `"루틴으로"` → {루틴, 틴으, 으로}
+ *   `"모닝루틴"` → {모닝, 닝루, 루틴}
+ *   shared   → {루틴}
+ * which lets the gate fire on semantically-related composite forms.
+ */
+export function charBigrams(s: string): Set<string> {
+  const grams = new Set<string>();
+  const str = s.toLowerCase().replace(/[^\p{L}\p{N}]/gu, '');
+  for (let i = 0; i + 2 <= str.length; i++) grams.add(str.slice(i, i + 2));
+  return grams;
+}
+
+/**
+ * Subword-aware center-gate score. For each center token, count it as
+ * "matched" when at least `SUBWORD_MIN_CENTER_MATCH` of its 2-grams
+ * appear in the title's combined 2-gram bag. Returns matched-tokens
+ * / total-center-tokens ∈ [0, 1].
+ */
+function subwordOverlap(
+  centerTokenGrams: ReadonlyArray<{ token: string; grams: Set<string> }>,
+  titleTokens: Set<string>
+): number {
+  if (centerTokenGrams.length === 0) return 0;
+  // Build the union of 2-grams from all title tokens. Per-token 2-grams
+  // are cheaper than a full-string 2-gram because we avoid bridging
+  // across word boundaries that the user never spoke together.
+  const titleGrams = new Set<string>();
+  for (const tt of titleTokens) {
+    for (const g of charBigrams(tt)) titleGrams.add(g);
+  }
+  let matched = 0;
+  for (const { grams } of centerTokenGrams) {
+    if (grams.size === 0) continue;
+    let hits = 0;
+    for (const g of grams) if (titleGrams.has(g)) hits++;
+    if (hits / grams.size >= SUBWORD_MIN_CENTER_MATCH) matched++;
+  }
+  return matched / centerTokenGrams.length;
 }
 
 function jaccard(bodyTokens: Set<string>, subGoalTokens: Set<string>): number {


### PR DESCRIPTION
## Summary

Fixes the **2/64 card prod outage** root cause: v3 `mandala-filter` dropped 89/94 candidates at the center-gate (95%) because **token-level substring match cannot detect Korean composite words**. Goal `1달 일일 루틴으로 전문가되기` produces center tokens that no title token contains as a substring, and composite titles (`모닝루틴`, `비밀루틴`) do not contain `루틴으로` either.

**Shipped flag-off** (default remains `substring`). Enable in prod with `V3_CENTER_GATE_MODE=subword` in a separate follow-up PR — keeps behavior change and env plumbing in separate commits for easy bisect/revert.

## Evidence (fixture-verified, `scripts/verify-mandala-filter-hypothesis.ts`)

20-candidate fixture (15 RELEVANT + 5 NOISE) with goal `1달 일일 루틴으로 전문가되기`:

| Mode | RELEVANT kept | NOISE kept | Recall | Precision |
|---|:---:|:---:|:---:|:---:|
| `substring` (pre-audit default) | **0/15** | 0/5 | 0.00 | n/a |
| `subword` (this PR) | **4/15** | 0/5 | 0.27 | 1.00 |
| `off` | 15/15 | 5/5 | 1.00 | 0.75 |

Subword lifts recall from 0 → 27% with **zero false positives**. Residual 11 drops are English-titled or vocabulary-disjoint videos that need a semantic embedding gate — tracked as follow-up.

Prod log match: `droppedByCenterGate: 89/94` in skill_runs for mandala `444cdf48-...` aligns exactly with fixture's 100% drop behavior.

## Algorithm (subword mode)

For each center token, build char 2-grams. Count it matched when ≥ 30% of its 2-grams appear in the title's combined 2-gram bag.

```
"루틴으로" 2-grams: {루틴, 틴으, 으로}
"모닝루틴" 2-grams: {모닝, 닝루, 루틴}
shared           : {루틴} → 1/3 ≥ 0.3 → MATCHED
```

## Files

- **`v3/config.ts`** — new `CenterGateMode` type (`substring | subword | off`), `DEFAULT_CENTER_GATE_MODE = 'substring'`, zod enum validator, `V3_CENTER_GATE_MODE` env with case-insensitive + trimmed accept.
- **`v3/mandala-filter.ts`** — `SUBWORD_MIN_CENTER_MATCH = 0.3` exported; `charBigrams` helper exported; new `subwordOverlap` private helper; `applyMandalaFilterWithStats` gains optional `centerGateMode` input + stats field for prod A/B observability.
- **`v3/executor.ts`** — passes `v3Config.centerGateMode` through to filter call (1-line prop).
- **Tests (6 new)** — config parse + mandala-filter behavior (substring drops composite / subword keeps composite / subword rejects noise / off skips gate / SUBWORD_MIN_CENTER_MATCH stability).

## Tests

- `v3/__tests__/`: **57/57 pass** (5 new mandala-filter + 2 new config).
- `tsc --noEmit`: clean.
- Full `video-discover` suite: 250/261 pass, 11 fail (all pre-existing v1 legacy per CP406 memo, baseline parity confirmed).

## Rollout

1. **Merge this PR** (flag-off default, no prod behavior change).
2. Separate PR: add `V3_CENTER_GATE_MODE: subword` to `deploy.yml` `envs` block.
3. Prod smoke: create mandala with Korean particle-heavy goal, verify `stats.centerGateMode='subword'` in skill_runs output + card count > 2.
4. If prod shows noise inflation → revert env to `substring` with no code deploy.

## Follow-ups

- **Semantic center-gate** (pgvector cosine similarity) — covers the 11 residual RELEVANT drops whose vocab doesn't overlap the goal. Requires video-dictionary pool expansion (CP414 A5 pilot in progress).
- **Shorts-duration filter review** — prod log also shows 145/250 drop at Shorts gate (58%); if this is over-aggressive after the subword change ships, revisit `isShortsByDuration` threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)