### PR TITLE
fix(ops): add PGDG apt repo setup to Install PostgreSQL client — CP421 hotfix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,8 +118,16 @@ jobs:
           DATABASE_URL: ${{ secrets.DIRECT_URL }}
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
       - name: Install PostgreSQL client (for custom SQL runner)
+        # PGDG apt repo setup — postgresql-client-17 is not in Ubuntu 24.04
+        # default repos. Block mirrored from .github/workflows/db-integrity-check.yml
+        # and backup.yml which have been running this pattern on green daily.
         run: |
-          sudo apt-get update
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq curl ca-certificates
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update -qq
           sudo apt-get install -y -qq postgresql-client-17
       - name: Apply custom SQL migrations (raw DDL fallback)
         run: bash scripts/apply-custom-sql.sh


### PR DESCRIPTION
## Summary

Hotfix for PR #469: `apply-custom-sql.sh` requires `postgresql-client-17`,
but CP421 PR #469 added only `apt-get install postgresql-client-17` without
the PGDG apt repository setup. `postgresql-client-17` is not in Ubuntu 24.04
(noble) default repos, so the install step failed with:

```
E: Unable to locate package postgresql-client-17
##[error]Process completed with exit code 100.
```

The migrate job failed at step 7, skipping both `apply-custom-sql.sh` and
`verify-db-tables.js`. Deploy to EC2 was skipped as intended.

## Fix

Mirror the PGDG install block already running green daily in:
- `.github/workflows/db-integrity-check.yml:18-26`
- `.github/workflows/backup.yml:22-30`

Both workflows confirmed on 5 consecutive successful runs (2026-04-19..23).

## Blast radius

- **Prod state unchanged**: PR #469 migrate failed before `apply-custom-sql.sh`
  ran. Table `mandala_create_timings` still missing. PR #468
  `persistCreateTiming` code still inactive.
- **Main branch**: commit `0a1d2d3` (PR #469) still in place. This hotfix
  layers on top.

## Post-merge expected sequence

1. Merge triggers Deploy workflow on main.
2. `migrate` job:
   - `prisma db push` → silent-fails on auth-owned tables (expected, warning).
   - `Install PostgreSQL client` → now passes via PGDG repo.
   - `apply-custom-sql.sh` → applies 5 allowlist files; `mandala-timings/001`
     creates the table.
   - `verify-db-tables.js` → all 56 public tables present → PASS.
3. `deploy` job: container swap → PR #468 `persistCreateTiming` activates.
4. Prod probe: `\d mandala_create_timings` shows 7 cols + 3 indexes + FK.

## Server version reference (CP421 probe)

```
PostgreSQL 17.6 on aarch64-unknown-linux-gnu (Supabase)
```

client-17 is the correct major-version match (already used by existing
workflows above).

## Root cause of the miss

During CP421 Step 2 "GHA psql 가용성" investigation I confirmed the existing
workflows used `postgresql-client-17` via a one-line grep. I did not read the
full install block (which includes the 5-line PGDG repo setup that precedes
the install). The CLAUDE.md LEVEL-3 Hard Rule "추측 전 소스 읽기" applies:
grep result + surrounding context should be read together before claiming
the pattern is a drop-in. This PR re-applies the full pattern.

## Test plan
- [x] Local `yamllint` / visual diff against source workflows — block is byte-identical.
- [ ] Post-merge: migrate job step 7 passes (postgresql-client-17 installed).
- [ ] Post-merge: `apply-custom-sql.sh` step runs 5 SQL files without error.
- [ ] Post-merge: `verify-db-tables.js` PASS (56 tables present).
- [ ] Post-merge: Deploy to EC2 succeeds; prod probe `\d mandala_create_timings` 7 cols + 3 indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)