### PR TITLE
ops: enable youtube metadata backfill cron (operator flip)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -93,6 +93,29 @@ services:
       # Revert: set to false or delete this line → cron stops at next process
       # restart (no in-flight call is interrupted).
       - RICH_SUMMARY_V2_CRON_ENABLED=true
+      # CP437 (2026-04-29) — Operator flip: enable YouTube metadata backfill cron.
+      # Default in code is `false` — cron stays dormant unless this env is
+      # explicitly true. With this set, `startYouTubeMetadataCron()` schedules
+      # the daily 18:00 UTC tick (1 hour after the rich-summary v2 tick to keep
+      # OpenRouter + YouTube quota windows separated).
+      #
+      # Behavior:
+      #   - Each tick selects up to YOUTUBE_METADATA_BACKFILL_BATCH_SIZE
+      #     (default 2,000) youtube_videos rows where metadata_fetched_at IS
+      #     NULL, ordered by user_video_states bookmark > recommendation_cache
+      #     > view_count DESC.
+      #   - Calls videos.list with parts=snippet,contentDetails,statistics,
+      #     topicDetails (1 quota unit per 50-id call → ~40 units per 2,000-row
+      #     batch, well under the daily 10,000 limit).
+      #   - Upserts the new columns: tags[], topic_categories[], has_caption,
+      #     default_language, comment_count, metadata_fetched_at.
+      #
+      # No LLM API call. No commentThreads.list / comments.list (commentCount
+      # alone, per the 2026-04-29 user directive).
+      #
+      # Revert: set to false or delete this line → cron stops at next process
+      # restart (no in-flight call is interrupted).
+      - YOUTUBE_METADATA_BACKFILL_ENABLED=true
       # CP424.2 (2026-04-24) — Wizard Precompute Pipeline.
       # Per docs/design/precompute-pipeline.md. Step 1 goal → /wizard-stream
       # fires fire-and-forget `runDiscoverEphemeral` keyed by session_id →


### PR DESCRIPTION
## Summary

CP437 operator flip per CC handoff. Adds \`YOUTUBE_METADATA_BACKFILL_ENABLED=true\` to \`docker-compose.prod.yml\`. No code change.

Mirrors PR #566 (\`RICH_SUMMARY_V2_CRON_ENABLED\` flip) pattern.

## Effect

\`startYouTubeMetadataCron()\` (shipped in #567) now runs on prod boot. First tick fires at 18:00 UTC (= 03:00 KST), 1 hour after the rich-summary v2 tick. Each tick processes up to \`YOUTUBE_METADATA_BACKFILL_BATCH_SIZE=2,000\` candidates (~40 quota units per batch).

## Hard Rule

- No LLM API call.
- statistics.commentCount only — no commentThreads.list / comments.list.
- Stays under the 10,000 daily YouTube quota.

## Revert

Set the env to \`false\` or delete the line → cron stops at next process restart. In-flight call is not interrupted.

## Test plan

- [x] No code change — CI checks should pass (only docker-compose.prod.yml diff).
- [ ] Post-deploy:
  - [ ] Container restart confirmed.
  - [ ] \`YOUTUBE_METADATA_BACKFILL_ENABLED=true\` reflected in container env.
  - [ ] Log line: "metadata cron started" with schedule + batchSize.
  - [ ] Next 18:00 UTC tick: 2,000 candidates picked, tags / topic_categories / has_caption populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)