### PR TITLE
feat(ops): flip WIZARD_PRECOMPUTE_ENABLED=true in prod (CP424.2)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -77,6 +77,15 @@ services:
       # inside enrichRichSummary via rich-summary-quota module.
       # Revert: delete this line → feature no-ops.
       - RICH_SUMMARY_ENABLED=true
+      # CP424.2 (2026-04-24) — Wizard Precompute Pipeline.
+      # Per docs/design/precompute-pipeline.md. Step 1 goal → /wizard-stream
+      # fires fire-and-forget `runDiscoverEphemeral` keyed by session_id →
+      # Step 3 save (/create-with-data) consumes result into recommendation_cache
+      # + cardPublisher.notify → dashboard first card ≤1s. Miss → legacy
+      # post-creation pipeline fallback (backward-compat preserved).
+      # Table: mandala_wizard_precompute (10min TTL, pg_cron sweep */5 min).
+      # Revert: delete this line → feature no-ops.
+      - WIZARD_PRECOMPUTE_ENABLED=true
       # OPENROUTER_EMBED_MODEL defaults to `qwen/qwen3-embedding-8b` in
       # code. Uncomment + override here ONLY if the exact OpenRouter
       # model id string differs (verify at https://openrouter.ai/models).


### PR DESCRIPTION
Activates the wizard precompute pipeline (PR #475) on prod.

Single-line env enable in `docker-compose.prod.yml` (non-secret config per CP392 rule). Revert = delete the line.

## Post-deploy smoke
1. Wizard → goal 입력 → (~3-8s) structure → save
2. Dashboard navigation 시 카드 ≤1s 도착 확인
3. DB: `SELECT status, COUNT(*) FROM mandala_wizard_precompute GROUP BY status` 로 라이프사이클 관찰
4. `docker logs insighta-api | grep wizard-precompute` 로 startPrecompute/consumePrecompute 로그 확인

## Rollback
Revert this commit or delete the env line → feature no-ops, 기존 post-creation pipeline 100% 유지.

Depends on: PR #475