### PR TITLE
fix(wizard): inline auto-add after precompute consume so cards display ≤2s (#543)

### DIFF
--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -382,5 +382,47 @@ export async function consumePrecompute(
       `slots=${slots.length} inserted=${inserted}`
   );
 
+  // CP436 PR-Y0c (Issue #543) — kick auto-add inline so user_video_states
+  // populates without waiting for pipeline-runner step3.
+  //
+  // Why this exists: pipeline-runner step1 (ensureMandalaEmbeddings) blocks
+  // step3 (maybeAutoAdd) and step1 currently takes ~30s end-to-end on prod
+  // (Mac-mini Ollama down → OpenRouter fallback). Wizard finalize returns
+  // in ~1.3s (CP436 PR-Y0a) but the dashboard shows 0 cards for the entire
+  // 30s window because user_video_states is empty until step3 fires.
+  //
+  // The recommendation_cache rows are already INSERTed above (status='pending'),
+  // so calling maybeAutoAddRecommendations here promotes them straight into
+  // user_video_states + flips status='shown' so the later step3 call
+  // (post-step1) sees an empty 'pending' set and no-ops cleanly.
+  //
+  // Race / dedup safety:
+  //   - userVideoState upsert (auto-add-recommendations.ts:234) keys on
+  //     @@unique([user_id, videoId]) → idempotent
+  //   - status='shown' UPDATE (auto-add-recommendations.ts:299-307) prevents
+  //     step3 from re-processing the same rows
+  //   - user_skill_config opt-in gate is identical (skill_type='video_discover',
+  //     enabled=true, config.auto_add!=false) — same opt-in posture as today
+  //
+  // Failure handling: log.warn + swallow. The caller (`/create-with-data`)
+  // does NOT depend on auto-add success for save success; pipeline-runner
+  // step3 will retry the same logic ~30s later as a safety net.
+  try {
+    const { maybeAutoAddRecommendations } = await import('./auto-add-recommendations');
+    const autoAddResult = await maybeAutoAddRecommendations(input.userId, input.mandalaId);
+    log.info(
+      `precompute consume → auto-add inline: ok=${autoAddResult.ok}` +
+        (autoAddResult.ok
+          ? ` inserted=${autoAddResult.rowsInserted ?? 0} preserved=${autoAddResult.rowsPreserved ?? 0}`
+          : ` reason=${autoAddResult.reason ?? 'unknown'}`)
+    );
+  } catch (err) {
+    log.warn(
+      `precompute consume → auto-add inline threw (non-fatal — pipeline-runner step3 will retry): ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+
   return { consumed: true, cardsInserted: inserted, slotsCount: slots.length };
 }

--- a/tests/unit/modules/wizard-precompute.test.ts
+++ b/tests/unit/modules/wizard-precompute.test.ts
@@ -48,6 +48,13 @@ jest.mock('@/modules/recommendations/publisher', () => ({
   notifyCardAdded: mockNotifyCardAdded,
 }));
 
+// CP436 PR-Y0c — consumePrecompute now invokes maybeAutoAddRecommendations
+// inline (dynamic import). Mock as a jest.fn so we can assert call shape.
+const mockMaybeAutoAdd = jest.fn().mockResolvedValue({ ok: true, rowsInserted: 0 });
+jest.mock('@/modules/mandala/auto-add-recommendations', () => ({
+  maybeAutoAddRecommendations: mockMaybeAutoAdd,
+}));
+
 jest.mock('@/config/wizard-precompute', () => ({
   loadWizardPrecomputeConfig: mockLoadConfig,
 }));
@@ -418,6 +425,7 @@ describe('wizard-precompute — consumePrecompute', () => {
       expires_at: FUTURE,
       discover_result: { slots },
     });
+    mockMaybeAutoAdd.mockClear();
 
     const r = await consumePrecompute({
       sessionId: SESSION,
@@ -436,6 +444,35 @@ describe('wizard-precompute — consumePrecompute', () => {
     expect(lastUpdate.data.status).toBe('consumed');
     expect(lastUpdate.data.consumed_mandala_id).toBe(MANDALA);
     expect(lastUpdate.data.consumed_at).toBeInstanceOf(Date);
+    // CP436 PR-Y0c: maybeAutoAddRecommendations called inline after consume
+    // so user_video_states populates without waiting for pipeline-runner step3.
+    expect(mockMaybeAutoAdd).toHaveBeenCalledTimes(1);
+    expect(mockMaybeAutoAdd).toHaveBeenCalledWith(USER, MANDALA);
+  });
+
+  test('PR-Y0c: maybeAutoAdd thrown error is non-fatal (consume still succeeds)', async () => {
+    const slots = [makeSlot(0, 'v1')];
+    mockFindUnique.mockResolvedValueOnce({
+      session_id: SESSION,
+      user_id: USER,
+      goal: 'g',
+      status: 'done',
+      expires_at: FUTURE,
+      discover_result: { slots },
+    });
+    mockMaybeAutoAdd.mockRejectedValueOnce(new Error('simulated DB blip'));
+
+    const r = await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+
+    expect(r.consumed).toBe(true);
+    expect(r.cardsInserted).toBe(1);
+    // pipeline-runner step3 still retries the same logic ~30s later
+    expect(mockMaybeAutoAdd).toHaveBeenCalledTimes(1);
   });
 
   test('case-insensitive + trimmed goal match (resilient to minor client edits)', async () => {


### PR DESCRIPTION
## Summary

CP436 PR-Y0c — emergency fix for wizard "0 cards displayed" incident (Issue #543).

After 4 prior PRs (#544/#545/#550/#551/#552) the dashboard still shows 0 cards for ~30s after wizard finalize even though `recommendation_cache` is fully populated. This PR closes the path.

### Root cause

| Layer | State |
|---|---|
| `recommendation_cache` (122 rows) | INSERT-ed by `wizard-precompute.consumePrecompute:294-323` at finalize time ✅ |
| `user_video_states` (which dashboard counts) | INSERT happens only via `auto-add-recommendations.ts:234` |
| `auto-add-recommendations` caller | `pipeline-runner.ts:242` step3 |
| step3 gating | step1 `ensureMandalaEmbeddings` success required |
| step1 latency | ~30s on prod (Mac-mini Ollama down → OpenRouter embed fallback per PR #550) |
| Dashboard query | `mandalas.ts:1473-1495` unions `user_local_cards + user_video_states` only — ignores `recommendation_cache` |

→ For 30s window after finalize, `user_video_states` is empty, dashboard cell badges show "0".

### Fix

Single block added to `wizard-precompute.ts:387-403`:

```ts
try {
  const { maybeAutoAddRecommendations } = await import('./auto-add-recommendations');
  const autoAddResult = await maybeAutoAddRecommendations(input.userId, input.mandalaId);
  log.info(`precompute consume → auto-add inline: ok=${autoAddResult.ok} ...`);
} catch (err) {
  log.warn(`... non-fatal — pipeline-runner step3 will retry: ${...}`);
}
```

Calls the existing `maybeAutoAddRecommendations` immediately after `consumePrecompute` finishes the `recommendation_cache` INSERT loop. No new logic — reuses the same dedup/upsert path that step3 currently uses.

### Race / dedup safety (verified, no new logic)

- `userVideoState.upsert` keys on `@@unique([user_id, videoId])` — idempotent
- `recommendation_cache.status` flips `pending`→`shown` — prevents later step3 from re-processing
- Same `user_skill_config` opt-in gate
- try/catch swallows errors — `/create-with-data` response unaffected, step3 retry remains as safety net

### Verification

- `tsc --noEmit` clean
- `npm run build` clean
- `jest tests/unit/modules/wizard-precompute.test.ts` **17/17 PASS** (15 existing + 2 new for inline auto-add)

### Test plan

- [ ] CI 6/6 green
- [ ] Squash merge → deploy
- [ ] User new wizard → dashboard cards visible within ~2s (was ~30s)
- [ ] Prod log: `precompute consume → auto-add inline: ok=true inserted=N` after each wizard finalize
- [ ] Prod DB: `user_video_states` row count grows simultaneously with `recommendation_cache` (was step3-delayed)

### Honest scope (out of band)

- step1 ~30s OpenRouter embed latency reduction — separate PR
- `V3_ENABLE_TIER1_CACHE=true` effect 0 (ephemeral path lacks mandalaId, `cache-matcher.ts:83`) — separate PR
- SSE backlog emits `recommendation_cache` but dashboard ignores it — separate decision

Issue: #543 (CP436 — wizard instant card display, service incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)