### PR TITLE
feat(recommendations): stream endpoint emits backlog + FE merge sorted globally (CP416 Phase B)

### DIFF
--- a/frontend/src/features/recommendation-feed/ui/RecommendationFeed.tsx
+++ b/frontend/src/features/recommendation-feed/ui/RecommendationFeed.tsx
@@ -40,14 +40,21 @@ export function RecommendationFeed({ mandalaId, subLabels, cardsByCell }: Recomm
   const stream = useVideoStream(mandalaId);
   const [filter, setFilter] = useState<CellFilter>('all');
 
-  // Merge polled and streamed items. Polling carries the
-  // authoritative cache view (including older rows and cellLabel
-  // resolved server-side); the SSE stream adds live-arriving rows
-  // the polling hasn't fetched yet. Dedupe by id — stream events
-  // win position (they arrived first in time).
+  // Merge polled and streamed items into a single relevance-ordered
+  // list. Both sources carry `recScore` and arrive in the same domain
+  // ordering (CP416 Phase A: /recommendations and the SSE stream both
+  // emit `recScore DESC, cellIndex ASC`). Dedupe by id, preferring the
+  // stream copy when both have a row — the stream is fed directly by
+  // the pipeline so its payload can't be staler than polling.
+  //
+  // A final combined-sort pass guarantees that when we have some ids
+  // only from polling and some only from streaming, the merged list is
+  // still sorted by score rather than a split "stream-block then
+  // polled-block". Phase B (2026-04-22) — prior merge appended block
+  // by block which created visible stripes in the UI.
   const items = useMemo<RecommendationItem[]>(() => {
     const polled = recommendations?.items ?? [];
-    if (stream.cards.length === 0) return polled;
+    if (stream.cards.length === 0 && polled.length === 0) return [];
     const seen = new Set<string>();
     const merged: RecommendationItem[] = [];
     for (const s of stream.cards) {
@@ -60,6 +67,12 @@ export function RecommendationFeed({ mandalaId, subLabels, cardsByCell }: Recomm
       seen.add(p.id);
       merged.push(p);
     }
+    merged.sort((a, b) => {
+      if (b.recScore !== a.recScore) return b.recScore - a.recScore;
+      const ai = a.cellIndex ?? Number.MAX_SAFE_INTEGER;
+      const bi = b.cellIndex ?? Number.MAX_SAFE_INTEGER;
+      return ai - bi;
+    });
     return merged;
   }, [recommendations?.items, stream.cards]);
 

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -2183,6 +2183,64 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         raw.write(`data: ${JSON.stringify(data)}\n\n`);
       };
 
+      // CP416 Phase B (2026-04-22): emit the backlog of already-upserted
+      // recommendation_cache rows before attaching the live subscriber.
+      // Without this, a client connecting after the wizard-stream
+      // pipeline has already finished (e.g. user navigating to dashboard
+      // a few seconds post-creation) would see an empty stream until the
+      // next upsert fires — and the initial `useRecommendations` poll
+      // carries a 5-minute stale-time window that can delay the backlog
+      // arrival further.
+      //
+      // Ordering: `rec_score DESC, cell_index ASC` matches the
+      // canonical /recommendations ordering set by CP416 Phase A so the
+      // client sees the same relevance-first sort whether it's hitting
+      // the poll or the stream backlog.
+      //
+      // Build a `cellIndex → cellLabel` lookup the same way
+      // /recommendations does, so the payload shape is identical to the
+      // live push path.
+      const childLevelsForStream = ((mandala as any).levels ?? []).filter(
+        (l: any) => l.depth === 1
+      );
+      const cellLabelByPosition = new Map<number, string>();
+      for (const child of childLevelsForStream) {
+        if (typeof child.position === 'number' && child.centerGoal) {
+          cellLabelByPosition.set(child.position, child.centerGoal);
+        }
+      }
+
+      const backlogRows = await getPrismaClient().recommendation_cache.findMany({
+        where: {
+          user_id: userId,
+          mandala_id: mandalaId,
+          status: RECOMMENDATION_DEFAULT_STATUS,
+          expires_at: { gt: new Date() },
+        },
+        orderBy: [{ rec_score: 'desc' }, { cell_index: 'asc' }],
+        take: RECOMMENDATION_FETCH_LIMIT,
+      });
+
+      for (const row of backlogRows) {
+        const payload: CardPayload = {
+          id: row.id,
+          videoId: row.video_id,
+          title: row.title,
+          channel: row.channel,
+          thumbnail: row.thumbnail,
+          durationSec: row.duration_sec,
+          recScore: row.rec_score,
+          cellIndex: row.cell_index ?? -1,
+          cellLabel:
+            row.cell_index != null ? (cellLabelByPosition.get(row.cell_index) ?? null) : null,
+          keyword: row.keyword,
+          source: row.weight_version === 0 ? 'manual' : 'auto_recommend',
+          recReason: row.rec_reason,
+        };
+        write('card_added', payload);
+      }
+      write('backlog_done', { count: backlogRows.length });
+
       const unsubscribe = cardPublisher.subscribe(mandalaId, (payload: CardPayload) => {
         write('card_added', payload);
       });


### PR DESCRIPTION
## Summary (1-liner)
Dashboard SSE now replays the current \`recommendation_cache\` backlog on connect so first-view cards are visible in ≤1s instead of waiting for the next live upsert or the 5-minute polling window.

## Changes

1. **BE** \`/api/v1/mandalas/:id/videos/stream\` — query \`recommendation_cache\` (\`rec_score DESC, cell_index ASC\`, matches CP416 Phase A ordering) before attaching \`cardPublisher.subscribe\`. Emit each row as a \`card_added\` SSE event, then a single \`backlog_done\` event with the count.

2. **FE** \`RecommendationFeed\` — add a final \`sort((a,b) => b.recScore - a.recScore)\` pass after the stream+polled dedupe. Fixes the previous \"stream-block then polled-block\" stripe in the UI by re-sorting the union by score.

## Why backlog on stream
Before this, a client hitting the endpoint after the pipeline had already upserted everything got an empty stream and had to wait for (a) the next live upsert (may never come) or (b) the 5-minute \`useRecommendations\` stale-time to expire and refetch. Backlog-on-connect means the client always sees the authoritative relevance-ordered list within its first \`data:\` frames.

## Rollback
\`git revert <sha>\`. No schema / data-migration touched.

## Related
- PR #457 — relevance-first sort (Phase A)
- \`docs/design/progressive-relevance-stream.md\` §7 Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)