### PR TITLE
feat(wizard): swap /mandalas/generate with streaming preview — Phase 1

### DIFF
--- a/frontend/src/features/mandala-wizard/model/useWizard.ts
+++ b/frontend/src/features/mandala-wizard/model/useWizard.ts
@@ -250,13 +250,48 @@ export function useWizard() {
       }),
   });
 
-  // ─── Tier 2: LoRA AI generation (background, ~80s) ───
+  // ─── Tier 2: AI generation ───
+  //
+  // Phase 1 (2026-04-22): primary path is now `apiClient.streamWizardPreview`,
+  // which calls `POST /mandalas/wizard-stream` with `previewOnly: true`.
+  // Backend uses the structure-only path (~3s) instead of the one-shot
+  // Haiku (~21-28s), shaving ~20s off the wizard Step 2 wait.
+  //
+  // On any SSE / HTTP failure we fall back to the legacy `generateMandala`
+  // call so a user-visible regression never occurs — the slow path still
+  // works even if OpenRouter / wizard-stream is degraded.
+  //
+  // The legacy hook consumers ingest a `{ mandala, source }` shape. The
+  // mapping preserves it bit-identically; `actions` come back as `{}` from
+  // the preview path and the post-creation pipeline fills them in after
+  // `createMandalaWithData`.
   const generateMutation = useMutation({
-    mutationFn: (goal: string) =>
-      apiClient.generateMandala(goal, {
-        language: detectGoalLanguage(goal),
-        signal: goalAbortRef.current?.signal,
-      }),
+    mutationFn: async (goal: string) => {
+      const lang = detectGoalLanguage(goal);
+      try {
+        const res = await apiClient.streamWizardPreview(goal, {
+          language: lang,
+          focusTags: state.focusTags,
+          targetLevel: state.targetLevel,
+          signal: goalAbortRef.current?.signal,
+        });
+        if (import.meta.env.DEV) {
+          console.info('[wizard-preview]', {
+            source: res.source,
+            template_ms: res.template_duration_ms,
+            structure_ms: res.structure_duration_ms,
+          });
+        }
+        return { mandala: res.mandala, source: 'llm-fallback' as const };
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') throw err;
+        console.warn('[wizard-preview] fallback to legacy generate:', err);
+        return apiClient.generateMandala(goal, {
+          language: lang,
+          signal: goalAbortRef.current?.signal,
+        });
+      }
+    },
   });
 
   // ─── Delay detection — CP361 Issue #375 ───
