### PR TITLE
fix(mandala): always scaffold depth=1 levels on create — actions fill recovery (CP416 Layer A)

### DIFF
--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -1057,24 +1057,43 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           },
         ];
 
-        if (subDetails) {
-          subjects.forEach((_, idx) => {
-            const actions = subDetails[String(idx)] ?? subDetails[idx as unknown as string] ?? [];
-            if (Array.isArray(actions) && actions.length > 0) {
-              // Pad to 8 items if needed
-              const padded = [...actions];
-              while (padded.length < 8) padded.push('');
-              levels.push({
-                levelKey: `sub_${idx}`,
-                centerGoal: subjects[idx] ?? '',
-                subjects: padded.slice(0, 8),
-                position: idx,
-                depth: 1,
-                parentLevelKey: 'root',
-              });
-            }
+        // Always create 8 depth=1 scaffold rows regardless of whether
+        // subDetails (actions) arrived with this request. The Phase 1
+        // wizard flow (wizard-stream previewOnly=true, CP415) ships the
+        // structure ahead of actions, and actions arrive asynchronously
+        // — fill-missing-actions later needs a depth=1 row per cell to
+        // write into. Previously, the bug skipped the push when
+        // subDetails was absent or empty, so depth=1 rows never existed,
+        // leaving mandalas permanently stuck at 0/64 actions.
+        //
+        // If subDetails is provided (legacy one-shot flow), merge the
+        // actions into the matching row; otherwise store empty subjects
+        // as a scaffold for the async fill path.
+        subjects.forEach((subject, idx) => {
+          const rawActions =
+            subDetails?.[String(idx)] ?? subDetails?.[idx as unknown as string] ?? [];
+          const provided = Array.isArray(rawActions) ? rawActions : [];
+          // Scaffold with [] when no actions were provided so the async
+          // fill-missing-actions job can detect the cell (subjects.length
+          // < 8 gate). When partial actions were provided, keep legacy
+          // behavior of padding to 8 with empty strings.
+          let cellSubjects: string[];
+          if (provided.length === 0) {
+            cellSubjects = [];
+          } else {
+            const padded = [...provided];
+            while (padded.length < 8) padded.push('');
+            cellSubjects = padded.slice(0, 8);
+          }
+          levels.push({
+            levelKey: `sub_${idx}`,
+            centerGoal: subject ?? '',
+            subjects: cellSubjects,
+            position: idx,
+            depth: 1,
+            parentLevelKey: 'root',
           });
-        }
+        });
 
         const result = await getMandalaManager().createMandala(userId, title, levels);
         stage('create_mandala');
@@ -1128,10 +1147,17 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         });
         stage('skill_config');
 
-        // Phase 2 revert: actions are now generated one-shot in generateMandalaWithHaiku
-        // (not fire-and-forget). FE receives mandala with 64 actions already populated
-        // and sends them via subDetails. No background actions generation needed.
-        // If FE sends empty subDetails, that's a FE bug — don't silently patch with LLM.
+        // Action population has two supported flows:
+        //  - Legacy one-shot: FE runs `generateMandalaWithHaiku` and sends
+        //    all 64 actions via `subDetails` — saved directly.
+        //  - Phase 1 (CP415): FE takes the `wizard-stream?previewOnly=true`
+        //    structure and calls `/create-with-data` without `subDetails`.
+        //    `fill-missing-actions` (invoked by `triggerMandalaPostCreationAsync`)
+        //    populates the depth=1 rows asynchronously in the background.
+        //
+        // Either way, depth=1 scaffold rows are always created above so the
+        // async fill path has a target to write into. An empty `subDetails`
+        // is expected under the Phase 1 flow and is not a bug.
 
         // Fire-and-forget post-creation pipeline for the new mandala.
         // Opt-in via user_skill_config; safe if not enabled.

--- a/src/modules/mandala/fill-missing-actions.ts
+++ b/src/modules/mandala/fill-missing-actions.ts
@@ -19,12 +19,15 @@
  *    depend on actions existing.
  */
 
+import { randomUUID } from 'node:crypto';
+
 import { getPrismaClient } from '@/modules/database';
 import { logger } from '@/utils/logger';
 import { generateMandalaActions } from './generator';
 
 const log = logger.child({ module: 'fill-missing-actions' });
 
+const EXPECTED_SUB_GOAL_COUNT = 8;
 const EXPECTED_ACTIONS_PER_CELL = 8;
 const MIN_ACTIONS_TO_CONSIDER_FILLED = 8;
 
@@ -51,7 +54,7 @@ export async function fillMissingActionsIfNeeded(mandalaId: string): Promise<{
     return { ok: false, action: 'skipped-not-found' };
   }
 
