### PR TITLE
fix(ops): V3_CENTER_GATE_MODE subword→semantic in compose override — CP416 flip correction

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,13 +30,17 @@ services:
       - REDIS_HOST=${INSIGHTA_TAILSCALE_IP}
       - REDIS_PORT=6379
       - REDIS_USER=insighta
-      # Phase-1 slice 5 followup (2026-04-21) — activate subword center-gate.
-      # Tuning knob, not a secret (per CLAUDE.md CP392 rule). Default in
-      # code is 'substring' (pre-audit). Flipping to 'subword' here
-      # enables char-2-gram composite-word matching so Korean titles
-      # like "모닝루틴" pass the gate for goals containing "루틴으로".
-      # Revert: delete this line and redeploy — code default takes over.
-      - V3_CENTER_GATE_MODE=subword
+      # CP416 Phase 3 (2026-04-22) — activate semantic center-gate.
+      # Cosine similarity over qwen3-embedding:8b (4096d, same space as
+      # mandala_embeddings). Replaces the 2026-04-21 'subword' activation
+      # whose char-2-gram recall (0.27) surfaced as the "2 cards" symptom
+      # — embedding-based recall admits paraphrase/composite-word pairs
+      # that the lexical gate dropped. Tuning knob, not a secret (CP392).
+      # Safety: code auto-fallbacks to 'substring' when embedBatch throws
+      # (mandala-filter.ts guard) — Ollama downtime does not break the gate.
+      # Revert: set to 'subword' / 'substring' or delete this line (code
+      # default 'substring' takes over) and redeploy.
+      - V3_CENTER_GATE_MODE=semantic
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the


### PR DESCRIPTION
## Core intent
Lexical recall 0.27 로 카드를 쥐어짜는 대신 embedding 유사도로 거른다 — "2 cards 현상" 근본 해결. PR #447 이 놓친 override layer 를 마저 고친다.

## Root cause
PR #447 은 `.env` (via `deploy.yml` sed) 를 `V3_CENTER_GATE_MODE=semantic` 로 업데이트했지만, `docker-compose.prod.yml:39` 에 `=subword` 하드코딩이 남아 있었고 docker compose 규칙상 `environment:` > `env_file` 이라 런타임은 여전히 subword.

```
$ ssh insighta-ec2 "docker exec insighta-api printenv V3_CENTER_GATE_MODE"
subword   # PR #447 deploy 완료 후에도
```

## Fix
`docker-compose.prod.yml:39`:
- `V3_CENTER_GATE_MODE=subword` → `V3_CENTER_GATE_MODE=semantic`
- 주석에 CP416 rationale + safety fallback + rollback 경로 갱신

## Safety nets (중첩)
1. `docker-compose.prod.yml` → `semantic` (이번 PR)
2. `.env` → `semantic` (PR #447, compose line 삭제 시 fallback)
3. Code → `'substring'` default (모든 env 제거 시 fallback)
4. `mandala-filter.ts` → `centerEmbedding` 누락/embedBatch throw 시 `'substring'` auto-downgrade

## Verify (deploy 후)
1. `ssh … docker exec insighta-api printenv V3_CENTER_GATE_MODE` → `semantic`
2. 새 wizard 생성 1건 → `step2_result.debug.timing.semanticGateEmbedMs > 0`
3. `stats.centerGateMode === 'semantic'` (safety fallback 아님)

## Lesson learned (memory 반영 예정)
**Env flip 시 2 layer 모두 확인 필수**: (a) `.env` + (b) `docker-compose.prod.yml environment:`. 후자가 전자를 override. 한쪽만 고치면 silent 미반영.

## Related
- Previous PR: #447 (incomplete — .env-only, overridden at runtime)
- Feature: #446 (`fb29d75`)
- Design: `docs/design/v3-semantic-center-gate.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)