### PR TITLE
feat(config): promote domains SSOT to src/config/domains.ts

### DIFF
--- a/scripts/dataset-v4/config.ts
+++ b/scripts/dataset-v4/config.ts
@@ -1,0 +1,145 @@
+/**
+ * V4 Dataset Pipeline — Configuration (SSOT)
+ *
+ * All frame types, domains, tiers, and label mappings for the V4 pipeline.
+ */
+
+// ---------------------------------------------------------------------------
+// Frame Types
+// ---------------------------------------------------------------------------
+
+export const FRAME_TYPES = [
+  'comprehensive',
+  'vision',
+  'periodic',
+  'sequential',
+  'problem',
+  'skill',
+  'project',
+  'lifestyle',
+] as const;
+
+export type FrameType = (typeof FRAME_TYPES)[number];
+
+export interface FrameMetadata {
+  id: FrameType;
+  labelKo: string;
+  labelEn: string;
+  description: string;
+  /** Prompt constraint injected during generation */
+  constraint: string;
+}
+
+export const FRAME_METADATA: Record<FrameType, FrameMetadata> = {
+  comprehensive: {
+    id: 'comprehensive',
+    labelKo: '교과서형',
+    labelEn: 'A-Z Comprehensive',
+    description: '주제의 모든 측면을 체계적으로 정리. 빈틈 없는 전체 지도.',
+    constraint:
+      '주제의 모든 측면을 빠짐없이 다루되, 카테고리 간 겹침 최소화',
+  },
+  vision: {
+    id: 'vision',
+    labelKo: '비전형',
+    labelEn: 'Long-term Vision',
+    description: '담대한 장기 목표 + 마일스톤. 1년~10년 단위.',
+    constraint: '최종 비전에서 역산한 마일스톤, 시간축 포함',
+  },
+  periodic: {
+    id: 'periodic',
+    labelKo: '반복주기형',
+    labelEn: 'Periodic Routine',
+    description: '주기적으로 반복하는 루틴/사이클. 매일/매주/매월.',
+    constraint: '반복 주기와 체크포인트 명시, 루틴화 가능한 action',
+  },
+  sequential: {
+    id: 'sequential',
+    labelKo: '단계실행형',
+    labelEn: 'Step-by-step Roadmap',
+    description:
+      'Phase 1→2→3 순서대로 실행. 의존성 있는 단계별 계획.',
+    constraint:
+      'Phase/Step 순서 의존성 반영, 앞 단계 완료가 다음 단계 전제',
+  },
+  problem: {
+    id: 'problem',
+    labelKo: '문제해결형',
+    labelEn: 'Problem-solving',
+    description: '문제 진단 → 원인 분석 → 해결 전략 → 예방.',
+    constraint: '문제 정의 → 원인 → 해결 → 예방 흐름',
+  },
+  skill: {
+    id: 'skill',
+    labelKo: '역량개발형',
+    labelEn: 'Skill Building',
+    description: '현재 수준에서 목표 수준까지 역량 성장 트리.',
+    constraint:
+      '현재 수준 → 중간 → 목표 수준, 측정 가능한 역량 지표',
+  },
+  project: {
+    id: 'project',
+    labelKo: '프로젝트형',
+    labelEn: 'Project Completion',
+    description: '구체적 산출물이 있는 프로젝트 시작→완료.',
+    constraint: '산출물 중심, 데드라인 내포, 리소스 배분',
+  },
+  lifestyle: {
+    id: 'lifestyle',
+    labelKo: '생활통합형',
+    labelEn: 'Lifestyle Integration',
+    description: '목표를 일상 속에 녹여내는 구조. 습관화 중심.',
+    constraint: '일상 습관으로 녹여내기, 최소 저항 경로',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Domains — re-exported from src/config/domains.ts (SSOT promotion at CP437)
+// ---------------------------------------------------------------------------
+
+import {
+  DOMAINS,
+  DOMAIN_LABEL_TO_SLUG,
+  DOMAIN_SLUG_TO_LABEL_KO,
+  DOMAIN_SLUG_TO_LABEL_EN,
+  type DomainSlug,
+} from '@/config/domains';
+
+export {
+  DOMAINS,
+  DOMAIN_LABEL_TO_SLUG,
+  DOMAIN_SLUG_TO_LABEL_KO,
+  DOMAIN_SLUG_TO_LABEL_EN,
+};
+export type { DomainSlug };
+
+// ---------------------------------------------------------------------------
+// Tiers
+// ---------------------------------------------------------------------------
+
+export const TIERS = ['v3_legacy', 'tier1', 'tier2', 'tier3'] as const;
+
+export type Tier = (typeof TIERS)[number];
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const V4_VERSION = 'v4';
+
+/** Total valid combinations: 9 domains × 8 frames = 72 */
+export const VALID_COMBINATIONS = DOMAINS.length * FRAME_TYPES.length;
+
+export const EXPECTED_SUB_GOALS = 8;
+export const EXPECTED_ACTIONS_PER_GOAL = 8;
+
+/**
+ * sub_labels 규칙 (v2, 2026-04-14):
+ * - 무의미 축약 절대 금지 (DecltrM, AttentTrn 등)
+ * - 카멜케이스 금지, 띄어쓰기 사용
+ * - KO: ~10자 soft limit (의미 보존 우선, 초과 허용)
+ * - EN: ~15자 soft limit (의미 보존 우선, 초과 허용)
+ * - 핵심어 추출 방식 (앞글자 절단 금지)
+ */
+export const SUB_LABEL_SOFT_LIMIT_KO = 10;
+export const SUB_LABEL_SOFT_LIMIT_EN = 15;

--- a/src/config/domains.ts
+++ b/src/config/domains.ts
@@ -1,0 +1,104 @@
+/**
+ * Domain SSOT — promoted to src/config/ at CP437 (2026-04-29).
+ *
+ * 9 fixed top-level domain slugs covering the entire Insighta knowledge
+ * taxonomy. The single source of truth for:
+ *   - `user_mandalas.domain` (lowercase slug, 9 distinct values)
+ *   - `mandala_embeddings.domain` (KO/EN paired labels)
+ *   - `video_pool_domain_tags.domain` (KO labels + 'user-derived' marker)
+ *   - V4 dataset pipeline (`scripts/dataset-v4/config.ts` re-exports here)
+ *   - Future v2 rich-summary `core.domain` field
+ *
+ * Two-tier structure reserved (`DomainSubSlug` placeholder) — current data
+ * uses top-level only.
+ *
+ * Label policy (CP437 decision C-1, 2026-04-29):
+ *   - prod labels preserved verbatim. mandala_embeddings holds ~17,985
+ *     KO/EN paired rows using these exact strings. Renaming the labels
+ *     (e.g. 'Mind/Spirituality' → 'Mindset/Mental Health') would force a
+ *     ~3K row backfill for cosmetic improvement, so the labels stay.
+ *
+ * Migration policy: any new prod table column referring to a domain MUST
+ * import `DomainSlug` from this file rather than redeclaring the enum.
+ */
+
+export const DOMAIN_SLUGS = [
+  'tech',
+  'learning',
+  'health',
+  'business',
+  'finance',
+  'social',
+  'creative',
+  'lifestyle',
+  'mind',
+] as const;
+
+export type DomainSlug = (typeof DOMAIN_SLUGS)[number];
+
+/**
+ * Reserved for future 2-tier expansion (sub-domain slugs). Keep as `never`
+ * until the data path is wired up so callers cannot accidentally narrow
+ * against an empty type.
+ */
+export type DomainSubSlug = never;
+
+export const DOMAIN_LABEL_KO: Record<DomainSlug, string> = {
+  tech: '기술/개발',
+  learning: '학습/교육',
+  health: '건강/피트니스',
+  business: '비즈니스/커리어',
+  finance: '재테크/투자',
+  social: '인간관계/커뮤니티',
+  creative: '창작/예술',
+  lifestyle: '라이프스타일/여행',
+  mind: '마인드/영성',
+};
+
+export const DOMAIN_LABEL_EN: Record<DomainSlug, string> = {
+  tech: 'Tech/Development',
+  learning: 'Learning/Education',
+  health: 'Health/Fitness',
+  business: 'Business/Career',
+  finance: 'Finance/Investment',
+  social: 'Relationships/Community',
+  creative: 'Creative/Arts',
+  lifestyle: 'Lifestyle/Travel',
+  mind: 'Mind/Spirituality',
+};
+
+/** KO/EN label → slug, both directions covered. Symmetric to DOMAIN_LABEL_KO/EN. */
+export const DOMAIN_LABEL_TO_SLUG: Record<string, DomainSlug> = {
+  '기술/개발': 'tech',
+  '학습/교육': 'learning',
+  '건강/피트니스': 'health',
+  '비즈니스/커리어': 'business',
+  '재테크/투자': 'finance',
+  '인간관계/커뮤니티': 'social',
+  '창작/예술': 'creative',
+  '라이프스타일/여행': 'lifestyle',
+  '마인드/영성': 'mind',
+  'Tech/Development': 'tech',
+  'Learning/Education': 'learning',
+  'Health/Fitness': 'health',
+  'Business/Career': 'business',
+  'Finance/Investment': 'finance',
+  'Relationships/Community': 'social',
+  'Creative/Arts': 'creative',
+  'Lifestyle/Travel': 'lifestyle',
+  'Mind/Spirituality': 'mind',
+};
+
+export function isDomainSlug(value: string | null | undefined): value is DomainSlug {
+  return typeof value === 'string' && (DOMAIN_SLUGS as readonly string[]).includes(value);
+}
+
+/**
+ * Legacy aliases — `scripts/dataset-v4/config.ts` re-exports these names.
+ * Prefer the canonical `DOMAIN_SLUGS` / `DOMAIN_LABEL_KO` / `DOMAIN_LABEL_EN`
+ * in new code; the aliases exist only so the existing dataset pipeline
+ * imports keep compiling without rename.
+ */
+export const DOMAINS = DOMAIN_SLUGS;
+export const DOMAIN_SLUG_TO_LABEL_KO = DOMAIN_LABEL_KO;
+export const DOMAIN_SLUG_TO_LABEL_EN = DOMAIN_LABEL_EN;

--- a/tests/unit/config/domains.test.ts
+++ b/tests/unit/config/domains.test.ts
@@ -1,0 +1,81 @@
+/**
+ * domains SSOT — invariant checks (CP437).
+ *
+ * Spec lock: 9 fixed slugs, KO/EN labels match prod data verbatim,
+ * label→slug map covers both languages.
+ */
+
+import {
+  DOMAIN_SLUGS,
+  DOMAIN_LABEL_KO,
+  DOMAIN_LABEL_EN,
+  DOMAIN_LABEL_TO_SLUG,
+  isDomainSlug,
+  DOMAINS,
+  DOMAIN_SLUG_TO_LABEL_KO,
+  DOMAIN_SLUG_TO_LABEL_EN,
+  type DomainSlug,
+} from '@/config/domains';
+
+describe('domains SSOT', () => {
+  test('exactly 9 slugs (locked)', () => {
+    expect(DOMAIN_SLUGS).toHaveLength(9);
+    expect([...DOMAIN_SLUGS]).toEqual([
+      'tech',
+      'learning',
+      'health',
+      'business',
+      'finance',
+      'social',
+      'creative',
+      'lifestyle',
+      'mind',
+    ]);
+  });
+
+  test('KO labels match prod data verbatim (mandala_embeddings.domain rows)', () => {
+    expect(DOMAIN_LABEL_KO).toEqual({
+      tech: '기술/개발',
+      learning: '학습/교육',
+      health: '건강/피트니스',
+      business: '비즈니스/커리어',
+      finance: '재테크/투자',
+      social: '인간관계/커뮤니티',
+      creative: '창작/예술',
+      lifestyle: '라이프스타일/여행',
+      mind: '마인드/영성',
+    });
+  });
+
+  test('EN labels match prod data verbatim (Relationships plural, Mind/Spirituality)', () => {
+    expect(DOMAIN_LABEL_EN.social).toBe('Relationships/Community');
+    expect(DOMAIN_LABEL_EN.mind).toBe('Mind/Spirituality');
+  });
+
+  test('label → slug map round-trips both KO and EN labels', () => {
+    for (const slug of DOMAIN_SLUGS) {
+      expect(DOMAIN_LABEL_TO_SLUG[DOMAIN_LABEL_KO[slug]]).toBe(slug);
+      expect(DOMAIN_LABEL_TO_SLUG[DOMAIN_LABEL_EN[slug]]).toBe(slug);
+    }
+  });
+
+  test('isDomainSlug type guard', () => {
+    expect(isDomainSlug('tech')).toBe(true);
+    expect(isDomainSlug('mind')).toBe(true);
+    expect(isDomainSlug('기술/개발')).toBe(false);
+    expect(isDomainSlug(null)).toBe(false);
+    expect(isDomainSlug(undefined)).toBe(false);
+    expect(isDomainSlug('unknown')).toBe(false);
+  });
+
+  test('legacy aliases identical to canonical exports', () => {
+    expect(DOMAINS).toBe(DOMAIN_SLUGS);
+    expect(DOMAIN_SLUG_TO_LABEL_KO).toBe(DOMAIN_LABEL_KO);
+    expect(DOMAIN_SLUG_TO_LABEL_EN).toBe(DOMAIN_LABEL_EN);
+  });
+
+  test('DomainSlug type narrows correctly', () => {
+    const ok: DomainSlug = 'tech';
+    expect(typeof ok).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary

- 9 fixed top-level domain slugs are the canonical taxonomy across prod runtime, V4 dataset pipeline, and future v2 rich-summary. Until now the single definition lived at \`scripts/dataset-v4/config.ts\` (build-time only) and \`src/\` runtime referenced domains as free-form strings — leading to the prod typo \`domain='기술/개발'\` in user_mandalas (1 row).
- \`src/config/domains.ts\` (new) holds \`DOMAIN_SLUGS\` / \`DomainSlug\` / \`DOMAIN_LABEL_KO\` / \`DOMAIN_LABEL_EN\` / \`DOMAIN_LABEL_TO_SLUG\` / \`isDomainSlug\` + legacy aliases (\`DOMAINS\`, \`DOMAIN_SLUG_TO_LABEL_KO/EN\`).
- \`scripts/dataset-v4/config.ts\` re-exports from the SSOT — existing imports (\`fetch-trends.ts\`, \`generate-goals.ts\`, \`generate-mandala.ts\`) keep compiling.
- 2-tier expansion reserved (\`DomainSubSlug\` as \`never\`).

## Label policy

prod labels preserved verbatim. \`mandala_embeddings.domain\` holds ~17,985 KO/EN paired rows using these exact strings. Renaming \`'Mind/Spirituality'\` → \`'Mindset/Mental Health'\` or plural \`'Relationships/Community'\` → \`'Relationship/Community'\` would force a ~3K row backfill for cosmetic improvement, so the labels stay.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx jest tests/unit/config/domains.test.ts\` → 7/7 PASS
- [x] \`npx jest\` (full) → 19 fail = baseline (no new failures), 934 passed (+7 new)
- [x] \`npm run build\` → tsc + tsc-alias clean
- [x] hardcode-audit → 33 violations = baseline (no new)
- [ ] After merge: follow-up PRs use this SSOT
  - \`feat(db): video_rich_summaries v2 schema migration\` (uses DomainSlug for core.domain)
  - \`fix(data): user_mandalas typo + null backfill\` (uses DOMAIN_SLUGS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)