### PR TITLE
feat(youtube): full metadata collection + Mac Mini yt-dlp transcript pipeline

### DIFF
--- a/mac-mini/transcript-collector/README.md
+++ b/mac-mini/transcript-collector/README.md
@@ -1,0 +1,57 @@
+# Mac Mini transcript-collector
+
+Runs on the Mac Mini. Pulls candidate video IDs from EC2, fetches
+auto-generated YouTube subtitles via `yt-dlp` (memory only — never written
+to disk), POSTs the transcript to EC2 for v2 rich-summary generation,
+and discards the transcript.
+
+## Why Mac Mini
+
+- Legal directive: raw transcripts must NOT be persisted in our DB. The
+  transcript only lives in process memory on the Mac Mini for the duration
+  of one HTTP round-trip to EC2.
+- Mac Mini already hosts other yt-dlp / Ollama dependencies and has no
+  prod DB credential — minimizes blast radius.
+
+## Usage
+
+```bash
+# 1. Install yt-dlp (homebrew works on macOS):
+brew install yt-dlp
+
+# 2. Configure env (DO NOT commit):
+export INSIGHTA_API_URL="https://insighta.one"
+export INTERNAL_BATCH_TOKEN="<value from credentials.md §INTERNAL_BATCH_TOKEN>"
+# Optional knobs:
+export TRANSCRIPT_BATCH_SIZE=50
+export TRANSCRIPT_YTDLP_TIMEOUT_MS=60000
+export YTDLP_BIN=/opt/homebrew/bin/yt-dlp  # if PATH-resolution fails
+
+# 3. Run from the repo root (or anywhere with the file copied):
+npx tsx mac-mini/transcript-collector/collect.ts
+```
+
+## Hard-rule compliance
+
+- No DB connection. The script speaks HTTP only.
+- No file persistence. `yt-dlp` is invoked with `-o -` (stdout pipe) and
+  the captured buffer is converted to text + sent + dropped.
+- No comment fetching. Per the 2026-04-29 directive, only auto-subs
+  (transcript) flow through this pipeline.
+
+## Production wiring
+
+Recommended cron line on the Mac Mini (every day 02:00 KST = 17:00 UTC,
+matching the `RICH_SUMMARY_V2_CRON_SCHEDULE` window so the EC2 generator
+quota is not contested by the user-facing wizard):
+
+```
+0 17 * * * cd /Users/jeonhokim/insighta && /usr/bin/env -i \
+  INSIGHTA_API_URL=https://insighta.one \
+  INTERNAL_BATCH_TOKEN=$(cat ~/.insighta/internal-token) \
+  /opt/homebrew/bin/npx tsx mac-mini/transcript-collector/collect.ts \
+  >> ~/insighta-transcript.log 2>&1
+```
+
+(Adjust paths for your install. Operator must populate the token file
+beforehand; never commit it.)

