### PR TITLE
feat(video-discover/v3): Tier 2 quality gate (flag-guarded, default off) — CP417

### DIFF
--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -3,6 +3,8 @@ import { DEFAULT_SEMANTIC_ALPHA, DEFAULT_SEMANTIC_BETA } from '@/modules/video-d
 import {
   DEFAULT_CENTER_GATE_MODE,
   DEFAULT_MAX_QUERIES,
+  DEFAULT_MIN_VIEW_COUNT,
+  DEFAULT_MIN_VIEWS_PER_DAY,
   DEFAULT_PUBLISHED_AFTER_DAYS,
   DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
   loadV3Config,
@@ -10,7 +12,7 @@ import {
 import { DEFAULT_RECENCY_HALF_LIFE_MONTHS, DEFAULT_RECENCY_WEIGHT } from '../mandala-filter';
 
 describe('loadV3Config', () => {
-  test('empty env → activated defaults (Tier 1 off, recency on, 3yr cutoff, semantic off, yt timeout 1s, center-gate substring)', () => {
+  test('empty env → activated defaults (Tier 1 off, recency on, 3yr cutoff, semantic off, yt timeout 1s, center-gate substring, quality gate off)', () => {
     expect(loadV3Config({})).toEqual({
       enableTier1Cache: false,
       recencyWeight: DEFAULT_RECENCY_WEIGHT,
@@ -23,6 +25,9 @@ describe('loadV3Config', () => {
       youtubeSearchTimeoutMs: DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
       centerGateMode: DEFAULT_CENTER_GATE_MODE,
       maxQueries: DEFAULT_MAX_QUERIES,
+      enableQualityGate: false,
+      minViewCount: DEFAULT_MIN_VIEW_COUNT,
+      minViewsPerDay: DEFAULT_MIN_VIEWS_PER_DAY,
     });
   });
 
@@ -88,7 +93,28 @@ describe('loadV3Config', () => {
       youtubeSearchTimeoutMs: DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
       centerGateMode: DEFAULT_CENTER_GATE_MODE,
       maxQueries: DEFAULT_MAX_QUERIES,
+      enableQualityGate: false,
+      minViewCount: DEFAULT_MIN_VIEW_COUNT,
+      minViewsPerDay: DEFAULT_MIN_VIEWS_PER_DAY,
     });
+  });
+
+  test('quality gate envs — enabled + custom thresholds', () => {
+    const cfg = loadV3Config({
+      V3_ENABLE_QUALITY_GATE: 'true',
+      V3_MIN_VIEW_COUNT: '500',
+      V3_MIN_VIEWS_PER_DAY: '5',
+    });
+    expect(cfg.enableQualityGate).toBe(true);
+    expect(cfg.minViewCount).toBe(500);
+    expect(cfg.minViewsPerDay).toBe(5);
+  });
+
+  test('quality gate envs — unset → flag off, defaults applied', () => {
+    const cfg = loadV3Config({});
+    expect(cfg.enableQualityGate).toBe(false);
+    expect(cfg.minViewCount).toBe(DEFAULT_MIN_VIEW_COUNT);
+    expect(cfg.minViewsPerDay).toBe(DEFAULT_MIN_VIEWS_PER_DAY);
   });
 
   test('V3_YOUTUBE_SEARCH_TIMEOUT_MS parses positive integer', () => {

--- a/src/skills/plugins/video-discover/v3/__tests__/quality-gate.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/quality-gate.test.ts
@@ -1,0 +1,88 @@
+import { filterByQualityGate, type QualityGateConfig } from '../quality-gate';
+
+const NOW = new Date('2026-04-22T12:00:00Z').getTime();
+const TEN_DAYS_AGO = new Date(NOW - 10 * 86_400_000);
+const THREE_HUNDRED_DAYS_AGO = new Date(NOW - 300 * 86_400_000);
+
+const baseOn: QualityGateConfig = {
+  enabled: true,
+  minViewCount: 1000,
+  minViewsPerDay: 10,
+};
+
+describe('filterByQualityGate', () => {
+  test('gate off → pass-through unchanged', () => {
+    const items = [
+      { viewCount: 1, publishedDate: TEN_DAYS_AGO },
+      { viewCount: 9999, publishedDate: TEN_DAYS_AGO },
+    ];
+    const result = filterByQualityGate(items, { ...baseOn, enabled: false }, NOW);
+    expect(result.kept).toEqual(items);
+    expect(result.droppedCount).toBe(0);
+  });
+
+  test('gate on — view < 1000 → dropped', () => {
+    const items = [{ viewCount: 500, publishedDate: TEN_DAYS_AGO }];
+    const result = filterByQualityGate(items, baseOn, NOW);
+    expect(result.kept).toHaveLength(0);
+    expect(result.droppedCount).toBe(1);
+  });
+
+  test('gate on — view=1500, 30d → vpd 50 → passes', () => {
+    const thirty = new Date(NOW - 30 * 86_400_000);
+    const items = [{ viewCount: 1500, publishedDate: thirty }];
+    const result = filterByQualityGate(items, baseOn, NOW);
+    expect(result.kept).toHaveLength(1);
+    expect(result.droppedCount).toBe(0);
+  });
+
+  test('gate on — view=2000, 300d → vpd 6.67 → dropped', () => {
+    const items = [{ viewCount: 2000, publishedDate: THREE_HUNDRED_DAYS_AGO }];
+    const result = filterByQualityGate(items, baseOn, NOW);
+    expect(result.kept).toHaveLength(0);
+    expect(result.droppedCount).toBe(1);
+  });
+
+  test('gate on — publishedDate null → dropped (zero-signal guard)', () => {
+    const items = [{ viewCount: 10000, publishedDate: null }];
+    const result = filterByQualityGate(items, baseOn, NOW);
+    expect(result.kept).toHaveLength(0);
+    expect(result.droppedCount).toBe(1);
+  });
+
+  test('gate on — viewCount null → treated as 0 → dropped', () => {
+    const items = [{ viewCount: null, publishedDate: TEN_DAYS_AGO }];
+    const result = filterByQualityGate(items, baseOn, NOW);
+    expect(result.kept).toHaveLength(0);
+    expect(result.droppedCount).toBe(1);
+  });
+
+  test('gate on — empty input → empty result, zero drops', () => {
+    const result = filterByQualityGate([], baseOn, NOW);
+    expect(result.kept).toEqual([]);
+    expect(result.droppedCount).toBe(0);
+  });
+
+  test('gate on — mixed pool preserves order of kept items', () => {
+    const items = [
+      { id: 'a', viewCount: 50, publishedDate: TEN_DAYS_AGO }, // drop (view)
+      { id: 'b', viewCount: 5000, publishedDate: TEN_DAYS_AGO }, // keep
+      { id: 'c', viewCount: 1000, publishedDate: THREE_HUNDRED_DAYS_AGO }, // drop (vpd=3.3)
+      { id: 'd', viewCount: 20_000, publishedDate: TEN_DAYS_AGO }, // keep
+    ];
+    const result = filterByQualityGate(items, baseOn, NOW);
+    expect(result.kept.map((i) => i.id)).toEqual(['b', 'd']);
+    expect(result.droppedCount).toBe(2);
+  });
+
+  test('custom thresholds are respected', () => {
+    const items = [{ viewCount: 500, publishedDate: TEN_DAYS_AGO }];
+    const looser: QualityGateConfig = {
+      enabled: true,
+      minViewCount: 100,
+      minViewsPerDay: 1,
+    };
+    const result = filterByQualityGate(items, looser, NOW);
+    expect(result.kept).toHaveLength(1);
+  });
+});

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -127,6 +127,23 @@ const centerGateMode = z
   )
   .transform((v) => v ?? DEFAULT_CENTER_GATE_MODE);
 
+export const DEFAULT_MIN_VIEW_COUNT = 1000;
+export const DEFAULT_MIN_VIEWS_PER_DAY = 10;
+
+const minViewCount = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().int().nonnegative().optional()
+  )
+  .transform((v) => v ?? DEFAULT_MIN_VIEW_COUNT);
+
+const minViewsPerDay = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().nonnegative().optional()
+  )
+  .transform((v) => v ?? DEFAULT_MIN_VIEWS_PER_DAY);
+
 export const v3EnvSchema = z.object({
   V3_ENABLE_TIER1_CACHE: booleanFlag.optional().default(false as unknown as string),
   V3_RECENCY_WEIGHT: clampedUnit,
@@ -139,6 +156,9 @@ export const v3EnvSchema = z.object({
   V3_YOUTUBE_SEARCH_TIMEOUT_MS: youtubeSearchTimeoutMs,
   V3_CENTER_GATE_MODE: centerGateMode,
   V3_MAX_QUERIES: maxQueries,
+  V3_ENABLE_QUALITY_GATE: booleanFlag.optional().default(false as unknown as string),
+  V3_MIN_VIEW_COUNT: minViewCount,
+  V3_MIN_VIEWS_PER_DAY: minViewsPerDay,
 });
 
 export interface V3Config {
@@ -153,6 +173,9 @@ export interface V3Config {
   youtubeSearchTimeoutMs: number;
   centerGateMode: CenterGateMode;
   maxQueries: number;
+  enableQualityGate: boolean;
+  minViewCount: number;
+  minViewsPerDay: number;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -168,6 +191,9 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_YOUTUBE_SEARCH_TIMEOUT_MS: env['V3_YOUTUBE_SEARCH_TIMEOUT_MS'],
     V3_CENTER_GATE_MODE: env['V3_CENTER_GATE_MODE'],
     V3_MAX_QUERIES: env['V3_MAX_QUERIES'],
+    V3_ENABLE_QUALITY_GATE: env['V3_ENABLE_QUALITY_GATE'],
+    V3_MIN_VIEW_COUNT: env['V3_MIN_VIEW_COUNT'],
+    V3_MIN_VIEWS_PER_DAY: env['V3_MIN_VIEWS_PER_DAY'],
   });
   if (!parsed.success) {
     return {
@@ -182,6 +208,9 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       youtubeSearchTimeoutMs: DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
       centerGateMode: DEFAULT_CENTER_GATE_MODE,
       maxQueries: DEFAULT_MAX_QUERIES,
+      enableQualityGate: false,
+      minViewCount: DEFAULT_MIN_VIEW_COUNT,
+      minViewsPerDay: DEFAULT_MIN_VIEWS_PER_DAY,
     };
   }
   return {
@@ -196,6 +225,9 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     youtubeSearchTimeoutMs: parsed.data.V3_YOUTUBE_SEARCH_TIMEOUT_MS,
     centerGateMode: parsed.data.V3_CENTER_GATE_MODE,
     maxQueries: parsed.data.V3_MAX_QUERIES,
+    enableQualityGate: parsed.data.V3_ENABLE_QUALITY_GATE,
+    minViewCount: parsed.data.V3_MIN_VIEW_COUNT,
+    minViewsPerDay: parsed.data.V3_MIN_VIEWS_PER_DAY,
   };
 }
 

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -46,6 +46,7 @@ import {
   type FilterCandidate,
 } from './mandala-filter';
 import { v3Config } from './config';
+import { filterByQualityGate } from './quality-gate';
 import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
 
 import {
@@ -410,6 +411,7 @@ interface Tier2Debug {
     semanticGateEmbedMs: number;
     mandalaFilterMs: number;
     scoringMs: number;
+    qualityGateMs: number;
     totalMs: number;
   };
   queries: Array<{ query: string; source: 'rule' | 'llm'; cellIndex: number | null }>;
@@ -418,6 +420,7 @@ interface Tier2Debug {
   droppedShortsDuration: number;
   droppedShortsTitle: number;
   droppedBlocklist: number;
+  droppedQuality: number;
   afterFilter: number;
   existingExcluded: number;
   mandalaFilterInput: number;
@@ -458,6 +461,7 @@ function makeEmptyDebug(input: Tier2Input): Tier2Debug {
       semanticGateEmbedMs: 0,
       mandalaFilterMs: 0,
       scoringMs: 0,
+      qualityGateMs: 0,
       totalMs: 0,
     },
     queries: [],
@@ -466,6 +470,7 @@ function makeEmptyDebug(input: Tier2Input): Tier2Debug {
     droppedShortsDuration: 0,
     droppedShortsTitle: 0,
     droppedBlocklist: 0,
+    droppedQuality: 0,
     afterFilter: 0,
     existingExcluded: 0,
     mandalaFilterInput: 0,
@@ -626,6 +631,21 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   }
   debug.timing.filterMs = Date.now() - tFilterStart;
   debug.afterFilter = enriched.length;
+
+  // Tier 2 quality gate — pure filter, flag-controlled. See quality-gate.ts.
+  if (v3Config.enableQualityGate) {
+    const tQualStart = Date.now();
+    const gated = filterByQualityGate(enriched, {
+      enabled: true,
+      minViewCount: v3Config.minViewCount,
+      minViewsPerDay: v3Config.minViewsPerDay,
+    });
+    enriched.length = 0;
+    enriched.push(...gated.kept);
+    debug.droppedQuality = gated.droppedCount;
+    debug.timing.qualityGateMs = Date.now() - tQualStart;
+  }
+
   if (enriched.length === 0) {
     debug.timing.totalMs = Date.now() - t0;
     return { slots: [], queriesUsed, debug };

--- a/src/skills/plugins/video-discover/v3/quality-gate.ts
+++ b/src/skills/plugins/video-discover/v3/quality-gate.ts
@@ -1,0 +1,58 @@
+/**
+ * Tier 2 quality gate (CP417 independent axis).
+ *
+ * Tier 1 cache (`video_pool`) already enforces bronze-floor
+ * (`view_count >= 1000`) at insert time (batch-video-collector).
+ * Tier 2 realtime historically skipped the floor on purpose —
+ * rationale: "less-viewed is better than empty slots" (executor.ts
+ * pre-CP417 comment). Prod showed this let `view_count = 4` titles
+ * slip through mandala-filter → visible to end user.
+ *
+ * This module is a pure filter; it has no side effects. Apply it
+ * between the shorts/blocklist filter and the mandala-filter
+ * (cell assign). Flag-controlled via `V3_ENABLE_QUALITY_GATE` so
+ * pool-size A/B stays measurable against baseline.
+ */
+
+export interface QualityGateInput {
+  viewCount: number | null;
+  publishedDate: Date | null;
+}
+
+export interface QualityGateConfig {
+  enabled: boolean;
+  minViewCount: number;
+  minViewsPerDay: number;
+}
+
+export interface QualityGateResult<T extends QualityGateInput> {
+  kept: T[];
+  droppedCount: number;
+}
+
+/**
+ * Returns the subset of `items` that pass the gate. When `config.enabled`
+ * is false, returns the input unchanged. When published date is unknown,
+ * the item is dropped under the strict floor — unknown publish date
+ * cannot yield a per-day rate, so the item is treated as zero signal.
+ */
+export function filterByQualityGate<T extends QualityGateInput>(
+  items: T[],
+  config: QualityGateConfig,
+  nowMs: number = Date.now()
+): QualityGateResult<T> {
+  if (!config.enabled) return { kept: items, droppedCount: 0 };
+
+  const kept: T[] = [];
+  for (const item of items) {
+    if (!item.publishedDate) continue;
+    const view = item.viewCount ?? 0;
+    if (view < config.minViewCount) continue;
+    const ageMs = nowMs - item.publishedDate.getTime();
+    const days = Math.max(1, ageMs / 86_400_000);
+    const vpd = view / days;
+    if (vpd < config.minViewsPerDay) continue;
+    kept.push(item);
+  }
+  return { kept, droppedCount: items.length - kept.length };
+}


### PR DESCRIPTION
## Summary
- Reintroduces a view-count + views-per-day floor on the Tier 2 realtime path; extracted into a pure \`filterByQualityGate\` helper for unit-testability.
- Tier 1 already enforces bronze-floor (\`view_count >= 1000\`) at insert time. Tier 2 historically skipped it; prod user report (CP417) showed \`view_count=4\` titles slipping through the mandala filter.
- Flag-guarded so pool-size impact stays measurable as an independent axis (per CP417 re-plan; bundling with other changes would break A/B attribution).

## Env
| Name | Default | Effect |
|------|---------|--------|
| \`V3_ENABLE_QUALITY_GATE\` | \`false\` | unset = no-op; gate off, 기존 동작 그대로 |
| \`V3_MIN_VIEW_COUNT\` | \`1000\` | absolute view floor |
| \`V3_MIN_VIEWS_PER_DAY\` | \`10\` | \`view_count / max(1, days_since_publish)\` floor |

## Debug surface
\`mandala_pipeline_runs.step2_result.debug\`:
- \`timing.qualityGateMs\`
- \`droppedQuality\`

## Pre-flight
- tsc (backend): ✅ clean
- jest (v3 suite): ✅ 83/83 pass (new: 9 quality-gate + 2 config)

## Rollback
\`V3_ENABLE_QUALITY_GATE=false\` 1-line env flip. No code revert needed.

## Design doc
\`docs/design/quality-gate.md\` (pending commit in a follow-up PR with 3 other design docs).

## Non-goals (separate PRs)
- Phase 3B video_pool growth loop
- Phase 3A semantic gate v2 (pgvector KNN)
- Phase 2 wizard pre-compute

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx jest src/skills/plugins/video-discover/v3/__tests__/\` — 83/83 pass
- [ ] CI pass
- [ ] Post-merge deploy — ship with flag off; flip only after 1 week baseline captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)