### PR TITLE
docs(cp417): design docs + perf log + flow anatomy — CP417

### DIFF
--- a/docs/design/precompute-pipeline.md
+++ b/docs/design/precompute-pipeline.md
@@ -1,0 +1,147 @@
+# Design — Wizard Pre-compute Pipeline (Phase 2, SLO-1)
+
+**Date**: 2026-04-22
+**Owner**: CP417+
+**Status**: DRAFT (설계 승인 대기)
+
+---
+
+## 핵심 목표 (1줄)
+
+위저드 save 완료 시점에 대시보드 첫 카드가 **≤1s** 로 나타나게 한다 (SLO-1 체감 즉시).
+
+## 본질 (1줄)
+
+"계산은 이미 끝나 있어야 한다" — 사용자가 Step 1 제목을 확정한 순간부터 서버가 discover 를 시작해, Step 3 저장 이전에 카드가 precompute 되어 있어야 사용자 지각 시간 = 0.
+
+## 컨셉 (1줄)
+
+Step 1→2 전환에서 이미 hit 되는 `/wizard-stream previewOnly=true` endpoint 에 **video discover 병렬 track** 을 추가 — 결과를 `mandala_wizard_precompute` 테이블에 `session_id` 키로 저장. Step 3 save 시 그 session_id 로 lookup → `recommendation_cache` 로 이전 → SSE backlog 즉시 emit.
+
+---
+
+## 제약 / 전제
+
+- **신규 인프라 금지** (Redis Stream / Kafka 제외). 현재 스택: Postgres + pg_cron + Supabase + Fastify
+- `POST /api/v1/mandalas` 계약 변경 금지 (body 에 optional `session_id` 만 추가)
+- `useWizard` 수정 최소 — 새 session_id 발행 + body 에 포함 수준
+- Phase 3B (pool 확장) 완료 여부와 **무관** (pool 규모가 작아도 precompute 저장소는 동작)
+
+---
+
+## 설계
+
+### 데이터 모델
+
+```sql
+-- migration: prisma/migrations/wizard-precompute/001_table.sql
+CREATE TABLE IF NOT EXISTS public.mandala_wizard_precompute (
+  session_id      UUID PRIMARY KEY,
+  user_id         UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  goal            TEXT NOT NULL,
+  language        VARCHAR(5) NOT NULL,
+  focus_tags      TEXT[],
+  status          VARCHAR(20) NOT NULL DEFAULT 'pending', -- pending|running|done|failed|consumed
+  discover_result JSONB,          -- step2_result shape (slots array)
+  error_message   TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at      TIMESTAMPTZ NOT NULL DEFAULT NOW() + INTERVAL '10 minutes'
+);
+CREATE INDEX idx_precompute_user_created ON public.mandala_wizard_precompute(user_id, created_at DESC);
+CREATE INDEX idx_precompute_expires ON public.mandala_wizard_precompute(expires_at) WHERE status != 'consumed';
+```
+
+TTL sweep (pg_cron):
+```sql
+SELECT cron.schedule('precompute-ttl-sweep', '*/5 * * * *',
+  $$DELETE FROM mandala_wizard_precompute WHERE expires_at < NOW() AND status != 'consumed'$$);
+```
+
+### Flow
+
+```
+[Step 1 goal 확정]
+   │  FE: sessionId = randomUUID()
+   │  POST /api/v1/mandalas/wizard-stream?previewOnly=true
+   │  body: { goal, language, focus_tags, session_id }
+   ▼
+[BE /wizard-stream handler]
+   │  기존 structure-gen 응답 즉시 반환 (변경 없음)
+   │  NEW: setImmediate(() => startPrecompute(session_id, goal, ...))
+   ▼
+[startPrecompute — fire-and-forget]
+   │  INSERT mandala_wizard_precompute (status=running)
+   │  runV3Discover(ephemeralContext) — mandala_id 없이 동작 가능하게 executor 리팩토
+   │  UPDATE discover_result, status=done
+   ▼
+[Step 3 save]
+   │  FE: POST /create-with-data body.session_id 포함
+   ▼
+[BE /create-with-data handler]
+   │  기존 wizard save tx 수행
+   │  NEW: tx 후 session_id 로 mandala_wizard_precompute lookup
+   │       - status=done AND expires_at > NOW() → INSERT recommendation_cache rows
+   │       - mark status=consumed
+   │       - cardPublisher.notify(mandalaId, ...) 연쇄 → SSE backlog emit
+   │  miss 시 기존 post-creation pipeline 경로로 fallback
+```
+
+### 계약 변경
+
+1. `/wizard-stream`: body 에 optional `session_id` 추가. 없으면 precompute 스킵 (backward-compat).
+2. `/create-with-data`: body 에 optional `session_id` 추가. 없으면 기존 post-creation pipeline 사용.
+
+### Invalidation
+
+- 제목 재편집: FE 가 기존 sessionId 폐기 + 새 sessionId 발행 + 새 `/wizard-stream` 호출
+- 서버 측 invalidation 별도 없음 — 옛 row 는 TTL 로 정리 (10min)
+- user_id 별 최근 N개만 보존하는 quota 는 v2 로 이월
+
+### Fallback
+
+- precompute miss (session_id 없음 / status ≠ done / expired) → 기존 post-creation pipeline 그대로 실행
+- discover 실패 (status=failed) → miss 로 간주 + 기존 경로
+
+### Feature flag
+
+- `WIZARD_PRECOMPUTE_ENABLED` (compose env, default `false`)
+- flag off 시: `/wizard-stream` 측에서 precompute 안 시작. `/create-with-data` 측에서 session_id lookup 안 함. 기존 동작 100% 보존.
+
+---
+
+## Risk / Rollback
+
+| Risk | 완화 |
+|------|------|
+| discover 병렬 실행이 OpenRouter/YouTube quota 를 2배 소모 | quota exhausted 시 precompute 실패 → miss 로 자연 fallback. 추가 비용 = quota 한도 내 실 사용량 |
+| precompute 가 틀린 결과 (goal 변경 전 version) 를 저장 | session_id 가 매 편집마다 재발행되므로 stale 은 TTL 로 제거 + consumed 시점에 goal match 검사 |
+| mandala_wizard_precompute row 폭증 | expires_at + pg_cron 로 자동 정리. 사용자당 최대 ~3 row (10분 TTL) |
+| discover 에서 수백 row 를 recommendation_cache 로 복사 시 lock | tx 밖에서 별도 세션으로 복사. INSERT … ON CONFLICT DO NOTHING |
+
+**Rollback**: `WIZARD_PRECOMPUTE_ENABLED=false` 1-line env flip. code revert 불필요.
+
+---
+
+## 측정
+
+- Target: `create-with-data` 응답 후 → 첫 SSE `card_added` event 수신까지 **≤1s** (브라우저 측 stopwatch)
+- 지표: `SELECT AVG(EXTRACT(EPOCH FROM (consumed_at - created_at))) FROM mandala_wizard_precompute WHERE status='consumed'` — 평균 precompute→consume 간격
+- Miss rate: `status='failed' OR status != 'consumed' by consume-time` 비율
+
+---
+
+## Non-goals (scope 밖)
+
+- session_id 가 없는 경로 (프로그램matic mandala 생성, template 등) — 기존 pipeline 그대로
+- Search 재검색 시 precompute — Phase 3A 영역
+- Redis 기반 구현 — 아래 근거로 배제
+
+## Redis vs 테이블 결정 근거
+
+**테이블 채택**. 근거:
+1. Redis 는 이미 video-dictionary 전용 pod. wizard precompute 섞으면 scope 혼선 + trace 복잡화
+2. 테이블은 persistent — server restart 시 in-flight precompute 보존 (10min TTL 내 복구 가능)
+3. pg_cron TTL sweep 이미 self-hosted Supabase 에 확장 설치됨 (별도 worker 불필요)
+4. Debug/trace 가 SQL 로 쉬움 (`SELECT * FROM mandala_wizard_precompute WHERE user_id=...`)
+5. throughput 요구 낮음 (user 당 ~분당 1회 발행) — Redis 의 낮은 latency 이점 불필요