--- a/mac-mini/transcript-collector/collect.ts
+++ b/mac-mini/transcript-collector/collect.ts
@@ -1,0 +1,251 @@
+/**
+ * Mac Mini transcript collector (CP437, 2026-04-29).
+ *
+ * Runs ON the Mac Mini (NOT on EC2). Hits the EC2 internal API to:
+ *   1. Pull a batch of candidate video IDs (`has_caption=true,
+ *      transcript_fetched_at IS NULL`).
+ *   2. Pipe yt-dlp stdout (auto-subs, vtt) into memory.
+ *   3. Strip VTT timing → plain text.
+ *   4. POST the transcript to /transcript/summarize. EC2 calls
+ *      generateRichSummaryV2() with it and stamps transcript_fetched_at.
+ *   5. Discard the transcript text immediately.
+ *
+ * Legal directive: the transcript NEVER touches disk on either side.
+ * yt-dlp is invoked with `-o -` (stdout) and the response stream is
+ * collected into a buffer in process memory only.
+ *
+ * Bot 절대 규칙: this script never opens a Postgres connection. It only
+ * speaks HTTP to the EC2 API.
+ */
+
+import { spawn } from 'node:child_process';
+
+interface Candidate {
+  youtube_video_id: string;
+  default_language: string | null;
+  has_caption: boolean | null;
+}
+
+interface CandidatesResponse {
+  videos: Candidate[];
+}
+
+interface SummarizeOutcomePass {
+  kind: 'pass';
+  videoId: string;
+  completeness: number;
+}
+interface SummarizeOutcomeOther {
+  kind: 'low' | 'skip';
+  videoId: string;
+  reason?: string;
+}
+type SummarizeOutcome = SummarizeOutcomePass | SummarizeOutcomeOther;
+
+const env = process.env;
+
+const API_URL = (env['INSIGHTA_API_URL'] ?? '').trim();
+const INTERNAL_TOKEN = (env['INTERNAL_BATCH_TOKEN'] ?? '').trim();
+const BATCH_SIZE = Math.max(
+  1,
+  Math.min(200, Number(env['TRANSCRIPT_BATCH_SIZE'] ?? '50') || 50)
+);
+const PER_VIDEO_TIMEOUT_MS = Math.max(
+  10_000,
+  Number(env['TRANSCRIPT_YTDLP_TIMEOUT_MS'] ?? '60000') || 60_000
+);
+const YTDLP_BIN = (env['YTDLP_BIN'] ?? 'yt-dlp').trim();
+
+if (!API_URL) {
+  console.error('INSIGHTA_API_URL env required');
+  process.exit(1);
+}
+if (!INTERNAL_TOKEN) {
+  console.error('INTERNAL_BATCH_TOKEN env required');
+  process.exit(1);
+}
+
+async function fetchCandidates(): Promise<Candidate[]> {
+  const url = `${API_URL.replace(/\/$/, '')}/api/v1/internal/transcript/candidates?limit=${BATCH_SIZE}`;
+  const res = await fetch(url, {
+    headers: { 'x-internal-token': INTERNAL_TOKEN },
+  });
+  if (!res.ok) {
+    throw new Error(`candidates HTTP ${res.status}: ${await res.text()}`);
+  }
+  const body = (await res.json()) as CandidatesResponse;
+  return body.videos ?? [];
+}
+
+/**
+ * Run yt-dlp and capture the auto-generated subtitle to stdout. Saves
+ * NOTHING to disk (`-o -` and `--skip-download`).
+ *
+ * Returns plain text (VTT timing stripped) or null when no captions are
+ * actually available (yt-dlp succeeds but produces empty output).
+ */
+async function fetchTranscript(videoId: string, language: 'ko' | 'en'): Promise<string | null> {
+  const args = [
+    '--skip-download',
+    '--write-auto-sub',
+    '--sub-lang',
+    language,
+    '--sub-format',
+    'vtt',
+    '--quiet',
+    '--no-warnings',
+    '-o',
+    '-',
+    `https://www.youtube.com/watch?v=${videoId}`,
+  ];
+  return new Promise((resolve, reject) => {
+    const child = spawn(YTDLP_BIN, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const chunks: Buffer[] = [];
+    let stderr = '';
+    let done = false;
+    const timer = setTimeout(() => {
+      if (done) return;
+      done = true;
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* ignore */
+      }
+      reject(new Error(`yt-dlp timeout after ${PER_VIDEO_TIMEOUT_MS}ms for ${videoId}`));
+    }, PER_VIDEO_TIMEOUT_MS);
+
+    child.stdout.on('data', (b: Buffer) => chunks.push(b));
+    child.stderr.on('data', (b: Buffer) => {
+      stderr += b.toString('utf-8');
+    });
+    child.on('error', (err) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (code) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(`yt-dlp exit ${code} for ${videoId}: ${stderr.slice(0, 200)}`));
+        return;
+      }
+      const raw = Buffer.concat(chunks).toString('utf-8');
+      const text = stripVtt(raw);
+      resolve(text.length > 0 ? text : null);
+    });
+  });
+}
+
+/**
+ * Strip VTT timing lines + cue identifiers, keep only spoken text.
+ * Best-effort: handles the standard YouTube auto-subtitle format with
+ * `WEBVTT` header, blank-line separators, and `00:00:00.000 --> 00:00:00.000`
+ * timing lines.
+ */
+export function stripVtt(vtt: string): string {
+  const lines = vtt.split(/\r?\n/);
+  const out: string[] = [];
+  for (const line of lines) {
+    const t = line.trim();
+    if (!t) continue;
+    if (t === 'WEBVTT') continue;
+    if (/^\d+$/.test(t)) continue; // cue id
+    if (/-->/u.test(t)) continue; // timing
+    if (/^Kind:|^Language:/i.test(t)) continue;
+    // Strip inline tags like <00:00:01.000><c> ... </c>
+    const stripped = t.replace(/<[^>]+>/g, '').trim();
+    if (stripped.length === 0) continue;
+    out.push(stripped);
+  }
+  return out.join(' ');
+}
+
+async function postSummary(
+  videoId: string,
+  transcript: string,
+  language: 'ko' | 'en'
+): Promise<SummarizeOutcome> {
+  const url = `${API_URL.replace(/\/$/, '')}/api/v1/internal/transcript/summarize`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-internal-token': INTERNAL_TOKEN,
+    },
+    body: JSON.stringify({ videoId, transcript, language }),
+  });
+  if (res.status === 401 || res.status === 503) {
+    throw new Error(`summarize HTTP ${res.status}`);
+  }
+  const data = (await res.json()) as SummarizeOutcome;
+  return data;
+}
+
+async function pickLanguage(c: Candidate): Promise<'ko' | 'en'> {
+  if (c.default_language && c.default_language.startsWith('en')) return 'en';
+  return 'ko';
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `[transcript-collector] start — API=${API_URL} batch=${BATCH_SIZE} ytdlp=${YTDLP_BIN}`
+  );
+  let candidates: Candidate[];
+  try {
+    candidates = await fetchCandidates();
+  } catch (err) {
+    console.error(
+      `candidate fetch failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+    process.exit(1);
+  }
+  console.log(`[transcript-collector] picked ${candidates.length} candidates`);
+  let pass = 0;
+  let low = 0;
+  let skip = 0;
+  let errors = 0;
+  for (const c of candidates) {
+    const lang = await pickLanguage(c);
+    let transcript: string | null = null;
+    try {
+      transcript = await fetchTranscript(c.youtube_video_id, lang);
+    } catch (err) {
+      errors += 1;
+      console.warn(
+        `[${c.youtube_video_id}] yt-dlp failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+      continue;
+    }
+    if (!transcript) {
+      skip += 1;
+      console.log(`[${c.youtube_video_id}] no captions (yt-dlp empty) — skipping`);
+      continue;
+    }
+    try {
+      const outcome = await postSummary(c.youtube_video_id, transcript, lang);
+      if (outcome.kind === 'pass') pass += 1;
+      else if (outcome.kind === 'low') low += 1;
+      else skip += 1;
+      // Discard transcript explicitly: variable goes out of scope here, but
+      // mark for clarity that no further use is allowed.
+      transcript = null;
+    } catch (err) {
+      errors += 1;
+      console.warn(
+        `[${c.youtube_video_id}] summarize failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+  console.log(
+    `[transcript-collector] done — pass=${pass} low=${low} skip=${skip} errors=${errors}`
+  );
+  process.exit(errors > 0 && pass === 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(`fatal: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/prisma/migrations/youtube-metadata-v2/001_add_fields.sql
+++ b/prisma/migrations/youtube-metadata-v2/001_add_fields.sql
@@ -1,0 +1,42 @@
+-- CP437 (2026-04-29) — youtube_videos full metadata expansion
+--
+-- Adds 6 new columns to capture the full set of fields returned by
+-- youtube videos.list (parts=snippet,contentDetails,statistics,topicDetails).
+-- `like_count` already exists in the table — included here as IF NOT EXISTS
+-- for idempotency only.
+--
+-- Backfill is driven by the prod-runtime cron in
+-- src/modules/scheduler/youtube-metadata-cron.ts. Default OFF
+-- (YOUTUBE_METADATA_BACKFILL_ENABLED) — operator must explicitly flip after
+-- design review.
+--
+-- IMPORTANT (CLAUDE.md "prisma db push silent fail" Hard Rule):
+--   Apply via psql, NOT `prisma db push`. After apply, verify with:
+--     SELECT column_name FROM information_schema.columns
+--     WHERE table_schema='public' AND table_name='youtube_videos'
+--       AND column_name IN ('comment_count','tags','topic_categories',
+--                            'has_caption','default_language','metadata_fetched_at');
+
+ALTER TABLE youtube_videos
+  ADD COLUMN IF NOT EXISTS like_count            BIGINT,
+  ADD COLUMN IF NOT EXISTS comment_count         BIGINT,
+  ADD COLUMN IF NOT EXISTS tags                  TEXT[],
+  ADD COLUMN IF NOT EXISTS topic_categories      TEXT[],
+  ADD COLUMN IF NOT EXISTS has_caption           BOOLEAN,
+  ADD COLUMN IF NOT EXISTS default_language      VARCHAR(10),
+  ADD COLUMN IF NOT EXISTS metadata_fetched_at   TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS transcript_fetched_at TIMESTAMPTZ;
+-- transcript_fetched_at: stamped by the Mac Mini transcript pipeline
+-- AFTER yt-dlp pull + v2 summary generation succeeds. The transcript
+-- text itself is never stored (memory-only on Mac Mini, immediately
+-- discarded post-summary per legal directive 2026-04-29). This column
+-- is the only persisted record that a transcript was ever fetched.
+
+-- Index on metadata_fetched_at to make the backfill candidate selector
+-- (`WHERE metadata_fetched_at IS NULL ORDER BY ...`) cheap on 5,874 rows.
+CREATE INDEX IF NOT EXISTS idx_youtube_videos_metadata_fetched_at
+  ON youtube_videos (metadata_fetched_at);
+
+-- Same idea for the transcript candidate selector.
+CREATE INDEX IF NOT EXISTS idx_youtube_videos_transcript_fetched_at
+  ON youtube_videos (transcript_fetched_at);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -881,6 +881,18 @@ model youtube_videos {
   published_at           DateTime?                @db.Timestamptz(6)
   view_count             BigInt?
   like_count             BigInt?
+  /// CP437 (2026-04-29) — full metadata expansion.
+  /// Raw SQL DDL: prisma/migrations/youtube-metadata-v2/001_add_fields.sql
+  /// Populated by youtube-metadata-cron + new save paths in collectors.
+  comment_count          BigInt?
+  tags                   String[]
+  topic_categories       String[]
+  has_caption            Boolean?
+  default_language       String?                  @db.VarChar(10)
+  metadata_fetched_at    DateTime?                @db.Timestamptz(6)
+  /// CP437 transcript pipeline (Mac Mini yt-dlp). Stamped on summary
+  /// success; transcript text itself is never persisted.
+  transcript_fetched_at  DateTime?                @db.Timestamptz(6)
   created_at             DateTime                 @default(now()) @db.Timestamptz(6)
   updated_at             DateTime                 @default(now()) @db.Timestamptz(6)
   userState              UserVideoState[]
@@ -890,6 +902,8 @@ model youtube_videos {
   youtube_playlist_items youtube_playlist_items[]
   youtube_watch_history  youtube_watch_history[]
 
+  @@index([metadata_fetched_at], map: "idx_youtube_videos_metadata_fetched_at")
+  @@index([transcript_fetched_at], map: "idx_youtube_videos_transcript_fetched_at")
   @@schema("public")
 }
 

--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -1,0 +1,119 @@
+/**
+ * Internal transcript pipeline endpoints (CP437, 2026-04-29).
+ *
+ * Protected by `INTERNAL_BATCH_TOKEN` (same shared header pattern as the
+ * other internal routes). The Mac Mini transcript collector polls these
+ * endpoints — never accessing the prod DB directly (Bot 절대 규칙).
+ *
+ *   GET  /api/v1/internal/transcript/candidates?limit=50
+ *     → { videos: [{ youtube_video_id, default_language, has_caption }] }
+ *
+ *   POST /api/v1/internal/transcript/summarize
+ *     Body: { videoId, transcript, language }
+ *     → calls generateRichSummaryV2 with the supplied transcript,
+ *       stamps `youtube_videos.transcript_fetched_at` on success.
+ *
+ * Legal directive (2026-04-29): the transcript text is NEVER persisted.
+ * It lives in the request body for the duration of the LLM call only.
+ */
+
+import type { FastifyPluginAsync } from 'fastify';
+import { Prisma } from '@prisma/client';
+
+import { getInternalBatchToken } from '@/config/internal-auth';
+import { getPrismaClient } from '@/modules/database/client';
+import { generateRichSummaryV2 } from '@/modules/skills/rich-summary-v2-generator';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'api/internal/transcript' });
+
+const DEFAULT_CANDIDATE_LIMIT = 50;
+const MAX_CANDIDATE_LIMIT = 200;
+
+interface CandidateRow {
+  youtube_video_id: string;
+  default_language: string | null;
+  has_caption: boolean | null;
+}
+
+export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get<{ Querystring: { limit?: string } }>(
+    '/transcript/candidates',
+    async (request, reply) => {
+      const expected = getInternalBatchToken();
+      if (!expected) return reply.code(503).send({ error: 'internal trigger not configured' });
+      const got = request.headers['x-internal-token'];
+      if (typeof got !== 'string' || got !== expected) {
+        return reply.code(401).send({ error: 'invalid internal token' });
+      }
+      const limitRaw = Number(request.query.limit ?? DEFAULT_CANDIDATE_LIMIT);
+      const limit = Math.min(
+        Math.max(Number.isFinite(limitRaw) ? Math.floor(limitRaw) : DEFAULT_CANDIDATE_LIMIT, 1),
+        MAX_CANDIDATE_LIMIT
+      );
+
+      // Candidate selector:
+      //   has_caption = true (YouTube reports captions exist)
+      //   transcript_fetched_at IS NULL
+      //   ordered by user_video_states presence (priority) then view_count
+      const prisma = getPrismaClient();
+      const rows = await prisma.$queryRaw<CandidateRow[]>(Prisma.sql`
+      SELECT
+        yv.youtube_video_id,
+        yv.default_language,
+        yv.has_caption
+      FROM youtube_videos yv
+      LEFT JOIN (
+        SELECT yv2.youtube_video_id, COUNT(*) AS bookmark_count
+        FROM user_video_states uvs
+        JOIN youtube_videos yv2 ON yv2.id = uvs.video_id
+        GROUP BY yv2.youtube_video_id
+      ) book ON book.youtube_video_id = yv.youtube_video_id
+      WHERE yv.has_caption = true
+        AND yv.transcript_fetched_at IS NULL
+      ORDER BY
+        (COALESCE(book.bookmark_count, 0) > 0) DESC,
+        yv.view_count DESC NULLS LAST
+      LIMIT ${Prisma.raw(String(limit))}
+    `);
+      return reply.code(200).send({ videos: rows });
+    }
+  );
+
+  fastify.post<{
+    Body: { videoId?: string; transcript?: string; language?: string };
+  }>('/transcript/summarize', async (request, reply) => {
+    const expected = getInternalBatchToken();
+    if (!expected) return reply.code(503).send({ error: 'internal trigger not configured' });
+    const got = request.headers['x-internal-token'];
+    if (typeof got !== 'string' || got !== expected) {
+      return reply.code(401).send({ error: 'invalid internal token' });
+    }
+    const body = request.body ?? {};
+    const videoId = typeof body.videoId === 'string' ? body.videoId.trim() : '';
+    const transcript = typeof body.transcript === 'string' ? body.transcript : '';
+    if (!videoId) {
+      return reply.code(400).send({ error: 'videoId required' });
+    }
+    if (transcript.length === 0) {
+      return reply.code(400).send({ error: 'transcript must be non-empty' });
+    }
+    try {
+      const outcome = await generateRichSummaryV2({
+        videoId,
+        transcript,
+        stampTranscriptFetchedAt: true,
+      });
+      log.info('transcript summarize completed', {
+        videoId,
+        outcome: outcome.kind,
+        transcriptLen: transcript.length,
+      });
+      return reply.code(outcome.kind === 'pass' ? 200 : 422).send(outcome);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error('transcript summarize failed', { videoId, error: msg });
+      return reply.code(500).send({ error: msg });
+    }
+  });
+};

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -28,6 +28,7 @@ import { skillRoutes } from './routes/skills';
 import { copilotKitRoutes } from './routes/copilotkit';
 import { internalBatchVideoCollectorRoutes } from './routes/internal/batch-video-collector';
 import { internalTrendCollectorRoutes } from './routes/internal/trend-collector';
+import { internalTranscriptRoutes } from './routes/internal/transcript';
 import { createErrorResponse, ErrorCode } from './schemas/common.schema';
 import { registerBotWriteGuard } from './plugins/bot-write-guard';
 import { registerBotUsageLogger } from './plugins/bot-usage-logger';
@@ -43,6 +44,10 @@ import {
   startRichSummaryV2Cron,
   stopRichSummaryV2Cron,
 } from '../modules/scheduler/rich-summary-v2-cron';
+import {
+  startYouTubeMetadataCron,
+  stopYouTubeMetadataCron,
+} from '../modules/scheduler/youtube-metadata-cron';
 
 // Load environment variables
 dotenv.config();
@@ -295,6 +300,10 @@ export async function buildServer() {
       await instance.register(internalTrendCollectorRoutes, {
         prefix: '/internal/skills',
       });
+      // CP437 — Mac Mini transcript pipeline (yt-dlp memory-only).
+      await instance.register(internalTranscriptRoutes, {
+        prefix: '/internal',
+      });
     },
     { prefix: '/api/v1' }
   );
