### PR TITLE
ops(prod): activate V3_CENTER_GATE_MODE=semantic — CP416 Phase 3 STEP 1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -201,6 +201,12 @@ jobs:
             # Add OPENROUTER keys if missing, update if present
             grep -q '^OPENROUTER_API_KEY=' .env 2>/dev/null && sed -i "s|^OPENROUTER_API_KEY=.*|OPENROUTER_API_KEY=${OR_KEY}|" .env || echo "OPENROUTER_API_KEY=${OR_KEY}" >> .env
             grep -q '^OPENROUTER_MODEL=' .env 2>/dev/null && sed -i "s|^OPENROUTER_MODEL=.*|OPENROUTER_MODEL=${OR_MODEL}|" .env || echo "OPENROUTER_MODEL=${OR_MODEL}" >> .env
+            # CP416 Phase 3 — activate v3 semantic center gate (cosine over
+            # qwen3-embedding:8b). Replaces lexical gate recall 0.27 that
+            # surfaced the "2 cards" symptom. Non-secret tuning knob per
+            # CP392: stdout-safe + open-source-safe → hardcoded here, not
+            # GH Secret. Rollback: change value to "substring" or delete row.
+            grep -q '^V3_CENTER_GATE_MODE=' .env 2>/dev/null && sed -i "s|^V3_CENTER_GATE_MODE=.*|V3_CENTER_GATE_MODE=semantic|" .env || echo "V3_CENTER_GATE_MODE=semantic" >> .env
             # 2026-04-18 — sync DB URLs from GitHub Secrets so password
             # rotations propagate to prod .env without manual SSH. Was
             # blocking deploy after Supabase password rotation (container


### PR DESCRIPTION
## Summary
Flip v3 mandala filter center gate from `substring` (default, precision 0 noise leak) to `semantic` (cosine over qwen3-embedding:8b 4096d, threshold 0.35).

**왜 지금**: lexical `subword` 모드 recall 0.27 이 "2 cards 현상"의 근본. `#446` 로 code path 는 이미 prod 에 있음 (opt-in). 이 PR 이 env flip 만 수행.

## Change
`.github/workflows/deploy.yml` 에 1 block 추가 — 기존 `OPENROUTER_MODEL` 패턴 그대로 복제.

```yaml
grep -q '^V3_CENTER_GATE_MODE=' .env 2>/dev/null \
  && sed -i "s|^V3_CENTER_GATE_MODE=.*|V3_CENTER_GATE_MODE=semantic|" .env \
  || echo "V3_CENTER_GATE_MODE=semantic" >> .env
```

Non-secret per CP392 "2 question test" (tuning knob, stdout-safe).

## Safety
- **Fallback**: `mandala-filter.ts` 에 이미 구현된 safety — `centerEmbedding` 누락 시 자동 `substring` degradation. Ollama 다운타임에도 gate 0-drop 없음.
- **Rollback cost**: 1줄 revert (5분). Downstream state (recommendation_cache / mandala_embeddings) 불변.

## Verify (post-deploy)
1. `ssh insighta-ec2 "docker exec <api> printenv | grep V3_CENTER_GATE_MODE"` → `semantic`
2. 새 wizard 생성 1건 → `mandala_pipeline_runs.step2_result.debug.timing.semanticGateEmbedMs > 0` 확인
3. `stats.centerGateMode === 'semantic'` (fallback 아님)
4. cell 당 카드 수 관찰

## Success criteria (before making this default)
상세: `docs/design/v3-semantic-center-gate.md §7`
- p95 `semanticGateEmbedMs` < 500 ms
- per-cell median fill >= 6/12
- zero unexplained safety fallbacks

## Related
- Feature PR: #446 (`fb29d75`)
- Design: `docs/design/v3-semantic-center-gate.md`
- CP392: non-secret config is not a Secret

## Test plan
- [ ] CI pass
- [ ] Deploy success
- [ ] `printenv` 로 prod env 확인
- [ ] wizard 생성 smoke (다음 세션 또는 manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)