--- a/docs/design/quality-gate.md
+++ b/docs/design/quality-gate.md
@@ -1,0 +1,126 @@
+# Design — Tier 2 Quality Gate (독립 축, 별도 PR)
+
+**Date**: 2026-04-22
+**Owner**: CP417+
+**Status**: DRAFT (승인 대기)
+
+---
+
+## 핵심 목표 (1줄)
+
+Tier 2 realtime 경로에 **view count + engagement 최소 기준** 을 적용해 "조회수 4" 류 저품질 카드 노출을 차단한다.
+
+## 본질 (1줄)
+
+pool 재충전과 관계없이 **즉시 효과**. 독립 축이므로 pool size 영향을 A/B 측정하려면 반드시 다른 변경과 분리되어야 한다.
+
+## 컨셉 (1줄)
+
+Tier 2 enrich 완료 → mandala-filter 진입 **직전** 에 bronze-floor 필터 삽입. Tier 1 cache 는 이미 저장 시점 적용됨 (executor.ts:591 주석), Tier 2 만 의도적으로 제외되어 있던 것을 **flag 로 제어 가능한 안전망**으로 승격.
+
+---
+
+## 제약 / 전제
+
+- **별도 PR** (핸드오프 8번 금기). 다른 변경과 묶지 않음
+- pool size 감소 가능성 → **default off** 로 ship, 나중 flip
+- Phase 3B 구현 전/후 어느 시점에서도 독립 적용 가능
+
+---
+
+## 설계
+
+### 환경 변수
+
+| env | default | 의미 |
+|---|---|---|
+| `V3_ENABLE_QUALITY_GATE` | `false` | gate on/off. default off (unset = no-op, 기존 동작 보존) |
+| `V3_MIN_VIEW_COUNT` | `1000` | 절대 조회수 floor (Tier 1 bronze 기준과 동일) |
+| `V3_MIN_VIEWS_PER_DAY` | `10` | `view_count / max(1, days_since_publish)` — 발행일 대비 인기도 |
+
+### 삽입 지점
+
+`src/skills/plugins/video-discover/v3/executor.ts:627` 전후 (`debug.timing.filterMs` 직전):
+
+```ts
+// Tier 2 quality gate (독립 flag, 별도 PR)
+if (v3Config.enableQualityGate) {
+  const tQualStart = Date.now();
+  const now = Date.now();
+  const before = enriched.length;
+  const minView = v3Config.minViewCount;
+  const minVpd = v3Config.minViewsPerDay;
+  for (let i = enriched.length - 1; i >= 0; i--) {
+    const e = enriched[i];
+    const view = e.viewCount ?? 0;
+    const ageMs = e.publishedDate ? now - e.publishedDate.getTime() : 1;
+    const days = Math.max(1, ageMs / 86_400_000);
+    const vpd = view / days;
+    if (view < minView || vpd < minVpd) {
+      enriched.splice(i, 1);
+    }
+  }
+  debug.droppedQuality = before - enriched.length;
+  debug.timing.qualityGateMs = Date.now() - tQualStart;
+}
+```
+
+Tier2Debug 필드 추가:
+```ts
+interface Tier2Debug {
+  timing: { ...기존..., qualityGateMs: number };
+  ...기존...
+  droppedQuality: number;
+}
+```
+
+config.ts 추가 (zod):
+```ts
+enableQualityGate: z.coerce.boolean().default(false),
+minViewCount: z.coerce.number().int().min(0).default(1000),
+minViewsPerDay: z.coerce.number().int().min(0).default(10),
+```
+
+### Test
+
+`tests/unit/skills/video-discover/v3/quality-gate.test.ts`:
+- gate off → pass-through (기존 동작)
+- gate on + view=500 → drop
+- gate on + view=1500, 발행 30일, vpd=50 → pass
+- gate on + view=2000, 발행 300일, vpd=6.7 → drop
+- gate on + view=5000, publishedDate null → drop (guard)
+- gate on + enriched=[] → no-op
+
+---
+
+## Risk / Rollback
+
+| Risk | 완화 |
+|------|------|
+| Pool size 30%+ 급감 | **default off** 로 ship. flip 후 1시간 동안 `debug.droppedQuality` 분포 관측. 과감하면 threshold 하향 |
+| 특정 mandala 는 quality 낮은 영상이 유일한 source | flip 전 샘플 QA 필요. 필요 시 mandala.focus_tags 기반 bypass 고려 (v2 이월) |
+
+**Rollback**: `V3_ENABLE_QUALITY_GATE=false` 1-line. code revert 불필요.
+
+---
+
+## 측정 / A/B
+
+Phase 1 (baseline, gate off): 1주일간 pool size 분포 (mean / p10 / p90) 기록.
+Phase 2 (gate on): 1주일간 같은 지표 측정.
+- Pool size **10% 내 감소** → OK, gate 유지
+- **10~30% 감소** → threshold 하향 검토 (`minViewCount=500` 등)
+- **30%+ 감소** → gate 디자인 재검토 (mandala type 별 threshold?)
+
+지표:
+- `SELECT AVG(total_recommendations), PERCENTILE_CONT(0.1) WITHIN GROUP (ORDER BY total_recommendations) FROM mandala_pipeline_runs WHERE step2_started_at > $window_start`
+- `SELECT AVG((step2_result->'debug'->>'droppedQuality')::int) FROM ...`
+
+---
+
+## Non-goals
+
+- Quality tier 가중치 tuning (silver/gold 선호) — Phase 3A 의 scoring 단계 영역
+- 발행일 1년 이상 영상 우대 / 역차별 — recency weight 로 따로 조절 (현 env `V3_RECENCY_WEIGHT`)
+- Channel authority / subscriber count 기반 gate — channel_whitelist 로 이미 간접 해결
+- Tier 1 cache 측 gate — 이미 저장 시점 bronze floor 적용됨 (중복 불필요)