@@ -505,6 +514,15 @@ export async function startServer() {
       fastify.log.warn({ err }, 'RichSummaryV2Cron init failed (non-fatal)');
     }
 
+    // CP437 — YouTube metadata backfill cron (videos.list parts expansion).
+    // Default OFF; flip YOUTUBE_METADATA_BACKFILL_ENABLED=true once the
+    // 6 new columns are ready to receive data.
+    try {
+      startYouTubeMetadataCron();
+    } catch (err) {
+      fastify.log.warn({ err }, 'YouTubeMetadataCron init failed (non-fatal)');
+    }
+
     // Graceful shutdown
     const shutdown = async (signal: string) => {
       fastify.log.info(`${signal} received, shutting down gracefully...`);
@@ -525,6 +543,11 @@ export async function startServer() {
       }
       try {
         stopRichSummaryV2Cron();
+      } catch {
+        /* ignore */
+      }
+      try {
+        stopYouTubeMetadataCron();
       } catch {
         /* ignore */
       }

--- a/src/config/youtube-metadata.ts
+++ b/src/config/youtube-metadata.ts
@@ -1,0 +1,65 @@
+/**
+ * YouTube metadata backfill config (CP437, 2026-04-29).
+ *
+ * Knobs for the prod-runtime cron that backfills the new
+ * `youtube_videos.{comment_count,tags,topic_categories,has_caption,
+ * default_language,metadata_fetched_at}` columns added in
+ * `prisma/migrations/youtube-metadata-v2/001_add_fields.sql`.
+ *
+ * Default OFF — operator must explicitly flip
+ * `YOUTUBE_METADATA_BACKFILL_ENABLED=true` after design review.
+ *
+ * Quota: videos.list = 1 unit per call regardless of parts. With
+ * VIDEOS_LIST_MAX_IDS_PER_CALL=50 a 2,000-video batch consumes 40 units.
+ * Combined with the user-facing search.list path (100 units/call), this
+ * stays well within the 10,000 daily quota even when both run.
+ */
+
+import { z } from 'zod';
+
+const boolFlag = z.preprocess((v) => {
+  if (v == null || v === '') return false;
+  const s = String(v).trim().toLowerCase();
+  return s === 'true' || s === '1' || s === 'yes';
+}, z.boolean());
+
+const positiveInt = z.preprocess(
+  (v) => (v == null || v === '' ? undefined : Number(v)),
+  z.number().finite().int().positive().optional()
+);
+
+export const youtubeMetadataEnvSchema = z.object({
+  YOUTUBE_METADATA_BACKFILL_ENABLED: boolFlag.default(false as unknown as string),
+  YOUTUBE_METADATA_BACKFILL_BATCH_SIZE: positiveInt.transform((v) => v ?? 2000),
+  YOUTUBE_METADATA_BACKFILL_SCHEDULE: z
+    .preprocess((v) => (v == null || v === '' ? '0 18 * * *' : String(v).trim()), z.string())
+    .default('0 18 * * *'),
+});
+
+export interface YouTubeMetadataConfig {
+  backfillEnabled: boolean;
+  backfillBatchSize: number;
+  backfillSchedule: string;
+}
+
+const FALLBACK: YouTubeMetadataConfig = {
+  backfillEnabled: false,
+  backfillBatchSize: 2000,
+  backfillSchedule: '0 18 * * *',
+};
+
+export function loadYouTubeMetadataConfig(
+  env: NodeJS.ProcessEnv = process.env
+): YouTubeMetadataConfig {
+  const parsed = youtubeMetadataEnvSchema.safeParse({
+    YOUTUBE_METADATA_BACKFILL_ENABLED: env['YOUTUBE_METADATA_BACKFILL_ENABLED'],
+    YOUTUBE_METADATA_BACKFILL_BATCH_SIZE: env['YOUTUBE_METADATA_BACKFILL_BATCH_SIZE'],
+    YOUTUBE_METADATA_BACKFILL_SCHEDULE: env['YOUTUBE_METADATA_BACKFILL_SCHEDULE'],
+  });
+  if (!parsed.success) return FALLBACK;
+  return {
+    backfillEnabled: parsed.data.YOUTUBE_METADATA_BACKFILL_ENABLED,
+    backfillBatchSize: parsed.data.YOUTUBE_METADATA_BACKFILL_BATCH_SIZE,
+    backfillSchedule: parsed.data.YOUTUBE_METADATA_BACKFILL_SCHEDULE,
+  };
+}

--- a/src/modules/scheduler/youtube-metadata-cron.ts
+++ b/src/modules/scheduler/youtube-metadata-cron.ts
@@ -1,0 +1,140 @@
+/**
+ * YouTube metadata backfill cron (CP437, 2026-04-29).
+ *
+ * Schedules a node-cron task that picks up to
+ * `YOUTUBE_METADATA_BACKFILL_BATCH_SIZE` (default 2,000) youtube_videos
+ * rows where `metadata_fetched_at IS NULL`, fetches full metadata via
+ * `videos.list` (50-id batches), and upserts the new columns.
+ *
+ * Priority (matches handoff §4 spec):
+ *   1. user_video_states-bookmarked videos
+ *   2. recommendation_cache-mentioned videos
+ *   3. view_count DESC
+ *
+ * Quota: 50-id batch = 1 unit; 2,000 = 40 units. Safe vs the 10,000
+ * daily quota even alongside the search.list path (100 units/call).
+ */
+
+import * as cron from 'node-cron';
+import { Prisma } from '@prisma/client';
+
+import { getPrismaClient } from '@/modules/database/client';
+import { loadYouTubeMetadataConfig } from '@/config/youtube-metadata';
+import { logger } from '@/utils/logger';
+import { collectAndUpsertMetadata } from '../youtube/metadata-collector';
+import { VIDEOS_LIST_MAX_IDS_PER_CALL } from '@/skills/plugins/video-discover/v2/youtube-client';
+
+const log = logger.child({ module: 'YouTubeMetadataCron' });
+
+let cronTask: cron.ScheduledTask | null = null;
+let runInProgress = false;
+
+export async function selectMetadataCandidates(limit: number): Promise<string[]> {
+  if (limit <= 0) return [];
+  const prisma = getPrismaClient();
+
+  // Single CTE-based query: candidates without metadata_fetched_at, joined to
+  // bookmark + recommendation counts for ordering. ORDER BY:
+  //   1. has_bookmark DESC (true first)
+  //   2. has_rec_cache DESC
+  //   3. view_count DESC NULLS LAST
+  const rows = await prisma.$queryRaw<{ youtube_video_id: string }[]>(Prisma.sql`
+    SELECT yv.youtube_video_id
+    FROM youtube_videos yv
+    LEFT JOIN (
+      SELECT yv2.youtube_video_id, COUNT(*) AS bookmark_count
+      FROM user_video_states uvs
+      JOIN youtube_videos yv2 ON yv2.id = uvs.video_id
+      GROUP BY yv2.youtube_video_id
+    ) book ON book.youtube_video_id = yv.youtube_video_id
+    LEFT JOIN (
+      SELECT video_id, COUNT(*) AS rec_count
+      FROM recommendation_cache
+      GROUP BY video_id
+    ) rec ON rec.video_id = yv.youtube_video_id
+    WHERE yv.metadata_fetched_at IS NULL
+    ORDER BY
+      (COALESCE(book.bookmark_count, 0) > 0) DESC,
+      (COALESCE(rec.rec_count, 0) > 0) DESC,
+      yv.view_count DESC NULLS LAST
+    LIMIT ${Prisma.raw(String(limit))}
+  `);
+  return rows.map((r) => r.youtube_video_id);
+}
+
+export async function runMetadataBatchOnce(batchSize: number): Promise<{
+  picked: number;
+  fetched: number;
+  upserted: number;
+  errors: number;
+}> {
+  if (runInProgress) {
+    log.warn('metadata cron tick skipped — previous run still in progress');
+    return { picked: 0, fetched: 0, upserted: 0, errors: 0 };
+  }
+  runInProgress = true;
+  const t0 = Date.now();
+  try {
+    const candidates = await selectMetadataCandidates(batchSize);
+    log.info('metadata cron batch start', { picked: candidates.length, batchSize });
+    let totalFetched = 0;
+    let totalUpserted = 0;
+    let totalErrors = 0;
+    // Chunk into 50-id calls (videos.list max). Each call = 1 quota unit.
+    for (let i = 0; i < candidates.length; i += VIDEOS_LIST_MAX_IDS_PER_CALL) {
+      const chunk = candidates.slice(i, i + VIDEOS_LIST_MAX_IDS_PER_CALL);
+      const result = await collectAndUpsertMetadata(chunk);
+      totalFetched += result.fetched;
+      totalUpserted += result.upserted;
+      totalErrors += result.errors;
+    }
+    log.info('metadata cron batch done', {
+      picked: candidates.length,
+      fetched: totalFetched,
+      upserted: totalUpserted,
+      errors: totalErrors,
+      elapsedMs: Date.now() - t0,
+    });
+    return {
+      picked: candidates.length,
+      fetched: totalFetched,
+      upserted: totalUpserted,
+      errors: totalErrors,
+    };
+  } finally {
+    runInProgress = false;
+  }
+}
+
+export function startYouTubeMetadataCron(): void {
+  const config = loadYouTubeMetadataConfig();
+  if (!config.backfillEnabled) {
+    log.info('metadata cron disabled (YOUTUBE_METADATA_BACKFILL_ENABLED=false)');
+    return;
+  }
+  if (cronTask) {
+    cronTask.stop();
+    cronTask = null;
+  }
+  if (!cron.validate(config.backfillSchedule)) {
+    log.error('metadata cron schedule invalid — not started', {
+      schedule: config.backfillSchedule,
+    });
+    return;
+  }
+  cronTask = cron.schedule(config.backfillSchedule, () => {
+    void runMetadataBatchOnce(config.backfillBatchSize);
+  });
+  log.info('metadata cron started', {
+    schedule: config.backfillSchedule,
+    batchSize: config.backfillBatchSize,
+  });
+}
+
+export function stopYouTubeMetadataCron(): void {
+  if (cronTask) {
+    cronTask.stop();
+    cronTask = null;
+    log.info('metadata cron stopped');
+  }
+}

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -48,6 +48,19 @@ export interface V2GenerationInput {
    * `'system'` user. For now, fall back to `null` (column is nullable).
    */
   userId?: string | null;
+  /**
+   * Optional transcript text supplied by the Mac Mini transcript pipeline
+   * (yt-dlp memory-only, never persisted). When present, the prompt
+   * instructs the LLM to prefer transcript-derived evidence. Caller is
+   * responsible for the legal directive: NEVER store the raw transcript
+   * in any column.
+   */
+  transcript?: string;
+  /**
+   * When true, the generator stamps `youtube_videos.transcript_fetched_at`
+   * to NOW() after a successful pass. Set by the Mac Mini route only.
+   */
+  stampTranscriptFetchedAt?: boolean;
 }
 
 export async function generateRichSummaryV2(
@@ -86,6 +99,7 @@ export async function generateRichSummaryV2(
     description: ytRow.description ?? '',
     channel: ytRow.channel_title ?? '',
     language,
+    transcript: input.transcript,
   });
 
   const provider = await createGenerationProvider();
@@ -153,11 +167,29 @@ export async function generateRichSummaryV2(
         },
       });
 
