### PR TITLE
feat(recommendations): relevance-first sort for list + stream (CP416 Phase A)

### DIFF
--- a/frontend/src/__tests__/smoke/video-stream-sort.test.ts
+++ b/frontend/src/__tests__/smoke/video-stream-sort.test.ts
@@ -1,0 +1,101 @@
+/**
+ * useVideoStream — binary-insert sorting regression (CP416 Phase A)
+ *
+ * Pins the "relevance desc" invariant for the SSE arrival buffer. User
+ * directive: cards must stream in by relevance, not arrival order, so
+ * the top-N viewport always shows the most relevant cards regardless
+ * of when they land from the pipeline.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { insertByScoreDesc } from '@/features/recommendation-feed/model/useVideoStream';
+import type { RecommendationItem } from '@/features/recommendation-feed/model/useRecommendations';
+
+function mk(id: string, recScore: number): RecommendationItem {
+  return {
+    id,
+    videoId: `v-${id}`,
+    title: `title-${id}`,
+    channel: null,
+    thumbnail: null,
+    durationSec: null,
+    recScore,
+    cellIndex: null,
+    cellLabel: null,
+    keyword: 'k',
+    source: 'auto_recommend',
+    recReason: null,
+  };
+}
+
+function scores(list: RecommendationItem[]): number[] {
+  return list.map((i) => i.recScore);
+}
+
+describe('insertByScoreDesc', () => {
+  test('inserts into empty list', () => {
+    const out = insertByScoreDesc([], mk('a', 0.5));
+    expect(scores(out)).toEqual([0.5]);
+  });
+
+  test('descending arrival stays ordered', () => {
+    let list: RecommendationItem[] = [];
+    list = insertByScoreDesc(list, mk('a', 0.9));
+    list = insertByScoreDesc(list, mk('b', 0.5));
+    list = insertByScoreDesc(list, mk('c', 0.1));
+    expect(scores(list)).toEqual([0.9, 0.5, 0.1]);
+  });
+
+  test('ascending arrival re-sorts to desc', () => {
+    let list: RecommendationItem[] = [];
+    list = insertByScoreDesc(list, mk('a', 0.1));
+    list = insertByScoreDesc(list, mk('b', 0.5));
+    list = insertByScoreDesc(list, mk('c', 0.9));
+    expect(scores(list)).toEqual([0.9, 0.5, 0.1]);
+    expect(list.map((i) => i.id)).toEqual(['c', 'b', 'a']);
+  });
+
+  test('interleaved arrival keeps sorted', () => {
+    const arrivals = [0.3, 0.8, 0.1, 0.9, 0.5, 0.2, 0.7];
+    let list: RecommendationItem[] = [];
+    arrivals.forEach((s, i) => {
+      list = insertByScoreDesc(list, mk(`id-${i}`, s));
+    });
+    const sorted = [...arrivals].sort((a, b) => b - a);
+    expect(scores(list)).toEqual(sorted);
+  });
+
+  test('tie — stable, earlier arrival stays above', () => {
+    let list: RecommendationItem[] = [];
+    list = insertByScoreDesc(list, mk('first', 0.5));
+    list = insertByScoreDesc(list, mk('second', 0.5));
+    list = insertByScoreDesc(list, mk('third', 0.5));
+    expect(list.map((i) => i.id)).toEqual(['first', 'second', 'third']);
+  });
+
+  test('tie with higher-score item pushed to top', () => {
+    let list: RecommendationItem[] = [];
+    list = insertByScoreDesc(list, mk('low-1', 0.2));
+    list = insertByScoreDesc(list, mk('low-2', 0.2));
+    list = insertByScoreDesc(list, mk('top', 0.9));
+    expect(list.map((i) => i.id)).toEqual(['top', 'low-1', 'low-2']);
+  });
+
+  test('does not mutate original list', () => {
+    const original: RecommendationItem[] = [mk('a', 0.8), mk('b', 0.4)];
+    const out = insertByScoreDesc(original, mk('c', 0.6));
+    expect(original.length).toBe(2);
+    expect(scores(original)).toEqual([0.8, 0.4]);
+    expect(scores(out)).toEqual([0.8, 0.6, 0.4]);
+  });
+
+  test('100 random arrivals end up fully sorted', () => {
+    const arrivals = Array.from({ length: 100 }, (_, i) => Math.sin(i) * 0.5 + 0.5);
+    let list: RecommendationItem[] = [];
+    arrivals.forEach((s, i) => {
+      list = insertByScoreDesc(list, mk(`v-${i}`, s));
+    });
+    const sorted = [...arrivals].sort((a, b) => b - a);
+    expect(scores(list)).toEqual(sorted);
+  });
+});

--- a/frontend/src/features/recommendation-feed/model/useVideoStream.ts
+++ b/frontend/src/features/recommendation-feed/model/useVideoStream.ts
@@ -124,7 +124,14 @@ export function useVideoStream(mandalaId: string | null | undefined): UseVideoSt
           if (!payload?.id) return;
           if (seenRef.current.has(payload.id)) return;
           seenRef.current.add(payload.id);
-          setCards((prev) => [...prev, payload]);
+          // CP416 Phase A (2026-04-22): sort by relevance (recScore desc)
+          // on arrival, not append order. User directive requires the
+          // most-relevant cards to float to the top as they arrive.
+          // Higher-score cards arriving later bubble up; lower-score
+          // arrivals slot underneath. Binary insert — O(log n) search,
+          // O(n) array splice; negligible at dashboard scale (<= 24-96
+          // cards per mandala).
+          setCards((prev) => insertByScoreDesc(prev, payload));
         } catch {
           // Ignore malformed event — the next event will come
           // through cleanly. Don't flip to error state for a
@@ -162,4 +169,31 @@ export function useVideoStream(mandalaId: string | null | undefined): UseVideoSt
   }, [mandalaId]);
 
   return { cards, status, error };
+}
+
+/**
+ * Insert `item` into the sorted `list` so the result stays ordered by
+ * `recScore` DESC. Ties: earlier-arriving item stays first (stable).
+ * Exported for testing.
+ */
+export function insertByScoreDesc(
+  list: RecommendationItem[],
+  item: RecommendationItem
+): RecommendationItem[] {
+  const s = item.recScore;
+  let lo = 0;
+  let hi = list.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    // First index where the existing card's score < s (we want to
+    // slot before it). Tie-break: keep existing above the incoming
+    // (stable arrival-time for equal scores).
+    const existing = list[mid];
+    if (existing !== undefined && existing.recScore < s) {
+      hi = mid;
+    } else {
+      lo = mid + 1;
+    }
+  }
+  return [...list.slice(0, lo), item, ...list.slice(lo)];
 }

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -1527,7 +1527,16 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       }
     }
 
