### PR TITLE
feat(video-discover-v3): Phase 3 semantic center gate + broad-queries env (CP416 TIER 1)

### DIFF
--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -256,7 +256,7 @@ export function CardList({
 
   console.log('[DEBUG-CARDLIST]', { isLoading, cardsLen: cards.length, cachedCardCount });
   if (isLoading && cards.length === 0) {
-    return <CardSkeleton count={cachedCardCount || 6} />;
+    return <CardSkeleton count={6} />;
   }
 
   if (cards.length === 0) {

--- a/src/skills/plugins/video-discover/v2/keyword-builder.ts
+++ b/src/skills/plugins/video-discover/v2/keyword-builder.ts
@@ -61,6 +61,13 @@ export interface KeywordBuilderOpts {
     prompt: string,
     options?: { temperature?: number; maxTokens?: number; format?: 'json' }
   ) => Promise<string>;
+  /**
+   * Runtime cap on the number of queries emitted. Clamped to
+   * `[1, MAX_QUERIES]`. Used by v3 to toggle "broad queries" mode
+   * (3-5 queries) via `V3_MAX_QUERIES` once the semantic gate covers
+   * recall. Defaults to `MAX_QUERIES` (20) for backward compat.
+   */
+  maxQueries?: number;
 }
 
 export type QuerySource = 'core' | 'llm' | 'focus' | 'level' | 'subgoal';
@@ -113,10 +120,10 @@ export async function buildSearchQueries(
   if (!center) return [];
 
   const candidates: SearchQuery[] = [
-    ...buildRuleBasedQueriesSync(input),
+    ...buildRuleBasedQueriesSync(input, opts.maxQueries),
     ...(await runLLMQueries(input, opts)),
   ];
-  return dedupeAndCap(candidates);
+  return dedupeAndCap(candidates, opts.maxQueries);
 }
 
 /**
@@ -124,13 +131,16 @@ export async function buildSearchQueries(
  * executor to start YouTube search immediately without waiting for the LLM.
  * Always returns ≥1 entry as long as centerGoal is non-empty.
  */
-export function buildRuleBasedQueriesSync(input: KeywordBuilderInput): SearchQuery[] {
+export function buildRuleBasedQueriesSync(
+  input: KeywordBuilderInput,
+  maxQueries?: number
+): SearchQuery[] {
   const center = input.centerGoal.trim();
   if (!center) return [];
   const out: SearchQuery[] = [];
   out.push({ query: clip(extractCoreKeyphrase(center, input.language)), source: 'core' });
   for (const q of buildRuleBasedQueries(input, center)) out.push(q);
-  return dedupeAndCap(out);
+  return dedupeAndCap(out, maxQueries);
 }
 
 /**
@@ -172,7 +182,8 @@ export async function runLLMQueries(
       format: 'json',
     });
     const queries = parseQueriesResponse(raw) ?? [];
-    return queries.slice(0, MAX_QUERIES).map((q) => ({ query: clip(q), source: 'llm' as const }));
+    const cap = resolveMaxQueries(opts.maxQueries);
+    return queries.slice(0, cap).map((q) => ({ query: clip(q), source: 'llm' as const }));
   } catch (err) {
     log.warn(
       `C+ LLM query failed: ${err instanceof Error ? err.message : String(err)} — falling back to rule-based`
@@ -318,7 +329,8 @@ function pickDistinctiveSubGoalsWithIndex(
   return cleaned.slice(0, n);
 }
 
-function dedupeAndCap(candidates: SearchQuery[]): SearchQuery[] {
+function dedupeAndCap(candidates: SearchQuery[], maxQueries?: number): SearchQuery[] {
+  const cap = resolveMaxQueries(maxQueries);
   const seen = new Set<string>();
   const out: SearchQuery[] = [];
   for (const c of candidates) {
@@ -326,7 +338,12 @@ function dedupeAndCap(candidates: SearchQuery[]): SearchQuery[] {
     if (!norm || seen.has(norm)) continue;
     seen.add(norm);
     out.push(c);
-    if (out.length >= MAX_QUERIES) break;
+    if (out.length >= cap) break;
   }
   return out;
+}
+
+function resolveMaxQueries(requested: number | undefined): number {
+  if (!Number.isFinite(requested) || !requested || requested <= 0) return MAX_QUERIES;
+  return Math.min(Math.floor(requested), MAX_QUERIES);
 }

--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -2,6 +2,7 @@ import { DEFAULT_SEMANTIC_ALPHA, DEFAULT_SEMANTIC_BETA } from '@/modules/video-d
 
 import {
   DEFAULT_CENTER_GATE_MODE,
+  DEFAULT_MAX_QUERIES,
   DEFAULT_PUBLISHED_AFTER_DAYS,
   DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
   loadV3Config,
@@ -21,6 +22,7 @@ describe('loadV3Config', () => {
       enableWhitelistGate: false,
       youtubeSearchTimeoutMs: DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
       centerGateMode: DEFAULT_CENTER_GATE_MODE,
+      maxQueries: DEFAULT_MAX_QUERIES,
     });
   });
 
@@ -85,6 +87,7 @@ describe('loadV3Config', () => {
       enableWhitelistGate: false,
       youtubeSearchTimeoutMs: DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
       centerGateMode: DEFAULT_CENTER_GATE_MODE,
+      maxQueries: DEFAULT_MAX_QUERIES,
     });
   });
 
@@ -128,11 +131,13 @@ describe('loadV3Config', () => {
     expect(loadV3Config({ V3_SEMANTIC_BETA: 'NaN' }).semanticBeta).toBe(DEFAULT_SEMANTIC_BETA);
   });
 
-  test('V3_CENTER_GATE_MODE accepts the three enum values, case-insensitive + trimmed', () => {
+  test('V3_CENTER_GATE_MODE accepts the four enum values, case-insensitive + trimmed', () => {
     expect(loadV3Config({ V3_CENTER_GATE_MODE: 'substring' }).centerGateMode).toBe('substring');
     expect(loadV3Config({ V3_CENTER_GATE_MODE: 'subword' }).centerGateMode).toBe('subword');
     expect(loadV3Config({ V3_CENTER_GATE_MODE: 'off' }).centerGateMode).toBe('off');
+    expect(loadV3Config({ V3_CENTER_GATE_MODE: 'semantic' }).centerGateMode).toBe('semantic');
     expect(loadV3Config({ V3_CENTER_GATE_MODE: '  SUBWORD  ' }).centerGateMode).toBe('subword');
+    expect(loadV3Config({ V3_CENTER_GATE_MODE: ' Semantic ' }).centerGateMode).toBe('semantic');
   });
 
   test('invalid V3_CENTER_GATE_MODE → baseline default (substring)', () => {
@@ -140,5 +145,18 @@ describe('loadV3Config', () => {
       DEFAULT_CENTER_GATE_MODE
     );
     expect(loadV3Config({ V3_CENTER_GATE_MODE: '' }).centerGateMode).toBe(DEFAULT_CENTER_GATE_MODE);
+  });
+
+  test('V3_MAX_QUERIES parses positive integer (broad-queries mode)', () => {
+    expect(loadV3Config({ V3_MAX_QUERIES: '5' }).maxQueries).toBe(5);
+    expect(loadV3Config({ V3_MAX_QUERIES: '1' }).maxQueries).toBe(1);
+    expect(loadV3Config({ V3_MAX_QUERIES: '20' }).maxQueries).toBe(20);
+  });
+
+  test('invalid V3_MAX_QUERIES → baseline (entire config falls back)', () => {
+    expect(loadV3Config({ V3_MAX_QUERIES: '0' }).maxQueries).toBe(DEFAULT_MAX_QUERIES);
+    expect(loadV3Config({ V3_MAX_QUERIES: '-3' }).maxQueries).toBe(DEFAULT_MAX_QUERIES);
+    expect(loadV3Config({ V3_MAX_QUERIES: 'garbage' }).maxQueries).toBe(DEFAULT_MAX_QUERIES);
+    expect(loadV3Config({ V3_MAX_QUERIES: '' }).maxQueries).toBe(DEFAULT_MAX_QUERIES);
   });
 });

--- a/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
@@ -9,8 +9,10 @@ import {
   applyMandalaFilterWithStats,
   buildScoreWeights,
   computeRecencyScore,
+  cosineSimilarity,
   DEFAULT_RECENCY_HALF_LIFE_MONTHS,
   MIN_SUB_RELEVANCE,
+  SEMANTIC_MIN_COSINE,
   type FilterCandidate,
 } from '../mandala-filter';
 
@@ -496,5 +498,171 @@ describe('applyMandalaFilter — centerGateMode', () => {
     // the 0.3 floor. If this starts passing, SUBWORD_MIN_CENTER_MATCH
     // has drifted too low and noise will leak.
     expect(stats.droppedByCenterGate).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CenterGateMode — semantic (Phase 3, CP416)
+// ---------------------------------------------------------------------------
+
+describe('cosineSimilarity helper', () => {
+  test('identical vectors → 1.0', () => {
+    expect(cosineSimilarity([1, 0, 0], [1, 0, 0])).toBe(1);
+  });
+
+  test('orthogonal vectors → 0', () => {
+    expect(cosineSimilarity([1, 0, 0], [0, 1, 0])).toBe(0);
+  });
+
+  test('negative dot clamps to 0 (opposite direction)', () => {
+    expect(cosineSimilarity([1, 0], [-1, 0])).toBe(0);
+  });
+
+  test('length mismatch → 0 (safety)', () => {
+    expect(cosineSimilarity([1, 2, 3], [1, 2])).toBe(0);
+  });
+
+  test('zero-magnitude vector → 0 (avoid NaN)', () => {
+    expect(cosineSimilarity([0, 0, 0], [1, 2, 3])).toBe(0);
+  });
+
+  test('partial overlap produces value in (0, 1)', () => {
+    const s = cosineSimilarity([1, 1, 0], [1, 0, 0]);
+    expect(s).toBeGreaterThan(0);
+    expect(s).toBeLessThan(1);
+  });
+});
+
+describe('applyMandalaFilter — centerGateMode: "semantic"', () => {
+  const input = {
+    centerGoal: '1달 일일 루틴으로 전문가되기',
+    subGoals: [
+      '전문 분야 선정 및 학습 계획 수립',
+      '매일 집중 학습 시간 확보 및 루틴화',
+      '실무 프로젝트 진행 및 포트폴리오 구축',
+      '전문 커뮤니티 참여 및 네트워킹',
+      '월간 집중 전문화',
+      '지식 체계화 및 아웃풋 생산',
+      '피드백 수집 및 개선 사이클',
+      '일일 진도 추적 및 동기 유지',
+    ],
+    language: 'ko' as const,
+  };
+
+  // Synthetic 8-dim vectors: semantic neighborhood modeled as near-axis
+  // alignment. Keeps tests hermetic (no Ollama) while exercising the
+  // threshold / fallback / gate-drop branches.
+  const centerVec = [1, 0.2, 0, 0, 0, 0, 0, 0];
+  const paraphraseVec = [0.9, 0.3, 0, 0, 0, 0, 0, 0]; // cosine ≈ 0.99
+  const unrelatedVec = [0, 0, 1, 0, 0, 0, 0, 0]; // cosine = 0
+  const borderlineVec = [0.3, 0.05, 0.95, 0, 0, 0, 0, 0]; // cosine ≈ 0.31 (below 0.35 default)
+
+  const paraphrase = cand('p1', '하루 습관 형성하는 법');
+  const unrelated = cand('u1', 'iPhone 16 프로 리뷰');
+  const borderline = cand('b1', '정보처리기능사 필기 22강');
+
+  test('paraphrase passes gate (cosine ≈ 0.99 > 0.35)', () => {
+    const { stats } = applyMandalaFilterWithStats([paraphrase], {
+      ...input,
+      centerGateMode: 'semantic',
+      centerEmbedding: centerVec,
+      candidateEmbeddings: new Map([['p1', paraphraseVec]]),
+    });
+    expect(stats.droppedByCenterGate).toBe(0);
+    expect(stats.centerGateMode).toBe('semantic');
+  });
+
+  test('unrelated dropped at gate (cosine = 0)', () => {
+    const { stats } = applyMandalaFilterWithStats([unrelated], {
+      ...input,
+      centerGateMode: 'semantic',
+      centerEmbedding: centerVec,
+      candidateEmbeddings: new Map([['u1', unrelatedVec]]),
+    });
+    expect(stats.droppedByCenterGate).toBe(1);
+  });
+
+  test('borderline below SEMANTIC_MIN_COSINE (0.35) dropped', () => {
+    const { stats } = applyMandalaFilterWithStats([borderline], {
+      ...input,
+      centerGateMode: 'semantic',
+      centerEmbedding: centerVec,
+      candidateEmbeddings: new Map([['b1', borderlineVec]]),
+    });
+    // Keep the test pinned to the constant so threshold drift is visible.
+    expect(SEMANTIC_MIN_COSINE).toBeCloseTo(0.35, 2);
+    expect(stats.droppedByCenterGate).toBe(1);
+  });
+
+  test('semanticMinCosine override admits borderline candidate', () => {
+    const { stats } = applyMandalaFilterWithStats([borderline], {
+      ...input,
+      centerGateMode: 'semantic',
+      centerEmbedding: centerVec,
+      candidateEmbeddings: new Map([['b1', borderlineVec]]),
+      semanticMinCosine: 0.1,
+    });
+    expect(stats.droppedByCenterGate).toBe(0);
+  });
+
+  test('missing centerEmbedding → safety fallback to substring mode', () => {
+    const { stats } = applyMandalaFilterWithStats([paraphrase], {
+      ...input,
+      centerGateMode: 'semantic',
+      // centerEmbedding intentionally omitted
+      candidateEmbeddings: new Map([['p1', paraphraseVec]]),
+    });
+    // Mode reported should reflect the effective mode, not the requested one.
+    expect(stats.centerGateMode).toBe('substring');
+  });
+
+  test('missing per-candidate embedding → dropped at gate (0 score, not matched)', () => {
+    const { stats } = applyMandalaFilterWithStats([paraphrase, unrelated], {
+      ...input,
+      centerGateMode: 'semantic',
+      centerEmbedding: centerVec,
+      // only paraphrase has a vector; unrelated has none
+      candidateEmbeddings: new Map([['p1', paraphraseVec]]),
+    });
+    // unrelated has no vector → centerScore stays 0 → dropped at gate.
+    // paraphrase still passes gate 1. Gate 2 (jaccard on sub-goals) may
+    // still drop it downstream — that's independent of the gate-1 branch
+    // we're testing here.
+    expect(stats.droppedByCenterGate).toBeGreaterThanOrEqual(1);
+  });
+
+  test('EN fixture: paraphrase admitted, off-domain dropped', () => {
+    const enInput = {
+      centerGoal: 'Master React hooks in 30 days',
+      subGoals: [
+        'useState patterns',
+        'useEffect cleanup',
+        'useMemo cost analysis',
+        'useCallback stability',
+        'custom hooks design',
+        'context optimization',
+        'concurrent rendering',
+        'testing hooks',
+      ],
+      language: 'en' as const,
+    };
+    const enCenterVec = [1, 0.2, 0, 0];
+    const enParaphraseVec = [0.88, 0.4, 0, 0]; // cosine > 0.35
+    const enNoiseVec = [0, 0, 1, 0];
+
+    const { stats } = applyMandalaFilterWithStats(
+      [cand('e1', 'Learn React hooks fast'), cand('e2', 'Latest iPhone 16 Pro review')],
+      {
+        ...enInput,
+        centerGateMode: 'semantic',
+        centerEmbedding: enCenterVec,
+        candidateEmbeddings: new Map<string, number[]>([
+          ['e1', enParaphraseVec],
+          ['e2', enNoiseVec],
+        ]),
+      }
+    );
+    expect(stats.centerGateMode).toBe('semantic');
+    expect(stats.droppedByCenterGate).toBe(1); // noise only; paraphrase passes
   });
 });

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -19,6 +19,17 @@ export const DEFAULT_PUBLISHED_AFTER_DAYS = 1095;
 export const DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS = 1000;
 
 /**
+ * Runtime ceiling for YouTube search queries issued per video-discover
+ * call (rule-based + LLM combined). CP416 Phase 3 direction: with the
+ * semantic center gate doing recall, 3-5 broad queries replace the
+ * 20 narrow queries of the lexical-gate era. Default stays at 20 for
+ * safety; flip `V3_MAX_QUERIES=5` in prod once semantic mode telemetry
+ * looks healthy. Hard upper bound remains `MAX_QUERIES = 20` in
+ * `v2/keyword-builder.ts` (this value is clamped to that ceiling).
+ */
+export const DEFAULT_MAX_QUERIES = 20;
+
+/**
  * Center-gate matching mode (post-SGNL-parity carding-quality audit).
  *
  * - `'substring'` (pre-audit default): token-level substring overlap.
@@ -39,8 +50,18 @@ export const DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS = 1000;
  *   stage (MIN_SUB_RELEVANCE) do the filtering alone. Widest net; use
  *   when the center phrase is highly specific and the sub-goals cover
  *   the semantic space.
+ *
+ * - `'semantic'` (CP416 Phase 3): cosine similarity between the center
+ *   goal embedding and each candidate's title embedding (4096d qwen3-
+ *   embedding:8b, same space as `mandala_embeddings`). A candidate
+ *   passes when cosine ≥ `SEMANTIC_MIN_COSINE` (default 0.35). Intended
+ *   to replace lexical gates: language-agnostic, catches paraphrases
+ *   ("루틴으로 전문가되기" ↔ "하루 습관 형성하는 법"). Requires
+ *   `centerEmbedding` + `candidateEmbeddings` on the filter input —
+ *   callers that omit embeddings fall back to `'substring'` behavior
+ *   for safety (mandala-filter.ts enforces).
  */
-export type CenterGateMode = 'substring' | 'subword' | 'off';
+export type CenterGateMode = 'substring' | 'subword' | 'off' | 'semantic';
 export const DEFAULT_CENTER_GATE_MODE: CenterGateMode = 'substring';
 
 export type V3EnvInput = Record<string, string | undefined>;
@@ -92,10 +113,17 @@ const youtubeSearchTimeoutMs = z
   )
   .transform((v) => v ?? DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS);
 
+const maxQueries = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().int().positive().optional()
+  )
+  .transform((v) => v ?? DEFAULT_MAX_QUERIES);
+
 const centerGateMode = z
   .preprocess(
     (v) => (typeof v === 'string' ? v.trim().toLowerCase() : v),
-    z.enum(['substring', 'subword', 'off']).optional()
+    z.enum(['substring', 'subword', 'off', 'semantic']).optional()
   )
   .transform((v) => v ?? DEFAULT_CENTER_GATE_MODE);
 
@@ -110,6 +138,7 @@ export const v3EnvSchema = z.object({
   V3_ENABLE_WHITELIST_GATE: booleanFlag.optional().default(false as unknown as string),
   V3_YOUTUBE_SEARCH_TIMEOUT_MS: youtubeSearchTimeoutMs,
   V3_CENTER_GATE_MODE: centerGateMode,
+  V3_MAX_QUERIES: maxQueries,
 });
 
 export interface V3Config {
@@ -123,6 +152,7 @@ export interface V3Config {
   enableWhitelistGate: boolean;
   youtubeSearchTimeoutMs: number;
   centerGateMode: CenterGateMode;
+  maxQueries: number;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -137,6 +167,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_ENABLE_WHITELIST_GATE: env['V3_ENABLE_WHITELIST_GATE'],
     V3_YOUTUBE_SEARCH_TIMEOUT_MS: env['V3_YOUTUBE_SEARCH_TIMEOUT_MS'],
     V3_CENTER_GATE_MODE: env['V3_CENTER_GATE_MODE'],
+    V3_MAX_QUERIES: env['V3_MAX_QUERIES'],
   });
   if (!parsed.success) {
     return {
@@ -150,6 +181,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       enableWhitelistGate: false,
       youtubeSearchTimeoutMs: DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
       centerGateMode: DEFAULT_CENTER_GATE_MODE,
+      maxQueries: DEFAULT_MAX_QUERIES,
     };
   }
   return {
@@ -163,6 +195,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     enableWhitelistGate: parsed.data.V3_ENABLE_WHITELIST_GATE,
     youtubeSearchTimeoutMs: parsed.data.V3_YOUTUBE_SEARCH_TIMEOUT_MS,
     centerGateMode: parsed.data.V3_CENTER_GATE_MODE,
+    maxQueries: parsed.data.V3_MAX_QUERIES,
   };
 }
 

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -46,6 +46,7 @@ import {
   type FilterCandidate,
 } from './mandala-filter';
 import { v3Config } from './config';
