### PR TITLE
fix(mandala): restore Haiku fallback in fill-missing-actions (CP426)

### DIFF
--- a/src/modules/mandala/fill-missing-actions.ts
+++ b/src/modules/mandala/fill-missing-actions.ts
@@ -25,10 +25,7 @@ import { Prisma } from '@prisma/client';
 
 import { getPrismaClient } from '@/modules/database';
 import { logger } from '@/utils/logger';
-// `generateMandalaActions` kept imported for the commented-out Haiku
-// fallback revive path below (CP416 policy). Silence unused-import lint.
-import { generateMandala, generateMandalaActions as _generateMandalaActions } from './generator';
-void _generateMandalaActions;
+import { generateMandala, generateMandalaActions } from './generator';
 
 const log = logger.child({ module: 'fill-missing-actions' });
 
@@ -150,24 +147,23 @@ export async function fillMissingActionsIfNeeded(mandalaId: string): Promise<{
   const targetLevel = mandala.target_level ?? undefined;
 
   log.info(
-    `[${mandalaId}] generating actions for ${needsFill.length}/${levels.length} cells (LoRA-only policy, CP416)`
+    `[${mandalaId}] generating actions for ${needsFill.length}/${levels.length} cells (LoRA primary + Haiku fallback, CP426)`
   );
 
-  // Policy (CP416 user directive, 2026-04-22): **LoRA-first, 100% target.**
-  //   - Mac Mini LoRA (`generateMandala`) handles action generation alone.
-  //   - OpenRouter Haiku fallback is kept in source for emergency revival
-  //     but NOT called at runtime (cost concern).
-  //   - Every LoRA failure is logged to `generation_log` so failure cases
-  //     become retraining data for the next LoRA fine-tune.
-  //     See `memory/project_lora_first_policy.md` +
-  //     `memory/feedback_lora_failure_as_training_data.md`.
-  //
-  // Revive Haiku ONLY after explicit user approval (cost sign-off). When
-  // reviving, uncomment the `haiku-fallback` block below and the export of
-  // `generateMandalaActions` from this module's imports.
+  // Policy (CP426, 2026-04-24): **LoRA primary + Haiku fallback.**
+  //   - Mac Mini LoRA (`generateMandala`) runs first.
+  //   - On LoRA failure (throw / incomplete / repetition-mode / key-mismatch),
+  //     fall through to OpenRouter Haiku (`generateMandalaActions`).
+  //   - Every LoRA failure is still logged to `generation_log` for retraining.
+  //   - Haiku was previously commented out under CP416 "LoRA-only, cost=0"
+  //     policy. Post-bd7f16f (2026-04-22) LoRA began returning invalid JSON
+  //     100% of the time, and the missing fallback caused ~87% of new
+  //     mandalas to land with empty depth=1 subjects. Revival approved by
+  //     user 2026-04-24.
+  //   - Admin alerting on consecutive LoRA failures is tracked in backlog
+  //     (see CP426 carryover: "Admin 모니터링 항목 일괄 검토").
   let actions: Record<string, string[]> | null = null;
   const centerGoal = rootLevel.center_goal ?? '';
-  let loraErrorForCaller: string | null = null;
 
   const loraStart = Date.now();
   let loraRawOutput: Record<string, unknown> | null = null;
@@ -288,14 +284,10 @@ export async function fillMissingActionsIfNeeded(mandalaId: string): Promise<{
     })();
   }
 
