### PR TITLE
feat(wizard): atomic set-default for new mandala (CP416 Phase C)

### DIFF
--- a/frontend/src/features/mandala-wizard/model/useWizard.ts
+++ b/frontend/src/features/mandala-wizard/model/useWizard.ts
@@ -543,7 +543,16 @@ export function useWizard() {
       // 2. Background server call — NOT inside useMutation so component unmount
       //    does not kill the continuation (CP386 PR #404 regression class).
       try {
-        const result = await apiClient.createMandalaWithData(params);
+        // CP416 Phase C: ask the server to set this mandala as the
+        // user's default atomically. Replaces the earlier fire-and-
+        // forget `updateMandala({isDefault:true})` post-create call
+        // that raced with the response and silently dropped on
+        // failure — leaving the user looking at the prior default
+        // in the dashboard after a successful wizard submit.
+        const result = await apiClient.createMandalaWithData({
+          ...params,
+          setAsDefault: true,
+        });
         const tResponse = performance.now();
         console.info('[wizard-timing]', {
           event: 'createMandalaWithData',
@@ -600,10 +609,13 @@ export function useWizard() {
           });
         }
 
-        // 3c. Fire-and-forget background updates (same as the old onSuccess).
-        apiClient.updateMandala(result.mandalaId, { isDefault: true }).catch(() => {
-          // Non-blocking — Zustand selection still works for current session.
-        });
+        // CP416 Phase C: the old fire-and-forget
+        //   apiClient.updateMandala(result.mandalaId, { isDefault: true })
+        // is deleted. setAsDefault=true in createMandalaWithData above
+        // promotes the new mandala to default inside the same create
+        // transaction. Removing the post-create call eliminates the
+        // silent-swallow race that caused new mandalas to sometimes
+        // stay with is_default=false.
         queryClient.invalidateQueries({
           queryKey: queryKeys.mandala.list(),
           refetchType: 'all',

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -866,6 +866,14 @@ class ApiClient {
     subLabels?: string[];
     focusTags?: string[];
     targetLevel?: string;
+    /**
+     * CP416 Phase C: ask the server to mark the new mandala as the
+     * user's default inside the create transaction. Eliminates the
+     * earlier "silent demotion race" where a fire-and-forget
+     * updateMandala({isDefault:true}) could fail and leave the user
+     * on the old default mandala.
+     */
+    setAsDefault?: boolean;
   }): Promise<{ mandalaId: string }> {
     // CP358: prod create writes ~73 INSERTs through pgbouncer (us-west-2 ↔
     // Korea RTT ~250ms × 73 ≈ 18s). BE Prisma transaction timeout is 30s

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -966,6 +966,15 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       language?: string;
       focusTags?: string[];
       targetLevel?: string;
+      /**
+       * CP416 Phase C (2026-04-22): when true, the created mandala is
+       * marked `is_default=true` atomically in the same transaction and
+       * the previous default is demoted. Wizard sends this so the user
+       * lands on the newly-created mandala in the dashboard instead of
+       * the prior default. Defaults to false to preserve explicit
+       * caller semantics for other (non-wizard) call paths.
+       */
+      setAsDefault?: boolean;
     };
   }>(
     '/create-with-data',
@@ -993,6 +1002,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         subLabels,
         focusTags,
         targetLevel,
+        setAsDefault,
       } = request.body;
 
       if (!title || typeof title !== 'string' || title.trim().length === 0) {
@@ -1095,7 +1105,9 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           });
         });
 
-        const result = await getMandalaManager().createMandala(userId, title, levels);
+        const result = await getMandalaManager().createMandala(userId, title, levels, {
+          promoteToDefault: setAsDefault === true,
+        });
         stage('create_mandala');
 
         // Save focus_tags and target_level if provided

--- a/src/modules/mandala/manager.ts
+++ b/src/modules/mandala/manager.ts
@@ -351,7 +351,8 @@ export class MandalaManager {
   async createMandala(
     userId: string,
     title: string,
-    levels: MandalaLevelData[]
+    levels: MandalaLevelData[],
+    options: { promoteToDefault?: boolean } = {}
   ): Promise<MandalaWithLevels> {
     // Per-step wall-clock timing so P2028 incidents have a data-driven
     // root cause trail. Emitted via console.info at function exit so the
@@ -403,7 +404,15 @@ export class MandalaManager {
       throw err;
     }
 
-    const isDefault = count === 0;
+    // CP416 Phase C (2026-04-22): `promoteToDefault` lets the wizard
+    // path atomically demote the existing default and promote the new
+    // mandala inside the same transaction, instead of relying on a
+    // fire-and-forget `updateMandala({isDefault:true}).catch(swallow)`
+    // after the insert. The old pattern raced with the response and
+    // silently dropped on failure, leaving the new mandala
+    // `is_default=false` and the user looking at the previous default
+    // in the dashboard.
+    const isDefault = count === 0 || options.promoteToDefault === true;
     const position = (maxPositionResult._max.position ?? -1) + 1;
 
     // Step 3: Transaction for writes only. Budget lives in TX_TIMEOUT_MS
@@ -412,6 +421,15 @@ export class MandalaManager {
       const tTx = Date.now();
       const result = await this.prisma.$transaction(
         async (tx) => {
+          // Phase C: if the caller asked for promoteToDefault AND there
+          // is already at least one existing mandala, demote the others
+          // in the same tx so at most one row ever has is_default=true.
+          if (options.promoteToDefault === true && count > 0) {
+            await tx.user_mandalas.updateMany({
+              where: { user_id: userId, is_default: true },
+              data: { is_default: false },
+            });
+          }
           const tMandalaCreate = Date.now();
           const mandala = await tx.user_mandalas.create({
             data: {


### PR DESCRIPTION
## Summary (1-liner)
Wizard-created mandala is now marked \`is_default=true\` atomically inside the same create transaction, removing the silent-swallow race that left new mandalas stuck as non-default and hid them from the dashboard.

## Problem
Prod observation (CP416): user created \"AI model master\" via wizard, dashboard kept showing the prior default. DB had \`is_default=false\` on the new row, and the fire-and-forget \`updateMandala({isDefault:true}).catch(swallow)\` that was supposed to promote it had silently failed. User saw the old default's 5 cards instead of the new mandala's 52.

## Changes
1. **\`manager.createMandala\`** — optional \`options.promoteToDefault\`. When \`true\` AND \`count > 0\`, demote existing defaults + insert new row as default in one \`$transaction\`.
2. **POST \`/mandalas/create-with-data\`** — accept \`setAsDefault?: boolean\` body param, passes through.
3. **\`apiClient.createMandalaWithData\` + \`useWizard.fireCreateMandala\`** — send \`setAsDefault: true\` and drop the old post-create fire-and-forget updateMandala.

## Behavior preserved
- First-mandala (\`count === 0\`) still defaults to true.
- Template path (\`goToUnifiedDashboard\`) not touched — out of scope, its fire-and-forget keeps working.

## Rollback
\`git revert <sha>\`. Reintroduces the fire-and-forget pattern.

## Related
- PR #457 (Phase A) / #459 (Phase B) / #456 (Lever A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)