-  const levels = await db.user_mandala_levels.findMany({
+  let levels = await db.user_mandala_levels.findMany({
     where: { mandala_id: mandalaId, depth: 1 },
     orderBy: { position: 'asc' },
     select: { id: true, center_goal: true, subjects: true, position: true },
@@ -59,11 +62,55 @@ export async function fillMissingActionsIfNeeded(mandalaId: string): Promise<{
 
   const rootLevel = await db.user_mandala_levels.findFirst({
     where: { mandala_id: mandalaId, depth: 0 },
-    select: { center_goal: true },
+    select: { id: true, center_goal: true, subjects: true },
   });
   if (!rootLevel) {
     log.warn(`fill-missing-actions: root level missing for mandala=${mandalaId}`);
     return { ok: false, action: 'skipped-not-found' };
+  }
+
+  // Recovery path: legacy mandalas created before the `/create-with-data`
+  // depth=1 scaffold fix have depth=0 only. Scaffold 8 empty depth=1 rows
+  // from root.subjects so the fill can proceed. Safe on first write — all
+  // rows arrive together via createMany; schema validation enforces unique
+  // (mandala_id, depth, position). If a concurrent writer inserted rows
+  // between read and write, the createMany will fail and the caller's
+  // next poll will see the now-populated levels.
+  if (levels.length === 0) {
+    const rootSubjects = Array.isArray(rootLevel.subjects)
+      ? rootLevel.subjects.filter((s): s is string => typeof s === 'string')
+      : [];
+    if (rootSubjects.length < EXPECTED_SUB_GOAL_COUNT) {
+      log.warn(
+        `fill-missing-actions: root has ${rootSubjects.length}/${EXPECTED_SUB_GOAL_COUNT} subjects — cannot scaffold depth=1 for mandala=${mandalaId}`
+      );
+      return { ok: false, action: 'skipped-not-found', reason: 'root has < 8 subjects' };
+    }
+    log.info(
+      `fill-missing-actions: scaffolding ${EXPECTED_SUB_GOAL_COUNT} depth=1 rows for legacy mandala=${mandalaId}`
+    );
+    const scaffoldData = rootSubjects.slice(0, EXPECTED_SUB_GOAL_COUNT).map((subject, idx) => ({
+      id: randomUUID(),
+      mandala_id: mandalaId,
+      parent_level_id: rootLevel.id,
+      level_key: `sub_${idx}`,
+      center_goal: subject,
+      subjects: [] as string[],
+      position: idx,
+      depth: 1,
+    }));
+    try {
+      await db.user_mandala_levels.createMany({ data: scaffoldData });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(`fill-missing-actions: scaffold createMany failed for ${mandalaId}: ${msg}`);
+      return { ok: false, action: 'failed', reason: `scaffold failed: ${msg}` };
+    }
+    levels = await db.user_mandala_levels.findMany({
+      where: { mandala_id: mandalaId, depth: 1 },
+      orderBy: { position: 'asc' },
+      select: { id: true, center_goal: true, subjects: true, position: true },
+    });
   }
 
   const needsFill = levels.filter(

--- a/tests/unit/modules/fill-missing-actions.test.ts
+++ b/tests/unit/modules/fill-missing-actions.test.ts
@@ -1,0 +1,207 @@
+/**
+ * fill-missing-actions — Layer A fix regression tests
+ *
+ * Scenarios pinned:
+ *   1. Legacy recovery: mandala has depth=0 root with 8 subjects but no
+ *      depth=1 rows — scaffold 8 depth=1 rows then generate + fill.
+ *   2. Standard happy path: depth=1 rows already exist (scaffolded by
+ *      `/create-with-data`), subjects empty → generateMandalaActions →
+ *      update each row.
+ *   3. Skip when all rows already have 8+ subjects.
+ *   4. Skip when root is missing or has fewer than 8 subjects.
+ */
+
+const mockFindUniqueMandala = jest.fn();
+const mockFindManyLevels = jest.fn();
+const mockFindFirstRoot = jest.fn();
+const mockCreateManyLevels = jest.fn();
+const mockUpdateLevel = jest.fn();
+const mockGenerateMandalaActions = jest.fn();
+
+jest.mock('@/modules/database', () => ({
+  getPrismaClient: () => ({
+    user_mandalas: { findUnique: mockFindUniqueMandala },
+    user_mandala_levels: {
+      findMany: mockFindManyLevels,
+      findFirst: mockFindFirstRoot,
+      createMany: mockCreateManyLevels,
+      update: mockUpdateLevel,
+    },
+  }),
+}));
+
+jest.mock('../../../src/modules/mandala/generator', () => ({
+  generateMandalaActions: mockGenerateMandalaActions,
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+import { fillMissingActionsIfNeeded } from '../../../src/modules/mandala/fill-missing-actions';
+
+const MANDALA_ID = '00000000-0000-0000-0000-000000000042';
+const ROOT_LEVEL_ID = '00000000-0000-0000-0000-0000000000a0';
+
+const SUB_GOALS = [
+  'Ultra learning 원리와 뇌과학 기초 이해',
+  '매일 집중학습 시간 블록 스케줄링',
+  '학습 주제별 마스터플랜 수립',
+  '효율적 노트필기 및 정보정리 시스템 구축',
+  '스팀(STEAM) 다중 학습법 적용',
+  '일일 학습 진도 측정 및 피드백 체계',
+  '뇌피로 관리와 회복 루틴 설계',
+  '학습 커뮤니티 참여 및 아웃풋 활동',
+];
+
+function mockActionsFor(subGoals: string[]): Record<string, string[]> {
+  const actions: Record<string, string[]> = {};
+  subGoals.forEach((_, idx) => {
+    actions[`sub_goal_${idx + 1}`] = Array.from({ length: 8 }, (_, i) => `action-${idx}-${i + 1}`);
+  });
+  return actions;
+}
+
+describe('fillMissingActionsIfNeeded', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindUniqueMandala.mockResolvedValue({
+      id: MANDALA_ID,
+      language: 'ko',
+      focus_tags: null,
+      target_level: null,
+    });
+    mockFindFirstRoot.mockResolvedValue({
+      id: ROOT_LEVEL_ID,
+      center_goal: '30일 ultra learning 습관 만들기',
+      subjects: SUB_GOALS,
+    });
+    mockGenerateMandalaActions.mockResolvedValue(mockActionsFor(SUB_GOALS));
+    mockUpdateLevel.mockImplementation(async () => ({}));
+    mockCreateManyLevels.mockImplementation(async () => ({ count: 8 }));
+  });
+
+  test('scaffolds 8 depth=1 rows when mandala has none (legacy recovery)', async () => {
+    // First call: 0 rows (legacy mandala). Second call (after scaffold):
+    // 8 empty rows.
+    mockFindManyLevels.mockResolvedValueOnce([]).mockResolvedValueOnce(
+      SUB_GOALS.map((sg, idx) => ({
+        id: `level-${idx}`,
+        center_goal: sg,
+        subjects: [],
+        position: idx,
+      }))
+    );
+
+    const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+
+    // Scaffold path was taken
+    expect(mockCreateManyLevels).toHaveBeenCalledTimes(1);
+    const scaffoldCall = mockCreateManyLevels.mock.calls[0]![0];
+    expect(scaffoldCall.data).toHaveLength(8);
+    expect(scaffoldCall.data[0]).toMatchObject({
+      mandala_id: MANDALA_ID,
+      parent_level_id: ROOT_LEVEL_ID,
+      depth: 1,
+      position: 0,
+      center_goal: SUB_GOALS[0],
+      subjects: [],
+    });
+    // Each scaffold row has a generated id
+    for (let i = 0; i < 8; i++) {
+      expect(scaffoldCall.data[i].id).toMatch(/^[0-9a-f-]{36}$/i);
+      expect(scaffoldCall.data[i].position).toBe(i);
+    }
+
+    // After scaffold, generate + fill runs
+    expect(mockGenerateMandalaActions).toHaveBeenCalledWith(
+      SUB_GOALS,
+      'ko',
+      '30일 ultra learning 습관 만들기',
+      undefined,
+      undefined
+    );
+    expect(mockUpdateLevel).toHaveBeenCalledTimes(8);
+    expect(result).toEqual({ ok: true, action: 'filled', cellsFilled: 8 });
+  });
+
+  test('standard path: depth=1 rows already scaffolded with empty subjects', async () => {
+    mockFindManyLevels.mockResolvedValueOnce(
+      SUB_GOALS.map((sg, idx) => ({
+        id: `level-${idx}`,
+        center_goal: sg,
+        subjects: [],
+        position: idx,
+      }))
+    );
+
+    const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+
+    expect(mockCreateManyLevels).not.toHaveBeenCalled(); // no scaffold
+    expect(mockGenerateMandalaActions).toHaveBeenCalledTimes(1);
+    expect(mockUpdateLevel).toHaveBeenCalledTimes(8);
+    expect(result).toEqual({ ok: true, action: 'filled', cellsFilled: 8 });
+  });
+
+  test('skipped-full when all cells already have 8 subjects', async () => {
+    mockFindManyLevels.mockResolvedValueOnce(
+      SUB_GOALS.map((sg, idx) => ({
+        id: `level-${idx}`,
+        center_goal: sg,
+        subjects: Array.from({ length: 8 }, (_, i) => `existing-${idx}-${i}`),
+        position: idx,
+      }))
+    );
+
+    const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+
+    expect(mockCreateManyLevels).not.toHaveBeenCalled();
+    expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
+    expect(mockUpdateLevel).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: true, action: 'skipped-full' });
+  });
+
+  test('refuses scaffold when root has fewer than 8 subjects', async () => {
+    mockFindFirstRoot.mockResolvedValue({
+      id: ROOT_LEVEL_ID,
+      center_goal: 'partial root',
+      subjects: ['one', 'two', 'three'],
+    });
+    mockFindManyLevels.mockResolvedValueOnce([]);
+
+    const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+
+    expect(mockCreateManyLevels).not.toHaveBeenCalled();
+    expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.action).toBe('skipped-not-found');
+  });
+
+  test('returns failed when scaffold createMany throws', async () => {
+    mockFindManyLevels.mockResolvedValueOnce([]);
+    mockCreateManyLevels.mockRejectedValueOnce(new Error('db down'));
+
+    const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+
+    expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.action).toBe('failed');
+    expect(result.reason).toContain('db down');
+  });
+
+  test('mandala missing → skipped-not-found without scaffold attempt', async () => {
+    mockFindUniqueMandala.mockResolvedValueOnce(null);
+
+    const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+
+    expect(mockCreateManyLevels).not.toHaveBeenCalled();
+    expect(mockFindManyLevels).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, action: 'skipped-not-found' });
+  });
+});


