### PR TITLE
ops: disable v2-summary + youtube-metadata cron (no API directive)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -92,7 +92,9 @@ services:
       # Tuning knob, not a secret (CP392 2-question test passes).
       # Revert: set to false or delete this line → cron stops at next process
       # restart (no in-flight call is interrupted).
-      - RICH_SUMMARY_V2_CRON_ENABLED=true
+      # CP437 (2026-04-29) — DISABLED per user directive: 무조건적인 API 사용금지.
+      # OpenRouter 호출 차단. v2 요약은 CC 콘솔(claude-code-direct) 경유로만 진행.
+      - RICH_SUMMARY_V2_CRON_ENABLED=false
       # CP437 (2026-04-29) — Operator flip: enable YouTube metadata backfill cron.
       # Default in code is `false` — cron stays dormant unless this env is
       # explicitly true. With this set, `startYouTubeMetadataCron()` schedules
@@ -115,7 +117,9 @@ services:
       #
       # Revert: set to false or delete this line → cron stops at next process
       # restart (no in-flight call is interrupted).
-      - YOUTUBE_METADATA_BACKFILL_ENABLED=true
+      # CP437 (2026-04-29) — DISABLED per user directive: 무조건적인 API 사용금지.
+      # YouTube Data API 호출 차단. 메타데이터는 Mac Mini yt-dlp 경유로만 진행.
+      - YOUTUBE_METADATA_BACKFILL_ENABLED=false
       # CP424.2 (2026-04-24) — Wizard Precompute Pipeline.
       # Per docs/design/precompute-pipeline.md. Step 1 goal → /wizard-stream
       # fires fire-and-forget `runDiscoverEphemeral` keyed by session_id →


### PR DESCRIPTION
## Summary

CP437 (2026-04-29) per the user directive: **무조건적인 API 사용금지**.

Both crons that hit external APIs are reverted to default OFF:

| ENV | before | after | API |
|-----|--------|-------|-----|
| \`RICH_SUMMARY_V2_CRON_ENABLED\` | true | false | OpenRouter (LLM) |
| \`YOUTUBE_METADATA_BACKFILL_ENABLED\` | true | false | YouTube Data API |

## Replacement path (already in flight in PR #570)

- \`POST /api/v1/internal/v2-summary/upsert-direct\` — CC 콘솔이 transcript 읽고 v2 JSON 직접 작성 → 단순 upsert. **No LLM call.**
- Mac Mini yt-dlp → metadata 보완 (별도 후속 핸드오프, no YouTube API).

## Revert

두 환경변수 다시 true 로. 단 user 승인 필수.

## Test plan

- [x] 변경 = docker-compose.prod.yml 만, 코드/스키마 변경 없음 — CI green 예상.
- [ ] Post-deploy:
  - [ ] 컨테이너 재시작 + ENV 적용 확인.
  - [ ] log 에 "v2 cron disabled" + "metadata cron disabled" 확인.
  - [ ] 다음 17:00 / 18:00 UTC tick 모두 firing 안 함 (no API call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)