### PR TITLE
feat(v3): bypass mandala-filter, trust YouTube search.list ranking (#543)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -108,6 +108,16 @@ services:
       # embedBatch call ([centerGoal, ...top30titles]) stays in a single
       # OpenRouter/Ollama request. Cap > 50 would cross the chunk boundary.
       - V3_SEMANTIC_MAX_CANDIDATES=30
+      # CP436 PR-Y0d (Issue #543) — bypass mandala-filter and trust YouTube's
+      # search.list ranking. User feedback (2026-04-28): the 9-axis filter
+      # actively degraded card quality vs the original YouTube-only path
+      # (e.g. "Google One AI 프로젝트" → 109 token-overlap matches in Nvidia
+      # NIM / MLOps / Intel oneAPI…). With this flag, candidates emit in
+      # YouTube's native order, distributed to cells via cellIndexHint set
+      # by v2/keyword-builder. centerGateMode and semantic cap above stay
+      # configured but become no-ops for the Tier 2 path while this is true.
+      # Revert: delete this line → re-enable applyMandalaFilter.
+      - V3_USE_YOUTUBE_RANKING_ONLY=true
       # QW-2/QW-4 (CP426): recency 편향 감소 + search timeout 확장
       - V3_RECENCY_WEIGHT=0.05
       - V3_YOUTUBE_SEARCH_TIMEOUT_MS=3000

--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -29,6 +29,7 @@ describe('loadV3Config', () => {
       minViewCount: DEFAULT_MIN_VIEW_COUNT,
       minViewsPerDay: DEFAULT_MIN_VIEWS_PER_DAY,
       semanticMaxCandidates: 30, // PR-Y0b2 default
+      useYoutubeRankingOnly: false, // PR-Y0d default
     });
   });
 
@@ -98,6 +99,7 @@ describe('loadV3Config', () => {
       minViewCount: DEFAULT_MIN_VIEW_COUNT,
       minViewsPerDay: DEFAULT_MIN_VIEWS_PER_DAY,
       semanticMaxCandidates: 30, // PR-Y0b2 default
+      useYoutubeRankingOnly: false, // PR-Y0d default
     });
   });
 

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -153,6 +153,33 @@ export const DEFAULT_MIN_VIEWS_PER_DAY = 10;
  */
 export const DEFAULT_SEMANTIC_MAX_CANDIDATES = 30;
 
+/**
+ * Bypass mandala-filter and trust YouTube's own search.list ranking
+ * (Issue #543, CP436 PR-Y0d).
+ *
+ * Default `false` keeps the existing 9-axis filter pipeline (token-overlap
+ * + sub_goal jaccard + recency + optional semantic gate). Pre-CP436 prod
+ * traffic showed that the filter actively degraded card quality for many
+ * goals: candidates were re-ranked by token overlap on a tokenizer that
+ * admits "AI" alone, discarding the strong topical-relevance signal that
+ * YouTube already encodes in `search.list` order.
+ *
+ * When `true`, the executor skips applyMandalaFilter and emits enriched
+ * candidates in the order returned by YouTube. Cell assignment uses the
+ * per-cell query's `cellIndexHint` (set in v2/keyword-builder), so cards
+ * land in the cell whose query produced them. Score is a descending
+ * cursor that preserves arrival order in the global desc sort that picks
+ * cards across cells.
+ *
+ * Trade-offs:
+ *   + restores YouTube's native relevance ranking
+ *   + avoids the "Google One AI 프로젝트 → Nvidia NIM" lexical false-positive
+ *   - no defense against mandala-irrelevant titles that YouTube ranks high
+ *     (best mitigated by tightening keyword-builder queries instead of
+ *     re-scoring downstream)
+ */
+export const DEFAULT_USE_YOUTUBE_RANKING_ONLY = false;
+
 const minViewCount = z
   .preprocess(
     (v) => (v == null || v === '' ? undefined : Number(v)),
@@ -190,6 +217,7 @@ export const v3EnvSchema = z.object({
   V3_MIN_VIEW_COUNT: minViewCount,
   V3_MIN_VIEWS_PER_DAY: minViewsPerDay,
   V3_SEMANTIC_MAX_CANDIDATES: semanticMaxCandidates,
+  V3_USE_YOUTUBE_RANKING_ONLY: booleanFlag.optional().default(false as unknown as string),
 });
 
 export interface V3Config {
@@ -208,6 +236,7 @@ export interface V3Config {
   minViewCount: number;
   minViewsPerDay: number;
   semanticMaxCandidates: number;
+  useYoutubeRankingOnly: boolean;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -227,6 +256,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_MIN_VIEW_COUNT: env['V3_MIN_VIEW_COUNT'],
     V3_MIN_VIEWS_PER_DAY: env['V3_MIN_VIEWS_PER_DAY'],
     V3_SEMANTIC_MAX_CANDIDATES: env['V3_SEMANTIC_MAX_CANDIDATES'],
+    V3_USE_YOUTUBE_RANKING_ONLY: env['V3_USE_YOUTUBE_RANKING_ONLY'],
   });
   if (!parsed.success) {
     return {
@@ -245,6 +275,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       minViewCount: DEFAULT_MIN_VIEW_COUNT,
       minViewsPerDay: DEFAULT_MIN_VIEWS_PER_DAY,
       semanticMaxCandidates: DEFAULT_SEMANTIC_MAX_CANDIDATES,
+      useYoutubeRankingOnly: DEFAULT_USE_YOUTUBE_RANKING_ONLY,
     };
   }
   return {
@@ -263,6 +294,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     minViewCount: parsed.data.V3_MIN_VIEW_COUNT,
     minViewsPerDay: parsed.data.V3_MIN_VIEWS_PER_DAY,
     semanticMaxCandidates: parsed.data.V3_SEMANTIC_MAX_CANDIDATES,
+    useYoutubeRankingOnly: parsed.data.V3_USE_YOUTUBE_RANKING_ONLY,
   };
 }
 

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -795,40 +795,68 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   }
 
   const tMandalaFilterStart = Date.now();