### PR DESCRIPTION
## 핵심 목적 / 본질 (1줄)
위자드가 만든 만다라트에 **실행아이템(actions) 64개가 저장될 자리(depth=1 × 8 rows)를 항상 만들어 두어** async fill 이 실제로 쓰일 수 있게 만든다. 지금은 그 자리가 없어서 만다라트가 영구 0/64 로 고장나 있음.

## Root cause
`/create-with-data` (`src/api/routes/mandalas.ts:1060-1077` 원본) 이 `subDetails[idx].length > 0` 일 때만 depth=1 level 을 push. Phase 1 wizard-stream (CP415, `previewOnly=true`) 은 **의도적으로** `subDetails` 없이 만다라트를 저장하고 actions 는 async 로 fill 하는 설계였지만, push 조건 때문에 **depth=1 rows 자체가 생성되지 않음** → `fill-missing-actions` 는 write 대상 0 개 → silent `skipped-full` → 만다라트 영구 0/64.

DB 관찰 (prod mandala `70ef45d9`):
- `user_mandala_levels`: depth=0 root 1 row, depth=1 **0 rows**
- edit UI "전체 8/72" = depth=0 root 의 subjects 8 개 뿐

## Fix
1. `/create-with-data`: **항상** 8 depth=1 scaffold rows 생성. subDetails 제공 시 merge (legacy pad-to-8 유지), 미제공 시 `subjects: []` 저장 → fill 경로의 `length < 8` gate 발동.
2. `fill-missing-actions`: legacy recovery — depth=1 rows 없으면 root.subjects 8 개로 scaffold 후 fill. root < 8 subjects 면 refuse.
3. 오래된 comment block 교체 (이전: "empty subDetails 는 FE bug" → 현재: Phase 1 flow 에서 정상).

