### PR TITLE
hotfix(ops): pin V3_CENTER_GATE_MODE=subword — CP418 prod regression recovery

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,7 +40,16 @@ services:
       # (mandala-filter.ts guard) — Ollama downtime does not break the gate.
       # Revert: set to 'subword' / 'substring' or delete this line (code
       # default 'substring' takes over) and redeploy.
-      - V3_CENTER_GATE_MODE=semantic
+      #
+      # CP418 (2026-04-23): rolled back from 'semantic' to 'subword' after
+      # prod regression. `step2_result.debug.timing.semanticGateEmbedMs`
+      # measured 36~56s per request (= 90%+ of total v3 run time) because
+      # `embedBatch` received [centerGoal, ...hundreds of candidate titles]
+      # as a single batch against mac mini Ollama `qwen3-embedding:8b`.
+      # Re-enable path: (a) pool >= 10k rows (Phase 3B), (b) candidate
+      # top-N cap before embed (e.g. top 30), (c) domain-tuned embedding.
+      # See docs/design/realtime-search-pipeline.md (Phase 3A).
+      - V3_CENTER_GATE_MODE=subword
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the


### PR DESCRIPTION
## Summary
Today's main=52c49ea deploy copied \`docker-compose.prod.yml\` (still reading \`V3_CENTER_GATE_MODE=semantic\`) over prod's manually-rolled-back \`subword\` value, reintroducing the 36~56s \`semanticGateEmbedMs\` bottleneck. User caught it; prod was re-sedded + container-recreated to restore \`subword\`. This PR pins the repo value so the next deploy won't revert it again.

## Evidence
\`mandala_pipeline_runs.step2_result.debug.timing.semanticGateEmbedMs\` showed 36-56s per run earlier today (CP417 diagnostic). Post-subword \`totalMs\` dropped to ~3s.

## Gate re-enable conditions (see \`docs/design/realtime-search-pipeline.md\`)
1. \`video_pool >= 10,000\` rows (Phase 3B cron shift #464 effects, ~1 week)
2. Candidate top-N cap before embedBatch
3. Domain-tuned embedding OR cosine threshold tuning

Until all 3 land, \`semantic\` stays off.

## Rollback
1-line flip back to \`semantic\` (not recommended until above).

## Test plan
- [x] prod already on \`subword\` (manual re-apply done, \`docker exec printenv\` verified)
- [ ] CI pass
- [ ] Post-merge deploy does not flip back to \`semantic\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)