-  const { byCell, stats: mfStats } = applyMandalaFilterWithStats(filterInputs, {
-    centerGoal: input.state.centerGoal,
-    subGoals: input.state.subGoals,
-    language: input.state.language,
-    focusTags: input.state.focusTags,
-    recencyWeight: v3Config.recencyWeight,
-    recencyHalfLifeMonths: v3Config.recencyHalfLifeMonths,
-    centerGateMode: v3Config.centerGateMode,
-    centerEmbedding,
-    candidateEmbeddings,
-  });
-  debug.timing.mandalaFilterMs = Date.now() - tMandalaFilterStart;
-
-  debug.mandalaFilterOutput = mfStats.output;
-  debug.mandalaFilterDroppedCenterGate = mfStats.droppedByCenterGate;
-  debug.mandalaFilterDroppedJaccard = mfStats.droppedByJaccardBelowThreshold;
-  debug.mandalaFilterCenterTokens = mfStats.centerTokens;
-  debug.mandalaFilterSubGoalTokenCounts = mfStats.subGoalTokenCounts;
-
-  // Flatten into a single scored list (per-cell order preserved inside the
-  // map by applyMandalaFilter; overall sort happens again below because the
-  // cap-per-cell loop needs a global desc order to pick the best slots
-  // across cells fairly).
-  const tScoringStart = Date.now();
   const deficitCellSet = new Set(input.deficitCells.map((c) => c.cellIndex));
   const scored: ScoredCandidate[] = [];
