### PR TITLE
chore(prod): activate V3 center-gate subword mode (follow-up to #432)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,6 +30,13 @@ services:
       - REDIS_HOST=${INSIGHTA_TAILSCALE_IP}
       - REDIS_PORT=6379
       - REDIS_USER=insighta
+      # Phase-1 slice 5 followup (2026-04-21) — activate subword center-gate.
+      # Tuning knob, not a secret (per CLAUDE.md CP392 rule). Default in
+      # code is 'substring' (pre-audit). Flipping to 'subword' here
+      # enables char-2-gram composite-word matching so Korean titles
+      # like "모닝루틴" pass the gate for goals containing "루틴으로".
+      # Revert: delete this line and redeploy — code default takes over.
+      - V3_CENTER_GATE_MODE=subword
     volumes:
       - cache_data:/app/cache
       - logs_data:/app/logs


### PR DESCRIPTION
## Summary

Flips prod `V3_CENTER_GATE_MODE` to `subword`. Activates the mode shipped as code in #432.

**Expected effect**: the 2/64 card Korean-goal outage (mandala `444cdf48-...`) resolves because composite titles (`모닝루틴`, `비밀루틴`) now pass the center gate. Fixture recall 0% → 27%; prod effect measurable against the same goal.

## Change

- `docker-compose.prod.yml` — one-line `V3_CENTER_GATE_MODE=subword` added to api service `environment`.

Per CLAUDE.md CP392 rule: this is a tuning knob, **not a secret** — no GH Secret plumbing, no `deploy.yml` `.env` echo, no `envs:` block update.

## Rollback

Delete the line and redeploy. Code default in `v3/config.ts` reverts to `substring`.

## Test plan

- [ ] CI green.
- [ ] Post-merge deploy: prod wizard with Korean particle-heavy goal (ex: `1달 일일 루틴으로 전문가되기`).
- [ ] Verify `skill_runs.output.debug.centerGateMode === 'subword'` in `video-discover-v3` runs.
- [ ] Verify `recommendation_cache` row count for the mandala > 2 (target: 8-15).
- [ ] Verify no NOISE contamination in cards (eye-ball top N by cell).
- [ ] Monitor `droppedByCenterGate` ratio in skill_runs — expect material drop vs pre-activation.

Rollback criteria: noise inflation observed, or downstream IKS score regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)