### PR TITLE
hotfix(wizard): allow empty actions + fill via post-creation — Phase 1 bug

### DIFF
--- a/frontend/src/features/mandala-wizard/model/useWizard.ts
+++ b/frontend/src/features/mandala-wizard/model/useWizard.ts
@@ -810,10 +810,19 @@ export function useWizard() {
       subDetails[idx] = actions;
       totalActions += actions.length;
     });
-    // Validate: AI-generated mandala MUST have all 64 actions (one-shot generation)
+    // Phase 1 (2026-04-22): wizard-stream previewOnly returns structure
+    // without actions (empty `{}`) so the user sees Step 2 in ~3s instead
+    // of ~21-28s. The 64-action validation that used to throw here was a
+    // one-shot-Haiku-era safety net — with the split path, actions are
+    // filled in by the post-creation pipeline (see
+    // `src/modules/mandala/fill-missing-actions.ts`). Empty action arrays
+    // are therefore a valid in-flight state; downstream consumers
+    // (`fireCreateMandala` → `createMandalaWithData` → post-creation) tolerate them.
+    // Kept a debug log to surface genuine regressions (e.g. zero actions
+    // when source === 'lora' which still does one-shot).
     if (totalActions < 64) {
-      throw new Error(
-        `AI generated mandala is incomplete: ${totalActions}/64 actions. Please retry.`
+      console.debug(
+        `[useWizard] preview actions: ${totalActions}/64 — fill runs in post-creation pipeline`
       );
     }
     const template: WizardTemplate = {
@@ -906,8 +915,10 @@ export function useWizard() {
         totalActions += actions.length;
       });
       if (totalActions < 64) {
-        throw new Error(
-          `AI generated mandala is incomplete: ${totalActions}/64 actions. Please retry.`
+        // Phase 1 (2026-04-22): same note as selectGeneratedMandala.
+        // Empty actions are valid in-flight; post-creation pipeline fills.
+        console.debug(
+          `[useWizard] submitFromWizard: ${totalActions}/64 — fill runs in post-creation pipeline`
         );
       }
       const template: WizardTemplate = {

--- a/src/modules/mandala/fill-missing-actions.ts
+++ b/src/modules/mandala/fill-missing-actions.ts
@@ -1,0 +1,128 @@
+/**
+ * fill-missing-actions.ts — Phase 1 (2026-04-22)
+ *
+ * Runs in parallel with the main post-creation pipeline for mandalas
+ * that were saved with empty `subjects` on their sub-goal levels. This
+ * is the expected state after the wizard-stream previewOnly path (~3s
+ * structure-only) swap — actions are no longer shipped inside the
+ * wizard response, so they are generated here asynchronously and
+ * written back to `user_mandala_levels.subjects` when done.
+ *
+ * Contract:
+ *  - Fire-and-forget. Never throws. All errors logged + swallowed.
+ *  - Idempotent. Re-running on a fully-filled mandala is a no-op.
+ *  - Tolerant. Partial progress is fine — each depth=1 level updates
+ *    independently. A crash mid-batch leaves partially-filled rows
+ *    rather than a half-committed transaction.
+ *  - Non-blocking on the pipeline. Starts alongside `executePipelineRun`
+ *    rather than as a step, because the wizard → card path doesn't
+ *    depend on actions existing.
+ */
+
+import { getPrismaClient } from '@/modules/database';
+import { logger } from '@/utils/logger';
+import { generateMandalaActions } from './generator';
+
+const log = logger.child({ module: 'fill-missing-actions' });
+
+const EXPECTED_ACTIONS_PER_CELL = 8;
+const MIN_ACTIONS_TO_CONSIDER_FILLED = 8;
+
+/**
+ * Read depth=1 rows, detect ones with empty / partial subjects, call
+ * `generateMandalaActions`, update each row's `subjects` in place.
+ *
+ * Returns a small summary for observability. Never throws.
+ */
+export async function fillMissingActionsIfNeeded(mandalaId: string): Promise<{
+  ok: boolean;
+  action: 'skipped-full' | 'filled' | 'skipped-not-found' | 'failed';
+  cellsFilled?: number;
+  reason?: string;
+}> {
+  const db = getPrismaClient();
+
+  const mandala = await db.user_mandalas.findUnique({
+    where: { id: mandalaId },
+    select: { id: true, language: true, focus_tags: true, target_level: true },
+  });
+  if (!mandala) {
+    log.warn(`fill-missing-actions: mandala not found: ${mandalaId}`);
+    return { ok: false, action: 'skipped-not-found' };
+  }
+
+  const levels = await db.user_mandala_levels.findMany({
+    where: { mandala_id: mandalaId, depth: 1 },
+    orderBy: { position: 'asc' },
+    select: { id: true, center_goal: true, subjects: true, position: true },
+  });
+
+  const rootLevel = await db.user_mandala_levels.findFirst({
+    where: { mandala_id: mandalaId, depth: 0 },
+    select: { center_goal: true },
+  });
+  if (!rootLevel) {
+    log.warn(`fill-missing-actions: root level missing for mandala=${mandalaId}`);
+    return { ok: false, action: 'skipped-not-found' };
+  }
+
+  const needsFill = levels.filter(
+    (lvl) => !Array.isArray(lvl.subjects) || lvl.subjects.length < MIN_ACTIONS_TO_CONSIDER_FILLED
+  );
+  if (needsFill.length === 0) {
+    return { ok: true, action: 'skipped-full' };
+  }
+
+  const subGoals = levels.map((l) => l.center_goal ?? '');
+  const language = (mandala.language as 'ko' | 'en' | null) ?? 'ko';
+  const focusTags = Array.isArray(mandala.focus_tags) ? mandala.focus_tags : undefined;
+  const targetLevel = mandala.target_level ?? undefined;
+
+  log.info(`[${mandalaId}] generating actions for ${needsFill.length}/${levels.length} cells`);
+
+  let actions: Record<string, string[]>;
+  try {
+    actions = await generateMandalaActions(
+      subGoals,
+      language,
+      rootLevel.center_goal ?? '',
+      focusTags,
+      targetLevel
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`[${mandalaId}] generateMandalaActions threw: ${msg}`);
+    return { ok: false, action: 'failed', reason: msg };
+  }
+
+  // Update each depth=1 level's subjects. Key layout from the prompt is
+  // `sub_goal_1`..`sub_goal_8`; fall back to index-keyed lookups per the
+  // tolerant reader in `useWizard.selectGeneratedMandala`.
+  let cellsFilled = 0;
+  for (const level of levels) {
+    const idx = level.position;
+    const keyA = `sub_goal_${idx + 1}`;
+    const keyB = String(idx);
+    const keyC = subGoals[idx] ?? '';
+    const next = actions[keyA] ?? actions[keyB] ?? actions[keyC] ?? null;
+    if (!Array.isArray(next) || next.length === 0) continue;
+    if (Array.isArray(level.subjects) && level.subjects.length >= MIN_ACTIONS_TO_CONSIDER_FILLED) {
+      // Already filled. Don't overwrite user edits.
+      continue;
+    }
+    try {
+      await db.user_mandala_levels.update({
+        where: { id: level.id },
+        data: { subjects: next.slice(0, EXPECTED_ACTIONS_PER_CELL) },
+      });
+      cellsFilled += 1;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(`[${mandalaId}] cell ${idx} update failed: ${msg}`);
+      // Continue with the next cell — partial fill is fine.
+    }
+  }
+
+  log.info(`[${mandalaId}] actions fill complete: ${cellsFilled}/${levels.length} cells`);
+  return { ok: true, action: 'filled', cellsFilled };
+}

--- a/src/modules/mandala/mandala-post-creation.ts
+++ b/src/modules/mandala/mandala-post-creation.ts
@@ -36,6 +36,13 @@ export function triggerMandalaPostCreationAsync(
   trigger: string = 'wizard'
 ): void {
   setImmediate(() => {
+    // Phase 1 (2026-04-22): run the main pipeline (embeddings → discover →
+    // auto-add) in parallel with missing-actions fill. The two tracks are
+    // independent — actions populate `user_mandala_levels.subjects` while
+    // the pipeline drives `recommendation_cache`. Both fire-and-forget;
+    // failures in one do not stall the other. User's "최고의 카드 빠르게"
+    // priority puts the pipeline on the faster path (cards) while actions
+    // fill in progressively for the edit view.
     (async () => {
       const runId = await createPipelineRun(mandalaId, userId, trigger);
       log.info(`Pipeline run created: ${runId} mandala=${mandalaId} trigger=${trigger}`);
@@ -43,6 +50,24 @@ export function triggerMandalaPostCreationAsync(
     })().catch((err) => {
       log.warn(
         `post-creation pipeline crashed for user=${userId} mandala=${mandalaId}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    });
+
+    (async () => {
+      // Lazy require so that test-time module graphs that do not need the
+      // generator / OpenRouter imports (e.g. `mandala-post-creation.test.ts`
+      // which mocks only a narrow surface) are not forced to resolve them.
+      const { fillMissingActionsIfNeeded } = await import('./fill-missing-actions');
+      const result = await fillMissingActionsIfNeeded(mandalaId);
+      log.info(
+        `actions-fill result for mandala=${mandalaId}: ${JSON.stringify({
+          action: result.action,
+          cellsFilled: result.cellsFilled ?? 0,
+        })}`
+      );
+    })().catch((err) => {
+      log.warn(
+        `fill-missing-actions crashed for user=${userId} mandala=${mandalaId}: ${err instanceof Error ? err.message : String(err)}`
       );
     });
   });


### PR DESCRIPTION
## Critical bug

User-reported after PR #444 deploy: clicking **AI 맞춤** in the wizard throws `AI generated mandala is incomplete: 0/64 actions. Please retry.` and the user cannot proceed to the dashboard.

Root cause: `streamWizardPreview` returns structure-only `GeneratedMandala` with `actions: {}`. Two call sites in `useWizard.ts` validated `totalActions < 64` as a hard error — a leftover contract from the one-shot Haiku era.

## Fix

Aligned with user direction: "사용자에게 중요한건 카드일것으로 보임 — 대시보드 카드 생성 시점에 병렬로 처리해서 반영하면 속도개선 효과를 가져갈수 있을듯."

- **Frontend** (`useWizard.ts:814 + 917`): `< 64` throw → debug log + fall through. Empty actions are now a valid in-flight state.
- **Backend new module** (`src/modules/mandala/fill-missing-actions.ts`): reads depth=1 rows, detects cells with `subjects.length < 8`, calls existing `generateMandalaActions`, updates each level independently. Idempotent. Tolerant of partial crashes.
- **`mandala-post-creation.ts`**: fires the filler **in parallel** with the existing pipeline (fire-and-forget, independent, failure-isolated). Lazy-import so the existing narrow mocks in `mandala-post-creation.test.ts` keep working.

## UX impact

- Step 2 preview hover: `WizardStepPreview.tsx` legacy / dead (user confirmed unused in current UI).
- Edit page may render empty cells for ~10-15s while actions generate. Cards (user priority) continue unaffected.

## Test

- [x] Backend `tsc` clean
- [x] Frontend `tsc` clean
- [x] Frontend vitest 263/263 pass
- [x] Backend `mandala-post-creation.test.ts`: 13 fail / 3 pass — baseline parity (stash A/B confirmed; all failures pre-existing, not caused by this hotfix)

## Rollback

Single-commit revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)