-  for (const [cellIndex, list] of byCell) {
-    if (!deficitCellSet.has(cellIndex)) continue;
-    for (const a of list) {
-      const enrichedVideo = enrichedById.get(a.candidate.videoId);
-      if (!enrichedVideo) continue;
-      scored.push({ video: enrichedVideo, cellIndex, score: a.score });
+
+  if (v3Config.useYoutubeRankingOnly) {
+    // CP436 PR-Y0d (Issue #543) — bypass mandala-filter, trust YouTube's
+    // native search.list ranking. Each enriched candidate keeps the
+    // cellIndexHint set by v2/keyword-builder (the per-cell query that
+    // produced it), so cards land in the cell whose query they came from.
+    // Score is a descending cursor that preserves arrival order through
+    // the global desc sort that picks cards across cells.
+    let scoreCursor = 1.0;
+    const STEP = 0.01;
+    const MIN_SCORE = 0.01;
+    let kept = 0;
+    let droppedNotInDeficit = 0;
+    for (const v of filterable) {
+      const cellIndex = v.cellIndexHint ?? 0;
+      if (!deficitCellSet.has(cellIndex)) {
+        droppedNotInDeficit++;
+        continue;
+      }
+      scored.push({ video: enrichedById.get(v.videoId)!, cellIndex, score: scoreCursor });
+      scoreCursor = Math.max(MIN_SCORE, scoreCursor - STEP);
+      kept++;
+    }
+    debug.timing.mandalaFilterMs = Date.now() - tMandalaFilterStart;
+    debug.mandalaFilterOutput = kept;
+    debug.mandalaFilterDroppedCenterGate = 0;
+    debug.mandalaFilterDroppedJaccard = droppedNotInDeficit;
+    debug.mandalaFilterCenterTokens = [];
+    debug.mandalaFilterSubGoalTokenCounts = [];
+    log.info(`youtube-ranking-only: kept=${kept} dropped_not_in_deficit=${droppedNotInDeficit}`);
+  } else {
+    const { byCell, stats: mfStats } = applyMandalaFilterWithStats(filterInputs, {
+      centerGoal: input.state.centerGoal,
+      subGoals: input.state.subGoals,
+      language: input.state.language,
+      focusTags: input.state.focusTags,
+      recencyWeight: v3Config.recencyWeight,
+      recencyHalfLifeMonths: v3Config.recencyHalfLifeMonths,
+      centerGateMode: v3Config.centerGateMode,
+      centerEmbedding,
+      candidateEmbeddings,
+    });
+    debug.timing.mandalaFilterMs = Date.now() - tMandalaFilterStart;
+
+    debug.mandalaFilterOutput = mfStats.output;
+    debug.mandalaFilterDroppedCenterGate = mfStats.droppedByCenterGate;
+    debug.mandalaFilterDroppedJaccard = mfStats.droppedByJaccardBelowThreshold;
+    debug.mandalaFilterCenterTokens = mfStats.centerTokens;
+    debug.mandalaFilterSubGoalTokenCounts = mfStats.subGoalTokenCounts;
+
+    for (const [cellIndex, list] of byCell) {
+      if (!deficitCellSet.has(cellIndex)) continue;
+      for (const a of list) {
+        const enrichedVideo = enrichedById.get(a.candidate.videoId);
+        if (!enrichedVideo) continue;
+        scored.push({ video: enrichedVideo, cellIndex, score: a.score });
+      }
     }
   }
+  const tScoringStart = Date.now();
   debug.scoredCandidates = scored.length;
 
   // Cap per cell using the deficit need + overall target remaining.


### PR DESCRIPTION
## Summary

CP436 PR-Y0d — architectural pivot per user feedback (2026-04-28):

> "위저드-대시보드의 카드 품질은 아무것도 적용하지 않은 youtube api 만 적용했던 초기가 가장 좋음. 현재 구현된 아키텍쳐는 전혀 의도데로 처리되지 않아서 조악한 품질이야!!!!!!!!"

The 9-axis mandala-filter actively degraded card quality vs the original YouTube-only path. Concrete failures observed in CP436 prod:

- "Google One AI 프로젝트 시작하기" → 129 cards, all token-overlap matches on "AI" (Nvidia NIM, MLOps 101, Intel oneAPI, …)
- "건강습관 만들기" → 109 cards, similar lexical noise

The filter's score recomputation (`mandala-filter.ts:333-334`) replaces YouTube's strong topical-relevance signal with a token-jaccard heuristic that admits broad single-word matches.

## Fix

New env `V3_USE_YOUTUBE_RANKING_ONLY=true` on prod (default `false` in code). When true, the executor's `runTier2` skips `applyMandalaFilter` and emits enriched candidates in YouTube's native order. Cell assignment via `cellIndexHint` (set by `v2/keyword-builder` per query). Score is a descending cursor preserving arrival order through the global desc sort that picks slots across cells.

## Behavior contract

- Cell assignment via `cellIndexHint` (same mechanism the orchestrator path already uses)
- Existing dedup + per-channel cap + deficit-cell-set filtering continue (`executor.ts:840-870` unchanged)
- `centerGateMode` and `V3_SEMANTIC_MAX_CANDIDATES` remain configured but become no-ops for Tier 2 while this flag is on
- Replaces filter logs with: `youtube-ranking-only: kept=N dropped_not_in_deficit=K`

## Verification

\`\`\`
tsc --noEmit                                                clean
jest config.test.ts + v3-semantic-cap.test.ts              26/26 PASS
jest --testPathPattern="(video-discover|wizard|mandala|search|iks-scorer)"
                                                            19 fail / 465 pass
   (19 fail = pre-stash baseline → 0 new regression)
npm run build                                               clean
\`\`\`

## Test plan post-deploy

- [ ] CI 6/6 green
- [ ] Squash merge → deploy
- [ ] Prod log: `youtube-ranking-only: kept=N dropped_not_in_deficit=K` once per Tier 2 run
- [ ] User new wizard ("Google One AI 프로젝트" or similar): expect ~30-50 cards in YouTube's native order; titles match the actual goal, not just the loose token "AI"
- [ ] `mandalaFilterMs` in debug ≈ 0 (no filter call)

## Out of scope

- Tightening `v2/keyword-builder` query precision (may further reduce upstream noise)
- Re-enabling mandala-filter as a post-rank refiner under flag once YouTube ranking-only baseline is measured

Issue: #543 (CP436 — YouTube ranking only, mandala-filter bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)