@@ -293,7 +328,11 @@ export function useWizard() {
   //       Phased progress labels (see WizardStepGoal) keep the user
   //       oriented during the long wait.
   const SEARCH_DELAY_MS = 8000;
-  const GENERATE_DELAY_MS = 60000;
+  // Phase 1 (2026-04-22): structure-only preview path normally returns in
+  // ~3s. Lowered from 60000 so the soft-slow hint actually surfaces if the
+  // stream takes longer than expected (e.g. OpenRouter latency spike) but
+  // without firing on healthy responses. 10s gives ~3x headroom.
+  const GENERATE_DELAY_MS = 10000;
 
   const [isSearchSoftSlow, setIsSearchSoftSlow] = useState(false);
   const [isGenerateSoftSlow, setIsGenerateSoftSlow] = useState(false);

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -879,6 +879,161 @@ class ApiClient {
     return res.data;
   }
 
+  /**
+   * Phase 1 (2026-04-22) — wizard-stream preview.
+   *
+   * Calls `POST /api/v1/mandalas/wizard-stream` with `previewOnly: true`
+   * and streams the SSE response until `structure_ready` or `complete`
+   * fires. Returns a shape drop-in compatible with `generateMandala` so
+   * the legacy `useWizard` hook can replace its `generateMutation`
+   * mutationFn without any UI component change.
+   *
+   * Key differences vs `generateMandala`:
+   * - Backend uses `generateMandalaStructure` (structure-only ~3s) not
+   *   the one-shot Haiku path (~21-28s).
+   * - `actions` come back empty. The legacy wizard has its own "actions
+   *   arrive from post-creation pipeline after save" fallback, so empty
+   *   actions here are valid.
+   * - `source` is always `'wizard-stream'`.
+   *
+   * On SSE parse / HTTP / structure_error, throws — the legacy hook's
+   * existing error handling (soft-slow + failed flags) engages the
+   * same way it did with the one-shot path.
+   */
+  async streamWizardPreview(
+    goal: string,
+    options?: {
+      language?: 'ko' | 'en';
+      focusTags?: string[];
+      targetLevel?: string;
+      signal?: AbortSignal;
+      onTemplateFound?: (
+        templates: Array<{
+          mandala_id: string;
+          center_goal: string;
+          center_label: string | null;
+          domain: string | null;
+          language: string | null;
+          similarity: number;
+          sub_goals: string[];
+          sub_labels: string[];
+          sub_actions: Record<number, string[]>;
+        }>
+      ) => void;
+    }
+  ): Promise<{
+    mandala: {
+      center_goal: string;
+      center_label: string;
+      language: string;
+      domain: string;
+      sub_goals: string[];
+      sub_labels?: string[];
+      actions: Record<string, string[]>;
+    };
+    source: 'wizard-stream';
+    template_duration_ms?: number;
+    structure_duration_ms?: number;
+  }> {
+    const token = await this.getFreshToken();
+    if (!token) throw new Error('Not authenticated');
+
+    const res = await fetch(`${this.baseUrl}/api/v1/mandalas/wizard-stream`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+      },
+      body: JSON.stringify({
+        goal,
+        language: options?.language,
+        previewOnly: true,
+        focus_tags: options?.focusTags,
+        target_level: options?.targetLevel,
+      }),
+      signal: options?.signal,
+    });
+
+    if (!res.ok || !res.body) {
+      throw new Error(`wizard-stream HTTP ${res.status}`);
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let structure: Awaited<ReturnType<ApiClient['streamWizardPreview']>>['mandala'] | null = null;
+    let templateDurationMs: number | undefined;
+    let structureDurationMs: number | undefined;
+
+    const parseBlock = (block: string): { event: string; data: string } | null => {
+      const lines = block.split('\n');
+      let event = '';
+      let data = '';
+      for (const line of lines) {
+        if (line.startsWith('event: ')) event = line.slice(7).trim();
+        else if (line.startsWith('data: ')) data += line.slice(6);
+      }
+      if (!event) return null;
+      return { event, data };
+    };
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const blocks = buffer.split('\n\n');
+        buffer = blocks.pop() ?? '';
+        for (const block of blocks) {
+          if (!block || block.startsWith(':')) continue;
+          const parsed = parseBlock(block);
+          if (!parsed) continue;
+          const payload = parsed.data ? JSON.parse(parsed.data) : {};
+          if (parsed.event === 'template_found') {
+            templateDurationMs = payload.duration_ms;
+            if (Array.isArray(payload.templates) && options?.onTemplateFound) {
+              options.onTemplateFound(payload.templates);
+            }
+          } else if (parsed.event === 'structure_ready') {
+            structureDurationMs = payload.duration_ms;
+            structure = payload.structure;
+          } else if (
+            parsed.event === 'error' ||
+            parsed.event === 'structure_error' ||
+            parsed.event === 'save_error'
+          ) {
+            throw new Error(payload.message || `wizard-stream ${parsed.event}`);
+          } else if (parsed.event === 'complete') {
+            // terminal — exit outer loop
+            return finalize();
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    return finalize();
+
+    function finalize(): {
+      mandala: NonNullable<typeof structure>;
+      source: 'wizard-stream';
+      template_duration_ms?: number;
+      structure_duration_ms?: number;
+    } {
+      if (!structure) {
+        throw new Error('wizard-stream closed without structure_ready');
+      }
+      return {
+        mandala: structure,
+        source: 'wizard-stream',
+        template_duration_ms: templateDurationMs,
+        structure_duration_ms: structureDurationMs,
+      };
+    }
+  }
+
   async searchMandalasByGoal(
     goal: string,
     options?: { limit?: number; threshold?: number; language?: string; signal?: AbortSignal }

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -648,7 +648,13 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
    *   P1:      frontend useWizardStream hook + flag-gated UI.
    */
   fastify.post<{
-    Body: { goal: string; language?: 'ko' | 'en' };
+    Body: {
+      goal: string;
+      language?: 'ko' | 'en';
+      previewOnly?: boolean;
+      focus_tags?: string[];
+      target_level?: string;
+    };
   }>(
     '/wizard-stream',
     {
@@ -659,7 +665,13 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       const userId = getUserId(request, reply);
       if (!userId) return;
 
-      const { goal, language = 'ko' } = request.body;
+      const {
+        goal,
+        language = 'ko',
+        previewOnly = false,
+        focus_tags: focusTags,
+        target_level: targetLevel,
+      } = request.body;
       if (!goal || typeof goal !== 'string' || goal.trim().length === 0) {
         return reply.code(400).send({
           status: 400,
@@ -717,6 +729,8 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       const structurePromise = generateMandalaStructure({
         goal: trimmedGoal,
         language: lang,
+        focusTags,
+        targetLevel,
       })
         .then((structure) => {
           write('structure_ready', {
@@ -741,6 +755,20 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
 
       try {
         const [_templates, structure] = await Promise.all([templatePromise, structurePromise]);
+
+        // Phase 1 preview mode (2026-04-22): the legacy `useWizard` hook
+        // calls this route with `previewOnly: true` to replace the slow
+        // one-shot Haiku `/mandalas/generate` call with the faster
+        // structure-only path. When preview mode is active we emit the
+        // template + structure events (already done above via the
+        // parallel promises) and short-circuit before the save + post-
+        // creation pipeline. The user's "완료" click in the legacy
+        // wizard Step 3 still drives the real save via the existing
+        // `createMandalaWithData` flow — no changes to that path.
+        if (previewOnly) {
+          write('complete', { duration_ms: Date.now() - t0, previewOnly: true });
+          return;
+        }
 
         if (structure && !closed) {
           // Build levels from the structure: 1 root + 8 sub-goals.

--- a/src/modules/mandala/generator.ts
+++ b/src/modules/mandala/generator.ts
@@ -34,6 +34,8 @@ export interface MandalaGenerateInput {
   goal: string;
   domain?: string;
   language?: 'ko' | 'en';
+  focusTags?: string[];
+  targetLevel?: string;
 }
 
 export interface GeneratedMandala {
@@ -530,6 +532,8 @@ export async function generateMandalaStructure(
     domain,
     language: lang,
     reference,
+    focusTags: input.focusTags,
+    targetLevel: input.targetLevel,
   });
 
   const provider = new OpenRouterGenerationProvider(STRUCTURE_MODEL);


### PR DESCRIPTION
## Summary

Replaces the 21-28s one-shot Haiku call inside `useWizard.generateMutation` with `POST /mandalas/wizard-stream` in `previewOnly: true` mode. **UI/UX 변경 0** — same Stepper, same template picks, same focus tags + target level, same Step 3 confirmation, same `navigate('/')` on success. Only the internal API call swaps.

Per user direction 2026-04-22:
> "기존 UX 는 이미 사용중인 경험이라 변경하면 안됨 — 위저드-대시보드 플로우의 전체 속도 개선을 위한 API 수정 로직만 사용하는거야."

## Expected user-visible effect

- Wizard Step 2 "AI 생성" latency: **~21-28s → ~3s** (structure-only replaces Haiku one-shot).
- The 64-action generation continues post-creation (unchanged by this PR).
- All other wizard steps / navigation / template cloning behave bit-identically.

## Changes

### Backend
- `src/modules/mandala/generator.ts` — `MandalaGenerateInput` accepts optional `focusTags` + `targetLevel`; `generateMandalaStructure` forwards to `buildStructurePrompt`.
- `src/api/routes/mandalas.ts` — `/wizard-stream` body extended with `previewOnly`, `focus_tags`, `target_level`. When `previewOnly === true`, emits `template_found` + `structure_ready` + `complete` and returns early (no save, no post-creation, no card subscribe, no actions). Non-preview path is byte-identical to pre-PR behavior.

### Frontend
- `frontend/src/shared/lib/api-client.ts` — new `streamWizardPreview()` method using `fetch` + `ReadableStream` + inline SSE parser. Returns `{mandala, source}` drop-in compatible with `generateMandala`. Throws on auth/HTTP/`structure_error`.
- `frontend/src/features/mandala-wizard/model/useWizard.ts` —
  - `generateMutation.mutationFn` tries `streamWizardPreview` first, graceful fallback to legacy `apiClient.generateMandala` on any non-abort error. Fallback preserves UX if OpenRouter / wizard-stream degrades.
  - `GENERATE_DELAY_MS` lowered 60s → 10s to match the ~3s latency floor.

## Verification

- [x] Backend `tsc --noEmit` clean
- [x] Frontend `tsc --noEmit` clean
- [x] Frontend vitest 263/263 pass
- [x] Backend v3 + wizard-stream smoke 57/57 pass (3 skipped keep skipping; no regression)
- [ ] Post-deploy: one real wizard run, confirm user-visible Step 2 latency drops to ~3-5s
- [ ] Post-deploy: confirm graceful fallback triggers if wizard-stream fails (forced HTTP 500 smoke)
- [ ] Post-deploy: `[wizard-preview]` console log visible in DEV confirms stream path active

## Rollback

- Revert this commit. All four files revert cleanly. No schema change, no data migration.

## Out of scope (explicit non-goals)

- No UI component edits.
- No change to `fireCreateMandala` / Step 3 save (`createMandalaWithData`) / navigate-to-`/` flow.
- No change to template clone path or blank mandala path.
- Post-creation card pipeline latency is a separate phase.
- `MandalaWizardStreamView` / `useWizardStream` remain dead code — cleanup in a follow-up PR.

Design doc: `docs/design/wizard-service-redesign-2026-04-22.md` §7 Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)