### PR TITLE
fix(v3): disable Tier 1 video_pool cache — noise exceeds signal (#543)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -121,18 +121,25 @@ services:
       # QW-2/QW-4 (CP426): recency 편향 감소 + search timeout 확장
       - V3_RECENCY_WEIGHT=0.05
       - V3_YOUTUBE_SEARCH_TIMEOUT_MS=3000
-      # CP436 PR-Y0b1 (Issue #543) — Tier 1 video_pool semantic match ON.
-      # Without this flag, executor.ts:254 short-circuits the pgvector path:
-      #   `tier1Matches = v3Config.enableTier1Cache ? matchFromVideoPool(...) : []`
-      # leaving only RedisProvider (lexical) + YouTubeProvider in the orchestrator
-      # chain. That path produced "Google One 129장 무관" because lexical token
-      # matching admits "AI 일반" video for any AI-mention sub_goal.
-      # PoolProvider uses raw pgvector cosine on `video_pool_embeddings` (3,121
-      # rows in prod 2026-04-28) and bypasses mandala-filter, so the CP418
-      # rollback path (V3_CENTER_GATE_MODE=semantic embed-on-titles 56s blocking)
-      # does NOT apply here. Cap unchanged: V3_TARGET_PER_CELL=8.
-      # Revert: delete this line → executor reverts to empty tier1 array.
-      - V3_ENABLE_TIER1_CACHE=true
+      # CP436 PR-Y0e (Issue #543) — Tier 1 video_pool cache REVERTED to off.
+      # Original Y0b1 enabled PoolProvider (pgvector cosine on 3,121
+      # video_pool_embeddings rows) hoping to add semantic recall to
+      # YouTubeProvider lexical results. Prod measurement (mandala
+      # 69b4e729 "일일 공부 습관 만들기"):
+      #   - rec_reason='cache' (PoolProvider) = 11/12 in cell_index=1,
+      #     all "시민참여 프로그램" (cosine ~0.5 against keyword
+      #     "최적의 공부 환경 구축"). Pure noise.
+      #   - 100% of cards in this mandala were rec_reason='cache' —
+      #     YouTube's own ranking was buried by video_pool noise.
+      # Root cause:
+      #   (1) video_pool 3.1K covers ≪ user mandala domains
+      #   (2) cache-matcher.ts:22 DEFAULT_RELEVANCE_THRESHOLD=0.3 admits
+      #       cosine ≥ 0.3, which is "barely closer than random"
+      # Revert leaves executor.ts:254 returning empty tier1Matches —
+      # YouTubeProvider becomes the sole source, restoring CP385-era
+      # quality (user feedback: "초기 youtube-only 가 가장 좋음").
+      # Re-enable path: video_pool ≥ 30K rows + threshold raised to 0.5+.
+      # - V3_ENABLE_TIER1_CACHE=true
       # OPENROUTER_EMBED_MODEL defaults to `qwen/qwen3-embedding-8b` in
       # code. Uncomment + override here ONLY if the exact OpenRouter
       # model id string differs (verify at https://openrouter.ai/models).


### PR DESCRIPTION
## Summary

CP436 PR-Y0e — Issue #543 LOW-risk emergency revert per user handoff (2026-04-28).

PR #552 (Y0b1) enabled the PoolProvider hoping pgvector cosine on \`video_pool_embeddings\` (3.1K rows) would add semantic recall. **Prod measurement shows the opposite**: video_pool noise dominates, YouTube's native ranking is buried under "barely closer than random" matches.

## Evidence (prod DB raw, mandala 69b4e729 "일일 공부 습관 만들기")

```
138 recommendation_cache rows
  rec_reason='cache' (Tier 1 PoolProvider)  : 138/138  (100%)
  rec_reason='realtime' (Tier 2 YouTube)    : 0/138    ← YouTube buried

cell_index=1 sample (11/12 cards):
  keyword: "최적의 공부 환경 구축 및 방해 요소 제거"
  matched: 시민참여 프로그램 / 광주폴리 / 비엔날레 / 통일부 시민참여 …
  cosine ~0.5 against the keyword
```

## Root cause

| File | Line | Issue |
|------|------|-------|
| `cache-matcher.ts` | 22 | `DEFAULT_RELEVANCE_THRESHOLD=0.3` too permissive |
| `video_pool` table | 3,121 rows | Covers ≪ user mandala domain breadth |
| Combined | — | Polysemous Korean nouns ("환경", "프로그램") match off-domain pool entries |

## Fix

\`docker-compose.prod.yml:135\` — \`V3_ENABLE_TIER1_CACHE=true\` commented out.
- \`executor.ts:254\` returns \`tier1Matches = []\` (empty)
- Orchestrator reverts to RedisProvider (Tier 0) + YouTubeProvider (Tier 2)
- Same as pre-CP436 baseline (user: "초기 youtube-only 가 가장 좋음")

## Re-enable path (out of scope)

- \`video_pool\` grown to ≥ 30K rows (10× current)
- \`DEFAULT_RELEVANCE_THRESHOLD\` raised to 0.5+
- Threshold tuning measured against prod cosine distribution

## Test plan post-deploy

- [ ] CI 6/6 green (env-only, no code change)
- [ ] Squash merge → deploy
- [ ] Prod DB query (30 min after deploy):
  \`\`\`sql
  SELECT rec_reason, COUNT(*) FROM recommendation_cache
  WHERE created_at > NOW() - INTERVAL '30 min'
  GROUP BY rec_reason
  -- Expect: cache=0, realtime > 0
  \`\`\`
- [ ] Prod log: \`youtube-ranking-only: kept=N dropped_not_in_deficit=K\` appears
- [ ] User new wizard test — cards should reflect YouTube native ranking

No code change. \`tsc\` / \`jest\` / \`build\` N/A — env-only revert.

Issue: #543 (CP436 — Y0b1 revert per LOW-risk handoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)