### PR TITLE
fix(mandala-search): raise hard floor to 0.4 + drop min-results fallback (#543)

### DIFF
--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -703,13 +703,14 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       // their sum.
       const t0 = Date.now();
       const templatePromise = searchMandalasByGoal(trimmedGoal, {
-        limit: 4,
-        threshold: 0.3,
+        limit: 5,
+        threshold: 0.4,
         language: lang,
       })
         .then((templates) => {
           write('template_found', {
             templates,
+            hasResults: templates.length > 0,
             duration_ms: Date.now() - t0,
           });
           return templates;

--- a/src/modules/mandala/search.ts
+++ b/src/modules/mandala/search.ts
@@ -46,11 +46,28 @@ const DEFAULT_LIMIT = 5;
 // CP358: Lowered from 0.5 to 0.3 after prod cosine sim measurement showed
 // "행복한 가족" → top match was 0.4166 against 1001 KO templates. dev's
 // data distribution clustered tighter; prod's broader template set produces
-// lower max sim values, so 0.5 always returned []. Minimum results below
-// also guarantees we never return an empty list when ANY data exists.
-const DEFAULT_THRESHOLD = 0.3;
-/** When threshold filter would return 0 rows, fall back to top-N regardless. */
-const MIN_RESULTS_GUARANTEE = 3;
+// lower max sim values, so 0.5 always returned []. Raised back to 0.4 after
+// MIN_RESULTS_GUARANTEE fallback was removed — fallback caused "수학" → "주짓수"
+// (0.05 cosine similarity) because it returned top-N without any floor.
+const DEFAULT_THRESHOLD = 0.4;
+/**
+ * Absolute lower bound on cosine similarity — results below this are always
+ * dropped even if the caller explicitly set a lower threshold. Set to 0.4
+ * after Issue #543 1-E prod measurement on 1306 KO+EN center-goal embeddings:
+ * for the "수학 올림피아드" template (used as a proxy for the user's "수학"
+ * search), nearest-neighbor distribution was top-1 0.47, top-15 in the
+ * 0.40-0.49 band, then 843 rows in the 0.25-0.39 band — so a 0.25 floor
+ * passed essentially every template. Raising to 0.4 keeps the top-15
+ * semantically-relevant results and drops the long tail of "barely closer
+ * than random" matches that produced the "수학 → 주짓수" report.
+ */
+const HARD_SIMILARITY_FLOOR = 0.4;
+/**
+ * Soft results target used only for logging/metrics. No longer controls
+ * query behaviour — removed fallback (CP358 MIN_RESULTS_GUARANTEE) because
+ * it caused irrelevant results when no good matches existed.
+ */
+const SOFT_RESULTS_TARGET = 3;
 const MAX_LIMIT = 20;
 const EMBED_TIMEOUT_MS = 30_000;
 
@@ -243,8 +260,6 @@ export async function searchMandalasByGoal(
   const queryVector = await embedGoalForMandala(goalText);
   const embeddingStr = `[${queryVector.join(',')}]`;
 
-  logger.info(`Mandala search: goal="${goalText}" limit=${limit} threshold=${threshold}`);
-
   const prisma = getPrismaClient();
 
   // Step 1: Top N unique mandalas by cosine similarity.
@@ -299,46 +314,18 @@ export async function searchMandalasByGoal(
     LIMIT ${limit}
   `;
 
-  // CP358 min-results guarantee: if the threshold filter returned fewer than
-  // MIN_RESULTS_GUARANTEE rows, retry WITHOUT the threshold filter so the
-  // user always sees the closest matches. UX rule: showing 3 imperfect
-  // matches > showing nothing.
-  if (topRows.length < MIN_RESULTS_GUARANTEE) {
-    const fallbackConditions: Prisma.Sql[] = [
-      Prisma.sql`level = 1`,
-      Prisma.sql`sub_goal_index IS NULL`,
-      Prisma.sql`embedding IS NOT NULL`,
-    ];
-    if (options.language) {
-      fallbackConditions.push(Prisma.sql`language = ${options.language}`);
-    }
-    const fallbackWhere = Prisma.join(fallbackConditions, ' AND ');
-    logger.info(
-      `Mandala search fallback: threshold ${threshold} produced ${topRows.length} rows for "${goalText}", retrying without threshold`
-    );
-    topRows = await prisma.$queryRaw<TopRow[]>`
-      WITH ranked AS (
-        SELECT
-          mandala_id::text AS mandala_id,
-          center_goal,
-          center_label,
-          domain,
-          language,
-          1 - (embedding <=> ${embeddingStr}::vector) AS similarity,
-          ROW_NUMBER() OVER (
-            PARTITION BY mandala_id
-            ORDER BY embedding <=> ${embeddingStr}::vector
-          ) AS rn
-        FROM mandala_embeddings
-        WHERE ${fallbackWhere}
-      )
-      SELECT mandala_id, center_goal, center_label, domain, language, similarity
-      FROM ranked
-      WHERE rn = 1
-      ORDER BY similarity DESC
-      LIMIT ${limit}
-    `;
-  }
+  // Apply the hard similarity floor as a post-filter safety belt.
+  // The SQL WHERE clause already filters by `threshold`, but a caller may
+  // pass a lower threshold than HARD_SIMILARITY_FLOOR. This guard ensures
+  // we never return results with cosine similarity below the floor regardless
+  // of what the caller requested.
+  topRows = topRows.filter((r) => Number(r.similarity) >= HARD_SIMILARITY_FLOOR);
+
+  logger.info(
+    `Mandala search: threshold=${threshold} floor=${HARD_SIMILARITY_FLOOR} ` +
+      `goal="${goalText}" results=${topRows.length} ` +
+      `(soft_target=${SOFT_RESULTS_TARGET})`
+  );
 
   if (topRows.length === 0) {
     return [];

--- a/tests/unit/modules/search-threshold.test.ts
+++ b/tests/unit/modules/search-threshold.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for searchMandalasByGoal threshold / floor behaviour.
+ *
+ * Covers the fix for "수학 → 주짓수" bug (Issue #543, CP358 MIN_RESULTS_GUARANTEE
+ * removal + HARD_SIMILARITY_FLOOR raise to 0.4):
+ *   - No fallback query fires when 0 rows pass the threshold.
+ *   - HARD_SIMILARITY_FLOOR always drops results below 0.4 even if the
+ *     caller passed a lower threshold.
+ *   - Sub-0.4 results that the pre-fix `MIN_RESULTS_GUARANTEE` fallback would
+ *     have leaked through are now dropped.
+ *   - Normal case: results above the floor are returned as-is.
+ */
+
+// ─── Mocks (declared before importing the module under test) ───
+
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: jest.fn(),
+}));
+
+// Mock global fetch so the embedding HTTP call (ollama or openrouter)
+// resolves synchronously with a fake 4096-dim vector. Same-module
+// `jest.requireActual` self-mocks do NOT intercept internal calls in
+// search.ts — fetch-level mock is the only reliable interception point.
+const FAKE_EMBEDDING = new Array(4096).fill(0.1);
+const fetchMock = jest.fn().mockResolvedValue({
+  ok: true,
+  status: 200,
+  json: async () => ({
+    // OpenRouter shape
+    data: [{ embedding: FAKE_EMBEDDING }],
+    // Ollama shape (responds whichever provider config picks)
+    embedding: FAKE_EMBEDDING,
+  }),
+  text: async () => '',
+});
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).fetch = fetchMock;
+
+import { getPrismaClient } from '@/modules/database/client';
+import { searchMandalasByGoal } from '@/modules/mandala/search';
+
+const mockPrisma = {
+  $queryRaw: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchMock.mockClear();
+  fetchMock.mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      data: [{ embedding: FAKE_EMBEDDING }],
+      embeddings: [FAKE_EMBEDDING],
+    }),
+    text: async () => '',
+  });
+  (getPrismaClient as jest.Mock).mockReturnValue(mockPrisma);
+});
+
+// ─── Helpers ───
+
+/** Build a minimal TopRow as returned by the pgvector query. */
+function makeTopRow(
+  similarity: number,
+  overrides: Partial<{
+    mandala_id: string;
+    center_goal: string;
+    center_label: string | null;
+    domain: string | null;
+    language: string | null;
+  }> = {}
+) {
+  return {
+    mandala_id: overrides.mandala_id ?? 'test-uuid-1',
+    center_goal: overrides.center_goal ?? '테스트 목표',
+    center_label: overrides.center_label ?? null,
+    domain: overrides.domain ?? null,
+    language: overrides.language ?? 'ko',
+    similarity,
+  };
+}
+
+// ─── Tests ───
+
+describe('searchMandalasByGoal — threshold / floor behaviour', () => {
+  it('returns empty array when no rows pass the threshold (no fallback)', async () => {
+    // Simulate DB returning 0 rows (all filtered by threshold in SQL)
+    mockPrisma.$queryRaw.mockResolvedValueOnce([]);
+
+    const results = await searchMandalasByGoal('수학', { threshold: 0.4, language: 'ko' });
+
+    expect(results).toEqual([]);
+    // Exactly one $queryRaw call: no fallback retry
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops results below HARD_SIMILARITY_FLOOR even when caller uses a lower threshold', async () => {
+    // DB respects the caller's low threshold and returns a row with similarity 0.15
+    // (well below HARD_SIMILARITY_FLOOR = 0.4). The post-filter must remove it.
+    mockPrisma.$queryRaw.mockResolvedValueOnce([
+      makeTopRow(0.15, { mandala_id: 'low-sim-uuid', center_goal: '주짓수' }),
+    ]);
+
+    // Even though caller passed threshold: 0.1, the hard floor should remove the result
+    const results = await searchMandalasByGoal('수학', { threshold: 0.1, language: 'ko' });
+
+    expect(results).toEqual([]);
+    // Still only one query — no fallback
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a 0.30-similarity row that the pre-fix MIN_RESULTS_GUARANTEE fallback would have leaked', async () => {
+    // Pre-fix behaviour: a 0.30 similarity row would either (a) come back from
+    // the threshold query when caller passed 0.3, or (b) be surfaced by the
+    // fallback retry when fewer than 3 rows passed. Both are now blocked by
+    // the 0.4 hard floor, regardless of caller threshold.
+    mockPrisma.$queryRaw.mockResolvedValueOnce([
+      makeTopRow(0.3, { mandala_id: 'borderline-uuid', center_goal: '청소년 멘토링' }),
+    ]);
+
+    const results = await searchMandalasByGoal('수학', { threshold: 0.3, language: 'ko' });
+
+    expect(results).toEqual([]);
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns results normally when similarity is above the floor', async () => {
+    // 0.55 is comfortably above the 0.4 floor — analogous to the 0.47 top-1
+    // similarity observed in the prod 1-E reproduction for "수학" queries.
+    const topRow = makeTopRow(0.55, {
+      mandala_id: 'good-uuid',
+      center_goal: '수학 실력 향상',
+      language: 'ko',
+    });
+    // First call: topRows query; second call: templateRows meta query;
+    // third call: levelRows query (returns empty — sub_goals not needed for this assertion)
+    mockPrisma.$queryRaw
+      .mockResolvedValueOnce([topRow]) // Step 1: top mandala_ids
+      .mockResolvedValueOnce([]) // Step 2: template meta rows
+      .mockResolvedValueOnce([]); // Step 3: level rows (empty, sub_goals not checked here)
+
+    const results = await searchMandalasByGoal('수학', { threshold: 0.4, language: 'ko' });
+
+    expect(results).toHaveLength(1);
+    const first = results[0];
+    expect(first).toBeDefined();
+    expect(first?.center_goal).toBe('수학 실력 향상');
+    expect(first?.similarity).toBeCloseTo(0.55, 5);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the user-reported "수학 → 주짓수" drift where searching for `수학` in the wizard returned a 주짓수 template with cosine similarity ≈ 0.05.

Round 2 PR X1 of Issue #543 — search accuracy fix train.

### Root cause (Issue #543 step 1-E, prod data)

For a "수학 올림피아드" template proxy across 1306 KO+EN center-goal embeddings:

| Bucket | Count |
|--------|-------|
| ≥ 0.70 | 1 |
| 0.40–0.49 | 15 |
| 0.25–0.39 | **843** |
| 0.10–0.24 | 447 |

The old `HARD_SIMILARITY_FLOOR = 0.25` passed essentially every row, and the now-removed `MIN_RESULTS_GUARANTEE` fallback retried without any threshold when fewer than 3 rows passed — surfacing the closest-but-irrelevant match (주짓수, 0.05) as the user's "math search result".

### Fix

- `HARD_SIMILARITY_FLOOR` 0.25 → **0.4** (data-driven from 1-E)
- `DEFAULT_THRESHOLD` 0.4 (already raised from 0.3 in earlier WIP)
- `MIN_RESULTS_GUARANTEE` fallback retry: removed (already removed in WIP, comments updated)
- `/wizard-stream` template search: `limit` 4→5, `threshold` 0.3→0.4
- SSE `template_found`: additive `hasResults: boolean` for future empty-state UI

### Verification

- `tsc --noEmit` clean
- 4/4 new unit tests in `tests/unit/modules/search-threshold.test.ts` PASS
- Backend jest related to (mandala|video-discover|search): **19 fail / 385 pass** — identical to pre-stash baseline → **0 new regression**
- Frontend `use-wizard-stream.test.ts` 7/7 PASS (additive SSE field is backward-compatible)
- `npm run build` clean
- `hardcode-audit`: 33 violations (under 35 baseline)

### FE consumer pre-flight (LEVEL-1 troubleshooting "API 응답 계약 변경")

Grep confirmed `template_found` consumers:
- `frontend/src/features/mandala-wizard/model/useWizardStream.ts:184` — reads `templates`, `duration_ms` only.
- `frontend/src/shared/lib/api-client.ts:1105` — reads `templates`, `duration_ms` only.
- `frontend/src/__tests__/smoke/use-wizard-stream.test.ts:63` — fixture matches new payload structure.

`hasResults` is purely additive and backward-compatible.

## Test plan

- [ ] Merge → deploy
- [ ] Manual prod test: open wizard → type "수학" → verify either (a) a math-related template appears, or (b) empty result (no 주짓수)
- [ ] Manual prod test: type "행복한 가족" → verify a 0.4+ matching template appears (regression check on CP358 case)
- [ ] Watch `recommendation_cache` row counts post-deploy for any drop indicating over-aggressive filtering on real user mandalas

Closes part of #543 (search accuracy axis). PR X1.5 (recommendation_cache batch upsert + FETCH_LIMIT 200) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)