### PR TITLE
fix(embed): OpenRouter fallback for embedBatch when Ollama unreachable (#543)

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -67,6 +67,16 @@ const envSchema = z.object({
   // Default = ollama so flag-off = pre-Phase-1 behaviour (CLAUDE.md C5).
   MANDALA_EMBED_PROVIDER: z.enum(['ollama', 'openrouter']).default('ollama'),
 
+  // IKS-scorer / shared embedBatch provider switch (Issue #543, 2026-04-28).
+  // Distinct from MANDALA_EMBED_PROVIDER: governs the multi-text batch
+  // path used by ensureMandalaEmbeddings, v3 executor semantic gate,
+  // iks-scorer, batch-video-collector, and v2 video-embedder.
+  //   'ollama'     → Mac-mini Ollama first; on transport/HTTP failure,
+  //                  auto-fallback to OpenRouter same-model embeddings.
+  //   'openrouter' → skip Mac-mini entirely (use when Mac-mini blocked).
+  // Reuses OPENROUTER_EMBED_BASE_URL / _MODEL / _DIMENSION below.
+  IKS_EMBED_PROVIDER: z.enum(['ollama', 'openrouter']).default('ollama'),
+
   // LLM Provider
   OLLAMA_URL: z.string().default('http://localhost:11434'),
   OLLAMA_EMBED_MODEL: z.string().default('nomic-embed-text'),
@@ -202,6 +212,12 @@ export const config = {
     openRouterBaseUrl: env.OPENROUTER_EMBED_BASE_URL,
     openRouterModel: env.OPENROUTER_EMBED_MODEL,
     openRouterDimension: env.OPENROUTER_EMBED_DIMENSION,
+  },
+
+  // IKS / batch embed provider (Issue #543). Reuses the OpenRouter embed
+  // endpoint config from mandalaEmbed.* — only `provider` differs.
+  iksEmbed: {
+    provider: env.IKS_EMBED_PROVIDER,
   },
 
   // LLM Provider

--- a/src/skills/plugins/iks-scorer/__tests__/embedding-fallback.test.ts
+++ b/src/skills/plugins/iks-scorer/__tests__/embedding-fallback.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for embedBatch OpenRouter fallback (Issue #543).
+ *
+ * Verifies the provider router in embedOneChunk:
+ *   IKS_EMBED_PROVIDER=openrouter → skip Ollama, go straight to OpenRouter
+ *   IKS_EMBED_PROVIDER=ollama     → try Ollama; on fetch/HTTP error, auto
+ *                                   fall back to OpenRouter same-model
+ *
+ * Why this exists: 2026-04-28 prod incident — Mac mini Ollama down →
+ * pipeline-runner step1 (ensureMandalaEmbeddings) threw → step2/3 skipped
+ * → maybeAutoAddRecommendations never called → user_video_states empty
+ * while recommendation_cache had 74 cards. The fallback restores the
+ * step1 success path so step2/3 (auto-add) run normally.
+ */
+
+const FAKE_OLLAMA_VECTOR = new Array(4096).fill(0.1);
+const FAKE_OPENROUTER_VECTOR = new Array(4096).fill(0.2);
+
+// ─── Mocks (declared before importing module under test) ────────────────────
+
+// logger.ts touches config.paths.logs at import — stub before any deeper
+// imports to avoid the file-transport bootstrap.
+const noopFn = jest.fn();
+const noopLogger = {
+  info: noopFn,
+  warn: noopFn,
+  error: noopFn,
+  debug: noopFn,
+  child: () => noopLogger,
+};
+jest.mock('@/utils/logger', () => ({ logger: noopLogger }));
+
+const configMock = {
+  iksEmbed: { provider: 'ollama' as 'ollama' | 'openrouter' },
+  openrouter: { apiKey: 'test-openrouter-key' },
+  mandalaEmbed: {
+    openRouterBaseUrl: 'https://openrouter.ai/api/v1',
+    openRouterModel: 'qwen/qwen3-embedding-8b',
+    openRouterDimension: 4096,
+  },
+};
+
+jest.mock('@/config/index', () => ({
+  get config() {
+    return configMock;
+  },
+}));
+
+const logLLMCallMock = jest.fn().mockResolvedValue(undefined);
+jest.mock('@/modules/llm/call-logger', () => ({
+  logLLMCall: logLLMCallMock,
+}));
+
+// embedding.ts also imports prisma — stub to no-op.
+jest.mock('@/modules/database', () => ({
+  getPrismaClient: () => ({}),
+}));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeOllamaResponse(count: number, vector: number[] = FAKE_OLLAMA_VECTOR): Response {
+  const embeddings = Array.from({ length: count }, () => vector);
+  return new Response(JSON.stringify({ embeddings }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeOpenRouterResponse(
+  count: number,
+  vector: number[] = FAKE_OPENROUTER_VECTOR
+): Response {
+  const data = Array.from({ length: count }, () => ({ embedding: vector }));
+  return new Response(JSON.stringify({ data, usage: { prompt_tokens: 10 } }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeErrorResponse(status: number, body = 'server error'): Response {
+  return new Response(body, { status });
+}
+
+// ─── Import after mocks ─────────────────────────────────────────────────────
+
+import { embedBatch, EmbeddingError } from '../embedding';
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('embedBatch — IKS_EMBED_PROVIDER fallback (Issue #543)', () => {
+  beforeEach(() => {
+    configMock.iksEmbed.provider = 'ollama';
+    logLLMCallMock.mockClear();
+  });
+
+  it('provider=ollama: ollama success → no OpenRouter call', async () => {
+    const fetchImpl = jest.fn().mockResolvedValueOnce(makeOllamaResponse(2));
+
+    const out = await embedBatch(['t1', 't2'], { fetchImpl });
+
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual(FAKE_OLLAMA_VECTOR);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const url0 = fetchImpl.mock.calls[0]?.[0] as string;
+    expect(url0).toContain('/api/embed'); // Ollama endpoint
+    expect(url0).not.toContain('openrouter.ai');
+    expect(logLLMCallMock).not.toHaveBeenCalled();
+  });
+
+  it('provider=ollama: ollama fetch throws → OpenRouter fallback success', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(makeOpenRouterResponse(2));
+
+    const out = await embedBatch(['t1', 't2'], { fetchImpl });
+
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual(FAKE_OPENROUTER_VECTOR);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const url1 = fetchImpl.mock.calls[1]?.[0] as string;
+    expect(url1).toContain('openrouter.ai/api/v1/embeddings');
+    // Cost tracking fired exactly once for the successful OpenRouter call
+    expect(logLLMCallMock).toHaveBeenCalledTimes(1);
+    const callArg = logLLMCallMock.mock.calls[0]?.[0] as { status: string; module: string };
+    expect(callArg.status).toBe('success');
+    expect(callArg.module).toBe('iks-embed-fallback');
+  });
+
+  it('provider=ollama: ollama HTTP 500 → OpenRouter fallback success', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(makeErrorResponse(500))
+      .mockResolvedValueOnce(makeOpenRouterResponse(1));
+
+    const out = await embedBatch(['t1'], { fetchImpl });
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual(FAKE_OPENROUTER_VECTOR);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('provider=ollama: ollama fail + OpenRouter fail → throw EmbeddingError', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(makeErrorResponse(429, 'rate limited'));
+
+    await expect(embedBatch(['t1'], { fetchImpl })).rejects.toBeInstanceOf(EmbeddingError);
+    // logLLMCall fired with status=error for the failed OpenRouter attempt
+    expect(logLLMCallMock).toHaveBeenCalledTimes(1);
+    const callArg = logLLMCallMock.mock.calls[0]?.[0] as { status: string };
+    expect(callArg.status).toBe('error');
+  });
+
+  it('provider=openrouter: skip ollama entirely — OpenRouter only', async () => {
+    configMock.iksEmbed.provider = 'openrouter';
+    const fetchImpl = jest.fn().mockResolvedValueOnce(makeOpenRouterResponse(2));
+
+    const out = await embedBatch(['t1', 't2'], { fetchImpl });
+
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual(FAKE_OPENROUTER_VECTOR);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const url0 = fetchImpl.mock.calls[0]?.[0] as string;
+    expect(url0).toContain('openrouter.ai');
+  });
+
+  it('OpenRouter dimension mismatch → throws (no silent acceptance)', async () => {
+    const wrongDim = new Array(2048).fill(0.5);
+    const fetchImpl = jest
+      .fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(makeOpenRouterResponse(1, wrongDim));
+
+    await expect(embedBatch(['t1'], { fetchImpl })).rejects.toBeInstanceOf(EmbeddingError);
+  });
+});

--- a/src/skills/plugins/iks-scorer/embedding.ts
+++ b/src/skills/plugins/iks-scorer/embedding.ts
@@ -22,6 +22,8 @@
 import { logger } from '@/utils/logger';
 import { getPrismaClient } from '@/modules/database';
 import { Prisma } from '@prisma/client';
+import { config } from '@/config/index';
+import { logLLMCall } from '@/modules/llm/call-logger';
 
 const log = logger.child({ module: 'iks-scorer/embedding' });
 
@@ -30,6 +32,9 @@ export const QWEN3_EMBED_DIMENSION = 4096;
 export const MAC_MINI_OLLAMA_DEFAULT_URL = 'http://100.91.173.17:11434';
 const HEALTH_CHECK_TIMEOUT_MS = 3000;
 const EMBED_TIMEOUT_MS = 60000;
+
+/** OpenRouter cost-logger module label (Issue #543 fallback path). */
+const OPENROUTER_FALLBACK_MODULE = 'iks-embed-fallback';
 /**
  * Embed chunk size — Mac Mini M4 handles ~50 texts in ~10s comfortably.
  * 456 texts in one call exceeds 60s timeout. Chunking gives predictable
@@ -112,7 +117,40 @@ export async function embedBatch(
   return out;
 }
 
+/**
+ * Issue #543 — provider-routed embed entry.
+ *
+ *   IKS_EMBED_PROVIDER=openrouter  → skip Mac-mini, go straight to OpenRouter
+ *   IKS_EMBED_PROVIDER=ollama      → try Mac-mini, on fetch/HTTP error fall
+ *                                    back to OpenRouter (same OPENROUTER_*
+ *                                    config as embedGoalForMandala)
+ *
+ * The fallback path keeps this codebase's auto-add chain alive when the
+ * Mac-mini host is unreachable (CP436 prod incident: pipeline-runner
+ * step1 ensureMandalaEmbeddings threw → step2/3 skipped → 0 cards in
+ * dashboard while recommendation_cache had 74 rows).
+ */
 async function embedOneChunk(texts: string[], opts: EmbeddingClientOptions): Promise<number[][]> {
+  const provider = config.iksEmbed.provider;
+  if (provider === 'openrouter') {
+    return embedOneChunkViaOpenRouter(texts, opts);
+  }
+  // 'ollama' (default): Mac-mini first, OpenRouter fallback on transport/HTTP error.
+  try {
+    return await embedOneChunkViaOllama(texts, opts);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    log.warn(
+      `Ollama embed failed (chunk size=${texts.length}), falling back to OpenRouter: ${reason}`
+    );
+    return embedOneChunkViaOpenRouter(texts, opts);
+  }
+}
+
+async function embedOneChunkViaOllama(
+  texts: string[],
+  opts: EmbeddingClientOptions
+): Promise<number[][]> {
   const baseUrl = opts.baseUrl ?? MAC_MINI_OLLAMA_DEFAULT_URL;
   const model = opts.model ?? QWEN3_EMBED_MODEL;
   const fetchFn = opts.fetchImpl ?? fetch;
@@ -164,6 +202,118 @@ async function embedOneChunk(texts: string[], opts: EmbeddingClientOptions): Pro
   }
 
   return data.embeddings;
+}
+
+/**
+ * OpenRouter embed (OpenAI-compatible /embeddings). Used either as primary
+ * (provider='openrouter') or as fallback when Ollama is unreachable.
+ *
+ * Reuses the same `OPENROUTER_EMBED_*` config that powers
+ * `embedGoalForMandala`'s `embedViaOpenRouter` path — same model
+ * (`qwen/qwen3-embedding-8b`, 4096d) so vectors stay co-comparable with
+ * existing `mandala_embeddings` rows produced by Mac-mini Ollama.
+ *
+ * Each call is fire-and-forget logged to `llm_call_logs` (cost tracking
+ * lands as input_tokens=null when token counts aren't returned by the
+ * provider — pricing fallback handles that).
+ */
+async function embedOneChunkViaOpenRouter(
+  texts: string[],
+  opts: EmbeddingClientOptions
+): Promise<number[][]> {
+  const apiKey = config.openrouter.apiKey;
+  if (!apiKey) {
+    throw new EmbeddingError('OPENROUTER_API_KEY not configured (cannot fall back from Ollama)');
+  }
+
+  const baseUrl = opts.baseUrl ?? config.mandalaEmbed.openRouterBaseUrl;
+  const model = opts.model ?? config.mandalaEmbed.openRouterModel;
+  const expectedDim = config.mandalaEmbed.openRouterDimension;
+  const fetchFn = opts.fetchImpl ?? fetch;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), EMBED_TIMEOUT_MS);
+  const t0 = Date.now();
+
+  let res: Response;
+  try {
+    res = await fetchFn(`${baseUrl}/embeddings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ model, input: texts }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    const reason = err instanceof Error ? err.message : String(err);
+    void logLLMCall({
+      module: OPENROUTER_FALLBACK_MODULE,
+      model: `openrouter/${model}`,
+      latencyMs: Date.now() - t0,
+      status: 'error',
+      errorMessage: reason,
+    });
+    throw new EmbeddingError(`OpenRouter embed call failed: ${reason}`);
+  }
+  clearTimeout(timer);
+
+  if (!res.ok) {
+    let body = '';
+    try {
+      body = await res.text();
+    } catch {
+      // ignore
+    }
+    const errMsg = `OpenRouter embed HTTP ${res.status}: ${body.slice(0, 200)}`;
+    void logLLMCall({
+      module: OPENROUTER_FALLBACK_MODULE,
+      model: `openrouter/${model}`,
+      latencyMs: Date.now() - t0,
+      status: 'error',
+      errorMessage: errMsg,
+    });
+    throw new EmbeddingError(errMsg, res.status);
+  }
+
+  const data = (await res.json()) as {
+    data?: Array<{ embedding?: number[] }>;
+    usage?: { prompt_tokens?: number; total_tokens?: number };
+    error?: { message?: string };
+  };
+  if (data.error) {
+    throw new EmbeddingError(`OpenRouter embed error: ${data.error.message ?? 'unknown'}`);
+  }
+
+  const items = data.data ?? [];
+  if (items.length !== texts.length) {
+    throw new EmbeddingError(
+      `OpenRouter embed returned ${items.length} vectors, expected ${texts.length}`
+    );
+  }
+
+  const vectors: number[][] = [];
+  for (const item of items) {
+    const vec = item.embedding;
+    if (!vec || vec.length !== expectedDim) {
+      throw new EmbeddingError(
+        `OpenRouter embedding dimension mismatch: got ${vec?.length ?? 0}, expected ${expectedDim}`
+      );
+    }
+    vectors.push(vec);
+  }
+
+  void logLLMCall({
+    module: OPENROUTER_FALLBACK_MODULE,
+    model: `openrouter/${model}`,
+    inputTokens: data.usage?.prompt_tokens,
+    latencyMs: Date.now() - t0,
+    status: 'success',
+  });
+
+  return vectors;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Production incident 2026-04-28 00:21 UTC: Mac mini Ollama (Tailscale 100.91.173.17:11434) unreachable → \`pipeline-runner\` step1 \`ensureMandalaEmbeddings\` threw → step2/3 skipped → \`maybeAutoAddRecommendations\` never called → user mandala \`1d752e19\` dashboard showed 0 cards while \`recommendation_cache\` had 74 rows.

Adds an environment-driven OpenRouter fallback to the IKS / batch embed path so the auto-add chain stays alive when the Mac mini host is down.

## Behavior

| \`IKS_EMBED_PROVIDER\` | Path |
|---|---|
| \`ollama\` (default) | Mac-mini Ollama first; on fetch/HTTP error, automatic OpenRouter fallback (same-model 4096d) |
| \`openrouter\` | Skip Mac-mini entirely — direct OpenRouter (use when Mac-mini blocked) |

Same \`OPENROUTER_EMBED_*\` config that powers \`embedGoalForMandala\`'s openrouter path. Same model (\`qwen/qwen3-embedding-8b\`, 4096d) so fallback vectors stay co-comparable with existing \`mandala_embeddings\` rows.

## Cost tracking

Each OpenRouter call is fire-and-forget logged to \`llm_call_logs\` via \`logLLMCall\` (Round 1 cost-tracking infrastructure, PR #540). Module label \`iks-embed-fallback\` for query/aggregation.

## Verification

- \`tsc --noEmit\` clean
- 6/6 new fallback tests in \`src/skills/plugins/iks-scorer/__tests__/embedding-fallback.test.ts\` PASS
- Backend jest \`(mandala|video-discover|search|iks-scorer|embedding)\`: **19 fail / 430 pass** — 19 fail identical to pre-stash baseline → **0 new regression**
- \`npm run build\` clean
- \`hardcode-audit\`: 33 violations (under 35 baseline)

## Out of scope

Five other Mac-mini hardcoded sites are NOT touched in this PR — they are unrelated to the step1 dependency that caused the CP436 incident. Follow-up PR planned for Round 2:
- \`src/skills/plugins/video-discover/sources/llm-query-generator.ts:39\`
- \`src/skills/plugins/video-discover/executor.ts:501\`
- \`src/skills/plugins/trend-collector/executor.ts:66\`
- \`src/skills/plugins/trend-collector/sources/llm-extract.ts:24\`
- \`src/skills/plugins/batch-video-collector/executor.ts:118\`

\`pipeline-runner\` step1-skip logic (lines 172-178) intentionally not modified per user direction: with this fix step1 succeeds via fallback, so bypassing the skip without valid embeddings is unnecessary and risks downstream cell-specific quality regressions.

## Test plan

- [ ] CI 6/6 green
- [ ] Squash merge → deploy
- [ ] Manual smoke: with Mac-mini still blocked, run a fresh wizard on prod → expect step1 success log via OpenRouter, step2/3 complete, dashboard cards appear
- [ ] \`llm_call_logs\` query: confirm \`module='iks-embed-fallback'\` rows after deploy
- [ ] Watch deploy log: no Ollama fetch errors propagating to step1 'failed' state

Issue: #543 (CP436 — Mac-mini fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)