### PR TITLE
fix(wizard-precompute): import MS_PER_DAY — hardcode audit hotfix (CP424.2)

### DIFF
--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -32,6 +32,7 @@ import {
   type EphemeralDiscoverResult,
 } from '@/skills/plugins/video-discover/v3/executor';
 import { notifyCardAdded, type CardPayload } from '@/modules/recommendations/publisher';
+import { MS_PER_DAY } from '@/utils/time-constants';
 import { randomUUID } from 'crypto';
 
 const log = logger.child({ module: 'wizard-precompute' });
@@ -39,7 +40,6 @@ const log = logger.child({ module: 'wizard-precompute' });
 const TTL_DAYS = 7; // recommendation_cache TTL when we upsert at consume-time.
 const RECOMMENDATION_STATUS_PENDING = 'pending';
 const WEIGHT_VERSION = 3;
-const MS_PER_DAY = 86_400_000;
 
 // ---------------------------------------------------------------------------
 // startPrecompute — /wizard-stream fire-and-forget entry


### PR DESCRIPTION
PR #475 deploy failed at CI Hardcode Audit step. MS_PER_DAY redeclared in wizard-precompute.ts — fixed by importing from @/utils/time-constants (CLAUDE.md '하드코딩 금지' LEVEL-3 compliance).

Local verify: hardcode-audit 0 violations, tsc clean.

Depends on: PR #475 (merged). Blocks: PR #476 flag flip (deploy won't apply until this hotfix merges).