### PR TITLE
feat(indexpage): SSE subscribe + invalidate card queries — P2 frontend

### DIFF
--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -27,6 +27,7 @@ import { useMandalaQuery, useMandalaList } from '@/features/mandala';
 import { useMandalaStore } from '@/stores/mandalaStore';
 import { youtubeSyncKeys } from '@/features/youtube-sync/model/useYouTubeSync';
 import { localCardsKeys } from '@/features/card-management/model/useLocalCards';
+import { useVideoStream } from '@/features/recommendation-feed/model/useVideoStream';
 import { useSearchCards, SearchBar } from '@/features/search';
 import { useMandalaNavigation } from '../model/useMandalaNavigation';
 import { useLayoutPreferences } from '../model/useLayoutPreferences';
@@ -206,6 +207,29 @@ function AuthenticatedApp() {
     },
     navigation.selectedCellIndex
   );
+
+  // 5b. SSE card stream — subscribe to `recommendation_cache` +
+  // `user_video_states` notifications (Slices 2 + #438) so the main
+  // grid refreshes as each card is persisted, instead of waiting for
+  // the 5s polling tick. Each new card in the stream invalidates the
+  // localCards + userVideoStates queries; React Query then refetches
+  // and cardOrchestrator re-renders with the new rows. Cheap — no
+  // new schema, no render loop risk (invalidate is a no-op if the
+  // subscriber is mid-request).
+  const cardStream = useVideoStream(effectiveMandalaId);
+  const cardStreamCountRef = useRef(0);
+  useEffect(() => {
+    if (cardStream.cards.length > cardStreamCountRef.current) {
+      cardStreamCountRef.current = cardStream.cards.length;
+      queryClient.invalidateQueries({ queryKey: localCardsKeys.list() });
+      queryClient.invalidateQueries({ queryKey: youtubeSyncKeys.allVideoStates });
+    }
+    // Reset the counter when the subscribed mandala changes so a
+    // cross-mandala navigation does not miss the first event.
+    if (cardStream.cards.length === 0 && cardStreamCountRef.current !== 0) {
+      cardStreamCountRef.current = 0;
+    }
+  }, [cardStream.cards.length, queryClient]);
 
   // 5c. Post-creation card polling: when a mandala was just created via wizard,
   // poll for cards every 5s until they appear or 90s timeout.


### PR DESCRIPTION
## Summary

Closes the P2 loop. Backend publishers emit `card_added` on both `recommendation_cache` and `user_video_states` writes (Slice 2 + #438). Frontend main grid was still polling every 5s. This subscribes `IndexPage` to the SSE channel and invalidates React Query caches as events arrive — grid refreshes in ~ms instead of 5s.

## Files

- `frontend/src/pages/index/ui/IndexPage.tsx` — import `useVideoStream`, subscribe with `effectiveMandalaId`, ref-counter tracks stream length, increments invalidate `localCardsKeys.list()` + `youtubeSyncKeys.allVideoStates`. Mandala change resets counter.

## Verification

- tsc: clean
- vitest: **263/263 pass** (zero regression)
- build: clean
- browser smoke: `/` 200, `/mandalas/new` 200

## Rollback

Remove the `useVideoStream` subscription block. Legacy 5s polling fallback retained — still works identically.