### PR TITLE
fix(mandala): step3 auto-add invariant on intra-run step2 skip (CP426 outage)

### DIFF
--- a/src/modules/mandala/pipeline-runner.ts
+++ b/src/modules/mandala/pipeline-runner.ts
@@ -179,6 +179,15 @@ export async function executePipelineRun(runId: string): Promise<void> {
 
   // ── Step 2: Video Discover (opt-in gated) ───────────────────
   let discoverSuccess = run.step2_status === 'completed';
+  // Track intra-run skip separately: `run.step2_status` is a snapshot taken
+  // at pipeline entry (line ~128) and stays stale after an `updateStep(...,
+  // 'skipped', ...)` call below. Without this flag, step3's "was step2
+  // skipped?" check reads the snapshot and misroutes an intra-run skip
+  // into the "discover failed" branch — auto-add is then never called
+  // (CP426 prod incident: wizard-precompute pre-populates rec_cache →
+  // step2 skips with "recent discover within 5min window" → user sees
+  // empty cards).
+  let step2Skipped = run.step2_status === 'skipped';
 
   if (!discoverSuccess) {
     await updateStep(runId, 2, 'running');
@@ -186,6 +195,7 @@ export async function executePipelineRun(runId: string): Promise<void> {
       const skipReason = await checkDiscoverPreconditions(userId, mandalaId);
       if (skipReason) {
         await updateStep(runId, 2, 'skipped', { reason: skipReason });
+        step2Skipped = true;
         log.info(`[${runId}] step2 skipped: ${skipReason}`);
       } else {
         const sub = await db.user_subscriptions.findUnique({
@@ -223,7 +233,7 @@ export async function executePipelineRun(runId: string): Promise<void> {
 
   // ── Step 3: Auto-Add Recommendations ────────────────────────
   if (run.step3_status !== 'completed') {
-    if (!discoverSuccess && run.step2_status !== 'skipped') {
+    if (!discoverSuccess && !step2Skipped) {
       // Step 2 failed (not skipped) → skip step 3
       await updateStep(runId, 3, 'skipped', null, 'discover failed');
     } else {

--- a/tests/unit/modules/pipeline-runner.test.ts
+++ b/tests/unit/modules/pipeline-runner.test.ts
@@ -1,0 +1,177 @@
+/**
+ * pipeline-runner — CP426 step2-skip regression test.
+ *
+ * Locks the invariant: when step2 is skipped intra-run (e.g., wizard-precompute
+ * pre-populated recommendation_cache → checkDiscoverPreconditions returns
+ * "recent discover within 5min window"), step3 MUST call
+ * maybeAutoAddRecommendations, not shortcut into the "discover failed" branch.
+ *
+ * Prior to the fix, step3 condition read `run.step2_status` (a stale snapshot
+ * captured at pipeline entry) instead of the intra-run state. A fresh run with
+ * null step2_status snapshot satisfied `run.step2_status !== 'skipped'` even
+ * though step2 had just been marked 'skipped' in the DB, causing step3 to
+ * skip auto-add and leaving `user_video_states` empty (prod cards = 0 장).
+ */
+
+const mockFindUniqueRun = jest.fn();
+const mockUpdateRun = jest.fn();
+const mockFindFirstRecCache = jest.fn();
+const mockFindFirstSkillConfig = jest.fn();
+const mockFindUniqueSubscription = jest.fn();
+const mockSkillExecute = jest.fn();
+const mockEnsureEmbeddings = jest.fn();
+const mockMaybeAutoAdd = jest.fn();
+const mockCreateGen = jest.fn();
+
+jest.mock('@/modules/database', () => ({
+  getPrismaClient: () => ({
+    mandala_pipeline_runs: {
+      findUnique: mockFindUniqueRun,
+      update: mockUpdateRun,
+    },
+    recommendation_cache: { findFirst: mockFindFirstRecCache },
+    user_skill_config: { findFirst: mockFindFirstSkillConfig },
+    user_subscriptions: { findUnique: mockFindUniqueSubscription },
+  }),
+}));
+
+jest.mock('../../../src/modules/mandala/ensure-mandala-embeddings', () => ({
+  ensureMandalaEmbeddings: mockEnsureEmbeddings,
+}));
+
+jest.mock('../../../src/modules/mandala/auto-add-recommendations', () => ({
+  maybeAutoAddRecommendations: mockMaybeAutoAdd,
+}));
+
+jest.mock('@/modules/skills', () => ({
+  skillRegistry: { execute: mockSkillExecute },
+}));
+
+jest.mock('@/modules/llm', () => ({
+  createGenerationProvider: mockCreateGen,
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+import { executePipelineRun } from '../../../src/modules/mandala/pipeline-runner';
+
+const RUN_ID = '00000000-0000-0000-0000-000000000001';
+const MANDALA_ID = '00000000-0000-0000-0000-000000000002';
+const USER_ID = '00000000-0000-0000-0000-000000000003';
+
+describe('executePipelineRun — CP426 step2-skip → auto-add invariant', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Fresh run snapshot: null step2_status — this is the case that triggered
+    // the production bug. An intra-run skip updates the DB but not this value.
+    mockFindUniqueRun.mockResolvedValueOnce({
+      id: RUN_ID,
+      mandala_id: MANDALA_ID,
+      user_id: USER_ID,
+      trigger: 'wizard',
+      status: 'pending',
+      step1_status: null,
+      step2_status: null,
+      step3_status: null,
+    });
+    // Final re-fetch for anyFailed calc.
+    mockFindUniqueRun.mockResolvedValue({
+      step1_status: 'completed',
+      step2_status: 'skipped',
+      step3_status: 'completed',
+    });
+    mockUpdateRun.mockResolvedValue({});
+    mockEnsureEmbeddings.mockResolvedValue({ ok: true, finalCount: 8, embedMs: 50 });
+    mockFindFirstSkillConfig.mockResolvedValue({ enabled: true });
+    mockMaybeAutoAdd.mockResolvedValue({
+      ok: true,
+      rowsInserted: 10,
+      rowsPreserved: 0,
+      rowsDeleted: 0,
+      cellsProcessed: 8,
+    });
+  });
+
+  test('step2 skipped intra-run (rec_cache pre-populated) → step3 calls auto-add', async () => {
+    // checkDiscoverPreconditions hits the 5min-window dedup gate.
+    mockFindFirstRecCache.mockResolvedValueOnce({ id: 'rc-precomputed' });
+
+    await executePipelineRun(RUN_ID);
+
+    // Auto-add MUST be called. Before the fix, it was never called.
+    expect(mockMaybeAutoAdd).toHaveBeenCalledTimes(1);
+    expect(mockMaybeAutoAdd).toHaveBeenCalledWith(USER_ID, MANDALA_ID);
+
+    // Skill registry MUST NOT be called — step2 was skipped.
+    expect(mockSkillExecute).not.toHaveBeenCalled();
+
+    // step2 was marked skipped.
+    const step2SkipCall = mockUpdateRun.mock.calls.find(
+      ([arg]: [{ data: Record<string, unknown> }]) => arg?.data?.['step2_status'] === 'skipped'
+    );
+    expect(step2SkipCall).toBeDefined();
+
+    // step3 was completed (NOT "skipped / discover failed").
+    const step3CompletedCall = mockUpdateRun.mock.calls.find(
+      ([arg]: [{ data: Record<string, unknown> }]) => arg?.data?.['step3_status'] === 'completed'
+    );
+    expect(step3CompletedCall).toBeDefined();
+    const step3SkipCall = mockUpdateRun.mock.calls.find(
+      ([arg]: [{ data: Record<string, unknown> }]) =>
+        arg?.data?.['step3_status'] === 'skipped' &&
+        arg?.data?.['step3_error'] === 'discover failed'
+    );
+    expect(step3SkipCall).toBeUndefined();
+  });
+
+  test('step2 completed (skill success) → step3 calls auto-add (happy path unchanged)', async () => {
+    mockFindFirstRecCache.mockResolvedValueOnce(null); // no precompute
+    mockFindUniqueSubscription.mockResolvedValue({ tier: 'free' });
+    mockCreateGen.mockResolvedValue({});
+    mockSkillExecute.mockResolvedValue({
+      success: true,
+      data: { queries: [], cached: 17 },
+    });
+
+    await executePipelineRun(RUN_ID);
+
+    expect(mockSkillExecute).toHaveBeenCalledTimes(1);
+    expect(mockMaybeAutoAdd).toHaveBeenCalledTimes(1);
+
+    const step2CompletedCall = mockUpdateRun.mock.calls.find(
+      ([arg]: [{ data: Record<string, unknown> }]) => arg?.data?.['step2_status'] === 'completed'
+    );
+    expect(step2CompletedCall).toBeDefined();
+  });
+
+  test('step2 failed (skill returns success=false) → step3 skips with "discover failed"', async () => {
+    mockFindFirstRecCache.mockResolvedValueOnce(null);
+    mockFindUniqueSubscription.mockResolvedValue({ tier: 'free' });
+    mockCreateGen.mockResolvedValue({});
+    mockSkillExecute.mockResolvedValue({
+      success: false,
+      error: 'quota_exhausted',
+      data: null,
+    });
+
+    await executePipelineRun(RUN_ID);
+
+    // Auto-add MUST NOT run when step2 genuinely failed.
+    expect(mockMaybeAutoAdd).not.toHaveBeenCalled();
+
+    const step3SkipCall = mockUpdateRun.mock.calls.find(
+      ([arg]: [{ data: Record<string, unknown> }]) =>
+        arg?.data?.['step3_status'] === 'skipped' &&
+        arg?.data?.['step3_error'] === 'discover failed'
+    );
+    expect(step3SkipCall).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

**Prod outage hotfix** — 2026-04-24 ~07:03 UTC onwards, every new mandala landed with `user_video_states = 0` (dashboard "카드 0장") even though `recommendation_cache` was populated. Service effectively unusable for new mandala creations.

## Root cause (facts, not hypothesis)

1. **Timing evidence** (prod DB read-only probe, 3 mandalas today)

   | Mandala | created | first rec_cache | pipeline_run | rec_cache vs pipeline_run |
   |---|---|---|---|---|
   | a1eed557 (OK 06:45 UTC) | 06:45:06.561 | 06:45:22.091 | **06:45:07.252** | pipeline_run **14.8s first** |
   | c447c3b6 (FAIL 08:47 UTC) | 08:47:24.601 | **08:47:24.864** | 08:47:25.036 | rec_cache **0.2s first** |
   | 2b1d6664 (FAIL 11:05 UTC) | 11:05:40.327 | **11:05:41.589** | 11:05:42.110 | rec_cache **0.5s first** |

2. **Responsible writer** (grep): `src/modules/mandala/wizard-precompute.ts:296` `INSERT INTO public.recommendation_cache` (CP424.2 precompute path, `WIZARD_PRECOMPUTE_ENABLED=true` in prod).

3. **Skip trigger** (`pipeline-runner.ts:275-280`): `checkDiscoverPreconditions` looks up `recommendation_cache` within a 5min window. If one exists, returns `'recent discover within 5min window'` → step2 marked `'skipped'` in DB.

4. **Stale snapshot bug** (`pipeline-runner.ts:128, 226`):
   - `const run = await db.mandala_pipeline_runs.findUnique(...)` snapshots `step2_status` at pipeline entry. For fresh runs, this is `null`.
   - Step 2 skip path updates the DB but **does not refresh** the `run` object in memory.
   - Step 3 condition `!discoverSuccess && run.step2_status !== 'skipped'` evaluates `null !== 'skipped'` = true → enters the "discover failed" branch → **`maybeAutoAddRecommendations` is never called**.
   - Result: `recommendation_cache.status` stays `'pending'`, `user_video_states` stays empty, dashboard shows 0 cards.

5. **Confirming record** (`mandala_pipeline_runs` for both FAIL mandalas):
   ```
   step1_status = 'completed', step2_status = 'skipped', step3_status = 'skipped', step3_error = 'discover failed', step3_result = null
   ```

6. **Regression boundary**: deploy `2026-04-24T06:54:01Z` (main) + container recreate 07:03 UTC. OK mandala @ 06:45 is pre-recreate; all FAIL cases are post-recreate.

## Fix

Add a local `step2Skipped` flag initialized from the snapshot and updated in the intra-run skip path. Use the flag in the step3 condition instead of the stale `run.step2_status`. 3 surgical edits in `pipeline-runner.ts`.

## Tests

`tests/unit/modules/pipeline-runner.test.ts` (NEW, 3 cases):
- step2 skipped intra-run → step3 calls auto-add ✅ (regression guard)
- step2 completed (skill success) → step3 calls auto-add (happy path unchanged)
- step2 failed (skill returns success=false) → step3 skips with "discover failed"

## Verification

- `npx tsc --noEmit -p tsconfig.json` → exit 0
- `npx jest tests/unit/modules/pipeline-runner.test.ts` → 3/3 PASS

## Scope

- Related but independent: PR #481 (Haiku fallback for LoRA, CP426) addresses the separate "64 sub items = 0" failure. Both hotfixes must ship.
- Backfill for existing broken mandalas (08:47, 11:05 UTC today + any others created in this window) is NOT in scope for this PR. Post-merge, new mandalas will be healthy; existing broken mandalas need a manual re-trigger (skill toggle OFF/ON) or a backfill script (separate work).

## Test plan

- [ ] CI PASS on this PR.
- [ ] Merge → deploy verify (`/health` 200 + uptime reset).
- [ ] Create one new mandala via wizard on prod after deploy; confirm dashboard cards populate within a minute.
- [ ] Spot-check `mandala_pipeline_runs` for the new mandala: `step3_status = 'completed'`, `step3_result.rowsInserted > 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)