### PR TITLE
[R1-PR2] Rich Summary Hotfix 4 — JSON Mode + Token Limit + One-liner Gate

### DIFF
--- a/prisma/migrations/video_rich_summaries/003_backfill_null_structured.sql
+++ b/prisma/migrations/video_rich_summaries/003_backfill_null_structured.sql
@@ -1,0 +1,15 @@
+-- Backfill: convert structured='{}' to NULL for low-quality rows.
+--
+-- Root cause: the original upsert path for quality_flag='low' stored `{}`
+-- instead of NULL when structured generation failed. The production code path
+-- now correctly writes Prisma.JsonNull, but historical rows remain as `{}`.
+--
+-- Impact: ~103 rows (as of 2026-04-27). Affects only quality_flag='low' rows.
+-- No pass rows are affected (pass rows always have a non-empty structured object).
+--
+-- Run: psql "$DIRECT_URL" -f prisma/migrations/video_rich_summaries/003_backfill_null_structured.sql
+
+UPDATE video_rich_summaries
+SET structured = NULL
+WHERE quality_flag = 'low'
+  AND structured = '{}'::jsonb;

--- a/src/modules/skills/rich-summary.ts
+++ b/src/modules/skills/rich-summary.ts
@@ -11,7 +11,7 @@
 import { getPrismaClient } from '@/modules/database/client';
 import { createGenerationProvider } from '@/modules/llm';
 import { logger } from '@/utils/logger';
-import { checkSummaryQuality } from './summary-gate';
+import { checkSummaryQuality, validateOneLiner } from './summary-gate';
 import { isV2Summary, type RichSummary } from './rich-summary-types';
 import { loadRichSummaryConfig } from '@/config/rich-summary';
 import { assertRichSummaryQuota } from './rich-summary-quota';
@@ -37,6 +37,8 @@ const TRANSCRIPT_CHUNK_SIZE = 3000;
 const DESCRIPTION_CHUNK_SIZE = 1000;
 const DESCRIPTION_PROMPT_LIMIT = 500;
 const TIMESTAMPED_SEGMENTS_LIMIT = 120; // cap timestamped lines passed to LLM
+// V2 schema responses can reach ~1000-1350 tokens; 1024 caused silent truncation.
+const RICH_SUMMARY_MAX_TOKENS = 4096;
 
 // ---------------------------------------------------------------------------
 // Prompts — v2 (KG Bridge + Learning Interface, #500)
@@ -173,8 +175,10 @@ export async function enrichRichSummary(
   });
 
   const generationProvider = await createGenerationProvider();
-  const generate = (prompt: string, opts?: { format?: 'json' | 'text'; temperature?: number }) =>
-    generationProvider.generate(prompt, opts);
+  const generate = (
+    prompt: string,
+    opts?: { format?: 'json' | 'text'; temperature?: number; maxTokens?: number }
+  ) => generationProvider.generate(prompt, opts);
 
   const transcriptChunk = options.transcript
     ? options.transcript.slice(0, TRANSCRIPT_CHUNK_SIZE)