+import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
 
 import {
   buildRuleBasedQueriesSync,
@@ -406,6 +407,7 @@ interface Tier2Debug {
     llmSearchMs: number;
     videosBatchMs: number;
     filterMs: number;
+    semanticGateEmbedMs: number;
     mandalaFilterMs: number;
     scoringMs: number;
     totalMs: number;
@@ -453,6 +455,7 @@ function makeEmptyDebug(input: Tier2Input): Tier2Debug {
       llmSearchMs: 0,
       videosBatchMs: 0,
       filterMs: 0,
+      semanticGateEmbedMs: 0,
       mandalaFilterMs: 0,
       scoringMs: 0,
       totalMs: 0,
@@ -498,13 +501,16 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   }
 
   const tKwRuleStart = Date.now();
-  const ruleQueries = buildRuleBasedQueriesSync({
-    centerGoal: input.state.centerGoal,
-    subGoals: deficitSubGoals,
-    focusTags: input.state.focusTags,
-    targetLevel: input.state.targetLevel,
-    language: input.state.language,
-  });
+  const ruleQueries = buildRuleBasedQueriesSync(
+    {
+      centerGoal: input.state.centerGoal,
+      subGoals: deficitSubGoals,
+      focusTags: input.state.focusTags,
+      targetLevel: input.state.targetLevel,
+      language: input.state.language,
+    },
+    v3Config.maxQueries
+  );
   debug.timing.keywordRuleMs = Date.now() - tKwRuleStart;
 
   const tKwLlmStart = Date.now();
@@ -519,6 +525,7 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     {
       openRouterApiKey: input.openRouterApiKey,
       openRouterModel: input.openRouterModel,
+      maxQueries: v3Config.maxQueries,
     }
   );
 
@@ -648,6 +655,38 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   const enrichedById = new Map<string, Enriched>();
   for (const v of filterable) enrichedById.set(v.videoId, v);
 
+  // Semantic gate prep: when centerGateMode === 'semantic', embed the
+  // center goal + all candidate titles in ONE batch (N+1 texts) and pass
+  // both into the filter. On failure the filter's internal safety
+  // fallback downgrades to 'substring' behavior (mandala-filter.ts).
+  let centerEmbedding: number[] | undefined;
+  let candidateEmbeddings: Map<string, number[]> | undefined;
+  if (v3Config.centerGateMode === 'semantic' && filterInputs.length > 0) {
+    const tSemEmbedStart = Date.now();
+    const texts: string[] = [input.state.centerGoal, ...filterInputs.map((f) => f.title)];
+    try {
+      const vectors = await embedBatch(texts);
+      if (vectors.length === texts.length) {
+        centerEmbedding = vectors[0];
+        candidateEmbeddings = new Map<string, number[]>();
+        for (let i = 0; i < filterInputs.length; i++) {
+          const vec = vectors[i + 1];
+          const id = filterInputs[i]?.videoId;
+          if (vec && id) candidateEmbeddings.set(id, vec);
+        }
+      } else {
+        log.warn(
+          `semantic gate embed vector mismatch: got ${vectors.length}/${texts.length} — falling back to substring`
+        );
+      }
+    } catch (err) {
+      log.warn(
+        `semantic gate embed failed: ${err instanceof Error ? err.message : String(err)} — falling back to substring`
+      );
+    }
+    debug.timing.semanticGateEmbedMs = Date.now() - tSemEmbedStart;
+  }
+
   const tMandalaFilterStart = Date.now();
   const { byCell, stats: mfStats } = applyMandalaFilterWithStats(filterInputs, {
     centerGoal: input.state.centerGoal,
@@ -657,6 +696,8 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     recencyWeight: v3Config.recencyWeight,
     recencyHalfLifeMonths: v3Config.recencyHalfLifeMonths,
     centerGateMode: v3Config.centerGateMode,
+    centerEmbedding,
+    candidateEmbeddings,
   });
   debug.timing.mandalaFilterMs = Date.now() - tMandalaFilterStart;
 

--- a/src/skills/plugins/video-discover/v3/mandala-filter.ts
+++ b/src/skills/plugins/video-discover/v3/mandala-filter.ts
@@ -41,6 +41,19 @@ import type { CenterGateMode } from './config';
 
 export const MIN_SUB_RELEVANCE = 0.05;
 
+/**
+ * Cosine-similarity threshold for the `'semantic'` center-gate mode.
+ * A candidate passes when cosine(centerEmbedding, titleEmbedding) ≥ this.
+ *
+ * 0.35 chosen as a permissive floor — qwen3-embedding:8b in-domain pairs
+ * typically score 0.5-0.8 (e.g. `"하루 루틴으로 전문가되기"` ↔
+ * `"모닝 루틴 7가지"` ≈ 0.62), cross-domain unrelated pairs score
+ * 0.05-0.20 (e.g. `"하루 루틴"` ↔ `"ArgoCD 설치"` ≈ 0.12). 0.35 admits
+ * paraphrases that the subword 2-gram gate (recall 0.27) dropped while
+ * keeping clear off-domain noise out. Tune via env once telemetry lands.
+ */
+export const SEMANTIC_MIN_COSINE = 0.35;
+
 export const DEFAULT_RECENCY_WEIGHT = 0.15;
 
 // 18mo half-life: 1y → 0.63, 3y → 0.25, 6y → 0.06.
@@ -89,6 +102,24 @@ export interface MandalaFilterInput {
    * callers that haven't opted in keep the old logic bit-identical.
    */
   centerGateMode?: CenterGateMode;
+  /**
+   * Center goal embedding (4096d qwen3-embedding:8b). Required when
+   * `centerGateMode === 'semantic'`. When omitted in semantic mode the
+   * filter falls back to `'substring'` behavior for safety.
+   */
+  centerEmbedding?: ReadonlyArray<number>;
+  /**
+   * Per-candidate title embeddings, keyed by videoId (same 4096d space
+   * as `centerEmbedding`). Candidates missing an entry are treated as
+   * `centerScore = 0` in semantic mode — they still pass if matched via
+   * focusTag, otherwise are dropped by the center gate.
+   */
+  candidateEmbeddings?: ReadonlyMap<string, ReadonlyArray<number>>;
+  /**
+   * Override for `SEMANTIC_MIN_COSINE` so admins/tests can tune the
+   * threshold without code changes. Clamped to [0, 1].
+   */
+  semanticMinCosine?: number;
 }
 
 export interface ScoreWeights {
@@ -158,7 +189,18 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
 ): { byCell: Map<number, ScoredAssignment<T>[]>; stats: MandalaFilterStats } {
   const centerCore = extractCoreKeyphrase(input.centerGoal, input.language);
   const centerTokens = tokenize(centerCore, input.language);
-  const mode: CenterGateMode = input.centerGateMode ?? 'substring';
+  const requestedMode: CenterGateMode = input.centerGateMode ?? 'substring';
+
+  // Safety fallback: `'semantic'` requires a center embedding. Callers that
+  // opt into the mode but failed to provide one degrade to `'substring'`
+  // rather than silently dropping every candidate.
+  const mode: CenterGateMode =
+    requestedMode === 'semantic' && !input.centerEmbedding ? 'substring' : requestedMode;
+
+  const semanticMinCosineRaw = input.semanticMinCosine ?? SEMANTIC_MIN_COSINE;
+  const semanticMinCosine = Number.isFinite(semanticMinCosineRaw)
+    ? Math.max(0, Math.min(1, semanticMinCosineRaw))
+    : SEMANTIC_MIN_COSINE;
 
   // Precompute per-center-token 2-grams once so the subword path is
   // O(title-tokens × centerTokens) per candidate, not per pair.
@@ -211,11 +253,23 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
     //   substring — legacy, token-level substring overlap
     //   subword   — char 2-gram overlap per center token, 30% floor
     //   off       — 1 always (gate disabled)
+    //   semantic  — cosine(centerEmbedding, titleEmbedding), 0 when missing
     let centerScore: number;
     if (mode === 'off') {
       centerScore = 1;
     } else if (mode === 'subword') {
       centerScore = subwordOverlap(centerTokenGrams, titleTokens);
+    } else if (mode === 'semantic') {
+      const titleVec = input.candidateEmbeddings?.get(c.videoId);
+      // Fallback to substring is handled at mode resolution above when
+      // centerEmbedding is missing entirely; here we only guard the
+      // per-candidate vector.
+      if (!titleVec || !input.centerEmbedding) {
+        centerScore = 0;
+      } else {
+        const cos = cosineSimilarity(input.centerEmbedding, titleVec);
+        centerScore = cos >= semanticMinCosine ? cos : 0;
+      }
     } else {
       centerScore = substringOverlap(centerTokens, titleTokens);
     }
@@ -233,7 +287,11 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
     // never fires regardless of tokens.
     if (focusMatched) {
       stats.passedByFocusTag = (stats.passedByFocusTag ?? 0) + 1;
-    } else if (mode !== 'off' && centerTokens.size > 0 && centerScore === 0) {
+    } else if (
+      mode !== 'off' &&
+      centerScore === 0 &&
+      (mode === 'semantic' || centerTokens.size > 0)
+    ) {
       stats.droppedByCenterGate++;
       continue;
     }
@@ -355,6 +413,30 @@ function jaccard(bodyTokens: Set<string>, subGoalTokens: Set<string>): number {
   let hits = 0;
   for (const t of subGoalTokens) if (bodyTokens.has(t)) hits++;
   return hits / subGoalTokens.size;
+}
+
+/**
+ * Cosine similarity between two equal-length numeric vectors. Returns 0
+ * for length mismatch or zero-magnitude inputs (treating them as "no
+ * signal"). Clamped to [0, 1] so a freshly-generated vector with tiny
+ * negative noise on a paraphrase pair doesn't under-cut the threshold.
+ */
+export function cosineSimilarity(a: ReadonlyArray<number>, b: ReadonlyArray<number>): number {
+  if (a.length === 0 || a.length !== b.length) return 0;
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    dot += ai * bi;
+    na += ai * ai;
+    nb += bi * bi;
+  }
+  if (na === 0 || nb === 0) return 0;
+  const raw = dot / (Math.sqrt(na) * Math.sqrt(nb));
+  if (!Number.isFinite(raw)) return 0;
+  return Math.max(0, Math.min(1, raw));
 }
 
 const KO_STOPWORDS = new Set([


### PR DESCRIPTION
## Summary
- **건 1 (Phase 3 semantic gate)**: `CenterGateMode` 에 `'semantic'` 추가. cosine(centerGoal embed, title embed) >= 0.35 (tunable) 판정. subword 모드의 recall 0.27 (2-card 현상) 해결 목표. opt-in — default 는 기존 `'substring'` 유지.
- **건 4 (V3_MAX_QUERIES env)**: `V3_MAX_QUERIES` env 추가 (default 20, hard ceiling 20). semantic telemetry 정상 확인 후 5로 flip 하여 quota/4 + broad-queries 모드 전환.
- 부록: `CardList.tsx` skeleton count 통일 (cache-dependent 동요 제거, 항상 6).

## 동작 변경
- **기본값 0 변경**: `V3_CENTER_GATE_MODE=substring` / `V3_MAX_QUERIES=20` — pre-change 와 bit-identical.
- 새 모드는 env flip 시에만 활성화. 회귀 노출 없음.

## Pre-flight (`/verify` PASS)
- `tsc` backend: PASS
- `tsc` frontend: PASS
- vitest: 263/263 PASS
- frontend build: PASS (22.78s, PWA precache 3960KiB)
- browser smoke `/` + `/mandalas/new`: 200 / 200
- jest backend: 28 failures = pre-existing baseline (v1 executor 11 + mandala-manager/post-creation/routes 17). `git stash` + main-only 재현 확인. **Net new regressions from this branch: 0.**

## Test coverage (new)
- `cosineSimilarity`: 6 cases (identical / orthogonal / negative-clamp / length-mismatch / zero-mag / partial)
- `applyMandalaFilter` semantic mode: 7 cases (KO paraphrase pass / unrelated drop / borderline drop / threshold override / missing centerEmbed fallback / missing per-candidate vec drop / EN fixture)
- `V3_MAX_QUERIES`: 2 cases (parse + invalid fallback)

## Rollback
- `V3_CENTER_GATE_MODE=substring` (env, default)
- `V3_MAX_QUERIES=20` (env, default)
- 또는 이 PR revert — 파급 6 파일(+1 FE cosmetic), 하위 호환 전제로 설계됨.

## CP416 상태
- TIER 1 건 1, 4 — 본 PR
- TIER 2 건 2 (DB INSERT 7s ontology trigger cascade) — 다음 PR
- TIER 2 건 3 (embed dedupe) — 조사 결과 wizard flow 에서는 1회 호출뿐 (false problem). 필요 시 cron-level shared cache 별도 설계.

## Test plan
- [ ] CI pass
- [ ] Deploy health check
- [ ] prod 에서 `V3_CENTER_GATE_MODE=semantic` flip 후 wizard 생성 smoke (다음 릴리즈 사이클)

🤖 Generated with [Claude Code](https://claude.com/claude-code)