### PR TITLE
feat(rich-summary): wire AI rich summary to wizard + video panel (CP425)

### DIFF
--- a/frontend/src/__tests__/smoke/rich-summary-client.test.ts
+++ b/frontend/src/__tests__/smoke/rich-summary-client.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Rich Summary API client smoke test — CP425 (C1).
+ *
+ * Covers:
+ *   - getVideoRichSummary returns null on 404 (empty-state contract)
+ *   - getVideoRichSummary returns data on 200
+ *   - getVideoRichSummary propagates 5xx errors (does NOT swallow)
+ *   - triggerMandalaRichSummary POSTs to the correct endpoint
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockGetSession } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+}));
+
+vi.mock('@/shared/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getSession: mockGetSession,
+      refreshSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
+    },
+  },
+}));
+
+vi.mock('../../shared/lib/auth-event-bus', () => ({
+  subscribeAuth: vi.fn(() => () => undefined),
+}));
+
+describe('apiClient rich-summary methods (CP425 C1)', () => {
+  const originalFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockGetSession.mockResolvedValue({ data: { session: { access_token: 'tok' } } });
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it('getVideoRichSummary returns null on 404', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'not found', statusCode: 404 }), { status: 404 })
+    );
+    const { apiClient } = await import('@/shared/lib/api-client');
+    const result = await apiClient.getVideoRichSummary('abc12345678');
+    expect(result).toBeNull();
+  });
+
+  it('getVideoRichSummary returns data on 200', async () => {
+    const payload = {
+      status: 'ok',
+      data: {
+        videoId: 'abc12345678',
+        oneLiner: 'A short one-liner',
+        structured: { key_points: ['p1', 'p2'], tl_dr_ko: '한 줄' },
+        qualityScore: 0.8,
+        model: 'test-model',
+        updatedAt: '2026-04-24T00:00:00.000Z',
+      },
+    };
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(payload), { status: 200 }));
+    const { apiClient } = await import('@/shared/lib/api-client');
+    const result = await apiClient.getVideoRichSummary('abc12345678');
+    expect(result).not.toBeNull();
+    expect(result?.videoId).toBe('abc12345678');
+    expect(result?.structured?.key_points).toEqual(['p1', 'p2']);
+  });
+
+  it('getVideoRichSummary propagates 500 errors (does NOT swallow)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'boom', statusCode: 500 }), { status: 500 })
+    );
+    const { apiClient } = await import('@/shared/lib/api-client');
+    await expect(apiClient.getVideoRichSummary('abc12345678')).rejects.toThrow(/boom/);
+  });
+
+  it('triggerMandalaRichSummary POSTs to /mandalas/:id/rich-summary-trigger', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 'ok', data: { enqueued: 3 } }), { status: 202 })
+    );
+    const { apiClient } = await import('@/shared/lib/api-client');
+    await apiClient.triggerMandalaRichSummary('mandala-uuid');
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/api\/v1\/mandalas\/mandala-uuid\/rich-summary-trigger$/);
+    expect(init.method).toBe('POST');
+  });
+});

--- a/frontend/src/features/mandala-wizard/model/useWizard.ts
+++ b/frontend/src/features/mandala-wizard/model/useWizard.ts
@@ -647,6 +647,13 @@ export function useWizard() {
           template_id: state.selectedTemplate?.id,
           language: detectGoalLanguage(state.goalInput),
         });
