### PR TITLE
feat(mandala): OpenRouter embed provider switch — Phase 1

### DIFF
--- a/docs/design/wizard-service-redesign-2026-04-22.md
+++ b/docs/design/wizard-service-redesign-2026-04-22.md
@@ -1,0 +1,499 @@
+# Wizard/Dashboard Service-Flow Redesign — 2026-04-22
+
+> Status: DESIGN ONLY. No code changes in this session.
+> Supersedes: `docs/design/wizard-dashboard-redesign-2026-04-21.md` (previous session's Slice 1-5 + PRs #428-#439 — see §8 "Why the prior redesign failed").
+
+## 0. Mission
+
+**Deliver the best possible cards to the user as fast as possible, without misrepresenting progress.**
+
+Every phase, every verification gate, every rollback trigger below is evaluated against this single statement. If a proposed change does not measurably improve one of the three axes — accuracy, completeness, speed — it is not in scope.
+
+### Three axes of "best cards, fast"
+
+| Axis | Definition | Primary metric |
+|------|------------|----------------|
+| **Accuracy** (정확성) | Every card surfaced to the user is actually relevant. Zero-target for false positives. | Precision on labelled prod sample |
+| **Completeness** (완결성) | Every card that would be relevant actually reaches the user. Zero-target for silent drops. | Recall on labelled prod sample |
+| **Speed** (속도) | Perceived wait from goal-submit → first relevant card. | Server-side `duration_ms` p50/p95 |
+
+Per-cell card count is **not an axis** — a cell with one truly-relevant card beats a cell with ten off-topic cards.
+
+## 1. Problem statement
+
+User-reported regression on 2026-04-21:
+
+- Template search ~7s
+- "AI 커스텀" ~21s
+- Cards rendering ~30s+
+- Cards per cell sparse (1 per cell in multiple cells)
+- Off-topic cards passing the relevance filter (e.g. 수능 입시 content under "AI 학습 로드맵" mandala)
+
+Net result: **worse than the pre-CP389 baseline**. User judgement: "짜깁기 patch 누적".
+
+## 2. Constraints (explicit, non-negotiable)
+
+- **C1** — Service/prod main path uses **OpenRouter** for all LLM + embedding calls. No exceptions for "small test" or "just one".
+- **C2** — Self-hosted models (Ollama, qwen3-embedding:8b, qwen3-4b, mandala-gen v13) are **R&D / post-processing / backfill only**. They MUST NOT sit on the service critical path — not as primary, not as a blocking parallel dependency.
+- **C3** — Filter purpose is **user receives relevant cards**, not "reduce card count per cell". Silent drop of a relevant card is the worst outcome.
+- **C4** — Plan → Approve → Execute. No code/deploy without explicit approval per change.
+- **C5** — 1 change / 1 deploy / 1 prod measurement. No layered deploys.
+
+### Operating rules (how each phase is executed, not what)
+
+- **R1** — No improvement claimed without prod measurement. "Theoretical 60s → 10s" is never an acceptance signal.
+- **R2** — If a phase fails its verification gate, report "effect: none / regression" honestly and roll back. Sunk cost and reputation are ignored.
+- **R3** — Symptom patches are forbidden. A phase ships only when the root cause is identified and the change targets it directly.
+- **R4** — Synthetic fixtures alone are never an acceptance gate. Real prod data (≥ 3 distinct mandalas, ≥ 50 cards each) is mandatory.
+- **R5** — Scope creep is forbidden. Any "while we're here, let's also…" triggers a new design doc, not an in-flight addition.
+
+## 3. Current-state violations (audit)
+
+Evidence from source + prod env (read-only, 2026-04-22):
+
+| # | Service-flow path | Calls out to | Blocking? | Violation of |
+|---|-------------------|--------------|-----------|--------------|
+| V1 | `POST /search-by-goal` → `embedGoalForMandala` | `MANDALA_GEN_URL=http://100.91.173.17:11434` (mac mini Ollama) | Yes, ~5s typical | C1, C2 |
+| V2 | `POST /mandalas/generate` → `generateMandalaWithHaiku` / v13 | Same mac mini Ollama | Yes, ~20-28s typical | C1, C2 |
+| V3 | `ensureMandalaEmbeddings` | Same mac mini Ollama | Yes | C1, C2 |
+| V4 | Template similarity search reads `mandala_embeddings` (qwen3 4096d) | DB table populated by V3 | Reads non-blocking, but vector space is qwen3 — service gate semantically depends on mac-mini-produced vectors | C1 indirect |
+
+**Source references**:
+- `src/modules/mandala/search.ts:5` — "Embed user goal with Qwen3-Embedding-8B (4096d) **via Mac Mini Ollama**"
+- `src/modules/mandala/search.ts:63` — same
+- `src/modules/mandala/generator.ts:4-5` — "Model is **served on Mac Mini via Ollama API**"
+- `src/modules/mandala/ensure-mandala-embeddings.ts:165` — "Step 4: generate **via Mac Mini Ollama**"
+- `src/config/index.ts:58-62` — `MANDALA_GEN_URL`, `MANDALA_EMBED_MODEL=qwen3-embedding:8b`, `MANDALA_EMBED_DIMENSION=4096`
+- Prod env: `MANDALA_GEN_URL=http://100.91.173.17:11434` (mac mini Tailscale IP)
+- Prod env: `OPENROUTER_MODEL=qwen/qwen3-30b-a3b` (OpenRouter already configured for other v3 calls; not wired to mandala generate/embed)
+
+## 4. Structural root cause
+
+**The wizard waits for mac mini.** Two mac-mini-Ollama calls dominate wall-clock:
+- Template embed (~5s) — on critical path even when user may never click a template
+- Mandala generate (~21-28s) — on critical path, user blocks on this
+
+Every prior "speed improvement" PR optimized around these two calls without replacing them:
+
+| Prior PR | Effect relative to mac-mini wait |
+|----------|----------------------------------|
+| #428 YouTube per-call timeout | Orthogonal (post-creation path) |
+| #434 wizard-stream parallel SSE | Parallelizes V1 ‖ V2 → `max(5s, 25s) = 25s` — **still blocked by V2** |
+| #435 save + skill + card subscribe | Orthogonal (post-creation path) |
+| #436 useWizardStream hook | UI only, latency floor unchanged |
+| #437 stream view flag-gate | UI only |
+| #438 auto-add notify publisher | Orthogonal (post-creation path) |
+| #439 IndexPage SSE subscribe | UI only; helps S3 `cards 30s` per-card append but mandala-create wait unchanged |
+
+So a valid latency improvement is **structurally impossible** without replacing V1+V2+V3. That replacement is the scope of this redesign.
+
+## 5. Card relevance — reframed
+
+User framing (accepted):
+
+> 필터의 목적은 카드수를 줄이는게 아니야, 불필요한 관련없는 카드를 제외해서 사용자가 필요한 카드를 받아 볼수 있게 하는 것이 목표야.
+
+Implications:
+- Metric is **"user received relevant cards"**, not "gate pass rate" or "cards per cell".
+- **Silent drop** of a relevant card is worse than a visible false positive (user can dismiss the visible one; they can't recover the invisible one).
+- `V3_CENTER_GATE_MODE` (substring/subword/off) **all fail** this framing:
+  - `substring`: silently drops composite-word matches (PR #432 "2/64 outage" pattern)
+  - `subword`: lets "하는" / "학습" bigrams through → false positives (2026-04-21 prod)
+  - `off`: sub_goal jaccard takes over, also token-based → same silent-drop class
+- Therefore **all token-based gates are deprecated**. Replacement: **semantic embedding gate**.
+
+## 6. Target architecture
+
+### 6.1. Two vector spaces
+
+**Space A — Service (OpenRouter)**  *[critical path, authoritative for gate]*
+- Model: one OpenRouter embedding model (selected in Phase 0)
+- Tables:
+  - `mandala_embeddings_service` — center_goal + 8 sub_goals, service-space embedding
+  - `video_meta_embeddings_service` — YouTube title + description, same space
+- Read path: cosine (`title_embed` vs `center_goal_embed`) for center gate; argmax over 8 sub_goal embeds for cell routing.
+- Write path: at mandala create (center/sub), at YouTube search result (title/desc).
+
+**Space B — R&D (mac mini qwen3)**  *[non-blocking, parallel]*
+- Existing `mandala_embeddings` (qwen3 4096d) repurposed as read-only R&D baseline.
+- New `video_meta_embeddings_qwen3` populated asynchronously by mac mini consuming a queue of the same inputs the service just embedded.
+- Never read on service path. Used for offline A/B quality eval (qwen3 vs OpenRouter) and future self-host re-adoption decisions.
+
+### 6.2. Service flow (new)
+
+```
+User submits goal
+      │
+      ▼
+POST /wizard-stream (existing route, already deployed)
+      │
+      ├── [OpenRouter] embed(center_goal) + embed(sub_goals × 8)
+      │        ↓
+      │   mandala_embeddings_service ← insert
+      │        ↓
+      │   pgvector similarity → template_found SSE event
+      │
+      ├── [OpenRouter] generate structure (replaces mac mini v13)
+      │        ↓
+      │   structure_ready SSE event  ← user can navigate here
+      │        ↓
+      │   mandala row saved
+      │        ↓
+      │   [async] v3 post-creation pipeline (existing, unchanged)
+      │        ↓
+      │   YouTube search returns ~50-100 candidate titles
+      │        ↓
+      │   [OpenRouter] embed(title+desc × N, batched or concurrent)
+      │        ↓
+      │   video_meta_embeddings_service ← insert
+      │        ↓
+      │   SEMANTIC GATE:
+      │     cosine(title_embed, center_embed) ≥ threshold  →  pass
+      │     argmax(title_embed · sub_goal_embeds[8])       →  cell
+      │        ↓
+      │   recommendation_cache ← upsert surviving rows
+      │        ↓
+      │   card_added SSE event per row (PR #438/#439 path, retained)
+      │
+      └── [fire-and-forget to mac mini queue] same inputs
+             ↓
+           mac mini qwen3 embed/generate → *_qwen3 tables (R&D)
+```
+
+Key properties:
+- Zero mac-mini calls on critical path.
+- `template_found` still arrives (now bounded by OpenRouter embed + pgvector RTT; target <1s).
+- `structure_ready` now bounded by OpenRouter LLM latency, not mac mini Ollama.
+- Cards arrive streaming; cell assignment via semantic argmax, not token jaccard.
+
+### 6.3. Deprecations
+
+After this redesign lands in full (phase 5):
+- `V3_CENTER_GATE_MODE` env + subword/substring/off logic — **removed**
+- `charBigrams`, `subwordOverlap`, `substringOverlap` — **removed**
+- `MANDALA_GEN_URL`, `MANDALA_EMBED_MODEL`, `MANDALA_EMBED_DIMENSION` env — **renamed to `MANDALA_GEN_URL_RND` / `MANDALA_EMBED_MODEL_RND`** (R&D only) or deleted if no R&D consumer exists.
+
+## 7. Implementation phases
+
+Each phase is independently deployable, independently rollback-able, and independently measurable. No phase merges with another.
+
+### Phase 0 — Model selection (documented-benchmark review, no API calls)
+
+**Axis**: supports R1 + R4 (decision record for downstream phases). No direct axis improvement.
+
+**Hard-rule note (2026-04-22 revision)**: Original Phase 0 proposed an empirical OpenRouter embed sweep. That violated CLAUDE.md rule "LLM API 호출 금지 — OpenRouter API 호출 금지 — 어떤 명목도 불가". Replaced with **document-only review** below. Empirical measurement happens during Phase 1 deploy's own verification gate; no standalone measurement script is written or run.
+
+**Scope (no code, no API calls)**:
+- Compare candidate OpenRouter embedding endpoints using **published benchmarks** (MTEB multilingual, model cards, OpenRouter model list) + **training-knowledge-derived tradeoffs**.
+- Cross-reference with existing Insighta constraints (4096d qwen3 schema precedent, Korean-primary traffic, OpenRouter already configured at `OPENROUTER_MODEL=qwen/qwen3-30b-a3b`).
+- Publish a recommendation + fallback (Appendix A of this doc).
+- Get user approval on one model before Phase 1 starts.
+
+**Output artifact**: Appendix A below.
+
+**Verification gate**: user-approved model choice recorded. That choice is the only input to Phase 1. If Phase 1 deploy misses its rollback triggers (see Phase 1 rollback triggers), the model is declared unfit and the next-ranked fallback in Appendix A is used for the retry.
+
+### Phase 1 — Service embedding path migration
+
+**Axis**: **Speed primary** (target: embed p95 5s → <500ms, search-by-goal p95 8s → <1.5s). Completeness secondary (same-space gate vectors enable Phase 3).
+
+Scope: replace V1/V3 with OpenRouter embed.
+
+Files touched:
+- `src/modules/mandala/search.ts:embedGoalForMandala` — swap fetch target
+- `src/modules/mandala/ensure-mandala-embeddings.ts` — swap embed source
+- New Prisma migration: `mandala_embeddings_service` table with pgvector dim matching Phase-0 choice
+- New raw SQL migration: IVFFlat index on the new table (`CREATE INDEX CONCURRENTLY`)
+- `src/config/index.ts` — new `openRouter.embedModel` config entry; keep `mandalaGen` block renamed `_RND` suffix
+
+Not touched this phase:
+- `V3_CENTER_GATE_MODE`, token-based filter logic, cards pipeline, wizard UI — all unchanged.
+- `generator.ts` (that's Phase 2).
+
+**Verification gate (prod)**:
+- `embedGoalForMandala` call time p95 < 500ms (was ~5s on mac mini)
+- Template search-by-goal end-to-end p95 < 1.5s (was ~8s)
+- No increase in 5xx rate on `/search-by-goal` over 24h
+- Prod smoke: create 1 mandala, verify `mandala_embeddings_service` row exists, dim matches
+
+**Rollback triggers (any one fires → revert within 24h)**:
+- Embed p95 ≥ 2s (missed target by 4×)
+- `/search-by-goal` 5xx rate > baseline + 1pp
+- Cosine similarity distribution on new space shows mean < 0.20 on known-relevant pairs (indicates wrong model choice)
+
+**Rollback mechanism**: config flag `MANDALA_EMBED_PROVIDER=ollama` temporary — re-route to mac mini endpoint. No data migration needed (old table untouched).
+
+### Phase 1b — Mac mini concurrent embedding queue  *(immediately after Phase 1 verification)*
+
+**Axis**: **R&D data accumulation** — enables future A/B eval, future self-host re-adoption, and vector-level comparison between OpenRouter qwen3 and mac mini qwen3 (same family, same dim). Does not directly improve Accuracy / Completeness / Speed, but is a day-1 prerequisite for any future model-quality improvement work (per user directive 2026-04-22: "mac mini는 동시에 호출되어 후처리로 데이터를 쌓아서 이후 모델, 혹은 임베딩을 개선하기 위한 용도").
+
+Scope: after Phase 1 deploy is verified and stable, add fire-and-forget enqueue of the same embedding inputs to mac mini. Service flow remains unaffected (never waits on mac mini).
+
+Files touched:
+- New pg-boss job type `mac_mini_embed_rnd`
+- `src/modules/mandala/search.ts` after OpenRouter embed call — enqueue same goal text + mandala_id reference
+- Mac mini side: queue consumer invokes local Ollama `qwen3-embedding:8b`, writes results to `mandala_embeddings_qwen3` (R&D table; either new, or the existing `mandala_embeddings` explicitly repurposed as R&D-only)
+
+**Verification gate**:
+- Job lag ≤ 5 min under normal load
+- Zero service-flow latency impact (`embedGoalForMandala` p95 post-Phase-1b equals pre-Phase-1b baseline, tolerance ≤ 50ms)
+- R&D table populated within 5 min of service embed for ≥ 95% of inputs
+
+**Rollback triggers (any fires → revert within 24h)**:
+- Service `embedGoalForMandala` p95 increases > 100ms after Phase 1b deploy (queue insert overhead too high)
+- Queue backlog grows unbounded (mac mini consumer too slow, queue saturates)
+
+**Rollback mechanism**: set queue throttle to 0 via config; no service flow impact.
+
+### Phase 2 — Service generation path migration
+
+**Axis**: **Speed primary** (target: structure generation p95 21-28s → <8s). Accuracy secondary (structure schema validation rate).
+
+Scope: replace V2 with OpenRouter LLM.
+
+Files touched:
+- `src/modules/mandala/generator.ts` — swap fetch target from mac mini Ollama to OpenRouter chat completion
+- Pick OpenRouter model: keep existing `qwen/qwen3-30b-a3b` (already configured in prod), or move to Claude Haiku / Sonnet. Phase-0 latency/quality data informs this.
+- Retain the split-generation pattern (structure-only streams first, actions fill in async) — already in wizard-stream route
+
+**Verification gate**:
+- `structure_ready` SSE event time p95 < 8s (was 21-28s)
+- Structure JSON schema validation pass rate ≥ 99% over 24h
+- "actions 0/8" failure rate on async path < 1% (matches pre-PR#429 one-shot rate)
+- User-visible: wizard completes + navigates within 10s of goal submission
+
+**Rollback triggers (any one fires → revert within 24h)**:
+- `structure_ready` p95 ≥ 15s
+- Structure schema validation pass rate < 95%
+- "actions 0/8" rate ≥ 5%
+- Any user-reported "wizard stuck / broken" within 48h of deploy
+
+**Rollback mechanism**: same flag pattern as Phase 1 — `MANDALA_GEN_PROVIDER=ollama` re-routes.
+
+### Phase 2b — Mac mini concurrent generation queue  *(immediately after Phase 2 verification)*
+
+**Axis**: Same as Phase 1b — R&D data accumulation for mandala-gen v13 outputs (mac mini) alongside OpenRouter structure generation (service). Enables A/B comparison of generated structures for quality improvement over time.
+
+Scope: analogous to Phase 1b, for the mandala-generate path. Service flow never waits on mac mini.
+
+Files touched:
+- New pg-boss job type `mac_mini_generate_rnd`
+- `src/modules/mandala/generator.ts` after OpenRouter structure generation — enqueue same goal + structure reference
+- Mac mini side: queue consumer invokes local mandala-gen v13, writes result to `mandala_generations_qwen3_rnd` table (new)
+
+**Verification gate**: same pattern as Phase 1b (job lag ≤ 5 min; zero service-flow latency impact; R&D table populated for ≥ 95% of service generations).
+
+**Rollback triggers**: same pattern as Phase 1b (service `structure_ready` p95 regression > 100ms; unbounded queue backlog).
+
+**Rollback mechanism**: set queue throttle to 0 via config; no service flow impact.
+
+### Phase 3 — Semantic relevance gate
+
+**Axis**: **Accuracy + Completeness primary** (this is the axis where the whole redesign pays off). Speed neutral (adds one batched embed call per search, latency budget <1s).
+
+Scope: replace token-based `V3_CENTER_GATE_MODE` with OpenRouter-embedding cosine gate.
+
+Files touched:
+- New table `video_meta_embeddings_service` (video_id PK, embedding vector(N), created_at)
+- `src/skills/plugins/video-discover/v3/executor.ts` — after YouTube search, embed titles + descriptions; store; feed to gate
+- New module `src/skills/plugins/video-discover/v3/semantic-gate.ts` — cosine + threshold + argmax routing
+- `src/skills/plugins/video-discover/v3/mandala-filter.ts` — `V3_CENTER_GATE_MODE=semantic` new branch, old branches untouched during transition
+- Threshold env `V3_SEMANTIC_GATE_THRESHOLD` (default from Phase-0 sweep)
+
+Token branches (substring/subword/off) remain until Phase 5, for rollback.
+
+**Verification gate**:
+- Relevance metric on labelled sample (user-verified or agent-labelled sample from real prod mandalas): precision ≥ 0.85, recall ≥ 0.85 (vs current subword precision < 0.60 on AI-학습 mandala)
+- No card count per cell target — cells may be empty or may have 20 cards, per content. Per-cell count is informational only.
+- Full per-mandala semantic-gate stats logged (drop count + reason + below-threshold scores) for post-hoc inspection
+
+**Rollback triggers (any one fires → revert within 24h)**:
+- Precision < 0.85 on labelled sample of ≥ 100 cards across ≥ 3 mandalas
+- Recall < 0.85 on same sample
+- Latency p95 increase > 500ms on full wizard flow vs Phase-2-deployed baseline
+- Any user-reported "fewer relevant cards than before" within 72h
+
+**Rollback mechanism**: `V3_CENTER_GATE_MODE=subword` (existing legacy path restored).
+
+### Phase 4 (former) — split into Phase 1b and Phase 2b
+
+The original v1-v3 design put mac-mini R&D data accumulation as a "Phase 4 backburner — may never land". That classification was incorrect per user's 2026-04-22 directive: mac mini must be concurrently collecting data from day 1. Phase 4's responsibilities are now Phase 1b and Phase 2b (inline above, immediately after their paired service-path phases).
+
+### Phase 5 — Token gate removal
+
+**Axis**: **none directly**. Maintenance cleanup — reduces code-base risk of accidental re-activation. Gate-kept by sustained Phase-3 success.
+
+Scope: delete all token-based center-gate code after 4 weeks of green Phase-3 metrics.
+
+Files touched:
+- Remove `charBigrams`, `subwordOverlap`, `substringOverlap`, `V3_CENTER_GATE_MODE` from `mandala-filter.ts` + `config.ts`
+- Remove `V3_CENTER_GATE_MODE` env from `docker-compose.prod.yml`
+- Delete `scripts/verify-mandala-filter-hypothesis.ts` (replaced by Phase-3 live metrics)
+
+**Verification gate**: 4 consecutive weeks of Phase-3 precision ≥ 0.85. No user-reported relevance regression open.
+
+## 8. Why the prior redesign failed (reference, not action)
+
+From `docs/design/wizard-dashboard-redesign-2026-04-21.md` + PRs #428-#439:
+
+- The prior redesign parallelized V1 ‖ V2 but kept both on mac mini. Wall-clock floor = max of two mac-mini calls = still mac mini-bound.
+- It did not identify mac mini as the latency root cause (attributed to "sequential awaits" instead).
+- The subword `V3_CENTER_GATE_MODE` follow-up (PR #432 + chore #433) was fixture-validated but the fixture did not represent prod distribution; real prod produced the 2026-04-21 false positives documented in §5.
+- The streaming wizard UI (PR #437) landed with `VITE_WIZARD_STREAMING_ENABLED` default-on, but VitePWA `registerType: 'prompt'` kept users on the old cached bundle → zero measured activation.
+- No per-PR prod measurement gate. "CI pass" treated as acceptance criterion → measurement debt compounded.
+
+This redesign addresses each of those failure modes explicitly via §2 C5 (1 change / 1 deploy / 1 measurement) and §7 per-phase verification gates.
+
+## 9. Measurement framework
+
+### 9.1. Primary metric
+
+**Relevance rate** = (user-kept cards) / (cards surfaced to user) over N days. Proxy signals until explicit user feedback exists:
+- Cards NOT deleted / dismissed within 7 days (positive)
+- Cards deleted within 24h of surface (negative)
+- Cards clicked (positive, but noisier — click != relevant)
+
+### 9.2. Secondary metrics
+
+- Server-side `duration_ms` per SSE event (already emitted by wizard-stream route)
+- Card-surface latency p50/p95 (mandala create → first card rendered)
+- Cell distribution per mandala (informational; no target)
+
+### 9.3. No synthetic fixtures as acceptance gate
+
+Phase 0 may use synthetic fixtures for model comparison. Phase 1-3 acceptance uses **real prod mandalas only** (at least 3 distinct goals, at least 50 cards per mandala).
+
+## 10. Out of scope for this redesign
+
+- PWA `registerType: 'prompt'` → `'autoUpdate'` migration. Separate ops PR, see `docs/design/` follow-up.
+- `mandala_embeddings` 18,009-row backfill in new space. Handled as a one-off script in Phase 1 (offline; doesn't block deploy).
+- wizard-stream UI activation for users still on cached old bundle. Handled by the PWA ops PR above.
+- Per-cell yield balancing (`MIN_CARDS_PER_CELL` env). Removed — §5 reframing says per-cell count is not a metric.
+- pgvector IVFFlat on old `mandala_embeddings` table. The new `_service` table gets IVFFlat from day 1; the old table is R&D-only and its index is out of scope.
+
+## 11. Open questions
+
+- ~~**Q1** — OpenRouter embedding model choice.~~ **DECIDED 2026-04-22**: `qwen3-embedding-8B`. See Appendix A.6.
+- **Q2** — OpenRouter generation model for mandala structure. Current prod has `OPENROUTER_MODEL=qwen/qwen3-30b-a3b`; this may stay, or move to Haiku/Sonnet based on Phase 2 deploy metrics.
+- **Q3** — Relevance threshold value for Phase 3 semantic gate. Answered by Phase 3 production calibration on labelled prod data.
+- ~~**Q4** — Backfill strategy for 18,009 existing `mandala_embeddings` rows.~~ **DECIDED 2026-04-22**: reuse as-is (same model family, same 4096d); re-embed only if Phase 1 rollback trigger fires. See Appendix A.6.
+- **Q5** — Mac mini consumer infrastructure. Does mac mini already have pg-boss / queue consumer plumbing? If not, Phase 1b/2b carry that cost.
+- **Q6** — OpenRouter rate limits / burst ceiling for qwen3-embedding-8B. Per-provider; verify during Phase 0 closeout (reading OpenRouter docs) or deferred until Phase 1 deploy reveals ceiling.
+
+## 12. Non-goals
+
+- Building a generic embedding abstraction library.
+- Replacing OpenRouter itself (it's the service-flow provider by C1).
+- Touching unrelated recommendation mechanics (auto-add, localCards, sync, etc.).
+
+## 13. Change log
+
+- 2026-04-22 (v1) — Initial redesign after user identified mac mini in service critical path; prior `wizard-dashboard-redesign-2026-04-21.md` superseded.
+- 2026-04-22 (v2) — Added §0 Mission statement and three-axis definition (accuracy / completeness / speed). Added §2bis Operating Rules (R1-R5). Tagged every phase with its primary+secondary axis. Replaced generic "verification gate" with quantitative rollback triggers per phase. Marked Phase 4 as backburner and Phase 5 as maintenance-only (neither improves the three axes directly). Reason: user statement — "사용자에게 최고의 카드를 빠르게 제공하는 것을 위한 서비스를 거짓없이 올바르게 정확한 알고리즘을 사용해서 가장 효과적으로 구현하는 것".
+- 2026-04-22 (v3) — Phase 0 revised: original empirical-sweep plan violated CLAUDE.md rule on OpenRouter API usage ("데이터셋 생성·실험·테스트 사용 절대 금지"). Replaced with documented-benchmark review (no API calls). Empirical measurement happens during Phase 1 deploy's verification gate. Added Appendix A — candidate model comparison.
+- 2026-04-22 (v4) — Phase 4 reclassified. User clarified: mac mini "동시에 호출되어 후처리로 데이터를 쌓아서 이후 모델/임베딩 개선" — concurrent collection is day-1 architecture, not deferred backburner. Phase 4 split into **Phase 1b** (concurrent embedding queue) and **Phase 2b** (concurrent generation queue), each deployed immediately after its paired service-path phase is verified.
+- 2026-04-22 (v5) — Model decision recorded in Appendix A.6. Primary: `qwen3-embedding-8B` via OpenRouter (user confirmed availability). Fallback order: Cohere multi-v3 → openai-3-small → openai-3-large. Existing 18,009 `mandala_embeddings` rows reused as-is (same family, same 4096d). Updated A.1 candidate set to mark qwen3-8B primary; updated A.2 quality ranking; updated A.3 operational table with latency+cost estimates and compatibility row; rewrote A.4 recommendation; converted A.6 from "decision required" to "decisions recorded". Resolved §11 Q1 and Q4.
+
+---
+
+## Appendix A — OpenRouter embedding model selection (2026-04-22)
+
+> All claims in this appendix are sourced from **published benchmarks and model cards available in training knowledge up to 2026-01**. No API calls were made to produce this document. Prod latency / cost / cosine-separation numbers for our specific Korean-goal distribution will first be observable during the Phase 1 deploy verification window.
+
+### A.1. Candidate set
+
+**Primary (user-confirmed available on OpenRouter, 2026-04-22)**:
+
+| Model | Dim | Architecture | OpenRouter availability |
+|-------|-----|--------------|-------------------------|
+| **`qwen3-embedding-8B`** | **4096** | Same family as mac mini `qwen3-embedding:8b` (Q4_K_M) | **Confirmed (user)** |
+
+Chosen because:
+- Top-tier Korean semantic quality (MTEB multilingual top class)
+- **Same model family and dimension as the existing mac mini R&D path** — existing 18,009 `mandala_embeddings` rows remain usable without re-embedding (see A.4 caveat)
+- Existing `mandala_embeddings` table schema (`vector(4096)`) and any attached pgvector index are reusable
+
+**Fallbacks (in case OpenRouter qwen3-embedding-8B provider becomes unavailable or fails Phase 1 rollback triggers)**:
+
+| Fallback rank | Model | Dim | Price / 1M tok | Max input | Availability |
+|---------------|-------|-----|----------------|-----------|--------------|
+| 1 | `cohere/embed-multilingual-v3.0` | 1024 | $0.10 | 512 | Confirmed |
+| 2 | `openai/text-embedding-3-small` | 1536 | $0.02 | 8,191 | Confirmed |
+| 3 | `openai/text-embedding-3-large` | 3072 | $0.13 | 8,191 | Confirmed |
+
+Omitted:
+- `voyage/voyage-multilingual-2` — Voyage typically requires direct API; OpenRouter routing unverified.
+- `openai/text-embedding-ada-002` — legacy, strictly dominated by `text-embedding-3-small`.
+- Self-hosted BGE / E5-multilingual via OpenRouter — unreliable multi-provider routing; would muddy the "OpenRouter main, self-host R&D" separation.
+
+### A.2. Relevance quality (Korean-focused)
+
+Ranked by MTEB multilingual benchmarks + published Korean-task evaluations as of training cutoff:
+
+| Rank | Model | Published multilingual avg | Korean-specific strength |
+|------|-------|----------------------------|-------------------------|
+| **1** | **`qwen3-embedding-8B`** | **~67 avg on MTEB multilingual** (top tier) | **Strongest in candidate set** — pretrained with large Korean + CJK corpus; same family currently in use on mac mini as existing R&D path |
+| 2 | `cohere/embed-multilingual-v3.0` | ~64 avg on MTEB multilingual | Trained explicitly with Korean + CJK corpus; strong cross-lingual alignment |
+| 3 | `openai/text-embedding-3-large` | ~62 avg on MTEB multilingual | English-dominant pretraining; Korean decent but not best-in-class |
+| 4 | `openai/text-embedding-3-small` | ~58-60 avg on MTEB multilingual | English-dominant; Korean acceptable, consistently behind multilingual-specialized models |
+
+**Uncertainty**: benchmark averages may not match our specific task (Korean goal ↔ Korean+English YouTube title cosine). Phase 1 deploy metrics are the authoritative signal.
+
+### A.3. Operational considerations
+
+| Axis | `qwen3-embedding-8B` | `cohere/multi-v3` | `openai/3-small` | `openai/3-large` |
+|------|----------------------|-------------------|------------------|------------------|
+| Storage cost per vector (f32) | 16 KB | 4 KB | 6 KB | 12 KB |
+| pgvector IVFFlat index build time | slow | fastest | fast | slower |
+| Korean-dominant workload precedent | strong (same family on mac mini) | strong | moderate | moderate |
+| Max input sufficient for title+desc? | ✓ | ✓ (512 — titles typ. ≤ 200 tok) | ✓ (8k) | ✓ (8k) |
+| Estimated per-call latency (short text) | ~300-800ms (cloud, warm) | ~150-300ms | ~100-200ms | ~150-300ms |
+| Estimated batch-100 latency | ~1-2s | ~300-600ms | ~200-500ms | ~300-700ms |
+| Cost per mandala (5.5k tok) | provider-dependent; expected <$0.01 | ~$0.00055 | ~$0.00011 | ~$0.00072 |
+| **Compatibility with existing 18k rows** | **full (same family, same dim)** | none (1024d) | none (1536d) | none (3072d) |
+
+Cost is trivially affordable at our scale across all candidates; **not the deciding factor**.
+
+Latency of qwen3-8B is ~200-500ms slower than Cohere per call. Wizard-flow total: qwen3 = ~9-14s user-visible; Cohere = ~8-12s user-visible. Difference below perceptual threshold when weighed against quality and migration-free reuse of existing 18k rows.
+
+### A.4. Recommendation (ranked) — **USER DECISION: qwen3-embedding-8B selected (2026-04-22)**
+
+**Primary (selected)**: `qwen3-embedding-8B` via OpenRouter
+- Top-tier Korean multilingual quality; exceeds all fallbacks on published Korean benchmarks
+- **4096d matches existing `mandala_embeddings` schema** — no new vector space, 18,009 existing rows remain usable as template pool from day 1
+- Existing pgvector infrastructure (vector(4096) column) reusable; no schema migration for the embedding column itself
+- Same model family currently running on mac mini as R&D baseline → vector-level A/B comparison between service and R&D paths is possible
+
+**Caveat (precision drift)**:
+- Mac mini uses `Q4_K_M` (4-bit quantization via Ollama llama.cpp)
+- OpenRouter provider will likely serve higher precision (BF16/FP16/Q8)
+- Resulting vectors are **not bit-identical** but same architecture → cosine rankings preserved (error typ. <1% on top-10)
+- Absolute cosine thresholds need Phase 3 calibration anyway (already in plan §9.2)
+- Phase 1 rollback trigger ("cosine mean < 0.20 on known-relevant pairs") catches pathological drift
+
+**Fallback 1 (if OpenRouter qwen3-embedding-8B provider is unavailable or fails Phase 1 rollback triggers)**: `cohere/embed-multilingual-v3.0`
+- Strong Korean multilingual, confirmed OpenRouter-hosted
+- 1024d → new vector space → existing 18k rows need re-embed (one-shot ~$0.18 + 3-10 min)
+
+**Fallback 2**: `openai/text-embedding-3-small`
+- Cheapest, most widely deployed, OpenAI SLA stable
+- 1536d, new vector space, same re-embed cost as Fallback 1
+
+**Fallback 3**: `openai/text-embedding-3-large`
+- Use only if quality signal demands it
+- 3072d doubles storage and index cost
+
+### A.5. What this appendix does NOT provide
+
+- Empirical latency measurements on our prod network — captured during Phase 1 deploy's verification window.
+- Empirical cosine-separation measurements on our specific labelled prod sample — captured during Phase 1 smoke and Phase 3 relevance evaluation.
+- Proof that benchmark averages translate to our Korean-goal distribution — verified only by Phase 1 + Phase 3 prod metrics.
+- Cost of mis-pick — mitigated by rollback triggers. A wrong primary pick costs one Phase 1 deploy + revert cycle (~1 day).
+
+### A.6. Decisions recorded
+
+**2026-04-22 (user approval)**:
+- **Primary model**: `qwen3-embedding-8B` via OpenRouter. Same family and 4096d as existing mac mini R&D path.
+- **Fallback order**: Cohere multilingual-v3 → openai-3-small → openai-3-large.
+- **Existing 18,009 `mandala_embeddings` rows**: reused as-is in service flow. No re-embed at Phase 1 start.
+- **Rollback protection**: Phase 1's "cosine mean < 0.20 on known-relevant pairs" trigger catches any quantization drift between Ollama Q4_K_M and OpenRouter provider precision. If fired, one-shot re-embed of the 18k rows (~$0.18, 3-10 min) before retry.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -61,6 +61,12 @@ const envSchema = z.object({
   MANDALA_EMBED_MODEL: z.string().default('qwen3-embedding:8b'),
   MANDALA_EMBED_DIMENSION: z.coerce.number().default(4096),
 
+  // Mandala embedding provider switch (Phase 1, 2026-04-22).
+  // 'ollama' keeps the legacy Mac-mini path bit-identical. 'openrouter' routes
+  // the service-flow embedGoalForMandala call through OpenRouter instead.
+  // Default = ollama so flag-off = pre-Phase-1 behaviour (CLAUDE.md C5).
+  MANDALA_EMBED_PROVIDER: z.enum(['ollama', 'openrouter']).default('ollama'),
+
   // LLM Provider
   OLLAMA_URL: z.string().default('http://localhost:11434'),
   OLLAMA_EMBED_MODEL: z.string().default('nomic-embed-text'),
@@ -70,6 +76,14 @@ const envSchema = z.object({
   // OpenRouter
   OPENROUTER_API_KEY: z.string().optional(),
   OPENROUTER_MODEL: z.string().default('qwen/qwen3.5-9b'),
+  // OpenRouter embedding endpoint (Phase 1). Same OPENROUTER_API_KEY is
+  // reused for auth. Base URL is OpenAI-compatible; model id is exact
+  // string as listed on the OpenRouter model catalogue. Dim must match
+  // the vector(N) column on mandala_embeddings — 4096 is correct for
+  // the Qwen3-Embedding-8B family currently in use.
+  OPENROUTER_EMBED_BASE_URL: z.string().default('https://openrouter.ai/api/v1'),
+  OPENROUTER_EMBED_MODEL: z.string().default('qwen/qwen3-embedding-8b'),
+  OPENROUTER_EMBED_DIMENSION: z.coerce.number().default(4096),
 
   // Gmail SMTP Relay (IP-authenticated via EC2)
   GMAIL_SMTP_HOST: z.string().default('smtp-relay.gmail.com'),
@@ -165,6 +179,15 @@ export const config = {
     model: env.MANDALA_GEN_MODEL,
     embedModel: env.MANDALA_EMBED_MODEL,
     embedDimension: env.MANDALA_EMBED_DIMENSION,
+  },
+
+  // Mandala embedding provider + OpenRouter embed endpoint (Phase 1,
+  // 2026-04-22). See docs/design/wizard-service-redesign-2026-04-22.md.
+  mandalaEmbed: {
+    provider: env.MANDALA_EMBED_PROVIDER,
+    openRouterBaseUrl: env.OPENROUTER_EMBED_BASE_URL,
+    openRouterModel: env.OPENROUTER_EMBED_MODEL,
+    openRouterDimension: env.OPENROUTER_EMBED_DIMENSION,
   },
 
   // LLM Provider

--- a/src/modules/mandala/search.ts
+++ b/src/modules/mandala/search.ts
@@ -57,13 +57,31 @@ const EMBED_TIMEOUT_MS = 30_000;
 /** UUID of the system-templates@insighta.one user that owns all explore templates */
 const SYSTEM_TEMPLATES_USER_ID = '00000000-0000-0000-0000-000000000001';
 
-// ─── Embedding (Ollama /api/embed) ───
+// ─── Embedding (provider-switched) ───
 
 /**
- * Embed a goal text using qwen3-embedding:8b on Mac Mini Ollama.
- * Returns 4096-dimensional vector matching mandala_embeddings table.
+ * Embed a goal text.
+ *
+ * Routes by `config.mandalaEmbed.provider`:
+ *   - 'ollama' (default): legacy Mac-mini Ollama path at MANDALA_GEN_URL
+ *     with qwen3-embedding:8b. Kept bit-identical so flag-off rollback
+ *     returns to pre-Phase-1 behaviour.
+ *   - 'openrouter' (Phase 1, 2026-04-22): OpenRouter-hosted same-family
+ *     Qwen3-Embedding-8B. Eliminates the mac-mini dependency on the
+ *     wizard critical path. Dim remains 4096 so existing vector(4096)
+ *     table and 18k rows are reusable.
+ *
+ * Both return a same-dim vector matching mandala_embeddings.
  */
 export async function embedGoalForMandala(goalText: string): Promise<number[]> {
+  const provider = config.mandalaEmbed.provider;
+  if (provider === 'openrouter') {
+    return embedViaOpenRouter(goalText);
+  }
+  return embedViaOllama(goalText);
+}
+
+async function embedViaOllama(goalText: string): Promise<number[]> {
   const url = config.mandalaGen.url;
   const model = config.mandalaGen.embedModel;
   const expectedDim = config.mandalaGen.embedDimension;
@@ -122,6 +140,86 @@ export async function embedGoalForMandala(goalText: string): Promise<number[]> {
       );
     }
     throw new MandalaSearchError(message, 'EMBED_FAILED');
+  }
+}
+
+/**
+ * OpenRouter embedding client (Phase 1).
+ *
+ * Uses the OpenAI-compatible /embeddings endpoint on OpenRouter. Provider
+ * routing and rate-limits are OpenRouter's responsibility; this client only
+ * translates the standard schema to our internal vector shape + enforces
+ * the same dim check as the Ollama path.
+ *
+ * On auth/network/timeout failure, throws MandalaSearchError with a code
+ * aligned with the Ollama path so upstream handlers don't need to special
+ * case.
+ */
+async function embedViaOpenRouter(goalText: string): Promise<number[]> {
+  const baseUrl = config.mandalaEmbed.openRouterBaseUrl;
+  const model = config.mandalaEmbed.openRouterModel;
+  const expectedDim = config.mandalaEmbed.openRouterDimension;
+  const apiKey = config.openrouter.apiKey;
+
+  if (!apiKey) {
+    throw new MandalaSearchError('OPENROUTER_API_KEY not configured', 'SERVICE_UNAVAILABLE');
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), EMBED_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${baseUrl}/embeddings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ model, input: goalText, encoding_format: 'float' }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      const body = await response.text();
+      const code =
+        response.status === 401
+          ? 'SERVICE_UNAVAILABLE'
+          : response.status === 429
+            ? 'RATE_LIMITED'
+            : 'SERVICE_UNAVAILABLE';
+      throw new MandalaSearchError(
+        `OpenRouter embed API error ${response.status}: ${body.slice(0, 200)}`,
+        code
+      );
+    }
+
+    const data = (await response.json()) as {
+      data?: Array<{ embedding?: number[] }>;
+    };
+    const vector = data.data?.[0]?.embedding;
+
+    if (!vector || vector.length === 0) {
+      throw new MandalaSearchError('OpenRouter returned empty embedding', 'EMBED_FAILED');
+    }
+
+    if (vector.length !== expectedDim) {
+      throw new MandalaSearchError(
+        `OpenRouter embedding dimension mismatch: got ${vector.length}, expected ${expectedDim}`,
+        'DIMENSION_MISMATCH'
+      );
+    }
+
+    return vector;
+  } catch (err) {
+    clearTimeout(timeout);
+    if (err instanceof MandalaSearchError) throw err;
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new MandalaSearchError('OpenRouter embed request timed out', 'TIMEOUT');
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    throw new MandalaSearchError(`OpenRouter embed failed: ${message}`, 'EMBED_FAILED');
   }
 }
 
@@ -391,6 +489,7 @@ export type MandalaSearchErrorCode =
   | 'SERVICE_UNAVAILABLE'
   | 'EMBED_FAILED'
   | 'DIMENSION_MISMATCH'
+  | 'RATE_LIMITED'
   | 'TIMEOUT';
 
 export class MandalaSearchError extends Error {

--- a/tests/unit/modules/mandala-embed-openrouter.test.ts
+++ b/tests/unit/modules/mandala-embed-openrouter.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Phase 1 (2026-04-22) — OpenRouter embedding provider smoke tests.
+ *
+ * Pins the contract between `embedGoalForMandala` and the OpenRouter
+ * `/embeddings` endpoint: request shape, response parse, auth-missing,
+ * HTTP 401 / 429 / 5xx routes to MandalaSearchError codes, dim-mismatch
+ * guard, and provider-switch default (ollama keeps the legacy path
+ * untouched).
+ *
+ * Per CLAUDE.md Hard Rule on LLM API usage, this test must NEVER make
+ * a real OpenRouter call. The `src/config` module is statically mocked
+ * via a jest-controlled object so process.env (which may carry a real
+ * API key from a developer's .env) cannot leak into the call path; the
+ * global `fetch` is also spied on in every case so a real network call
+ * is impossible.
+ */
+
+interface TestConfig {
+  mandalaEmbed: {
+    provider: 'ollama' | 'openrouter';
+    openRouterBaseUrl: string;
+    openRouterModel: string;
+    openRouterDimension: number;
+  };
+  mandalaGen: {
+    url: string;
+    model: string;
+    embedModel: string;
+    embedDimension: number;
+  };
+  openrouter: {
+    apiKey: string | undefined;
+    model: string;
+  };
+}
+
+const mockConfig: TestConfig = {
+  mandalaEmbed: {
+    provider: 'openrouter',
+    openRouterBaseUrl: 'https://openrouter.test/api/v1',
+    openRouterModel: 'qwen/qwen3-embedding-8b',
+    openRouterDimension: 4096,
+  },
+  mandalaGen: {
+    url: 'http://ollama.local:11434',
+    model: 'mandala-gen',
+    embedModel: 'qwen3-embedding:8b',
+    embedDimension: 4096,
+  },
+  openrouter: {
+    apiKey: 'test-key',
+    model: 'qwen/qwen3-30b-a3b',
+  },
+};
+
+jest.mock('../../../src/config', () => {
+  // Lazy reference — jest.mock factory is evaluated before mockConfig is
+  // assigned, so we use a getter proxy that resolves to mockConfig at
+  // access time. Per-test mutations of mockConfig.mandalaEmbed.provider
+  // must reach the module under test.
+  return {
+    config: new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (prop === 'mandalaEmbed') return mockConfig.mandalaEmbed;
+          if (prop === 'mandalaGen') return mockConfig.mandalaGen;
+          if (prop === 'openrouter') return mockConfig.openrouter;
+          if (prop === 'database')
+            return { url: 'postgresql://test:test@localhost:5432/test', directUrl: undefined };
+          if (prop === 'app')
+            return {
+              env: 'test',
+              isDevelopment: false,
+              isProduction: false,
+              isTest: true,
+              logLevel: 'silent',
+            };
+          if (prop === 'supabase')
+            return { url: '', anonKey: '', serviceRoleKey: '', jwtSecret: '' };
+          return undefined;
+        },
+      }
+    ),
+  };
+});
+
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({}),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import { embedGoalForMandala } from '../../../src/modules/mandala/search';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  mockConfig.mandalaEmbed.provider = 'openrouter';
+  mockConfig.mandalaEmbed.openRouterBaseUrl = 'https://openrouter.test/api/v1';
+  mockConfig.mandalaEmbed.openRouterModel = 'qwen/qwen3-embedding-8b';
+  mockConfig.mandalaEmbed.openRouterDimension = 4096;
+  mockConfig.openrouter.apiKey = 'test-key';
+});
+
+describe('embedGoalForMandala (Phase 1 provider switch)', () => {
+  it('routes via Ollama when provider=ollama', async () => {
+    mockConfig.mandalaEmbed.provider = 'ollama';
+
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ embeddings: [Array(4096).fill(0.001)] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const vec = await embedGoalForMandala('test goal');
+    expect(vec).toHaveLength(4096);
+
+    const calledUrl = fetchSpy.mock.calls[0]?.[0];
+    expect(String(calledUrl)).toContain('ollama.local:11434');
+    expect(String(calledUrl)).toContain('/api/embed');
+  });
+
+  it('routes via OpenRouter when provider=openrouter', async () => {
+    mockConfig.mandalaEmbed.provider = 'openrouter';
+    mockConfig.openrouter.apiKey = 'test-key-opaque';
+
+    const vector = Array(4096).fill(0.01);
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: vector }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const vec = await embedGoalForMandala('단백질이 풍부한 식단 설계하기');
+    expect(vec).toHaveLength(4096);
+
+    const req = fetchSpy.mock.calls[0];
+    expect(String(req?.[0])).toBe('https://openrouter.test/api/v1/embeddings');
+
+    const init = req?.[1] as RequestInit | undefined;
+    expect(init?.method).toBe('POST');
+    const headers = init?.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer test-key-opaque');
+    expect(headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(String(init?.body));
+    expect(body.model).toBe('qwen/qwen3-embedding-8b');
+    expect(body.input).toBe('단백질이 풍부한 식단 설계하기');
+    expect(body.encoding_format).toBe('float');
+  });
+
+  it('throws SERVICE_UNAVAILABLE when OPENROUTER_API_KEY missing', async () => {
+    mockConfig.openrouter.apiKey = undefined;
+
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('network should not be reached'));
+
+    await expect(embedGoalForMandala('goal')).rejects.toMatchObject({
+      name: 'MandalaSearchError',
+      code: 'SERVICE_UNAVAILABLE',
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('maps HTTP 401 from OpenRouter to SERVICE_UNAVAILABLE', async () => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('unauthorized', { status: 401 }));
+
+    await expect(embedGoalForMandala('goal')).rejects.toMatchObject({
+      code: 'SERVICE_UNAVAILABLE',
+    });
+  });
+
+  it('maps HTTP 429 from OpenRouter to RATE_LIMITED', async () => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('rate limited', { status: 429 }));
+
+    await expect(embedGoalForMandala('goal')).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+    });
+  });
+
+  it('maps HTTP 5xx from OpenRouter to SERVICE_UNAVAILABLE', async () => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('upstream fail', { status: 502 }));
+
+    await expect(embedGoalForMandala('goal')).rejects.toMatchObject({
+      code: 'SERVICE_UNAVAILABLE',
+    });
+  });
+
+  it('throws DIMENSION_MISMATCH when returned vector dim differs from config', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ embedding: Array(1024).fill(0.1) }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await expect(embedGoalForMandala('goal')).rejects.toMatchObject({
+      code: 'DIMENSION_MISMATCH',
+    });
+  });
+
+  it('throws EMBED_FAILED on empty response data', async () => {
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await expect(embedGoalForMandala('goal')).rejects.toMatchObject({
+      code: 'EMBED_FAILED',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the redesign in `docs/design/wizard-service-redesign-2026-04-22.md`: remove mac-mini Ollama from the wizard critical path by routing `embedGoalForMandala` through OpenRouter behind a flag.

- **Flag default OFF** (`MANDALA_EMBED_PROVIDER=ollama`). Legacy path bit-identical. Rollback = env flip, no code revert.
- **Service-flow critical-path only** — `search-by-goal` + wizard template retrieval. R&D paths (`ensure-mandala-embeddings`, `iks-scorer embedBatch`) deferred to follow-up.
- **Dim preserved (4096)** — same family Qwen3-Embedding-8B, existing 18,009 `mandala_embeddings` rows reused as-is.

## Files

- `src/config/index.ts` — 4 new envs + `config.mandalaEmbed` block
- `src/modules/mandala/search.ts` — provider switch, extracted `embedViaOllama`, new `embedViaOpenRouter`, `RATE_LIMITED` error code
- `tests/unit/modules/mandala-embed-openrouter.test.ts` — 8 smoke tests (proxy-mocked config, no real network)
- `docs/design/wizard-service-redesign-2026-04-22.md` — full redesign doc

## Test plan

- [x] `tsc --noEmit` clean
- [x] New unit tests 8/8 pass
- [x] v3 regression 57/57 pass
- [x] Broader mandala test baseline parity (stash A/B: 72 pass / 16 pre-existing fail, no new regression)
- [ ] Post-merge: flip `MANDALA_EMBED_PROVIDER=openrouter` + `OPENROUTER_EMBED_MODEL=<exact OpenRouter id>` in `docker-compose.prod.yml` (separate ops PR)
- [ ] Post-deploy: verify per §7 Phase 1 gates — embed p95 < 500ms, `/search-by-goal` p95 < 1.5s, cosine mean ≥ 0.20 on known-relevant pairs

## Rollback

Set `MANDALA_EMBED_PROVIDER=ollama` in prod env and redeploy. No data migration.

## Prerequisites before activating in prod

1. `OPENROUTER_API_KEY` rotation (user-deferred per 2026-04-22 decision)
2. Exact OpenRouter model id string confirmation — current default `qwen/qwen3-embedding-8b` is best-guess; operator verifies at deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)