### PR TITLE
fix(ops): add MANDALA_GEN_MODEL to compose environment — restore LoRA action fill (CP416)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -50,6 +50,15 @@ services:
       # Revert: delete this line and redeploy — code default 'ollama'
       # restores the pre-Phase-1 behavior bit-identically.
       - MANDALA_EMBED_PROVIDER=openrouter
+      # CP416 (2026-04-22) — restore the LoRA action-fill path. Without
+      # this, generateMandala() called config.mandalaGen.model=undefined,
+      # Ollama /api/generate returned 400, LoRA threw, and the Haiku
+      # fallback shipped short truncated JSON → 0 cellsFilled on prod
+      # mandala 70ef45d9. Mac mini Ollama has `mandala-gen:latest`
+      # loaded (verified via /api/tags). Non-secret per CP392: model
+      # tag is stdout-safe / open-source-safe. Revert: delete this
+      # line → LoRA auto-falls back to Haiku (pre-fix state).
+      - MANDALA_GEN_MODEL=mandala-gen:latest
       # OPENROUTER_EMBED_MODEL defaults to `qwen/qwen3-embedding-8b` in
       # code. Uncomment + override here ONLY if the exact OpenRouter
       # model id string differs (verify at https://openrouter.ai/models).


### PR DESCRIPTION
## 핵심 목적/본질 (1줄)
PR #450 LoRA primary swap 이 prod 에서 즉시 Haiku fallback 되던 원인 = `config.mandalaGen.model = undefined` 였음. 모델 태그 1줄 주입으로 LoRA 경로 실질 활성화.

## 근거
- `docker exec insighta-api printenv MANDALA_GEN_MODEL` → empty
- `curl $MANDALA_GEN_URL/api/tags` → 200, `mandala-gen:latest` 존재 확인
- PR #450 검증 시 `[OpenRouter] model=anthropic/claude-haiku-4.5 prompt=361 completion=113` 만 관측 (LoRA 라인 0) → LoRA throw → Haiku fallback → 113-token truncated JSON → `cellsFilled: 0`

## 변경
`docker-compose.prod.yml` 의 `environment:` 블록에 1줄:
```yaml
- MANDALA_GEN_MODEL=mandala-gen:latest
```

**왜 compose `environment:` 에** (not deploy.yml secret, not .env):
- CP392 2-question test: 모델명은 stdout/open-source 노출 OK → not a secret
- CP416 env flip 2-layer lesson: `environment:` > `env_file:` → 재발 방지

## 롤백
1줄 삭제 → 즉시 pre-fix 상태 (Haiku fallback). **회귀 위험 0** — 이 라인 없을 때도 LoRA 는 이미 throw 중이었으므로 runtime 차이 없음.

## 검증 계획 (post-deploy, 내가 수행)
1. `docker exec insighta-api printenv MANDALA_GEN_MODEL` = `mandala-gen:latest`
2. `generateMandala()` 직접 호출 → 64+ actions + unique-rate ≥ 0.7
3. orphan `70ef45d9` refill → `cellsFilled: 8`, `source=lora`
4. api log "actions source=lora" 확인

## Related
- PR #450 (LoRA swap code, merged)
- PR #448 (env flip 2-layer lesson source)
- `memory/troubleshooting.md` "docker-compose environment override"

🤖 Generated with [Claude Code](https://claude.com/claude-code)