### PR TITLE
fix(keyword-builder): extract core keyword from sub_goal to reduce YouTube broad match (#543)

### DIFF
--- a/src/skills/plugins/video-discover/v2/keyword-builder.ts
+++ b/src/skills/plugins/video-discover/v2/keyword-builder.ts
@@ -236,8 +236,16 @@ function buildRuleBasedQueries(input: KeywordBuilderInput, center: string): Sear
   // one query seeded specifically for it. Niche cells can still come up
   // empty if no relevant video exists — that is the intended honest
   // behavior, not a symptom of missing queries.
+  //
+  // Issue #543 (2026-04-28): the sub_goal text is condensed to a 2-noun
+  // phrase via `extractCoreKeyword` before concatenation. Mandala-gen
+  // emits Haiku-natural sentences for sub_goals (e.g. "최적의 공부 환경
+  // 구축 및 방해 요소 제거", 22 chars), which when concatenated to the
+  // centerGoal produced 30+ char broad-match queries that recalled
+  // cross-domain noise (Google One AI 프로젝트 → Nvidia NIM / Intel oneAPI).
   for (const { s, i } of pickDistinctiveSubGoalsWithIndex(input.subGoals, 8)) {
-    out.push({ query: clip(`${center} ${s}`), source: 'subgoal', cellIndex: i });
+    const coreKw = extractCoreKeyword(s, input.language);
+    out.push({ query: clip(`${center} ${coreKw}`), source: 'subgoal', cellIndex: i });
   }
   return out;
 }
@@ -307,6 +315,108 @@ export function extractCoreKeyphrase(phrase: string, language: KeywordLanguage):
   const tokens = s.split(/\s+/).filter((t) => t && !EN_STOPWORDS.has(t));
   s = tokens.join(' ').trim();
   return s.length > 0 ? s : original;
+}
+
+// Korean stopword sets used by `extractCoreKeyword` to condense a sub_goal
+// natural-language sentence into a short keyword phrase. Three layers:
+//   1. KO_VERBAL_ENDINGS — drop the entire token if it ends with one of these
+//      (e.g. "정의하기" → drop, "향상시키기" → drop).
+//   2. KO_POSTPOSITION_ENDINGS — strip the suffix from the token (multi-char
+//      only; single-char particles like "을/를" are skipped to avoid false
+//      strips on nouns ending in those characters).
+//   3. KO_STOPWORDS_EXACT — drop the token outright on exact match
+//      (light verbs, modifiers, conjunctions).
+const KO_VERBAL_ENDINGS = [
+  '시작하기',
+  '달성하기',
+  '강화하기',
+  '개선하기',
+  '시키기',
+  '높이기',
+  '늘리기',
+  '줄이기',
+  '익히기',
+  '배우기',
+  '만들기',
+  '되기',
+  '하기',
+  '정하고',
+];
+const KO_POSTPOSITION_ENDINGS = ['으로', '에서', '에게', '부터', '까지'];
+const KO_STOPWORDS_EXACT = new Set<string>([
+  '및',
+  '또는',
+  '으로',
+  '에서',
+  '에게',
+  '부터',
+  '까지',
+  '이며',
+  '하여',
+  '구축',
+  '제거',
+  '향상',
+  '극대화',
+  '활용',
+  '정의',
+  '통해',
+  '위한',
+  '위해',
+  '명확히',
+  '효율적인',
+  '최적의',
+  '매일',
+  '꾸준히',
+  '체계적으로',
+]);
+
+/**
+ * Condense a sub_goal natural-language phrase into a short 2-noun keyword
+ * for YouTube search. Issue #543: prod incident showed sentences like "최적의
+ * 공부 환경 구축 및 방해 요소 제거" (22 chars) when concatenated with the
+ * centerGoal produced broad-match queries that recalled cross-domain noise.
+ *
+ * Strategy:
+ *   - Drop tokens that match exact stopwords (modifiers, conjunctions).
+ *   - Drop tokens that end with a verbal ending (whole token, e.g. 정의하기).
+ *   - Strip multi-char postposition suffixes (으로/에서/...).
+ *   - Take the first 2 surviving tokens, cap at 10 chars.
+ *   - Empty fallback → `extractCoreKeyphrase` (centerGoal logic).
+ *
+ * English / non-Hangul input passes through `extractCoreKeyphrase('en')` —
+ * the centerGoal-targeted stopword set is good enough for short sub_goals.
+ */
+export function extractCoreKeyword(subGoal: string, language: KeywordLanguage): string {
+  const original = subGoal.trim();
+  if (!original) return '';
+  if (language === 'en' || !/[가-힯]/u.test(original)) {
+    return extractCoreKeyphrase(original, 'en');
+  }
+  const tokens = original.split(/\s+/u).filter(Boolean);
+  const kept: string[] = [];
+  for (const raw of tokens) {
+    if (KO_STOPWORDS_EXACT.has(raw)) continue;
+    let endsWithVerbal = false;
+    for (const ve of KO_VERBAL_ENDINGS) {
+      if (raw.endsWith(ve)) {
+        endsWithVerbal = true;
+        break;
+      }
+    }
+    if (endsWithVerbal) continue;
+    let stripped = raw;
+    for (const pp of KO_POSTPOSITION_ENDINGS) {
+      if (raw.length > pp.length + 1 && raw.endsWith(pp)) {
+        stripped = raw.slice(0, -pp.length);
+        break;
+      }
+    }
+    if (stripped) kept.push(stripped);
+  }
+  let result = kept.slice(0, 2).join(' ').trim();
+  if (!result) return extractCoreKeyphrase(original, 'ko');
+  if (result.length > 10) result = result.slice(0, 10).trim();
+  return result;
 }
 
 /** Shortest sub_goals first (≤30 chars). Stable on ties. */