-  // Haiku fallback — disabled by CP416 policy (cost). Revive condition:
-  // explicit user approval after a LoRA outage that exceeds acceptable
-  // action-fill downtime. To revive:
-  //   1. Uncomment the block below.
-  //   2. Ensure `generateMandalaActions` stays imported from ./generator.
-  //   3. Add a log line `actions source=haiku-fallback` so the revive is
-  //      observable in prod logs.
-  /* if (!actions) {
+  // Haiku fallback (CP426 revival, 2026-04-24). Runs only when LoRA output
+  // was rejected above. `actions source=haiku-fallback` log line is load-
+  // bearing for ops observability.
+  if (!actions) {
     try {
       actions = await generateMandalaActions(
         subGoals,
@@ -304,24 +296,15 @@ export async function fillMissingActionsIfNeeded(mandalaId: string): Promise<{
         focusTags,
         targetLevel
       );
-      log.info(`[${mandalaId}] actions source=haiku-fallback (REVIVED)`);
+      log.info(`[${mandalaId}] actions source=haiku-fallback`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`[${mandalaId}] Haiku fallback also threw: ${msg}`);
       return { ok: false, action: 'failed', reason: `lora+haiku both failed: ${msg}` };
     }
-  } */
-
-  if (!actions) {
-    loraErrorForCaller = loraFailureReason ?? 'lora returned null';
-    return {
-      ok: false,
-      action: 'failed',
-      reason: `lora-only policy; lora failed: ${loraErrorForCaller}`,
-    };
+  } else {
+    log.info(`[${mandalaId}] actions source=lora`);
   }
-
-  log.info(`[${mandalaId}] actions source=lora`);
 
   // Update each depth=1 level's subjects. Key layout from the prompt is
   // `sub_goal_1`..`sub_goal_8`; fall back to index-keyed lookups per the

--- a/tests/unit/modules/fill-missing-actions.test.ts
+++ b/tests/unit/modules/fill-missing-actions.test.ts
@@ -103,9 +103,12 @@ describe('fillMissingActionsIfNeeded', () => {
       subjects: SUB_GOALS,
     });
     // Default: LoRA succeeds with a valid 64-action, high-unique-rate output.
-    // Individual tests override to exercise fallback paths.
+    // Haiku default rejects — happy-path tests override explicitly to
+    // exercise the CP426-revived fallback.
     mockGenerateMandala.mockResolvedValue(mockLoraMandalaFor(SUB_GOALS));
-    mockGenerateMandalaActions.mockResolvedValue(mockActionsFor(SUB_GOALS));
+    mockGenerateMandalaActions.mockRejectedValue(
+      new Error('haiku default mock — override in fallback-success tests')
+    );
     mockUpdateLevel.mockImplementation(async () => ({}));
     mockCreateManyLevels.mockImplementation(async () => ({ count: 8 }));
     mockGenLogCreate.mockImplementation(async () => ({}));
@@ -175,7 +178,7 @@ describe('fillMissingActionsIfNeeded', () => {
     expect(result).toEqual({ ok: true, action: 'filled', cellsFilled: 8 });
   });
 
