### PR TITLE
fix(mandala): swap action fill primary path from Haiku to mac mini LoRA (CP416)

### DIFF
--- a/src/modules/mandala/fill-missing-actions.ts
+++ b/src/modules/mandala/fill-missing-actions.ts
@@ -23,13 +23,32 @@ import { randomUUID } from 'node:crypto';
 
 import { getPrismaClient } from '@/modules/database';
 import { logger } from '@/utils/logger';
-import { generateMandalaActions } from './generator';
+import { generateMandala, generateMandalaActions } from './generator';
 
 const log = logger.child({ module: 'fill-missing-actions' });
 
 const EXPECTED_SUB_GOAL_COUNT = 8;
 const EXPECTED_ACTIONS_PER_CELL = 8;
 const MIN_ACTIONS_TO_CONSIDER_FILLED = 8;
+
+/**
+ * Minimum action-uniqueness rate for a LoRA output to be accepted.
+ * LoRA's known failure mode is repetition ("학습하기, 학습하기, ...")
+ * — unique-rate below this suggests that mode and we fall back to the
+ * OpenRouter Haiku path. Picked conservatively; tune after telemetry.
+ */
+const MIN_ACTION_UNIQUE_RATE = 0.7;
+
+function computeActionUniqueRate(actions: Record<string, string[]>): number {
+  const all: string[] = [];
+  for (const arr of Object.values(actions)) {
+    if (Array.isArray(arr)) {
+      for (const a of arr) all.push(a.trim().toLowerCase());
+    }
+  }
+  if (all.length === 0) return 0;
+  return new Set(all).size / all.length;
+}
 
 /**
  * Read depth=1 rows, detect ones with empty / partial subjects, call
@@ -125,22 +144,78 @@ export async function fillMissingActionsIfNeeded(mandalaId: string): Promise<{
   const focusTags = Array.isArray(mandala.focus_tags) ? mandala.focus_tags : undefined;
   const targetLevel = mandala.target_level ?? undefined;
 
-  log.info(`[${mandalaId}] generating actions for ${needsFill.length}/${levels.length} cells`);
+  log.info(
+    `[${mandalaId}] generating actions for ${needsFill.length}/${levels.length} cells (primary: LoRA, fallback: Haiku)`
+  );
 
-  let actions: Record<string, string[]>;
+  // Primary: Mac Mini LoRA via `generateMandala` (one-shot full mandala).
+  // LoRA is purpose-trained on the mandala domain (2 months of background
+  // training-data accumulation, v14) so action quality is substantially
+  // better than generic Haiku prompting. We consume only the `actions`
+  // field from the LoRA output — `sub_goals` are already locked by the
+  // wizard, LoRA must not rewrite them.
+  //
+  // Fallback: OpenRouter Haiku via `generateMandalaActions` (action-only
+  // prompt). Used when LoRA fails / times out / fails quality gate
+  // (repetition-mode detection via action unique-rate).
+  let actions: Record<string, string[]> | null = null;
+  let sourceUsed: 'lora' | 'haiku-fallback' = 'lora';
+  const centerGoal = rootLevel.center_goal ?? '';
+
+  const loraStart = Date.now();
   try {
-    actions = await generateMandalaActions(
-      subGoals,
+    const loraMandala = await generateMandala({
+      goal: centerGoal,
       language,
-      rootLevel.center_goal ?? '',
       focusTags,
-      targetLevel
+      targetLevel,
+    });
+    const loraActions = loraMandala?.actions ?? {};
+    const totalActions = Object.values(loraActions).reduce(
+      (sum, arr) => sum + (Array.isArray(arr) ? arr.length : 0),
+      0
     );
+    const uniqueRate = computeActionUniqueRate(loraActions);
+    const loraMs = Date.now() - loraStart;
+    const expectedTotal = EXPECTED_SUB_GOAL_COUNT * EXPECTED_ACTIONS_PER_CELL;
+
+    if (totalActions < expectedTotal) {
+      log.warn(
+        `[${mandalaId}] LoRA returned ${totalActions}/${expectedTotal} actions (ms=${loraMs}) — falling back to Haiku`
+      );
+    } else if (uniqueRate < MIN_ACTION_UNIQUE_RATE) {
+      log.warn(
+        `[${mandalaId}] LoRA unique-rate ${uniqueRate.toFixed(2)} < ${MIN_ACTION_UNIQUE_RATE} (repetition mode, ms=${loraMs}) — falling back to Haiku`
+      );
+    } else {
+      actions = loraActions;
+      log.info(
+        `[${mandalaId}] LoRA accepted: ${totalActions} actions, unique-rate ${uniqueRate.toFixed(2)}, ms=${loraMs}`
+      );
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    log.warn(`[${mandalaId}] generateMandalaActions threw: ${msg}`);
-    return { ok: false, action: 'failed', reason: msg };
+    log.warn(`[${mandalaId}] LoRA threw: ${msg} — falling back to Haiku`);
   }
+
+  if (!actions) {
+    sourceUsed = 'haiku-fallback';
+    try {
+      actions = await generateMandalaActions(
+        subGoals,
+        language,
+        centerGoal,
+        focusTags,
+        targetLevel
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(`[${mandalaId}] Haiku fallback also threw: ${msg}`);
+      return { ok: false, action: 'failed', reason: `lora+haiku both failed: ${msg}` };
+    }
+  }
+
+  log.info(`[${mandalaId}] actions source=${sourceUsed}`);
 
   // Update each depth=1 level's subjects. Key layout from the prompt is
   // `sub_goal_1`..`sub_goal_8`; fall back to index-keyed lookups per the

--- a/tests/unit/modules/fill-missing-actions.test.ts
+++ b/tests/unit/modules/fill-missing-actions.test.ts
@@ -16,6 +16,7 @@ const mockFindManyLevels = jest.fn();
 const mockFindFirstRoot = jest.fn();
 const mockCreateManyLevels = jest.fn();
 const mockUpdateLevel = jest.fn();
+const mockGenerateMandala = jest.fn();
 const mockGenerateMandalaActions = jest.fn();
 
 jest.mock('@/modules/database', () => ({
@@ -31,6 +32,7 @@ jest.mock('@/modules/database', () => ({
 }));
 
 jest.mock('../../../src/modules/mandala/generator', () => ({
+  generateMandala: mockGenerateMandala,
   generateMandalaActions: mockGenerateMandalaActions,
 }));
 
@@ -68,6 +70,17 @@ function mockActionsFor(subGoals: string[]): Record<string, string[]> {
   return actions;
 }
 
+function mockLoraMandalaFor(subGoals: string[]) {
+  return {
+    center_goal: '30일 ultra learning 습관 만들기',
+    center_label: '',
+    language: 'ko',
+    domain: 'general',
+    sub_goals: subGoals,
+    actions: mockActionsFor(subGoals),
+  };
+}
+
 describe('fillMissingActionsIfNeeded', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -82,6 +95,9 @@ describe('fillMissingActionsIfNeeded', () => {
       center_goal: '30일 ultra learning 습관 만들기',
       subjects: SUB_GOALS,
     });
+    // Default: LoRA succeeds with a valid 64-action, high-unique-rate output.
+    // Individual tests override to exercise fallback paths.
+    mockGenerateMandala.mockResolvedValue(mockLoraMandalaFor(SUB_GOALS));
     mockGenerateMandalaActions.mockResolvedValue(mockActionsFor(SUB_GOALS));
     mockUpdateLevel.mockImplementation(async () => ({}));
     mockCreateManyLevels.mockImplementation(async () => ({ count: 8 }));
@@ -119,19 +135,19 @@ describe('fillMissingActionsIfNeeded', () => {
       expect(scaffoldCall.data[i].position).toBe(i);
     }
 
-    // After scaffold, generate + fill runs
-    expect(mockGenerateMandalaActions).toHaveBeenCalledWith(
-      SUB_GOALS,
-      'ko',
-      '30일 ultra learning 습관 만들기',
-      undefined,
-      undefined
-    );
+    // After scaffold, LoRA (primary) runs and fills — Haiku fallback not called
+    expect(mockGenerateMandala).toHaveBeenCalledWith({
+      goal: '30일 ultra learning 습관 만들기',
+      language: 'ko',
+      focusTags: undefined,
+      targetLevel: undefined,
+    });
+    expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
     expect(mockUpdateLevel).toHaveBeenCalledTimes(8);
     expect(result).toEqual({ ok: true, action: 'filled', cellsFilled: 8 });
   });
 
-  test('standard path: depth=1 rows already scaffolded with empty subjects', async () => {
+  test('standard path: LoRA fills all 8 cells, Haiku fallback untouched', async () => {
     mockFindManyLevels.mockResolvedValueOnce(
       SUB_GOALS.map((sg, idx) => ({
         id: `level-${idx}`,
@@ -144,9 +160,117 @@ describe('fillMissingActionsIfNeeded', () => {
     const result = await fillMissingActionsIfNeeded(MANDALA_ID);
 
     expect(mockCreateManyLevels).not.toHaveBeenCalled(); // no scaffold
-    expect(mockGenerateMandalaActions).toHaveBeenCalledTimes(1);
+    expect(mockGenerateMandala).toHaveBeenCalledTimes(1);
+    expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
     expect(mockUpdateLevel).toHaveBeenCalledTimes(8);
     expect(result).toEqual({ ok: true, action: 'filled', cellsFilled: 8 });
+  });
+
+  test('LoRA throws → Haiku fallback fills the cells', async () => {
+    mockFindManyLevels.mockResolvedValueOnce(
+      SUB_GOALS.map((sg, idx) => ({
+        id: `level-${idx}`,
+        center_goal: sg,
+        subjects: [],
+        position: idx,
+      }))
+    );
+    mockGenerateMandala.mockRejectedValueOnce(new Error('ollama timeout'));
+
+    const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+
+    expect(mockGenerateMandala).toHaveBeenCalledTimes(1);
+    expect(mockGenerateMandalaActions).toHaveBeenCalledWith(
+      SUB_GOALS,
+      'ko',
+      '30일 ultra learning 습관 만들기',
+      undefined,
+      undefined
+    );
+    expect(mockUpdateLevel).toHaveBeenCalledTimes(8);
+    expect(result).toEqual({ ok: true, action: 'filled', cellsFilled: 8 });
+  });
+
+  test('LoRA returns < 64 actions → Haiku fallback used', async () => {
+    mockFindManyLevels.mockResolvedValueOnce(
+      SUB_GOALS.map((sg, idx) => ({
+        id: `level-${idx}`,
+        center_goal: sg,
+        subjects: [],
+        position: idx,
+      }))
+    );
+    // LoRA returns only 5 sub_goals' worth of actions (40 total < 64)
+    const partialActions: Record<string, string[]> = {};
+    for (let i = 0; i < 5; i++) {
+      partialActions[`sub_goal_${i + 1}`] = Array.from(
+        { length: 8 },
+        (_, j) => `partial-${i}-${j}`
+      );
+    }
+    mockGenerateMandala.mockResolvedValueOnce({
+      center_goal: 'x',
+      center_label: '',
+      language: 'ko',
+      domain: 'general',
+      sub_goals: SUB_GOALS,
+      actions: partialActions,
+    });
+
+    const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+
+    expect(mockGenerateMandala).toHaveBeenCalledTimes(1);
+    expect(mockGenerateMandalaActions).toHaveBeenCalledTimes(1);
+    expect(result.action).toBe('filled');
+  });
+
+  test('LoRA repetition mode (low unique-rate) → Haiku fallback used', async () => {
+    mockFindManyLevels.mockResolvedValueOnce(
+      SUB_GOALS.map((sg, idx) => ({
+        id: `level-${idx}`,
+        center_goal: sg,
+        subjects: [],
+        position: idx,
+      }))
+    );
+    // All 64 actions identical → unique-rate = 1/64 ≈ 0.016, below 0.7 floor
+    const repetitive: Record<string, string[]> = {};
+    SUB_GOALS.forEach((_, idx) => {
+      repetitive[`sub_goal_${idx + 1}`] = Array(8).fill('학습하기');
+    });
+    mockGenerateMandala.mockResolvedValueOnce({
+      center_goal: 'x',
+      center_label: '',
+      language: 'ko',
+      domain: 'general',
+      sub_goals: SUB_GOALS,
+      actions: repetitive,
+    });
+
+    const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+
+    expect(mockGenerateMandala).toHaveBeenCalledTimes(1);
+    expect(mockGenerateMandalaActions).toHaveBeenCalledTimes(1);
+    expect(result.action).toBe('filled');
+  });
+
+  test('LoRA + Haiku both throw → failed', async () => {
+    mockFindManyLevels.mockResolvedValueOnce(
+      SUB_GOALS.map((sg, idx) => ({
+        id: `level-${idx}`,
+        center_goal: sg,
+        subjects: [],
+        position: idx,
+      }))
+    );
+    mockGenerateMandala.mockRejectedValueOnce(new Error('lora down'));
+    mockGenerateMandalaActions.mockRejectedValueOnce(new Error('haiku 500'));
+
+    const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+
+    expect(result.ok).toBe(false);
+    expect(result.action).toBe('failed');
+    expect(result.reason).toContain('haiku 500');
   });
 
   test('skipped-full when all cells already have 8 subjects', async () => {
@@ -162,6 +286,7 @@ describe('fillMissingActionsIfNeeded', () => {
     const result = await fillMissingActionsIfNeeded(MANDALA_ID);
 
     expect(mockCreateManyLevels).not.toHaveBeenCalled();
+    expect(mockGenerateMandala).not.toHaveBeenCalled();
     expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
     expect(mockUpdateLevel).not.toHaveBeenCalled();
     expect(result).toEqual({ ok: true, action: 'skipped-full' });
@@ -178,6 +303,7 @@ describe('fillMissingActionsIfNeeded', () => {
     const result = await fillMissingActionsIfNeeded(MANDALA_ID);
 
     expect(mockCreateManyLevels).not.toHaveBeenCalled();
+    expect(mockGenerateMandala).not.toHaveBeenCalled();
     expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
     expect(result.ok).toBe(false);
     expect(result.action).toBe('skipped-not-found');
@@ -189,6 +315,7 @@ describe('fillMissingActionsIfNeeded', () => {
 
     const result = await fillMissingActionsIfNeeded(MANDALA_ID);
 
+    expect(mockGenerateMandala).not.toHaveBeenCalled();
     expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
     expect(result.ok).toBe(false);
     expect(result.action).toBe('failed');


### PR DESCRIPTION
## 핵심 목적 / 본질 (1줄)
Action 은 UX payload (사용자가 만데일라 열면 보이는 실제 콘텐츠). Haiku generic 프롬프트 대신 2개월째 training 데이터 축적한 **mac mini LoRA** 를 primary 로, Haiku 를 fallback 으로 두어 action 품질을 올린다.

## 배경
- LoRA (`generateMandala`) 는 v14 background fire-and-forget 로 2개월째 가동, prewarm + keep_alive=24h 로 warm, `generation_log` 품질 metrics 축적 중 — 인프라 이미 완비.
- 직전 PR #449 배포 후 prod orphan `70ef45d9` fill 에서 Haiku 가 5/8 cell 만 채움 (completion truncation + key lookup skip). LoRA one-shot 은 전 cell 동시 생성으로 이 문제 없음.

## 변경
- `fill-missing-actions.ts`: LoRA primary call (`generateMandala` → `actions` 필드만 추출). 수락 조건:
  - `totalActions >= 64` (8×8 grid full)
  - `unique-rate >= 0.7` (repetition 실패 모드 감지)
- 실패 / 조건 미달 시 자동 Haiku fallback (`generateMandalaActions`, 기존 경로)
- 둘 다 throw 시 `failed` with Haiku 에러 메시지. structure 는 절대 재작성 안 함 (actions 만 사용).

## 안전망 (층층이)
1. LoRA throw → Haiku
2. LoRA 응답 < 64 actions → Haiku
3. LoRA unique-rate < 0.7 (repetition) → Haiku
4. Haiku 도 throw → `failed` 반환

## Tests
`tests/unit/modules/fill-missing-actions.test.ts` 10 cases (6 → 10):
- LoRA primary success (scaffold + non-scaffold)
- LoRA throws → Haiku
- LoRA < 64 actions → Haiku
- LoRA repetition → Haiku
- LoRA + Haiku 둘 다 throw → failed
- 기존 4 safety case 를 새 source 순서에 맞춰 업데이트
- **10/10 PASS**

## 관찰 가능성
로그로 source 선택 추적:
- `LoRA accepted: X actions, unique-rate Y, ms=Z`
- `LoRA returned X/64 actions — falling back to Haiku`
- `LoRA unique-rate N < 0.7 (repetition mode) — falling back to Haiku`
- `actions source=lora|haiku-fallback`

Post-deploy 에 내가 직접 api 컨테이너 log tail 로 LoRA 실제 선택률 확인.

## Rollback
이 commit 1건 revert → Haiku-primary 복귀. 스키마/env/설정 변경 없음.

## Related
- Layer A: PR #449 (depth=1 scaffold, merged + deployed `24761824738` rerun)
- Gate 2 design: `docs/design/v3-semantic-cell-gate.md` (iter 2 대기 중, 별도 track)

🤖 Generated with [Claude Code](https://claude.com/claude-code)