## Tests
`tests/unit/modules/fill-missing-actions.test.ts` (new, 6 cases):
- legacy recovery (scaffold then fill)
- standard path (scaffold already present, just fill)
- skipped-full (이미 8 subjects)
- partial-root refusal
- createMany failure → `failed`
- missing-mandala → `skipped-not-found`

## Verification (post-deploy, 내가 수행 — 사용자 test 요청 없음)
per `memory/feedback_verify_before_user_test.md` (CP416 신규):
1. Test 만다라트 1건 생성 → `user_mandala_levels` 에서 depth=1 = 8 rows 확인
2. ~15s 대기 후 각 depth=1 row 의 `subjects.length === 8` 확인
3. 기존 orphan `70ef45d9` 상대로 fill 재trigger → scaffold recovery 성공 확인

## /verify
- `tsc --noEmit`: PASS
- `npx jest tests/unit/modules/fill-missing-actions.test.ts`: **6/6 PASS**
- 기존 failing tests (mandala-post-creation / mandala-manager / video-discover/executor): 16 fail — `git stash` 로 baseline 확인, **zero new regressions**

## Rollback
`git revert <sha>` — 단일 주제, 3 파일. scaffolded empty rows 는 harmless (fill 실행 전이면 즉시 cleanup, 실행 후면 정상 카드).

## Known limitations
- 기존 orphan mandala 들은 자동 복구 안 됨 — 해당 사용자 flow 에서 `fill-missing-actions` 재호출이 trigger 될 때만 복구. 필요 시 admin endpoint 로 일괄 trigger.

## Related
- CP415 PR #444/#445 (Phase 1 wizard-stream + fill-missing-actions 도입)
- CP416 Layer B (action prompt 품질 — one-shot vs action-only) 는 별도 track

🤖 Generated with [Claude Code](https://claude.com/claude-code)