### PR TITLE
fix(mandala): raise ACTIONS_MAX_TOKENS 2500 → 4096 — Korean truncation (CP426)

### DIFF
--- a/src/prompts/actions-generator.ts
+++ b/src/prompts/actions-generator.ts
@@ -9,7 +9,7 @@
 
 export const ACTIONS_MODEL = 'anthropic/claude-haiku-4.5';
 export const ACTIONS_TEMPERATURE = 0.7;
-export const ACTIONS_MAX_TOKENS = 2500;
+export const ACTIONS_MAX_TOKENS = 4096;
 
 export interface ActionsPromptInput {
   centerGoal: string;


### PR DESCRIPTION
## Summary
- `ACTIONS_MAX_TOKENS` raised from 2500 → 4096 in `src/prompts/actions-generator.ts`
- Korean mandala actions (64 items) require ~3400 completion tokens; 2500 was causing truncation at positions 6-7
- Every Haiku fill-missing-actions call hit `completion=2500` exactly (OpenRouter log evidence)
- All 3 observed cases filled only 6/8 cells: 04-22 05:41 (5/8), 04-22 07:27 (6/8), 04-24 11:57 (6/8)

## Root cause
`buildActionsPrompt` asks Haiku to output `{"0":["8 actions"],...,"7":["8 actions"]}` (64 total Korean sentences). At 2500 max tokens, the response is truncated before positions 6-7 are generated.

## Test plan
- [x] tsc --noEmit clean
- [x] jest passing (pre-existing mandala-manager.test.ts failures unrelated)
- [ ] Deploy → create new mandala → verify 8/8 cells filled (subjects_total = 64)
- [ ] OpenRouter log shows completion < 4096 (no truncation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)