### PR TITLE
ci: drop feature-branch push trigger — halves CI runs per PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,13 @@
 name: CI
 
 on:
-  push:
-    branches-ignore: [main]
+  # Feature-branch push used to fire here (branches-ignore: [main]), which
+  # caused every PR to see two CI runs: one from the push event and one
+  # from the subsequent pull_request event. The concurrency group below
+  # does not dedupe them because push and pull_request produce different
+  # github.ref values. PR coverage via pull_request already validates
+  # feature branches, and deploy.yml re-invokes this workflow via
+  # `workflow_call` on main merge, so the push trigger was redundant.
   pull_request:
     branches: [main]
   workflow_call:


### PR DESCRIPTION
## Summary
Every PR from a feature branch fired CI twice: once from the push event, once from the pull_request event. The concurrency group does not dedupe them because push and pull_request produce different \`github.ref\` values. This removes the redundant push trigger.

## After
- PR open/update → 1 CI run (pull_request)
- Main merge → deploy.yml invokes ci via workflow_call, 1 CI run + deploy
- Net: ~40-50% fewer CI minutes, no coverage loss

## Rollback
Re-add the \`push: branches-ignore: [main]\` block if direct pushes to feature branches ever need fire-on-push validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)