--- a/tests/unit/modules/keyword-builder-core-kw.test.ts
+++ b/tests/unit/modules/keyword-builder-core-kw.test.ts
@@ -1,0 +1,116 @@
+/**
+ * keyword-builder — extractCoreKeyword (Issue #543, 2026-04-28)
+ *
+ * Sub_goal natural-language sentences from mandala-gen are condensed to a
+ * 2-noun keyword phrase so concatenation with centerGoal stays short and
+ * avoids YouTube broad-match cross-domain noise.
+ *
+ * Prod incident reference: "최적의 공부 환경 구축 및 방해 요소 제거"
+ * (22 chars) + center "일일 공부 습관 만들기" produced a 33-char broad
+ * query that recalled "Google One AI 프로젝트" → 109 unrelated cards.
+ */
+
+import {
+  buildSearchQueries,
+  extractCoreKeyword,
+  type KeywordBuilderInput,
+} from '@/skills/plugins/video-discover/v2/keyword-builder';
+
+describe('extractCoreKeyword (Issue #543)', () => {
+  test('drops modifiers + light verbs + conjunctions ("최적의 공부 환경 구축 및 방해 요소 제거")', () => {
+    const result = extractCoreKeyword('최적의 공부 환경 구축 및 방해 요소 제거', 'ko');
+    expect(result).toContain('공부');
+    expect(result).toContain('환경');
+    expect(result.length).toBeLessThanOrEqual(10);
+  });
+
+  test('strips multi-char postpositions + verbal endings ("포모도로 기법으로 집중력 향상시키기")', () => {
+    const result = extractCoreKeyword('포모도로 기법으로 집중력 향상시키기', 'ko');
+    expect(result).toContain('포모도로');
+    // verbal-ending token "향상시키기" must not survive
+    expect(result).not.toContain('시키기');
+    // postposition "으로" must be stripped from "기법으로"
+    expect(result).not.toMatch(/기법으로/);
+    expect(result.length).toBeLessThanOrEqual(10);
+  });
+
+  test('drops modifier "매일" + verbal endings ("매일 공부할 시간 정하고 고정 루틴 만들기")', () => {
+    const result = extractCoreKeyword('매일 공부할 시간 정하고 고정 루틴 만들기', 'ko');
+    expect(result).not.toMatch(/^매일/);
+    expect(result).not.toContain('만들기');
+    expect(result).not.toContain('정하고');
+    expect(result.length).toBeLessThanOrEqual(10);
+  });
+
+  test('caps result at 10 chars even with all-noun input', () => {
+    const result = extractCoreKeyword('데이터베이스 마이크로서비스 분산처리 아키텍처', 'ko');
+    expect(result.length).toBeLessThanOrEqual(10);
+  });
+
+  test('empty input returns empty string', () => {
+    expect(extractCoreKeyword('', 'ko')).toBe('');
+    expect(extractCoreKeyword('   ', 'ko')).toBe('');
+  });
+
+  test('all-stopword input falls back to extractCoreKeyphrase (= original after centerGoal cleanup)', () => {
+    const result = extractCoreKeyword('하기', 'ko');
+    expect(result).toBe('하기');
+  });
+
+  test('English language path delegates to extractCoreKeyphrase ("en")', () => {
+    const result = extractCoreKeyword('Master Spanish Vocabulary', 'en');
+    expect(result.toLowerCase()).toContain('master');
+    expect(result.toLowerCase()).toContain('spanish');
+  });
+
+  test('non-Hangul Korean-language input still passes through gracefully', () => {
+    const result = extractCoreKeyword('react hooks', 'ko');
+    expect(result.toLowerCase()).toContain('react');
+  });
+});
+
+describe('buildSearchQueries — Issue #543 query length regression', () => {
+  const baseInput: KeywordBuilderInput = {
+    centerGoal: '일일 공부 습관 만들기',
+    subGoals: [
+      '최적의 공부 환경 구축 및 방해 요소 제거',
+      '포모도로 기법으로 집중력 향상시키기',
+      '공부 목표와 학습 영역 명확히 정의하기',
+      '매일 공부할 시간 정하고 고정 루틴 만들기',
+      '자기 평가와 복습으로 학습 효과 극대화',
+      '학습 동기 부여를 위한 보상 체계 마련',
+      '집중력 향상을 위한 멘탈 관리 기법',
+      '효율적인 노트 정리와 정보 구조화 방법',
+    ],
+    language: 'ko',
+  };
+
+  test('subgoal queries stay ≤ 20 chars after extractCoreKeyword condensation', async () => {
+    const queries = await buildSearchQueries(baseInput);
+    const subgoalQueries = queries.filter((q) => q.source === 'subgoal');
+    expect(subgoalQueries.length).toBeGreaterThan(0);
+    for (const q of subgoalQueries) {
+      expect(q.query.length).toBeLessThanOrEqual(20);
+    }
+  });
+
+  test('subgoal query for prod-incident sub_goal contains "공부 환경"', async () => {
+    const queries = await buildSearchQueries(baseInput);
+    const subgoalQueries = queries.filter((q) => q.source === 'subgoal');
+    const hasEnvironment = subgoalQueries.some(
+      (q) => q.query.includes('공부') && q.query.includes('환경')
+    );
+    expect(hasEnvironment).toBe(true);
+  });
+
+  test('subgoal query never contains the dropped tokens "구축", "제거", "만들기"', async () => {
+    const queries = await buildSearchQueries(baseInput);
+    const subgoalQueries = queries.filter((q) => q.source === 'subgoal');
+    for (const q of subgoalQueries) {
+      const subgoalPart = q.query.replace(baseInput.centerGoal, '').trim();
+      expect(subgoalPart).not.toMatch(/구축\s*$/);
+      expect(subgoalPart).not.toMatch(/제거\s*$/);
+      expect(subgoalPart).not.toMatch(/만들기\s*$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Issue #543** prod incident: `centerGoal + full sub_goal text` produced 30+ char broad-match queries → cross-domain YouTube noise (e.g. "Google One AI 프로젝트" → 109 unrelated cards: Nvidia NIM / Intel oneAPI / MLOps).
- New `extractCoreKeyword(subGoal, language)` helper in `src/skills/plugins/video-discover/v2/keyword-builder.ts:249-329`. Korean stopword filtering — modifier/conjunction exact drops, verbal-ending suffix drops (~하기/~만들기/~시키기), multi-char postposition strips (으로/에서/에게/부터/까지). 10-char cap + fallback to existing `extractCoreKeyphrase`.
- `buildRuleBasedQueries` line 240 now uses `${center} ${coreKw}` instead of `${center} ${s}`. Other sources (`core` / `focus` / `level` / `llm`) unchanged.
- Trace: "최적의 공부 환경 구축 및 방해 요소 제거" (22) → "공부 환경" (5). Final query: "일일 공부 습관 만들기 공부 환경" (16 chars vs 33 prior).

## Test plan

- [x] tsc --noEmit clean
- [x] npx jest --testPathPattern="keyword-builder" → 31/31 PASS (existing v2-keyword-builder.test.ts unaffected — its sub_goals were already short)
- [x] npx jest (full) → 19 fail = pre-existing baseline (no new failures)
- [x] npm run build → tsc + tsc-alias clean
- [x] hardcode-audit → 33 violations = baseline (no new)
- [ ] Post-deploy prod verify:
  - [ ] Wizard creation with goal similar to "일일 공부 습관" template
  - [ ] `docker logs insighta-api | grep buildRuleBasedQueries` → query length ≤ 20 chars (vs 29-33 prior)
  - [ ] `SELECT rec_reason, COUNT(*) FROM recommendation_cache WHERE created_at > NOW() - INTERVAL '10 min' GROUP BY rec_reason` → realtime > 0, cache = 0 (Tier 1 disabled by Y0e)

## Backward compatibility

- `extractCoreKeyword` exported (tests reference it). Call site only at line 240. No API surface change.
- Empty sub_goal still produces empty `coreKw` → query degrades to `${center}` after `clip().trim()` (acceptable single-token query).
- English sub_goals delegate to `extractCoreKeyphrase('en')` (centerGoal logic — good enough for short English sub_goals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)