### PR TITLE
[R1-PR5] Quality Metrics M1+M3 — Title Overlap + Timestamp Check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ prisma/migrations/*
 !prisma/migrations/video_rich_summaries/
 !prisma/migrations/wizard-precompute/
 !prisma/migrations/llm_call_logs/
+!prisma/migrations/quality_metrics/
 
 # Logs
 logs/

--- a/prisma/migrations/quality_metrics/001_add_metric_columns.sql
+++ b/prisma/migrations/quality_metrics/001_add_metric_columns.sql
@@ -1,0 +1,6 @@
+ALTER TABLE video_rich_summaries ADD COLUMN IF NOT EXISTS m1_title_overlap DOUBLE PRECISION;
+ALTER TABLE video_rich_summaries ADD COLUMN IF NOT EXISTS m3_timestamp_null_ratio DOUBLE PRECISION;
+ALTER TABLE video_rich_summaries ADD COLUMN IF NOT EXISTS m3_timestamp_pattern VARCHAR(20);
+ALTER TABLE video_rich_summaries ADD COLUMN IF NOT EXISTS specificity_score DOUBLE PRECISION;
+
+CREATE INDEX IF NOT EXISTS idx_vrs_specificity ON video_rich_summaries (specificity_score) WHERE specificity_score IS NOT NULL;

--- a/src/api/routes/admin/index.ts
+++ b/src/api/routes/admin/index.ts
@@ -16,6 +16,7 @@ import { adminEnrichmentRoutes } from './enrichment';
 import { adminClawbotRoutes } from './clawbot';
 import { adminEnrichmentSchedulerRoutes } from './enrichment-scheduler';
 import { adminChatbotRoutes } from './chatbot';
+import { adminQualityMetricsRoutes } from './quality-metrics';
 
 /**
  * Admin routes plugin.
@@ -43,5 +44,6 @@ export async function adminRoutes(fastify: FastifyInstance) {
   await fastify.register(adminClawbotRoutes, { prefix: '/clawbot' });
   await fastify.register(adminEnrichmentSchedulerRoutes, { prefix: '/enrichment-scheduler' });
   await fastify.register(adminChatbotRoutes, { prefix: '/chatbot' });
+  await fastify.register(adminQualityMetricsRoutes, { prefix: '/quality-metrics' });
   await fastify.register(stripeWebhookRoutes, { prefix: '/webhooks/stripe' });
 }

--- a/src/api/routes/admin/quality-metrics.ts
+++ b/src/api/routes/admin/quality-metrics.ts
@@ -1,0 +1,277 @@
+/**
+ * Admin Quality Metrics Routes
+ *
+ * POST /api/v1/admin/quality-metrics/recompute — batch-recompute M1+M3 for existing rows
+ * GET  /api/v1/admin/quality-metrics/summary   — aggregate stats across all rows
+ */
+
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { db } from '@/modules/database/client';
+import { createSuccessResponse } from '../../schemas/common.schema';
+import { computeSpecificity } from '@/modules/quality-metrics';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'AdminQualityMetrics' });
+
+const DEFAULT_RECOMPUTE_LIMIT = 1000;
+
+// ============================================================================
+// Schemas
+// ============================================================================
+
+const RecomputeBodySchema = z.object({
+  qualityFlag: z.string().optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+  limit: z.number().int().min(1).max(5000).default(DEFAULT_RECOMPUTE_LIMIT),
+});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+interface RichSummaryRow {
+  video_id: string;
+  structured: unknown;
+  title: string | null;
+}
+
+// ============================================================================
+// Routes
+// ============================================================================
+
+export async function adminQualityMetricsRoutes(fastify: FastifyInstance) {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  /**
+   * POST /api/v1/admin/quality-metrics/recompute
+   * Fetch matching rows, compute M1+M3 metrics, update each row.
+   */
+  fastify.post('/recompute', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
+    const body = RecomputeBodySchema.parse(request.body);
+
+    const conditions: string[] = ['vrs.structured IS NOT NULL'];
+    const params: unknown[] = [];
+    let idx = 1;
+
+    if (body.qualityFlag) {
+      conditions.push(`vrs.quality_flag = $${idx}`);
+      params.push(body.qualityFlag);
+      idx++;
+    }
+    if (body.dateFrom) {
+      conditions.push(`vrs.updated_at >= $${idx}::timestamptz`);
+      params.push(body.dateFrom);
+      idx++;
+    }
+    if (body.dateTo) {
+      conditions.push(`vrs.updated_at <= $${idx}::timestamptz`);
+      params.push(body.dateTo);
+      idx++;
+    }
+
+    params.push(body.limit);
+    const whereClause = conditions.join(' AND ');
+
+    const rows = await db.$queryRawUnsafe<RichSummaryRow[]>(
+      `SELECT
+           vrs.video_id,
+           vrs.structured,
+           yv.title
+         FROM public.video_rich_summaries vrs
+         LEFT JOIN public.youtube_videos yv ON yv.youtube_video_id = vrs.video_id
+         WHERE ${whereClause}
+         LIMIT $${idx}`,
+      ...params
+    );
+
+    let updated = 0;
+    let skipped = 0;
+
+    for (const row of rows) {
+      const title = row.title ?? row.video_id;
+      const structured = row.structured as Record<string, unknown> | null;
+      const metrics = computeSpecificity(title, structured);
+
+      if (!metrics) {
+        skipped++;
+        continue;
+      }
+
+      try {
+        await db.video_rich_summaries.update({
+          where: { video_id: row.video_id },
+          data: {
+            m1_title_overlap: metrics.m1TitleOverlap,
+            m3_timestamp_null_ratio: metrics.m3TimestampNullRatio,
+            m3_timestamp_pattern: metrics.m3TimestampPattern,
+            specificity_score: metrics.specificityScore,
+          },
+        });
+        updated++;
+      } catch (err) {
+        log.error('Failed to update metrics for video', {
+          videoId: row.video_id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        skipped++;
+      }
+    }
+
+    log.info('Quality metrics recompute completed', { updated, skipped, total: rows.length });
+
+    return reply.send(createSuccessResponse({ total: rows.length, updated, skipped }));
+  });
+
+  /**
+   * GET /api/v1/admin/quality-metrics/summary
+   * Aggregate stats: by quality_flag, by schema version, daily averages, outliers.
+   */
+  fastify.get('/summary', adminAuth, async (_request: FastifyRequest, reply: FastifyReply) => {
+    // Total count
+    const [totalRow] = await db.$queryRaw<Array<{ total: bigint }>>`
+        SELECT COUNT(*) AS total FROM public.video_rich_summaries
+      `;
+    const total = Number(totalRow?.total ?? 0);
+
+    // By quality_flag: count + avg/p25/p50/p75 specificity
+    const byFlagRows = await db.$queryRaw<
+      Array<{
+        quality_flag: string | null;
+        cnt: bigint;
+        avg_specificity: number | null;
+        p25: number | null;
+        p50: number | null;
+        p75: number | null;
+      }>
+    >`
+        SELECT
+          quality_flag,
+          COUNT(*)                                                  AS cnt,
+          AVG(specificity_score)                                    AS avg_specificity,
+          PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY specificity_score) AS p25,
+          PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY specificity_score) AS p50,
+          PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY specificity_score) AS p75
+        FROM public.video_rich_summaries
+        GROUP BY quality_flag
+      `;
+
+    const byQualityFlag: Record<
+      string,
+      {
+        count: number;
+        avg_specificity: number | null;
+        p25: number | null;
+        p50: number | null;
+        p75: number | null;
+      }
+    > = {};
+    for (const r of byFlagRows) {
+      const key = r.quality_flag ?? 'null';
+      byQualityFlag[key] = {
+        count: Number(r.cnt),
+        avg_specificity: r.avg_specificity != null ? Number(r.avg_specificity) : null,
+        p25: r.p25 != null ? Number(r.p25) : null,
+        p50: r.p50 != null ? Number(r.p50) : null,
+        p75: r.p75 != null ? Number(r.p75) : null,
+      };
+    }
+
+    // By schema version (V2 = has atoms array, V1 = no atoms)
+    const bySchemaRows = await db.$queryRaw<
+      Array<{
+        schema_version: string;
+        cnt: bigint;
+        avg_m1: number | null;
+        avg_m3_null_ratio: number | null;
+      }>
+    >`
+        SELECT
+          CASE
+            WHEN structured->'atoms' IS NOT NULL THEN 'v2'
+            ELSE 'v1'
+          END                         AS schema_version,
+          COUNT(*)                    AS cnt,
+          AVG(m1_title_overlap)       AS avg_m1,
+          AVG(m3_timestamp_null_ratio) AS avg_m3_null_ratio
+        FROM public.video_rich_summaries
+        WHERE structured IS NOT NULL
+        GROUP BY schema_version
+      `;
+
+    const bySchema: Record<
+      string,
+      { count: number; avg_m1: number | null; avg_m3_null_ratio: number | null | 'N/A' }
+    > = {};
+    for (const r of bySchemaRows) {
+      bySchema[r.schema_version] = {
+        count: Number(r.cnt),
+        avg_m1: r.avg_m1 != null ? Number(r.avg_m1) : null,
+        avg_m3_null_ratio:
+          r.schema_version === 'v1'
+            ? 'N/A'
+            : r.avg_m3_null_ratio != null
+              ? Number(r.avg_m3_null_ratio)
+              : null,
+      };
+    }
+
+    // Daily average specificity (last 30 days)
+    const dailyRows = await db.$queryRaw<
+      Array<{ date: string; avg_specificity: number | null; cnt: bigint }>
+    >`
+        SELECT
+          DATE(updated_at AT TIME ZONE 'UTC') AS date,
+          AVG(specificity_score)              AS avg_specificity,
+          COUNT(*)                            AS cnt
+        FROM public.video_rich_summaries
+        WHERE updated_at >= NOW() - INTERVAL '30 days'
+          AND specificity_score IS NOT NULL
+        GROUP BY DATE(updated_at AT TIME ZONE 'UTC')
+        ORDER BY date DESC
+      `;
+
+    const dailyAvg = dailyRows.map((r) => ({
+      date: r.date,
+      avg_specificity: r.avg_specificity != null ? Number(r.avg_specificity) : null,
+      count: Number(r.cnt),
+    }));
+
+    // Top 10 and bottom 10 by specificity_score
+    const top10 = await db.$queryRaw<Array<{ video_id: string; specificity_score: number }>>`
+        SELECT video_id, specificity_score
+        FROM public.video_rich_summaries
+        WHERE specificity_score IS NOT NULL
+        ORDER BY specificity_score DESC
+        LIMIT 10
+      `;
+
+    const bottom10 = await db.$queryRaw<Array<{ video_id: string; specificity_score: number }>>`
+        SELECT video_id, specificity_score
+        FROM public.video_rich_summaries
+        WHERE specificity_score IS NOT NULL
+        ORDER BY specificity_score ASC
+        LIMIT 10
+      `;
+
+    return reply.send(
+      createSuccessResponse({
+        total,
+        by_quality_flag: byQualityFlag,
+        by_schema: bySchema,
+        daily_avg: dailyAvg,
+        outliers: {
+          top_10: top10.map((r) => ({
+            video_id: r.video_id,
+            specificity_score: Number(r.specificity_score),
+          })),
+          bottom_10: bottom10.map((r) => ({
+            video_id: r.video_id,
+            specificity_score: Number(r.specificity_score),
+          })),
+        },
+      })
+    );
+  });
+}

--- a/src/modules/quality-metrics/index.ts
+++ b/src/modules/quality-metrics/index.ts
@@ -1,0 +1,7 @@
+export { measureTitleOverlap, extractContentTexts } from './title-overlap';
+export {
+  checkTimestamps,
+  type TimestampCheckResult,
+  type TimestampPattern,
+} from './timestamp-check';
+export { computeSpecificity, type SpecificityResult } from './specificity-score';

--- a/src/modules/quality-metrics/specificity-score.ts
+++ b/src/modules/quality-metrics/specificity-score.ts
@@ -25,12 +25,14 @@ export interface SpecificityResult {
  * uniform_fake = 0 (timestamps exist but are fabricated).
  * real = 1 (timestamps are varied, likely genuine).
  * mixed = complement of null ratio.
+ * insufficient = 0.25 (too few non-null to judge confidently).
  * all_null / no_atoms = 0.
  */
 function timestampPatternScore(result: TimestampCheckResult): number {
   if (result.pattern === 'uniform_fake') return 0;
   if (result.pattern === 'real') return 1;
   if (result.pattern === 'mixed') return 1 - result.nullRatio;
+  if (result.pattern === 'insufficient') return 0.25;
   // all_null or no_atoms
   return 0;
 }

--- a/src/modules/quality-metrics/specificity-score.ts
+++ b/src/modules/quality-metrics/specificity-score.ts
@@ -1,0 +1,76 @@
+/**
+ * Specificity Score — combined M1 + M3 quality metric.
+ * Weights: M1 (title overlap) = 0.55, M3 (timestamp quality) = 0.45
+ */
+
+import { measureTitleOverlap, extractContentTexts } from './title-overlap';
+import {
+  checkTimestamps,
+  type TimestampCheckResult,
+  type TimestampPattern,
+} from './timestamp-check';
+
+const M1_WEIGHT = 0.55;
+const M3_WEIGHT = 0.45;
+
+export interface SpecificityResult {
+  m1TitleOverlap: number;
+  m3TimestampNullRatio: number;
+  m3TimestampPattern: TimestampPattern;
+  specificityScore: number | null; // null if not enough data
+}
+
+/**
+ * Convert a TimestampCheckResult into a [0, 1] score.
+ * uniform_fake = 0 (timestamps exist but are fabricated).
+ * real = 1 (timestamps are varied, likely genuine).
+ * mixed = complement of null ratio.
+ * all_null / no_atoms = 0.
+ */
+function timestampPatternScore(result: TimestampCheckResult): number {
+  if (result.pattern === 'uniform_fake') return 0;
+  if (result.pattern === 'real') return 1;
+  if (result.pattern === 'mixed') return 1 - result.nullRatio;
+  // all_null or no_atoms
+  return 0;
+}
+
+/**
+ * Compute M1 + M3 specificity for a single summary.
+ *
+ * @param title - Video title used for M1 calculation
+ * @param structured - Parsed JSON from video_rich_summaries.structured (null-safe)
+ * @returns SpecificityResult, or null if structured is empty/null
+ */
+export function computeSpecificity(
+  title: string,
+  structured: Record<string, unknown> | null
+): SpecificityResult | null {
+  if (!structured || Object.keys(structured).length === 0) return null;
+
+  // M1: Title overlap
+  const contentTexts = extractContentTexts(structured);
+  const m1 = measureTitleOverlap(title, contentTexts);
+
+  // M3: Timestamp check (V2 only — atoms array)
+  const atoms = structured['atoms'] as Array<{ timestamp_sec?: number | null }> | undefined;
+  const m3Result = checkTimestamps(atoms);
+
+  const hasAtoms = Array.isArray(atoms) && atoms.length > 0;
+
+  let specificityScore: number | null;
+  if (hasAtoms) {
+    const m3Score = timestampPatternScore(m3Result);
+    specificityScore = m1 * M1_WEIGHT + m3Score * M3_WEIGHT;
+  } else {
+    // V1: only M1 applies; score equals M1 alone
+    specificityScore = m1;
+  }
+
+  return {
+    m1TitleOverlap: m1,
+    m3TimestampNullRatio: m3Result.nullRatio,
+    m3TimestampPattern: m3Result.pattern,
+    specificityScore,
+  };
+}

--- a/src/modules/quality-metrics/timestamp-check.ts
+++ b/src/modules/quality-metrics/timestamp-check.ts
@@ -1,24 +1,28 @@
 /**
  * M3: Timestamp Quality Check — measures whether atom timestamps
  * are real (derived from actual video segments) or fabricated.
+ *
+ * Uniformity detection uses coefficient of variation (CV) on non-null
+ * timestamp intervals.  CV < 0.1 → uniform_fake, regardless of whether
+ * some atoms have null timestamps.
  */
 
-/** Maximum deviation from average interval to still be considered "uniform" (seconds). */
-const UNIFORM_TOLERANCE_SEC = 5;
+const MIN_NON_NULL_FOR_UNIFORMITY = 3;
+const UNIFORMITY_CV_THRESHOLD = 0.1;
 
-export type TimestampPattern = 'all_null' | 'uniform_fake' | 'real' | 'mixed' | 'no_atoms';
+export type TimestampPattern =
+  | 'all_null'
+  | 'uniform_fake'
+  | 'mixed'
+  | 'real'
+  | 'insufficient'
+  | 'no_atoms';
 
 export interface TimestampCheckResult {
   nullRatio: number;
   pattern: TimestampPattern;
 }
 
-/**
- * Inspect atom timestamps and classify their pattern.
- *
- * @param atoms - Array of atoms from a V2 structured summary (undefined = V1 / no atoms)
- * @returns null ratio (0–1) and a pattern classification
- */
 export function checkTimestamps(
   atoms: Array<{ timestamp_sec?: number | null }> | undefined
 ): TimestampCheckResult {
@@ -29,36 +33,35 @@ export function checkTimestamps(
   const nullCount = atoms.filter((a) => a.timestamp_sec == null).length;
   const nullRatio = nullCount / atoms.length;
 
-  // All null
   if (nullCount === atoms.length) {
     return { nullRatio: 1, pattern: 'all_null' };
   }
 
-  // Mixed (some null, some not)
-  if (nullCount > 0) {
-    return { nullRatio, pattern: 'mixed' };
+  const nonNullTs = atoms
+    .map((a) => a.timestamp_sec)
+    .filter((ts): ts is number => ts != null)
+    .sort((a, b) => a - b);
+
+  if (nonNullTs.length < MIN_NON_NULL_FOR_UNIFORMITY) {
+    return { nullRatio, pattern: 'insufficient' };
   }
 
-  // All have timestamps — check if uniform (fake) or varied (real)
-  const timestamps = atoms.map((a) => a.timestamp_sec!).sort((a, b) => a - b);
-
-  if (timestamps.length < 2) {
-    return { nullRatio: 0, pattern: 'real' }; // single atom, cannot determine uniformity
-  }
-
-  // Calculate intervals between consecutive timestamps
   const intervals: number[] = [];
-  for (let i = 1; i < timestamps.length; i++) {
-    const prev = timestamps[i - 1] ?? 0;
-    const curr = timestamps[i] ?? 0;
-    intervals.push(curr - prev);
+  for (let i = 1; i < nonNullTs.length; i++) {
+    intervals.push(nonNullTs[i]! - nonNullTs[i - 1]!);
   }
 
-  const avgInterval = intervals.reduce((a, b) => a + b, 0) / intervals.length;
-  const isUniform = intervals.every((iv) => Math.abs(iv - avgInterval) <= UNIFORM_TOLERANCE_SEC);
+  const mean = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+  const isUniform = mean > 0 && coefficientOfVariation(intervals, mean) < UNIFORMITY_CV_THRESHOLD;
 
-  return {
-    nullRatio: 0,
-    pattern: isUniform ? 'uniform_fake' : 'real',
-  };
+  if (isUniform) {
+    return { nullRatio, pattern: 'uniform_fake' };
+  }
+
+  return { nullRatio, pattern: nullCount > 0 ? 'mixed' : 'real' };
+}
+
+function coefficientOfVariation(values: number[], mean: number): number {
+  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / values.length;
+  return Math.sqrt(variance) / mean;
 }

--- a/src/modules/quality-metrics/timestamp-check.ts
+++ b/src/modules/quality-metrics/timestamp-check.ts
@@ -1,0 +1,64 @@
+/**
+ * M3: Timestamp Quality Check — measures whether atom timestamps
+ * are real (derived from actual video segments) or fabricated.
+ */
+
+/** Maximum deviation from average interval to still be considered "uniform" (seconds). */
+const UNIFORM_TOLERANCE_SEC = 5;
+
+export type TimestampPattern = 'all_null' | 'uniform_fake' | 'real' | 'mixed' | 'no_atoms';
+
+export interface TimestampCheckResult {
+  nullRatio: number;
+  pattern: TimestampPattern;
+}
+
+/**
+ * Inspect atom timestamps and classify their pattern.
+ *
+ * @param atoms - Array of atoms from a V2 structured summary (undefined = V1 / no atoms)
+ * @returns null ratio (0–1) and a pattern classification
+ */
+export function checkTimestamps(
+  atoms: Array<{ timestamp_sec?: number | null }> | undefined
+): TimestampCheckResult {
+  if (!atoms || atoms.length === 0) {
+    return { nullRatio: 1, pattern: 'no_atoms' };
+  }
+
+  const nullCount = atoms.filter((a) => a.timestamp_sec == null).length;
+  const nullRatio = nullCount / atoms.length;
+
+  // All null
+  if (nullCount === atoms.length) {
+    return { nullRatio: 1, pattern: 'all_null' };
+  }
+
+  // Mixed (some null, some not)
+  if (nullCount > 0) {
+    return { nullRatio, pattern: 'mixed' };
+  }
+
+  // All have timestamps — check if uniform (fake) or varied (real)
+  const timestamps = atoms.map((a) => a.timestamp_sec!).sort((a, b) => a - b);
+
+  if (timestamps.length < 2) {
+    return { nullRatio: 0, pattern: 'real' }; // single atom, cannot determine uniformity
+  }
+
+  // Calculate intervals between consecutive timestamps
+  const intervals: number[] = [];
+  for (let i = 1; i < timestamps.length; i++) {
+    const prev = timestamps[i - 1] ?? 0;
+    const curr = timestamps[i] ?? 0;
+    intervals.push(curr - prev);
+  }
+
+  const avgInterval = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+  const isUniform = intervals.every((iv) => Math.abs(iv - avgInterval) <= UNIFORM_TOLERANCE_SEC);
+
+  return {
+    nullRatio: 0,
+    pattern: isUniform ? 'uniform_fake' : 'real',
+  };
+}

--- a/src/modules/quality-metrics/title-overlap.ts
+++ b/src/modules/quality-metrics/title-overlap.ts
@@ -1,0 +1,180 @@
+/**
+ * M1: Title-Content Overlap — measures how much of the video title
+ * is reflected in the structured summary content.
+ */
+
+// Korean stopwords (common particles/suffixes that add no specificity)
+const KO_STOPWORDS = new Set([
+  '의',
+  '가',
+  '이',
+  '은',
+  '는',
+  '을',
+  '를',
+  '에',
+  '에서',
+  '와',
+  '과',
+  '도',
+  '로',
+  '으로',
+  '에게',
+  '한',
+  '하는',
+  '된',
+  '하다',
+  '있다',
+  '없다',
+  '것',
+  '수',
+  '등',
+  '및',
+  '더',
+  '또',
+  '그',
+  '이런',
+  '저런',
+  '그런',
+  '위한',
+  '대한',
+  '통한',
+  '관한',
+]);
+
+// English stopwords
+const EN_STOPWORDS = new Set([
+  'the',
+  'a',
+  'an',
+  'is',
+  'are',
+  'was',
+  'were',
+  'be',
+  'been',
+  'being',
+  'have',
+  'has',
+  'had',
+  'do',
+  'does',
+  'did',
+  'will',
+  'would',
+  'could',
+  'should',
+  'may',
+  'might',
+  'can',
+  'shall',
+  'to',
+  'of',
+  'in',
+  'for',
+  'on',
+  'with',
+  'at',
+  'by',
+  'from',
+  'as',
+  'into',
+  'through',
+  'during',
+  'before',
+  'after',
+  'above',
+  'below',
+  'between',
+  'and',
+  'but',
+  'or',
+  'not',
+  'no',
+  'nor',
+  'so',
+  'if',
+  'then',
+  'than',
+  'that',
+  'this',
+  'these',
+  'those',
+  'it',
+  'its',
+  'how',
+  'what',
+  'which',
+  'who',
+  'whom',
+]);
+
+const MIN_TOKEN_LENGTH = 2;
+
+/**
+ * Tokenize text into a deduplicated set of meaningful lowercase tokens.
+ * Strips punctuation, splits on whitespace, and removes stopwords.
+ */
+function tokenize(text: string): Set<string> {
+  const tokens = text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ') // keep letters and numbers
+    .split(/\s+/)
+    .filter((t) => t.length >= MIN_TOKEN_LENGTH)
+    .filter((t) => !KO_STOPWORDS.has(t) && !EN_STOPWORDS.has(t));
+  return new Set(tokens);
+}
+
+/**
+ * Measure the fraction of title tokens that appear in contentTexts.
+ *
+ * @param title - Video title
+ * @param contentTexts - Flat array of text strings extracted from the summary
+ * @returns Overlap ratio in [0, 1]. Returns 0 if title has no meaningful tokens.
+ */
+export function measureTitleOverlap(title: string, contentTexts: string[]): number {
+  const titleTokens = tokenize(title);
+  if (titleTokens.size === 0) return 0;
+
+  const contentText = contentTexts.join(' ');
+  const contentTokens = tokenize(contentText);
+
+  let matchCount = 0;
+  for (const token of titleTokens) {
+    if (contentTokens.has(token)) matchCount++;
+  }
+
+  return matchCount / titleTokens.size;
+}
+
+/**
+ * Extract flat array of content text strings from a structured summary (V1 or V2).
+ * Covers atoms (V2), key_points (V1), core_argument, tl_dr_ko, tl_dr_en.
+ */
+export function extractContentTexts(structured: Record<string, unknown>): string[] {
+  const texts: string[] = [];
+
+  // V2: atoms
+  const atoms = structured['atoms'] as Array<{ text?: string }> | undefined;
+  if (Array.isArray(atoms)) {
+    for (const atom of atoms) {
+      if (atom.text) texts.push(atom.text);
+    }
+  }
+
+  // V1: key_points
+  const keyPoints = structured['key_points'] as Array<{ text?: string } | string> | undefined;
+  if (Array.isArray(keyPoints)) {
+    for (const kp of keyPoints) {
+      if (typeof kp === 'string') texts.push(kp);
+      else if (kp.text) texts.push(kp.text);
+    }
+  }
+
+  // Also include core_argument, tl_dr_ko, tl_dr_en
+  if (typeof structured['core_argument'] === 'string') texts.push(structured['core_argument']);
+  if (typeof structured['tl_dr_ko'] === 'string') texts.push(structured['tl_dr_ko']);
+  if (typeof structured['tl_dr_en'] === 'string') texts.push(structured['tl_dr_en']);
+
+  return texts;
+}

--- a/src/modules/skills/rich-summary.ts
+++ b/src/modules/skills/rich-summary.ts
@@ -16,6 +16,7 @@ import { isV2Summary, type RichSummary } from './rich-summary-types';
 import { loadRichSummaryConfig } from '@/config/rich-summary';
 import { assertRichSummaryQuota } from './rich-summary-quota';
 import { bridgeRichSummaryToKG } from '@/modules/ontology/kg-bridge';
+import { computeSpecificity } from '@/modules/quality-metrics';
 import { Prisma } from '@prisma/client';
 
 export interface RichSummarySegment {
@@ -209,6 +210,30 @@ export async function enrichRichSummary(
           score: result.score,
           attempt,
         });
+
+        // Quality metrics: compute M1 + M3 specificity and persist (non-fatal)
+        const metrics = computeSpecificity(
+          options.title,
+          structured as unknown as Record<string, unknown>
+        );
+        if (metrics) {
+          prisma.video_rich_summaries
+            .update({
+              where: { video_id: videoId },
+              data: {
+                m1_title_overlap: metrics.m1TitleOverlap,
+                m3_timestamp_null_ratio: metrics.m3TimestampNullRatio,
+                m3_timestamp_pattern: metrics.m3TimestampPattern,
+                specificity_score: metrics.specificityScore,
+              },
+            })
+            .catch((err: unknown) => {
+              log.error('Failed to save quality metrics', {
+                videoId,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            });
+        }
 
         // KG Bridge: auto-convert v2 summaries to ontology nodes/edges (#506)
         if (isV2Summary(structured)) {

--- a/tests/smoke/quality-metrics.test.ts
+++ b/tests/smoke/quality-metrics.test.ts
@@ -84,7 +84,36 @@ describe('checkTimestamps', () => {
     expect(result.nullRatio).toBe(0);
   });
 
-  it('returns mixed with correct null ratio when some timestamps are null', () => {
+  it('returns uniform_fake when non-null timestamps are uniformly spaced despite nulls', () => {
+    // Sample 4 pattern: [120, 180, 240, 300, 360, 420, 480, None]
+    const atoms = [
+      { timestamp_sec: 120 },
+      { timestamp_sec: 180 },
+      { timestamp_sec: 240 },
+      { timestamp_sec: 300 },
+      { timestamp_sec: 360 },
+      { timestamp_sec: 420 },
+      { timestamp_sec: 480 },
+      { timestamp_sec: null },
+    ];
+    const result = checkTimestamps(atoms);
+    expect(result.pattern).toBe('uniform_fake');
+    expect(result.nullRatio).toBeCloseTo(0.125);
+  });
+
+  it('returns mixed when non-null timestamps vary and some are null', () => {
+    const atoms = [
+      { timestamp_sec: 5 },
+      { timestamp_sec: null },
+      { timestamp_sec: 91 },
+      { timestamp_sec: 200 },
+    ];
+    const result = checkTimestamps(atoms);
+    expect(result.pattern).toBe('mixed');
+    expect(result.nullRatio).toBeCloseTo(0.25);
+  });
+
+  it('returns insufficient when fewer than 3 non-null timestamps', () => {
     const atoms = [
       { timestamp_sec: 30 },
       { timestamp_sec: null },
@@ -92,7 +121,7 @@ describe('checkTimestamps', () => {
       { timestamp_sec: null },
     ];
     const result = checkTimestamps(atoms);
-    expect(result.pattern).toBe('mixed');
+    expect(result.pattern).toBe('insufficient');
     expect(result.nullRatio).toBeCloseTo(0.5);
   });
 

--- a/tests/smoke/quality-metrics.test.ts
+++ b/tests/smoke/quality-metrics.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Quality Metrics — unit tests for M1 (title overlap) + M3 (timestamp check) + combined score.
+ */
+
+import {
+  measureTitleOverlap,
+  extractContentTexts,
+} from '../../src/modules/quality-metrics/title-overlap';
+import { checkTimestamps } from '../../src/modules/quality-metrics/timestamp-check';
+import { computeSpecificity } from '../../src/modules/quality-metrics/specificity-score';
+
+// ============================================================================
+// M1: measureTitleOverlap
+// ============================================================================
+
+describe('measureTitleOverlap', () => {
+  it('returns overlap ratio for Korean title vs atom texts', () => {
+    const title = '파이썬 머신러닝 입문 강좌';
+    const texts = ['파이썬을 사용하여 머신러닝 모델을 학습합니다.', '입문자를 위한 기초 개념 설명'];
+    const ratio = measureTitleOverlap(title, texts);
+    // "파이썬", "머신러닝", "입문" should partially match (Korean particles prevent exact match for some)
+    expect(ratio).toBeGreaterThan(0.2);
+    expect(ratio).toBeLessThanOrEqual(1);
+  });
+
+  it('returns overlap ratio for English title', () => {
+    const title = 'machine learning python tutorial beginners';
+    const texts = [
+      'This tutorial covers machine learning fundamentals using Python.',
+      'Designed for beginners with no prior knowledge.',
+    ];
+    const ratio = measureTitleOverlap(title, texts);
+    // "machine", "learning", "python", "tutorial", "beginners" — most should match
+    expect(ratio).toBeGreaterThan(0.5);
+    expect(ratio).toBeLessThanOrEqual(1);
+  });
+
+  it('returns 0 when content texts are empty', () => {
+    const ratio = measureTitleOverlap('파이썬 강좌', []);
+    expect(ratio).toBe(0);
+  });
+
+  it('returns 0 when title has only stopwords', () => {
+    const ratio = measureTitleOverlap('the a an is', ['some content here']);
+    expect(ratio).toBe(0);
+  });
+});
+
+// ============================================================================
+// M3: checkTimestamps
+// ============================================================================
+
+describe('checkTimestamps', () => {
+  it('returns all_null when all atom timestamps are null', () => {
+    const atoms = [{ timestamp_sec: null }, { timestamp_sec: null }, { timestamp_sec: null }];
+    const result = checkTimestamps(atoms);
+    expect(result.pattern).toBe('all_null');
+    expect(result.nullRatio).toBe(1);
+  });
+
+  it('returns uniform_fake when intervals are all equal (60s each)', () => {
+    const atoms = [
+      { timestamp_sec: 0 },
+      { timestamp_sec: 60 },
+      { timestamp_sec: 120 },
+      { timestamp_sec: 180 },
+      { timestamp_sec: 240 },
+    ];
+    const result = checkTimestamps(atoms);
+    expect(result.pattern).toBe('uniform_fake');
+    expect(result.nullRatio).toBe(0);
+  });
+
+  it('returns real when intervals vary significantly', () => {
+    const atoms = [
+      { timestamp_sec: 5 },
+      { timestamp_sec: 43 },
+      { timestamp_sec: 91 },
+      { timestamp_sec: 200 },
+      { timestamp_sec: 310 },
+    ];
+    const result = checkTimestamps(atoms);
+    expect(result.pattern).toBe('real');
+    expect(result.nullRatio).toBe(0);
+  });
+
+  it('returns mixed with correct null ratio when some timestamps are null', () => {
+    const atoms = [
+      { timestamp_sec: 30 },
+      { timestamp_sec: null },
+      { timestamp_sec: 90 },
+      { timestamp_sec: null },
+    ];
+    const result = checkTimestamps(atoms);
+    expect(result.pattern).toBe('mixed');
+    expect(result.nullRatio).toBeCloseTo(0.5);
+  });
+
+  it('returns no_atoms when atoms array is undefined', () => {
+    const result = checkTimestamps(undefined);
+    expect(result.pattern).toBe('no_atoms');
+    expect(result.nullRatio).toBe(1);
+  });
+
+  it('returns no_atoms when atoms array is empty', () => {
+    const result = checkTimestamps([]);
+    expect(result.pattern).toBe('no_atoms');
+    expect(result.nullRatio).toBe(1);
+  });
+});
+
+// ============================================================================
+// computeSpecificity
+// ============================================================================
+
+describe('computeSpecificity', () => {
+  it('returns high specificity for V2 with real timestamps and matching title', () => {
+    const title = 'Python machine learning tutorial';
+    const structured = {
+      core_argument: 'A practical guide to machine learning with Python.',
+      atoms: [
+        { text: 'Python is used for machine learning models.', timestamp_sec: 5 },
+        { text: 'Tutorial covers scikit-learn basics.', timestamp_sec: 43 },
+        { text: 'Real-world examples help beginners learn quickly.', timestamp_sec: 200 },
+        { text: 'Advanced topics covered at the end.', timestamp_sec: 410 },
+      ],
+      tl_dr_en: 'A hands-on Python machine learning tutorial for beginners.',
+    };
+
+    const result = computeSpecificity(title, structured);
+    expect(result).not.toBeNull();
+    expect(result!.m3TimestampPattern).toBe('real');
+    // M1 should be high (python, machine, learning, tutorial all match)
+    expect(result!.m1TitleOverlap).toBeGreaterThan(0.4);
+    // Combined score should be meaningful
+    expect(result!.specificityScore).toBeGreaterThan(0.2);
+  });
+
+  it('returns low M3 score for V2 with uniform_fake timestamps', () => {
+    const title = 'Python tutorial basics';
+    const structured = {
+      core_argument: 'Python tutorial for beginners.',
+      atoms: [
+        { text: 'Python basics explained.', timestamp_sec: 0 },
+        { text: 'Variables and types in Python.', timestamp_sec: 60 },
+        { text: 'Control flow in Python.', timestamp_sec: 120 },
+        { text: 'Functions in Python.', timestamp_sec: 180 },
+      ],
+      tl_dr_en: 'Python basics tutorial.',
+    };
+
+    const result = computeSpecificity(title, structured);
+    expect(result).not.toBeNull();
+    expect(result!.m3TimestampPattern).toBe('uniform_fake');
+    // specificity_score = M1 * 0.55 + 0 * 0.45 — M3 contributes 0
+    expect(result!.specificityScore).toBeCloseTo(result!.m1TitleOverlap * 0.55, 5);
+  });
+
+  it('uses only M1 for V1 summaries (no atoms)', () => {
+    const title = '파이썬 머신러닝 강좌';
+    const structured = {
+      core_argument: '파이썬으로 머신러닝을 배우는 강좌입니다.',
+      key_points: ['파이썬 기초 문법 설명', '머신러닝 알고리즘 소개', '실습 예제 제공'],
+    };
+
+    const result = computeSpecificity(title, structured);
+    expect(result).not.toBeNull();
+    expect(result!.m3TimestampPattern).toBe('no_atoms');
+    // V1 → specificityScore === m1TitleOverlap
+    expect(result!.specificityScore).toBeCloseTo(result!.m1TitleOverlap, 10);
+  });
+
+  it('returns null for null structured input', () => {
+    const result = computeSpecificity('some title', null);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty structured object', () => {
+    const result = computeSpecificity('some title', {});
+    expect(result).toBeNull();
+  });
+});
+
+// ============================================================================
+// extractContentTexts
+// ============================================================================
+
+describe('extractContentTexts', () => {
+  it('extracts V2 atom texts', () => {
+    const structured = {
+      atoms: [{ text: 'Atom one.' }, { text: 'Atom two.' }],
+    };
+    const texts = extractContentTexts(structured);
+    expect(texts).toContain('Atom one.');
+    expect(texts).toContain('Atom two.');
+  });
+
+  it('extracts V1 key_points as strings', () => {
+    const structured = {
+      key_points: ['Point A', 'Point B'],
+    };
+    const texts = extractContentTexts(structured);
+    expect(texts).toContain('Point A');
+    expect(texts).toContain('Point B');
+  });
+
+  it('includes core_argument, tl_dr_ko, tl_dr_en', () => {
+    const structured = {
+      core_argument: 'Core thesis.',
+      tl_dr_ko: '핵심 요약.',
+      tl_dr_en: 'Core summary.',
+    };
+    const texts = extractContentTexts(structured);
+    expect(texts).toContain('Core thesis.');
+    expect(texts).toContain('핵심 요약.');
+    expect(texts).toContain('Core summary.');
+  });
+});


### PR DESCRIPTION
## Summary
- M1 `title-overlap.ts` — Korean/English stopword-aware token matching
- M3 `timestamp-check.ts` — null ratio + **uniform_fake CV detection** (null-tolerant, CV < 0.1)
- `specificity-score.ts` — weighted M1(0.55) + M3(0.45) combined metric
- 4 new columns on `video_rich_summaries` + raw DDL + partial index
- `admin/quality-metrics.ts` — POST /recompute + GET /summary
- Enrichment hook in `rich-summary.ts` (fire-and-forget)
- 20 unit tests (all pass)

### M3 Fix (f351206)
Original logic skipped uniformity check when any null timestamp existed.
Sample 4 ([120,180,...,480,None] — 60s intervals) was falsely classified as `mixed` (score 0.76).
Fixed: extracts non-null timestamps, uses coefficient of variation < 0.1 → now correctly `uniform_fake` (score 0.37).

## Round 1
Part of #530 (Rich Summary Quality Engine Round 1). Closes #536.

## Merge Order
Merge **after** PR #540 (cost tracking). Prisma schema is byte-identical — clean rebase.

## Test plan
- [x] `npx jest tests/smoke/quality-metrics.test.ts` — 20/20 pass
- [x] `npx tsc --noEmit` — clean
- [x] 13-sample offline specificity verified (Sample 4: 0.76 → 0.37, uniform_fake)
- [ ] Post-merge: apply `prisma/migrations/quality_metrics/001_add_metric_columns.sql`
- [ ] Post-merge: `POST /api/v1/admin/quality-metrics/recompute` for 903 prod rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)