@@ -189,12 +193,25 @@ export async function enrichRichSummary(
         .replace('{transcript_chunk}', transcriptChunk)
         .replace('{segments_block}', segmentsBlock);
 
-      const raw = await generate(prompt, { format: 'json', temperature: 0.3 });
+      const raw = await generate(prompt, {
+        format: 'json',
+        temperature: 0.3,
+        maxTokens: RICH_SUMMARY_MAX_TOKENS,
+      });
       const structured = JSON.parse(raw.trim()) as RichSummary;
       const result = checkSummaryQuality(structured);
 
       if (result.passed) {
-        const oneLiner = structured.core_argument ?? '';
+        const rawOneLiner = structured.core_argument ?? '';
+        const oneLinerCheck = validateOneLiner(rawOneLiner);
+        if (!oneLinerCheck.valid) {
+          log.warn('one_liner validation failed — storing empty string', {
+            videoId,
+            reason: oneLinerCheck.reason,
+            length: rawOneLiner.length,
+          });
+        }
+        const oneLiner = oneLinerCheck.valid ? rawOneLiner : '';
 
         await upsertRichSummary(prisma, videoId, {
           oneLiner,

--- a/src/modules/skills/summary-gate.ts
+++ b/src/modules/skills/summary-gate.ts
@@ -20,6 +20,7 @@ export { isV2Summary };
 // ============================================================================
 
 const PASS_THRESHOLD = 0.7;
+const ONE_LINER_MAX_LENGTH = 200;
 
 const HALLUCINATION_PATTERNS = [
   /as an ai/i,
@@ -45,6 +46,48 @@ const COT_LEAKAGE_PATTERNS = [
 const VALID_CONTENT_TYPES = new Set(['tutorial', 'opinion', 'research', 'news', 'entertainment']);
 
 const VALID_DEPTH_LEVELS = new Set(['beginner', 'intermediate', 'advanced']);
+
+// ============================================================================
+// one_liner validation
+// ============================================================================
+
+/**
+ * Validate the one_liner string extracted from core_argument.
+ *
+ * PR 3-3 confirmed: all passing rows have one_liner <= 142 chars (max observed).
+ * The 200-char threshold is therefore safe — no retroactive impact on pass rows.
+ *
+ * @returns `{ valid: true }` when the string passes all checks.
+ * @returns `{ valid: false, reason }` on the first failing check.
+ */
+export function validateOneLiner(oneLiner: string | undefined): {
+  valid: boolean;
+  reason?: string;
+} {
+  // Empty / undefined is allowed — handled upstream (empty one_liner stored as '')
+  if (!oneLiner) return { valid: true };
+
+  // Length check — CoT leakage typically produces 2000+ char "sentences"
+  if (oneLiner.length > ONE_LINER_MAX_LENGTH) {
+    return { valid: false, reason: 'one_liner_overflow' };
+  }
+
+  // CoT leakage — same patterns used for full structured validation
+  for (const pattern of COT_LEAKAGE_PATTERNS) {
+    if (pattern.test(oneLiner)) {
+      return { valid: false, reason: 'one_liner_cot_leakage' };
+    }
+  }
+
+  // Hallucination signals
+  for (const pattern of HALLUCINATION_PATTERNS) {
+    if (pattern.test(oneLiner)) {
+      return { valid: false, reason: 'one_liner_hallucination' };
+    }
+  }
+
+  return { valid: true };
+}
 
 // ============================================================================
 // Score weights

--- a/tests/unit/modules/summary-gate.test.ts
+++ b/tests/unit/modules/summary-gate.test.ts
@@ -5,7 +5,11 @@
  * Interface contract: check(summary) → { score, passed, action, reasons }
  */
 
-import { checkSummaryQuality, type RichSummary } from '../../../src/modules/skills/summary-gate';
+import {
+  checkSummaryQuality,
+  validateOneLiner,
+  type RichSummary,
+} from '../../../src/modules/skills/summary-gate';
 
 // ============================================================================
 // Fixtures
@@ -175,5 +179,77 @@ describe('checkSummaryQuality', () => {
       expect(['use', 'retry', 'fallback']).toContain(result.action);
       expect(Array.isArray(result.reasons)).toBe(true);
     });
+  });
+});
+
+// ============================================================================
+// validateOneLiner
+// ============================================================================
+
+describe('validateOneLiner', () => {
+  it('returns valid:true for a normal short string', () => {
+    const result = validateOneLiner('Node.js로 REST API 구축하는 법을 배웁니다');
+    expect(result.valid).toBe(true);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('returns valid:true for undefined (empty is allowed)', () => {
+    const result = validateOneLiner(undefined);
+    expect(result.valid).toBe(true);
+  });
+
+  it('returns valid:true for empty string (empty is allowed)', () => {
+    const result = validateOneLiner('');
+    expect(result.valid).toBe(true);
+  });
+
+  it('returns valid:false with reason one_liner_overflow when length > 200', () => {
+    // 201-char string
+    const longString = 'a'.repeat(201);
+    const result = validateOneLiner(longString);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('one_liner_overflow');
+  });
+
+  it('returns valid:true for a string of exactly 200 chars (boundary)', () => {
+    // Use a realistic sentence repeated to hit exactly 200 chars.
+    // Cannot use 'a'.repeat(200) — that triggers the repeated-char hallucination pattern.
+    const unit = 'Node.js로 REST API를 구축하는 실용 가이드입니다. ';
+    const boundary = unit.repeat(Math.ceil(200 / unit.length)).slice(0, 200);
+    expect(boundary.length).toBe(200);
+    const result = validateOneLiner(boundary);
+    expect(result.valid).toBe(true);
+  });
+
+  it('returns valid:false with reason one_liner_cot_leakage for <think> pattern', () => {
+    const result = validateOneLiner('<think>Let me analyze this video carefully</think>');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('one_liner_cot_leakage');
+  });
+
+  it('returns valid:false with reason one_liner_cot_leakage for reasoning preamble', () => {
+    const result = validateOneLiner('Let me start by summarizing the content here');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('one_liner_cot_leakage');
+  });
+
+  it('returns valid:false with reason one_liner_hallucination for "as an AI" pattern', () => {
+    const result = validateOneLiner('As an AI, I think this video covers machine learning basics');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('one_liner_hallucination');
+  });
+
+  it('returns valid:false with reason one_liner_hallucination for Korean apology', () => {
+    const result = validateOneLiner('죄송합니다 이 영상은 요약이 어렵습니다');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('one_liner_hallucination');
+  });
+
+  it('length check takes priority over CoT check (overflow detected first)', () => {
+    // >200 chars AND contains CoT pattern — overflow reported first
+    const overflowWithCoT = 'Let me start: ' + 'a'.repeat(200);
+    const result = validateOneLiner(overflowWithCoT);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('one_liner_overflow');
   });
 });


### PR DESCRIPTION
## Summary
4 fixes targeting V2 schema success rate (H1.1–H1.4):

1. **response_format** (H1.1): OpenRouter `format:'json'` silently dropped → add `response_format: { type: 'json_object' }` to request body
2. **maxTokens** (H1.2): DEFAULT_MAX_TOKENS=1024 insufficient for V2 (~1000-1350 tokens) → `RICH_SUMMARY_MAX_TOKENS = 4096`
3. **validateOneLiner** (H1.3): 2 prod rows with 2068/3098 char CoT leaks → 200-char limit + pattern detection
4. **null consistency** (H1.4): 103 low rows have `structured = {}` instead of null → backfill SQL

## Cross-dependencies
- `openrouter.ts` imports `logLLMCall` from PR #540 (cost tracking)
- `rich-summary.ts` imports `computeSpecificity` from PR #541 (quality metrics)
- **Must merge after both #540 and #541**

## Round 1
Part of #530 (Rich Summary Quality Engine Round 1). Closes #537.

## Merge Order
Merge **last** — after PR #540 + PR #541. Rebase required to resolve `openrouter.ts` and `rich-summary.ts` conflicts.

## Test plan
- [x] `npx jest tests/unit/modules/summary-gate.test.ts` — 28/28 pass
- [x] Retroactive reject impact: 0 pass rows affected (max pass one_liner = 142 chars < 200)
- [ ] Post-merge: run backfill SQL on prod
- [ ] Post-merge: trigger rich summary → verify V2 structured response

🤖 Generated with [Claude Code](https://claude.com/claude-code)