-    // Read pending, unexpired recs ordered by cell then score
+    // Read pending, unexpired recs ordered by **relevance first, cell second**.
+    // CP416 Phase A (2026-04-22): user directive requires relevance-desc
+    // sort across all cells, with cell_index as a stable tie-break only.
+    // Previous order ([cell_index asc, rec_score desc]) clustered cards by
+    // cell, which forced the worst card of cell 0 ahead of the best card
+    // of cell 1 — opposite of what relevance-first viewing wants.
+    //
+    // The `idx_recommendation_cache_rec_score_desc` index on rec_score
+    // already exists (see `schema.prisma`), so the re-ordered query hits
+    // the index for the primary sort.
     const rows = await prisma.recommendation_cache.findMany({
       where: {
         user_id: userId,
@@ -1536,7 +1545,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         expires_at: { gt: new Date() },
         ...(cellIndexFilter !== undefined ? { cell_index: cellIndexFilter } : {}),
       },
-      orderBy: [{ cell_index: 'asc' }, { rec_score: 'desc' }],
+      orderBy: [{ rec_score: 'desc' }, { cell_index: 'asc' }],
       take: RECOMMENDATION_FETCH_LIMIT,
     });
 


### PR DESCRIPTION
## Summary (1-liner)
Cards on the mandala dashboard now sort by \`rec_score\` DESC (topic relevance) instead of \`created_at\` DESC. Small, infra-free win.

## Two call sites

1. **BE** \`/api/v1/mandalas/:id/recommendations\` — \`orderBy\` flipped:
   \`[cell_index asc, rec_score desc]\` → \`[rec_score desc, cell_index asc]\`.
   Index \`idx_recommendation_cache_rec_score_desc\` already exists.

2. **FE** \`useVideoStream\` — SSE arrival buffer now binary-inserts by
   \`recScore\` DESC instead of appending. Higher-score cards arriving
   later bubble to the top; lower-score arrivals slot in below.

## Tests
\`frontend/src/__tests__/smoke/video-stream-sort.test.ts\` — 8 cases
(empty / descending / ascending / interleaved / ties / top-swap / no
mutation / 100 random arrivals stay fully sorted).

## Related (design docs, this session)
- \`docs/design/progressive-relevance-stream.md\` — reusable pattern, §7 Phase 1
- \`docs/design/card-refresh-strategy.md\` §13 — progressive delivery cross-ref

## Rollback
\`git revert <sha>\`. No schema or data migration touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)