### PR TITLE
fix(wizard-precompute): POLL_BUDGET_MS 15s → 1s for sub-1s save SLO (#543)

### DIFF
--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -225,14 +225,27 @@ export async function consumePrecompute(
     return { consumed: false, reason: 'wrong-user' };
   }
 
-  // CP424.2 race handling: fast user clicks Step 3 save while startPrecompute
-  // is still mid-flight (status='pending' | 'running'). Design doc's "Step 2
-  // review 5-20s" assumption is structurally wrong — don't depend on user
-  // dwelling. Poll up to POLL_BUDGET_MS for the row to transition out of
-  // running. If still running when budget exhausts → miss, legacy fallback.
-  // Tier 2 discover observed 4.6s on first prod hit; 5s budget covers p95
-  // with small margin, user perceives as part of existing save latency.
-  const POLL_BUDGET_MS = 15_000;
+  // CP436 (Issue #543) — POLL_BUDGET_MS reduced 15_000 → 1_000.
+  //
+  // Original CP424.2 rationale (kept for context): poll while precompute
+  // is still mid-flight so consumePrecompute can hit even when user clicks
+  // Step 3 sooner than discover finishes. 15s covered p95 of Tier 2.
+  //
+  // Why 1s: user spec — `/create-with-data` ≤1s response is mandatory for
+  // wizard-dashboard SLO. Polling up to 15s blocked the response on
+  // precompute fairness, exceeding spec by 15×. Sub-1s budget aligns the
+  // hit window with the Tier 1 envelope only — Tier 2 misses immediately
+  // fall back to `triggerMandalaPostCreationAsync` (mandala-post-creation.ts:33),
+  // which fires the same v3 discover async and streams cards through
+  // cardPublisher → /videos/stream SSE backlog (mandalas.ts:2284-2316).
+  //
+  // Trade-off: precompute hit-rate drops for the slow-Tier-2 cases; SSE
+  // path absorbs the latency without blocking save. Net wizard finalize
+  // p99 ≤1s when precompute is done | running-but-fast | not-needed.
+  //
+  // Tracking: log.info on poll-wait end captures `final_status` +
+  // `waited_ms` so we can quantify miss reasons in prod log post-deploy.
+  const POLL_BUDGET_MS = 1_000;
   const POLL_INTERVAL_MS = 250;
   if (row.status === 'pending' || row.status === 'running') {
     const pollStart = Date.now();

--- a/tests/unit/modules/wizard-precompute.test.ts
+++ b/tests/unit/modules/wizard-precompute.test.ts
@@ -264,7 +264,9 @@ describe('wizard-precompute — consumePrecompute', () => {
   });
 
   test('status=running throughout budget → miss (not-done) after poll timeout', async () => {
-    // Always returns running — simulate precompute that doesn't finish in 5s.
+    // Always returns running — simulate precompute that doesn't finish in 1s.
+    // CP436 (Issue #543): POLL_BUDGET_MS reduced 15_000 → 1_000 for sub-1s
+    // wizard finalize SLO. Misses fall back to triggerMandalaPostCreationAsync.
     mockFindUnique.mockResolvedValue({
       session_id: SESSION,
       user_id: USER,
@@ -283,10 +285,12 @@ describe('wizard-precompute — consumePrecompute', () => {
     const elapsed = Date.now() - t0;
     expect(r.consumed).toBe(false);
     expect(r.reason).toBe('not-done');
-    // Should have polled for close to 5s before giving up.
-    expect(elapsed).toBeGreaterThanOrEqual(4500);
-    expect(elapsed).toBeLessThan(7000);
-  }, 15_000);
+    // Should give up within ~1s (POLL_BUDGET_MS=1000). Lower bound allows
+    // for the polling interval (250ms) to catch the budget-exhausted state
+    // on its next tick. Upper bound guards against budget creep.
+    expect(elapsed).toBeGreaterThanOrEqual(800);
+    expect(elapsed).toBeLessThan(1500);
+  }, 5_000);
 
   test('status=running → done within budget → consume succeeds', async () => {
     // First read: running. Subsequent reads: done.


### PR DESCRIPTION
## Summary

Round 2 PR-Y0a — wizard finalize ≤1s spec (Issue #543 / CP436). Single-line constant change + test expectation update.

### Root cause

CP424.2 set \`POLL_BUDGET_MS = 15_000\` in \`consumePrecompute\` so fast Step 3 clicks could still benefit from in-flight startPrecompute. Side effect: \`/create-with-data\` blocks up to 15s on every call before deciding hit-or-miss → user-spec wizard finalize 1s exceeded by 15×.

### Fix

| | Before | After |
|---|---|---|
| \`POLL_BUDGET_MS\` (wizard-precompute.ts:235) | 15_000 | **1_000** |
| Test elapsed assertion (running budget timeout) | 4500-7000ms | **800-1500ms** |

Misses fall back to \`triggerMandalaPostCreationAsync\` (mandala-post-creation.ts:33), which already runs v3 discover async and streams cards through \`cardPublisher\` → \`/videos/stream\` SSE backlog (mandalas.ts:2284-2316). Slow-Tier-2 cases reach the dashboard via the same SSE channel without blocking the save.

### Verification (raw)

```
tsc --noEmit                                           clean
npm run build                                          clean
jest tests/unit/modules/wizard-precompute.test.ts     16/16 PASS
   (running-budget-timeout test elapsed = 1003ms = budget hit exactly)
jest --testPathPattern="(wizard|precompute|mandala)"  19 fail / 200 pass
   (19 fail = pre-stash baseline → 0 new regression)
hardcode-audit                                         33 (≤35 baseline)
```

### Test plan

- [ ] CI 6/6 green
- [ ] Squash merge → deploy
- [ ] Prod log post-deploy: \`precompute poll-wait end ... waited_ms\` distribution. Expect waited_ms ≤ 1000 for all entries.
- [ ] Prod DB: \`SELECT status, COUNT(*) FROM mandala_wizard_precompute WHERE created_at >= NOW() - INTERVAL '1 hour' GROUP BY status\` — track 'consumed' vs 'done'/'failed' ratio over 24h.
- [ ] Manual: complete a wizard end-to-end — \`/create-with-data\` response < 1s; cards arrive on dashboard via SSE within 12s.

### Out of scope (intentionally minimal)

- **PR-Y0b ENV fix** (\`V3_ENABLE_TIER1_CACHE=true\`, \`V3_CENTER_GATE_MODE=semantic\`, \`V3_ENABLE_SEMANTIC_RERANK=true\`) — Round 3 read + CP418 rollback risk review must complete first. Tracked in handoff redesign doc.
- **\`user_video_states.tier\` column** — design doc decision pending.
- **New endpoints** (\`/wizard-step1\`, \`/card-stream\`) — redundant; existing \`/wizard-stream\` + \`/videos/stream\` already cover the spec (mandalas.ts:638, 2196).

Issue: #543 (CP436 — wizard finalize sub-1s SLO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)