### PR TITLE
revert: PR #454 card target 96→24 — wrong design direction (CP416)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -59,15 +59,6 @@ services:
       # tag is stdout-safe / open-source-safe. Revert: delete this
       # line → LoRA auto-falls back to Haiku (pre-fix state).
       - MANDALA_GEN_MODEL=mandala-gen:latest
-      # CP416 (2026-04-22) — cap YouTube search queries at 5 (default in
-      # code is 20). With V3_TARGET_PER_CELL lowered 12→3 (total 96→24),
-      # the narrow-query path no longer needs 20 queries to saturate a
-      # bigger pool. 5 queries × ~50 results each × shorts filter still
-      # yields plenty (observed pool-after-shorts = 71 / filter-output
-      # = 21 under 15 queries; 5 queries should comfortably clear 24
-      # target). Quota drop: 2000 → 500 units/mandala. Revert: delete
-      # this line (code default V3_MAX_QUERIES=20 restores).
-      - V3_MAX_QUERIES=5
       # OPENROUTER_EMBED_MODEL defaults to `qwen/qwen3-embedding-8b` in
       # code. Uncomment + override here ONLY if the exact OpenRouter
       # model id string differs (verify at https://openrouter.ai/models).

--- a/src/skills/plugins/video-discover/v3/manifest.ts
+++ b/src/skills/plugins/video-discover/v3/manifest.ts
@@ -30,17 +30,7 @@ import { defineManifest } from '@/skills/_shared/runtime';
  *     small for popular cells to reach 8. Raising this in tandem with
  *     MAX_QUERIES 12→20 gives cells room to absorb the wider pool.
  */
-// CP416 (2026-04-22) — product target revised 96 → **24 cards total**.
-// User directive during live latency measurement: 템플릿 7s / AI custom
-// 21s / dashboard 60s+ → "서비스 불가" 진단. 96-card target was the
-// quadruple of what the first viewport (dashboard CardList PAGE_SIZE=24)
-// actually renders, and the over-collection was amplifying downstream
-// latency (more queries, more filter work, more upserts). 3/cell × 8
-// cells = 24 aligns the pipeline target with actual UX consumption.
-//
-// Rollback: restore 12 and the matching V3_MAX_QUERIES=20 — both were
-// the pre-CP416 post-CP391 tuning, no schema change required.
-export const V3_TARGET_PER_CELL = 3;
+export const V3_TARGET_PER_CELL = 12;
 export const V3_NUM_CELLS = 8;
 /**
  * Upper bound on total slots across the mandala. Used by the executor
@@ -48,7 +38,7 @@ export const V3_NUM_CELLS = 8;
  * Tier 1 disabled, total filling is driven entirely by what the filter
  * admits from Tier 2, bounded per-cell by V3_TARGET_PER_CELL.
  */
-export const V3_TARGET_TOTAL = V3_TARGET_PER_CELL * V3_NUM_CELLS; // 24
+export const V3_TARGET_TOTAL = V3_TARGET_PER_CELL * V3_NUM_CELLS; // 96
 
 export const manifest: SkillManifest = defineManifest({
   id: 'video-discover-v3',


### PR DESCRIPTION
## 핵심 목적/본질 (1줄)
PR #454 가 **수집 pool 자체를 24 로 cap** 했는데, 사용자 실제 설계는 **수집은 최대한 많이 / 노출 24-30 / refresh 시 pool 다변화** 3단 분리. 수집 줄이면 refresh 풀 사라져 사용자 경험 더 나빠짐. 즉시 원상 복구.

## User clarification (2026-04-22, PR #454 merge 직후)
> "카드는 한번에 최대한 많이 가져와야 해. 그중 일부를 가령 24~30 등.. 으로 기준에 의해 보여주고,
> 사용자가 추가 refresh 를 하는 경우 나머지 카드 + 신규 카드 + 캐시 등으로 다양한 카드를 추가로 제공할 수 있어야 함"

## 복구
- `V3_TARGET_PER_CELL = 3 → 12` (total 96)
- `docker-compose.prod.yml` `V3_MAX_QUERIES=5` 줄 삭제 (code default 20 으로 복귀)

## 대체 방향 (CP417)
latency 개선은 다른 축에서:
1. 건 2 ontology trigger fire-and-forget (템플릿 7s → 1s)
2. 대시보드 SSE progressive render (DB 19 → UI 즉시 노출)
3. Tier 1 cache 활성화 (video-dict 1000 적재 후)
4. 신규: display-layer cap (24-30 화면 표시) + refresh API (나머지 pool rotation)

## Rollback of revert
`git revert <this-revert-sha>` — 96 → 24 재전환이 다시 의미 있어지면.

🤖 Generated with [Claude Code](https://claude.com/claude-code)