### PR TITLE
fix(v3): Tier 0 RedisProvider kill switch — disable lexical token-overlap path (#543)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -121,6 +121,31 @@ services:
       # QW-2/QW-4 (CP426): recency 편향 감소 + search timeout 확장
       - V3_RECENCY_WEIGHT=0.05
       - V3_YOUTUBE_SEARCH_TIMEOUT_MS=3000
+      # CP436 PR-Y0g (Issue #543) — Tier 0 RedisProvider kill switch.
+      # Prod incident: mandala 1ee990a9 ("감정 컨트롤 하기") produced 96 cards
+      # in cell 2 alone, 100% rec_reason='cache' from RedisProvider. Domain
+      # breakdown:
+      #   ~30 한글 속기, ~30 마케팅/홍보, ~25 자각몽/루시드드림, ~5 한복.
+      # Zero of the 96 were emotion-management content.
+      #
+      # Root cause: redis-provider.ts:179-203 matches sub_goal tokens against
+      # topic-slug parts via simple overlap (≥1 for single-token slugs, ≥2
+      # otherwise), then admits up to 30 videos per matched slug with
+      # `relevanceScore` HARDCODED to 0.5 (no quality gate). Korean tokens
+      # are broad enough that any sub_goal hits multiple unrelated slugs.
+      # The 96-budget was exhausted by cell 2's first matched slugs, leaving
+      # cells 0/1/3/4/5/6/7 with 0 cards each.
+      #
+      # With Y0g default `false`, executor.ts:200-260 + executor.ts:1341-1389
+      # skip RedisProvider. Combined with Y0e (Tier 1 off), effective pipeline
+      # is Tier 2 YouTube only — matches CP436 user feedback "초기 youtube-only
+      # 가 가장 좋음".
+      #
+      # Re-enable path: V3_ENABLE_REDIS_PROVIDER=true ONLY after a quality
+      # gate is in place (semantic cosine threshold + raised minOverlap +
+      # MAX_VIDEOS_PER_TOPIC ≤ 5). Do NOT re-enable without that gate.
+      # Default = false; this line is a redundancy/clarity guard.
+      - V3_ENABLE_REDIS_PROVIDER=false
       # CP436 PR-Y0e (Issue #543) — Tier 1 video_pool cache REVERTED to off.
       # Original Y0b1 enabled PoolProvider (pgvector cosine on 3,121
       # video_pool_embeddings rows) hoping to add semantic recall to

--- a/src/skills/plugins/video-discover/__tests__/v3-upsert-slots.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v3-upsert-slots.test.ts
@@ -65,6 +65,7 @@ jest.mock('@/skills/plugins/video-discover/v3/config', () => ({
     enableTier1Cache: false,
     enableSemanticRerank: false,
     enableWhitelistGate: false,
+    enableRedisProvider: false,
     maxQueries: 2,
   },
 }));

--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -30,6 +30,7 @@ describe('loadV3Config', () => {
       minViewsPerDay: DEFAULT_MIN_VIEWS_PER_DAY,
       semanticMaxCandidates: 30, // PR-Y0b2 default
       useYoutubeRankingOnly: false, // PR-Y0d default
+      enableRedisProvider: false, // PR-Y0g default (kill switch)
     });
   });
 
@@ -100,6 +101,7 @@ describe('loadV3Config', () => {
       minViewsPerDay: DEFAULT_MIN_VIEWS_PER_DAY,
       semanticMaxCandidates: 30, // PR-Y0b2 default
       useYoutubeRankingOnly: false, // PR-Y0d default
+      enableRedisProvider: false, // PR-Y0g default (kill switch)
     });
   });
 
