### PR TITLE
perf(video-discover/v3): batch upsert recommendation_cache + raise fetch limit (#543)

### DIFF
--- a/src/config/recommendations.ts
+++ b/src/config/recommendations.ts
@@ -10,7 +10,7 @@
  */
 
 /** Max items returned by GET /api/v1/mandalas/:id/recommendations. */
-export const RECOMMENDATION_FETCH_LIMIT = 80;
+export const RECOMMENDATION_FETCH_LIMIT = 200;
 
 /** Default cache row status considered "active" (not yet acted on or expired). */
 export const RECOMMENDATION_DEFAULT_STATUS = 'pending' as const;

--- a/src/skills/plugins/video-discover/__tests__/v3-upsert-slots.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v3-upsert-slots.test.ts
@@ -1,0 +1,279 @@
+/**
+ * v3/executor — upsertSlots batch path tests
+ *
+ * Verifies that the batch INSERT … ON CONFLICT … RETURNING path:
+ *  1. Returns `rows_upserted` as a number in the execute result (contract unchanged)
+ *  2. Calls `notifyCardAdded` once per row returned by the batch RETURNING query
+ *  3. Falls back to per-row Prisma upserts when `$queryRaw` throws
+ *  4. Returns status='failed' with no DB calls when no slots are produced
+ *
+ * `upsertSlots` is private; it is exercised indirectly via `executor.execute`.
+ */
+
+// ─── Logger mock (must come before any module imports that use logger) ─────────
+// database/client.ts calls logger.info at module-init time (line 94 / getPrismaClient
+// singleton), so the mock must provide top-level methods, not just child().
+const noopFn = jest.fn();
+const noopLogger = {
+  info: noopFn,
+  warn: noopFn,
+  error: noopFn,
+  debug: noopFn,
+  child: () => noopLogger,
+};
+jest.mock('@/utils/logger', () => ({ logger: noopLogger }));
+
+// ─── Primary mocks ────────────────────────────────────────────────────────────
+
+const mockQueryRaw = jest.fn();
+const mockRecCacheUpsert = jest.fn();
+const mockNotifyCardAdded = jest.fn();
+
+jest.mock('@/modules/database', () => ({
+  getPrismaClient: () => ({
+    user_mandalas: {
+      findFirst: jest.fn().mockResolvedValue({ id: 'mid' }),
+    },
+    recommendation_cache: {
+      upsert: mockRecCacheUpsert,
+    },
+    $queryRaw: mockQueryRaw,
+  }),
+}));
+
+jest.mock('@/modules/recommendations/publisher', () => ({
+  notifyCardAdded: mockNotifyCardAdded,
+}));
+
+// ─── RedisProvider — unavailable so Tier 0 is a no-op ────────────────────────
+jest.mock('@/skills/plugins/video-discover/v3/providers/redis-provider', () => ({
+  RedisProvider: jest.fn().mockImplementation(() => ({
+    health: jest.fn().mockResolvedValue({ available: false, lastError: 'test-mock' }),
+    match: jest.fn().mockResolvedValue({ candidates: [], meta: { latencyMs: 0 } }),
+  })),
+}));
+
+// ─── Tier 1 video pool — disabled ────────────────────────────────────────────
+jest.mock('@/skills/plugins/video-discover/v3/cache-matcher', () => ({
+  matchFromVideoPool: jest.fn().mockResolvedValue([]),
+  groupByCell: jest.fn().mockReturnValue(new Map()),
+}));
+
+// ─── v3 feature flags — all disabled so no extra async paths ─────────────────
+jest.mock('@/skills/plugins/video-discover/v3/config', () => ({
+  v3Config: {
+    enableTier1Cache: false,
+    enableSemanticRerank: false,
+    enableWhitelistGate: false,
+    maxQueries: 2,
+  },
+}));
+
+// ─── Semantic rerank / whitelist gate ─────────────────────────────────────────
+jest.mock('@/modules/video-dictionary', () => ({
+  applySemanticRerank: jest.fn(),
+  getSemanticRank: jest.fn().mockResolvedValue([]),
+  filterByWhitelist: jest.fn(),
+  getChannelWhitelist: jest.fn().mockResolvedValue(null),
+}));
+
+// ─── Mandala filter — pass all candidates through, assign to cell 0 ───────────
+jest.mock('@/skills/plugins/video-discover/v3/mandala-filter', () => ({
+  applyMandalaFilterWithStats: jest
+    .fn()
+    .mockImplementation((inputs: Array<{ videoId: string; title: string }>) => ({
+      byCell: new Map([
+        [0, inputs.map((c) => ({ candidate: { videoId: c.videoId }, score: 0.8 }))],
+      ]),
+      stats: {
+        output: inputs.length,
+        droppedByCenterGate: 0,
+        droppedByJaccardBelowThreshold: 0,
+        centerTokens: ['guitar'],
+        subGoalTokenCounts: [1],
+      },
+    })),
+  MIN_SUB_RELEVANCE: 0.05,
+}));
+
+// ─── Embedding (semantic gate, only used when centerGateMode==='semantic') ────
+jest.mock('@/skills/plugins/iks-scorer/embedding', () => ({
+  embedBatch: jest.fn().mockResolvedValue([]),
+}));
+
+// ─── YouTube client — provide one video for Tier 2 searches ──────────────────
+const mockSearchVideos = jest.fn();
+const mockVideosBatch = jest.fn();
+jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
+  searchVideos: mockSearchVideos,
+  videosBatch: mockVideosBatch,
+  parseIsoDuration: jest.requireActual('@/skills/plugins/video-discover/v2/youtube-client')
+    .parseIsoDuration,
+  isShortsByDuration: jest.fn().mockReturnValue(false),
+  titleIndicatesShorts: jest.fn().mockReturnValue(false),
+  titleHitsBlocklist: jest.fn().mockReturnValue(false),
+  resolveSearchApiKeys: jest.fn().mockReturnValue(['test-api-key']),
+}));
+
+// ─── LLM keyword builder — return one search query per cell ──────────────────
+jest.mock('@/skills/plugins/video-discover/v2/keyword-builder', () => ({
+  buildRuleBasedQueriesSync: jest
+    .fn()
+    .mockReturnValue([{ query: 'guitar chords beginner', cellIndex: 0 }]),
+  runLLMQueries: jest.fn().mockResolvedValue([]),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { executor } from '../v3/executor';
+import type { ExecuteContext } from '@/skills/_shared/types';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const USER_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
+const MANDALA_ID = 'bbbbbbbb-0000-0000-0000-000000000002';
+
+function makeCtx(): ExecuteContext {
+  return {
+    userId: USER_ID,
+    mandalaId: MANDALA_ID,
+    tier: 'admin',
+    env: {
+      YOUTUBE_API_KEY_SEARCH: 'test-key',
+      OPENROUTER_API_KEY: '',
+    },
+    llm: {} as never,
+    state: {
+      centerGoal: 'Learn guitar',
+      subGoals: ['Chords', '', '', '', '', '', '', ''],
+      language: 'en' as const,
+      focusTags: [],
+      targetLevel: 'standard',
+    },
+  };
+}
+
+/** Canned RETURNING row — matches the UpsertedRow interface in v3/executor.ts. */
+function makeUpsertedRow(videoId: string) {
+  return {
+    id: `row-id-${videoId}`,
+    video_id: videoId,
+    title: `Title for ${videoId}`,
+    channel: 'Test Channel',
+    thumbnail: `https://img/${videoId}.jpg`,
+    duration_sec: 300,
+    rec_score: 0.75,
+    cell_index: 0,
+    keyword: 'Chords',
+    weight_version: 3,
+    rec_reason: 'realtime',
+    published_at: new Date('2026-01-01T00:00:00Z'),
+  };
+}
+
+/**
+ * Canned YouTube search result in the shape expected by runSearchTraced
+ * (YouTubeSearchItem with nested id/snippet).
+ */
+function makeSearchResult(videoId: string) {
+  return {
+    id: { videoId },
+    snippet: {
+      title: `Title for ${videoId}`,
+      channelTitle: 'Test Channel',
+      channelId: 'tc1',
+      publishedAt: '2026-01-01T00:00:00Z',
+      thumbnails: { high: { url: `https://img/${videoId}.jpg` } },
+    },
+  };
+}
+
+/**
+ * Canned videos.list enrichment result in the shape of YouTubeVideoStatsItem
+ * (nested statistics + contentDetails).
+ */
+function makeStatsResult(videoId: string) {
+  return {
+    id: videoId,
+    statistics: {
+      viewCount: '50000',
+      likeCount: '2000',
+    },
+    contentDetails: { duration: 'PT5M' },
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('v3/executor — upsertSlots batch path', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: searchVideos returns one video so Tier 2 produces one slot
+    mockSearchVideos.mockResolvedValue([makeSearchResult('vid-default')]);
+    mockVideosBatch.mockResolvedValue([makeStatsResult('vid-default')]);
+  });
+
+  it('returns rows_upserted as a number in the execute result (contract unchanged)', async () => {
+    // Batch INSERT RETURNING yields two rows
+    mockQueryRaw.mockResolvedValueOnce([makeUpsertedRow('vid-1'), makeUpsertedRow('vid-2')]);
+
+    const result = await executor.execute(makeCtx());
+
+    expect(result.status).toBe('success');
+    expect(typeof result.data['rows_upserted']).toBe('number');
+    expect(result.metrics?.rows_written?.['recommendation_cache']).toBeGreaterThanOrEqual(0);
+  });
+
+  it('calls notifyCardAdded once per row returned by the batch RETURNING query (SSE requirement)', async () => {
+    const returnedRows = [makeUpsertedRow('vid-sse-1'), makeUpsertedRow('vid-sse-2')];
+    // Tier 2 search returns two distinct videos
+    mockSearchVideos.mockResolvedValueOnce([
+      makeSearchResult('vid-sse-1'),
+      makeSearchResult('vid-sse-2'),
+    ]);
+    mockVideosBatch.mockResolvedValue([makeStatsResult('vid-sse-1'), makeStatsResult('vid-sse-2')]);
+    // Batch upsert returns the two rows
+    mockQueryRaw.mockResolvedValueOnce(returnedRows);
+
+    await executor.execute(makeCtx());
+
+    // notifyCardAdded must be called exactly once per row in the RETURNING result
+    expect(mockNotifyCardAdded).toHaveBeenCalledTimes(returnedRows.length);
+    const notifiedVideoIds = (
+      mockNotifyCardAdded.mock.calls as Array<[string, { videoId: string }]>
+    ).map((args) => args[1].videoId);
+    expect(notifiedVideoIds).toContain('vid-sse-1');
+    expect(notifiedVideoIds).toContain('vid-sse-2');
+  });
+
+  it('falls back to per-row upserts when $queryRaw throws, still returns rows_upserted', async () => {
+    // Batch INSERT fails (e.g. SQLite in CI)
+    mockQueryRaw.mockRejectedValueOnce(new Error('syntax error near unnest'));
+    // Per-row fallback succeeds
+    mockRecCacheUpsert.mockResolvedValue(makeUpsertedRow('vid-fallback'));
+    mockSearchVideos.mockResolvedValue([makeSearchResult('vid-fallback')]);
+    mockVideosBatch.mockResolvedValue([makeStatsResult('vid-fallback')]);
+
+    const result = await executor.execute(makeCtx());
+
+    expect(['success', 'partial']).toContain(result.status);
+    expect(typeof result.data['rows_upserted']).toBe('number');
+    expect(result.data['rows_upserted'] as number).toBeGreaterThan(0);
+    // per-row fallback was used
+    expect(mockRecCacheUpsert).toHaveBeenCalled();
+    // notifyCardAdded still fires via fallback path
+    expect(mockNotifyCardAdded).toHaveBeenCalled();
+  });
+
+  it('returns status failed with no DB writes when Tier 2 produces zero slots', async () => {
+    mockSearchVideos.mockResolvedValue([]);
+    mockVideosBatch.mockResolvedValue([]);
+
+    const result = await executor.execute(makeCtx());
+
+    expect(result.status).toBe('failed');
+    expect(mockQueryRaw).not.toHaveBeenCalled();
+    expect(mockRecCacheUpsert).not.toHaveBeenCalled();
+    expect(mockNotifyCardAdded).not.toHaveBeenCalled();
+  });
+});

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -975,113 +975,256 @@ function dedupePool(items: ReadonlyArray<PoolItem>): PoolItem[] {
 // Upsert — single pass for Tier 1 + Tier 2 slots
 // ============================================================================
 
+/**
+ * Row shape returned by the batch INSERT … RETURNING query.
+ * Only the columns needed to build the SSE CardPayload are selected.
+ */
+interface UpsertedRow {
+  id: string;
+  video_id: string;
+  title: string;
+  channel: string | null;
+  thumbnail: string | null;
+  duration_sec: number | null;
+  rec_score: number;
+  cell_index: number | null;
+  keyword: string;
+  weight_version: number;
+  rec_reason: string | null;
+  published_at: Date | null;
+}
+
+/**
+ * Batch-upsert all slots in a single SQL round-trip using
+ * INSERT … ON CONFLICT … DO UPDATE … RETURNING.
+ *
+ * Falls back to per-row Prisma upserts if the batch statement fails,
+ * so a SQL dialect mismatch or constraint surprise does not block the
+ * entire run.
+ *
+ * The SSE notification (notifyCardAdded) fires for every successfully
+ * persisted row — identical behaviour to the previous loop implementation.
+ */
 async function upsertSlots(
   userId: string,
   mandalaId: string,
   slots: ReadonlyArray<AssembledSlot>,
   subGoals: ReadonlyArray<string>
 ): Promise<number> {
+  if (slots.length === 0) return 0;
+
   const db = getPrismaClient();
   const expiresAt = new Date(Date.now() + TTL_DAYS * MS_PER_DAY);
-  let count = 0;
 
-  for (const slot of slots) {
-    const keyword = (subGoals[slot.cellIndex] ?? '').slice(0, 255);
-    try {
-      const row = await db.recommendation_cache.upsert({
-        where: {
-          user_id_mandala_id_video_id: {
+  // ------------------------------------------------------------------
+  // Build per-slot derived values once so we don't recompute inside loops
+  // ------------------------------------------------------------------
+  const prepared = slots.map((slot) => ({
+    slot,
+    keyword: (subGoals[slot.cellIndex] ?? '').slice(0, 255),
+    likeRatio:
+      slot.likeCount != null && slot.viewCount && slot.viewCount > 0
+        ? Math.min(slot.likeCount / slot.viewCount, 1)
+        : null,
+    recScore: Math.max(0, Math.min(1, slot.score)),
+  }));
+
+  // ------------------------------------------------------------------
+  // Attempt: single batch INSERT … ON CONFLICT … DO UPDATE … RETURNING
+  // ------------------------------------------------------------------
+  let upsertedRows: UpsertedRow[] | null = null;
+  try {
+    // Build a VALUES list: one Prisma.sql fragment per row, then join.
+    const valueFragments = prepared.map(
+      ({ slot, keyword, likeRatio, recScore }) =>
+        Prisma.sql`(
+        ${userId}::uuid,
+        ${mandalaId}::uuid,
+        ${slot.cellIndex}::int,
+        ${keyword}::varchar(255),
+        ${slot.videoId}::varchar(64),
+        ${slot.title},
+        ${slot.thumbnail},
+        ${slot.channelName?.slice(0, 255) ?? null}::varchar(255),
+        ${slot.viewCount}::int,
+        ${likeRatio}::float8,
+        ${slot.durationSec}::int,
+        ${recScore}::float8,
+        ${slot.tier},
+        ${RECOMMENDATION_STATUS_PENDING}::varchar(20),
+        ${WEIGHT_VERSION}::int,
+        ${expiresAt}::timestamptz,
+        ${slot.publishedAt}::timestamptz
+      )`
+    );
+
+    upsertedRows = await db.$queryRaw<UpsertedRow[]>`
+      INSERT INTO recommendation_cache (
+        user_id, mandala_id, cell_index, keyword, video_id,
+        title, thumbnail, channel, view_count, like_ratio,
+        duration_sec, rec_score, rec_reason, status, weight_version,
+        expires_at, published_at
+      )
+      VALUES ${Prisma.join(valueFragments)}
+      ON CONFLICT (user_id, mandala_id, video_id) DO UPDATE SET
+        cell_index     = EXCLUDED.cell_index,
+        keyword        = EXCLUDED.keyword,
+        title          = EXCLUDED.title,
+        thumbnail      = EXCLUDED.thumbnail,
+        channel        = EXCLUDED.channel,
+        view_count     = EXCLUDED.view_count,
+        like_ratio     = EXCLUDED.like_ratio,
+        duration_sec   = EXCLUDED.duration_sec,
+        rec_score      = EXCLUDED.rec_score,
+        rec_reason     = EXCLUDED.rec_reason,
+        weight_version = EXCLUDED.weight_version,
+        expires_at     = EXCLUDED.expires_at,
+        published_at   = EXCLUDED.published_at
+      RETURNING
+        id, video_id, title, channel, thumbnail, duration_sec,
+        rec_score, cell_index, keyword, weight_version, rec_reason,
+        published_at
+    `;
+  } catch (batchErr) {
+    log.warn(
+      `recommendation_cache batch upsert failed (${slots.length} slots), falling back to per-row: ${
+        batchErr instanceof Error ? batchErr.message : String(batchErr)
+      }`
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Fallback: per-row Prisma upserts (preserves pre-existing behaviour)
+  // ------------------------------------------------------------------
+  if (upsertedRows === null) {
+    let count = 0;
+    for (const { slot, keyword, likeRatio, recScore } of prepared) {
+      try {
+        const row = await db.recommendation_cache.upsert({
+          where: {
+            user_id_mandala_id_video_id: {
+              user_id: userId,
+              mandala_id: mandalaId,
+              video_id: slot.videoId,
+            },
+          },
+          create: {
             user_id: userId,
             mandala_id: mandalaId,
+            cell_index: slot.cellIndex,
+            keyword,
             video_id: slot.videoId,
+            title: slot.title,
+            thumbnail: slot.thumbnail,
+            channel: slot.channelName?.slice(0, 255) ?? null,
+            view_count: slot.viewCount,
+            like_ratio: likeRatio,
+            duration_sec: slot.durationSec,
+            rec_score: recScore,
+            rec_reason: slot.tier,
+            status: RECOMMENDATION_STATUS_PENDING,
+            weight_version: WEIGHT_VERSION,
+            expires_at: expiresAt,
+            published_at: slot.publishedAt,
           },
-        },
-        create: {
-          user_id: userId,
-          mandala_id: mandalaId,
-          cell_index: slot.cellIndex,
-          keyword,
-          video_id: slot.videoId,
-          title: slot.title,
-          thumbnail: slot.thumbnail,
-          channel: slot.channelName?.slice(0, 255) ?? null,
-          view_count: slot.viewCount,
-          like_ratio:
-            slot.likeCount != null && slot.viewCount && slot.viewCount > 0
-              ? Math.min(slot.likeCount / slot.viewCount, 1)
-              : null,
-          duration_sec: slot.durationSec,
-          rec_score: Math.max(0, Math.min(1, slot.score)),
-          rec_reason: slot.tier,
-          status: RECOMMENDATION_STATUS_PENDING,
-          weight_version: WEIGHT_VERSION,
-          expires_at: expiresAt,
-          published_at: slot.publishedAt,
-        },
-        update: {
-          cell_index: slot.cellIndex,
-          keyword,
-          title: slot.title,
-          thumbnail: slot.thumbnail,
-          channel: slot.channelName?.slice(0, 255) ?? null,
-          view_count: slot.viewCount,
-          like_ratio:
-            slot.likeCount != null && slot.viewCount && slot.viewCount > 0
-              ? Math.min(slot.likeCount / slot.viewCount, 1)
-              : null,
-          duration_sec: slot.durationSec,
-          rec_score: Math.max(0, Math.min(1, slot.score)),
-          rec_reason: slot.tier,
-          weight_version: WEIGHT_VERSION,
-          expires_at: expiresAt,
-          published_at: slot.publishedAt,
-        },
-      });
-      count++;
+          update: {
+            cell_index: slot.cellIndex,
+            keyword,
+            title: slot.title,
+            thumbnail: slot.thumbnail,
+            channel: slot.channelName?.slice(0, 255) ?? null,
+            view_count: slot.viewCount,
+            like_ratio: likeRatio,
+            duration_sec: slot.durationSec,
+            rec_score: recScore,
+            rec_reason: slot.tier,
+            weight_version: WEIGHT_VERSION,
+            expires_at: expiresAt,
+            published_at: slot.publishedAt,
+          },
+        });
+        count++;
 
-      // Phase 1 slice 2 (SSE streaming): push the freshly-upserted card
-      // to any SSE subscriber for this mandala. Non-fatal — notification
-      // delivery is best-effort, persistence has already succeeded above.
-      try {
-        const payload: CardPayload = {
-          id: row.id,
-          videoId: row.video_id,
-          title: row.title,
-          channel: row.channel,
-          thumbnail: row.thumbnail,
-          durationSec: row.duration_sec,
-          recScore: row.rec_score,
-          cellIndex: row.cell_index ?? slot.cellIndex,
-          // cellLabel is derived at read-time in /recommendations (from
-          // mandala levels). The SSE consumer resolves it client-side
-          // from the already-loaded mandala state to avoid a DB round-
-          // trip per notification.
-          cellLabel: null,
-          keyword: row.keyword ?? keyword,
-          source: row.weight_version === 0 ? 'manual' : 'auto_recommend',
-          recReason: row.rec_reason,
-          publishedAt: row.published_at?.toISOString() ?? null,
-        };
-        notifyCardAdded(mandalaId, payload);
-      } catch (notifyErr) {
-        // EventEmitter.emit can only throw if a listener throws
-        // synchronously, which would be a listener bug. Log and move
-        // on — the row is persisted regardless.
+        // Phase 1 slice 2 (SSE streaming) — best-effort, non-fatal.
+        try {
+          const payload: CardPayload = {
+            id: row.id,
+            videoId: row.video_id,
+            title: row.title,
+            channel: row.channel,
+            thumbnail: row.thumbnail,
+            durationSec: row.duration_sec,
+            recScore: row.rec_score,
+            cellIndex: row.cell_index ?? slot.cellIndex,
+            cellLabel: null,
+            keyword: row.keyword ?? keyword,
+            source: row.weight_version === 0 ? 'manual' : 'auto_recommend',
+            recReason: row.rec_reason,
+            publishedAt: row.published_at?.toISOString() ?? null,
+          };
+          notifyCardAdded(mandalaId, payload);
+        } catch (notifyErr) {
+          log.warn(
+            `notifyCardAdded failed for ${slot.videoId}: ${
+              notifyErr instanceof Error ? notifyErr.message : String(notifyErr)
+            }`
+          );
+        }
+      } catch (err) {
         log.warn(
-          `notifyCardAdded failed for ${slot.videoId}: ${
-            notifyErr instanceof Error ? notifyErr.message : String(notifyErr)
+          `recommendation_cache upsert failed for ${slot.videoId}: ${
+            err instanceof Error ? err.message : String(err)
           }`
         );
       }
-    } catch (err) {
+    }
+    return count;
+  }
+
+  // ------------------------------------------------------------------
+  // Batch succeeded — fire SSE notifications for each returned row
+  // ------------------------------------------------------------------
+  const slotByVideoId = new Map(
+    prepared.map(({ slot, keyword }) => [slot.videoId, { slot, keyword }])
+  );
+
+  for (const row of upsertedRows) {
+    const entry = slotByVideoId.get(row.video_id);
+    const fallbackCellIndex = entry?.slot.cellIndex ?? 0;
+    const fallbackKeyword = entry?.keyword ?? row.keyword;
+
+    // Phase 1 slice 2 (SSE streaming) — best-effort, non-fatal.
+    try {
+      const payload: CardPayload = {
+        id: row.id,
+        videoId: row.video_id,
+        title: row.title,
+        channel: row.channel,
+        thumbnail: row.thumbnail,
+        durationSec: row.duration_sec,
+        recScore: row.rec_score,
+        cellIndex: row.cell_index ?? fallbackCellIndex,
+        // cellLabel is derived at read-time in /recommendations (from
+        // mandala levels). The SSE consumer resolves it client-side
+        // from the already-loaded mandala state to avoid a DB round-
+        // trip per notification.
+        cellLabel: null,
+        keyword: row.keyword ?? fallbackKeyword,
+        source: row.weight_version === 0 ? 'manual' : 'auto_recommend',
+        recReason: row.rec_reason,
+        publishedAt: row.published_at?.toISOString() ?? null,
+      };
+      notifyCardAdded(mandalaId, payload);
+    } catch (notifyErr) {
       log.warn(
-        `recommendation_cache upsert failed for ${slot.videoId}: ${
-          err instanceof Error ? err.message : String(err)
+        `notifyCardAdded failed for ${row.video_id}: ${
+          notifyErr instanceof Error ? notifyErr.message : String(notifyErr)
         }`
       );
     }
   }
-  return count;
+
+  return upsertedRows.length;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Round 2 PR X1.5 of Issue #543 — quick perf wins parallel-merge-able with PR #544.

### Changes

**`src/skills/plugins/video-discover/v3/executor.ts` (`upsertSlots`)**
- Per-row Prisma `recommendation_cache.upsert` loop → single `INSERT … ON CONFLICT … DO UPDATE … RETURNING` batch.
- Round-trip count: **N → 1** (~64× reduction at `V3_TARGET_TOTAL=64`).
- Per-row fallback retained on `$queryRaw` throw — batch failure cannot block a wizard run.
- `notifyCardAdded` SSE fires once per `RETURNING` row, identical to the loop semantics. Verified by new test.

**`src/config/recommendations.ts`**
- `RECOMMENDATION_FETCH_LIMIT` 80 → 200. The GET endpoint cap was the dominant truncation for large wizard runs.

### Verification

- `tsc --noEmit` clean
- `npm run build` clean
- 4/4 new tests in `src/skills/plugins/video-discover/__tests__/v3-upsert-slots.test.ts` PASS
- Backend jest related to `(mandala|video-discover|search)`: **19 fail / 385 pass** — identical to pre-stash baseline → **0 new regression**
- `hardcode-audit`: 33 violations (under 35 baseline)

### Test plan

- [ ] Merge → deploy
- [ ] Watch deploy logs for `recommendation_cache batch upsert failed (...) falling back to per-row` warnings — should be absent on Postgres prod
- [ ] Smoke: complete a fresh wizard run, verify `recommendation_cache` row count for the new mandala equals discovered slot count (no batch row drop)
- [ ] Confirm GET /api/v1/mandalas/:id/recommendations returns up to 200 rows (was capped at 80)
- [ ] SSE smoke: subscribe to `/wizard-stream` for a fresh mandala — confirm `card_added` event count matches batch RETURNING row count

Related: PR #544 (PR X1 — search accuracy).
Issue: #543 (Round 2 PR X1.5 — Step 5 quick fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)