### PR TITLE
feat(mandala): persist create timings to DB for CP421 Lever A++ baseline — CP420 γ (Path B step 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ prisma/migrations/*
 !prisma/migrations/video_discover/
 !prisma/migrations/manual/
 !prisma/migrations/video_chunk_embeddings/
+!prisma/migrations/mandala-timings/
 
 # Logs
 logs/

--- a/prisma/migrations/mandala-timings/001_create_table.sql
+++ b/prisma/migrations/mandala-timings/001_create_table.sql
@@ -1,0 +1,63 @@
+-- ============================================================================
+-- Mandala create timings: CP420 γ (Path B step 1)
+-- ============================================================================
+-- Wizard mandala-create 의 per-step timing 을 DB 에 persist.
+-- `src/modules/mandala/manager.ts` 의 createMandala 에서 tx commit 직후
+-- (ok path) 또는 catch block (error path) 에서 fire-and-forget 으로 INSERT.
+--
+-- Purpose (CP420 → CP421):
+--   - Lever A++ DROP trg_structural_edges_level 의 pre/post M7 비교 (n≥3)
+--   - SELECT 만으로 tx_levels_createMany latency 분포 추출 가능
+--   - 현재 console.info log 만으로는 docker log retention (~48h) 안에서
+--     n=1 샘플만 확보. γ persistence 로 retention 확장.
+--
+-- Column design:
+--   mandala_id NULLABLE: tx rollback 시 mandala row 미생성 (전체 rollback
+--     by Prisma $transaction). error outcome 은 mandala 참조 없이 기록.
+--   outcome VARCHAR(10): 'ok' | 'error' (manager.ts:476, 486 실제 emit 값)
+--   timings JSONB: dup_check, parallel_reads, tx_mandala_create,
+--     tx_levels_createMany, tx_find_unique, tx_total, total (일부 key 는
+--     error path 에서 set 안 됨 — whatever-set 저장)
+--   error TEXT: outcome='error' 시 err.message.slice(0, 500)
+--
+-- CLAUDE.md LEVEL-3 "prisma db push silent fail 대응":
+--   - 본 파일 (feature-namespace fallback DDL) + prisma/schema.prisma
+--     (Prisma client type 생성) 양쪽 유지
+--   - Deploy verification: Local `\d mandala_create_timings` + Prod
+--     `ssh + docker exec psql \d mandala_create_timings`
+--   - Idempotent: CREATE IF NOT EXISTS 사용
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.mandala_create_timings (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  mandala_id UUID        REFERENCES public.user_mandalas(id) ON DELETE CASCADE,
+  user_id    UUID        NOT NULL,
+  outcome    VARCHAR(10) NOT NULL,
+  timings    JSONB       NOT NULL,
+  error      TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mandala_create_timings_mandala_id
+  ON public.mandala_create_timings (mandala_id);
+
+CREATE INDEX IF NOT EXISTS idx_mandala_create_timings_created_at_desc
+  ON public.mandala_create_timings (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_mandala_create_timings_outcome_created_at
+  ON public.mandala_create_timings (outcome, created_at DESC);
+
+-- Sanity check (deploy verification 용)
+DO $$
+DECLARE
+  col_count INT;
+BEGIN
+  SELECT COUNT(*) INTO col_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'mandala_create_timings';
+
+  IF col_count < 7 THEN
+    RAISE EXCEPTION 'mandala_create_timings table missing columns: expected ≥7, got %', col_count;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -439,6 +439,7 @@ model user_mandalas {
   skill_configs        user_skill_config[]
   recommendation_cache recommendation_cache[]
   pipeline_runs        mandala_pipeline_runs[]
+  create_timings       mandala_create_timings[]
 
   source_template_id String?  @db.Uuid
   focus_tags         String[] @default([])
@@ -451,6 +452,27 @@ model user_mandalas {
   @@index([domain], map: "idx_user_mandalas_domain")
   @@index([like_count], map: "idx_user_mandalas_like_count")
   @@index([language], map: "idx_user_mandalas_language")
+  @@schema("public")
+}
+
+/// CP420 γ: wizard mandala create per-step timing persistence.
+/// Populated by `src/modules/mandala/manager.ts` createMandala as
+/// fire-and-forget after tx commit (ok path) OR after catch (error path).
+/// Enables Lever A++ DROP pre/post M7 comparison (n≥3) via SELECT.
+/// mandala_id nullable: tx rollback 시 mandala row 미생성이므로 error outcome 은 null.
+model mandala_create_timings {
+  id         String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  mandala_id String?        @db.Uuid
+  user_id    String         @db.Uuid
+  outcome    String         @db.VarChar(10) // 'ok' | 'error'
+  timings    Json
+  error      String?
+  created_at DateTime       @default(now()) @db.Timestamptz(6)
+  mandala    user_mandalas? @relation(fields: [mandala_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([mandala_id], map: "idx_mandala_create_timings_mandala_id")
+  @@index([created_at(sort: Desc)], map: "idx_mandala_create_timings_created_at_desc")
+  @@index([outcome, created_at(sort: Desc)], map: "idx_mandala_create_timings_outcome_created_at")
   @@schema("public")
 }
 

--- a/src/modules/mandala/manager.ts
+++ b/src/modules/mandala/manager.ts
@@ -345,6 +345,46 @@ export class MandalaManager {
   }
 
   /**
+   * CP420 γ (Path B step 1): Persist createMandala per-step timings
+   * to `mandala_create_timings` table. Fire-and-forget after tx commit
+   * (ok path) or inside catch (error path) — does NOT affect the M7
+   * measurement being recorded.
+   *
+   * Rationale: console.info '[mandala-create-timing]' logs are only
+   * retained in docker stdout (~48h). DB persistence enables CP421+
+   * Lever A++ DROP pre/post M7 comparison (n≥3) via SELECT.
+   *
+   * Failure is logged via logger.error (non-blocking, never re-thrown)
+   * per work-efficiency.md line 298 convention.
+   */
+  private persistCreateTiming(params: {
+    mandalaId: string | null;
+    userId: string;
+    outcome: 'ok' | 'error';
+    timings: Record<string, number>;
+    error?: string;
+  }): void {
+    this.prisma.mandala_create_timings
+      .create({
+        data: {
+          mandala_id: params.mandalaId,
+          user_id: params.userId,
+          outcome: params.outcome,
+          timings: params.timings as Prisma.InputJsonValue,
+          error: params.error ?? null,
+        },
+      })
+      .catch((err) => {
+        logger.error('mandala_create_timings persist failed (non-blocking)', {
+          err,
+          mandalaId: params.mandalaId,
+          userId: params.userId,
+          outcome: params.outcome,
+        });
+      });
+  }
+
+  /**
    * Creates a new mandala with tier-based quota enforcement.
    * The quota check and insert are atomic inside a transaction.
    */
@@ -475,19 +515,33 @@ export class MandalaManager {
         '[mandala-create-timing]',
         JSON.stringify({ userId, title, outcome: 'ok', ...timings })
       );
+      this.persistCreateTiming({
+        mandalaId: result.id,
+        userId,
+        outcome: 'ok',
+        timings,
+      });
       return result;
     } catch (err) {
       timings['total'] = Date.now() - tFnStart;
+      const errMsg = err instanceof Error ? err.message.slice(0, 500) : String(err).slice(0, 500);
       console.info(
         '[mandala-create-timing]',
         JSON.stringify({
           userId,
           title,
           outcome: 'error',
-          error: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
+          error: errMsg.slice(0, 200),
           ...timings,
         })
       );
+      this.persistCreateTiming({
+        mandalaId: null,
+        userId,
+        outcome: 'error',
+        timings,
+        error: errMsg,
+      });
       throw err;
     }
   }

