### PR TITLE
ops(prod): activate OpenRouter embedding provider — Phase 1 activation

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,6 +37,19 @@ services:
       # like "모닝루틴" pass the gate for goals containing "루틴으로".
       # Revert: delete this line and redeploy — code default takes over.
       - V3_CENTER_GATE_MODE=subword
+      # Wizard redesign Phase 1 activation (2026-04-22).
+      # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
+      # hosted Qwen3-Embedding-8B. Same model family and 4096d so the
+      # existing 18,009 mandala_embeddings rows are reused as-is. See
+      # docs/design/wizard-service-redesign-2026-04-22.md §7 Phase 1
+      # for the Phase 1 verification gate + rollback triggers.
+      # Revert: delete this line and redeploy — code default 'ollama'
+      # restores the pre-Phase-1 behavior bit-identically.
+      - MANDALA_EMBED_PROVIDER=openrouter
+      # OPENROUTER_EMBED_MODEL defaults to `qwen/qwen3-embedding-8b` in
+      # code. Uncomment + override here ONLY if the exact OpenRouter
+      # model id string differs (verify at https://openrouter.ai/models).
+      # - OPENROUTER_EMBED_MODEL=qwen/qwen3-embedding-8b
     volumes:
       - cache_data:/app/cache
       - logs_data:/app/logs


### PR DESCRIPTION
## Summary

Activates the Phase 1 provider switch landed in PR #440 by setting `MANDALA_EMBED_PROVIDER=openrouter` in `docker-compose.prod.yml`. Flips `embedGoalForMandala` from Mac-mini Ollama to OpenRouter's hosted Qwen3-Embedding-8B.

Pairs with PR #441 (PWA auto-update). Either order works; both are needed for the full user-visible improvement.

## Compatibility (no data migration)

- Same model family as Mac-mini `qwen3-embedding:8b`.
- 4096d preserved → existing **18,009** `mandala_embeddings` rows reusable as-is.
- Quantization differs (Ollama Q4_K_M vs OpenRouter provider default). Rankings preserved; absolute cosine values may drift <1%. Phase 1 rollback trigger catches pathological drift.

## ⚠️ Pre-merge verification required

- [ ] **Confirm the exact OpenRouter model id string** for Qwen3-Embedding-8B. Code default is `qwen/qwen3-embedding-8b`. If OpenRouter's actual slug differs, uncomment + set `OPENROUTER_EMBED_MODEL` in this file before merging. Check: https://openrouter.ai/models
- [ ] `OPENROUTER_API_KEY` rotation status (user previously deferred per this session 2026-04-22; risk accepted short-term)
- [ ] Ensure PR #440 (code) + PR #441 (PWA) merge order decisions

## Verification gate (post-deploy)

- [ ] `embedGoalForMandala` p95 < 500ms (was ~5s via Mac-mini Tailscale)
- [ ] `/search-by-goal` end-to-end p95 < 1.5s (was ~8s)
- [ ] No `/search-by-goal` 5xx rate increase over 24h
- [ ] Prod smoke: create 1 mandala, confirm `mandala_embeddings` still populates correctly

## Rollback

Delete the `MANDALA_EMBED_PROVIDER=openrouter` line and redeploy. Code default `ollama` restores pre-Phase-1 behavior bit-identically.

## References

- Phase 1 code: PR #440 (merged as `d87f0e3`)
- Phase 2 PWA: PR #441 (open, CI green)
- Design doc: `docs/design/wizard-service-redesign-2026-04-22.md` §7 Phase 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)