### PR TITLE
[R1-PR1] Cost Tracking Infrastructure + 5-Layer Gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ prisma/migrations/*
 !prisma/migrations/mandala-timings/
 !prisma/migrations/video_rich_summaries/
 !prisma/migrations/wizard-precompute/
+!prisma/migrations/llm_call_logs/
 
 # Logs
 logs/

--- a/prisma/migrations/llm_call_logs/001_create_table.sql
+++ b/prisma/migrations/llm_call_logs/001_create_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS llm_call_logs (
+  call_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  module        VARCHAR(50) NOT NULL,
+  model         VARCHAR(100) NOT NULL,
+  input_tokens  INTEGER,
+  output_tokens INTEGER,
+  cost_usd      DOUBLE PRECISION,
+  latency_ms    INTEGER,
+  status        VARCHAR(20) NOT NULL DEFAULT 'success',
+  error_message TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  user_id       UUID,
+  video_id      VARCHAR(50)
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_call_logs_created_at ON llm_call_logs (created_at);
+CREATE INDEX IF NOT EXISTS idx_llm_call_logs_module ON llm_call_logs (module);
+CREATE INDEX IF NOT EXISTS idx_llm_call_logs_model ON llm_call_logs (model);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1373,20 +1373,27 @@ model payment_transactions {
 // --- Skill System --------------------------------------------------------
 
 model video_rich_summaries {
-  video_id      String   @id @db.VarChar(11)
-  tier_required String   @default("free") @db.VarChar(10)
-  one_liner     String?
-  structured    Json?
-  quality_score Float?
-  quality_flag  String?  @default("pending") @db.VarChar(20)
-  model         String?  @db.VarChar(50)
+  video_id                String   @id @db.VarChar(11)
+  tier_required           String   @default("free") @db.VarChar(10)
+  one_liner               String?
+  structured              Json?
+  quality_score           Float?
+  quality_flag            String?  @default("pending") @db.VarChar(20)
+  model                   String?  @db.VarChar(50)
   /// CP423: user who triggered this generation. NULL for pre-CP423 rows
   /// (backfilled via migrations/video_rich_summaries/001_add_user_id.sql).
-  user_id       String?  @db.Uuid
-  created_at    DateTime @default(now()) @db.Timestamptz(6)
-  updated_at    DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+  user_id                 String?  @db.Uuid
+  /// Quality metrics added in feat/quality-metrics-m1-m3.
+  /// Raw SQL DDL: prisma/migrations/quality_metrics/001_add_metric_columns.sql
+  m1_title_overlap        Float?
+  m3_timestamp_null_ratio Float?
+  m3_timestamp_pattern    String?  @db.VarChar(20)
+  specificity_score       Float?
+  created_at              DateTime @default(now()) @db.Timestamptz(6)
+  updated_at              DateTime @default(now()) @updatedAt @db.Timestamptz(6)
 
   @@index([user_id, updated_at(sort: Desc)], map: "idx_vrs_user_updated_at")
+  @@index([specificity_score], map: "idx_vrs_specificity")
   @@schema("public")
 }
 
@@ -1803,5 +1810,28 @@ model video_pool_collection_runs {
 
   @@index([started_at(sort: Desc)], map: "idx_vpool_runs_started")
   @@index([status, run_type], map: "idx_vpool_runs_status_type")
+  @@schema("public")
+}
+
+/// Per-call log for LLM API calls across all providers (OpenRouter, Ollama, Gemini).
+/// Used for cost tracking, performance analysis, and the §1.5 daily cost gate.
+/// Raw SQL DDL: prisma/migrations/llm_call_logs/001_create_table.sql
+model llm_call_logs {
+  call_id       String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  module        String   @db.VarChar(50)
+  model         String   @db.VarChar(100)
+  input_tokens  Int?
+  output_tokens Int?
+  cost_usd      Float?
+  latency_ms    Int?
+  status        String   @default("success") @db.VarChar(20)
+  error_message String?
+  created_at    DateTime @default(now()) @db.Timestamptz(6)
+  user_id       String?  @db.Uuid
+  video_id      String?  @db.VarChar(50)
+
+  @@index([created_at])
+  @@index([module])
+  @@index([model])
   @@schema("public")
 }

--- a/src/api/routes/admin/llm.ts
+++ b/src/api/routes/admin/llm.ts
@@ -4,6 +4,7 @@ import { createEmbeddingProvider, createGenerationProvider, resetProviders } fro
 import { isOllamaAvailable } from '@/modules/llm/ollama';
 import { config } from '@/config/index';
 import { createSuccessResponse } from '../../schemas/common.schema';
+import { db } from '@/modules/database/client';
 
 interface OpenRouterHealthResult {
   available: boolean;
@@ -47,6 +48,16 @@ const UpdateLlmBodySchema = z.object({
   provider: z.enum(['auto', 'gemini', 'ollama', 'openrouter']),
   openrouter_model: z.string().optional(),
 });
+
+const UsageQuerySchema = z.object({
+  period: z.enum(['daily', 'weekly', 'monthly']).default('daily'),
+  days: z.coerce.number().int().min(1).max(365).default(30),
+});
+
+type DailyRow = { date: string; total_cost: number; total_calls: number; avg_latency_ms: number };
+type ModelRow = { model: string; total_cost: number; total_calls: number };
+type ModuleRow = { module: string; total_cost: number; total_calls: number };
+type BlockedRow = { count: number };
 
 export async function adminLlmRoutes(fastify: FastifyInstance) {
   const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
@@ -109,6 +120,87 @@ export async function adminLlmRoutes(fastify: FastifyInstance) {
         active: {
           embedding: { provider: embeddingProvider.name },
           generation: { provider: generationProvider.name, model: generationProvider.model },
+        },
+      })
+    );
+  });
+
+  // GET /api/v1/admin/llm/usage — LLM cost and call aggregates
+  fastify.get('/usage', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
+    const query = UsageQuerySchema.parse(request.query);
+    const { period, days } = query;
+
+    // Build date-truncation expression based on period
+    const truncUnit = period === 'monthly' ? 'month' : period === 'weekly' ? 'week' : 'day';
+
+    const [dailyRows, modelRows, moduleRows, blockedRows] = await Promise.all([
+      // Aggregated by date/week/month
+      db.$queryRawUnsafe<DailyRow[]>(`
+        SELECT
+          DATE_TRUNC('${truncUnit}', created_at)::date::text AS date,
+          COALESCE(SUM(cost_usd), 0)::float                  AS total_cost,
+          COUNT(*)::int                                       AS total_calls,
+          COALESCE(AVG(latency_ms), 0)::int                  AS avg_latency_ms
+        FROM llm_call_logs
+        WHERE created_at >= NOW() - INTERVAL '${days} days'
+        GROUP BY DATE_TRUNC('${truncUnit}', created_at)
+        ORDER BY DATE_TRUNC('${truncUnit}', created_at) DESC
+      `),
+
+      // Aggregated by model
+      db.$queryRawUnsafe<ModelRow[]>(`
+        SELECT
+          model,
+          COALESCE(SUM(cost_usd), 0)::float AS total_cost,
+          COUNT(*)::int                      AS total_calls
+        FROM llm_call_logs
+        WHERE created_at >= NOW() - INTERVAL '${days} days'
+        GROUP BY model
+        ORDER BY total_cost DESC
+      `),
+
+      // Aggregated by module
+      db.$queryRawUnsafe<ModuleRow[]>(`
+        SELECT
+          module,
+          COALESCE(SUM(cost_usd), 0)::float AS total_cost,
+          COUNT(*)::int                      AS total_calls
+        FROM llm_call_logs
+        WHERE created_at >= NOW() - INTERVAL '${days} days'
+        GROUP BY module
+        ORDER BY total_cost DESC
+      `),
+
+      // Blocked calls today
+      db.$queryRawUnsafe<BlockedRow[]>(`
+        SELECT COUNT(*)::int AS count
+        FROM llm_call_logs
+        WHERE created_at >= CURRENT_DATE
+          AND status = 'blocked'
+      `),
+    ]);
+
+    // Daily cost total for warnings section
+    const [todayRow] = await db.$queryRaw<[{ total: number }]>`
+      SELECT COALESCE(SUM(cost_usd), 0)::float AS total
+      FROM llm_call_logs
+      WHERE created_at >= CURRENT_DATE
+        AND status = 'success'
+    `;
+    const dailyUsed = todayRow?.total ?? 0;
+    const dailyLimitStr = process.env['LLM_DAILY_COST_LIMIT_USD'];
+    const dailyLimit = dailyLimitStr ? parseFloat(dailyLimitStr) : null;
+
+    return reply.send(
+      createSuccessResponse({
+        period,
+        data: dailyRows,
+        by_model: modelRows,
+        by_module: moduleRows,
+        warnings: {
+          daily_limit: Number.isFinite(dailyLimit) ? dailyLimit : null,
+          daily_used: dailyUsed,
+          blocked_calls_today: blockedRows[0]?.count ?? 0,
         },
       })
     );

--- a/src/api/routes/admin/llm.ts
+++ b/src/api/routes/admin/llm.ts
@@ -188,8 +188,7 @@ export async function adminLlmRoutes(fastify: FastifyInstance) {
         AND status = 'success'
     `;
     const dailyUsed = todayRow?.total ?? 0;
-    const dailyLimitStr = process.env['LLM_DAILY_COST_LIMIT_USD'];
-    const dailyLimit = dailyLimitStr ? parseFloat(dailyLimitStr) : null;
+    const dailyLimit = config.llm.dailyCostLimitUsd ?? null;
 
     return reply.send(
       createSuccessResponse({

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -72,6 +72,8 @@ const envSchema = z.object({
   OLLAMA_EMBED_MODEL: z.string().default('nomic-embed-text'),
   OLLAMA_GENERATE_MODEL: z.string().default('qwen3.5:9b'),
   LLM_PROVIDER: z.enum(['gemini', 'ollama', 'openrouter', 'auto']).default('auto'),
+  LLM_DAILY_COST_LIMIT_USD: z.coerce.number().optional(),
+  LLM_MONTHLY_COST_LIMIT_USD: z.coerce.number().optional(),
 
   // OpenRouter
   OPENROUTER_API_KEY: z.string().optional(),
@@ -205,6 +207,8 @@ export const config = {
   // LLM Provider
   llm: {
     provider: env.LLM_PROVIDER,
+    dailyCostLimitUsd: env.LLM_DAILY_COST_LIMIT_USD,
+    monthlyCostLimitUsd: env.LLM_MONTHLY_COST_LIMIT_USD,
   },
 
   // Ollama (local inference)

--- a/src/config/llm-pricing.ts
+++ b/src/config/llm-pricing.ts
@@ -67,6 +67,15 @@ export const LLM_PRICING: Record<string, LLMPricing> = {
     source: 'openrouter.ai/api/v1/models',
   },
 
+  // --- OpenRouter: Anthropic family (sourced 2026-04-27) ---
+  // Used by mandala generator (structure, actions, labels, legacy full-gen)
+  // and search query generator — 5 call sites total.
+  'anthropic/claude-haiku-4.5': {
+    inputPerToken: 0.000001,
+    outputPerToken: 0.000005,
+    source: 'openrouter.ai/api/v1/models (2026-04-27)',
+  },
+
   // --- Ollama: Local inference (zero cost) ---
   // config.ollama.generateModel default = 'qwen3.5:9b'
   'qwen3.5:9b': {

--- a/src/config/llm-pricing.ts
+++ b/src/config/llm-pricing.ts
@@ -1,0 +1,120 @@
+/**
+ * LLM Pricing SSOT
+ *
+ * Per-token costs for known models, sourced from provider APIs.
+ * Prices are in USD per token (NOT per 1K tokens).
+ *
+ * OpenRouter prices fetched from https://openrouter.ai/api/v1/models on 2026-04-27.
+ * Gemini prices: gemini-pro is a local alias for GEMINI_GENERATE_MODEL — zero-cost
+ * placeholder until Gemini billing is confirmed via google.com/pricing.
+ * Ollama models are local inference: zero cost.
+ *
+ * IMPORTANT: Re-fetch from OpenRouter API when adding new models:
+ *   curl -s https://openrouter.ai/api/v1/models | python3 -c "
+ *     import sys, json; data = json.load(sys.stdin)
+ *     for m in data['data']:
+ *       p = m.get('pricing', {})
+ *       print(m['id'], p.get('prompt'), p.get('completion'))
+ *   "
+ */
+
+export interface LLMPricing {
+  /** Cost per input token in USD */
+  inputPerToken: number;
+  /** Cost per output token in USD */
+  outputPerToken: number;
+  /** Where this price was sourced from */
+  source: string;
+}
+
+/**
+ * Known model pricing table.
+ * Key is the canonical model ID without provider prefix
+ * (e.g., 'qwen/qwen3-30b-a3b', NOT 'openrouter/qwen/qwen3-30b-a3b').
+ */
+export const LLM_PRICING: Record<string, LLMPricing> = {
+  // --- OpenRouter: Qwen family (sourced 2026-04-27) ---
+  'qwen/qwen3-30b-a3b': {
+    inputPerToken: 0.00000008,
+    outputPerToken: 0.00000028,
+    source: 'openrouter.ai/api/v1/models',
+  },
+  'qwen/qwen3.5-9b': {
+    inputPerToken: 0.0000001,
+    outputPerToken: 0.00000015,
+    source: 'openrouter.ai/api/v1/models',
+  },
+  'qwen/qwen3-30b-a3b-thinking-2507': {
+    inputPerToken: 0.00000008,
+    outputPerToken: 0.0000004,
+    source: 'openrouter.ai/api/v1/models',
+  },
+  'qwen/qwen3-30b-a3b-instruct-2507': {
+    inputPerToken: 0.00000009,
+    outputPerToken: 0.0000003,
+    source: 'openrouter.ai/api/v1/models',
+  },
+
+  // --- OpenRouter: Google Gemini family (sourced 2026-04-27) ---
+  'google/gemini-2.5-flash': {
+    inputPerToken: 0.0000003,
+    outputPerToken: 0.0000025,
+    source: 'openrouter.ai/api/v1/models',
+  },
+  'google/gemini-2.5-flash-lite': {
+    inputPerToken: 0.0000001,
+    outputPerToken: 0.0000004,
+    source: 'openrouter.ai/api/v1/models',
+  },
+
+  // --- Ollama: Local inference (zero cost) ---
+  // config.ollama.generateModel default = 'qwen3.5:9b'
+  'qwen3.5:9b': {
+    inputPerToken: 0,
+    outputPerToken: 0,
+    source: 'local',
+  },
+  'mandala-gen': {
+    inputPerToken: 0,
+    outputPerToken: 0,
+    source: 'local',
+  },
+
+  // --- Gemini direct API (via gemini.ts, not OpenRouter) ---
+  // gemini-pro is the GEMINI_GENERATE_MODEL constant in gemini.ts.
+  // Direct Gemini API billing is tracked via Google Cloud — this entry
+  // is a placeholder so cost_usd is not null for Gemini calls.
+  // Update when confirmed from Google AI pricing page.
+  'gemini-pro': {
+    inputPerToken: 0.0000005,
+    outputPerToken: 0.0000015,
+    source: 'ai.google.dev/pricing (placeholder)',
+  },
+};
+
+/**
+ * Calculate the cost of an LLM call in USD.
+ *
+ * Strips provider prefixes before looking up pricing:
+ *   'openrouter/qwen/qwen3-30b-a3b' -> 'qwen/qwen3-30b-a3b'
+ *   'ollama/qwen3.5:9b'             -> 'qwen3.5:9b'
+ *   'gemini/gemini-pro'             -> 'gemini-pro'
+ *
+ * @returns Cost in USD, or null if the model is not in the pricing table.
+ */
+export function calculateCost(
+  model: string,
+  inputTokens: number,
+  outputTokens: number
+): number | null {
+  // Strip known provider prefixes
+  const normalizedModel = model
+    .replace(/^openrouter\//, '')
+    .replace(/^ollama\//, '')
+    .replace(/^gemini\//, '');
+
+  const pricing = LLM_PRICING[normalizedModel];
+  if (!pricing) return null; // unknown model — cost_usd stays NULL
+
+  return inputTokens * pricing.inputPerToken + outputTokens * pricing.outputPerToken;
+}

--- a/src/config/llm-pricing.ts
+++ b/src/config/llm-pricing.ts
@@ -68,8 +68,11 @@ export const LLM_PRICING: Record<string, LLMPricing> = {
   },
 
   // --- OpenRouter: Anthropic family (sourced 2026-04-27) ---
-  // Used by mandala generator (structure, actions, labels, legacy full-gen)
-  // and search query generator — 5 call sites total.
+  'anthropic/claude-sonnet-4': {
+    inputPerToken: 0.000003,
+    outputPerToken: 0.000015,
+    source: 'openrouter.ai/api/v1/models (2026-04-27)',
+  },
   'anthropic/claude-haiku-4.5': {
     inputPerToken: 0.000001,
     outputPerToken: 0.000005,

--- a/src/modules/llm/call-logger.ts
+++ b/src/modules/llm/call-logger.ts
@@ -1,0 +1,70 @@
+/**
+ * LLM Call Logger
+ *
+ * Fire-and-forget DB logging for every LLM API call.
+ * Errors inside this module are caught and logged — they MUST NOT propagate
+ * to the caller. A logging failure should never break a user-facing LLM call.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { calculateCost } from '@/config/llm-pricing';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'LLMCallLogger' });
+
+export interface LLMCallLogEntry {
+  /** Source module or skill (e.g., 'openrouter', 'rich_summary', 'mandala') */
+  module: string;
+  /** Full model identifier including provider prefix (e.g., 'openrouter/qwen/qwen3-30b-a3b') */
+  model: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  latencyMs?: number;
+  status: 'success' | 'error' | 'blocked';
+  errorMessage?: string;
+  /** Optional: user UUID for per-user cost attribution */
+  userId?: string;
+  /** Optional: YouTube video ID for per-video cost attribution */
+  videoId?: string;
+}
+
+/**
+ * Log an LLM call to the llm_call_logs table.
+ *
+ * This function is safe to call without awaiting — it swallows all errors
+ * internally. Use `.catch(() => {})` at the call site for fire-and-forget.
+ *
+ * @param entry - Call metadata to persist
+ */
+export async function logLLMCall(entry: LLMCallLogEntry): Promise<void> {
+  try {
+    const prisma = getPrismaClient();
+
+    const costUsd =
+      entry.inputTokens != null && entry.outputTokens != null
+        ? calculateCost(entry.model, entry.inputTokens, entry.outputTokens)
+        : null;
+
+    await prisma.llm_call_logs.create({
+      data: {
+        module: entry.module,
+        model: entry.model,
+        input_tokens: entry.inputTokens ?? null,
+        output_tokens: entry.outputTokens ?? null,
+        cost_usd: costUsd,
+        latency_ms: entry.latencyMs ?? null,
+        status: entry.status,
+        error_message: entry.errorMessage ?? null,
+        user_id: entry.userId ?? null,
+        video_id: entry.videoId ?? null,
+      },
+    });
+  } catch (err) {
+    // CRITICAL: logging failure must NOT propagate to the LLM call
+    log.error('Failed to log LLM call', {
+      module: entry.module,
+      model: entry.model,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/src/modules/llm/cost-gate.ts
+++ b/src/modules/llm/cost-gate.ts
@@ -1,10 +1,12 @@
 /**
- * LLM Cost Gate
+ * LLM Cost Gate — §1.5 (enhanced, 4/14 incident prevention)
  *
- * §1.5 hard stop: blocks individual calls that exceed the per-call USD threshold,
- * warns on calls approaching the threshold, and enforces an optional daily budget.
- *
- * Thresholds are named constants — no magic numbers.
+ * Layers:
+ *   L1 — Single call:   warn $0.50, block $5.00
+ *   L2 — Daily budget:  warn $5, block $10 (LLM_DAILY_COST_LIMIT_USD)
+ *   L3 — Monthly budget: alert $30, throttle $50 (LLM_MONTHLY_COST_LIMIT_USD)
+ *   L4 — Module concentration: single module > 60% daily → alert
+ *   L5 — User rate limit: 100 calls/hour per user_id → throttle
  */
 
 import { getPrismaClient } from '@/modules/database/client';
@@ -13,11 +15,27 @@ import { logger } from '@/utils/logger';
 
 const log = logger.child({ module: 'CostGate' });
 
-/** Emit a warn-level log when a single call is estimated above this amount (USD) */
+// --- L1: Single call thresholds ---
 const SINGLE_CALL_WARN_USD = 0.5;
-
-/** Block a single call when its estimated cost exceeds this amount (USD) */
 const SINGLE_CALL_BLOCK_USD = 5.0;
+
+// --- L2: Daily aggregate thresholds ---
+const DAILY_WARN_USD = 5.0;
+const DAILY_BLOCK_USD_DEFAULT = 10.0;
+
+// --- L3: Monthly aggregate thresholds ---
+const MONTHLY_ALERT_USD = 30.0;
+const MONTHLY_THROTTLE_USD_DEFAULT = 50.0;
+
+// --- L4: Module concentration ---
+const MODULE_CONCENTRATION_ALERT_RATIO = 0.6;
+
+// --- L5: User rate limit ---
+const USER_RATE_LIMIT_PER_HOUR = 100;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 export interface SingleCallCheckResult {
   allowed: boolean;
@@ -28,20 +46,36 @@ export interface SingleCallCheckResult {
 export interface DailyCostCheckResult {
   allowed: boolean;
   dailyTotal: number;
-  limit: number | null;
+  limit: number;
+  warning?: string;
 }
 
-/**
- * Check whether a single LLM call is within acceptable cost bounds.
- *
- * - Unknown pricing → always allowed (cost_usd will be NULL in the log).
- * - estimatedCost > SINGLE_CALL_BLOCK_USD ($5) → blocked.
- * - estimatedCost > SINGLE_CALL_WARN_USD ($0.5) → allowed with warning.
- *
- * @param model - Full model identifier (provider prefix included)
- * @param estimatedInputTokens - Estimated prompt token count
- * @param estimatedOutputTokens - Estimated completion token count
- */
+export interface MonthlyCostCheckResult {
+  allowed: boolean;
+  monthlyTotal: number;
+  limit: number;
+  throttled?: boolean;
+  warning?: string;
+}
+
+export interface ModuleConcentrationResult {
+  alert: boolean;
+  topModule: string | null;
+  ratio: number;
+  warning?: string;
+}
+
+export interface UserRateLimitResult {
+  allowed: boolean;
+  callCount: number;
+  limit: number;
+  warning?: string;
+}
+
+// ---------------------------------------------------------------------------
+// L1: Single call gate (sync — no DB)
+// ---------------------------------------------------------------------------
+
 export function checkSingleCallCost(
   model: string,
   estimatedInputTokens: number,
@@ -49,7 +83,6 @@ export function checkSingleCallCost(
 ): SingleCallCheckResult {
   const cost = calculateCost(model, estimatedInputTokens, estimatedOutputTokens);
 
-  // Unknown pricing — allow but return null cost
   if (cost === null) {
     return { allowed: true, estimatedCost: null };
   }
@@ -85,24 +118,16 @@ export function checkSingleCallCost(
   return { allowed: true, estimatedCost: cost };
 }
 
-/**
- * Check whether the daily LLM spend is within the configured budget.
- *
- * Reads the optional LLM_DAILY_COST_LIMIT_USD env var. If the var is not set
- * or is not a valid number, the gate is disabled and always returns allowed.
- *
- * Queries llm_call_logs for today's successful call costs.
- */
+// ---------------------------------------------------------------------------
+// L2: Daily aggregate gate
+// ---------------------------------------------------------------------------
+
 export async function checkDailyCostLimit(): Promise<DailyCostCheckResult> {
   const limitStr = process.env['LLM_DAILY_COST_LIMIT_USD'];
-  if (!limitStr) {
-    return { allowed: true, dailyTotal: 0, limit: null };
-  }
-
-  const limit = parseFloat(limitStr);
-  if (!Number.isFinite(limit)) {
-    return { allowed: true, dailyTotal: 0, limit: null };
-  }
+  const limit =
+    limitStr && Number.isFinite(parseFloat(limitStr))
+      ? parseFloat(limitStr)
+      : DAILY_BLOCK_USD_DEFAULT;
 
   const prisma = getPrismaClient();
   const result = await prisma.$queryRaw<[{ total: number }]>`
@@ -115,12 +140,143 @@ export async function checkDailyCostLimit(): Promise<DailyCostCheckResult> {
   const dailyTotal = result[0]?.total ?? 0;
 
   if (dailyTotal >= limit) {
-    log.error('Daily LLM cost limit reached — calls will be blocked', {
+    log.error('Daily LLM cost BLOCKED — limit reached', { dailyTotal, limit });
+    return {
+      allowed: false,
       dailyTotal,
       limit,
-    });
-    return { allowed: false, dailyTotal, limit };
+      warning: `Blocked: daily spend $${dailyTotal.toFixed(2)} >= $${limit.toFixed(2)} limit`,
+    };
+  }
+
+  if (dailyTotal >= DAILY_WARN_USD) {
+    log.warn('Daily LLM cost warning', { dailyTotal, warnAt: DAILY_WARN_USD, limit });
+    return {
+      allowed: true,
+      dailyTotal,
+      limit,
+      warning: `Warning: daily spend $${dailyTotal.toFixed(2)} >= $${DAILY_WARN_USD.toFixed(2)} threshold`,
+    };
   }
 
   return { allowed: true, dailyTotal, limit };
+}
+
+// ---------------------------------------------------------------------------
+// L3: Monthly aggregate gate
+// ---------------------------------------------------------------------------
+
+export async function checkMonthlyCostLimit(): Promise<MonthlyCostCheckResult> {
+  const limitStr = process.env['LLM_MONTHLY_COST_LIMIT_USD'];
+  const limit =
+    limitStr && Number.isFinite(parseFloat(limitStr))
+      ? parseFloat(limitStr)
+      : MONTHLY_THROTTLE_USD_DEFAULT;
+
+  const prisma = getPrismaClient();
+  const result = await prisma.$queryRaw<[{ total: number }]>`
+    SELECT COALESCE(SUM(cost_usd), 0)::float AS total
+    FROM llm_call_logs
+    WHERE created_at >= date_trunc('month', CURRENT_DATE)
+      AND status = 'success'
+  `;
+
+  const monthlyTotal = result[0]?.total ?? 0;
+
+  if (monthlyTotal >= limit) {
+    log.error('Monthly LLM cost THROTTLED — essential calls only', { monthlyTotal, limit });
+    return {
+      allowed: false,
+      monthlyTotal,
+      limit,
+      throttled: true,
+      warning: `Throttled: monthly spend $${monthlyTotal.toFixed(2)} >= $${limit.toFixed(2)} limit`,
+    };
+  }
+
+  if (monthlyTotal >= MONTHLY_ALERT_USD) {
+    log.warn('Monthly LLM cost alert', { monthlyTotal, alertAt: MONTHLY_ALERT_USD, limit });
+    return {
+      allowed: true,
+      monthlyTotal,
+      limit,
+      warning: `Alert: monthly spend $${monthlyTotal.toFixed(2)} >= $${MONTHLY_ALERT_USD.toFixed(2)} threshold`,
+    };
+  }
+
+  return { allowed: true, monthlyTotal, limit };
+}
+
+// ---------------------------------------------------------------------------
+// L4: Module concentration alert
+// ---------------------------------------------------------------------------
+
+export async function checkModuleConcentration(): Promise<ModuleConcentrationResult> {
+  const prisma = getPrismaClient();
+  const rows = await prisma.$queryRaw<{ module: string; total: number; ratio: number }[]>`
+    WITH daily AS (
+      SELECT module, COALESCE(SUM(cost_usd), 0)::float AS total
+      FROM llm_call_logs
+      WHERE created_at >= CURRENT_DATE AND status = 'success'
+      GROUP BY module
+    ),
+    grand AS (
+      SELECT COALESCE(SUM(total), 0) AS grand_total FROM daily
+    )
+    SELECT d.module, d.total,
+           CASE WHEN g.grand_total > 0 THEN d.total / g.grand_total ELSE 0 END AS ratio
+    FROM daily d, grand g
+    ORDER BY d.total DESC
+    LIMIT 1
+  `;
+
+  const top = rows[0];
+  if (!top || top.ratio < MODULE_CONCENTRATION_ALERT_RATIO) {
+    return { alert: false, topModule: top?.module ?? null, ratio: top?.ratio ?? 0 };
+  }
+
+  log.warn('Module concentration alert — single module dominates daily cost', {
+    module: top.module,
+    ratio: top.ratio,
+    total: top.total,
+  });
+
+  return {
+    alert: true,
+    topModule: top.module,
+    ratio: top.ratio,
+    warning: `Alert: module "${top.module}" uses ${(top.ratio * 100).toFixed(0)}% of daily cost`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// L5: User rate limit
+// ---------------------------------------------------------------------------
+
+export async function checkUserRateLimit(userId: string | null): Promise<UserRateLimitResult> {
+  if (!userId) {
+    return { allowed: true, callCount: 0, limit: USER_RATE_LIMIT_PER_HOUR };
+  }
+
+  const prisma = getPrismaClient();
+  const result = await prisma.$queryRaw<[{ cnt: number }]>`
+    SELECT COUNT(*)::int AS cnt
+    FROM llm_call_logs
+    WHERE created_at >= NOW() - INTERVAL '1 hour'
+      AND module LIKE ${'%' + userId + '%'}
+  `;
+
+  const callCount = result[0]?.cnt ?? 0;
+
+  if (callCount >= USER_RATE_LIMIT_PER_HOUR) {
+    log.warn('User rate limit exceeded — throttling', { userId, callCount });
+    return {
+      allowed: false,
+      callCount,
+      limit: USER_RATE_LIMIT_PER_HOUR,
+      warning: `Throttled: user ${userId} made ${callCount} calls in last hour (limit: ${USER_RATE_LIMIT_PER_HOUR})`,
+    };
+  }
+
+  return { allowed: true, callCount, limit: USER_RATE_LIMIT_PER_HOUR };
 }

--- a/src/modules/llm/cost-gate.ts
+++ b/src/modules/llm/cost-gate.ts
@@ -1,0 +1,126 @@
+/**
+ * LLM Cost Gate
+ *
+ * §1.5 hard stop: blocks individual calls that exceed the per-call USD threshold,
+ * warns on calls approaching the threshold, and enforces an optional daily budget.
+ *
+ * Thresholds are named constants — no magic numbers.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { calculateCost } from '@/config/llm-pricing';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'CostGate' });
+
+/** Emit a warn-level log when a single call is estimated above this amount (USD) */
+const SINGLE_CALL_WARN_USD = 0.5;
+
+/** Block a single call when its estimated cost exceeds this amount (USD) */
+const SINGLE_CALL_BLOCK_USD = 5.0;
+
+export interface SingleCallCheckResult {
+  allowed: boolean;
+  estimatedCost: number | null;
+  warning?: string;
+}
+
+export interface DailyCostCheckResult {
+  allowed: boolean;
+  dailyTotal: number;
+  limit: number | null;
+}
+
+/**
+ * Check whether a single LLM call is within acceptable cost bounds.
+ *
+ * - Unknown pricing → always allowed (cost_usd will be NULL in the log).
+ * - estimatedCost > SINGLE_CALL_BLOCK_USD ($5) → blocked.
+ * - estimatedCost > SINGLE_CALL_WARN_USD ($0.5) → allowed with warning.
+ *
+ * @param model - Full model identifier (provider prefix included)
+ * @param estimatedInputTokens - Estimated prompt token count
+ * @param estimatedOutputTokens - Estimated completion token count
+ */
+export function checkSingleCallCost(
+  model: string,
+  estimatedInputTokens: number,
+  estimatedOutputTokens: number
+): SingleCallCheckResult {
+  const cost = calculateCost(model, estimatedInputTokens, estimatedOutputTokens);
+
+  // Unknown pricing — allow but return null cost
+  if (cost === null) {
+    return { allowed: true, estimatedCost: null };
+  }
+
+  if (cost > SINGLE_CALL_BLOCK_USD) {
+    log.error('LLM call BLOCKED — cost exceeds hard limit', {
+      model,
+      estimatedCost: cost,
+      limitUsd: SINGLE_CALL_BLOCK_USD,
+      estimatedInputTokens,
+      estimatedOutputTokens,
+    });
+    return {
+      allowed: false,
+      estimatedCost: cost,
+      warning: `Blocked: estimated cost $${cost.toFixed(4)} exceeds $${SINGLE_CALL_BLOCK_USD.toFixed(2)} hard limit`,
+    };
+  }
+
+  if (cost > SINGLE_CALL_WARN_USD) {
+    log.warn('LLM call cost warning — above warn threshold', {
+      model,
+      estimatedCost: cost,
+      warnThresholdUsd: SINGLE_CALL_WARN_USD,
+    });
+    return {
+      allowed: true,
+      estimatedCost: cost,
+      warning: `Warning: estimated cost $${cost.toFixed(4)} exceeds $${SINGLE_CALL_WARN_USD.toFixed(2)} warn threshold`,
+    };
+  }
+
+  return { allowed: true, estimatedCost: cost };
+}
+
+/**
+ * Check whether the daily LLM spend is within the configured budget.
+ *
+ * Reads the optional LLM_DAILY_COST_LIMIT_USD env var. If the var is not set
+ * or is not a valid number, the gate is disabled and always returns allowed.
+ *
+ * Queries llm_call_logs for today's successful call costs.
+ */
+export async function checkDailyCostLimit(): Promise<DailyCostCheckResult> {
+  const limitStr = process.env['LLM_DAILY_COST_LIMIT_USD'];
+  if (!limitStr) {
+    return { allowed: true, dailyTotal: 0, limit: null };
+  }
+
+  const limit = parseFloat(limitStr);
+  if (!Number.isFinite(limit)) {
+    return { allowed: true, dailyTotal: 0, limit: null };
+  }
+
+  const prisma = getPrismaClient();
+  const result = await prisma.$queryRaw<[{ total: number }]>`
+    SELECT COALESCE(SUM(cost_usd), 0)::float AS total
+    FROM llm_call_logs
+    WHERE created_at >= CURRENT_DATE
+      AND status = 'success'
+  `;
+
+  const dailyTotal = result[0]?.total ?? 0;
+
+  if (dailyTotal >= limit) {
+    log.error('Daily LLM cost limit reached — calls will be blocked', {
+      dailyTotal,
+      limit,
+    });
+    return { allowed: false, dailyTotal, limit };
+  }
+
+  return { allowed: true, dailyTotal, limit };
+}

--- a/src/modules/llm/cost-gate.ts
+++ b/src/modules/llm/cost-gate.ts
@@ -9,6 +9,7 @@
  *   L5 — User rate limit: 100 calls/hour per user_id → throttle
  */
 
+import { config } from '@/config/index';
 import { getPrismaClient } from '@/modules/database/client';
 import { calculateCost } from '@/config/llm-pricing';
 import { logger } from '@/utils/logger';
@@ -123,11 +124,7 @@ export function checkSingleCallCost(
 // ---------------------------------------------------------------------------
 
 export async function checkDailyCostLimit(): Promise<DailyCostCheckResult> {
-  const limitStr = process.env['LLM_DAILY_COST_LIMIT_USD'];
-  const limit =
-    limitStr && Number.isFinite(parseFloat(limitStr))
-      ? parseFloat(limitStr)
-      : DAILY_BLOCK_USD_DEFAULT;
+  const limit = config.llm.dailyCostLimitUsd ?? DAILY_BLOCK_USD_DEFAULT;
 
   const prisma = getPrismaClient();
   const result = await prisma.$queryRaw<[{ total: number }]>`
@@ -167,11 +164,7 @@ export async function checkDailyCostLimit(): Promise<DailyCostCheckResult> {
 // ---------------------------------------------------------------------------
 
 export async function checkMonthlyCostLimit(): Promise<MonthlyCostCheckResult> {
-  const limitStr = process.env['LLM_MONTHLY_COST_LIMIT_USD'];
-  const limit =
-    limitStr && Number.isFinite(parseFloat(limitStr))
-      ? parseFloat(limitStr)
-      : MONTHLY_THROTTLE_USD_DEFAULT;
+  const limit = config.llm.monthlyCostLimitUsd ?? MONTHLY_THROTTLE_USD_DEFAULT;
 
   const prisma = getPrismaClient();
   const result = await prisma.$queryRaw<[{ total: number }]>`

--- a/src/modules/llm/gemini.ts
+++ b/src/modules/llm/gemini.ts
@@ -6,6 +6,7 @@
  */
 
 import type { EmbeddingProvider, GenerationProvider, GenerateOptions } from './provider';
+import { logLLMCall } from './call-logger';
 
 const GEMINI_EMBED_MODEL = 'gemini-embedding-001';
 const GEMINI_EMBED_DIMENSION = 768;
@@ -54,6 +55,7 @@ export class GeminiGenerationProvider implements GenerationProvider {
   readonly model = `gemini/${GEMINI_GENERATE_MODEL}`;
 
   async generate(prompt: string, options?: GenerateOptions): Promise<string> {
+    const startTime = Date.now();
     const apiKey = getApiKey();
 
     const body: Record<string, unknown> = {
@@ -69,25 +71,64 @@ export class GeminiGenerationProvider implements GenerationProvider {
       genConfig['responseMimeType'] = 'application/json';
     }
 
-    const response = await fetch(`${GEMINI_GENERATE_URL}?key=${apiKey}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
+    let response: Response;
+    try {
+      response = await fetch(`${GEMINI_GENERATE_URL}?key=${apiKey}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      logLLMCall({
+        module: 'gemini',
+        model: this.model,
+        latencyMs: Date.now() - startTime,
+        status: 'error',
+        errorMessage: err instanceof Error ? err.message : String(err),
+      }).catch(() => {});
+      throw err;
+    }
 
     if (!response.ok) {
       const errorBody = await response.text();
+      logLLMCall({
+        module: 'gemini',
+        model: this.model,
+        latencyMs: Date.now() - startTime,
+        status: 'error',
+        errorMessage: `API error ${response.status}: ${errorBody.slice(0, 200)}`,
+      }).catch(() => {});
       throw new Error(`Gemini generation API error ${response.status}: ${errorBody}`);
     }
 
     const data = (await response.json()) as {
       candidates?: Array<{ content: { parts: Array<{ text: string }> } }>;
+      usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number };
     };
 
     const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
     if (!text) {
+      logLLMCall({
+        module: 'gemini',
+        model: this.model,
+        inputTokens: data.usageMetadata?.promptTokenCount,
+        outputTokens: data.usageMetadata?.candidatesTokenCount,
+        latencyMs: Date.now() - startTime,
+        status: 'error',
+        errorMessage: 'Empty response returned',
+      }).catch(() => {});
       throw new Error('Gemini returned empty response');
     }
+
+    // Fire-and-forget cost log
+    logLLMCall({
+      module: 'gemini',
+      model: this.model,
+      inputTokens: data.usageMetadata?.promptTokenCount,
+      outputTokens: data.usageMetadata?.candidatesTokenCount,
+      latencyMs: Date.now() - startTime,
+      status: 'success',
+    }).catch(() => {});
 
     return text;
   }

--- a/src/modules/llm/ollama.ts
+++ b/src/modules/llm/ollama.ts
@@ -7,6 +7,7 @@
 
 import type { EmbeddingProvider, GenerationProvider, GenerateOptions } from './provider';
 import { config } from '../../config';
+import { logLLMCall } from './call-logger';
 
 const OLLAMA_EMBED_DIMENSION = 768;
 const HEALTH_CHECK_TIMEOUT_MS = 2000;
@@ -55,6 +56,8 @@ export class OllamaGenerationProvider implements GenerationProvider {
   }
 
   async generate(prompt: string, options?: GenerateOptions): Promise<string> {
+    const startTime = Date.now();
+
     // Use /api/chat with think:false to disable qwen3 thinking mode.
     // Thinking mode consumes tokens internally and returns empty response.
     const body: Record<string, unknown> = {
@@ -76,23 +79,66 @@ export class OllamaGenerationProvider implements GenerationProvider {
       body['format'] = 'json';
     }
 
-    const response = await fetch(`${this.baseUrl}/api/chat`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseUrl}/api/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      logLLMCall({
+        module: 'ollama',
+        model: this.model,
+        latencyMs: Date.now() - startTime,
+        status: 'error',
+        errorMessage: err instanceof Error ? err.message : String(err),
+      }).catch(() => {});
+      throw err;
+    }
 
     if (!response.ok) {
       const errorBody = await response.text();
+      logLLMCall({
+        module: 'ollama',
+        model: this.model,
+        latencyMs: Date.now() - startTime,
+        status: 'error',
+        errorMessage: `API error ${response.status}: ${errorBody.slice(0, 200)}`,
+      }).catch(() => {});
       throw new Error(`Ollama generate API error ${response.status}: ${errorBody}`);
     }
 
-    const data = (await response.json()) as { message?: { content: string } };
+    // Ollama /api/chat response includes prompt_eval_count and eval_count for token usage
+    const data = (await response.json()) as {
+      message?: { content: string };
+      prompt_eval_count?: number;
+      eval_count?: number;
+    };
     const content = data.message?.content;
 
     if (!content) {
+      logLLMCall({
+        module: 'ollama',
+        model: this.model,
+        inputTokens: data.prompt_eval_count,
+        outputTokens: data.eval_count,
+        latencyMs: Date.now() - startTime,
+        status: 'error',
+        errorMessage: 'Empty response returned',
+      }).catch(() => {});
       throw new Error('Ollama returned empty response');
     }
+
+    // Fire-and-forget cost log (Ollama = local inference, zero cost)
+    logLLMCall({
+      module: 'ollama',
+      model: this.model,
+      inputTokens: data.prompt_eval_count,
+      outputTokens: data.eval_count,
+      latencyMs: Date.now() - startTime,
+      status: 'success',
+    }).catch(() => {});
 
     return content;
   }

--- a/src/modules/llm/openrouter.ts
+++ b/src/modules/llm/openrouter.ts
@@ -8,6 +8,7 @@
 
 import type { GenerationProvider, GenerateOptions } from './provider';
 import { config } from '../../config';
+import { logLLMCall } from './call-logger';
 
 const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
 const DEFAULT_MAX_TOKENS = 1024;
@@ -26,6 +27,7 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
   }
 
   async generate(prompt: string, options?: GenerateOptions): Promise<string> {
+    const startTime = Date.now();
     const apiKey = config.openrouter.apiKey;
     if (!apiKey) {
       throw new Error('OPENROUTER_API_KEY not configured');
@@ -39,6 +41,14 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
       temperature: options?.temperature ?? 0.3,
       max_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
     };
+
+    // JSON mode: instruct the model to return valid JSON only.
+    // OpenRouter requires explicit response_format to enforce JSON output —
+    // unlike Ollama (body['format']='json') and Gemini (responseMimeType),
+    // OpenRouter silently drops format hints unless this field is present.
+    if (options?.format === 'json') {
+      body['response_format'] = { type: 'json_object' };
+    }
 
     // Disable thinking/reasoning mode for Qwen models only — Qwen3 consumes
     // token budget on reasoning, leaving content empty.
@@ -77,13 +87,35 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
         signal: controller.signal,
       });
     } catch (err) {
+      const latencyMs = Date.now() - startTime;
       if ((err as Error).name === 'AbortError') {
         // Distinguish "external cancel" from internal timeout for clearer logs.
         if (externalSignal?.aborted) {
+          logLLMCall({
+            module: 'openrouter',
+            model: this.model,
+            latencyMs,
+            status: 'error',
+            errorMessage: 'Request cancelled by external signal',
+          }).catch(() => {});
           throw new Error('OpenRouter request cancelled by external signal');
         }
+        logLLMCall({
+          module: 'openrouter',
+          model: this.model,
+          latencyMs,
+          status: 'error',
+          errorMessage: `Request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`,
+        }).catch(() => {});
         throw new Error(`OpenRouter request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`);
       }
+      logLLMCall({
+        module: 'openrouter',
+        model: this.model,
+        latencyMs,
+        status: 'error',
+        errorMessage: err instanceof Error ? err.message : String(err),
+      }).catch(() => {});
       throw err;
     } finally {
       clearTimeout(timeout);
@@ -94,6 +126,13 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
 
     if (!response.ok) {
       const errorBody = await response.text();
+      logLLMCall({
+        module: 'openrouter',
+        model: this.model,
+        latencyMs: Date.now() - startTime,
+        status: 'error',
+        errorMessage: `API error ${response.status}: ${errorBody.slice(0, 200)}`,
+      }).catch(() => {});
       throw new Error(`OpenRouter API error ${response.status}: ${errorBody}`);
     }
 
@@ -102,7 +141,7 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
       usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
     };
 
-    // Log token usage for performance analysis
+    // Log token usage for performance analysis (existing behaviour preserved)
     if (data.usage) {
       console.info(
         `[OpenRouter] model=${activeModel} prompt=${data.usage.prompt_tokens} completion=${data.usage.completion_tokens} total=${data.usage.total_tokens}`
@@ -113,10 +152,31 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
     const content = message?.content;
     if (!content) {
       const hasReasoning = !!message?.reasoning;
+      logLLMCall({
+        module: 'openrouter',
+        model: this.model,
+        inputTokens: data.usage?.prompt_tokens,
+        outputTokens: data.usage?.completion_tokens,
+        latencyMs: Date.now() - startTime,
+        status: 'error',
+        errorMessage: hasReasoning
+          ? 'Empty content: reasoning-only response (CoT leakage blocked)'
+          : 'Empty content returned',
+      }).catch(() => {});
       throw new Error(
         `OpenRouter returned empty content${hasReasoning ? ' (reasoning-only response detected — CoT leakage blocked)' : ''}`
       );
     }
+
+    // Fire-and-forget cost log — errors handled inside logLLMCall
+    logLLMCall({
+      module: 'openrouter',
+      model: this.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+      latencyMs: Date.now() - startTime,
+      status: 'success',
+    }).catch(() => {});
 
     return content;
   }

--- a/tests/smoke/llm-cost-tracking.test.ts
+++ b/tests/smoke/llm-cost-tracking.test.ts
@@ -79,6 +79,15 @@ describe('calculateCost — pricing table lookup', () => {
     expect(cost).not.toBeNull();
   });
 
+  it('returns correct cost for anthropic/claude-haiku-4.5 (mandala generator)', () => {
+    // inputPerToken=0.000001, outputPerToken=0.000005
+    // 2000 input + 700 output (structure prompt) = 0.000001*2000 + 0.000005*700
+    //   = 0.002 + 0.0035 = 0.0055
+    const cost = calculateCost('anthropic/claude-haiku-4.5', 2000, 700);
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeCloseTo(0.0055, 8);
+  });
+
   it('returns null for unknown model', () => {
     const cost = calculateCost('unknown/model-xyz', 1000, 500);
     expect(cost).toBeNull();

--- a/tests/smoke/llm-cost-tracking.test.ts
+++ b/tests/smoke/llm-cost-tracking.test.ts
@@ -1,0 +1,251 @@
+/**
+ * LLM Cost Tracking — smoke tests
+ *
+ * Covers:
+ *   1. calculateCost() — known model returns correct cost, unknown returns null
+ *   2. checkSingleCallCost() — under threshold allows, over $5 blocks, $0.5-$5 warns
+ *   3. logLLMCall() — does not throw when Prisma is unavailable (mock)
+ *
+ * No server boot required — all tests are unit-level or use mocked Prisma.
+ */
+export {};
+
+// ---------------------------------------------------------------------------
+// Module-level Prisma mock — hoisted by Jest before any imports
+// ---------------------------------------------------------------------------
+
+const mockCreate = jest.fn();
+const mockPrisma = {
+  llm_call_logs: {
+    create: mockCreate,
+  },
+};
+
+jest.mock('../../src/modules/database/client', () => ({
+  getPrismaClient: jest.fn(() => mockPrisma),
+  db: mockPrisma,
+  connectDatabase: jest.fn(),
+  disconnectDatabase: jest.fn(),
+  resetConnectionPool: jest.fn(),
+  withRetry: jest.fn((fn: () => unknown) => fn()),
+  executeTransaction: jest.fn(),
+  testDatabaseConnection: jest.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Group 1: calculateCost
+// ---------------------------------------------------------------------------
+
+describe('calculateCost — pricing table lookup', () => {
+  let calculateCost: (model: string, inputTokens: number, outputTokens: number) => number | null;
+
+  beforeAll(async () => {
+    const mod = await import('../../src/config/llm-pricing');
+    calculateCost = mod.calculateCost;
+  });
+
+  it('returns correct cost for qwen/qwen3-30b-a3b (OpenRouter pricing)', () => {
+    // inputPerToken=0.00000008, outputPerToken=0.00000028
+    // 1000 input + 500 output = 0.00000008*1000 + 0.00000028*500
+    //   = 0.00008 + 0.00014 = 0.00022
+    const cost = calculateCost('qwen/qwen3-30b-a3b', 1000, 500);
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeCloseTo(0.00022, 8);
+  });
+
+  it('returns correct cost for qwen/qwen3.5-9b', () => {
+    // inputPerToken=0.0000001, outputPerToken=0.00000015
+    // 2000 input + 1000 output = 0.0000001*2000 + 0.00000015*1000
+    //   = 0.0002 + 0.00015 = 0.00035
+    const cost = calculateCost('qwen/qwen3.5-9b', 2000, 1000);
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeCloseTo(0.00035, 8);
+  });
+
+  it('strips openrouter/ prefix before lookup', () => {
+    const cost = calculateCost('openrouter/qwen/qwen3-30b-a3b', 1000, 500);
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeCloseTo(0.00022, 8);
+  });
+
+  it('strips ollama/ prefix before lookup', () => {
+    const cost = calculateCost('ollama/qwen3.5:9b', 100, 100);
+    expect(cost).not.toBeNull();
+    expect(cost!).toBe(0); // local inference = zero cost
+  });
+
+  it('strips gemini/ prefix before lookup', () => {
+    const cost = calculateCost('gemini/gemini-pro', 1000, 500);
+    expect(cost).not.toBeNull();
+  });
+
+  it('returns null for unknown model', () => {
+    const cost = calculateCost('unknown/model-xyz', 1000, 500);
+    expect(cost).toBeNull();
+  });
+
+  it('returns zero for Ollama local model', () => {
+    const cost = calculateCost('qwen3.5:9b', 5000, 2000);
+    expect(cost).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 2: checkSingleCallCost
+// ---------------------------------------------------------------------------
+
+describe('checkSingleCallCost — gate logic', () => {
+  let checkSingleCallCost: (
+    model: string,
+    estimatedInputTokens: number,
+    estimatedOutputTokens: number
+  ) => { allowed: boolean; estimatedCost: number | null; warning?: string };
+
+  beforeAll(async () => {
+    const mod = await import('../../src/modules/llm/cost-gate');
+    checkSingleCallCost = mod.checkSingleCallCost;
+  });
+
+  it('allows calls under $0.5 with no warning', () => {
+    // qwen3-30b-a3b: 1000 input + 500 output = ~$0.00022 → well under $0.5
+    const result = checkSingleCallCost('qwen/qwen3-30b-a3b', 1000, 500);
+    expect(result.allowed).toBe(true);
+    expect(result.warning).toBeUndefined();
+    expect(result.estimatedCost).toBeCloseTo(0.00022, 8);
+  });
+
+  it('allows calls between $0.5 and $5 with a warning', () => {
+    // qwen3-30b-a3b: inputPerToken=0.00000008, outputPerToken=0.00000028
+    // To get ~$1: need ~(1 / 0.00000028) ≈ 3,571,429 output tokens
+    // Use 0 input + 3,600,000 output = 3,600,000 * 0.00000028 = $1.008
+    const result = checkSingleCallCost('qwen/qwen3-30b-a3b', 0, 3_600_000);
+    expect(result.allowed).toBe(true);
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toMatch(/warning/i);
+    expect(result.estimatedCost).toBeGreaterThan(0.5);
+    expect(result.estimatedCost).toBeLessThan(5.0);
+  });
+
+  it('blocks calls over $5', () => {
+    // qwen3-30b-a3b: 0 input + 20,000,000 output = 20M * 0.00000028 = $5.6
+    const result = checkSingleCallCost('qwen/qwen3-30b-a3b', 0, 20_000_000);
+    expect(result.allowed).toBe(false);
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toMatch(/blocked/i);
+    expect(result.estimatedCost).toBeGreaterThan(5.0);
+  });
+
+  it('allows unknown model with null cost (no pricing data)', () => {
+    const result = checkSingleCallCost('unknown/some-model', 1_000_000, 1_000_000);
+    expect(result.allowed).toBe(true);
+    expect(result.estimatedCost).toBeNull();
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('allows Ollama local calls regardless of token count (zero cost)', () => {
+    const result = checkSingleCallCost('ollama/qwen3.5:9b', 100_000_000, 100_000_000);
+    expect(result.allowed).toBe(true);
+    expect(result.estimatedCost).toBe(0);
+    expect(result.warning).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 3: logLLMCall — error resilience
+// ---------------------------------------------------------------------------
+
+describe('logLLMCall — does not throw on DB failure', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves without throwing when Prisma create succeeds', async () => {
+    mockCreate.mockResolvedValue({ call_id: 'test-id' });
+
+    const { logLLMCall } = await import('../../src/modules/llm/call-logger');
+
+    await expect(
+      logLLMCall({
+        module: 'openrouter',
+        model: 'openrouter/qwen/qwen3-30b-a3b',
+        inputTokens: 100,
+        outputTokens: 50,
+        latencyMs: 1200,
+        status: 'success',
+      })
+    ).resolves.toBeUndefined();
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const callArg = mockCreate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+    expect(callArg?.data?.['module']).toBe('openrouter');
+    expect(callArg?.data?.['model']).toBe('openrouter/qwen/qwen3-30b-a3b');
+    expect(callArg?.data?.['status']).toBe('success');
+    // cost_usd should be calculated (100 * 0.00000008 + 50 * 0.00000028 = 0.000008 + 0.000014 = 0.000022)
+    expect(callArg?.data?.['cost_usd']).toBeCloseTo(0.000022, 8);
+  });
+
+  it('resolves without throwing when Prisma throws', async () => {
+    mockCreate.mockRejectedValue(new Error('DB connection refused'));
+
+    const { logLLMCall } = await import('../../src/modules/llm/call-logger');
+
+    // Must NOT throw — logging failure is swallowed
+    await expect(
+      logLLMCall({
+        module: 'ollama',
+        model: 'ollama/qwen3.5:9b',
+        latencyMs: 500,
+        status: 'error',
+        errorMessage: 'Ollama returned empty response',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('stores null cost_usd for unknown model', async () => {
+    mockCreate.mockResolvedValue({ call_id: 'test-id-2' });
+
+    const { logLLMCall } = await import('../../src/modules/llm/call-logger');
+
+    await logLLMCall({
+      module: 'openrouter',
+      model: 'openrouter/some/unknown-model',
+      inputTokens: 500,
+      outputTokens: 200,
+      latencyMs: 800,
+      status: 'success',
+    });
+
+    const callArg = mockCreate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+    expect(callArg?.data?.['cost_usd']).toBeNull();
+  });
+
+  it('stores null cost_usd when token counts are absent', async () => {
+    mockCreate.mockResolvedValue({ call_id: 'test-id-3' });
+
+    const { logLLMCall } = await import('../../src/modules/llm/call-logger');
+
+    await logLLMCall({
+      module: 'openrouter',
+      model: 'openrouter/qwen/qwen3-30b-a3b',
+      // No inputTokens / outputTokens
+      latencyMs: 120_000,
+      status: 'error',
+      errorMessage: 'Request timed out',
+    });
+
+    const callArg = mockCreate.mock.calls[0]?.[0] as { data: Record<string, unknown> };
+    expect(callArg?.data?.['cost_usd']).toBeNull();
+    expect(callArg?.data?.['input_tokens']).toBeNull();
+    expect(callArg?.data?.['output_tokens']).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Environment report — always runs
+// ---------------------------------------------------------------------------
+
+describe('LLM cost tracking environment check', () => {
+  it('reports test suite capability', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/tests/smoke/llm-cost-tracking.test.ts
+++ b/tests/smoke/llm-cost-tracking.test.ts
@@ -7,7 +7,10 @@
  *   3. logLLMCall() — does not throw when Prisma is unavailable (mock)
  *
  * No server boot required — all tests are unit-level or use mocked Prisma.
+ * ENCRYPTION_SECRET is set below so config validation passes in CI.
  */
+process.env['ENCRYPTION_SECRET'] ??=
+  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 export {};
 
 // ---------------------------------------------------------------------------
@@ -30,6 +33,34 @@ jest.mock('../../src/modules/database/client', () => ({
   withRetry: jest.fn((fn: () => unknown) => fn()),
   executeTransaction: jest.fn(),
   testDatabaseConnection: jest.fn(),
+}));
+
+const mockChildLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+};
+
+jest.mock('../../src/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(() => mockChildLogger),
+  },
+}));
+
+jest.mock('../../src/config/index', () => ({
+  config: {
+    llm: {
+      provider: 'auto',
+      dailyCostLimitUsd: undefined,
+      monthlyCostLimitUsd: undefined,
+    },
+  },
 }));
 
 // ---------------------------------------------------------------------------

--- a/tests/smoke/llm-cost-tracking.test.ts
+++ b/tests/smoke/llm-cost-tracking.test.ts
@@ -241,11 +241,136 @@ describe('logLLMCall — does not throw on DB failure', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Environment report — always runs
+// Group 4: checkDailyCostLimit — aggregate gate
 // ---------------------------------------------------------------------------
 
-describe('LLM cost tracking environment check', () => {
-  it('reports test suite capability', () => {
-    expect(true).toBe(true);
+describe('checkDailyCostLimit — L2 daily aggregate', () => {
+  let checkDailyCostLimit: () => Promise<{
+    allowed: boolean;
+    dailyTotal: number;
+    limit: number;
+    warning?: string;
+  }>;
+
+  beforeAll(async () => {
+    const mod = await import('../../src/modules/llm/cost-gate');
+    checkDailyCostLimit = mod.checkDailyCostLimit;
+  });
+
+  it('blocks when daily total >= $10 default limit', async () => {
+    (mockPrisma as Record<string, unknown>)['$queryRaw'] = jest
+      .fn()
+      .mockResolvedValue([{ total: 12.5 }]);
+    const result = await checkDailyCostLimit();
+    expect(result.allowed).toBe(false);
+    expect(result.dailyTotal).toBe(12.5);
+    expect(result.limit).toBe(10);
+    expect(result.warning).toMatch(/blocked/i);
+  });
+
+  it('warns when daily total >= $5 but under limit', async () => {
+    (mockPrisma as Record<string, unknown>)['$queryRaw'] = jest
+      .fn()
+      .mockResolvedValue([{ total: 7.0 }]);
+    const result = await checkDailyCostLimit();
+    expect(result.allowed).toBe(true);
+    expect(result.dailyTotal).toBe(7.0);
+    expect(result.warning).toMatch(/warning/i);
+  });
+
+  it('allows when daily total is under $5', async () => {
+    (mockPrisma as Record<string, unknown>)['$queryRaw'] = jest
+      .fn()
+      .mockResolvedValue([{ total: 2.0 }]);
+    const result = await checkDailyCostLimit();
+    expect(result.allowed).toBe(true);
+    expect(result.warning).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 5: checkMonthlyCostLimit — L3 monthly aggregate
+// ---------------------------------------------------------------------------
+
+describe('checkMonthlyCostLimit — L3 monthly aggregate', () => {
+  let checkMonthlyCostLimit: () => Promise<{
+    allowed: boolean;
+    monthlyTotal: number;
+    limit: number;
+    throttled?: boolean;
+    warning?: string;
+  }>;
+
+  beforeAll(async () => {
+    const mod = await import('../../src/modules/llm/cost-gate');
+    checkMonthlyCostLimit = mod.checkMonthlyCostLimit;
+  });
+
+  it('throttles when monthly total >= $50 default limit', async () => {
+    (mockPrisma as Record<string, unknown>)['$queryRaw'] = jest
+      .fn()
+      .mockResolvedValue([{ total: 55.0 }]);
+    const result = await checkMonthlyCostLimit();
+    expect(result.allowed).toBe(false);
+    expect(result.throttled).toBe(true);
+    expect(result.warning).toMatch(/throttled/i);
+  });
+
+  it('alerts when monthly total >= $30 but under limit', async () => {
+    (mockPrisma as Record<string, unknown>)['$queryRaw'] = jest
+      .fn()
+      .mockResolvedValue([{ total: 35.0 }]);
+    const result = await checkMonthlyCostLimit();
+    expect(result.allowed).toBe(true);
+    expect(result.warning).toMatch(/alert/i);
+  });
+
+  it('allows when monthly total under $30', async () => {
+    (mockPrisma as Record<string, unknown>)['$queryRaw'] = jest
+      .fn()
+      .mockResolvedValue([{ total: 10.0 }]);
+    const result = await checkMonthlyCostLimit();
+    expect(result.allowed).toBe(true);
+    expect(result.warning).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 6: checkUserRateLimit — L5 per-user
+// ---------------------------------------------------------------------------
+
+describe('checkUserRateLimit — L5 user rate', () => {
+  let checkUserRateLimit: (
+    userId: string | null
+  ) => Promise<{ allowed: boolean; callCount: number; limit: number; warning?: string }>;
+
+  beforeAll(async () => {
+    const mod = await import('../../src/modules/llm/cost-gate');
+    checkUserRateLimit = mod.checkUserRateLimit;
+  });
+
+  it('allows null userId without DB query', async () => {
+    const result = await checkUserRateLimit(null);
+    expect(result.allowed).toBe(true);
+    expect(result.callCount).toBe(0);
+  });
+
+  it('throttles user with 100+ calls in last hour', async () => {
+    (mockPrisma as Record<string, unknown>)['$queryRaw'] = jest
+      .fn()
+      .mockResolvedValue([{ cnt: 120 }]);
+    const result = await checkUserRateLimit('user-abc-123');
+    expect(result.allowed).toBe(false);
+    expect(result.callCount).toBe(120);
+    expect(result.warning).toMatch(/throttled/i);
+  });
+
+  it('allows user under rate limit', async () => {
+    (mockPrisma as Record<string, unknown>)['$queryRaw'] = jest
+      .fn()
+      .mockResolvedValue([{ cnt: 42 }]);
+    const result = await checkUserRateLimit('user-abc-123');
+    expect(result.allowed).toBe(true);
+    expect(result.callCount).toBe(42);
   });
 });

--- a/tests/smoke/llm-cost-tracking.test.ts
+++ b/tests/smoke/llm-cost-tracking.test.ts
@@ -88,6 +88,25 @@ describe('calculateCost — pricing table lookup', () => {
     expect(cost!).toBeCloseTo(0.0055, 8);
   });
 
+  it('returns correct cost for anthropic/claude-sonnet-4 (4/14 incident model)', () => {
+    // inputPerToken=0.000003, outputPerToken=0.000015
+    // 2000 input + 1000 output = 0.000003*2000 + 0.000015*1000
+    //   = 0.006 + 0.015 = 0.021
+    const cost = calculateCost('anthropic/claude-sonnet-4', 2000, 1000);
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeCloseTo(0.021, 8);
+  });
+
+  it('computes 4/14 burst scenario: 1.93K Sonnet calls ≈ $48', () => {
+    // 1930 calls × avg 2K input + 1K output per call
+    const perCall = calculateCost('anthropic/claude-sonnet-4', 2000, 1000)!;
+    const totalBurst = perCall * 1930;
+    // Should be ~$40.5 (0.021 × 1930). Dashboard showed ~$48 so
+    // actual token counts were likely higher, but order of magnitude matches.
+    expect(totalBurst).toBeGreaterThan(30);
+    expect(totalBurst).toBeLessThan(60);
+  });
+
   it('returns null for unknown model', () => {
     const cost = calculateCost('unknown/model-xyz', 1000, 500);
     expect(cost).toBeNull();
@@ -381,5 +400,59 @@ describe('checkUserRateLimit — L5 user rate', () => {
     const result = await checkUserRateLimit('user-abc-123');
     expect(result.allowed).toBe(true);
     expect(result.callCount).toBe(42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 7: 4/14 incident replay — gate coverage verification
+// ---------------------------------------------------------------------------
+
+describe('4/14 incident replay — which gates catch Sonnet burst', () => {
+  let checkSingleCallCost: (
+    model: string,
+    inputTokens: number,
+    outputTokens: number
+  ) => { allowed: boolean; estimatedCost: number | null; warning?: string };
+  let checkDailyCostLimit: () => Promise<{
+    allowed: boolean;
+    dailyTotal: number;
+    limit: number;
+    warning?: string;
+  }>;
+  let checkUserRateLimit: (
+    userId: string | null
+  ) => Promise<{ allowed: boolean; callCount: number; limit: number; warning?: string }>;
+
+  beforeAll(async () => {
+    const gate = await import('../../src/modules/llm/cost-gate');
+    checkSingleCallCost = gate.checkSingleCallCost;
+    checkDailyCostLimit = gate.checkDailyCostLimit;
+    checkUserRateLimit = gate.checkUserRateLimit;
+  });
+
+  it('L1: single Sonnet call ($0.021) passes — under $0.50 warn', () => {
+    const result = checkSingleCallCost('anthropic/claude-sonnet-4', 2000, 1000);
+    expect(result.allowed).toBe(true);
+    expect(result.warning).toBeUndefined();
+    expect(result.estimatedCost!).toBeCloseTo(0.021, 4);
+  });
+
+  it('L2: daily total $40+ blocks at $10 limit — catches burst by call ~476', async () => {
+    // After ~476 calls: 476 × $0.021 = $10.0 → L2 blocks
+    (mockPrisma as Record<string, unknown>)['$queryRaw'] = jest
+      .fn()
+      .mockResolvedValue([{ total: 40.53 }]);
+    const result = await checkDailyCostLimit();
+    expect(result.allowed).toBe(false);
+    expect(result.warning).toMatch(/blocked/i);
+  });
+
+  it('L5: 1930 calls in 1 hour blocks at 100/hr — catches burst by call ~100', async () => {
+    (mockPrisma as Record<string, unknown>)['$queryRaw'] = jest
+      .fn()
+      .mockResolvedValue([{ cnt: 1930 }]);
+    const result = await checkUserRateLimit('dataset-script');
+    expect(result.allowed).toBe(false);
+    expect(result.warning).toMatch(/throttled/i);
   });
 });


### PR DESCRIPTION
## Summary
- `llm_call_logs` table with Prisma model + raw DDL (silent-fail mitigation)
- `llm-pricing.ts` — OpenRouter API-sourced per-token SSOT (fetched 2026-04-27)
- `call-logger.ts` — fire-and-forget DB write on every LLM call
- `cost-gate.ts` — **5-layer protection** (4/14 $50 incident prevention):
  - L1: Single call $0.50 warn / $5 block
  - L2: Daily aggregate $5 warn / $10 block (configurable)
  - L3: Monthly aggregate $30 alert / $50 throttle (configurable)
  - L4: Module concentration >60% daily → alert
  - L5: User rate limit 100 calls/hour → throttle
- Provider wiring: `openrouter.ts`, `ollama.ts`, `gemini.ts` all log calls
- `admin/llm.ts` — GET /api/v1/admin/llm/usage
- 25 unit tests (all pass)

## Round 1
Part of #530 (Rich Summary Quality Engine Round 1). Closes #535.

## Merge Order
**This PR merges first** (independent). Then PR 5 (quality metrics), then PR 2 (hotfix).

## Test plan
- [x] `npx jest tests/smoke/llm-cost-tracking.test.ts` — 25/25 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Post-merge: apply `prisma/migrations/llm_call_logs/001_create_table.sql` to local + prod
- [ ] Post-merge: verify `SELECT * FROM llm_call_logs LIMIT 1` after first rich summary trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)