--- a/tests/unit/modules/mandala-manager.test.ts
+++ b/tests/unit/modules/mandala-manager.test.ts
@@ -54,6 +54,9 @@ const mockPrisma: any = {
     findMany: jest.fn(),
     count: jest.fn(),
   },
+  mandala_create_timings: {
+    create: jest.fn().mockResolvedValue({ id: 'timing-1' }),
+  },
   userVideoState: {
     updateMany: jest.fn(),
   },
@@ -393,6 +396,79 @@ describe('MandalaManager', () => {
           position: 3,
         }),
       });
+    });
+
+    test('CP420 γ — should persist create timings on ok path with mandala_id', async () => {
+      stubStep1Reads({ tier: 'free', count: 0 });
+      const mockTx = createMockTx();
+      mockTx.user_mandalas.create.mockResolvedValue({ id: 'new-mandala', user_id: mockUserId });
+      mockTx.user_mandala_levels.createMany.mockResolvedValue({ count: 2 });
+      mockTx.user_mandalas.findUnique.mockResolvedValue({
+        ...mockRawMandala,
+        id: 'new-mandala',
+      });
+      mockPrisma.$transaction.mockImplementation(async (fn: any) => fn(mockTx));
+      mockPrisma.mandala_create_timings.create.mockClear();
+
+      await manager.createMandala(mockUserId, 'My Mandala', mockLevelsInput);
+
+      // Fire-and-forget — may resolve after test body, but create should
+      // have been synchronously called during createMandala return path.
+      expect(mockPrisma.mandala_create_timings.create).toHaveBeenCalledTimes(1);
+      const call = mockPrisma.mandala_create_timings.create.mock.calls[0][0];
+      expect(call.data.mandala_id).toBe('new-mandala');
+      expect(call.data.user_id).toBe(mockUserId);
+      expect(call.data.outcome).toBe('ok');
+      expect(call.data.error).toBeNull();
+      // timings should include at least pre-tx keys + tx_total/total for ok path
+      expect(call.data.timings).toEqual(
+        expect.objectContaining({
+          dup_check: expect.any(Number),
+          parallel_reads: expect.any(Number),
+          tx_total: expect.any(Number),
+          total: expect.any(Number),
+        })
+      );
+    });
+
+    test('CP420 γ — should persist create timings on error path with null mandala_id', async () => {
+      stubStep1Reads({ tier: 'free', count: 0 });
+      const mockTx = createMockTx();
+      const txError = new Error('simulated tx failure');
+      mockTx.user_mandalas.create.mockRejectedValue(txError);
+      mockPrisma.$transaction.mockImplementation(async (fn: any) => fn(mockTx));
+      mockPrisma.mandala_create_timings.create.mockClear();
+
+      await expect(manager.createMandala(mockUserId, 'Err', mockLevelsInput)).rejects.toThrow(
+        'simulated tx failure'
+      );
+
+      expect(mockPrisma.mandala_create_timings.create).toHaveBeenCalledTimes(1);
+      const call = mockPrisma.mandala_create_timings.create.mock.calls[0][0];
+      expect(call.data.mandala_id).toBeNull();
+      expect(call.data.user_id).toBe(mockUserId);
+      expect(call.data.outcome).toBe('error');
+      expect(call.data.error).toContain('simulated tx failure');
+    });
+
+    test('CP420 γ — persist failure must not block caller (fire-and-forget)', async () => {
+      stubStep1Reads({ tier: 'free', count: 0 });
+      const mockTx = createMockTx();
+      mockTx.user_mandalas.create.mockResolvedValue({ id: 'm-ff', user_id: mockUserId });
+      mockTx.user_mandala_levels.createMany.mockResolvedValue({ count: 0 });
+      mockTx.user_mandalas.findUnique.mockResolvedValue({ ...mockRawMandala, id: 'm-ff' });
+      mockPrisma.$transaction.mockImplementation(async (fn: any) => fn(mockTx));
+      mockPrisma.mandala_create_timings.create.mockRejectedValueOnce(new Error('db down'));
+
+      // Primary result must not throw even if persistence fails.
+      const result = await manager.createMandala(mockUserId, 'FF', mockLevelsInput);
+      expect(result.id).toBe('m-ff');
+
+      // Allow microtask queue to drain so the .catch handler runs.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Reset mock so later tests don't inherit the mockRejectedValueOnce.
+      mockPrisma.mandala_create_timings.create.mockResolvedValue({ id: 'timing-ok' });
     });
 
     test('should use pro quota for pro tier', async () => {


### PR DESCRIPTION
## Summary

CP420 Path B step 1 — `mandala_create_timings` 테이블 + `MandalaManager.persistCreateTiming()` helper 추가. Wizard mandala-create 의 per-step timing 을 DB 에 persist 해서 **CP421+ Lever A++ DROP pre/post M7 비교 (n≥3) 기반 마련**.

## Why

- 현재 `tx_levels_createMany` latency 는 `console.info '[mandala-create-timing]'` 로그에만 존재 → docker stdout retention (~48h)
- CP419 조사 결과: 48h 내 live sample **n=1 (cfa8a4bf=2145ms)** 만 가용. Pre/post DROP 비교에 statistical power 부족
- γ persistence 로 retention 확장 + SELECT 만으로 n≥3 샘플 추출 가능

## Changes

- **`prisma/schema.prisma`**: `mandala_create_timings` 모델 + `user_mandalas` relation
  - `mandala_id` NULLABLE (tx rollback 시 mandala row 미생성 → error outcome 은 null)
  - `outcome VARCHAR(10)` (`'ok'` | `'error'`)
  - `timings JSONB` (dup_check, parallel_reads, tx_mandala_create, tx_levels_createMany, tx_find_unique, tx_total, total — error path 일부 key 없음)
  - 3 indexes: mandala_id / created_at DESC / (outcome, created_at DESC)
- **`prisma/migrations/mandala-timings/001_create_table.sql`** (LEVEL-3 fallback DDL): idempotent CREATE TABLE IF NOT EXISTS + DO sanity check
- **`src/modules/mandala/manager.ts`**: `private persistCreateTiming()` helper (fire-and-forget after tx commit 또는 inside catch) + 2 호출 (ok / error path). `logger.error` non-blocking on failure (work-efficiency.md:298 convention)
- **`tests/unit/modules/mandala-manager.test.ts`**: 3 new tests (ok persist / error persist / fire-and-forget failure non-blocking)
- **`.gitignore`**: `!prisma/migrations/mandala-timings/` negate rule (sibling feature namespaces 관행)

## Design rationale (CP420 Path B)

Path A vs Path B comparison: Lever A++ DROP `trg_structural_edges_level` 의 M7 savings 재계산 결과 **0.2-0.6s** (guard skip 반영, 10-15% marginal). CP419 v4 summary 에 따라 **rigor-first Path B** 채택 — γ 먼저 ship 해서 1-3일 natural traffic 수집 → CP421+ 에 Lever A++ with n≥3 pre/post.

상세 rationale: `memory/checkpoint.md` 의 CP420 Entry Plan section + Block C read-only investigation 결과.

## Verification

- `tsc --noEmit` ✅
- `npm run build` ✅
- `jest tests/unit/modules/mandala-manager.test.ts` → **65 pass / 3 pre-existing baseline fail** (γ 무관: checkDuplicateTitle / duplicate title guard / deleteMandala — all present in main baseline). γ 3 new tests 전부 pass
- Local DB: `psql \d public.mandala_create_timings` → 7 columns + 3 indexes + FK cascade 검증
- FK integrity: `onDelete: Cascade` (mandala 삭제 시 timings row 도 제거 — GDPR 관점 cleanup 자동)

## Deploy verification checklist (post-merge, prod)

1. Deploy 성공 + `/health` 200
2. `ssh insighta-ec2 + docker exec insighta-api psql "$DIRECT_URL" -c "\d public.mandala_create_timings"` → 테이블 실존 + 7 columns (LEVEL-3 silent-fail 대응 필수)
3. 1 mandala 생성 (wizard 경로) → `SELECT * FROM mandala_create_timings ORDER BY created_at DESC LIMIT 1` → row 존재 + timings JSON 완전

## Scope (명시적 non-goals)

- Lever A++ DROP `trg_structural_edges_level` — **이 PR 아님**. CP421 natural traffic 수집 후 별도 PR
- M7 target <1s 달성 — Lever A++ 만으로는 미달 (재계산 0.2-0.6s savings). 추가 optimization track 필요
- 009/010 ontology migration git commit — CP418 LEVEL-3 carryover, 별도 PR
- Observability dashboard — raw SELECT 쿼리로 충분 (CP421 수집 후 필요 시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)