@@ -188,5 +190,16 @@ describe('loadV3Config', () => {
     expect(loadV3Config({ V3_MAX_QUERIES: '-3' }).maxQueries).toBe(DEFAULT_MAX_QUERIES);
     expect(loadV3Config({ V3_MAX_QUERIES: 'garbage' }).maxQueries).toBe(DEFAULT_MAX_QUERIES);
     expect(loadV3Config({ V3_MAX_QUERIES: '' }).maxQueries).toBe(DEFAULT_MAX_QUERIES);
+  });
+
+  test('V3_ENABLE_REDIS_PROVIDER kill switch (PR-Y0g, default false)', () => {
+    // Default: kill switch ON (Tier 0 disabled)
+    expect(loadV3Config({}).enableRedisProvider).toBe(false);
+    // Explicit re-enable
+    expect(loadV3Config({ V3_ENABLE_REDIS_PROVIDER: 'true' }).enableRedisProvider).toBe(true);
+    expect(loadV3Config({ V3_ENABLE_REDIS_PROVIDER: '  TRUE  ' }).enableRedisProvider).toBe(true);
+    // Explicit off / empty / unset all collapse to default false
+    expect(loadV3Config({ V3_ENABLE_REDIS_PROVIDER: 'false' }).enableRedisProvider).toBe(false);
+    expect(loadV3Config({ V3_ENABLE_REDIS_PROVIDER: '' }).enableRedisProvider).toBe(false);
   });
 });

--- a/src/skills/plugins/video-discover/v3/__tests__/executor-whitelist-gate.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/executor-whitelist-gate.test.ts
@@ -46,6 +46,7 @@ jest.mock('../config', () => ({
     semanticAlpha: 0.6,
     semanticBeta: 0.4,
     enableWhitelistGate: false, // overridden per-test
+    enableRedisProvider: false, // PR-Y0g default
   },
   DEFAULT_PUBLISHED_AFTER_DAYS: 1095,
 }));

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -180,6 +180,32 @@ export const DEFAULT_SEMANTIC_MAX_CANDIDATES = 30;
  */
 export const DEFAULT_USE_YOUTUBE_RANKING_ONLY = false;
 
