### PR TITLE
feat(wizard): precompute pipeline — SLO-1 dashboard first card ≤1s (CP424.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ prisma/migrations/*
 !prisma/migrations/video_chunk_embeddings/
 !prisma/migrations/mandala-timings/
 !prisma/migrations/video_rich_summaries/
+!prisma/migrations/wizard-precompute/
 
 # Logs
 logs/

--- a/frontend/src/features/mandala-wizard/model/useWizard.ts
+++ b/frontend/src/features/mandala-wizard/model/useWizard.ts
@@ -240,6 +240,12 @@ export function useWizard() {
   // Stored in a ref so cancel() can reach the current controller across renders.
   const goalAbortRef = useRef<AbortController | null>(null);
 
+  // CP424.2 wizard precompute — client-generated UUID correlating the
+  // /wizard-stream preview request with the subsequent /create-with-data save.
+  // Regenerated on every new goal submission so stale server rows are naturally
+  // ignored (TTL 10min + goal-match check on server).
+  const precomputeSessionIdRef = useRef<string | null>(null);
+
   // ─── Tier 1: Embedding search (instant) ───
   const searchMutation = useMutation({
     mutationFn: (goal: string) =>
@@ -268,12 +274,22 @@ export function useWizard() {
   const generateMutation = useMutation({
     mutationFn: async (goal: string) => {
       const lang = detectGoalLanguage(goal);
+      // CP424.2: mint a fresh sessionId for each new generation so server-side
+      // precompute rows for prior goals don't get consumed against the new
+      // mandala. crypto.randomUUID() is widely available in modern browsers;
+      // fallback to Math.random-based id in the rare case it isn't.
+      const sessionId =
+        typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+          ? crypto.randomUUID()
+          : `fallback-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+      precomputeSessionIdRef.current = sessionId;
       try {
         const res = await apiClient.streamWizardPreview(goal, {
           language: lang,
           focusTags: state.focusTags,
           targetLevel: state.targetLevel,
           signal: goalAbortRef.current?.signal,
+          sessionId,
         });
         if (import.meta.env.DEV) {
           console.info('[wizard-preview]', {
@@ -552,6 +568,11 @@ export function useWizard() {
         const result = await apiClient.createMandalaWithData({
           ...params,
           setAsDefault: true,
+          // CP424.2: pass the sessionId from streamWizardPreview so the server
+          // can consume the precomputed discover result. When flag disabled or
+          // id missing, server falls through to the legacy post-creation
+          // pipeline (backward-compat).
+          session_id: precomputeSessionIdRef.current ?? undefined,
         });
         const tResponse = performance.now();
         console.info('[wizard-timing]', {

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -874,6 +874,14 @@ class ApiClient {
      * on the old default mandala.
      */
     setAsDefault?: boolean;
+    /**
+     * CP424.2 wizard precompute: the same UUID sent to streamWizardPreview
+     * at Step 1. Server looks up the precomputed discover result and copies
+     * it into recommendation_cache under the new mandala_id. Miss → server
+     * falls back to the legacy post-creation pipeline. Flag-gated on the
+     * server (WIZARD_PRECOMPUTE_ENABLED, default false).
+     */
+    session_id?: string;
   }): Promise<{ mandalaId: string }> {
     // CP358: prod create writes ~73 INSERTs through pgbouncer (us-west-2 ↔
     // Korea RTT ~250ms × 73 ≈ 18s). BE Prisma transaction timeout is 30s
@@ -915,6 +923,14 @@ class ApiClient {
       focusTags?: string[];
       targetLevel?: string;
       signal?: AbortSignal;
+      /**
+       * CP424.2 wizard precompute: client-generated UUID that correlates this
+       * preview request with the subsequent `/create-with-data` save. When
+       * provided AND WIZARD_PRECOMPUTE_ENABLED on server, server kicks off a
+       * background `runDiscoverEphemeral` whose result is consumed at save
+       * time. Omit → precompute skipped (backward-compat, legacy behavior).
+       */
+      sessionId?: string;
       onTemplateFound?: (
         templates: Array<{
           mandala_id: string;
@@ -959,6 +975,7 @@ class ApiClient {
         previewOnly: true,
         focus_tags: options?.focusTags,
         target_level: options?.targetLevel,
+        session_id: options?.sessionId,
       }),
       signal: options?.signal,
     });

--- a/prisma/migrations/wizard-precompute/001_table.sql
+++ b/prisma/migrations/wizard-precompute/001_table.sql
@@ -1,0 +1,98 @@
+-- ============================================================================
+-- Wizard Precompute Pipeline — SLO-1 dashboard-first-card ≤1s (CP424.2)
+-- ============================================================================
+-- Per docs/design/precompute-pipeline.md (CP417 draft).
+--
+-- Flow:
+--   Step 1 goal 확정 → FE `sessionId = randomUUID()` → /wizard-stream?previewOnly=true
+--     + body.session_id → BE fire-and-forget `startPrecompute(session_id)` →
+--     runV3Discover(ephemeralContext) → UPDATE status=done + discover_result
+--   Step 3 save → FE /create-with-data body.session_id → BE lookup →
+--     INSERT recommendation_cache + cardPublisher.notify → status=consumed
+--   Miss → existing post-creation pipeline (backward-compat)
+--
+-- Feature flag: WIZARD_PRECOMPUTE_ENABLED (compose env, default false).
+--   flag off: /wizard-stream precompute skip, /create-with-data lookup skip.
+--   기존 동작 100% 보존.
+--
+-- TTL: 10min. pg_cron */5 min sweep removes expired non-consumed rows.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.mandala_wizard_precompute (
+  session_id       UUID         PRIMARY KEY,
+  user_id          UUID         NOT NULL,
+  goal             TEXT         NOT NULL,
+  language         VARCHAR(5)   NOT NULL,
+  focus_tags       TEXT[]       NOT NULL DEFAULT '{}',
+  target_level     VARCHAR(30),
+  status           VARCHAR(20)  NOT NULL DEFAULT 'pending',
+    -- 'pending' | 'running' | 'done' | 'failed' | 'consumed'
+  discover_result  JSONB,       -- { slots: [...], tier1_matches, tier2_matches, debug, metrics }
+  error_message    TEXT,
+  consumed_mandala_id UUID,     -- set on consume; null until then
+  created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  consumed_at      TIMESTAMPTZ,
+  expires_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW() + INTERVAL '10 minutes'
+);
+
+CREATE INDEX IF NOT EXISTS idx_precompute_user_created
+  ON public.mandala_wizard_precompute (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_precompute_expires
+  ON public.mandala_wizard_precompute (expires_at)
+  WHERE status != 'consumed';
+
+CREATE INDEX IF NOT EXISTS idx_precompute_status
+  ON public.mandala_wizard_precompute (status);
+
+-- pg_cron TTL sweep — remove expired non-consumed rows every 5 minutes.
+-- Consumed rows are kept permanently as audit trail; expires_at filter
+-- in the index keeps the sweep cost O(expired rows).
+-- Requires pg_cron extension (self-hosted Supabase already has it per
+-- design doc §Redis vs 테이블 결정 근거 item 3).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    -- Unschedule any prior version idempotently, then re-schedule.
+    PERFORM cron.unschedule(jobid)
+    FROM cron.job
+    WHERE jobname = 'precompute-ttl-sweep';
+
+    PERFORM cron.schedule(
+      'precompute-ttl-sweep',
+      '*/5 * * * *',
+      $cron$DELETE FROM public.mandala_wizard_precompute
+            WHERE expires_at < NOW() AND status != 'consumed'$cron$
+    );
+  ELSE
+    RAISE NOTICE 'pg_cron extension not installed — TTL sweep skipped; rows accumulate until manual cleanup.';
+  END IF;
+END $$;
+
+-- Sanity check (deploy verification)
+DO $$
+DECLARE
+  col_count INT;
+  idx_count INT;
+BEGIN
+  SELECT COUNT(*) INTO col_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'mandala_wizard_precompute';
+
+  SELECT COUNT(*) INTO idx_count
+  FROM pg_indexes
+  WHERE schemaname = 'public'
+    AND tablename = 'mandala_wizard_precompute';
+
+  IF col_count < 12 THEN
+    RAISE EXCEPTION 'mandala_wizard_precompute table missing columns: expected >=12, got %', col_count;
+  END IF;
+  IF idx_count < 3 THEN  -- PK + 3 secondary
+    RAISE EXCEPTION 'mandala_wizard_precompute indexes missing: expected >=4 (incl PK), got %', idx_count;
+  END IF;
+END $$;
+
+-- PostgREST schema reload (ALTER/CREATE → Supabase client silent-drop 방지).
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -476,6 +476,33 @@ model mandala_create_timings {
   @@schema("public")
 }
 
+/// Wizard precompute — stages v3 discover results between Step 1 (goal input)
+/// and Step 3 (save), keyed by client-generated session_id. Consumed at save
+/// time to populate recommendation_cache immediately → dashboard first card ≤1s.
+/// TTL 10min, pg_cron sweep every 5min (migration 001 handles scheduling).
+model mandala_wizard_precompute {
+  session_id          String   @id @db.Uuid
+  user_id             String   @db.Uuid
+  goal                String
+  language            String   @db.VarChar(5)
+  focus_tags          String[] @default([])
+  target_level        String?  @db.VarChar(30)
+  /// 'pending' | 'running' | 'done' | 'failed' | 'consumed'
+  status              String   @default("pending") @db.VarChar(20)
+  discover_result     Json?
+  error_message       String?
+  consumed_mandala_id String?  @db.Uuid
+  created_at          DateTime @default(now()) @db.Timestamptz(6)
+  updated_at          DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+  consumed_at         DateTime? @db.Timestamptz(6)
+  expires_at          DateTime @default(dbgenerated("(now() + interval '10 minutes')")) @db.Timestamptz(6)
+
+  @@index([user_id, created_at(sort: Desc)], map: "idx_precompute_user_created")
+  @@index([expires_at], map: "idx_precompute_expires")
+  @@index([status], map: "idx_precompute_status")
+  @@schema("public")
+}
+
 /// Mandala share links — controls visibility, expiry, and PIN protection
 model mandala_shares {
   id         String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -58,6 +58,7 @@ APPLY_FILES=(
   "prisma/migrations/mandala-timings/001_create_table.sql"
   "prisma/migrations/video_chunk_embeddings/001_create_table.sql"
   "prisma/migrations/video_rich_summaries/001_add_user_id.sql"
+  "prisma/migrations/wizard-precompute/001_table.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -654,6 +654,11 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       previewOnly?: boolean;
       focus_tags?: string[];
       target_level?: string;
+      // CP424.2 wizard precompute: client-generated UUID for correlating
+      // /wizard-stream pre-compute with /create-with-data consume. Optional —
+      // when absent, precompute is skipped (backward-compat). Flag-gated by
+      // WIZARD_PRECOMPUTE_ENABLED at the trigger site.
+      session_id?: string;
     };
   }>(
     '/wizard-stream',
@@ -671,6 +676,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         previewOnly = false,
         focus_tags: focusTags,
         target_level: targetLevel,
+        session_id: sessionId,
       } = request.body;
       if (!goal || typeof goal !== 'string' || goal.trim().length === 0) {
         return reply.code(400).send({
@@ -737,6 +743,32 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             structure,
             duration_ms: Date.now() - t0,
           });
+          // CP424.2 wizard precompute trigger — fire-and-forget after structure
+          // resolves so we have real sub_goals. No await: the wizard SSE stream
+          // is not blocked by discover latency (Tier 2 YouTube search ~5-15s).
+          // Feature-flag + session_id gated inside startPrecompute; callers pass
+          // unconditionally.
+          if (sessionId && Array.isArray(structure.sub_goals) && structure.sub_goals.length === 8) {
+            setImmediate(() => {
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
+              import('../../modules/mandala/wizard-precompute').then(({ startPrecompute }) =>
+                startPrecompute({
+                  sessionId,
+                  userId,
+                  goal: structure.center_goal,
+                  language: lang,
+                  focusTags: focusTags ?? [],
+                  targetLevel,
+                  subGoals: structure.sub_goals,
+                }).catch((err) => {
+                  request.log.warn(
+                    { err, sessionId, userId },
+                    'wizard-precompute startPrecompute threw (fire-and-forget)'
+                  );
+                })
+              );
+            });
+          }
           return structure;
         })
         .catch((err: unknown) => {
@@ -975,6 +1007,15 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
        * caller semantics for other (non-wizard) call paths.
        */
       setAsDefault?: boolean;
+      /**
+       * CP424.2 wizard precompute: the same UUID sent to /wizard-stream at
+       * Step 1. When present AND WIZARD_PRECOMPUTE_ENABLED AND row status=done,
+       * we consume it into recommendation_cache and skip the legacy
+       * post-creation discover path (still fires fill-missing-actions etc).
+       * Miss (not-found / expired / not-done / goal-mismatch) → fallback to
+       * full `triggerMandalaPostCreationAsync` (legacy behavior).
+       */
+      session_id?: string;
     };
   }>(
     '/create-with-data',
@@ -1003,6 +1044,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         focusTags,
         targetLevel,
         setAsDefault,
+        session_id: sessionId,
       } = request.body;
 
       if (!title || typeof title !== 'string' || title.trim().length === 0) {
@@ -1170,6 +1212,35 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         // Either way, depth=1 scaffold rows are always created above so the
         // async fill path has a target to write into. An empty `subDetails`
         // is expected under the Phase 1 flow and is not a bug.
+
+        // CP424.2 wizard precompute consume — if flag enabled + session_id
+        // present + row status=done + goal matches, copy pre-computed slots
+        // into recommendation_cache under the new mandala_id and fire
+        // card_added events. Miss → no-op; post-creation pipeline fills the
+        // gap below (legacy behavior). On hit, pipeline-runner's checkDiscoverPreconditions
+        // will still see existing rec_cache rows and skip step 2 (video-discover)
+        // via the existing dedup-window guard; steps 1/3/4/5 still run.
+        if (sessionId) {
+          try {
+            const { consumePrecompute } = await import('../../modules/mandala/wizard-precompute');
+            const outcome = await consumePrecompute({
+              sessionId,
+              userId,
+              mandalaId: result.id,
+              centerGoal: centerGoal ?? title,
+            });
+            stage('precompute_consume');
+            request.log.info(
+              { mandalaId: result.id, sessionId, userId, outcome },
+              'wizard-precompute consume outcome'
+            );
+          } catch (err) {
+            request.log.warn(
+              { err, sessionId, userId, mandalaId: result.id },
+              'wizard-precompute consumePrecompute threw (non-fatal, falling through)'
+            );
+          }
+        }
 
         // Fire-and-forget post-creation pipeline for the new mandala.
         // Opt-in via user_skill_config; safe if not enabled.

--- a/src/config/wizard-precompute.ts
+++ b/src/config/wizard-precompute.ts
@@ -1,0 +1,41 @@
+/**
+ * Wizard Precompute Pipeline config (CP424.2).
+ *
+ * Single feature flag gates the entire precompute path:
+ * - /wizard-stream: when enabled + body.session_id present → fire-and-forget
+ *   `startPrecompute(session_id)` via setImmediate.
+ * - /create-with-data: when enabled + body.session_id present → lookup
+ *   precompute row; if status=done, INSERT recommendation_cache + notify;
+ *   else fall back to existing post-creation pipeline.
+ *
+ * Default: OFF. Turning on requires explicit compose env set; code revert
+ * unnecessary for rollback.
+ */
+
+import { z } from 'zod';
+
+const boolFlag = z.preprocess((v) => {
+  if (v == null || v === '') return false;
+  const s = String(v).trim().toLowerCase();
+  return s === 'true' || s === '1' || s === 'yes';
+}, z.boolean());
+
+export const wizardPrecomputeEnvSchema = z.object({
+  WIZARD_PRECOMPUTE_ENABLED: boolFlag.default(false as unknown as string),
+});
+
+export interface WizardPrecomputeConfig {
+  enabled: boolean;
+}
+
+export function loadWizardPrecomputeConfig(
+  env: NodeJS.ProcessEnv = process.env
+): WizardPrecomputeConfig {
+  const parsed = wizardPrecomputeEnvSchema.safeParse({
+    WIZARD_PRECOMPUTE_ENABLED: env['WIZARD_PRECOMPUTE_ENABLED'],
+  });
+  if (!parsed.success) {
+    return { enabled: false };
+  }
+  return { enabled: parsed.data.WIZARD_PRECOMPUTE_ENABLED };
+}

--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -1,0 +1,337 @@
+/**
+ * Wizard Precompute Pipeline — runtime module (CP424.2).
+ *
+ * Design: docs/design/precompute-pipeline.md (CP417 draft).
+ *
+ * Lifecycle:
+ *   1. /wizard-stream handler, after Haiku structure completes, calls
+ *      `setImmediate(() => startPrecompute(...))` with real sub_goals.
+ *   2. startPrecompute: INSERT row (status=pending) → UPDATE running →
+ *      runDiscoverEphemeral() → UPDATE done + discover_result / failed +
+ *      error_message.
+ *   3. /create-with-data handler, after mandala save tx, calls
+ *      `consumePrecompute(mandalaId, sessionId)`:
+ *        - SELECT row WHERE session_id + status=done + expires_at > NOW()
+ *          + goal matches
+ *        - INSERT recommendation_cache rows with new mandala_id
+ *        - cardPublisher.notify per slot → SSE card_added backlog
+ *        - UPDATE status=consumed + consumed_mandala_id + consumed_at
+ *        - Miss → returns { consumed: false, reason } so caller falls back
+ *          to existing triggerMandalaPostCreationAsync.
+ *
+ * Feature flag: WIZARD_PRECOMPUTE_ENABLED (compose env, default false).
+ * Rollback: 1-line env flip. No code revert.
+ */
+
+import { Prisma } from '@prisma/client';
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+import { loadWizardPrecomputeConfig } from '@/config/wizard-precompute';
+import {
+  runDiscoverEphemeral,
+  type EphemeralDiscoverResult,
+} from '@/skills/plugins/video-discover/v3/executor';
+import { notifyCardAdded, type CardPayload } from '@/modules/recommendations/publisher';
+import { randomUUID } from 'crypto';
+
+const log = logger.child({ module: 'wizard-precompute' });
+
+const TTL_DAYS = 7; // recommendation_cache TTL when we upsert at consume-time.
+const RECOMMENDATION_STATUS_PENDING = 'pending';
+const WEIGHT_VERSION = 3;
+const MS_PER_DAY = 86_400_000;
+
+// ---------------------------------------------------------------------------
+// startPrecompute — /wizard-stream fire-and-forget entry
+// ---------------------------------------------------------------------------
+
+export interface StartPrecomputeInput {
+  sessionId: string;
+  userId: string;
+  goal: string;
+  language: 'ko' | 'en';
+  focusTags: string[];
+  targetLevel?: string;
+  subGoals: string[]; // length 8 — from Haiku structure response
+}
+
+/**
+ * Fire-and-forget precompute launcher. Never throws — all failures are
+ * persisted to the precompute row's status=failed + error_message.
+ *
+ * Honors WIZARD_PRECOMPUTE_ENABLED flag at call site; if disabled, returns
+ * immediately. Keep the flag check here so callers can unconditionally
+ * invoke without worrying about state.
+ */
+export async function startPrecompute(input: StartPrecomputeInput): Promise<void> {
+  const cfg = loadWizardPrecomputeConfig();
+  if (!cfg.enabled) return;
+
+  const db = getPrismaClient();
+  const t0 = Date.now();
+
+  // Step 1: INSERT row (status=pending). Idempotent via session_id PK —
+  // duplicate startPrecompute calls for the same session are no-ops. We
+  // intentionally do NOT update an existing row here, because concurrent
+  // callers should cooperate on the earlier row's lifecycle.
+  try {
+    await db.mandala_wizard_precompute.create({
+      data: {
+        session_id: input.sessionId,
+        user_id: input.userId,
+        goal: input.goal,
+        language: input.language,
+        focus_tags: input.focusTags,
+        target_level: input.targetLevel ?? null,
+        status: 'pending',
+      },
+    });
+  } catch (err) {
+    // Likely PK duplicate — another in-flight call owns this session.
+    // Honest log and return; never crash the wizard SSE stream.
+    log.info(
+      `precompute row already exists for session=${input.sessionId} (dup startPrecompute); skipping`,
+      {
+        error: err instanceof Error ? err.message : String(err),
+      }
+    );
+    return;
+  }
+
+  // Step 2: UPDATE status=running (separate tx to make running visible in
+  // admin dashboards while discover is in flight).
+  await db.mandala_wizard_precompute.update({
+    where: { session_id: input.sessionId },
+    data: { status: 'running' },
+  });
+
+  log.info(`precompute running: session=${input.sessionId} goal="${input.goal.slice(0, 40)}"`, {
+    sessionId: input.sessionId,
+    userId: input.userId,
+  });
+
+  // Step 3: runDiscoverEphemeral → persist result
+  try {
+    const result = await runDiscoverEphemeral({
+      centerGoal: input.goal,
+      subGoals: input.subGoals,
+      language: input.language,
+      focusTags: input.focusTags,
+      targetLevel: input.targetLevel ?? 'standard',
+      env: process.env,
+    });
+
+    await db.mandala_wizard_precompute.update({
+      where: { session_id: input.sessionId },
+      data: {
+        status: 'done',
+        discover_result: result as unknown as Prisma.InputJsonValue,
+      },
+    });
+
+    log.info(
+      `precompute done: session=${input.sessionId} slots=${result.slots.length} ` +
+        `queries=${result.queriesUsed} duration_ms=${Date.now() - t0}`,
+      {
+        sessionId: input.sessionId,
+        slotsCount: result.slots.length,
+        queriesUsed: result.queriesUsed,
+      }
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(
+      `precompute failed: session=${input.sessionId} error=${msg.slice(0, 200)} duration_ms=${Date.now() - t0}`,
+      {
+        sessionId: input.sessionId,
+        error: msg,
+      }
+    );
+    try {
+      await db.mandala_wizard_precompute.update({
+        where: { session_id: input.sessionId },
+        data: {
+          status: 'failed',
+          error_message: msg.slice(0, 2000),
+        },
+      });
+    } catch (updateErr) {
+      log.error(
+        `precompute failed-status update also threw for session=${input.sessionId}: ${
+          updateErr instanceof Error ? updateErr.message : String(updateErr)
+        }`
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// consumePrecompute — /create-with-data consume entry
+// ---------------------------------------------------------------------------
+
+export interface ConsumePrecomputeInput {
+  sessionId: string;
+  userId: string;
+  mandalaId: string;
+  /** Expected goal (from save payload). If mismatch → treat as miss. */
+  centerGoal: string;
+}
+
+export interface ConsumePrecomputeResult {
+  consumed: boolean;
+  reason?:
+    | 'disabled'
+    | 'no-session-id'
+    | 'not-found'
+    | 'wrong-user'
+    | 'not-done'
+    | 'expired'
+    | 'goal-mismatch'
+    | 'empty-slots';
+  cardsInserted?: number;
+  slotsCount?: number;
+}
+
+/**
+ * Consume a precompute row at mandala save time. On hit, copies slots into
+ * recommendation_cache under the new mandala_id and publishes card_added
+ * events through the existing cardPublisher bus (same mechanism the
+ * post-creation pipeline uses, so the dashboard/SSE consumer code path is
+ * unchanged).
+ *
+ * Miss semantics are explicit (see `reason` enum). Callers SHOULD fall back
+ * to `triggerMandalaPostCreationAsync` on miss so dashboard still fills via
+ * the legacy path.
+ *
+ * Never throws — all errors produce `{ consumed: false, reason }`.
+ */
+export async function consumePrecompute(
+  input: ConsumePrecomputeInput
+): Promise<ConsumePrecomputeResult> {
+  const cfg = loadWizardPrecomputeConfig();
+  if (!cfg.enabled) return { consumed: false, reason: 'disabled' };
+  if (!input.sessionId) return { consumed: false, reason: 'no-session-id' };
+
+  const db = getPrismaClient();
+  const row = await db.mandala_wizard_precompute.findUnique({
+    where: { session_id: input.sessionId },
+  });
+
+  if (!row) return { consumed: false, reason: 'not-found' };
+  if (row.user_id !== input.userId) {
+    log.warn(
+      `precompute user mismatch: session=${input.sessionId} row.user=${row.user_id} req.user=${input.userId}`
+    );
+    return { consumed: false, reason: 'wrong-user' };
+  }
+  if (row.status !== 'done') return { consumed: false, reason: 'not-done' };
+  if (row.expires_at.getTime() < Date.now()) return { consumed: false, reason: 'expired' };
+
+  // Goal match: allow minor whitespace / case variance but reject substantive
+  // edits. Design doc §Invalidation: "consumed 시점에 goal match 검사".
+  const normalize = (s: string): string => s.trim().toLowerCase();
+  if (normalize(row.goal) !== normalize(input.centerGoal)) {
+    log.info(
+      `precompute goal mismatch: session=${input.sessionId} expected="${row.goal.slice(0, 40)}" got="${input.centerGoal.slice(0, 40)}"`
+    );
+    return { consumed: false, reason: 'goal-mismatch' };
+  }
+
+  // Extract slots from discover_result JSON.
+  const discover = row.discover_result as unknown as EphemeralDiscoverResult | null;
+  const slots = discover?.slots ?? [];
+  if (slots.length === 0) {
+    // Mark consumed anyway so we don't retry a known-empty result; fall back.
+    await db.mandala_wizard_precompute.update({
+      where: { session_id: input.sessionId },
+      data: {
+        status: 'consumed',
+        consumed_mandala_id: input.mandalaId,
+        consumed_at: new Date(),
+      },
+    });
+    return { consumed: false, reason: 'empty-slots', slotsCount: 0 };
+  }
+
+  // Copy slots → recommendation_cache. Use INSERT … ON CONFLICT DO NOTHING
+  // so the unique (user_id, mandala_id, video_id) constraint silently dedupes
+  // if somehow the row already exists.
+  const expiresAt = new Date(Date.now() + TTL_DAYS * MS_PER_DAY);
+  let inserted = 0;
+  for (const slot of slots) {
+    try {
+      await db.$executeRaw(
+        Prisma.sql`
+          INSERT INTO public.recommendation_cache (
+            user_id, mandala_id, cell_index, keyword, video_id, title,
+            thumbnail, channel, channel_subs, view_count, like_ratio,
+            duration_sec, rec_score, rec_reason, weight_version, status, expires_at
+          )
+          VALUES (
+            ${input.userId}::uuid,
+            ${input.mandalaId}::uuid,
+            ${slot.cellIndex},
+            ${''},
+            ${slot.videoId},
+            ${slot.title},
+            ${slot.thumbnail},
+            ${slot.channelName},
+            ${null},
+            ${slot.viewCount ? BigInt(slot.viewCount) : null},
+            ${null},
+            ${slot.durationSec},
+            ${slot.score},
+            ${'realtime'},
+            ${WEIGHT_VERSION},
+            ${RECOMMENDATION_STATUS_PENDING},
+            ${expiresAt}
+          )
+          ON CONFLICT (user_id, mandala_id, video_id) DO NOTHING
+        `
+      );
+      inserted += 1;
+
+      // Publish card_added on the same bus the legacy pipeline uses. Dashboard
+      // SSE subscribers receive these identically whether they came from
+      // precompute consume or post-creation v3 executor.
+      const payload: CardPayload = {
+        id: randomUUID(),
+        videoId: slot.videoId,
+        title: slot.title,
+        channel: slot.channelName ?? null,
+        thumbnail: slot.thumbnail ?? null,
+        durationSec: slot.durationSec ?? null,
+        recScore: slot.score,
+        cellIndex: slot.cellIndex,
+        cellLabel: null,
+        keyword: '',
+        source: 'auto_recommend',
+        recReason: 'realtime',
+      };
+      notifyCardAdded(input.mandalaId, payload);
+    } catch (err) {
+      log.warn(
+        `precompute consume upsert failed: session=${input.sessionId} video=${slot.videoId} error=${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
+  // Mark consumed.
+  await db.mandala_wizard_precompute.update({
+    where: { session_id: input.sessionId },
+    data: {
+      status: 'consumed',
+      consumed_mandala_id: input.mandalaId,
+      consumed_at: new Date(),
+    },
+  });
+
+  log.info(
+    `precompute consumed: session=${input.sessionId} mandala=${input.mandalaId} ` +
+      `slots=${slots.length} inserted=${inserted}`
+  );
+
+  return { consumed: true, cardsInserted: inserted, slotsCount: slots.length };
+}

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -83,7 +83,7 @@ const TIER2_MAX_QUERIES_PER_CELL = 2;
 // Types
 // ---------------------------------------------------------------------------
 
-interface HydratedState {
+export interface HydratedState {
   centerGoal: string;
   subGoals: string[]; // length 8
   language: KeywordLanguage;
@@ -1004,4 +1004,95 @@ async function upsertSlots(
     }
   }
   return count;
+}
+
+// ---------------------------------------------------------------------------
+// CP424.2 Wizard Precompute — ephemeral discovery (no mandala_id)
+// ---------------------------------------------------------------------------
+//
+// Design: docs/design/precompute-pipeline.md (CP417 draft).
+// Called by /wizard-stream at Step 1 via setImmediate fire-and-forget.
+// Produces the same AssembledSlot[] shape as `executor.execute` but:
+//   - Tier 1 (video_pool KNN) disabled — no mandala_id to scope candidates,
+//     and flag-gated off in prod anyway (V3_ENABLE_TIER1_CACHE=false default).
+//   - No upsertSlots — caller persists to mandala_wizard_precompute.discover_result
+//     as JSON, then copies to recommendation_cache at consume-time (/create-with-data).
+//   - No cardPublisher.notify — no mandala_id to publish under. Notify fires
+//     at consume-time when mandala row exists.
+//   - Semantic rerank + whitelist gate skipped (both require mandala_id); can be
+//     revisited in a follow-up if precompute quality warrants.
+//
+// Result shape mirrors Tier2Output + metadata so caller stores it intact.
+
+export interface EphemeralDiscoverInput {
+  centerGoal: string;
+  subGoals: string[]; // length 8
+  language: KeywordLanguage;
+  focusTags: string[];
+  targetLevel: string;
+  env: NodeJS.ProcessEnv;
+}
+
+export interface EphemeralDiscoverResult {
+  slots: AssembledSlot[];
+  queriesUsed: number;
+  tier1_matches: 0;
+  tier2_matches: number;
+  duration_ms: number;
+  debug: Tier2Debug;
+}
+
+/**
+ * Run v3 Tier 2 discovery with an ephemeral hydrated state (no mandala_id
+ * required). Intended for wizard precompute path: caller hydrates state from
+ * client-provided goal + inferred/echoed sub_goals at Step 1, stores result in
+ * mandala_wizard_precompute table, consumes at Step 3 save.
+ *
+ * Throws:
+ *   - `Error('YOUTUBE_API_KEY_SEARCH is not configured')` if no API keys
+ *
+ * Caller responsibility:
+ *   - Catch errors and persist them to precompute.error_message
+ *   - Never call with a sub_goals array shorter than V3_NUM_CELLS; the queries
+ *     will silently skip empty cells.
+ */
+export async function runDiscoverEphemeral(
+  input: EphemeralDiscoverInput
+): Promise<EphemeralDiscoverResult> {
+  const t0 = Date.now();
+  const apiKeys = resolveSearchApiKeys(input.env);
+  if (apiKeys.length === 0) {
+    throw new Error('YOUTUBE_API_KEY_SEARCH is not configured');
+  }
+  const openRouterApiKey = input.env['OPENROUTER_API_KEY'];
+  const openRouterModel = input.env['OPENROUTER_MODEL'] ?? 'qwen/qwen3-30b-a3b';
+
+  const deficitCells = Array.from({ length: V3_NUM_CELLS }, (_, i) => ({
+    cellIndex: i,
+    need: V3_TARGET_PER_CELL,
+  }));
+
+  const tier2 = await runTier2({
+    deficitCells,
+    state: {
+      centerGoal: input.centerGoal,
+      subGoals: input.subGoals,
+      language: input.language,
+      focusTags: input.focusTags,
+      targetLevel: input.targetLevel,
+    },
+    apiKeys,
+    openRouterApiKey: openRouterApiKey || undefined,
+    openRouterModel,
+    existingVideoIds: new Set(),
+  });
+
+  return {
+    slots: tier2.slots,
+    queriesUsed: tier2.queriesUsed,
+    tier1_matches: 0,
+    tier2_matches: tier2.slots.length,
+    duration_ms: Date.now() - t0,
+    debug: tier2.debug,
+  };
 }

--- a/tests/unit/modules/wizard-precompute-config.test.ts
+++ b/tests/unit/modules/wizard-precompute-config.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Wizard Precompute config — feature flag parsing (CP424.2).
+ */
+
+import { loadWizardPrecomputeConfig } from '../../../src/config/wizard-precompute';
+
+describe('loadWizardPrecomputeConfig', () => {
+  it('defaults to disabled when env unset', () => {
+    expect(loadWizardPrecomputeConfig({})).toEqual({ enabled: false });
+  });
+
+  it.each([
+    ['true', true],
+    ['TRUE', true],
+    ['1', true],
+    ['yes', true],
+    [' true ', true],
+    ['false', false],
+    ['0', false],
+    ['', false],
+    ['anything', false],
+  ])('WIZARD_PRECOMPUTE_ENABLED=%s → enabled=%s', (raw, expected) => {
+    expect(loadWizardPrecomputeConfig({ WIZARD_PRECOMPUTE_ENABLED: raw })).toEqual({
+      enabled: expected,
+    });
+  });
+});

--- a/tests/unit/modules/wizard-precompute.test.ts
+++ b/tests/unit/modules/wizard-precompute.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Wizard Precompute Pipeline — unit tests (CP424.2).
+ *
+ * Cross-checks the lifecycle + miss semantics that matter end-to-end:
+ *   - Feature flag OFF → startPrecompute + consumePrecompute both no-op.
+ *   - startPrecompute happy path: pending → running → done (discover_result persisted).
+ *   - startPrecompute failure path: pending → running → failed (error_message persisted).
+ *   - consumePrecompute miss semantics: each enum value triggers fallback.
+ *   - consumePrecompute happy path: done row → recommendation_cache rows + notify + consumed.
+ *   - Goal mismatch → miss (not consumed, fallback triggers).
+ *   - User mismatch → miss + warning log.
+ *
+ * Shallow mocks: Prisma client + runDiscoverEphemeral + notifyCardAdded. No
+ * real DB, no real YouTube calls. Tests focus on orchestration correctness —
+ * invariants that a prod outage would violate.
+ */
+
+const mockFindUnique = jest.fn();
+const mockCreate = jest.fn();
+const mockUpdate = jest.fn();
+const mockExecuteRaw = jest.fn();
+const mockRunDiscoverEphemeral = jest.fn();
+const mockNotifyCardAdded = jest.fn();
+const mockLoadConfig = jest.fn();
+
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    mandala_wizard_precompute: {
+      findUnique: mockFindUnique,
+      create: mockCreate,
+      update: mockUpdate,
+    },
+    $executeRaw: mockExecuteRaw,
+  }),
+}));
+
+jest.mock('@prisma/client', () => ({
+  Prisma: {
+    sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values }),
+  },
+}));
+
+jest.mock('@/skills/plugins/video-discover/v3/executor', () => ({
+  runDiscoverEphemeral: mockRunDiscoverEphemeral,
+}));
+
+jest.mock('@/modules/recommendations/publisher', () => ({
+  notifyCardAdded: mockNotifyCardAdded,
+}));
+
+jest.mock('@/config/wizard-precompute', () => ({
+  loadWizardPrecomputeConfig: mockLoadConfig,
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+import { startPrecompute, consumePrecompute } from '../../../src/modules/mandala/wizard-precompute';
+
+const SESSION = 'aaaaaaaa-1111-2222-3333-cccccccccccc';
+const USER = 'bbbbbbbb-1111-2222-3333-dddddddddddd';
+const MANDALA = 'ccccccc1-1111-2222-3333-eeeeeeeeeeee';
+
+const SUB_GOALS = Array.from({ length: 8 }, (_, i) => `sub_${i}`);
+
+function makeSlot(
+  cellIndex: number,
+  videoId: string
+): {
+  videoId: string;
+  title: string;
+  description: string | null;
+  channelName: string | null;
+  channelId: string | null;
+  thumbnail: string | null;
+  viewCount: number | null;
+  likeCount: number | null;
+  durationSec: number | null;
+  publishedAt: Date | null;
+  cellIndex: number;
+  score: number;
+  tier: 'cache' | 'realtime';
+} {
+  return {
+    videoId,
+    title: `Title ${videoId}`,
+    description: null,
+    channelName: 'ch',
+    channelId: null,
+    thumbnail: 'https://thumb',
+    viewCount: 1000,
+    likeCount: null,
+    durationSec: 600,
+    publishedAt: new Date('2026-01-01T00:00:00Z'),
+    cellIndex,
+    score: 0.5 + cellIndex * 0.01,
+    tier: 'realtime',
+  };
+}
+
+describe('wizard-precompute — startPrecompute', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoadConfig.mockReturnValue({ enabled: true });
+  });
+
+  test('flag OFF → no DB writes, no discover call', async () => {
+    mockLoadConfig.mockReturnValue({ enabled: false });
+    await startPrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      goal: 'g',
+      language: 'ko',
+      focusTags: [],
+      subGoals: SUB_GOALS,
+    });
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockRunDiscoverEphemeral).not.toHaveBeenCalled();
+  });
+
+  test('happy path: pending → running → done (result persisted)', async () => {
+    const discoverResult = {
+      slots: [makeSlot(0, 'v1'), makeSlot(1, 'v2')],
+      queriesUsed: 3,
+      tier1_matches: 0 as const,
+      tier2_matches: 2,
+      duration_ms: 1234,
+      debug: { timing: { totalMs: 1234 } },
+    };
+    mockCreate.mockResolvedValueOnce({});
+    mockUpdate.mockResolvedValue({});
+    mockRunDiscoverEphemeral.mockResolvedValueOnce(discoverResult);
+
+    await startPrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      goal: 'g',
+      language: 'ko',
+      focusTags: ['t1'],
+      targetLevel: 'standard',
+      subGoals: SUB_GOALS,
+    });
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate.mock.calls[0]![0].data).toMatchObject({
+      session_id: SESSION,
+      user_id: USER,
+      status: 'pending',
+    });
+    // Two updates: running → done
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+    expect(mockUpdate.mock.calls[0]![0].data).toMatchObject({ status: 'running' });
+    expect(mockUpdate.mock.calls[1]![0].data).toMatchObject({ status: 'done' });
+    expect(mockUpdate.mock.calls[1]![0].data.discover_result).toBe(discoverResult);
+  });
+
+  test('discover failure → status=failed + error_message', async () => {
+    mockCreate.mockResolvedValueOnce({});
+    mockUpdate.mockResolvedValue({});
+    mockRunDiscoverEphemeral.mockRejectedValueOnce(new Error('youtube quota'));
+
+    await startPrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      goal: 'g',
+      language: 'ko',
+      focusTags: [],
+      subGoals: SUB_GOALS,
+    });
+
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+    expect(mockUpdate.mock.calls[1]![0].data).toMatchObject({ status: 'failed' });
+    expect(mockUpdate.mock.calls[1]![0].data.error_message).toContain('youtube quota');
+  });
+
+  test('duplicate PK on create → swallow (log + return)', async () => {
+    mockCreate.mockRejectedValueOnce(new Error('duplicate key'));
+    await startPrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      goal: 'g',
+      language: 'ko',
+      focusTags: [],
+      subGoals: SUB_GOALS,
+    });
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockRunDiscoverEphemeral).not.toHaveBeenCalled();
+  });
+});
+
+describe('wizard-precompute — consumePrecompute', () => {
+  const FUTURE = new Date(Date.now() + 5 * 60_000);
+  const PAST = new Date(Date.now() - 60_000);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoadConfig.mockReturnValue({ enabled: true });
+    mockUpdate.mockResolvedValue({});
+    mockExecuteRaw.mockResolvedValue(1);
+  });
+
+  test('flag OFF → reason=disabled, consumed=false', async () => {
+    mockLoadConfig.mockReturnValue({ enabled: false });
+    const r = await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+    expect(r).toEqual({ consumed: false, reason: 'disabled' });
+    expect(mockFindUnique).not.toHaveBeenCalled();
+  });
+
+  test('no session_id → reason=no-session-id', async () => {
+    const r = await consumePrecompute({
+      sessionId: '',
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+    expect(r.consumed).toBe(false);
+    expect(r.reason).toBe('no-session-id');
+  });
+
+  test('row not found → reason=not-found', async () => {
+    mockFindUnique.mockResolvedValueOnce(null);
+    const r = await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+    expect(r.consumed).toBe(false);
+    expect(r.reason).toBe('not-found');
+  });
+
+  test('wrong user → reason=wrong-user (no rec_cache writes)', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      session_id: SESSION,
+      user_id: 'other-user',
+      goal: 'g',
+      status: 'done',
+      expires_at: FUTURE,
+      discover_result: { slots: [makeSlot(0, 'v1')] },
+    });
+    const r = await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+    expect(r.consumed).toBe(false);
+    expect(r.reason).toBe('wrong-user');
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
+  });
+
+  test('status≠done → reason=not-done', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      session_id: SESSION,
+      user_id: USER,
+      goal: 'g',
+      status: 'running',
+      expires_at: FUTURE,
+      discover_result: null,
+    });
+    const r = await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+    expect(r.consumed).toBe(false);
+    expect(r.reason).toBe('not-done');
+  });
+
+  test('expired → reason=expired', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      session_id: SESSION,
+      user_id: USER,
+      goal: 'g',
+      status: 'done',
+      expires_at: PAST,
+      discover_result: { slots: [makeSlot(0, 'v1')] },
+    });
+    const r = await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+    expect(r.consumed).toBe(false);
+    expect(r.reason).toBe('expired');
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
+  });
+
+  test('goal mismatch → reason=goal-mismatch (no writes)', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      session_id: SESSION,
+      user_id: USER,
+      goal: '원래 목표',
+      status: 'done',
+      expires_at: FUTURE,
+      discover_result: { slots: [makeSlot(0, 'v1')] },
+    });
+    const r = await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: '다른 목표',
+    });
+    expect(r.consumed).toBe(false);
+    expect(r.reason).toBe('goal-mismatch');
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
+    expect(mockNotifyCardAdded).not.toHaveBeenCalled();
+  });
+
+  test('empty slots → reason=empty-slots + still marks consumed (no retry)', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      session_id: SESSION,
+      user_id: USER,
+      goal: 'g',
+      status: 'done',
+      expires_at: FUTURE,
+      discover_result: { slots: [] },
+    });
+    const r = await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+    expect(r.consumed).toBe(false);
+    expect(r.reason).toBe('empty-slots');
+    // Marked consumed so we don't retry on the next save.
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate.mock.calls[0]![0].data).toMatchObject({ status: 'consumed' });
+  });
+
+  test('happy path: done + match → INSERT rec_cache + notifyCardAdded per slot + consumed', async () => {
+    const slots = [makeSlot(0, 'v1'), makeSlot(1, 'v2'), makeSlot(3, 'v3')];
+    mockFindUnique.mockResolvedValueOnce({
+      session_id: SESSION,
+      user_id: USER,
+      goal: 'g',
+      status: 'done',
+      expires_at: FUTURE,
+      discover_result: { slots },
+    });
+
+    const r = await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+
+    expect(r.consumed).toBe(true);
+    expect(r.cardsInserted).toBe(3);
+    expect(r.slotsCount).toBe(3);
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(3);
+    expect(mockNotifyCardAdded).toHaveBeenCalledTimes(3);
+    // Final update → status=consumed with consumed_mandala_id + consumed_at
+    const lastUpdate = mockUpdate.mock.calls[mockUpdate.mock.calls.length - 1]![0];
+    expect(lastUpdate.data.status).toBe('consumed');
+    expect(lastUpdate.data.consumed_mandala_id).toBe(MANDALA);
+    expect(lastUpdate.data.consumed_at).toBeInstanceOf(Date);
+  });
+
+  test('case-insensitive + trimmed goal match (resilient to minor client edits)', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      session_id: SESSION,
+      user_id: USER,
+      goal: '  영어 회화 실력 향상  ',
+      status: 'done',
+      expires_at: FUTURE,
+      discover_result: { slots: [makeSlot(0, 'v1')] },
+    });
+    const r = await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: '영어 회화 실력 향상',
+    });
+    expect(r.consumed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Per \`docs/design/precompute-pipeline.md\` (CP417 draft). Implements the full wizard pre-compute pipeline so the dashboard first card arrives ≤1s after Step 3 save.

**Flow**:
1. Step 1 goal submit → FE mints \`sessionId = crypto.randomUUID()\` → \`/wizard-stream\` body.session_id
2. BE after Haiku structure resolves → \`setImmediate(startPrecompute(sessionId))\` fires v3 \`runDiscoverEphemeral\` in background
3. Result persisted to new \`mandala_wizard_precompute\` table (session_id PK, 10min TTL, pg_cron sweep)
4. Step 3 save → FE passes same sessionId to \`/create-with-data\` → BE \`consumePrecompute\` copies slots into \`recommendation_cache\` + \`cardPublisher.notify\` → SSE backlog hits dashboard immediately
5. Miss (not-found / expired / not-done / goal-mismatch / empty-slots) → existing post-creation pipeline (backward-compat)

## Feature flag

\`WIZARD_PRECOMPUTE_ENABLED\` compose env, default \`false\`. Rollback = 1-line env flip.

## Scope

P1 schema + pg_cron → P2 v3 ephemeral mode (new \`runDiscoverEphemeral\` export, Tier 2 only) → P3 wizard-stream trigger → P4 create-with-data consume → P5 FE useWizard wiring → P6 24 new tests.

## Verification

- tsc --noEmit clean (BE + FE)
- jest wizard-precompute* 24/24 pass covering:
  - flag on/off no-op
  - startPrecompute lifecycle (pending→running→done/failed, dup PK swallow)
  - consumePrecompute miss enum (disabled / no-session-id / not-found / wrong-user / not-done / expired / goal-mismatch / empty-slots)
  - consume happy path (INSERT rec_cache + notify per slot + status=consumed)
  - case-insensitive trimmed goal match

## Test plan

- [ ] CI 6/6
- [ ] Deploy
- [ ] Flip \`WIZARD_PRECOMPUTE_ENABLED=true\` via docker-compose.prod.yml env (separate PR)
- [ ] Wizard end-to-end smoke: goal → preview → save → dashboard shows cards within 1s