### PR TITLE
feat(v3): enable Tier 1 video_pool semantic match in prod (#543)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -100,6 +100,18 @@ services:
       # QW-2/QW-4 (CP426): recency 편향 감소 + search timeout 확장
       - V3_RECENCY_WEIGHT=0.05
       - V3_YOUTUBE_SEARCH_TIMEOUT_MS=3000
+      # CP436 PR-Y0b1 (Issue #543) — Tier 1 video_pool semantic match ON.
+      # Without this flag, executor.ts:254 short-circuits the pgvector path:
+      #   `tier1Matches = v3Config.enableTier1Cache ? matchFromVideoPool(...) : []`
+      # leaving only RedisProvider (lexical) + YouTubeProvider in the orchestrator
+      # chain. That path produced "Google One 129장 무관" because lexical token
+      # matching admits "AI 일반" video for any AI-mention sub_goal.
+      # PoolProvider uses raw pgvector cosine on `video_pool_embeddings` (3,121
+      # rows in prod 2026-04-28) and bypasses mandala-filter, so the CP418
+      # rollback path (V3_CENTER_GATE_MODE=semantic embed-on-titles 56s blocking)
+      # does NOT apply here. Cap unchanged: V3_TARGET_PER_CELL=8.
+      # Revert: delete this line → executor reverts to empty tier1 array.
+      - V3_ENABLE_TIER1_CACHE=true
       # OPENROUTER_EMBED_MODEL defaults to `qwen/qwen3-embedding-8b` in
       # code. Uncomment + override here ONLY if the exact OpenRouter
       # model id string differs (verify at https://openrouter.ai/models).


### PR DESCRIPTION
## Summary

Round 2 PR-Y0b1 — flip `V3_ENABLE_TIER1_CACHE=true` in prod compose. **Env-only, no code change.**

### Root cause this fixes

`src/skills/plugins/video-discover/v3/executor.ts:254`:
```ts
const tier1Matches = v3Config.enableTier1Cache
  ? await matchFromVideoPool({...})
  : [];
```
- `config.ts:148` default `false`
- prod compose currently has no `V3_ENABLE_TIER1_CACHE` line → false
- Result: PoolProvider semantic match is dead weight in prod. Orchestrator chain = RedisProvider (lexical) + YouTubeProvider only.
- "Google One AI 프로젝트 시작하기" mandala (CP436) → 129 cards `rec_reason='realtime'`, lexically valid ("AI") but semantically off-topic (Nvidia NIM, MLOps 101, Intel oneAPI). Direct consequence of missing semantic layer.

### Why low risk (CP418 unrelated)

- `PoolProvider` (`pool-provider.ts:86`) → `matchFromVideoPool` (`cache-matcher.ts:79-121`) uses raw pgvector cosine `<=>` between `mandala_embeddings` and `video_pool_embeddings`. **No `embedBatch` call.**
- CP418 56s blocking incident was `V3_CENTER_GATE_MODE=semantic` → `mandala-filter.ts` requires `candidateEmbeddings` Map → caller (`executor.ts:753 embedBatch(texts)`) embedding hundreds of candidate titles synchronously. **Different code branch.**
- PoolProvider results enter `slots.push(...)` directly (executor.ts:266-281), bypassing mandala-filter entirely. Lexical token-overlap quirks (which produced "Google One → AI 일반") don't apply.
- Cap unchanged: `V3_TARGET_PER_CELL=8`. `runTier2` (executor.ts:303-314) fills any deficit. Cold-start mandalas (no Tier 1 hit) behave identically to today.
- Dependency: `ensureMandalaEmbeddings` step1 must succeed (PoolProvider joins on `mandala_embeddings WHERE mandala_id=$1 AND level=1`). PR #550 OpenRouter fallback restored step1 reliability under Mac-mini outage.

### Verification (prod log + DB after deploy)

- prod log: `cache match: mandala=… lang=… matches=N` (cache-matcher.ts:123). `matches=N>0` confirms Tier 1 firing.
- prod DB: `SELECT rec_reason, COUNT(*) FROM recommendation_cache WHERE created_at >= NOW() - INTERVAL '1 hour' GROUP BY rec_reason`. Expect `'cache'` rows alongside `'realtime'` (zero today).
- User manual smoke: new wizard on a domain covered by video_pool (3.1k rows). Cards should include topically-fit items, not just lexical matches.

### Test plan

- [ ] CI 6/6 green (compose-only, no code change → all checks should pass)
- [ ] Squash merge → deploy
- [ ] Prod log grep `cache match:` after first wizard
- [ ] DB rec_reason distribution check (1h post-deploy)
- [ ] Manual: new "Google One" or similar mandala → check card relevance

### Out of scope (follow-up PRs)

- **Y0b2**: `V3_CENTER_GATE_MODE=semantic` + executor.ts:753 candidate-embed cap (`texts.slice(0, V3_SEMANTIC_MAX_CANDIDATES=30)`) to prevent CP418 recurrence.
- **Y0b3**: `V3_ENABLE_SEMANTIC_RERANK=true` after `@/modules/video-dictionary` rerank path read.

Issue: #543 (CP436 — semantic layer activation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)