+
+        // CP425 Trigger 1 — fire-and-forget rich-summary enqueue for the
+        // freshly-created mandala's cards. Errors are swallowed: quota /
+        // auth / server failures must never block the wizard completion UX.
+        void apiClient.triggerMandalaRichSummary(result.mandalaId).catch((err) => {
+          console.warn('[wizard] rich-summary trigger failed (non-fatal)', err);
+        });
       } catch (err) {
         // 4. Rollback: remove optimistic entry, clear store selection if it
         //    pointed at tempId, restore wizard inputs via navigation state.

--- a/frontend/src/features/video-side-panel/model/useRichSummary.ts
+++ b/frontend/src/features/video-side-panel/model/useRichSummary.ts
@@ -1,0 +1,40 @@
+/**
+ * useRichSummary — fetch cached AI rich summary for a YouTube video.
+ *
+ * CP425 (C2) — wraps `GET /api/v1/videos/:id/rich-summary`. 404 → null
+ * (empty state), other errors surface via TanStack Query `error`.
+ *
+ * Contract: hook MUST NOT trigger generation. Generation is driven by
+ * CP425 Trigger 1 (wizard completion) + the server's on-demand enrich
+ * hook. This hook is read-only.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { apiClient, type VideoRichSummaryResponse } from '@/shared/lib/api-client';
+import { queryKeys } from '@/shared/config/query-client';
+
+const RICH_SUMMARY_STALE_MS = 5 * 60 * 1000;
+
+export interface UseRichSummaryResult {
+  richSummary: VideoRichSummaryResponse | null;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export function useRichSummary(videoId: string | null | undefined): UseRichSummaryResult {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: videoId
+      ? queryKeys.video.richSummary(videoId)
+      : ['video', 'rich-summary', 'disabled'],
+    queryFn: () => apiClient.getVideoRichSummary(videoId as string),
+    enabled: Boolean(videoId),
+    staleTime: RICH_SUMMARY_STALE_MS,
+    retry: false,
+  });
+
+  return {
+    richSummary: data ?? null,
+    isLoading,
+    isError,
+  };
+}

--- a/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
@@ -1,17 +1,35 @@
 /**
  * AI summary read-only view for the side panel.
- * Shows summary_ko (fallback summary_en) + tags.
+ *
+ * Renders two layers:
+ *  1. Rich AI summary (CP425 / `video_rich_summaries`) — tl_dr, key_points,
+ *     actionables, chapters. Fetched via `useRichSummary`. Empty-state on
+ *     404 (not yet generated / quota exceeded).
+ *  2. Short metadata summary (`videoSummary.summary_ko|en` + tags) —
+ *     existing path, always renders when available.
  *
  * Design tokens: insighta-side-editor-mockup-v3.html
  */
 import type { VideoSummary } from '@/entities/card/model/types';
+import { getYouTubeVideoId } from '@/widgets/video-player/model/youtube-api';
+import { useRichSummary } from '../model/useRichSummary';
 
 export interface PanelAISummaryProps {
   videoSummary: VideoSummary | undefined;
+  videoUrl?: string;
 }
 
-export function PanelAISummary({ videoSummary }: PanelAISummaryProps) {
-  if (!videoSummary) {
+export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) {
+  const youtubeId = videoUrl ? getYouTubeVideoId(videoUrl) : null;
+  const { richSummary, isLoading: isRichLoading } = useRichSummary(youtubeId);
+
+  const short = videoSummary?.summary_ko || videoSummary?.summary_en || null;
+  const tags = videoSummary?.tags ?? [];
+
+  const hasRich = Boolean(richSummary?.structured);
+  const hasShort = Boolean(short) || tags.length > 0;
+
+  if (!hasRich && !hasShort && !isRichLoading) {
     return (
       <p className="py-8 text-center text-[13px] text-[#4e4f5c]">
         아직 AI 요약이 생성되지 않았어요
@@ -19,39 +37,140 @@ export function PanelAISummary({ videoSummary }: PanelAISummaryProps) {
     );
   }
 
-  const summaryText = videoSummary.summary_ko || videoSummary.summary_en || null;
-  const tags = videoSummary.tags ?? [];
-
   return (
-    <div className="space-y-4">
-      {/* Summary */}
-      {summaryText && (
-        <section>
-          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
-            요약
-          </h3>
-          <p className="text-[13px] leading-[1.6] text-[rgba(237,237,240,0.78)]">{summaryText}</p>
-        </section>
+    <div className="space-y-5">
+      {hasRich && richSummary?.structured && (
+        <RichSummaryBlock structured={richSummary.structured} />
       )}
 
-      {/* Tags */}
-      {tags.length > 0 && (
-        <section>
-          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
-            키워드
-          </h3>
-          <div className="flex flex-wrap gap-x-1 gap-y-[3px]">
-            {tags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-block rounded-[4px] bg-[rgba(129,140,248,0.08)] px-[7px] py-[2px] text-[10px] font-semibold text-[#818cf8]"
-              >
-                {tag}
-              </span>
-            ))}
-          </div>
+      {hasShort && (
+        <section className="space-y-4">
+          {hasRich && (
+            <h2 className="text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
+              메타 요약
+            </h2>
+          )}
+          {short && (
+            <section>
+              {!hasRich && (
+                <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
+                  요약
+                </h3>
+              )}
+              <p className="text-[13px] leading-[1.6] text-[rgba(237,237,240,0.78)]">{short}</p>
+            </section>
+          )}
+          {tags.length > 0 && (
+            <section>
+              <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
+                키워드
+              </h3>
+              <div className="flex flex-wrap gap-x-1 gap-y-[3px]">
+                {tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-block rounded-[4px] bg-[rgba(129,140,248,0.08)] px-[7px] py-[2px] text-[10px] font-semibold text-[#818cf8]"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </section>
+          )}
         </section>
       )}
     </div>
   );
+}
+
+interface RichSummaryBlockProps {
+  structured: NonNullable<import('@/shared/lib/api-client').VideoRichSummaryResponse['structured']>;
+}
+
+function RichSummaryBlock({ structured }: RichSummaryBlockProps) {
+  const tlDr = structured.tl_dr_ko || structured.tl_dr_en || null;
+  const keyPoints = structured.key_points ?? [];
+  const actionables = structured.actionables ?? [];
+  const chapters = structured.chapters ?? [];
+
+  return (
+    <div className="space-y-4">
+      {tlDr && (
+        <section>
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#818cf8]">
+            한 줄 요약
+          </h3>
+          <p className="text-[13px] leading-[1.6] text-[#ededf0]">{tlDr}</p>
+        </section>
+      )}
+
+      {keyPoints.length > 0 && (
+        <section>
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#818cf8]">
+            핵심 포인트
+          </h3>
+          <ul className="space-y-1.5 text-[13px] leading-[1.55] text-[rgba(237,237,240,0.84)]">
+            {keyPoints.map((pt, idx) => (
+              <li key={idx} className="flex gap-2">
+                <span aria-hidden className="mt-[6px] h-1 w-1 shrink-0 rounded-full bg-[#818cf8]" />
+                <span>{pt}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {actionables.length > 0 && (
+        <section>
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#818cf8]">
+            실행 아이템
+          </h3>
+          <ul className="space-y-1.5 text-[13px] leading-[1.55] text-[rgba(237,237,240,0.84)]">
+            {actionables.map((item, idx) => (
+              <li key={idx} className="flex gap-2">
+                <span
+                  aria-hidden
+                  className="mt-[2px] flex h-[14px] w-[14px] shrink-0 items-center justify-center rounded-[3px] border border-[#818cf8] text-[10px] text-[#818cf8]"
+                >
+                  →
+                </span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {chapters.length > 0 && (
+        <section>
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#818cf8]">
+            챕터
+          </h3>
+          <ul className="divide-y divide-[rgba(255,255,255,0.04)] rounded-[6px] bg-[rgba(255,255,255,0.02)]">
+            {chapters.map((ch, idx) => (
+              <li
+                key={idx}
+                className="flex gap-3 px-3 py-2 text-[12px] text-[rgba(237,237,240,0.84)]"
+              >
+                <span className="w-[46px] shrink-0 font-mono text-[11px] text-[#818cf8]">
+                  {formatSeconds(ch.start_sec)}
+                </span>
+                <span>{ch.title}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function formatSeconds(sec: number): string {
+  if (!Number.isFinite(sec) || sec < 0) return '0:00';
+  const s = Math.floor(sec);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const r = s % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(r).padStart(2, '0')}`;
+  return `${m}:${String(r).padStart(2, '0')}`;
 }

--- a/frontend/src/features/video-side-panel/ui/VideoSidePanel.tsx
+++ b/frontend/src/features/video-side-panel/ui/VideoSidePanel.tsx
@@ -161,7 +161,7 @@ export function VideoSidePanel({ onCollapseToPopup }: VideoSidePanelProps = {}) 
             videoUrl={card?.videoUrl}
           />
         ) : (
-          <PanelAISummary videoSummary={card?.videoSummary} />
+          <PanelAISummary videoSummary={card?.videoSummary} videoUrl={card?.videoUrl} />
         )}
       </div>
 

--- a/frontend/src/shared/config/query-client.ts
+++ b/frontend/src/shared/config/query-client.ts
@@ -85,4 +85,8 @@ export const queryKeys = {
   uiPreferences: {
     all: ['ui-preferences'] as const,
   },
+  video: {
+    all: ['video'] as const,
+    richSummary: (videoId: string) => [...queryKeys.video.all, 'rich-summary', videoId] as const,
+  },
 } as const;

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -68,6 +68,40 @@ interface Note {
   updatedAt: string;
 }
 
+export interface VideoRichSummaryChapter {
+  start_sec: number;
+  title: string;
+}
+
+export interface VideoRichSummaryQuote {
+  timestamp_sec: number;
+  text: string;
+}
+
+export interface VideoRichSummaryStructured {
+  core_argument?: string;
+  key_points?: string[];
+  evidence?: string[];
+  actionables?: string[];
+  prerequisites?: string[];
+  bias_signals?: string[];
+  content_type?: string;
+  depth_level?: string;
+  chapters?: VideoRichSummaryChapter[];
+  quotes?: VideoRichSummaryQuote[];
+  tl_dr_ko?: string;
+  tl_dr_en?: string;
+}
+
+export interface VideoRichSummaryResponse {
+  videoId: string;
+  oneLiner: string | null;
+  structured: VideoRichSummaryStructured | null;
+  qualityScore: number | null;
+  model: string | null;
+  updatedAt: string;
+}
+
 interface ClawbotConfig {
   cronExpression: string;
   threshold: number;
@@ -503,6 +537,44 @@ class ApiClient {
 
   async getVideo(id: string): Promise<Video> {
     return this.request<Video>(`/videos/${id}`);
+  }
+
+  /**
+   * CP425 — read cached AI rich summary for a YouTube video.
+   *
+   * Returns null on 404 (no passing row) so callers can show an empty-state
+   * instead of throwing. Other errors (401/5xx) propagate.
+   */
+  async getVideoRichSummary(videoId: string): Promise<VideoRichSummaryResponse | null> {
+    try {
+      const res = await this.request<{ data: VideoRichSummaryResponse }>(
+        `/videos/${videoId}/rich-summary`
+      );
+      return res.data;
+    } catch (err) {
+      if (err instanceof ApiHttpError && err.statusCode === 404) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * CP425 Trigger 1 — fire-and-forget rich-summary enqueue for all videos
+   * in a newly-created mandala. Server enqueues one enrich-video job per
+   * unique video_id with withRichSummary=true. Respects per-tier quota.
+   *
+   * Idempotent: repeated calls are safe (server cache-hits on existing
+   * passing rows and does not consume quota for cache hits).
+   *
+   * Errors (quota / auth / 5xx) are swallowed by the caller's void
+   * pattern — this never blocks the wizard save UX.
+   */
+  async triggerMandalaRichSummary(mandalaId: string): Promise<void> {
+    await this.request<{ status: 'ok'; data: unknown }>(
+      `/mandalas/${mandalaId}/rich-summary-trigger`,
+      { method: 'POST', body: JSON.stringify({}) }
+    );
   }
 
   async getPlaylistVideos(playlistId: string): Promise<Video[]> {


### PR DESCRIPTION
## Summary
Closes the FE half of Issue #417 / CP422-P1. BE endpoints (POST mandalas/:id/rich-summary-trigger, GET videos/:id/rich-summary, video_rich_summaries + per-tier quota) landed CP423. This PR wires the FE.

## Changes (C1+C2+C3, single PR per spec)

- **C1 Trigger 1 wiring** (useWizard.ts): after `createMandalaWithData` success + `trackMandalaCreated`, fire `POST /api/v1/mandalas/:id/rich-summary-trigger` fire-and-forget. Errors (quota / auth / 5xx) swallowed by .catch with warn — never blocks wizard completion UX.
- **C2 AI 요약 탭 표시** (PanelAISummary.tsx + useRichSummary.ts): existing "AI 요약" tab now renders rich summary (tl_dr / key_points / actionables / chapters), fallback to legacy short summary + tags beneath when rich absent.
- **C3 Empty/404 states**: `getVideoRichSummary` returns null on 404 → renders "아직 AI 요약이 생성되지 않았어요" empty-state. 5xx still propagates.

## API client additions
- `VideoRichSummaryResponse` + `VideoRichSummaryStructured` types
- `getVideoRichSummary(videoId): null on 404, data on 200`
- `triggerMandalaRichSummary(mandalaId): fire-forget enqueue`

## Canonical audit (per docs/architecture/system-core.md §5-axis, gated by PR #479)
1. Upstream: no change — `video_rich_summaries` from existing enrichVideo LLM pipeline
2. Staging: no change — reuses video_pool + rich_summary columns
3. **Quality signal: rich_summary NOW surfaced to user** — was generated but invisible (0 FE consumers pre-CP425)
4. Caching: TanStack Query 5min staleTime, no new server cache
5. Serving: new FE consumer of existing endpoint; no new path

**No new tables, no shortcut paths. Canonical extension only** — passes CLAUDE.md §"Canonical path 우선" 4-question gate (N/A: canonical extension).

## Test plan
- [x] /verify PASS: tsc + 275/275 vitest + build + lint clean + hardcode-audit 35=baseline + browser smoke (GET / + GET /mandalas/new both 200)
- [x] 4 new smoke tests (rich-summary-client.test.ts): null-on-404 / data-on-200 / 500-propagates / trigger endpoint shape
- [ ] Manual: create a mandala via wizard, confirm POST rich-summary-trigger fires (dev tools Network tab) + rich summary visible within minutes on video side panel
- [ ] Manual: quota-exhausted user shows short-summary fallback without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)