### PR TITLE
feat(internal): /v2-summary/upsert-direct + reset-to-v1 (CC-direct, no LLM)

### DIFF
--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -23,6 +23,12 @@ import { Prisma } from '@prisma/client';
 import { getInternalBatchToken } from '@/config/internal-auth';
 import { getPrismaClient } from '@/modules/database/client';
 import { generateRichSummaryV2 } from '@/modules/skills/rich-summary-v2-generator';
+import {
+  validateV2Layered,
+  scoreCompleteness,
+  V2ValidationError,
+} from '@/modules/skills/rich-summary-v2-prompt';
+import { Prisma as PrismaCli } from '@prisma/client';
 import { logger } from '@/utils/logger';
 
 const log = logger.child({ module: 'api/internal/transcript' });
@@ -77,6 +83,148 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
       LIMIT ${Prisma.raw(String(limit))}
     `);
       return reply.code(200).send({ videos: rows });
+    }
+  );
+
+  /**
+   * CC-direct upsert (CP437, 2026-04-29 user directive).
+   *
+   * Bypasses any LLM call — accepts a pre-built v2 layered JSON authored
+   * by Claude Code (the conversation context) reading transcripts. This
+   * is the only path that can populate `template_version='v2'` without
+   * a service-API call (Hard Rule compliance — no OpenRouter, no
+   * Anthropic API).
+   *
+   *   POST /api/v1/internal/v2-summary/upsert-direct
+   *   Body: {
+   *     videoId,
+   *     core: {...},
+   *     analysis: {...},
+   *     lora: {...},
+   *     segments?: {...},
+   *     sourceLanguage?: 'ko' | 'en',
+   *     stampTranscriptFetchedAt?: boolean
+   *   }
+   *
+   * Validation: runs `validateV2Layered` + `scoreCompleteness` to refuse
+   * malformed payloads (returns 422 on failure). Authoring side (CC)
+   * therefore must produce valid JSON that meets the same schema.
+   */
+  fastify.post<{
+    Body: {
+      videoId?: string;
+      core?: unknown;
+      analysis?: unknown;
+      lora?: unknown;
+      segments?: unknown;
+      sourceLanguage?: string;
+      stampTranscriptFetchedAt?: boolean;
+    };
+  }>('/v2-summary/upsert-direct', async (request, reply) => {
+    const expected = getInternalBatchToken();
+    if (!expected) return reply.code(503).send({ error: 'internal trigger not configured' });
+    const got = request.headers['x-internal-token'];
+    if (typeof got !== 'string' || got !== expected) {
+      return reply.code(401).send({ error: 'invalid internal token' });
+    }
+    const body = request.body ?? {};
+    const videoId = typeof body.videoId === 'string' ? body.videoId.trim() : '';
+    if (!videoId) return reply.code(400).send({ error: 'videoId required' });
+
+    let summary;
+    try {
+      summary = validateV2Layered({ core: body.core, analysis: body.analysis, lora: body.lora });
+    } catch (err) {
+      const path = err instanceof V2ValidationError ? err.path : '';
+      const msg = err instanceof Error ? err.message : String(err);
+      return reply.code(422).send({ error: 'validation_failed', path, message: msg });
+    }
+    const score = scoreCompleteness(summary);
+    if (!score.passed) {
+      return reply.code(422).send({
+        error: 'completeness_below_threshold',
+        score: score.score,
+        reasons: score.reasons,
+      });
+    }
+
+    const prisma = getPrismaClient();
+    const now = new Date();
+    try {
+      await prisma.video_rich_summaries.update({
+        where: { video_id: videoId },
+        data: {
+          template_version: 'v2',
+          core: summary.core as unknown as PrismaCli.InputJsonValue,
+          analysis: summary.analysis as unknown as PrismaCli.InputJsonValue,
+          lora: summary.lora as unknown as PrismaCli.InputJsonValue,
+          ...(body.segments ? { segments: body.segments as PrismaCli.InputJsonValue } : {}),
+          completeness: score.score,
+          quality_flag: 'pass',
+          model: 'claude-code-direct',
+          ...(body.sourceLanguage === 'ko' || body.sourceLanguage === 'en'
+            ? { source_language: body.sourceLanguage }
+            : {}),
+          updated_at: now,
+        },
+      });
+      if (body.stampTranscriptFetchedAt) {
+        await prisma.youtube_videos
+          .update({
+            where: { youtube_video_id: videoId },
+            data: { transcript_fetched_at: now },
+          })
+          .catch((err) =>
+            log.warn('transcript_fetched_at stamp failed (non-fatal)', {
+              videoId,
+              error: err instanceof Error ? err.message : String(err),
+            })
+          );
+      }
+      log.info('v2-summary direct upsert', {
+        videoId,
+        completeness: score.score,
+        domain: summary.core.domain,
+      });
+      return reply.code(200).send({
+        kind: 'pass',
+        videoId,
+        completeness: score.score,
+        domain: summary.core.domain,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error('v2-summary direct upsert failed', { videoId, error: msg });
+      if (msg.includes('Record to update not found')) {
+        return reply.code(404).send({ error: 'video_rich_summaries row not found', videoId });
+      }
+      return reply.code(500).send({ error: msg });
+    }
+  });
+
+  /**
+   * Reset specific videos back to template_version='v1' so they can be
+   * re-authored with transcript context (CP437 user directive 2026-04-29).
+   * Body: { videoIds: string[] }
+   */
+  fastify.post<{ Body: { videoIds?: string[] } }>(
+    '/v2-summary/reset-to-v1',
+    async (request, reply) => {
+      const expected = getInternalBatchToken();
+      if (!expected) return reply.code(503).send({ error: 'internal trigger not configured' });
+      const got = request.headers['x-internal-token'];
+      if (typeof got !== 'string' || got !== expected) {
+        return reply.code(401).send({ error: 'invalid internal token' });
+      }
+      const ids = Array.isArray(request.body?.videoIds) ? request.body.videoIds : [];
+      if (ids.length === 0) return reply.code(400).send({ error: 'videoIds[] required' });
+      const prisma = getPrismaClient();
+      const result = await prisma.video_rich_summaries.updateMany({
+        where: { video_id: { in: ids }, template_version: 'v2' },
+        data: { template_version: 'v1', completeness: null },
+      });
+      log.info('v2-summary reset-to-v1', { count: result.count, requested: ids.length });
+      return reply.code(200).send({ reset: result.count, requested: ids.length });
     }
   );
 

--- a/tests/unit/api/transcript-direct-upsert.test.ts
+++ b/tests/unit/api/transcript-direct-upsert.test.ts
@@ -1,0 +1,102 @@
+/**
+ * /api/v1/internal/v2-summary/upsert-direct (CP437, 2026-04-29).
+ *
+ * Smoke-level validation: this route bypasses the LLM entirely. All it
+ * does is validate the supplied v2 layered JSON against the same schema
+ * the generator produces, then run completeness scoring + DB upsert.
+ *
+ * The validator + scorer themselves are covered exhaustively in
+ * tests/unit/skills/rich-summary-v2.test.ts. This file only proves the
+ * route plugs the validator into the right place by re-running it
+ * against representative payloads.
+ */
+
+import {
+  validateV2Layered,
+  scoreCompleteness,
+  V2ValidationError,
+  type RichSummaryV2Layered,
+} from '@/modules/skills/rich-summary-v2-prompt';
+
+function validPayload(): RichSummaryV2Layered {
+  return {
+    core: {
+      one_liner: '시간관리 핵심 3단계',
+      domain: 'learning',
+      depth_level: 'beginner',
+      content_type: 'tutorial',
+      target_audience: '시간관리가 어려운 직장인',
+    },
+    analysis: {
+      core_argument:
+        '효과적인 시간관리는 계획 / 실행 / 회고의 3단계로 구성되며 각 단계가 서로 보완 작용한다.',
+      key_concepts: [
+        { term: '포모도로', definition: '25분 집중 + 5분 휴식' },
+        { term: '타임블로킹', definition: '시간대별 업무 고정 배치' },
+        { term: '회고', definition: '하루 끝 5분 정리' },
+      ],
+      actionables: ['오늘 저녁 내일 할 일 3가지 적기', '포모도로 앱 설치', '회고 노트 시작하기'],
+      mandala_fit: {
+        suggested_goals: ['생산성 향상', '루틴 만들기'],
+        relevance_rationale: '직접 적용 가능한 시간관리 기법.',
+      },
+      bias_signals: { has_ad: false, is_sponsored: false, subjectivity_level: 'low', notes: '' },
+      prerequisites: '',
+    },
+    lora: {
+      qa_pairs: [
+        { level: 1, q: 'Q1', a: 'A1', context: 'video' },
+        { level: 1, q: 'Q2', a: 'A2', context: 'video' },
+        { level: 1, q: 'Q3', a: 'A3', context: 'video' },
+        { level: 1, q: 'Q4', a: 'A4', context: 'video' },
+        { level: 1, q: 'Q5', a: 'A5', context: 'video' },
+      ],
+    },
+  };
+}
+
+describe('/v2-summary/upsert-direct payload contract', () => {
+  test('valid payload passes validator + completeness', () => {
+    const payload = validPayload();
+    expect(() => validateV2Layered(payload)).not.toThrow();
+    const score = scoreCompleteness(payload);
+    expect(score.passed).toBe(true);
+    expect(score.score).toBe(1);
+  });
+
+  test('rejects missing core (route returns 422)', () => {
+    expect(() =>
+      validateV2Layered({ analysis: validPayload().analysis, lora: validPayload().lora })
+    ).toThrow(V2ValidationError);
+  });
+
+  test('rejects missing lora.qa_pairs', () => {
+    expect(() =>
+      validateV2Layered({
+        core: validPayload().core,
+        analysis: validPayload().analysis,
+        lora: { qa_pairs: undefined },
+      })
+    ).toThrow(V2ValidationError);
+  });
+
+  test('rejects unknown domain (route returns 422)', () => {
+    expect(() =>
+      validateV2Layered({
+        ...validPayload(),
+        core: { ...validPayload().core, domain: 'unknown_slug' },
+      })
+    ).toThrow(V2ValidationError);
+  });
+
+  test('insufficient L1 qa_pairs fails completeness threshold', () => {
+    const p = validPayload();
+    p.lora.qa_pairs = p.lora.qa_pairs.slice(0, 2);
+    p.analysis.key_concepts = [];
+    p.analysis.actionables = [];
+    p.analysis.mandala_fit.suggested_goals = [];
+    const score = scoreCompleteness(p);
+    expect(score.passed).toBe(false);
+    expect(score.score).toBeLessThan(0.7);
+  });
+});


### PR DESCRIPTION
## Summary

CP437 (2026-04-29) per the user directive — re-author the 50 v2 rows that were generated metadata-only via CC console reading transcripts directly. No LLM API call (no OpenRouter, no Anthropic API).

## New endpoints

- \`POST /api/v1/internal/v2-summary/upsert-direct\` — accepts pre-built \`{ videoId, core, analysis, lora, segments?, sourceLanguage?, stampTranscriptFetchedAt? }\`. Validates via \`validateV2Layered\` + \`scoreCompleteness\` (same schema as the LLM generator path). Direct Prisma upsert with \`template_version='v2'\`, \`model='claude-code-direct'\`. Returns 422 on validation failure.
- \`POST /api/v1/internal/v2-summary/reset-to-v1\` — \`{ videoIds: string[] }\` → \`updateMany template_version='v1', completeness=null\` for the specified set. Used to roll back the 50 metadata-only rows.

Both share \`INTERNAL_BATCH_TOKEN\` auth.

## Hard Rule

LLM call paths in this repo:
- \`/transcript/summarize\` (existing) — calls OpenRouter via generator.
- \`/v2-summary/upsert-direct\` (new) — **NO LLM**. Plain validate + upsert.

CC reads transcripts (Mac Mini yt-dlp tmpdir), authors layered JSON in conversation, POSTs to upsert-direct → row stamps \`v2\`. Pure data-bridge.

## Tests

- \`tests/unit/api/transcript-direct-upsert.test.ts\` (5): valid + 4 rejection paths.
- /verify: 19 fail = baseline (+5 pass), build clean, audit baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)