### PR TITLE
hotfix(wizard): flip streaming-view flag default to off — critical incident

### DIFF
--- a/frontend/src/pages/mandala-wizard/ui/MandalaWizardPage.tsx
+++ b/frontend/src/pages/mandala-wizard/ui/MandalaWizardPage.tsx
@@ -13,13 +13,18 @@ import { useMandalaQuota } from '@/features/mandala';
 import type { PendingMandalaInputs } from '@/stores/mandalaStore';
 
 /**
- * Feature flag: when set to a falsy string ('false'), the page mounts
- * the legacy `useWizard` flow (template + AI pick, 3-step UX).
- * Otherwise it mounts the streaming flow built on POST /wizard-stream.
- * Default = streaming ON for new users; ops flip this off in an env
- * if the streaming path regresses.
+ * Feature flag: legacy `useWizard` flow (template + AI pick, 3-step UX)
+ * is the default. Set `VITE_WIZARD_STREAMING_ENABLED=true` at build time
+ * to mount the streaming flow built on POST /wizard-stream.
+ *
+ * Default flipped 2026-04-22 after critical incident: the streaming view
+ * (MandalaWizardStreamView) is deliberately narrow — no stepper, no
+ * template-pick, no focus tags, no sidebar navigation. When activated via
+ * PR #441 (PWA autoUpdate), users got stuck on a wizard page with no way
+ * back to the dashboard. Until streaming view reaches feature parity with
+ * the legacy wizard, keep the default off.
  */
-const WIZARD_STREAMING_ENABLED = import.meta.env.VITE_WIZARD_STREAMING_ENABLED !== 'false';
+const WIZARD_STREAMING_ENABLED = import.meta.env.VITE_WIZARD_STREAMING_ENABLED === 'true';
 
 /**
  * Shape pushed by `fireCreateMandala` on failure via


### PR DESCRIPTION
## Critical incident

After PR #441 (PWA autoUpdate) activated the new bundle for end users, `MandalaWizardPage` began rendering the deliberately-minimal `MandalaWizardStreamView`. The streaming view is missing WizardStepper, template cards, focus tags, target level, and the sidebar — leaving users **stuck on the wizard page with no way back to the dashboard**. The auto-navigate on `mandala_saved` also pointed to `/mandalas/:id/edit`, which is not part of the legacy wizard UX.

Screenshots from user: trapped goal-only input + unexpected `/edit` + `/mandalas/:id` landings.

## Fix

Single-line flip of the feature-flag default in `MandalaWizardPage.tsx`:

```
const WIZARD_STREAMING_ENABLED = import.meta.env.VITE_WIZARD_STREAMING_ENABLED === 'true';
```

(was `!== 'false'`).

Legacy 3-step wizard + legacy `useWizard` hook renders by default. Stream view path is retained in code but unreachable until proper Phase 1 integration lands.

## Retained benefits (not lost by this hotfix)

- **Phase 1 OpenRouter embed speed gain** — legacy `search-by-goal` route already calls `embedGoalForMandala`, which was switched to OpenRouter in PR #442. Template search should still be faster than pre-migration.
- **Phase 2 PWA autoUpdate** — PR #441 remains in effect. Users auto-receive future bundle updates.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Vitest 263/263 pass
- [ ] Post-deploy smoke: `/mandalas/new` renders the full 3-step wizard (sidebar, stepper, template cards, focus tags, target level)
- [ ] Post-deploy smoke: a user who hits the page can navigate back to the dashboard

## Rollback

Revert this single commit. `feat/wizard-stream-p1-ui` PR #437 default returns.

## Follow-up (Phase 1 proper)

Per user direction: "기존 UX 는 이미 사용중인 경험이라 변경하면 안됨 — 위저드-대시보드 플로우의 전체 속도 개선을 위한 API 수정 로직만 사용하는거야."

Next phase: modify the `useWizard` hook internals to call `POST /wizard-stream` under the hood while every visible UI element + navigation destination stays bit-identical to today's legacy wizard. Dead code (`MandalaWizardStreamView`, `useWizardStream`) is removed in a cleanup PR after the integration lands.

Design doc update pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)