--- a/docs/design/realtime-search-pipeline.md
+++ b/docs/design/realtime-search-pipeline.md
@@ -1,0 +1,145 @@
+# Design — Realtime Search Pipeline (Phase 3A, SLO-2 latency + quality)
+
+**Date**: 2026-04-22
+**Owner**: CP417+
+**Status**: DRAFT (Phase 3B 완료 후 활성화)
+
+---
+
+## 핵심 목표 (1줄)
+
+pool 규모 도달 이후 실시간 검색 경로를 **≤12s + 50~80 cards** 로 복귀 (SLO-2).
+
+## 본질 (1줄)
+
+request-time **O(N_videos)** embed 를 사전 계산된 **O(1) KNN** 으로 교체 — #446 이 놓친 구조적 해결.
+
+## 컨셉 (1줄)
+
+**Tier 1 pgvector KNN 재활성 + semantic gate v2** — candidates top-N cap + center_goal embedding 1회만. O(수백) embed → O(1) 로 구조 전환.
+
+---
+
+## 선행 조건 (엄격)
+
+이 설계는 **Phase 3B readiness gate 3개 모두 충족 후** 에만 구현 착수.
+
+1. `SELECT COUNT(*) FROM video_pool` ≥ **10,000**
+2. KNN top-60 precision ≥ 50% (샘플 mandala 10건 수동 QA)
+3. embedding 누락률 < 5%
+
+**충족 안 되면**: PR #398 prod incident 재현 위험 (cosine 0.3-0.5 in small pool → unrelated matches). 이 design 은 **미완결 상태로 유지** — Phase 3B 가 끝나기 전까지 구현 절대 금지.
+
+---
+
+## 설계
+
+### 호출 경로 (변경 후)
+
+```
+v3 executor.execute(ctx):
+  t0 = now
+  
+  # 1. center embedding (1회)
+  centerEmbedding = await embedBatch([centerGoal])[0]   # ~100ms OpenRouter
+  
+  # 2. Tier 1 KNN (pgvector)
+  tier1 = await matchFromVideoPoolV2({
+    centerEmbedding,             # NEW: 기존 sub_goal 기반 KNN 대신 center 기반
+    language,
+    topN: V3_TIER1_KNN_LIMIT,    # default 540 (9 cells × 60 buffer)
+    cosineThreshold: V3_SEMANTIC_THRESHOLD   # default 0.45
+  })                             # ~100-300ms (1 SQL query)
+  
+  # 3. mandala filter (PR #398 로직 공유)
+  filtered = applyMandalaFilter(tier1, { centerGoal, subGoals, language, focusTags })
+  # Gate 1 + Gate 2, cell assignment. 기존 코드 그대로.
+  
+  # 4. deficit 이 있을 때만 Tier 2 realtime
+  deficitCells = cells where have < V3_TARGET_PER_CELL
+  if deficitCells.length > 0:
+    tier2 = await runTier2({ deficitCells, ... })   # 기존 경로
+  
+  # 5. 최종 per-cell top-N + upsert
+```
+
+### 신규 쿼리 (`matchFromVideoPoolV2`)
+
+```sql
+-- center_goal embedding 기준 KNN
+SELECT vp.video_id, vp.title, vp.description, vp.channel_name, vp.channel_id,
+       vp.view_count, vp.like_count, vp.duration_seconds, vp.published_at,
+       vp.thumbnail_url, vp.quality_tier,
+       1 - (vpe.embedding <=> $center_emb::vector) AS similarity
+  FROM public.video_pool vp
+  JOIN public.video_pool_embeddings vpe ON vpe.video_id = vp.video_id
+ WHERE vp.language = $language
+   AND vp.is_active = true
+   AND vp.expires_at > NOW()
+   AND (vpe.embedding <=> $center_emb::vector) < (1 - $cosine_threshold)
+ ORDER BY vpe.embedding <=> $center_emb::vector
+ LIMIT $top_n;
+```
+
+index:
+```sql
+-- 이미 있음 (video_pool_embeddings.embedding 에 ivfflat/hnsw index 전제)
+-- 없으면 follow-up: CREATE INDEX ... USING hnsw (embedding vector_cosine_ops);
+```
+
+### Env / flag
+
+| env | default | 의미 |
+|---|---|---|
+| `V3_ENABLE_TIER1_CACHE` | `false` | Phase 3B readiness gate 통과 후 `true` 로 flip |
+| `V3_SEMANTIC_THRESHOLD` | `0.45` | cosine 하한 (PR #398 은 0.3 사용 + incident, 0.5 로 bandaid 검토했지만 mandala-filter 병행 전제 0.45 예비) |
+| `V3_TIER1_KNN_LIMIT` | `540` | KNN 결과 상한 (9 cells × 60 buffer) |
+
+### Shadow mode (활성 전 의무)
+
+`V3_ENABLE_TIER1_CACHE=true` flip 전, **shadow 1주일**:
+- Tier 1 결과를 실행하되 실제 recommendation_cache upsert 는 Tier 2 경로만 사용
+- Tier 1 결과는 `mandala_pipeline_runs.step2_result.debug.tier1_shadow` 에 기록
+- 1주일 후 비교:
+  - Tier 1 상위 N 이 Tier 2 선택과 얼마나 겹치는가 (precision)
+  - Tier 1 이 새로 제시한 카드의 mandala-filter 통과율 (recall)
+- 통과 기준: precision ≥ 50%, mandala-filter 통과율 ≥ 60%
+
+### semantic gate v2 (realtime 경로 내)
+
+Tier 2 realtime 의 기존 `semanticGateEmbedMs` (56s 병목) **제거**:
+- request-time embed 제거
+- Tier 2 candidates 를 받자마자 **mandala-filter.ts 의 Gate 1 (substring) 만** 통과 필터
+- Tier 2 에서 새로 들어온 영상을 다시 embed 하려면 Phase 3B 의 embedding worker 가 처리 (비동기)
+- 결과: Tier 2 latency 3s 그대로 유지, semantic 은 Tier 1 이 담당
+
+---
+
+## Risk / Rollback
+
+| Risk | 완화 |
+|------|------|
+| Phase 3B 미완 상태에서 Tier 1 재활성 → PR #398 incident 재현 | readiness gate 3개 엄격 준수. shadow 1주일 결과 승인 전 flip 금지 |
+| pgvector KNN 성능 저하 (index 없음) | HNSW index 생성 migration 선행 (`CREATE INDEX ... USING hnsw`) |
+| center embedding 1회 호출도 OpenRouter down 시 blocking | fallback 경로: OpenRouter 실패 → Tier 1 스킵 → Tier 2 only (기존 동작) |
+| cosine threshold mis-tune | shadow mode 결과로 threshold 결정. tuning 값은 env 로 외부화 |
+
+**Rollback**: `V3_ENABLE_TIER1_CACHE=false` 1-line env flip. code revert 불필요.
+
+---
+
+## 측정 / SLO 검증
+
+- `step2_result.metrics.duration_ms` p50/p95/p99 (by `trigger` column)
+- `step2_result.total_recommendations` — pool 축 SLO (≥40)
+- `step2_result.debug.tier1_shadow` (shadow mode 기간 동안만)
+- `recommendation_cache` 분포 (quality tier / view count / cell coverage)
+- p95 기준 12s 통과 여부 (SLO-2 confirm)
+
+---
+
+## Non-goals
+
+- Domain-tuned embedding model (PR #398 follow-up Step 5 의 본래 조건) — 본 PR 에서 qwen3-8b 로 시작, 결과 나쁠 시 별도 track 으로 이전
+- Redis caching of center embedding — 같은 mandala 재실행은 이미 mandala_embeddings 테이블 있음, 추가 layer 불필요
+- Tier 1 cache 결과를 다른 소비자 (batch auto-add 등) 로 공유 — 현 consumer 만 대상

--- a/docs/reports/wizard-dashboard-flow-anatomy.md
+++ b/docs/reports/wizard-dashboard-flow-anatomy.md
@@ -1,0 +1,568 @@
+# Wizard → Dashboard End-to-End Flow Anatomy
+
+**Purpose**: e2e 각 모듈의 **실제 코드**, **프롬프트 원문**, **SQL 원문**, **timing 측정 포인트**, **결과 도달 검증 지점** 을 한 화면에서 보기 위한 reference. 실험 시도/결과 ledger 는 `wizard-dashboard-perf-log.md` 에서 관리. 이 파일은 "무엇이 실제로 실행되는가" 의 사실 스냅샷.
+
+**Last updated**: 2026-04-22 (CP416 말, Lever A+ 이후)
+
+---
+
+## E2E flow (module sequence)
+
+```
+Client (wizard) ─POST /create-with-data─▶ API Route
+                                              │
+                                              ▼
+                              [A] manager.createMandala() ───┐
+                              ┌───────────────────────────┐  │
+                              │  TRANSACTION (tx)         │  │
+                              │  [B1] user_mandalas.create│  │
+                              │  [B2] user_mandala_levels │  │  ★ Wizard 저장 시간 측정 구간
+                              │       .createMany         │  │     (M1, M2, M7)
+                              │  [B3] findUnique          │  │
+                              │       (DB trigger [C]    │  │
+                              │        auto-fires)        │  │
+                              └───────────────────────────┘  │
+                                              │              │
+                                              ▼              │
+                              setImmediate() fire-and-forget │
+                              ┌────────┬──────────┬────────┐ │
+                              ▼        ▼          ▼        ▼ │
+                        [D1] Pipeline [D2] Fill  [D3] Sync  │
+                             Run       Missing   Ontology   │
+                             │         Actions   Edges      │
+                             ▼         │         │          │
+                    [E] Embeddings     ▼         ▼          │
+                       (Ollama         [F] LoRA  [K] goal+  │
+                        qwen3-8b)     → Haiku   topic nodes │
+                             │        fallback  +edges      │
+                             ▼            │       upsert    │
+                    [G] Video-Discover v3 │                 │
+                       ├ YouTube search   ▼                 │
+                       ├ Tier 1 semantic  DB update         │
+                       │   center gate    user_mandala_     │
+                       ├ Tier 2 cell      levels.subjects   │
+                       │   assign         (generation_log)  │
+                       ├ (optional) semantic rerank          │
+                       └ upsert recommendation_cache         │
+                             │                               │
+                             ▼                               │
+                    [H] Auto-add → user_video_states         │
+                        + cardPublisher.notify               │
+                             │                               │
+                             ▼                               │
+Client (dashboard) ◀─[I] GET /recommendations ◀──────────────┘
+                      + SSE /:id/videos/stream
+                       (backlog emit → live subscribe)
+                             │
+                             ▼
+                    [J] useVideoStream (FE)
+                        + insertByScoreDesc (binary)
+                        + RecommendationFeed 전역 재정렬
+```
+
+---
+
+## Module A — POST /create-with-data (API entry)
+
+**파일**: `src/api/routes/mandalas.ts`, `src/modules/mandala/manager.ts:351-475`
+
+**입력**: `{ title, levels, focus_tags, language, target_level, setAsDefault? }`
+
+**외부 호출**: DB only (Prisma)
+
+**타이밍 로그 (`[mandala-create-timing]`)**:
+- `dup_check` (manager.ts:367) — 현재 no-op (2026-04-16 이후)
+- `parallel_reads` (manager.ts:387) — subscriptions + auth.users + mandala count
+- `tx_mandala_create` (manager.ts:424)
+- **`tx_levels_createMany` (manager.ts:428)** ← M7 측정 대상
+- `tx_find_unique` (manager.ts:441)
+- `tx_total` (manager.ts:454)
+
+**핵심 결과 도달 검증**: 응답 200 + `mandala.id` 반환 + 클라이언트 navigate. 실제 저장 완결성은 post-creation 파이프라인에서 비동기 검증.
+
+---
+
+## Module B — $transaction (wizard save tx)
+
+**파일**: `src/modules/mandala/manager.ts:413-453`, `:176-228`
+
+**SQL (Prisma 호출 순서)**:
+```ts
+// B1: 메인 mandala row
+tx.user_mandalas.create({ data: { id, user_id, title, focus_tags, ... } })
+
+// B2: depth=1 levels 전부 한 번에 (9 row)
+tx.user_mandala_levels.createMany({
+  data: levels.map(l => ({ id, mandala_id, parent_level_id, level_key,
+    center_goal, center_label, subjects, subject_labels, position, depth, color }))
+})
+// ★ Postgres 트리거 trg_sync_mandala_level (mig 004) 이 여기서 발화:
+//   → ontology.nodes 에 type='mandala_sector' 행을 row 단위로 INSERT (9 row)
+
+// B3: 최종 상태 반환용 findUnique (mandala + levels)
+tx.user_mandalas.findUnique({ where: { id }, include: { levels: true } })
+```
+
+**트랜잭션 타임아웃**: `TX_TIMEOUT_MS = 60_000` (manager.ts:33). 연혁: 5s → 30s (CP358) → 60s (2026-04-18 incident).
+
+**현재 살아있는 DB 트리거** (2026-04-22 Lever A+ 이후):
+- ✅ `trg_sync_mandala_level` (mig 004) — `mandala_sector` 노드 생성. **유지** (기초 row, 비용 9 row × 1 INSERT = ~18 queries).
+- ❌ `trg_goal_edge`, `trg_topic_edges` (mig 011 에서 DROP)
+- ❌ `trg_sync_goal`, `trg_sync_topics` (mig 012 에서 DROP)
+
+**결과 도달 검증**: tx 커밋 시 `user_mandalas`, `user_mandala_levels`, `ontology.nodes (type=mandala_sector)` 3 테이블에 값 존재해야 함. 확인 쿼리:
+```sql
+SELECT COUNT(*) FROM user_mandala_levels WHERE mandala_id = $1;  -- 9 expected
+SELECT COUNT(*) FROM ontology.nodes
+  WHERE (source_ref->>'table') = 'user_mandala_levels'
+    AND (source_ref->>'id') IN (SELECT id::text FROM user_mandala_levels WHERE mandala_id = $1);
+-- 9 expected
+```
+
+---
+
+## Module C — Ontology migrations (trigger history)
+
+**파일**: `prisma/migrations/ontology/*.sql`
+
+| Mig | 내용 | 현 상태 |
+|-----|------|---------|
+| 001 | schema + dictionaries | ✅ active |
+| 002 | core tables (ontology.nodes, ontology.edges) | ✅ |
+| 003 | RLS policies | ✅ |
+| 004 | `trg_sync_mandala_level` + fn `ontology.sync_mandala_level` | ✅ 유지 |
+| 005 | structural_edges | ✅ |
+| 006 | graph functions | ✅ |
+| 007 | service/system 도메인 분리 | ✅ |
+| 008 | `trg_sync_mandala`, `trg_sync_goal`, `trg_sync_topics`, `trg_sync_video_note` | 부분 유지 (video_note 만) |
+| 009 | backfill edges (one-shot data migration) | ✅ |
+| 010 | `trg_goal_edge`, `trg_topic_edges` | ❌ mig 011 이 삭제 |
+| 011 | `DROP TRIGGER trg_goal_edge, trg_topic_edges` (Lever A) | ✅ prod 반영 (수동 apply) |
+| 012 | `DROP TRIGGER trg_sync_goal, trg_sync_topics` (Lever A+) | ⏳ prod 수동 apply 대기 |
+
+---
+
+## Module D — Post-creation pipeline dispatcher
+
+**파일**: `src/modules/mandala/mandala-post-creation.ts:33-100`
+
+`setImmediate()` 내부에서 **3 track 병렬** fire-and-forget:
+
+### D1. Main pipeline
+```ts
+const runId = await createPipelineRun(mandalaId, userId, trigger);
+await executePipelineRun(runId);
+// Steps (tracked in mandala_pipeline_runs):
+//   1. ensureMandalaEmbeddings  ← Module E
+//   2. runVideoDiscover          ← Module G
+//   3. maybeAutoAddRecommendations ← Module H
+```
+
+### D2. Action fill
+```ts
+const { fillMissingActionsIfNeeded } = await import('./fill-missing-actions');
+const result = await fillMissingActionsIfNeeded(mandalaId);
+// ← Module F
+```
+
+### D3. Ontology edge/node sync
+```ts
+const { syncOntologyEdges } = await import('@/modules/ontology/sync-edges');
+const result = await syncOntologyEdges(mandalaId);
+// ← Module K
+```
+
+**타이밍 로그 (모두 `log.info` 로 남음)**:
+- Pipeline: `Pipeline run created: {runId}` + 각 step 완료 로그
+- Actions fill: `actions-fill result for mandala={id}: {action, cellsFilled}`
+- Ontology: `ontology sync for mandala={id}: {ok, goalNodes, topicNodes, goalEdges, topicEdges, ms}`
+
+**결과 도달 검증**: 3 track 모두 독립 실패 가능. 각 catch 블록에서 warn 로그. 한 track 실패가 나머지 차단 안 함.
+
+---
+
+## Module E — Embeddings (sub_goal level 1)
+
+**파일**: `src/modules/mandala/ensure-mandala-embeddings.ts`
+
+**Provider**: Mac Mini Ollama `qwen3-embedding:8b` (4096d). `embedBatch` import from `iks-scorer/embedding`.
+
+**호출 대상**: 각 mandala 의 root.subjects[0..7] (8 sub_goal).
+
+**SQL (idempotency check)**:
+```sql
+SELECT sub_goal_index, sub_goal, (embedding IS NOT NULL) AS has_embedding
+FROM mandala_embeddings
+WHERE mandala_id = $1 AND level = 1
+```
+
+**INSERT/UPDATE**: `mandala_embeddings` 테이블 (컬럼 `embedding vector(4096)`).
+
+**Idempotency 전략**: 각 index 를 `ok / missing / stale` 분류. stale = sub_goal 텍스트가 현재 값과 다름 → 재생성.
+
+**결과 도달 검증**: `SELECT COUNT(*) FROM mandala_embeddings WHERE mandala_id = $1 AND level = 1 AND embedding IS NOT NULL` = 8 expected.
+
+---
+
+## Module F — Action fill (LoRA → Haiku fallback)
+
+**파일**: `src/modules/mandala/fill-missing-actions.ts:64-150`, `src/modules/mandala/generator.ts`
+
+**상수** (fill-missing-actions.ts):
+- `EXPECTED_SUB_GOAL_COUNT = 8`
+- `EXPECTED_ACTIONS_PER_CELL = 8`
+- `MIN_ACTIONS_TO_CONSIDER_FILLED = 8`
+- `MIN_ACTION_UNIQUE_RATE = 0.7`
+
+### F.1 LoRA (primary path since PR #450, CP416)
+
+**호출 대상**: Mac Mini Ollama `mandala-gen:latest` (4.0B Q8_0 LoRA tuned on mandalart).
+
+**URL**: `${MANDALA_GEN_URL}/api/generate` (env 로 주입, 예: `http://100.91.173.17:11434`)
+
+**Request body** (generator.ts:393-410):
+```json
+{
+  "model": "mandala-gen:latest",
+  "prompt": "### Instruction:\n다음 목표에 대한 만다라트를 생성하세요: {goal}\n### Input:\n도메인: {domain}\n언어: ko\n### Output:\n",
+  "stream": false,
+  "keep_alive": "24h",
+  "options": {
+    "num_predict": 5000,
+    "temperature": 0.7,
+    "top_p": 0.9
+  }
+}
+```
+
+**Prompt 템플릿** (generator.ts:107-120, Alpaca 형식):
+```
+### Instruction:
+다음 목표에 대한 만다라트를 생성하세요: {input.goal}
+### Input:
+도메인: {input.domain ?? 'general'}
+언어: {lang ?? 'ko'}
+### Output:
+```
+
+**파싱**: generator.ts:122~ 의 Robust JSON Parser v4.1 (Devin 5/5 pass). `fixBracketTypos` + `removeOutputField` + `escapeInnerNewlines` + `extractJsonRobust` 순차 적용.
+
+**예상 응답 스키마**:
+```json
+{
+  "center_goal": "...",
+  "center_label": "...",
+  "language": "ko",
+  "domain": "general",
+  "sub_goals": ["8 items"],
+  "actions": { "sub_goal_1": ["8 items"], ..., "sub_goal_8": [...] }
+}
+```
+
+### F.2 Haiku fallback (generator.ts:748-757)
+
+**Provider**: `OpenRouterGenerationProvider('anthropic/claude-haiku-4.5')`.
+
+**Prompt** (generator.ts:712-743, few-shot 포함):
+```
+당신은 만다라트 차트 전문가입니다. 주어진 목표에 대해 9x9 만다라트 차트를 JSON으로 생성합니다.
+
+다음은 유사한 기존 만다라 참고 예시입니다:
+
+{formatMandalasForFewShot(similar)  ← 과거 mandala N개를 JSON 형식으로 join}
+
+아래 목표에 대해 새로운 만다라를 생성하세요. 반드시 아래 구조의 유효한 JSON 객체만 출력하세요:
+{"center_goal": "...", "center_label": "short label", "language": "ko", "domain": "general", "sub_goals": ["8 items"], "actions": {"sub_goal_1": ["8 items per sub_goal"], ...}}
+
+목표: {input.goal}
+도메인: {domain}
+언어: {lang}
+```
+
+**Request**: `provider.generate(prompt, { temperature: 0.7, maxTokens: 5000, format: 'json' })`.
+
+### F.3 DB update (action fill 결과 반영)
+
+**SQL** (fill-missing-actions.ts 후반부):
+```ts
+tx.user_mandala_levels.update({
+  where: { id: levelId },
+  data: { subjects: [...8 actions], subject_labels: [...labels] }
+})
+```
+
+**실패 로그**: `generation_log` 테이블에 `{provider, model, status, raw_response, error}` 행 INSERT (PR #453).
+
+**결과 도달 검증**: `SELECT array_length(subjects, 1) FROM user_mandala_levels WHERE mandala_id = $1 AND depth = 1` 의 모든 row 가 `8` 반환해야 M5 = 64/64.
+
+---
+
+## Module G — Video-Discover V3
+
+**파일**: `src/skills/plugins/video-discover/v3/executor.ts:114-300`
+
+### G.1 Preflight (114-184)
+
+- `mandala_embeddings` level=1 확인 (존재해야 Tier 1/semantic rerank 가능)
+- sub-goal texts + center_goal 로드
+
+### G.2 환경 변수 (config.ts)
+
+| Env | Default | 의미 |
+|-----|---------|------|
+| `V3_MAX_QUERIES` | 20 | LLM 생성 query 수 cap |
+| `V3_TARGET_PER_CELL` | 8 | 셀당 목표 카드 수 |
+| `V3_CENTER_GATE_MODE` | `'substring'` (code) → prod `semantic` (compose) | Tier 1 gate 방식 |
+| `V3_ENABLE_SEMANTIC_RERANK` | false | pgvector cosine rerank (현재 off) |
+| `V3_ENABLE_WHITELIST_GATE` | false | 채널 화이트리스트 적용 (off) |
+| `V3_RECENCY_WEIGHT` | 상수 | 최신성 가중치 |
+| `V3_PUBLISHED_AFTER_DAYS` | 1095 (3yr) | 게시일 cutoff |
+| `V3_YOUTUBE_SEARCH_TIMEOUT_MS` | 1000 | 단건 search timeout |
+| `V3_ENABLE_TIER1_CACHE` | false | Tier 1 pool cache 사용 여부 |
+
+### G.3 Query 생성 (executor.ts:52-56)
+
+```ts
+buildRuleBasedQueriesSync(...)  // 규칙 기반 (center_goal + subjects 조합)
++ runLLMQueries(...)            // OpenRouter 'qwen/qwen3-30b-a3b' 로 확장
+```
+
+### G.4 YouTube search 호출
+
+- `search.list` API (YouTube Data v3)
+- key rotation: `YOUTUBE_API_KEY_SEARCH`, `_2`, `_3`
+- `Promise.allSettled` + per-call timeout (PR #428)
+
+### G.5 Tier 1 Center Gate
+
+**Lexical 모드** (legacy, `V3_CENTER_GATE_MODE=substring`):
+- video.title / description 에 center_goal 단어 substring 매칭. Korean 조사 drop 문제 있었음 (#432 subword mode 로 일부 완화).
+
+**Semantic 모드** (`V3_CENTER_GATE_MODE=semantic`, PR #446 prod 활성):
+```ts
+// 의사코드 (실제 코드는 executor.ts 후반부)
+const centerEmb = await embedBatch([centerGoalText]);
+const videoEmbs = await embedBatch(videoTitles);
+const sims = videoEmbs.map(v => cosineSimilarity(centerEmb[0], v));
+// gate: sims[i] >= SEMANTIC_THRESHOLD
+```
+
+### G.6 Tier 2 Cell Assignment
+
+- deficit cells (`have < target`) 에만 realtime search
+- 각 video 를 sub_goal embedding 과 비교해 argmax cell 에 배치
+- 현재 lexical (Jaccard 기반) 이 기본. **Gate 2 semantic cell 은 설계만, 미구현** (`docs/design/v3-semantic-cell-gate.md` iter 2).
+
+### G.7 upsert recommendation_cache
+
+```ts
+upsertSlots(userId, mandalaId, slots, subGoals)
+// Schema: (mandala_id, video_id, cell_index, rec_score, cell_label, keyword, source, rec_reason, published_at, ...)
+// 이 INSERT 후 auto-add 가 recommendation_cache → user_video_states 로 이동
+```
+
+**Stage 계측** (executor.ts:402-436): timing, queries, perQueryCounts, poolAfterDedupe, 각 drop count (Tier 1 drop, Jaccard drop, mandala filter drop).
+
+**결과 도달 검증**: `SELECT COUNT(*) FROM recommendation_cache WHERE mandala_id = $1` ≥ 1. M6 측정 값.
+
+---
+
+## Module H — Auto-add
+
+**파일**: `src/modules/mandala/auto-add-recommendations.ts`
+
+**Opt-in gate**: `user_skill_config` 의 `video_discover` 활성 + `config.auto_add` JSONB 체크.
+
+**규칙**: AUTO_ADD_PER_CELL cap 은 2026-04-18 이후 제거 (PR 2d2a770). 모든 pending rec auto-add.
+
+**SQL** (insertion):
+```ts
+// 추천 pool 에서 조회
+recommendation_cache.findMany({
+  where: { mandala_id },
+  orderBy: [{ cell_index: 'asc' }, { rec_score: 'desc' }]
+})
+// Dedup: video_id 가 이미 user.youtube_videos 에 있으면 스킵
+// Insert:
+user_video_states.create({ data: { user_id, mandala_id, video_id, cell_index, auto_added: true, ... } })
+```
+
+**Eviction policy** (user가 손 안 댄 auto-added 카드):
+```sql
+DELETE FROM user_video_states WHERE
+  user_id = $1 AND mandala_id = $2 AND cell_index = $3
+  AND auto_added = true
+  AND user_note IS NULL
+  AND (is_watched IS NULL OR is_watched = false)
+  AND (watch_position_seconds IS NULL OR watch_position_seconds = 0)
+  AND is_in_ideation = false
+```
+
+**Notify**: `notifyCardAdded(mandalaId, payload)` → `cardPublisher.notify` → EventEmitter.emit (Module I 소비).
+
+**결과 도달 검증**: `SELECT COUNT(*) FROM user_video_states WHERE mandala_id = $1 AND auto_added = true` 가 기대 수 이상.
+
+---
+
+## Module I — API Delivery (GET + SSE)
+
+**파일**: `src/api/routes/mandalas.ts:1485-2270`
+
+### I.1 GET `/api/v1/mandalas/:id/recommendations` (라인 1485-1580)
+
+```ts
+recommendation_cache.findMany({
+  where: { mandala_id, user_id },
+  orderBy: [{ rec_score: 'desc' }, { cell_index: 'asc' }],  // CP416 Phase A (#457)
+  take: RECOMMENDATION_FETCH_LIMIT
+})
+```
+
+### I.2 GET `/api/v1/mandalas/:id/videos/stream` (SSE, 라인 2121-2270)
+
+**연결 직후 backlog emit** (라인 2213-2222, CP416 Phase B #459):
+```ts
+const backlog = await prisma.recommendation_cache.findMany({
+  where: { mandala_id, user_id },
+  orderBy: [{ rec_score: 'desc' }, { cell_index: 'asc' }],
+  take: RECOMMENDATION_FETCH_LIMIT
+});
+for (const row of backlog) {
+  sendEvent({ type: 'card_added', payload: toCardPayload(row) });
+}
+```
+
+**Live subscribe** (라인 2244):
+```ts
+const unsubscribe = cardPublisher.subscribe(mandalaId, (payload) => {
+  sendEvent({ type: 'card_added', payload });
+});
+```
+
+**Heartbeat**: 20초마다 `event: ping`.
+
+**Payload 스키마** (라인 2225-2239):
+```ts
+interface CardPayload {
+  id, videoId, title, channel, thumbnail, durationSec, recScore,
+  cellIndex, cellLabel, keyword, source, recReason
+}
+```
+
+**결과 도달 검증**: 클라이언트 EventSource 에서 연결 직후 N개 backlog card 수신 → 이후 live 추가 수신. 서버 측 로그 `SSE backlog emitted={N}`.
+
+---
+
+## Module J — Frontend merge + sort
+
+**파일**: `frontend/src/features/recommendation-feed/model/useVideoStream.ts:53-200`
+
+**연결**:
+```ts
+const es = new EventSource(
+  `${API_BASE_URL}/api/v1/mandalas/${mandalaId}/videos/stream?access_token=${token}`
+);
+```
+
+**Binary insert** (라인 179-199):
+```ts
+function insertByScoreDesc(list, item) {
+  const s = item.recScore;
+  let lo = 0, hi = list.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (list[mid].recScore < s) hi = mid;
+    else lo = mid + 1;
+  }
+  return [...list.slice(0, lo), item, ...list.slice(lo)];
+}
+```
+
+**호출**: `setCards(prev => insertByScoreDesc(prev, payload))` (라인 134).
+
+**RecommendationFeed 측 전역 재정렬** (CP416 Phase B): 
+- 기존 로컬 카드 + SSE 수신 카드 merge 후 `recScore desc` 전역 재정렬 (`frontend/src/features/recommendation-feed/ui/RecommendationFeed.tsx`).
+
+**결과 도달 검증**: `cards` 배열이 `recScore DESC` 정렬 유지. FE dev tool / redux devtools 로 확인.
+
+---
+
+## Module K — sync-edges (Lever A/A+)
+
+**파일**: `src/modules/ontology/sync-edges.ts:63-343`
+
+4단계 multi-row SQL (모든 INSERT `ON CONFLICT DO NOTHING` 또는 `DO UPDATE`):
+
+### K.1 Goal nodes upsert (라인 141-162)
+```sql
+INSERT INTO ontology.nodes (user_id, type, title, properties, source_ref)
+SELECT ${userId}::uuid, 'goal', t,
+       jsonb_build_object('level_key', lk, 'depth', d::int, 'mandala_id', mid::uuid),
+       jsonb_build_object('table', 'user_mandala_levels_goal', 'id', rid)
+  FROM unnest(${titles}::text[], ${levelKeys}::text[], ${depths}::int[],
+              ${mandalaIds}::text[], ${refIds}::text[]) AS u(t, lk, d, mid, rid)
+ON CONFLICT ((source_ref->>'table'), (source_ref->>'id'))
+  WHERE source_ref IS NOT NULL
+DO UPDATE SET title=EXCLUDED.title, properties=EXCLUDED.properties, updated_at=now()
+```
+
+### K.2 Topic nodes upsert (라인 189-219)
+
+동일 패턴, `type='topic'`, source_ref.id = `"{level-id}:{subject}"`.
+
+### K.3 Goal edges (라인 303-312)
+```sql
+INSERT INTO ontology.edges (user_id, source_id, target_id, relation)
+SELECT ${userId}::uuid, s::uuid, t::uuid, 'CONTAINS'
+  FROM unnest(${sources}::text[], ${targets}::text[]) AS u(s, t)
+ON CONFLICT (source_id, target_id, relation) DO NOTHING
+```
+`source = sector node`, `target = goal node`.
+
+### K.4 Topic edges (라인 315-325)
+
+동일 패턴, `target = topic node`.
+
+**결과 도달 검증**:
+```sql
+SELECT (SELECT COUNT(*) FROM ontology.nodes n WHERE n.source_ref->>'id' LIKE '<mandala-id>%' AND n.type='goal') AS goals,
+       (SELECT COUNT(*) FROM ontology.nodes n WHERE n.type='topic' AND n.properties->>'mandala_id' = '<mandala-id>') AS topics,
+       (SELECT COUNT(*) FROM ontology.edges e JOIN ontology.nodes s ON s.id = e.source_id WHERE s.properties->>'mandala_id' = '<mandala-id>' AND e.relation='CONTAINS') AS edges;
+```
+
+---
+
+## Timing measurement reference
+
+모든 측정은 `[mandala-create-timing]` 접두사 로그로 prod 수집. 조회:
+```bash
+ssh insighta-ec2 "docker logs <api-container> 2>&1 | grep 'mandala-create-timing' | tail -20"
+```
+
+| Metric | 로그 라벨 | 파일:라인 | 현 baseline (CP416) | Target (서비스 선) |
+|--------|-----------|-----------|---------------------|--------------------|
+| M7 | `tx_levels_createMany` | manager.ts:428 | 6.9s (Lever A 전) → 5.1s (Lever A 후) → **측정 대기 (Lever A+ 후)** | <1s |
+| M1 | (사용자 체감) | — | 7s | ≤1s |
+| M2 | (사용자 체감) | — | 21s | ≤4s |
+| M3 | (사용자 체감) | — | 60s+ | 즉시 |
+| M5 | `actions-fill result` `cellsFilled` | mandala-post-creation.ts:64 | 간헐 (6/8, 0/8) | 64/64 |
+| M6 | `SELECT count(*) from recommendation_cache` | — | 19 | 50+ |
+| M8 | V3 stage observability (Tier 1 drop rate) | executor.ts:402-436 | 73% (lexical) → 개선 (semantic, 수치 미관찰) | <30% |
+| M9 | Jaccard/cell drop (Tier 2) | 동일 | 44 drop | ~12 |
+
+---
+
+## Update protocol
+
+이 파일은 **실제 구현 스냅샷**. 실험 시도/결과는 `wizard-dashboard-perf-log.md` 쪽.
+
+- 새 모듈 추가 / 기존 모듈 재설계 시 해당 섹션 업데이트.
+- 환경 변수 / 상수 값 변경 시 표 갱신.
+- 트리거 drop/create 시 Module C 표 + Module B "현재 살아있는 DB 트리거" 갱신.
+- Prompt 템플릿 변경 시 Module F 전문 교체.
+- SQL 변경 시 해당 모듈 블록 교체.
+
+Cross-ref:
+- 실험 ledger: `docs/reports/wizard-dashboard-perf-log.md`
+- 설계 문서: `docs/design/wizard-service-redesign-2026-04-22.md`, `docs/design/v3-semantic-cell-gate.md`, `docs/design/card-refresh-strategy.md`, `docs/design/progressive-relevance-stream.md`
+- 마이그레이션: `prisma/migrations/ontology/*.sql`

--- a/docs/reports/wizard-dashboard-perf-log.md
+++ b/docs/reports/wizard-dashboard-perf-log.md
@@ -1,0 +1,192 @@
+# Wizard → Dashboard Performance Experiments Log
+
+**Purpose**: 위저드 저장 → 대시보드 카드 노출 e2e 체감 지연 회복 작업의 **running ledger**. 새 실험 착수 / 실측 결과 확인 / 롤백 시 반드시 이 파일을 먼저 업데이트. 한 번의 정리 문서가 아니라 지속 관리 대상.
+
+**Owner**: 위저드-대시보드 성능 arc 에 직접 commit 하는 세션이 갱신 책임. 최소 CP 단위 갱신.
+
+**Last updated**: 2026-04-22 (CP416 말, PR #462 merged)
+
+---
+
+## Tracked metrics (user-visible, end-to-end)
+
+| ID | 정의 | 측정 소스 |
+|----|------|-----------|
+| M1 | 템플릿 만다라트 생성 시간 (wizard save complete) | 사용자 stopwatch + `[mandala-create-timing]` log |
+| M2 | AI custom 만다라트 생성 시간 | 사용자 stopwatch + `[mandala-create-timing]` log |
+| M3 | 대시보드 첫 카드 노출 (mandala open → first card render) | 사용자 체감 + RecommendationFeed mount → first `<VideoCard>` |
+| M4 | 대시보드 24 카드 채움 (mandala open → 24 cards visible) | 사용자 체감 |
+| M5 | action slot fill rate (target 64 = 8 cells × 8 subjects) | `generation_log` + `user_mandala_levels.subjects` |
+| M6 | card pool size (`recommendation_cache` rows per mandala) | SQL `count(*) where mandala_id=$1` |
+| M7 | `tx_levels_createMany` wall time (prod log) | `[mandala-create-timing]` 구조 |
+| M8 | center gate drop rate (Tier 1) | `video-discover v3` stage observability |
+| M9 | cell assignment drop (Tier 2) | 동일 |
+
+---
+
+## Baselines
+
+| Metric | CP388 기점 (2026-04-15) | CP416 중반 (user 보고, 2026-04-22 아침) |
+|--------|-------------------------|----------------------------------------|
+| M1 | 측정 안 됨 | 7s |
+| M2 | 측정 안 됨 | 21s |
+| M3 | 대기 지속 | 60s+ (사용자 판단 "서비스 불가") |
+| M4 | 미도달 | 미도달 ("2 cards 현상", 최대 19) |
+| M5 | 부분 성공 | 간헐 실패 (LoRA silent fail) |
+| M6 | 2~19 | 2~19 |
+| M7 | n/a | 6.9s (PR #449 직후) |
+| M8 | ~73% drop (lexical) | (Phase 3 semantic 전까지 유지) |
+
+**Target (서비스 가능 선)**: M1 ≤ 1s / M2 ≤ 4s / M3 즉시 / M4 수 초 / M5 64/64 / M6 50+ / M7 < 1s.
+
+---
+
+## Experiment ledger (chronological)
+
+> **열 약어**: PR = merged PR 번호 (없으면 commit hash). **Status**: ✅ landed+prod, 🔄 landed but reverted, ⏳ landed pending verification, ❌ reverted same-day, 📝 design-only.
+
+### Layer 1 — Data acquisition (YouTube discovery)
+
+| Date | PR | Change | Hypothesis | Expected | Actual | Status |
+|------|----|----|-----------|----------|--------|--------|
+| 2026-04-15 | #393 | v3 cache+realtime + batch-video-collector pipeline | 3-tier cache 로 YouTube API 비용/지연 절감 | pool 채움 가속 | pool 채움 유지, 지연 개선 미측정 | ✅ |
+| 2026-04-16 | #397 | Tier 2 gates + wizard UX + C+ prompt | 품질 낮은 카드 배제 | 관련도↑ | 관련도 감정적 개선, M6 에는 영향 없음 | ✅ |
+| 2026-04-16 | #398 | 추천은 mandala 자체로 라우팅, legacy pool 우회 | pool mismatch 제거 | dashboard empty 감소 | empty 감소 관측, M3 여전 slow | ✅ |
+| 2026-04-17 | #401 | shorts threshold 60s → 180s (YouTube 2024 policy) | 쇼츠 배제 정확도 | 지속 유지 | 유지 | ✅ |
+| 2026-04-17 | #410 | stage-level observability | Tier 1/2 drop rate 계측 가능 | drop rate 숫자화 | M8 ~73% drop 발견 (lexical) | ✅ |
+| 2026-04-18 | #414 (revert 동반) | 1-char Hangul + focusTags bypass center gate | 한글 단음절 drop 제거 | Tier 1 drop ↓ | 부분 개선, 근본 해결 아님 | 🔄 |
+| 2026-04-18 | 3e4d0c2 | MAX_QUERIES 12→20, TARGET_PER_CELL 8→12 | recall 확대 | M6 ↑ | M6 부분 상승, pool 다양성 한계 | ✅ |
+| 2026-04-21 | #428 | YouTube search per-call timeout + Promise.allSettled | 단건 timeout 이 전체를 blocking 하는 현상 제거 | pool 채움 안정화 | 안정화 확인 | ✅ |
+| 2026-04-21 | #432, #433 | center-gate subword mode | Korean composite-word drop 해소 | Tier 1 drop ↓ | 부분 개선 | ✅ |
+| 2026-04-22 | #446 | Phase 3 semantic center gate + V3_MAX_QUERIES env | semantic cosine gate 로 Tier 1 recall 0.27 → 높임 | M8 drop ↓, M6 ↑ | prod runtime `printenv=semantic` 확인. **M6 19 (target 50+) 미달** — cell assign bottleneck (Layer 2) 이 지배적 | ✅ |
+| 2026-04-22 | #447 | `.env` 에 `V3_CENTER_GATE_MODE=semantic` sed 주입 | prod 활성화 | semantic 동작 | **silent miss** — compose `environment:` override 무시 | 🔄 |
+| 2026-04-22 | #448 | compose `environment:` 에 `V3_CENTER_GATE_MODE=semantic` 직접 수정 | 실제 runtime 반영 | semantic 실제 활성화 | `docker exec printenv` 로 실측 | ✅ |
+| 2026-04-22 | (CP416 revert) #454→#455 | V3_MAX_QUERIES=5, V3_TARGET_PER_CELL=3 세팅 | dashboard first-viewport 24 로 정렬 | pool 작아짐 | **"2 cards 현상" 악화** — 사용자 "수집 pool 자르지 말고 유지" | ❌ |
+
+### Layer 2 — Scoring / gating (cell assignment + relevance)
+
+| Date | PR | Change | Hypothesis | Expected | Actual | Status |
+|------|----|----|-----------|----------|--------|--------|
+| 2026-04-19 | 7c82a04 | recency + 3yr publishedAfter 기본 활성화 | 최신성 우대 | 관련도 유지 + 신선함 | 부작용 없음 | ✅ |
+| 2026-04-19 | 352ad1f | `video_chunk_embeddings` 테이블 (semantic rating) | pgvector 기반 rerank 기반 마련 | 0 row 운영 | infra only | ✅ |
+| 2026-04-20 | #423 | semantic rerank consumer module (flag off) | 점진 rollout | flag off = no-op | flag off | ✅ |
+| 2026-04-20 | #424 | CP407 Phase B semantic rerank dev-probe | PASS 보고 | PASS | PASS (187 chunks) | ✅ |
+| 2026-04-22 | (design) | `docs/design/v3-semantic-cell-gate.md` iter 1+2 | cosine cell assign + top-2 fallback + focus_tags bypass + gate-relative normalization | M9 drop 44→~12, M6 19→50+ | 미구현 (CP417 Primary) | 📝 |
+
+### Layer 3 — Action fill (LoRA / Haiku)
+
+| Date | PR | Change | Hypothesis | Expected | Actual | Status |
+|------|----|----|-----------|----------|--------|--------|
+| 2026-04-22 | #442 | prod OpenRouter embedding provider 활성화 | service critical path 에서 mac mini 제거 | 안정성↑ | 안정성 확인 | ✅ |
+| 2026-04-22 | #440 | OpenRouter embed provider switch (Phase 1) | 동일 | embed latency 개선 | 개선 | ✅ |
+| 2026-04-22 | #445 | wizard allow empty actions + post-creation fill | 빈 actions 에서도 저장 허용, 뒤에서 채움 | wizard 저장 가속 | 저장은 빨라졌지만 fill 경로 silent fail 존재 | ✅ |
+| 2026-04-22 | #449 | 항상 depth=1 scaffold + legacy recovery | orphan mandala (level_2 → channels) 복구 | 8 scaffold rows | 적용 확인 (orphan 70ef45d9 → 8 rows) | ✅ |
+| 2026-04-22 | #450 | action-fill primary: Haiku → mac mini LoRA (Haiku fallback) | 비용 해결 + 학습 데이터 축적 | primary LoRA | LoRA primary 동작 | ✅ |
+| 2026-04-22 | #451 | compose env 에 `MANDALA_GEN_MODEL` 추가 | LoRA 호출이 실제 prod 에서 읽히도록 | LoRA 활성 | silent Haiku fallback 원인 해결 | ✅ |
+| 2026-04-22 | #452 | LoRA NUM_PREDICT 2500 → 5000 | Korean mandala truncation (`done_reason: length`) 해결 | 완결 JSON | 완결 확인 (orphan refill cells 6/8) | ✅ |
+| 2026-04-22 | #453 | LoRA-only action fill policy + failure log + retry CLI | 실패 재학습 데이터 보존 | 사용자 directive 반영 | landed | ✅ |
+| TBD | — | LoRA direct-call JSON parse error root cause | `generation_log` valid/invalid diff 로 format drift 규명 | slot 2개 (positions 6-7) 채움 | 미착수 (CP417 Secondary) | 📝 |
+
+### Layer 4 — DB write (wizard save)
+
+| Date | PR | Change | Hypothesis | Expected | Actual | Status |
+|------|----|----|-----------|----------|--------|--------|
+| 2026-04-17 | #402 | Prisma `connection_limit` override at client construction | 접속풀 고갈 방지 | 안정성 | 안정성 | ✅ |
+| 2026-04-17 | #403 | default sort relevance + parallelize post-creation + timing log | 정렬 기본값 + 병렬 | M1/M2 개선 | **prod 런타임 실패** (tsc pass + jest pass, 브라우저 실패) | ❌ (`b134812` 즉시 revert) |
+| 2026-04-17 | #404 | 대시보드 즉시 네비게이트 (서버 대기 안 함) | M3 즉시 | **prod 런타임 실패** (CI green, 브라우저 실패) | ❌ (`15011d5` 즉시 revert) |
+| 2026-04-18 | f0f0025 | 자동 pgbouncer=true for :6543 transaction pooler | 잘못된 pooler URL 패턴 방지 | 안정성 | 안정성 | ✅ |
+| 2026-04-18 | #413 + 2d2a770 | wizard optimistic UI + AUTO_ADD_PER_CELL cap 제거 | M1 즉시 + auto-add throughput | M1 개선 | **CP389 revert** (557900d) — 같은 이유 | ❌ |
+| 2026-04-22 | #456 | **Lever A**: `trg_goal_edge` / `trg_topic_edges` drop + `syncOntologyEdges` 앱레이어 fire-and-forget | edge trigger cascade per-row 210 queries → tx 에서 제거 | M7 5.1s → ~2s | Lever A 단독으로는 ~5.1s 잔존 (node 트리거 남음) | ✅ |
+| 2026-04-22 | #462 | **Lever A+**: `trg_sync_goal` / `trg_sync_topics` drop + node upsert 앱레이어화 | 117 queries → 18 queries | M7 < 1s | **측정 대기** (Deploy 진행 중, merged `bd2651b`) | ⏳ |
+
+### Layer 5 — Delivery (dashboard stream / sort)
+
+| Date | PR | Change | Hypothesis | Expected | Actual | Status |
+|------|----|----|-----------|----------|--------|--------|
+| 2026-04-21 | #430 | in-process SSE card stream endpoint (Phase 1 slice 2) | push 기반 전환 | M3 즉시 | endpoint ready, 소비자 없음 | ✅ |
+| 2026-04-21 | #431 | SSE-stream consumer hook + merge into RecommendationFeed | FE 측 소비 | M3 즉시 | 처음 연결 시 **백로그 emit 안 함** — 이후 Phase B 에서 수정 | ✅ (미흡) |
+| 2026-04-21 | #434 | POST /wizard-stream parallel SSE endpoint (P0) | wizard 저장 자체를 스트리밍화 | M1/M2 체감 ↑ | **설계 redesign** (CP415) 필요 — 미적용 상태 | ✅ (미활용) |
+| 2026-04-21 | #435, #436, #437 | wizard-stream save skill + hook + 플래그 mount | 사용자 전환 | flag off 유지 | flag off (미활성) | ✅ |
+| 2026-04-21 | #438 | `cardPublisher` notify on `user_video_states` upsert | auto-add → SSE notify | push 전파 | push 전파 확인 | ✅ |
+| 2026-04-21 | #439 | IndexPage subscribe useVideoStream + invalidate | FE query invalidation | live 업데이트 | live 확인 | ✅ |
+| 2026-04-22 | #443 | streaming-view flag default off (hotfix) | PR #444 prod 사고 롤백 | 안정성 | 안정성 | ✅ |
+| 2026-04-22 | #444 | wizard streaming preview (Phase 1) | 생성 과정 프리뷰 | M2 체감 ↑ | CP416 에서 flag 관리 | ✅ |
+| 2026-04-22 | #457 | **Phase A**: `/recommendations` orderBy `[rec_score desc, cell_index asc]` + stream | 관련도 순 전달 | 첫 카드 = 점수 최고 | landed, prod | ✅ |
+| 2026-04-22 | #459 | **Phase B**: SSE endpoint backlog emit on connect + FE merge 전역 재정렬 | 대시보드 오픈 즉시 기존 row 스트리밍 | M3 즉시 | landed, prod, health 200 | ✅ |
+
+### Layer 6 — UX (default, refresh)
+
+| Date | PR | Change | Hypothesis | Expected | Actual | Status |
+|------|----|----|-----------|----------|--------|--------|
+| 2026-04-15 | #389 (postponed→#425) | Newly Synced tab | sync 결과 즉시 확인 | UX 정합성 | #425 로 landed | ✅ |
+| 2026-04-22 | #441 | PWA autoUpdate + `/api/*` cache drop | stale cache 로 인한 "새 카드 미반영" 방지 | 실시간성↑ | landed | ✅ |
+| 2026-04-22 | #460 | **Phase C**: atomic set-default for new mandala | wizard 생성 직후 대시보드 default 전환 | "영어면접 default 의 5 카드" 버그 제거 | landed, prod | ✅ |
+| TBD | — | `docs/design/card-refresh-strategy.md` (4-layer: Coverage + MMR + Exploration + Feedback bias) | 카드 refresh 정책 | M6 다양성 + 새로고침 가치 | 설계만, 미구현 | 📝 |
+| TBD | — | `docs/design/progressive-relevance-stream.md` | stream 내 점수 정렬 알고리즘 | 첫 카드 = best | 설계만, 미구현 | 📝 |
+
+---
+
+## Reverted experiments (주의 — 재시도 전 이전 실패 원인 확인)
+
+| Date | PR | 반전 사유 | 재시도 조건 |
+|------|----|----------|-------------|
+| 2026-04-17 | #403 | prod 런타임 실패 (tsc/jest pass + 브라우저 실패) | `/verify` browser smoke 통과 필수 (CLAUDE.md Hard Rule) |
+| 2026-04-17 | #404 | 동일 | 동일 |
+| 2026-04-18 | #413 + 2d2a770 | CP389 retrospective — optimistic UI 가 실제 저장 실패를 숨김 | 서버 응답 확정 후 상태 전환하는 패턴으로만 |
+| 2026-04-22 | #454 | "2 cards 현상" 악화 — pool 축소가 사용자 가치 파괴 | pool 축소는 금지. 필요 시 display cap 만 (refresh diversification 전제) |
+
+---
+
+## Current state (2026-04-22 end of CP416)
+
+**Prod live**:
+- Phase 3 semantic center gate (#446/448) — `printenv=semantic` 실측
+- Phase A relevance-first sort (#457)
+- Phase B SSE backlog (#459)
+- Phase C atomic default mandala (#460)
+- Lever A edge trigger defer (#456) — prod DROP TRIGGER 완료
+- Action-fill LoRA primary (#450~453)
+- LoRA NUM_PREDICT 5000 (#452)
+
+**Deploy in flight**:
+- Lever A+ (#462) — node 트리거 drop + 앱레이어 upsert. Post-deploy 수동 DROP + M7 측정 필요.
+
+**M1~M9 실측 후 업데이트 대상** (이 섹션은 Deploy 완료 + 사용자 재측정 시 갱신):
+- M1 (템플릿): 예상 7s → ~1s
+- M2 (AI custom): 예상 21s → 3~4s
+- M3 (첫 카드): 예상 60s+ → 즉시 (backlog)
+- M4 (24 카드): 수 초
+- M6 (pool): 여전히 19 (Layer 2 gate 2 미적용)
+
+---
+
+## Outstanding hypotheses (CP417+)
+
+| # | Hypothesis | Layer | Expected lever | Design status |
+|---|------------|-------|----------------|---------------|
+| H1 | Gate 2 semantic cell assignment 으로 M6 19→50+ | L2 | `docs/design/v3-semantic-cell-gate.md` iter 2 | ready, option (a)/(b)/(c) 결정 대기 |
+| H2 | LoRA direct-call JSON parse error 해소로 M5 62/64 → 64/64 | L3 | `generation_log` valid/invalid diff | 착수 전 |
+| H3 | DB INSERT 추가 튜닝 (M7 Lever A+ 실측 후 잔여 bottleneck 분석) | L4 | pending M7 실측 | 측정 대기 |
+| H4 | Card refresh 4-layer (Coverage + MMR + Exploration + Feedback) | L6 | `docs/design/card-refresh-strategy.md` | 설계 있음, 구현 전 |
+| H5 | Progressive relevance stream | L5 | `docs/design/progressive-relevance-stream.md` | 설계 있음, 구현 전 |
+| H6 | V3_ENABLE_SEMANTIC_RERANK=true activation | L2 | 187 chunks already in pgvector | flag off 대기 |
+| H7 | deploy.yml 에 `prisma/migrations/ontology/*.sql` 러너 추가 | 인프라 | Lever A/A+ post-deploy 수동 DROP 필요 없도록 | 설계 미작성 |
+
+---
+
+## Update protocol (이 파일의 유지관리)
+
+1. **PR merge 직후**: 해당 Layer 표에 새 row 추가. Status = ✅ landed pending verification (⏳ 사용 가능).
+2. **Deploy + 실측 후**: Actual 열을 실제 숫자로 교체. Status → ✅.
+3. **Revert 시**: 원 row 의 Status 를 ❌ 로 변경하고 "Reverted experiments" 섹션에 추가. 재시도 조건 명시.
+4. **새 hypothesis 착수 시**: "Outstanding hypotheses" 에서 제거하고 해당 Layer 표에 새 row 로 이동 (Status 📝 → ⏳).
+5. **Baseline 재측정 시**: Baselines 섹션의 "최신 확인" 열 추가/갱신 (옛 값 보존).
+6. **갱신 주기**: 최소 CP 단위. 실험 한 단위 완료 시 바로 반영 권장.
+
+---
+
+## Cross-references
+
+- Design docs: `docs/design/wizard-dashboard-redesign-2026-04-21.md`, `docs/design/wizard-service-redesign-2026-04-22.md`, `docs/design/v3-semantic-center-gate.md`, `docs/design/v3-semantic-cell-gate.md`, `docs/design/card-refresh-strategy.md`, `docs/design/progressive-relevance-stream.md`
+- Related migrations: `prisma/migrations/ontology/011_drop_goal_topic_edge_triggers.sql` (Lever A), `prisma/migrations/ontology/012_drop_goal_topic_node_triggers.sql` (Lever A+)
+- Memory: `~/.claude/projects/-Users-jeonhokim-cursor-insighta/memory/checkpoint.md` (CP388~CP416), `work-efficiency.md`, `architecture.md`, `troubleshooting.md`


### PR DESCRIPTION
## Summary
Ships the CP417 documentation artefacts that accompany the wizard-dashboard performance arc. Split out of PR #463 (quality gate) and #464 (cron shift) so design reviews stay focused on code vs. docs.

## Design docs (3 new)
| File | Scope | Status |
|------|-------|--------|
| \`docs/design/precompute-pipeline.md\` | Phase 2 SLO-1 — wizard → dashboard ≤1s via draft mandala (Option C) | design locked, impl deferred |
| \`docs/design/realtime-search-pipeline.md\` | Phase 3A SLO-2 — semantic gate v2 over pgvector KNN + shadow mode | waits on Phase 3B pool growth |
| \`docs/design/quality-gate.md\` | Tier 2 view-count / views-per-day floor | code shipped in #463 |

(Phase 3B doc \`video-pool-growth.md\` already landed in #464.)

## Reports (2 new, running ledgers)
| File | Purpose | Update cadence |
|------|---------|----------------|
| \`docs/reports/wizard-dashboard-perf-log.md\` | Experiment ledger — every attempt, outcome, rollback (Layer A/B/C/D tables) | On each PR merge, Deploy, revert |
| \`docs/reports/wizard-dashboard-flow-anatomy.md\` | Implementation snapshot — e2e flow + Module A-K with file:line, prompts, SQL, timing points | On module refactor, env change, trigger flip |

## Why bundled
1. Reports are meta-artefacts; keeping them in a docs PR avoids blocking code PRs on doc review churn.
2. Three of the designs span future sessions; locking direction now lets code PRs land piecemeal.

## Test plan
- [x] No runtime code touched (docs-only)
- [ ] CI pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)