### PR TITLE
fix(wizard-precompute): 5s poll-wait to handle fast-save race (CP424.2)

### DIFF
--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -213,7 +213,7 @@ export async function consumePrecompute(
   if (!input.sessionId) return { consumed: false, reason: 'no-session-id' };
 
   const db = getPrismaClient();
-  const row = await db.mandala_wizard_precompute.findUnique({
+  let row = await db.mandala_wizard_precompute.findUnique({
     where: { session_id: input.sessionId },
   });
 
@@ -224,6 +224,37 @@ export async function consumePrecompute(
     );
     return { consumed: false, reason: 'wrong-user' };
   }
+
+  // CP424.2 race handling: fast user clicks Step 3 save while startPrecompute
+  // is still mid-flight (status='pending' | 'running'). Design doc's "Step 2
+  // review 5-20s" assumption is structurally wrong — don't depend on user
+  // dwelling. Poll up to POLL_BUDGET_MS for the row to transition out of
+  // running. If still running when budget exhausts → miss, legacy fallback.
+  // Tier 2 discover observed 4.6s on first prod hit; 5s budget covers p95
+  // with small margin, user perceives as part of existing save latency.
+  const POLL_BUDGET_MS = 5_000;
+  const POLL_INTERVAL_MS = 250;
+  if (row.status === 'pending' || row.status === 'running') {
+    const pollStart = Date.now();
+    while (
+      Date.now() - pollStart < POLL_BUDGET_MS &&
+      (row.status === 'pending' || row.status === 'running')
+    ) {
+      await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+      const refreshed = await db.mandala_wizard_precompute.findUnique({
+        where: { session_id: input.sessionId },
+      });
+      if (!refreshed) {
+        // Row vanished mid-poll (TTL sweep racing — unlikely within 5s).
+        return { consumed: false, reason: 'not-found' };
+      }
+      row = refreshed;
+    }
+    log.info(
+      `precompute poll-wait end: session=${input.sessionId} final_status=${row.status} waited_ms=${Date.now() - pollStart}`
+    );
+  }
+
   if (row.status !== 'done') return { consumed: false, reason: 'not-done' };
   if (row.expires_at.getTime() < Date.now()) return { consumed: false, reason: 'expired' };
 

--- a/tests/unit/modules/wizard-precompute.test.ts
+++ b/tests/unit/modules/wizard-precompute.test.ts
@@ -263,8 +263,9 @@ describe('wizard-precompute — consumePrecompute', () => {
     expect(mockExecuteRaw).not.toHaveBeenCalled();
   });
 
-  test('status≠done → reason=not-done', async () => {
-    mockFindUnique.mockResolvedValueOnce({
+  test('status=running throughout budget → miss (not-done) after poll timeout', async () => {
+    // Always returns running — simulate precompute that doesn't finish in 5s.
+    mockFindUnique.mockResolvedValue({
       session_id: SESSION,
       user_id: USER,
       goal: 'g',
@@ -272,14 +273,72 @@ describe('wizard-precompute — consumePrecompute', () => {
       expires_at: FUTURE,
       discover_result: null,
     });
+    const t0 = Date.now();
     const r = await consumePrecompute({
       sessionId: SESSION,
       userId: USER,
       mandalaId: MANDALA,
       centerGoal: 'g',
     });
+    const elapsed = Date.now() - t0;
     expect(r.consumed).toBe(false);
     expect(r.reason).toBe('not-done');
+    // Should have polled for close to 5s before giving up.
+    expect(elapsed).toBeGreaterThanOrEqual(4500);
+    expect(elapsed).toBeLessThan(7000);
+  }, 15_000);
+
+  test('status=running → done within budget → consume succeeds', async () => {
+    // First read: running. Subsequent reads: done.
+    mockFindUnique
+      .mockResolvedValueOnce({
+        session_id: SESSION,
+        user_id: USER,
+        goal: 'g',
+        status: 'running',
+        expires_at: FUTURE,
+        discover_result: null,
+      })
+      .mockResolvedValue({
+        session_id: SESSION,
+        user_id: USER,
+        goal: 'g',
+        status: 'done',
+        expires_at: FUTURE,
+        discover_result: { slots: [makeSlot(0, 'v1')] },
+      });
+    const r = await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+    expect(r.consumed).toBe(true);
+    expect(r.cardsInserted).toBe(1);
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+  }, 15_000);
+
+  test('status=failed → reason=not-done (no poll, immediate miss)', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      session_id: SESSION,
+      user_id: USER,
+      goal: 'g',
+      status: 'failed',
+      expires_at: FUTURE,
+      discover_result: null,
+    });
+    const t0 = Date.now();
+    const r = await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+    const elapsed = Date.now() - t0;
+    expect(r.consumed).toBe(false);
+    expect(r.reason).toBe('not-done');
+    // Failed should NOT trigger poll — returns fast.
+    expect(elapsed).toBeLessThan(500);
   });
 
   test('expired → reason=expired', async () => {


### PR DESCRIPTION
Prod smoke revealed race: fast user (save within 3s of goal) hits precompute while status='running' → miss → 16s legacy fallback.

Fix: 5s poll budget (250ms interval) in `consumePrecompute` so fast saves still land hit when precompute finishes within 5s. Tier 2 discover observed ~4.6s p95 so budget absorbs that.

Tests 16/16 pass (2 new: running→timeout miss / running→done consume).