### PR TITLE
feat(ops): flip RICH_SUMMARY_ENABLED=true in prod (CP423 smoke)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -68,6 +68,15 @@ services:
       # tag is stdout-safe / open-source-safe. Revert: delete this
       # line → LoRA auto-falls back to Haiku (pre-fix state).
       - MANDALA_GEN_MODEL=mandala-gen:latest
+      # CP423 (2026-04-24) — Rich Summary feature flag ON for prod smoke.
+      # Metadata-only mode: CAPTION_SOURCE stays at default 'disabled', so
+      # no direct YouTube caption API calls from prod per user directive.
+      # rich summary falls back to description+title+channel metadata for
+      # chapters/quotes generation (empty arrays expected, tl_dr always).
+      # Quota per-tier (free=30 / pro=200 / lifetime=admin=unlimited) enforced
+      # inside enrichRichSummary via rich-summary-quota module.
+      # Revert: delete this line → feature no-ops.
+      - RICH_SUMMARY_ENABLED=true
       # OPENROUTER_EMBED_MODEL defaults to `qwen/qwen3-embedding-8b` in
       # code. Uncomment + override here ONLY if the exact OpenRouter
       # model id string differs (verify at https://openrouter.ai/models).


### PR DESCRIPTION
Enable RICH_SUMMARY_ENABLED on prod insighta-api to smoke-test PR #472 end-to-end.

CAPTION_SOURCE stays default 'disabled' — no direct prod YouTube caption calls per user directive. Metadata-only mode: chapters/quotes empty, tl_dr generated from description.

Quota enforced per-tier via rich-summary-quota module.

Rollback: delete the env line + redeploy.