-  test('LoRA throws → logs failure to generation_log and returns failed (no Haiku)', async () => {
+  test('LoRA throws + Haiku throws → both-failed (CP426 fallback revival)', async () => {
     mockFindManyLevels.mockResolvedValueOnce(
       SUB_GOALS.map((sg, idx) => ({
         id: `level-${idx}`,
@@ -185,6 +188,7 @@ describe('fillMissingActionsIfNeeded', () => {
       }))
     );
     mockGenerateMandala.mockRejectedValueOnce(new Error('ollama timeout'));
+    // Haiku default mock (beforeEach) rejects — no override needed.
 
     const result = await fillMissingActionsIfNeeded(MANDALA_ID);
     // Fire-and-forget log runs on next tick — flush microtasks.
@@ -192,16 +196,43 @@ describe('fillMissingActionsIfNeeded', () => {
     await new Promise((r) => setImmediate(r));
 
     expect(mockGenerateMandala).toHaveBeenCalledTimes(1);
-    expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
+    expect(mockGenerateMandalaActions).toHaveBeenCalledTimes(1);
     expect(mockUpdateLevel).not.toHaveBeenCalled();
     expect(result.ok).toBe(false);
     expect(result.action).toBe('failed');
-    expect(result.reason).toContain('lora-only policy');
+    expect(result.reason).toContain('lora+haiku both failed');
     expect(mockGenLogCreate).toHaveBeenCalledTimes(1);
     const logEntry = mockGenLogCreate.mock.calls[0]![0].data;
     expect(logEntry.lora_error).toContain(`[mandala=${MANDALA_ID}]`);
     expect(logEntry.lora_error).toContain('throw');
     expect(logEntry.source_returned).toBe('failed');
+    expect(logEntry.lora_valid).toBe(false);
+  });
+
+  test('LoRA throws + Haiku succeeds → filled via Haiku fallback (CP426 revival)', async () => {
+    mockFindManyLevels.mockResolvedValueOnce(
+      SUB_GOALS.map((sg, idx) => ({
+        id: `level-${idx}`,
+        center_goal: sg,
+        subjects: [],
+        position: idx,
+      }))
+    );
+    mockGenerateMandala.mockRejectedValueOnce(new Error('ollama timeout'));
+    mockGenerateMandalaActions.mockResolvedValueOnce(mockActionsFor(SUB_GOALS));
+
+    const result = await fillMissingActionsIfNeeded(MANDALA_ID);
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(mockGenerateMandala).toHaveBeenCalledTimes(1);
+    expect(mockGenerateMandalaActions).toHaveBeenCalledTimes(1);
+    expect(mockUpdateLevel).toHaveBeenCalledTimes(8);
+    expect(result).toEqual({ ok: true, action: 'filled', cellsFilled: 8 });
+    // LoRA failure is still logged to generation_log for retraining data.
+    expect(mockGenLogCreate).toHaveBeenCalledTimes(1);
+    const logEntry = mockGenLogCreate.mock.calls[0]![0].data;
+    expect(logEntry.lora_error).toContain('throw');
     expect(logEntry.lora_valid).toBe(false);
   });
 
@@ -234,10 +265,13 @@ describe('fillMissingActionsIfNeeded', () => {
     await new Promise((r) => setImmediate(r));
     await new Promise((r) => setImmediate(r));
 
-    expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
+    // Post-CP426: Haiku fallback runs (default rejects), so result surfaces
+    // as lora+haiku both-failed. LoRA's specific failure reason stays in
+    // generation_log for retraining signal.
+    expect(mockGenerateMandalaActions).toHaveBeenCalledTimes(1);
     expect(result.ok).toBe(false);
     expect(result.action).toBe('failed');
-    expect(result.reason).toContain('incomplete-actions');
+    expect(result.reason).toContain('lora+haiku both failed');
     expect(mockGenLogCreate).toHaveBeenCalledTimes(1);
     const logEntry = mockGenLogCreate.mock.calls[0]![0].data;
     expect(logEntry.lora_actions_total).toBe(40);
@@ -270,12 +304,15 @@ describe('fillMissingActionsIfNeeded', () => {
     await new Promise((r) => setImmediate(r));
     await new Promise((r) => setImmediate(r));
 
-    expect(mockGenerateMandalaActions).not.toHaveBeenCalled();
+    // Post-CP426: Haiku fallback runs (default rejects). 'repetition-mode'
+    // stays in generation_log; result.reason reflects both-failed.
+    expect(mockGenerateMandalaActions).toHaveBeenCalledTimes(1);
     expect(result.ok).toBe(false);
     expect(result.action).toBe('failed');
-    expect(result.reason).toContain('repetition-mode');
+    expect(result.reason).toContain('lora+haiku both failed');
     expect(mockGenLogCreate).toHaveBeenCalledTimes(1);
     const logEntry = mockGenLogCreate.mock.calls[0]![0].data;
+    expect(logEntry.lora_error).toContain('repetition-mode');
     expect(logEntry.lora_action_unique_rate).toBeLessThan(0.7);
   });
 
@@ -396,10 +433,19 @@ describe('fillMissingActionsIfNeeded', () => {
     const result = await fillMissingActionsIfNeeded(MANDALA_ID);
 
     // Invariant: cellsFilled=0 MUST NOT be action='filled'.
+    // Post-CP426: LoRA key-mismatch triggers Haiku fallback (default rejects),
+    // so result surfaces as both-failed. LoRA key-mismatch detail is in the
+    // generation_log entry.
     expect(mockUpdateLevel).not.toHaveBeenCalled();
     expect(result.ok).toBe(false);
     expect(result.action).toBe('failed');
-    expect(result.reason).toMatch(/key|match|mismatch/i);
+    expect(result.reason).toMatch(/key|match|mismatch|both failed/i);
+    // Fire-and-forget log runs on next tick — flush microtasks.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    expect(mockGenLogCreate).toHaveBeenCalledTimes(1);
+    const logEntry = mockGenLogCreate.mock.calls[0]![0].data;
+    expect(logEntry.lora_error).toMatch(/key|match|mismatch/i);
   });
 
   test('CP424 T2: real LoRA output (Korean-text keys + 14-key metadata nesting) MUST NOT silently pass', async () => {


### PR DESCRIPTION
## Summary

Hotfix: LoRA-only policy (`bd7f16f`, CP416, 2026-04-22) caused ~87% of mandalas created after 2026-04-22 03:38 UTC to land with empty `depth=1` subjects because LoRA output started failing JSON parse + key-mismatch validation and there was no fallback.

## Evidence (prod `generation_log`, read-only audit, CP425 session)

| Period | total | lora_valid_true | lora_valid_false | llm_ran |
|--------|-------|-----------------|------------------|---------|
| Before bd7f16f (Apr 18 ~ Apr 22 03:38 UTC) | 20 | 17 (85%) | 0 | 17 (85%) |
| After bd7f16f (Apr 22 03:38 UTC ~ Apr 24) | 7 | 0 (0%) | 7 (100%) | 0 (0%) |

Top LoRA error patterns after boundary:
- 6× "Failed to parse generated mandala JSON"
- 1× "sub_goals count: 16/8" (structural mismatch)

## Changes

- `src/modules/mandala/fill-missing-actions.ts`
  - Uncomment the Haiku fallback block that was disabled under CP416.
  - Remove the dead "lora-only policy" termination branch that followed the comment.
  - Update policy comment + module log line to reflect LoRA primary + Haiku fallback.
  - `generateMandalaActions` import reverted to direct (no `_` alias).
- `tests/unit/modules/fill-missing-actions.test.ts`
  - `beforeEach` Haiku default now rejects (happy-path tests override explicitly).
  - 3 existing LoRA-fail tests updated to expect Haiku call + `lora+haiku both failed` reason; generation_log-level assertions on LoRA-specific reasons (incomplete-actions / repetition-mode / key-mismatch) preserved.
  - 2 new CP426 tests: both-failed path + Haiku-success happy path.
  - CP424 silent-zero guard tests unchanged in intent (reason assertion widened to accept both-failed).
- LoRA JSON parse/regression **root cause is NOT addressed in this PR** — deferred to a separate workstream (CP426 carryover). This hotfix restores user-facing functionality via Haiku fallback; LoRA still runs first and logs failures for retraining.
- Admin alerting on consecutive LoRA failures deferred to backlog per user directive 2026-04-24 ("Admin 모니터링 항목 일괄 검토").

## Verification

- `npx tsc --noEmit -p tsconfig.json` — clean (exit 0).
- `npx jest tests/unit/modules/fill-missing-actions` — 14/14 PASS (12 existing + 2 new).
- `npx jest tests/unit/modules/{lora-prompt-schema,mandala-structure-labels}` — PASS.
- Pre-existing baseline failures in `mandala-manager` + `mandala-post-creation` unchanged vs. stashed main (16 fail / 68 pass, baseline parity).

## Test plan

- [ ] CI PASS on this PR.
- [ ] Merge → deploy verify (`/health` 200 + uptime reset).
- [ ] Create 1 new mandala via wizard on prod after deploy; confirm depth=1 subjects populate (Haiku path OK when LoRA fails; LoRA path OK when LoRA succeeds).
- [ ] Spot-check `generation_log` post-deploy: LoRA failures still recorded (source_returned=failed + lora_error populated).
- [ ] Follow-up backlog issue created for LoRA prompt regression + admin monitoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)