+      // Stamp transcript_fetched_at on the video row when the Mac Mini
+      // pipeline successfully fed a transcript through. Persisting only
+      // the timestamp — the transcript text is never written to DB.
+      if (input.stampTranscriptFetchedAt) {
+        try {
+          await prisma.youtube_videos.update({
+            where: { youtube_video_id: input.videoId },
+            data: { transcript_fetched_at: new Date() },
+          });
+        } catch (err) {
+          log.warn('transcript_fetched_at stamp failed (non-fatal)', {
+            videoId: input.videoId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
       log.info('v2 generated', {
         videoId: input.videoId,
         attempt,
         completeness: score.score,
         domain: summary.core.domain,
+        withTranscript: Boolean(input.transcript && input.transcript.length > 0),
       });
       return { kind: 'pass', videoId: input.videoId, completeness: score.score };
     } catch (err) {

--- a/src/modules/skills/rich-summary-v2-prompt.ts
+++ b/src/modules/skills/rich-summary-v2-prompt.ts
@@ -115,6 +115,7 @@ export const RICH_SUMMARY_V2_LAYERED_PROMPT = `You are a learning content analys
 Video title: {title}
 Video description: {description}
 Channel: {channel}
+Transcript (when available; empty otherwise): {transcript_block}
 
 Respond with this exact JSON structure (no extra keys, no comments):
 {{
@@ -162,7 +163,8 @@ Field rules:
 
 Output rules:
 - Return JSON only — no markdown fences, no commentary, no chain-of-thought.
-- Use {language} consistently across every string field (Korean if 'ko', English if 'en').`;
+- Use {language} consistently across every string field (Korean if 'ko', English if 'en').
+- When the Transcript block is non-empty, prefer transcript content over description/title for evidence in qa_pairs.a and analysis.core_argument. When empty, fall back to title + description.`;
 
 // ============================================================================
 // Prompt fill helper
@@ -173,13 +175,32 @@ export interface PromptInput {
   description: string;
   channel: string;
   language: 'ko' | 'en';
+  /**
+   * Optional transcript text. When provided, the LLM is instructed to
+   * prefer transcript-derived evidence over description/title. The
+   * transcript is truncated to TRANSCRIPT_MAX_CHARS to stay within
+   * provider token limits.
+   */
+  transcript?: string;
 }
+
+/**
+ * Hard limit on transcript chars passed to the LLM. ~6,000 Korean chars ≈
+ * ~3,000 tokens — leaves room for system prompt + JSON output budget under
+ * 4,096 max tokens.
+ */
+export const TRANSCRIPT_MAX_CHARS = 6000;
 
 export function buildV2Prompt(input: PromptInput): string {
   const languageLabel = input.language === 'ko' ? 'Korean' : 'English';
+  const transcriptBlock =
+    input.transcript && input.transcript.length > 0
+      ? input.transcript.slice(0, TRANSCRIPT_MAX_CHARS)
+      : '(no transcript)';
   return RICH_SUMMARY_V2_LAYERED_PROMPT.replace(/\{title\}/g, input.title.slice(0, 200))
     .replace(/\{description\}/g, input.description.slice(0, 800))
     .replace(/\{channel\}/g, input.channel.slice(0, 80))
+    .replace(/\{transcript_block\}/g, transcriptBlock)
     .replace(/\{language\}/g, input.language)
     .replace(/\{language_label\}/g, languageLabel);
 }

--- a/src/modules/youtube/metadata-collector.ts
+++ b/src/modules/youtube/metadata-collector.ts
@@ -1,0 +1,172 @@
+/**
+ * YouTube metadata collector (CP437, 2026-04-29).
+ *
+ * Fetches full videos.list metadata (parts=snippet,contentDetails,
+ * statistics,topicDetails) and upserts the new columns added to
+ * `youtube_videos` in migration 001_add_fields.sql.
+ *
+ * Hard Rule note (2026-04-29 user directive):
+ *   - Collects `comment_count` (numeric quality signal) only.
+ *   - Does NOT call commentThreads.list / comments.list — comment text
+ *     and pinned comments are out of scope. Transcript path
+ *     (rich-summary v2) is the canonical text source.
+ */
+
+import { Prisma } from '@prisma/client';
+
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+import {
+  videosBatchFullMetadata,
+  topicCategoryUrlToSlug,
+  type YouTubeVideoFullMetadata,
+} from '@/skills/plugins/video-discover/v2/youtube-client';
+import { resolveSearchApiKeys } from '@/skills/plugins/video-discover/v2/youtube-client';
+import { isDomainSlug, type DomainSlug } from '@/config/domains';
+
+const log = logger.child({ module: 'YouTubeMetadataCollector' });
+
+export interface MetadataUpsertResult {
+  videoIds: string[];
+  fetched: number;
+  upserted: number;
+  errors: number;
+}
+
+/**
+ * Fetch + upsert metadata for the given youtube_video_id list. Idempotent.
+ * Returns counters for logging by callers (cron tick reporter).
+ */
+export async function collectAndUpsertMetadata(
+  videoIds: string[],
+  env: Readonly<Record<string, string | undefined>> = process.env
+): Promise<MetadataUpsertResult> {
+  if (videoIds.length === 0) {
+    return { videoIds: [], fetched: 0, upserted: 0, errors: 0 };
+  }
+  const apiKeys = resolveSearchApiKeys(env);
+  if (apiKeys.length === 0) {
+    log.warn('No YouTube API key available — metadata collector aborting');
+    return { videoIds, fetched: 0, upserted: 0, errors: videoIds.length };
+  }
+
+  let items: YouTubeVideoFullMetadata[];
+  try {
+    items = await videosBatchFullMetadata({ videoIds, apiKey: apiKeys });
+  } catch (err) {
+    log.error('videos.list batch failed', {
+      videoIds: videoIds.length,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { videoIds, fetched: 0, upserted: 0, errors: videoIds.length };
+  }
+
+  let upserted = 0;
+  let errors = 0;
+  const prisma = getPrismaClient();
+  const now = new Date();
+
+  for (const item of items) {
+    if (!item.id) continue;
+    try {
+      const data = mapToColumns(item, now);
+      await prisma.youtube_videos.update({
+        where: { youtube_video_id: item.id },
+        data,
+      });
+      upserted += 1;
+    } catch (err) {
+      errors += 1;
+      log.warn('upsert failed (non-fatal)', {
+        videoId: item.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  log.info('metadata batch upserted', {
+    requested: videoIds.length,
+    fetched: items.length,
+    upserted,
+    errors,
+  });
+  return { videoIds, fetched: items.length, upserted, errors };
+}
+
+interface MetadataColumns {
+  view_count: bigint | null;
+  like_count: bigint | null;
+  comment_count: bigint | null;
+  tags: string[];
+  topic_categories: string[];
+  has_caption: boolean | null;
+  default_language: string | null;
+  metadata_fetched_at: Date;
+  updated_at: Date;
+}
+
+function mapToColumns(item: YouTubeVideoFullMetadata, now: Date): Prisma.youtube_videosUpdateInput {
+  const stats = item.statistics ?? {};
+  const snippet = item.snippet ?? {};
+  const cd = item.contentDetails ?? {};
+  const td = item.topicDetails ?? {};
+
+  const cols: MetadataColumns = {
+    view_count: parseBigInt(stats.viewCount),
+    like_count: parseBigInt(stats.likeCount),
+    comment_count: parseBigInt(stats.commentCount),
+    tags: Array.isArray(snippet.tags) ? snippet.tags.slice(0, 100) : [],
+    topic_categories: extractTopicCategories(td.topicCategories ?? []),
+    has_caption: typeof cd.caption === 'string' ? cd.caption.toLowerCase() === 'true' : null,
+    default_language:
+      typeof snippet.defaultLanguage === 'string'
+        ? snippet.defaultLanguage.slice(0, 10)
+        : typeof snippet.defaultAudioLanguage === 'string'
+          ? snippet.defaultAudioLanguage.slice(0, 10)
+          : null,
+    metadata_fetched_at: now,
+    updated_at: now,
+  };
+  return cols as unknown as Prisma.youtube_videosUpdateInput;
+}
+
+function parseBigInt(s: string | undefined): bigint | null {
+  if (!s) return null;
+  try {
+    return BigInt(s);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract slug-only categories from the topicCategories URL list. Keeps
+ * the original URL list out of the column (decreases payload, normalizes
+ * to lowercase slugs that align with `src/config/domains.ts`).
+ *
+ * Returns the union of Wikipedia URL slugs (lowercased + underscores
+ * stripped). Output may include slugs that are NOT in `DOMAIN_SLUGS`
+ * (e.g. 'sports', 'politics' from YouTube's topic taxonomy) — callers
+ * that need strict mapping should filter via `isDomainSlug`.
+ */
+function extractTopicCategories(urls: string[]): string[] {
+  const out: string[] = [];
+  for (const u of urls) {
+    if (typeof u !== 'string' || u.length === 0) continue;
+    const slug = topicCategoryUrlToSlug(u);
+    if (slug && !out.includes(slug)) out.push(slug);
+  }
+  return out;
+}
+
+/**
+ * Convenience: filter raw topic categories to only the 9 SSOT domain
+ * slugs. Used by downstream consumers that want a strict domain mapping.
+ */
+export function filterTopicCategoriesToDomainSlugs(raw: string[]): DomainSlug[] {
+  const out: DomainSlug[] = [];
+  for (const s of raw) {
+    if (isDomainSlug(s) && !out.includes(s)) out.push(s);
+  }
+  return out;
+}

--- a/src/skills/plugins/video-discover/v2/youtube-client.ts
+++ b/src/skills/plugins/video-discover/v2/youtube-client.ts
@@ -45,6 +45,51 @@ interface YouTubeVideosResponse {
   error?: { code: number; message: string };
 }
 
+/**
+ * Full metadata response shape (CP437) — videos.list with
+ * parts=snippet,contentDetails,statistics,topicDetails.
+ *
+ * Spec note (2026-04-29 user directive): we collect commentCount (numeric
+ * quality signal) but never call commentThreads.list / comments.list.
+ * Comment text / pinned comments are out of scope; transcript path
+ * (rich-summary v2) is the canonical text source.
+ */
+export interface YouTubeVideoFullMetadata {
+  id?: string;
+  snippet?: {
+    title?: string;
+    description?: string;
+    channelTitle?: string;
+    channelId?: string;
+    publishedAt?: string;
+    thumbnails?: {
+      high?: { url?: string };
+      standard?: { url?: string };
+      default?: { url?: string };
+    };
+    tags?: string[];
+    defaultLanguage?: string;
+    defaultAudioLanguage?: string;
+  };
+  contentDetails?: {
+    duration?: string;
+    caption?: string;
+  };
+  statistics?: {
+    viewCount?: string;
+    likeCount?: string;
+    commentCount?: string;
+  };
+  topicDetails?: {
+    topicCategories?: string[];
+  };
+}
+
+interface YouTubeVideosFullResponse {
+  items?: YouTubeVideoFullMetadata[];
+  error?: { code: number; message: string };
+}
+
 export interface SearchOpts {
   query: string;
   /**
@@ -251,6 +296,95 @@ async function videosBatchSingle(
   const body = (await res.json()) as YouTubeVideosResponse;
   if (body.error) throw new Error(`videos.list error: ${body.error.message}`);
   return body.items ?? [];
+}
+
+// ============================================================================
+// Full-metadata batch (CP437) — backfill cron uses this
+// ============================================================================
+
+export interface VideosBatchFullOpts {
+  videoIds: string[];
+  apiKey: string | string[];
+  fetchFn?: typeof fetch;
+}
+
+export async function videosBatchFullMetadata(
+  opts: VideosBatchFullOpts
+): Promise<YouTubeVideoFullMetadata[]> {
+  if (opts.videoIds.length === 0) return [];
+  const keys = Array.isArray(opts.apiKey) ? opts.apiKey : [opts.apiKey];
+  if (keys.length === 0 || keys.every((k) => !k)) {
+    throw new Error('videosBatchFullMetadata: server API key is required');
+  }
+  const chunks: string[][] = [];
+  for (let i = 0; i < opts.videoIds.length; i += VIDEOS_LIST_MAX_IDS_PER_CALL) {
+    chunks.push(opts.videoIds.slice(i, i + VIDEOS_LIST_MAX_IDS_PER_CALL));
+  }
+  const results = await Promise.all(
+    chunks.map(async (chunk) => {
+      let lastErr: unknown = null;
+      for (const key of keys) {
+        if (!key) continue;
+        try {
+          return await videosBatchFullSingle(chunk, key, opts.fetchFn);
+        } catch (err) {
+          lastErr = err;
+          if (!isVideosBatchQuotaError(err)) throw err;
+        }
+      }
+      throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+    })
+  );
+  return results.flat();
+}
+
+async function videosBatchFullSingle(
+  videoIds: string[],
+  apiKey: string,
+  fetchFn?: typeof fetch
+): Promise<YouTubeVideoFullMetadata[]> {
+  const url = new URL(`${YOUTUBE_API_BASE}/videos`);
+  // 4 parts. videos.list quota = 1 unit per call regardless of part count.
+  // We deliberately do NOT request `commentThreads` here — comment text
+  // is out of scope per the 2026-04-29 user directive.
+  url.searchParams.set('part', 'snippet,contentDetails,statistics,topicDetails');
+  url.searchParams.set('id', videoIds.join(','));
+  url.searchParams.set('key', apiKey);
+
+  const f = fetchFn ?? fetch;
+  const res = await f(url.toString());
+  if (!res.ok) {
+    let msg = '';
+    try {
+      const body = (await res.json()) as YouTubeVideosFullResponse;
+      msg = body.error?.message ?? '';
+    } catch {
+      // ignore
+    }
+    throw new Error(`videos.list HTTP ${res.status}${msg ? ` — ${msg}` : ''}`);
+  }
+  const body = (await res.json()) as YouTubeVideosFullResponse;
+  if (body.error) throw new Error(`videos.list error: ${body.error.message}`);
+  return body.items ?? [];
+}
+
+/**
+ * Convert a YouTube `topicDetails.topicCategories` URL (Wikipedia) to a
+ * lowercase slug. Examples:
+ *   https://en.wikipedia.org/wiki/Health   → 'health'
+ *   https://en.wikipedia.org/wiki/Lifestyle_(sociology) → 'lifestyle'
+ *   https://en.wikipedia.org/wiki/Mind     → 'mind'
+ *
+ * Strips trailing `_(disambig)` parens, replaces underscores with empty
+ * (so multi-word topics collapse), lowercases.
+ */
+export function topicCategoryUrlToSlug(url: string): string {
+  const m = url.match(/\/wiki\/([^?#]+)/);
+  if (!m) return '';
+  const raw = decodeURIComponent(m[1] ?? '').trim();
+  // Drop trailing parenthetical disambiguation: "Lifestyle_(sociology)" → "Lifestyle"
+  const noDisamb = raw.replace(/_\([^)]*\)$/u, '');
+  return noDisamb.replace(/_/g, '').toLowerCase();
 }
 
 /**

--- a/tests/unit/config/youtube-metadata.test.ts
+++ b/tests/unit/config/youtube-metadata.test.ts
@@ -1,0 +1,60 @@
+/**
+ * YouTube metadata config (CP437).
+ */
+
+import { loadYouTubeMetadataConfig } from '@/config/youtube-metadata';
+
+describe('loadYouTubeMetadataConfig', () => {
+  test('defaults — backfill OFF, batch 2000, schedule 0 18 * * *', () => {
+    expect(loadYouTubeMetadataConfig({})).toEqual({
+      backfillEnabled: false,
+      backfillBatchSize: 2000,
+      backfillSchedule: '0 18 * * *',
+    });
+  });
+
+  test('YOUTUBE_METADATA_BACKFILL_ENABLED parses booleans', () => {
+    expect(
+      loadYouTubeMetadataConfig({ YOUTUBE_METADATA_BACKFILL_ENABLED: 'true' }).backfillEnabled
+    ).toBe(true);
+    expect(
+      loadYouTubeMetadataConfig({ YOUTUBE_METADATA_BACKFILL_ENABLED: '1' }).backfillEnabled
+    ).toBe(true);
+    expect(
+      loadYouTubeMetadataConfig({ YOUTUBE_METADATA_BACKFILL_ENABLED: 'false' }).backfillEnabled
+    ).toBe(false);
+    expect(
+      loadYouTubeMetadataConfig({ YOUTUBE_METADATA_BACKFILL_ENABLED: '' }).backfillEnabled
+    ).toBe(false);
+  });
+
+  test('YOUTUBE_METADATA_BACKFILL_BATCH_SIZE accepts positive int', () => {
+    expect(
+      loadYouTubeMetadataConfig({ YOUTUBE_METADATA_BACKFILL_BATCH_SIZE: '500' }).backfillBatchSize
+    ).toBe(500);
+  });
+
+  test('invalid batch size falls back to 2000', () => {
+    expect(
+      loadYouTubeMetadataConfig({ YOUTUBE_METADATA_BACKFILL_BATCH_SIZE: '0' }).backfillBatchSize
+    ).toBe(2000);
+    expect(
+      loadYouTubeMetadataConfig({ YOUTUBE_METADATA_BACKFILL_BATCH_SIZE: 'garbage' })
+        .backfillBatchSize
+    ).toBe(2000);
+  });
+
+  test('schedule passes through valid cron string', () => {
+    const cfg = loadYouTubeMetadataConfig({
+      YOUTUBE_METADATA_BACKFILL_SCHEDULE: '*/30 * * * *',
+    });
+    expect(cfg.backfillSchedule).toBe('*/30 * * * *');
+  });
+
+  test('empty schedule falls back to 0 18 * * *', () => {
+    expect(loadYouTubeMetadataConfig({}).backfillSchedule).toBe('0 18 * * *');
+    expect(
+      loadYouTubeMetadataConfig({ YOUTUBE_METADATA_BACKFILL_SCHEDULE: '' }).backfillSchedule
+    ).toBe('0 18 * * *');
+  });
+});

--- a/tests/unit/mac-mini/transcript-collector.test.ts
+++ b/tests/unit/mac-mini/transcript-collector.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Mac Mini transcript-collector — pure helpers (CP437).
+ *
+ * The Node script in mac-mini/transcript-collector/collect.ts runs out
+ * of process so we don't import it as a module here. The tests in this
+ * file mirror the `stripVtt` logic by re-implementing the exact same
+ * regex stack and locking it against representative auto-subs samples.
+ */
+
+// Re-implement the Mac Mini collector's stripVtt to lock its behavior.
+// Keep this verbatim with `mac-mini/transcript-collector/collect.ts`.
+function stripVtt(vtt: string): string {
+  const lines = vtt.split(/\r?\n/);
+  const out: string[] = [];
+  for (const line of lines) {
+    const t = line.trim();
+    if (!t) continue;
+    if (t === 'WEBVTT') continue;
+    if (/^\d+$/.test(t)) continue;
+    if (/-->/u.test(t)) continue;
+    if (/^Kind:|^Language:/i.test(t)) continue;
+    const stripped = t.replace(/<[^>]+>/g, '').trim();
+    if (stripped.length === 0) continue;
+    out.push(stripped);
+  }
+  return out.join(' ');
+}
+
+describe('Mac Mini transcript-collector / stripVtt', () => {
+  test('drops WEBVTT header + Kind/Language metadata + empty lines', () => {
+    const vtt = `WEBVTT
+Kind: captions
+Language: ko
+
+00:00:00.000 --> 00:00:02.000
+첫 번째 자막
+
+00:00:02.500 --> 00:00:05.000
+두 번째 자막
+`;
+    expect(stripVtt(vtt)).toBe('첫 번째 자막 두 번째 자막');
+  });
+
+  test('drops cue numeric IDs', () => {
+    const vtt = `WEBVTT
+
+1
+00:00:00.000 --> 00:00:02.000
+hello
+
+2
+00:00:02.500 --> 00:00:05.000
+world
+`;
+    expect(stripVtt(vtt)).toBe('hello world');
+  });
+
+  test('strips inline timing tags <00:00:01.000><c>', () => {
+    const vtt = `WEBVTT
+
+00:00:00.000 --> 00:00:02.000
+This <00:00:01.000><c>is</c> a test
+`;
+    expect(stripVtt(vtt)).toBe('This is a test');
+  });
+
+  test('returns empty string for VTT with no caption text', () => {
+    const vtt = `WEBVTT
+Kind: captions
+Language: ko
+
+00:00:00.000 --> 00:00:02.000
+`;
+    expect(stripVtt(vtt)).toBe('');
+  });
+
+  test('handles \\r\\n line endings (Windows-style)', () => {
+    const vtt = 'WEBVTT\r\n\r\n00:00:00.000 --> 00:00:02.000\r\nhello world\r\n';
+    expect(stripVtt(vtt)).toBe('hello world');
+  });
+});

--- a/tests/unit/skills/rich-summary-v2-transcript.test.ts
+++ b/tests/unit/skills/rich-summary-v2-transcript.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Rich Summary v2 — transcript injection (CP437).
+ *
+ * Locks the prompt builder's behavior when a transcript is supplied.
+ * Generator-level integration (DB + LLM) is covered by smoke tests; here
+ * we just ensure the prompt template path is wired correctly.
+ */
+
+import { buildV2Prompt, TRANSCRIPT_MAX_CHARS } from '@/modules/skills/rich-summary-v2-prompt';
+
+describe('buildV2Prompt — transcript injection', () => {
+  const base = {
+    title: '시간관리 강의',
+    description: '핵심 요약',
+    channel: 'TestChannel',
+    language: 'ko' as const,
+  };
+
+  test('omitting transcript results in (no transcript) placeholder', () => {
+    const out = buildV2Prompt(base);
+    expect(out).toContain('Transcript');
+    expect(out).toContain('(no transcript)');
+  });
+
+  test('supplied transcript appears verbatim under TRANSCRIPT_MAX_CHARS', () => {
+    const transcript = '이 영상은 시간관리의 3단계를 다룬다. 계획 / 실행 / 회고.';
+    const out = buildV2Prompt({ ...base, transcript });
+    expect(out).toContain(transcript);
+    expect(out).not.toContain('(no transcript)');
+  });
+
+  test('long transcript is truncated to TRANSCRIPT_MAX_CHARS', () => {
+    const transcript = '가'.repeat(TRANSCRIPT_MAX_CHARS + 500);
+    const out = buildV2Prompt({ ...base, transcript });
+    // Verify the full overflow segment is NOT present.
+    expect(out.includes('가'.repeat(TRANSCRIPT_MAX_CHARS))).toBe(true);
+    expect(out.includes('가'.repeat(TRANSCRIPT_MAX_CHARS + 1))).toBe(false);
+  });
+
+  test('empty-string transcript falls back to (no transcript)', () => {
+    const out = buildV2Prompt({ ...base, transcript: '' });
+    expect(out).toContain('(no transcript)');
+  });
+});

--- a/tests/unit/youtube/metadata-collector.test.ts
+++ b/tests/unit/youtube/metadata-collector.test.ts
@@ -1,0 +1,60 @@
+/**
+ * YouTube metadata collector — pure-fn helpers (CP437).
+ *
+ * Tests the URL→slug parser + topic-category filter without touching the
+ * DB or YouTube API. The full collector path (HTTP → upsert) is covered by
+ * smoke tests in CI; here we just lock the deterministic mappings.
+ */
+
+import { topicCategoryUrlToSlug } from '@/skills/plugins/video-discover/v2/youtube-client';
+import { filterTopicCategoriesToDomainSlugs } from '@/modules/youtube/metadata-collector';
+
+describe('topicCategoryUrlToSlug', () => {
+  test('canonical /wiki/Health → health', () => {
+    expect(topicCategoryUrlToSlug('https://en.wikipedia.org/wiki/Health')).toBe('health');
+  });
+
+  test('multi-word /wiki/Lifestyle_(sociology) drops disambig + collapses underscores', () => {
+    expect(topicCategoryUrlToSlug('https://en.wikipedia.org/wiki/Lifestyle_(sociology)')).toBe(
+      'lifestyle'
+    );
+  });
+
+  test('multi-word /wiki/Mind_(philosophy) → mind', () => {
+    expect(topicCategoryUrlToSlug('https://en.wikipedia.org/wiki/Mind_(philosophy)')).toBe('mind');
+  });
+
+  test('non-wiki URL → empty string', () => {
+    expect(topicCategoryUrlToSlug('https://example.com/Health')).toBe('');
+  });
+
+  test('url-encoded wiki path is decoded', () => {
+    expect(topicCategoryUrlToSlug('https://en.wikipedia.org/wiki/Sport%20%28activity%29')).toMatch(
+      /sport/
+    );
+  });
+
+  test('strict slug match for tech domain', () => {
+    expect(topicCategoryUrlToSlug('https://en.wikipedia.org/wiki/Technology')).toBe('technology');
+    // Note: 'technology' is NOT a DOMAIN slug ('tech' is). filter step below maps.
+  });
+});
+
+describe('filterTopicCategoriesToDomainSlugs', () => {
+  test('keeps only the 9 SSOT slugs from a mixed input', () => {
+    const raw = ['health', 'sport', 'lifestyle', 'unknown', 'mind', 'finance', 'sport'];
+    const filtered = filterTopicCategoriesToDomainSlugs(raw);
+    expect(filtered).toEqual(['health', 'lifestyle', 'mind', 'finance']);
+  });
+
+  test('returns empty when none match', () => {
+    expect(filterTopicCategoriesToDomainSlugs(['sport', 'politics', 'music'])).toEqual([]);
+  });
+
+  test('dedupes when a slug appears twice', () => {
+    expect(filterTopicCategoriesToDomainSlugs(['tech', 'tech', 'health'])).toEqual([
+      'tech',
+      'health',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

CP437 (2026-04-29). Two complementary cron paths shipped together. Default OFF until operator flip.

### A. EC2 — youtube_videos full metadata expansion (Track 1)

- **8 new columns** on \`youtube_videos\`: \`comment_count\`, \`tags[]\`, \`topic_categories[]\`, \`has_caption\`, \`default_language\`, \`metadata_fetched_at\`, \`transcript_fetched_at\` (+ \`like_count IF NOT EXISTS\`).
- \`videos.list\` parts expanded to \`snippet,contentDetails,statistics,topicDetails\` (still 1 quota unit/call, 50 ids/batch).
- New backfill cron: priority \`user_video_states bookmark > recommendation_cache > view_count DESC\`. Daily 18:00 UTC, batch 2,000 → ~40 quota units.
- 3 new ENV: \`YOUTUBE_METADATA_BACKFILL_ENABLED\` (default false) / \`_BATCH_SIZE\` / \`_SCHEDULE\`.
- \`topicCategoryUrlToSlug()\` Wikipedia URL → lowercase slug.

### B. Mac Mini — yt-dlp transcript pipeline (Track 3, memory-only)

- \`mac-mini/transcript-collector/collect.ts\`: Node script, runs ON Mac Mini (NO YouTube API v3, NO quota). yt-dlp \`-o -\` stdout → buffer → POST to EC2 → discard.
- EC2 internal routes (\`src/api/routes/internal/transcript.ts\`): \`GET /candidates\` (has_caption=true + transcript_fetched_at IS NULL) + \`POST /summarize\` (calls v2 generator with transcript, stamps \`transcript_fetched_at\`).
- Auth: existing \`INTERNAL_BATCH_TOKEN\` shared header pattern.

### C. Rich Summary v2 generator — transcript injection

- \`generateRichSummaryV2({ videoId, transcript?, stampTranscriptFetchedAt? })\`. When transcript present, prompt instructs LLM to prefer transcript-derived evidence. \`TRANSCRIPT_MAX_CHARS=6000\`.

## Hard Rule compliance

- \`statistics.commentCount\` only — never calls \`commentThreads.list\` / \`comments.list\`.
- Mac Mini script speaks HTTP only — no Postgres credential, no DB direct access.
- Transcript text NEVER persisted; \`transcript_fetched_at\` is the only persisted record.
- All cron defaults OFF on prod until operator flip.

## Tests

- \`tests/unit/youtube/metadata-collector.test.ts\` (8): URL→slug parser + filter to 9 SSOT slugs.
- \`tests/unit/config/youtube-metadata.test.ts\` (7): env parsing.
- \`tests/unit/mac-mini/transcript-collector.test.ts\` (5): VTT stripping.
- \`tests/unit/skills/rich-summary-v2-transcript.test.ts\` (4): prompt builder transcript injection + truncation.
- 24 new tests, all PASS. 19 fail = baseline (no new failures).
- tsc + build clean. hardcode-audit 33 = baseline.

## Test plan

- [x] tsc --noEmit clean
- [x] jest 19 fail = baseline (982 passed, +24 new)
- [x] npm run build clean
- [x] hardcode-audit baseline
- [ ] Post-merge prod DDL apply via psql wrapper (8 ALTER columns + 2 indexes)
- [ ] Verify columns exist on prod schema
- [ ] Operator flip \`YOUTUBE_METADATA_BACKFILL_ENABLED=true\` (separate PR)
- [ ] First nightly tick processes 2,000 candidates

## Roll-out

1. Merge + deploy (cron stays OFF).
2. Apply prod DDL (8 columns + 2 indexes).
3. (Track 2 separate handoff) Mac Mini Redis tags backfill.
4. Operator flip post-2K analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)