### PR TITLE
feat(mandala): LoRA-only action fill policy + failure log + retry CLI (CP416)

### DIFF
--- a/scripts/retry-action-fill.ts
+++ b/scripts/retry-action-fill.ts
@@ -1,0 +1,115 @@
+/**
+ * retry-action-fill — re-run fill-missing-actions for one or many mandalas
+ *
+ * CP416 user directive (2026-04-22): LoRA 실패 기록을 남기고 재처리 가능해야 함.
+ * This script provides the re-processing path.
+ *
+ * Usage:
+ *   # Retry a single mandala (e.g. known orphan from generation_log)
+ *   npx tsx scripts/retry-action-fill.ts <mandala-id>
+ *
+ *   # Retry all mandalas whose depth=1 rows have incomplete subjects
+ *   npx tsx scripts/retry-action-fill.ts --all
+ *
+ *   # Dry run — list candidates without calling LoRA
+ *   npx tsx scripts/retry-action-fill.ts --all --dry-run
+ *
+ * Failure candidates are the mandalas that still have fewer than 8
+ * subjects on any depth=1 row. The fill function is idempotent: cells
+ * already at length 8 are not overwritten (preserves user edits).
+ *
+ * On prod the script runs inside the api container:
+ *   ssh insighta-ec2 "docker exec insighta-api npx tsx scripts/retry-action-fill.ts --all"
+ */
+
+import { getPrismaClient } from '../src/modules/database';
+import { fillMissingActionsIfNeeded } from '../src/modules/mandala/fill-missing-actions';
+
+const MIN_ACTIONS_PER_CELL = 8;
+
+interface RunResult {
+  mandalaId: string;
+  result: Awaited<ReturnType<typeof fillMissingActionsIfNeeded>>;
+}
+
+async function listFailureCandidates(): Promise<string[]> {
+  const db = getPrismaClient();
+  // A mandala needs retry if any depth=1 row has fewer than 8 subjects.
+  // Covers orphans (no depth=1 rows → scaffold path triggers) AND partial
+  // fills (some cells subjects=[], 4, etc.).
+  const rows = await db.$queryRaw<Array<{ mandala_id: string }>>`
+    SELECT DISTINCT m.id AS mandala_id
+    FROM user_mandalas m
+    LEFT JOIN user_mandala_levels l
+      ON l.mandala_id = m.id AND l.depth = 1
+    WHERE l.id IS NULL
+       OR COALESCE(array_length(l.subjects, 1), 0) < ${MIN_ACTIONS_PER_CELL}
+    ORDER BY m.id
+  `;
+  return rows.map((r) => r.mandala_id);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const all = args.includes('--all');
+  const positional = args.find((a) => !a.startsWith('--'));
+
+  let targets: string[];
+  if (all) {
+    targets = await listFailureCandidates();
+    console.log(`[retry-action-fill] ${targets.length} mandalas with incomplete actions`);
+  } else if (positional) {
+    targets = [positional];
+  } else {
+    console.error('usage: retry-action-fill <mandala-id> | --all [--dry-run]');
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    for (const id of targets) console.log(id);
+    return;
+  }
+
+  const results: RunResult[] = [];
+  for (const mandalaId of targets) {
+    const t0 = Date.now();
+    try {
+      const result = await fillMissingActionsIfNeeded(mandalaId);
+      const ms = Date.now() - t0;
+      console.log(
+        `[retry-action-fill] ${mandalaId} -> ${result.action} ` +
+          `(cellsFilled=${result.cellsFilled ?? 0}, ms=${ms}${result.reason ? `, reason=${result.reason}` : ''})`
+      );
+      results.push({ mandalaId, result });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[retry-action-fill] ${mandalaId} -> ERROR: ${msg}`);
+      results.push({
+        mandalaId,
+        result: { ok: false, action: 'failed', reason: msg },
+      });
+    }
+  }
+
+  const filled = results.filter((r) => r.result.action === 'filled').length;
+  const skipped = results.filter((r) => r.result.action === 'skipped-full').length;
+  const failed = results.filter((r) => r.result.action === 'failed').length;
+  const notFound = results.filter((r) => r.result.action === 'skipped-not-found').length;
+  console.log('---');
+  console.log(
+    `summary: filled=${filled} skipped-full=${skipped} failed=${failed} skipped-not-found=${notFound} total=${results.length}`
+  );
+  if (failed > 0) process.exitCode = 2;
+}
+
+main()
+  .catch((err) => {
+    console.error('[retry-action-fill] fatal:', err);
+    process.exit(1);
+  })
+  .finally(() => {
+    // Best-effort disconnect so the script exits cleanly
+    const db = getPrismaClient();
+    void db.$disconnect().catch(() => {});
+  });

--- a/src/modules/mandala/fill-missing-actions.ts
+++ b/src/modules/mandala/fill-missing-actions.ts
@@ -21,9 +21,14 @@
 
 import { randomUUID } from 'node:crypto';
 
+import { Prisma } from '@prisma/client';
+
 import { getPrismaClient } from '@/modules/database';
 import { logger } from '@/utils/logger';
-import { generateMandala, generateMandalaActions } from './generator';
+// `generateMandalaActions` kept imported for the commented-out Haiku
+// fallback revive path below (CP416 policy). Silence unused-import lint.
+import { generateMandala, generateMandalaActions as _generateMandalaActions } from './generator';
+void _generateMandalaActions;
 
 const log = logger.child({ module: 'fill-missing-actions' });
 
@@ -145,24 +150,29 @@ export async function fillMissingActionsIfNeeded(mandalaId: string): Promise<{
   const targetLevel = mandala.target_level ?? undefined;
 
   log.info(
-    `[${mandalaId}] generating actions for ${needsFill.length}/${levels.length} cells (primary: LoRA, fallback: Haiku)`
+    `[${mandalaId}] generating actions for ${needsFill.length}/${levels.length} cells (LoRA-only policy, CP416)`
   );
 
-  // Primary: Mac Mini LoRA via `generateMandala` (one-shot full mandala).
-  // LoRA is purpose-trained on the mandala domain (2 months of background
-  // training-data accumulation, v14) so action quality is substantially
-  // better than generic Haiku prompting. We consume only the `actions`
-  // field from the LoRA output — `sub_goals` are already locked by the
-  // wizard, LoRA must not rewrite them.
+  // Policy (CP416 user directive, 2026-04-22): **LoRA-first, 100% target.**
+  //   - Mac Mini LoRA (`generateMandala`) handles action generation alone.
+  //   - OpenRouter Haiku fallback is kept in source for emergency revival
+  //     but NOT called at runtime (cost concern).
+  //   - Every LoRA failure is logged to `generation_log` so failure cases
+  //     become retraining data for the next LoRA fine-tune.
+  //     See `memory/project_lora_first_policy.md` +
+  //     `memory/feedback_lora_failure_as_training_data.md`.
   //
-  // Fallback: OpenRouter Haiku via `generateMandalaActions` (action-only
-  // prompt). Used when LoRA fails / times out / fails quality gate
-  // (repetition-mode detection via action unique-rate).
+  // Revive Haiku ONLY after explicit user approval (cost sign-off). When
+  // reviving, uncomment the `haiku-fallback` block below and the export of
+  // `generateMandalaActions` from this module's imports.
   let actions: Record<string, string[]> | null = null;
-  let sourceUsed: 'lora' | 'haiku-fallback' = 'lora';
   const centerGoal = rootLevel.center_goal ?? '';
+  let loraErrorForCaller: string | null = null;
 
   const loraStart = Date.now();
+  let loraRawOutput: Record<string, unknown> | null = null;
+  let loraFailureReason: string | null = null;
+
   try {
     const loraMandala = await generateMandala({
       goal: centerGoal,
@@ -170,6 +180,7 @@ export async function fillMissingActionsIfNeeded(mandalaId: string): Promise<{
       focusTags,
       targetLevel,
     });
+    loraRawOutput = loraMandala as unknown as Record<string, unknown>;
     const loraActions = loraMandala?.actions ?? {};
     const totalActions = Object.values(loraActions).reduce(
       (sum, arr) => sum + (Array.isArray(arr) ? arr.length : 0),
@@ -180,13 +191,11 @@ export async function fillMissingActionsIfNeeded(mandalaId: string): Promise<{
     const expectedTotal = EXPECTED_SUB_GOAL_COUNT * EXPECTED_ACTIONS_PER_CELL;
 
     if (totalActions < expectedTotal) {
-      log.warn(
-        `[${mandalaId}] LoRA returned ${totalActions}/${expectedTotal} actions (ms=${loraMs}) — falling back to Haiku`
-      );
+      loraFailureReason = `incomplete-actions: ${totalActions}/${expectedTotal}`;
+      log.warn(`[${mandalaId}] LoRA ${loraFailureReason} (ms=${loraMs})`);
     } else if (uniqueRate < MIN_ACTION_UNIQUE_RATE) {
-      log.warn(
-        `[${mandalaId}] LoRA unique-rate ${uniqueRate.toFixed(2)} < ${MIN_ACTION_UNIQUE_RATE} (repetition mode, ms=${loraMs}) — falling back to Haiku`
-      );
+      loraFailureReason = `repetition-mode: unique-rate ${uniqueRate.toFixed(2)} < ${MIN_ACTION_UNIQUE_RATE}`;
+      log.warn(`[${mandalaId}] LoRA ${loraFailureReason} (ms=${loraMs})`);
     } else {
       actions = loraActions;
       log.info(
@@ -195,11 +204,79 @@ export async function fillMissingActionsIfNeeded(mandalaId: string): Promise<{
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    log.warn(`[${mandalaId}] LoRA threw: ${msg} — falling back to Haiku`);
+    loraFailureReason = `throw: ${msg}`;
+    log.warn(`[${mandalaId}] LoRA threw: ${msg}`);
   }
 
-  if (!actions) {
-    sourceUsed = 'haiku-fallback';
+  // Persist failure case for retraining. Fire-and-forget — never blocks
+  // the fill path. `generation_log` has the columns we need (lora_output /
+  // lora_error / lora_duration_ms / lora_sub_goals / lora_actions_total /
+  // lora_action_unique_rate). raw_prompt / raw_response_text are a CP417
+  // schema extension candidate.
+  if (loraFailureReason) {
+    const loraMs = Date.now() - loraStart;
+    void (async () => {
+      try {
+        // Type-narrowed projections from the raw LoRA output so Prisma's
+        // typed `.create` data accepts the values.
+        const subGoalsLen: number | null = Array.isArray(loraRawOutput?.['sub_goals'])
+          ? (loraRawOutput['sub_goals'] as unknown[]).length
+          : null;
+        let actionsTotal: number | null = null;
+        if (loraRawOutput?.['actions'] && typeof loraRawOutput['actions'] === 'object') {
+          const actionsObj = loraRawOutput['actions'] as Record<string, unknown>;
+          actionsTotal = Object.values(actionsObj).reduce<number>(
+            (sum, v) => sum + (Array.isArray(v) ? v.length : 0),
+            0
+          );
+        }
+        const uniqueRateLog = loraRawOutput?.['actions']
+          ? computeActionUniqueRate(loraRawOutput['actions'] as Record<string, string[]>)
+          : null;
+
+        await db.generation_log.create({
+          data: {
+            user_id: null,
+            goal: centerGoal.slice(0, 500),
+            domain: null,
+            language,
+            lora_won: false,
+            source_returned: 'failed',
+            ...(loraRawOutput != null
+              ? { lora_output: loraRawOutput as Prisma.InputJsonValue }
+              : {}),
+            lora_duration_ms: loraMs,
+            lora_valid: false,
+            lora_sub_goals: subGoalsLen,
+            lora_actions_total: actionsTotal,
+            lora_action_unique_rate: uniqueRateLog,
+            // `[mandala=<uuid>]` prefix is load-bearing — `scripts/retry-action-fill.ts`
+            // does NOT parse this (it scans user_mandala_levels directly), but
+            // ops scripts / admin queries grep this token to correlate failures
+            // with specific mandalas. Keep the exact format.
+            lora_error: `[mandala=${mandalaId}] ${loraFailureReason}`.slice(0, 2000),
+            llm_duration_ms: null,
+            llm_error: null,
+          },
+        });
+        log.info(
+          `[${mandalaId}] LoRA failure logged to generation_log (reason=${loraFailureReason.slice(0, 60)})`
+        );
+      } catch (logErr) {
+        const msg = logErr instanceof Error ? logErr.message : String(logErr);
+        log.warn(`[${mandalaId}] generation_log insert failed: ${msg}`);
+      }
+    })();
+  }
+
+  // Haiku fallback — disabled by CP416 policy (cost). Revive condition:
+  // explicit user approval after a LoRA outage that exceeds acceptable
+  // action-fill downtime. To revive:
+  //   1. Uncomment the block below.
+  //   2. Ensure `generateMandalaActions` stays imported from ./generator.
+  //   3. Add a log line `actions source=haiku-fallback` so the revive is
+  //      observable in prod logs.
+  /* if (!actions) {
     try {
       actions = await generateMandalaActions(
         subGoals,
@@ -208,14 +285,24 @@ export async function fillMissingActionsIfNeeded(mandalaId: string): Promise<{
         focusTags,
         targetLevel
       );
+      log.info(`[${mandalaId}] actions source=haiku-fallback (REVIVED)`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`[${mandalaId}] Haiku fallback also threw: ${msg}`);
       return { ok: false, action: 'failed', reason: `lora+haiku both failed: ${msg}` };
     }
+  } */
+
+  if (!actions) {
+    loraErrorForCaller = loraFailureReason ?? 'lora returned null';
+    return {
+      ok: false,
+      action: 'failed',
+      reason: `lora-only policy; lora failed: ${loraErrorForCaller}`,
+    };
   }
 
-  log.info(`[${mandalaId}] actions source=${sourceUsed}`);
+  log.info(`[${mandalaId}] actions source=lora`);
 
   // Update each depth=1 level's subjects. Key layout from the prompt is
   // `sub_goal_1`..`sub_goal_8`; fall back to index-keyed lookups per the

--- a/tests/unit/modules/fill-missing-actions.test.ts
+++ b/tests/unit/modules/fill-missing-actions.test.ts
@@ -19,6 +19,8 @@ const mockUpdateLevel = jest.fn();
 const mockGenerateMandala = jest.fn();
 const mockGenerateMandalaActions = jest.fn();
 
+const mockGenLogCreate = jest.fn();
+
 jest.mock('@/modules/database', () => ({
   getPrismaClient: () => ({
     user_mandalas: { findUnique: mockFindUniqueMandala },
@@ -28,7 +30,12 @@ jest.mock('@/modules/database', () => ({
       createMany: mockCreateManyLevels,
       update: mockUpdateLevel,
     },
+    generation_log: { create: mockGenLogCreate },
   }),
+}));
+
+jest.mock('@prisma/client', () => ({
+  Prisma: { JsonNull: null },
 }));
 
 jest.mock('../../../src/modules/mandala/generator', () => ({
@@ -101,6 +108,7 @@ describe('fillMissingActionsIfNeeded', () => {
     mockGenerateMandalaActions.mockResolvedValue(mockActionsFor(SUB_GOALS));
     mockUpdateLevel.mockImplementation(async () => ({}));
     mockCreateManyLevels.mockImplementation(async () => ({ count: 8 }));
+    mockGenLogCreate.mockImplementation(async () => ({}));
   });
 
   test('scaffolds 8 depth=1 rows when mandala has none (legacy recovery)', async () => {
@@ -135,7 +143,8 @@ describe('fillMissingActionsIfNeeded', () => {
       expect(scaffoldCall.data[i].position).toBe(i);
     }
 
-    // After scaffold, LoRA (primary) runs and fills — Haiku fallback not called
+    // After scaffold, LoRA (sole source) runs and fills — Haiku call MUST
+    // stay disabled per CP416 LoRA-only policy.
     expect(mockGenerateMandala).toHaveBeenCalledWith({
       goal: '30일 ultra learning 습관 만들기',
       language: 'ko',
@@ -147,7 +156,7 @@ describe('fillMissingActionsIfNeeded', () => {
     expect(result).toEqual({ ok: true, action: 'filled', cellsFilled: 8 });
   });
 
-  test('standard path: LoRA fills all 8 cells, Haiku fallback untouched', async () => {
+  test('standard path: LoRA fills all 8 cells (Haiku never called)', async () => {
     mockFindManyLevels.mockResolvedValueOnce(
       SUB_GOALS.map((sg, idx) => ({
         id: `level-${idx}`,
@@ -159,14 +168,14 @@ describe('fillMissingActionsIfNeeded', () => {
 
     const result = await fillMissingActionsIfNeeded(MANDALA_ID);
 
-    expect(mockCreateManyLevels).not.toHaveBeenCalled(); // no scaffold
+    expect(mockCreateManyLevels).not.toHaveBeenCalled();
     expect(mockGenerateMandala).toHaveBeenCalledTimes(1);
     expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
     expect(mockUpdateLevel).toHaveBeenCalledTimes(8);
     expect(result).toEqual({ ok: true, action: 'filled', cellsFilled: 8 });
   });
 
-  test('LoRA throws → Haiku fallback fills the cells', async () => {
+  test('LoRA throws → logs failure to generation_log and returns failed (no Haiku)', async () => {
     mockFindManyLevels.mockResolvedValueOnce(
       SUB_GOALS.map((sg, idx) => ({
         id: `level-${idx}`,
@@ -178,20 +187,25 @@ describe('fillMissingActionsIfNeeded', () => {
     mockGenerateMandala.mockRejectedValueOnce(new Error('ollama timeout'));
 
     const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+    // Fire-and-forget log runs on next tick — flush microtasks.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
 
     expect(mockGenerateMandala).toHaveBeenCalledTimes(1);
-    expect(mockGenerateMandalaActions).toHaveBeenCalledWith(
-      SUB_GOALS,
-      'ko',
-      '30일 ultra learning 습관 만들기',
-      undefined,
-      undefined
-    );
-    expect(mockUpdateLevel).toHaveBeenCalledTimes(8);
-    expect(result).toEqual({ ok: true, action: 'filled', cellsFilled: 8 });
+    expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
+    expect(mockUpdateLevel).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.action).toBe('failed');
+    expect(result.reason).toContain('lora-only policy');
+    expect(mockGenLogCreate).toHaveBeenCalledTimes(1);
+    const logEntry = mockGenLogCreate.mock.calls[0]![0].data;
+    expect(logEntry.lora_error).toContain(`[mandala=${MANDALA_ID}]`);
+    expect(logEntry.lora_error).toContain('throw');
+    expect(logEntry.source_returned).toBe('failed');
+    expect(logEntry.lora_valid).toBe(false);
   });
 
-  test('LoRA returns < 64 actions → Haiku fallback used', async () => {
+  test('LoRA returns < 64 actions → logs failure (no Haiku, retry-able via generation_log)', async () => {
     mockFindManyLevels.mockResolvedValueOnce(
       SUB_GOALS.map((sg, idx) => ({
         id: `level-${idx}`,
@@ -200,7 +214,6 @@ describe('fillMissingActionsIfNeeded', () => {
         position: idx,
       }))
     );
-    // LoRA returns only 5 sub_goals' worth of actions (40 total < 64)
     const partialActions: Record<string, string[]> = {};
     for (let i = 0; i < 5; i++) {
       partialActions[`sub_goal_${i + 1}`] = Array.from(
@@ -218,13 +231,20 @@ describe('fillMissingActionsIfNeeded', () => {
     });
 
     const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
 
-    expect(mockGenerateMandala).toHaveBeenCalledTimes(1);
-    expect(mockGenerateMandalaActions).toHaveBeenCalledTimes(1);
-    expect(result.action).toBe('filled');
+    expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.action).toBe('failed');
+    expect(result.reason).toContain('incomplete-actions');
+    expect(mockGenLogCreate).toHaveBeenCalledTimes(1);
+    const logEntry = mockGenLogCreate.mock.calls[0]![0].data;
+    expect(logEntry.lora_actions_total).toBe(40);
+    expect(logEntry.lora_error).toContain('incomplete-actions: 40/64');
   });
 
-  test('LoRA repetition mode (low unique-rate) → Haiku fallback used', async () => {
+  test('LoRA repetition mode (low unique-rate) → logs failure (no Haiku)', async () => {
     mockFindManyLevels.mockResolvedValueOnce(
       SUB_GOALS.map((sg, idx) => ({
         id: `level-${idx}`,
@@ -233,7 +253,6 @@ describe('fillMissingActionsIfNeeded', () => {
         position: idx,
       }))
     );
-    // All 64 actions identical → unique-rate = 1/64 ≈ 0.016, below 0.7 floor
     const repetitive: Record<string, string[]> = {};
     SUB_GOALS.forEach((_, idx) => {
       repetitive[`sub_goal_${idx + 1}`] = Array(8).fill('학습하기');
@@ -248,29 +267,16 @@ describe('fillMissingActionsIfNeeded', () => {
     });
 
     const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
 
-    expect(mockGenerateMandala).toHaveBeenCalledTimes(1);
-    expect(mockGenerateMandalaActions).toHaveBeenCalledTimes(1);
-    expect(result.action).toBe('filled');
-  });
-
-  test('LoRA + Haiku both throw → failed', async () => {
-    mockFindManyLevels.mockResolvedValueOnce(
-      SUB_GOALS.map((sg, idx) => ({
-        id: `level-${idx}`,
-        center_goal: sg,
-        subjects: [],
-        position: idx,
-      }))
-    );
-    mockGenerateMandala.mockRejectedValueOnce(new Error('lora down'));
-    mockGenerateMandalaActions.mockRejectedValueOnce(new Error('haiku 500'));
-
-    const result = await fillMissingActionsIfNeeded(MANDALA_ID);
-
+    expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
     expect(result.ok).toBe(false);
     expect(result.action).toBe('failed');
-    expect(result.reason).toContain('haiku 500');
+    expect(result.reason).toContain('repetition-mode');
+    expect(mockGenLogCreate).toHaveBeenCalledTimes(1);
+    const logEntry = mockGenLogCreate.mock.calls[0]![0].data;
+    expect(logEntry.lora_action_unique_rate).toBeLessThan(0.7);
   });
 
   test('skipped-full when all cells already have 8 subjects', async () => {


### PR DESCRIPTION
## 핵심 목적/본질 (1줄)
LoRA 100% 단독 처리 + 모든 실패 케이스를 `generation_log` 에 보존해 재학습 자산화 + 언제든 재처리 가능한 CLI. OpenRouter Haiku 는 주석처리로 revive 가능한 상태 보존 (비용 0).

## User directive (2026-04-22)
> "100% 단독 모델로 처리 가능해야해. openrouter는 붙여는 놓되, 처리되지 않게 주석처리할것 (비용이슈)"
> "실패하는 모든 케이스는 정리해두어서 이후에 모델 재학습을 통해서 성능을 올리는데 활용"
> "LoRA 실패 시, 해당 기록을 남기고 >> 재처리 가능해야해"

## 변경 요약

### 1. `fill-missing-actions.ts`
- Haiku fallback 블록 주석처리 (`/* ... */` + revive 조건 명시). `generateMandalaActions` import 는 유지 (`_generateMandalaActions + void`).
- LoRA 실패 3 유형 분류:
  - `incomplete-actions: N/64` (< 64 actions)
  - `repetition-mode: unique-rate X < 0.7`
  - `throw: <msg>` (Ollama / parse / validation)
- 실패 시 **fire-and-forget** 로 `generation_log.create({...})`:
  - `source_returned='failed'`, `lora_valid=false`, `lora_won=false`
  - `lora_output` (parsed mandala if any), `lora_duration_ms`, `lora_sub_goals`, `lora_actions_total`, `lora_action_unique_rate`
  - `lora_error = [mandala=<uuid>] <reason>` (load-bearing prefix)
- 실패 시 return: `{ ok: false, action: 'failed', reason: 'lora-only policy; lora failed: <reason>' }`

### 2. `scripts/retry-action-fill.ts` (신규)
```bash
npx tsx scripts/retry-action-fill.ts <mandala-id>      # 개별 재처리
npx tsx scripts/retry-action-fill.ts --all             # 전체 스캔 + 재처리
npx tsx scripts/retry-action-fill.ts --all --dry-run   # 후보 나열만
```
- `--all` 은 `user_mandala_levels` 에서 depth=1 & subjects<8 인 모든 만데일라 조회 → fillMissingActionsIfNeeded 재호출
- Idempotent — 이미 8개 채워진 cell 은 건드리지 않음 (사용자 편집 보존)
- Prod 실행: `ssh insighta-ec2 "docker exec insighta-api npx tsx scripts/retry-action-fill.ts --all"`

### 3. Tests
`tests/unit/modules/fill-missing-actions.test.ts` 9 cases — Haiku 는 **NEVER called** 로 pin. 3 신규 failure 케이스는 `generation_log.create` 호출 확인 + `lora_error` / `lora_actions_total` / `lora_action_unique_rate` 정확성.

**9/9 PASS**, tsc clean.

## Policy SSOT (memory)
- `project_lora_first_policy.md` — 방향성 + phase
- `feedback_lora_failure_as_training_data.md` — silent swallow 금지 rule

## Rollback
`git revert <sha>` — 현재 상태로 복귀 (LoRA-primary + Haiku-fallback 재활성). 실패 로깅 만 사라짐, action fill 은 계속 작동.

## Known Follow-ups (CP417)
- LoRA parse error root cause (prompt head noise / stop token premature hit?). 이제 `generation_log` 에 실패 예시 누적 → 분석 기반.
- `raw_prompt` / `raw_response_text` 컬럼 schema 확장 (더 풍부한 재학습 신호)
- Admin UI — generation_log 실패 rows 조회 + one-click retry 통합

## Related
- PR #452 (NUM_PREDICT 5000 — truncation 해소 기반)
- PR #450 (LoRA primary swap 초판 — fallback 은 폐쇄)

🤖 Generated with [Claude Code](https://claude.com/claude-code)