+/**
+ * Tier 0 RedisProvider kill switch (Issue #543, CP436 PR-Y0g).
+ *
+ * Default `false` — Tier 0 is OFF. Pre-Y0g default was always-on with no
+ * gate; prod incident on mandala 1ee990a9 ("감정 컨트롤 하기") produced 96
+ * cards in cell 2 alone, sourced 100% from RedisProvider. Domain breakdown:
+ *   ~30 한글 속기, ~30 마케팅/홍보, ~25 자각몽/루시드드림, ~5 한복.
+ * Zero of the 96 were emotion-management content. Root cause:
+ *   redis-provider.ts:179-203 matches sub_goal tokens against topic-slug
+ *   parts via simple overlap (≥1 for single-token slugs, ≥2 otherwise),
+ *   then admits up to 30 videos per matched slug with `relevanceScore`
+ *   hardcoded to 0.5. Korean tokenization is broad enough that any
+ *   sub_goal hits multiple unrelated slugs by accident.
+ *
+ * When `true`: re-enables the lexical Tier 0 path (do NOT flip without
+ * adding a quality gate first — semantic cosine threshold or strict
+ * minOverlap raise). Suggested re-enable path documented in
+ * docs/design/v3-tier0-quality-gate.md (TBD).
+ *
+ * When `false` (default): Tier 0 is bypassed in both `executor.ts` main
+ * and `runDiscoverEphemeral` paths. Tier 1 (video_pool) is also off via
+ * V3_ENABLE_TIER1_CACHE → effective pipeline is YouTube-only (Tier 2),
+ * matching user feedback "초기 youtube-only 가 가장 좋음" (CP436).
+ */
+export const DEFAULT_ENABLE_REDIS_PROVIDER = false;
+
 const minViewCount = z
   .preprocess(
     (v) => (v == null || v === '' ? undefined : Number(v)),
@@ -218,6 +244,7 @@ export const v3EnvSchema = z.object({
   V3_MIN_VIEWS_PER_DAY: minViewsPerDay,
   V3_SEMANTIC_MAX_CANDIDATES: semanticMaxCandidates,
   V3_USE_YOUTUBE_RANKING_ONLY: booleanFlag.optional().default(false as unknown as string),
+  V3_ENABLE_REDIS_PROVIDER: booleanFlag.optional().default(false as unknown as string),
 });
 
 export interface V3Config {
@@ -237,6 +264,7 @@ export interface V3Config {
   minViewsPerDay: number;
   semanticMaxCandidates: number;
   useYoutubeRankingOnly: boolean;
+  enableRedisProvider: boolean;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -257,6 +285,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_MIN_VIEWS_PER_DAY: env['V3_MIN_VIEWS_PER_DAY'],
     V3_SEMANTIC_MAX_CANDIDATES: env['V3_SEMANTIC_MAX_CANDIDATES'],
     V3_USE_YOUTUBE_RANKING_ONLY: env['V3_USE_YOUTUBE_RANKING_ONLY'],
+    V3_ENABLE_REDIS_PROVIDER: env['V3_ENABLE_REDIS_PROVIDER'],
   });
   if (!parsed.success) {
     return {
@@ -276,6 +305,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       minViewsPerDay: DEFAULT_MIN_VIEWS_PER_DAY,
       semanticMaxCandidates: DEFAULT_SEMANTIC_MAX_CANDIDATES,
       useYoutubeRankingOnly: DEFAULT_USE_YOUTUBE_RANKING_ONLY,
+      enableRedisProvider: DEFAULT_ENABLE_REDIS_PROVIDER,
     };
   }
   return {
@@ -295,6 +325,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     minViewsPerDay: parsed.data.V3_MIN_VIEWS_PER_DAY,
     semanticMaxCandidates: parsed.data.V3_SEMANTIC_MAX_CANDIDATES,
     useYoutubeRankingOnly: parsed.data.V3_USE_YOUTUBE_RANKING_ONLY,
+    enableRedisProvider: parsed.data.V3_ENABLE_REDIS_PROVIDER,
   };
 }
 

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -193,55 +193,64 @@ export const executor: SkillExecutor = {
     const state = ctx.state as unknown as HydratedState;
     const mandalaId = ctx.mandalaId!;
 
-    // ── Tier 0: Redis video-dictionary (always runs, quota-independent) ─
+    // ── Tier 0: Redis video-dictionary (gated by v3Config.enableRedisProvider; default off)
+    // CP436 PR-Y0g (Issue #543): Tier 0 was always-on with no quality gate. Prod
+    // incident on mandala 1ee990a9 ("감정 컨트롤 하기") admitted 96 cards in cell 2,
+    // 100% from RedisProvider, with cross-domain noise (속기/마케팅/자각몽/한복) and
+    // hardcoded score 0.5. Re-enable only after a quality gate (semantic cosine
+    // threshold or strict minOverlap raise) is in place — see config.ts comment.
     const slots: AssembledSlot[] = [];
     let redisMatchCount = 0;
-    const redisProvider = new RedisProvider();
-    const redisHealth = await redisProvider.health();
-    if (redisHealth.available) {
-      const cells: CellDefinition[] = state.subGoals.map((sg, i) => ({
-        cellIndex: i,
-        subGoal: sg,
-        keywords: [],
-      }));
-      try {
-        const redisResult = await redisProvider.match({
-          mandalaId,
-          userId: ctx.userId,
-          cells,
-          budget: V3_TARGET_TOTAL,
-          excludeVideoIds: new Set<string>(),
-          language: state.language,
-          centerGoal: state.centerGoal,
-          focusTags: state.focusTags,
-        });
-        for (const c of redisResult.candidates) {
-          slots.push({
-            videoId: c.videoId,
-            title: c.title,
-            description: c.description,
-            channelName: c.channelTitle,
-            channelId: c.channelId,
-            thumbnail: c.thumbnailUrl,
-            viewCount: c.viewCount,
-            likeCount: c.likeCount,
-            durationSec: c.durationSec,
-            publishedAt: c.publishedAt,
-            cellIndex: c.cellIndex,
-            score: c.relevanceScore,
-            tier: 'cache',
+    if (v3Config.enableRedisProvider) {
+      const redisProvider = new RedisProvider();
+      const redisHealth = await redisProvider.health();
+      if (redisHealth.available) {
+        const cells: CellDefinition[] = state.subGoals.map((sg, i) => ({
+          cellIndex: i,
+          subGoal: sg,
+          keywords: [],
+        }));
+        try {
+          const redisResult = await redisProvider.match({
+            mandalaId,
+            userId: ctx.userId,
+            cells,
+            budget: V3_TARGET_TOTAL,
+            excludeVideoIds: new Set<string>(),
+            language: state.language,
+            centerGoal: state.centerGoal,
+            focusTags: state.focusTags,
           });
+          for (const c of redisResult.candidates) {
+            slots.push({
+              videoId: c.videoId,
+              title: c.title,
+              description: c.description,
+              channelName: c.channelTitle,
+              channelId: c.channelId,
+              thumbnail: c.thumbnailUrl,
+              viewCount: c.viewCount,
+              likeCount: c.likeCount,
+              durationSec: c.durationSec,
+              publishedAt: c.publishedAt,
+              cellIndex: c.cellIndex,
+              score: c.relevanceScore,
+              tier: 'cache',
+            });
+          }
+          redisMatchCount = redisResult.candidates.length;
+          log.info(
+            `[redis] mandala=${mandalaId} candidates=${redisMatchCount} latencyMs=${redisResult.meta.latencyMs}`
+          );
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          log.warn(`[redis] match failed (non-fatal): ${msg}`);
         }
-        redisMatchCount = redisResult.candidates.length;
-        log.info(
-          `[redis] mandala=${mandalaId} candidates=${redisMatchCount} latencyMs=${redisResult.meta.latencyMs}`
-        );
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        log.warn(`[redis] match failed (non-fatal): ${msg}`);
+      } else {
+        log.info(`[redis] unavailable: ${redisHealth.lastError}`);
       }
     } else {
-      log.info(`[redis] unavailable: ${redisHealth.lastError}`);
+      log.info(`[redis] disabled by V3_ENABLE_REDIS_PROVIDER=false (Y0g)`);
     }
 
     // ── Tier 1: video_pool cache (disabled by default — see v3Config.enableTier1Cache)
@@ -1338,53 +1347,57 @@ export async function runDiscoverEphemeral(
   const openRouterApiKey = input.env['OPENROUTER_API_KEY'];
   const openRouterModel = input.env['OPENROUTER_MODEL'] ?? 'qwen/qwen3-30b-a3b';
 
-  // ── Tier 0: Redis video-dictionary (same as execute(), quota-independent) ─
+  // ── Tier 0: Redis video-dictionary (gated by v3Config.enableRedisProvider; default off, Y0g) ─
   const redisSlots: AssembledSlot[] = [];
-  const redisProvider = new RedisProvider();
-  const redisHealth = await redisProvider.health();
-  if (redisHealth.available) {
-    const cells: CellDefinition[] = input.subGoals.map((sg, i) => ({
-      cellIndex: i,
-      subGoal: sg,
-      keywords: [],
-    }));
-    try {
-      const redisResult = await redisProvider.match({
-        mandalaId: 'ephemeral',
-        userId: 'precompute',
-        cells,
-        budget: V3_TARGET_TOTAL,
-        excludeVideoIds: new Set<string>(),
-        language: input.language,
-        centerGoal: input.centerGoal,
-        focusTags: input.focusTags,
-      });
-      for (const c of redisResult.candidates) {
-        redisSlots.push({
-          videoId: c.videoId,
-          title: c.title,
-          description: c.description,
-          channelName: c.channelTitle,
-          channelId: c.channelId,
-          thumbnail: c.thumbnailUrl,
-          viewCount: c.viewCount,
-          likeCount: c.likeCount,
-          durationSec: c.durationSec,
-          publishedAt: c.publishedAt,
-          cellIndex: c.cellIndex,
-          score: c.relevanceScore,
-          tier: 'cache',
+  if (v3Config.enableRedisProvider) {
+    const redisProvider = new RedisProvider();
+    const redisHealth = await redisProvider.health();
+    if (redisHealth.available) {
+      const cells: CellDefinition[] = input.subGoals.map((sg, i) => ({
+        cellIndex: i,
+        subGoal: sg,
+        keywords: [],
+      }));
+      try {
+        const redisResult = await redisProvider.match({
+          mandalaId: 'ephemeral',
+          userId: 'precompute',
+          cells,
+          budget: V3_TARGET_TOTAL,
+          excludeVideoIds: new Set<string>(),
+          language: input.language,
+          centerGoal: input.centerGoal,
+          focusTags: input.focusTags,
         });
+        for (const c of redisResult.candidates) {
+          redisSlots.push({
+            videoId: c.videoId,
+            title: c.title,
+            description: c.description,
+            channelName: c.channelTitle,
+            channelId: c.channelId,
+            thumbnail: c.thumbnailUrl,
+            viewCount: c.viewCount,
+            likeCount: c.likeCount,
+            durationSec: c.durationSec,
+            publishedAt: c.publishedAt,
+            cellIndex: c.cellIndex,
+            score: c.relevanceScore,
+            tier: 'cache',
+          });
+        }
+        log.info(
+          `[redis][ephemeral] candidates=${redisResult.candidates.length} latencyMs=${redisResult.meta.latencyMs}`
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn(`[redis][ephemeral] match failed (non-fatal): ${msg}`);
       }
-      log.info(
-        `[redis][ephemeral] candidates=${redisResult.candidates.length} latencyMs=${redisResult.meta.latencyMs}`
-      );
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.warn(`[redis][ephemeral] match failed (non-fatal): ${msg}`);
+    } else {
+      log.info(`[redis][ephemeral] unavailable: ${redisHealth.lastError}`);
     }
   } else {
-    log.info(`[redis][ephemeral] unavailable: ${redisHealth.lastError}`);
+    log.info(`[redis][ephemeral] disabled by V3_ENABLE_REDIS_PROVIDER=false (Y0g)`);
   }
 
   // ── Compute per-cell deficit after Redis ─


### PR DESCRIPTION
## Summary

- Issue #543 prod incident: mandala \`1ee990a9-...\` ("감정 컨트롤 하기") produced 96 cards in cell 2, 100% \`rec_reason='cache'\` (= Tier 0 RedisProvider). Domain breakdown: ~30 한글 속기, ~30 마케팅/홍보, ~25 자각몽/루시드드림, ~5 한복. Zero emotion-management content. Cells 0/1/3-7 = 0 cards each.
- Root cause: \`redis-provider.ts:179-203\` matches sub_goal tokens against topic-slug parts (overlap ≥1 for single-token slugs, ≥2 otherwise), admits up to 30 videos per slug, \`relevanceScore\` **hardcoded to 0.5**. Korean tokens broad enough that any sub_goal hits multiple unrelated slugs.
- Prior PRs (Y0d Y0e) couldn't touch this path: Y0d bypasses mandala-filter only, Y0e disables Tier 1 PoolProvider only.
- This PR adds \`V3_ENABLE_REDIS_PROVIDER\` env flag (default \`false\`), gates RedisProvider in both \`executor.ts\` main path (~line 200) and \`runDiscoverEphemeral\` (~line 1340).
- \`docker-compose.prod.yml\` updated with explicit \`V3_ENABLE_REDIS_PROVIDER=false\` + full incident doc + re-enable preconditions.

## Net effect

Combined with Y0e (Tier 1 off), pipeline collapses to **Tier 2 YouTube-only** — matches CP436 user feedback "초기 youtube-only 가 가장 좋음".

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx jest --testPathPattern=v3/__tests__/config\` → 19/19 PASS (1 new test for V3_ENABLE_REDIS_PROVIDER)
- [x] \`npx jest\` (full) → 19 fail = baseline (no new failures), 927 passed (+1 from new test)
- [x] \`npm run build\` → tsc + tsc-alias clean
- [x] \`hardcode-audit\` → 33 violations = baseline (no new)
- [ ] Post-deploy prod verify:
  - [ ] Container restart timestamp confirms env applied
  - [ ] Log: \`[redis] disabled by V3_ENABLE_REDIS_PROVIDER=false (Y0g)\` per call
  - [ ] New wizard mandala creation: \`SELECT rec_reason, COUNT(*) FROM recommendation_cache WHERE created_at > NOW() - INTERVAL '10 min' GROUP BY rec_reason\` → \`cache\` should be 0; \`realtime\` (Tier 2 YouTube) > 0.

## Re-enable path (do NOT flip without these)

\`V3_ENABLE_REDIS_PROVIDER=true\` requires:
1. Semantic cosine threshold gate on RedisProvider results
2. \`MAX_VIDEOS_PER_TOPIC\` reduced from 30 → ≤ 5
3. \`minOverlap\` raised (single-token slugs require ≥ 2 overlap, multi-token slugs require ≥ 3)
4. Per-cell budget cap to prevent one cell exhausting global budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)