### PR TITLE
fix(v2-bridge): UPSERT properties on existing nodes + DDL inverse non-null

### DIFF
--- a/prisma/migrations/ontology-v2-bridge/001_register_v2_types.sql
+++ b/prisma/migrations/ontology-v2-bridge/001_register_v2_types.sql
@@ -19,14 +19,18 @@ INSERT INTO ontology.object_types (code, label, category, description, is_active
   ('action_node',    'Action',          'action',       'Actionable extracted from rich-summary v2 analysis.actionables', true, 'service')
 ON CONFLICT (code) DO NOTHING;
 
+-- Note: ontology.relation_types.inverse is NOT NULL. Symmetric relations
+-- (RELATES_TO) self-pair like the existing RELATED_TO/SIMILAR_TO; directional
+-- relations get a paired inverse code that we may or may not register
+-- separately (only the forward edge is written by the v2-bridge code path).
 INSERT INTO ontology.relation_types (code, label, inverse, description, is_active, domain) VALUES
-  ('RELEVANT_TO',   'Relevant To',     NULL, 'Video resource is relevant to goal (mandala_fit.suggested_goals match)', true, 'service'),
-  ('COVERS',        'Covers',          NULL, 'Video resource covers a concept (analysis.key_concepts)', true, 'service'),
-  ('HAS_SECTION',   'Has Section',     NULL, 'Video resource has a section (segments.sections)', true, 'service'),
-  ('HAS_ATOM',      'Has Atom',        NULL, 'Video resource (or section) has an atom (segments.atoms)', true, 'service'),
-  ('SUGGESTS',      'Suggests',        NULL, 'Video resource suggests an action (analysis.actionables)', true, 'service'),
-  ('ENABLES',       'Enables',         NULL, 'Concept enables a goal (downstream graph reasoning)', true, 'service'),
-  ('RELATES_TO',    'Relates To',      NULL, 'General relation between rich-summary nodes (kept distinct from existing RELATED_TO per CP437 spec)', true, 'service')
+  ('RELEVANT_TO',   'Relevant To',  'ATTRACTS',     'Video resource is relevant to goal (mandala_fit.suggested_goals match)', true, 'service'),
+  ('COVERS',        'Covers',       'COVERED_BY',   'Video resource covers a concept (analysis.key_concepts)', true, 'service'),
+  ('HAS_SECTION',   'Has Section',  'SECTION_OF',   'Video resource has a section (segments.sections)', true, 'service'),
+  ('HAS_ATOM',      'Has Atom',     'ATOM_OF',      'Video resource (or section) has an atom (segments.atoms)', true, 'service'),
+  ('SUGGESTS',      'Suggests',     'SUGGESTED_BY', 'Video resource suggests an action (analysis.actionables)', true, 'service'),
+  ('ENABLES',       'Enables',      'ENABLED_BY',   'Concept enables a goal (downstream graph reasoning)', true, 'service'),
+  ('RELATES_TO',    'Relates To',   'RELATES_TO',   'General relation between rich-summary nodes (kept distinct from existing RELATED_TO per CP437 spec)', true, 'service')
 ON CONFLICT (code) DO NOTHING;
 
 COMMIT;

--- a/src/modules/ontology/v2-bridge.ts
+++ b/src/modules/ontology/v2-bridge.ts
@@ -197,6 +197,13 @@ async function upsertVideoResource(
   videoId: string,
   layered: RichSummaryV2Layered
 ): Promise<string> {
+  const title = layered.core.one_liner;
+  const props = JSON.stringify({
+    domain: layered.core.domain,
+    depth_level: layered.core.depth_level,
+    content_type: layered.core.content_type,
+  });
+  const sourceRef = JSON.stringify({ table: 'youtube_videos', id: videoId });
   const existing = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
     SELECT id FROM ontology.nodes
     WHERE type = 'video_resource'
@@ -204,19 +211,25 @@ async function upsertVideoResource(
       AND source_ref->>'id' = ${videoId}
     LIMIT 1
   `);
-  if (existing.length > 0) return existing[0]!.id;
+  if (existing.length > 0) {
+    await prisma.$executeRaw(Prisma.sql`
+      UPDATE ontology.nodes
+      SET title = ${title},
+          properties = ${props}::jsonb,
+          source_ref = ${sourceRef}::jsonb,
+          updated_at = NOW()
+      WHERE id = ${existing[0]!.id}::uuid
+    `);
+    return existing[0]!.id;
+  }
   const inserted = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
     INSERT INTO ontology.nodes (user_id, type, title, properties, source_ref, domain)
     VALUES (
       ${userId}::uuid,
       'video_resource',
-      ${layered.core.one_liner},
-      ${JSON.stringify({
-        domain: layered.core.domain,
-        depth_level: layered.core.depth_level,
-        content_type: layered.core.content_type,
-      })}::jsonb,
-      ${JSON.stringify({ table: 'youtube_videos', id: videoId })}::jsonb,
+      ${title},
+      ${props}::jsonb,
+      ${sourceRef}::jsonb,
       'service'
     )
     RETURNING id
@@ -229,20 +242,34 @@ async function upsertConcept(
   userId: string,
   concept: KeyConcept
 ): Promise<string> {
+  const props = JSON.stringify({ definition: concept.definition });
+  const sourceRef = JSON.stringify({
+    table: 'video_rich_summaries.key_concepts',
+    term: concept.term,
+  });
   const existing = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
     SELECT id FROM ontology.nodes
     WHERE type = 'concept' AND title = ${concept.term}
     LIMIT 1
   `);
-  if (existing.length > 0) return existing[0]!.id;
+  if (existing.length > 0) {
+    await prisma.$executeRaw(Prisma.sql`
+      UPDATE ontology.nodes
+      SET properties = ${props}::jsonb,
+          source_ref = ${sourceRef}::jsonb,
+          updated_at = NOW()
+      WHERE id = ${existing[0]!.id}::uuid
+    `);
+    return existing[0]!.id;
+  }
   const inserted = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
     INSERT INTO ontology.nodes (user_id, type, title, properties, source_ref, domain)
     VALUES (
       ${userId}::uuid,
       'concept',
       ${concept.term},
-      ${JSON.stringify({ definition: concept.definition })}::jsonb,
-      ${JSON.stringify({ table: 'video_rich_summaries.key_concepts', term: concept.term })}::jsonb,
+      ${props}::jsonb,
+      ${sourceRef}::jsonb,
       'service'
     )
     RETURNING id
@@ -257,6 +284,17 @@ async function upsertSection(
   idx: number,
   section: V2Section
 ): Promise<string> {
+  const title = section.title ?? `Section ${idx}`;
+  const props = JSON.stringify({
+    from_sec: section.from_sec ?? 0,
+    to_sec: section.to_sec ?? 0,
+    summary: section.summary ?? '',
+  });
+  const sourceRef = JSON.stringify({
+    table: 'video_rich_summaries.sections',
+    video_id: videoId,
+    idx,
+  });
   const existing = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
     SELECT id FROM ontology.nodes
     WHERE type = 'section_node'
@@ -265,23 +303,25 @@ async function upsertSection(
       AND source_ref->>'idx' = ${String(idx)}
     LIMIT 1
   `);
-  if (existing.length > 0) return existing[0]!.id;
+  if (existing.length > 0) {
+    await prisma.$executeRaw(Prisma.sql`
+      UPDATE ontology.nodes
+      SET title = ${title},
+          properties = ${props}::jsonb,
+          source_ref = ${sourceRef}::jsonb,
+          updated_at = NOW()
+      WHERE id = ${existing[0]!.id}::uuid
+    `);
+    return existing[0]!.id;
+  }
   const inserted = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
     INSERT INTO ontology.nodes (user_id, type, title, properties, source_ref, domain)
     VALUES (
       ${userId}::uuid,
       'section_node',
-      ${section.title ?? `Section ${idx}`},
-      ${JSON.stringify({
-        from_sec: section.from_sec ?? 0,
-        to_sec: section.to_sec ?? 0,
-        summary: section.summary ?? '',
-      })}::jsonb,
-      ${JSON.stringify({
-        table: 'video_rich_summaries.sections',
-        video_id: videoId,
-        idx,
-      })}::jsonb,
+      ${title},
+      ${props}::jsonb,
+      ${sourceRef}::jsonb,
       'service'
     )
     RETURNING id
@@ -296,6 +336,20 @@ async function upsertAtom(
   idx: number,
   atom: V2Atom
 ): Promise<string> {
+  const title = (atom.text ?? '').slice(0, 200);
+  const props = JSON.stringify({
+    text: atom.text ?? '',
+    timestamp_sec: atom.timestamp_sec ?? null,
+  });
+  const sourceRef = JSON.stringify({
+    table: 'video_rich_summaries.atoms',
+    video_id: videoId,
+    idx,
+    anchor:
+      typeof atom.timestamp_sec === 'number'
+        ? { kind: 'atom', idx, timestamp_sec: atom.timestamp_sec }
+        : null,
+  });
   const existing = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
     SELECT id FROM ontology.nodes
     WHERE type = 'atom_node'
@@ -304,26 +358,25 @@ async function upsertAtom(
       AND source_ref->>'idx' = ${String(idx)}
     LIMIT 1
   `);
-  if (existing.length > 0) return existing[0]!.id;
+  if (existing.length > 0) {
+    await prisma.$executeRaw(Prisma.sql`
+      UPDATE ontology.nodes
+      SET title = ${title},
+          properties = ${props}::jsonb,
+          source_ref = ${sourceRef}::jsonb,
+          updated_at = NOW()
+      WHERE id = ${existing[0]!.id}::uuid
+    `);
+    return existing[0]!.id;
+  }
   const inserted = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
     INSERT INTO ontology.nodes (user_id, type, title, properties, source_ref, domain)
     VALUES (
       ${userId}::uuid,
       'atom_node',
-      ${(atom.text ?? '').slice(0, 200)},
-      ${JSON.stringify({
-        text: atom.text ?? '',
-        timestamp_sec: atom.timestamp_sec ?? null,
-      })}::jsonb,
-      ${JSON.stringify({
-        table: 'video_rich_summaries.atoms',
-        video_id: videoId,
-        idx,
-        anchor:
-          typeof atom.timestamp_sec === 'number'
-            ? { kind: 'atom', idx, timestamp_sec: atom.timestamp_sec }
-            : null,
-      })}::jsonb,
+      ${title},
+      ${props}::jsonb,
+      ${sourceRef}::jsonb,
       'service'
     )
     RETURNING id
@@ -338,6 +391,13 @@ async function upsertAction(
   idx: number,
   text: string
 ): Promise<string> {
+  const title = text.slice(0, 200);
+  const props = JSON.stringify({ text });
+  const sourceRef = JSON.stringify({
+    table: 'video_rich_summaries.actionables',
+    video_id: videoId,
+    idx,
+  });
   const existing = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
     SELECT id FROM ontology.nodes
     WHERE type = 'action_node'
@@ -346,19 +406,25 @@ async function upsertAction(
       AND source_ref->>'idx' = ${String(idx)}
     LIMIT 1
   `);
-  if (existing.length > 0) return existing[0]!.id;
+  if (existing.length > 0) {
+    await prisma.$executeRaw(Prisma.sql`
+      UPDATE ontology.nodes
+      SET title = ${title},
+          properties = ${props}::jsonb,
+          source_ref = ${sourceRef}::jsonb,
+          updated_at = NOW()
+      WHERE id = ${existing[0]!.id}::uuid
+    `);
+    return existing[0]!.id;
+  }
   const inserted = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
     INSERT INTO ontology.nodes (user_id, type, title, properties, source_ref, domain)
     VALUES (
       ${userId}::uuid,
       'action_node',
-      ${text.slice(0, 200)},
-      ${JSON.stringify({ text })}::jsonb,
-      ${JSON.stringify({
-        table: 'video_rich_summaries.actionables',
-        video_id: videoId,
-        idx,
-      })}::jsonb,
+      ${title},
+      ${props}::jsonb,
+      ${sourceRef}::jsonb,
       'service'
     )
     RETURNING id

--- a/tests/unit/ontology/v2-bridge.test.ts
+++ b/tests/unit/ontology/v2-bridge.test.ts
@@ -59,6 +59,14 @@ describe('v2-bridge module purity (Hard Rule no-API)', () => {
     expect(SOURCE).toMatch(/if \(existing\.length > 0\) return false/);
   });
 
+  test('node upserts UPDATE properties on existing match (not just return)', () => {
+    // Sections / atoms / actions / video_resource / concept upserts must
+    // refresh properties + source_ref when an existing row is found, not
+    // simply return the id (otherwise re-POST cannot correct field values).
+    const updateMatches = SOURCE.match(/UPDATE ontology\.nodes\s+SET\s+/g) ?? [];
+    expect(updateMatches.length).toBeGreaterThanOrEqual(5);
+  });
+
   test('findGoalNodesByExactTitle uses exact title match (no fuzzy)', () => {
     expect(SOURCE).toMatch(/title = \$\{title\}/);
     // No actual embedding/similarity function invocation. (Comments may


### PR DESCRIPTION
## Summary
- Bridge upserts (video_resource/concept/section/atom/action) now UPDATE title + properties + source_ref + updated_at on existing match instead of returning early
- DDL fix: `ontology.relation_types.inverse` is NOT NULL → set proper inverse codes (ATTRACTS / COVERED_BY / SECTION_OF / ATOM_OF / SUGGESTED_BY / ENABLED_BY) and self-pair RELATES_TO
- Re-POSTing v2 layered JSON after schema corrections now propagates cleanly

## Background
First v2 sample POSTs used wrong field names (`start_sec` instead of `from_sec`, `ts_sec` instead of `timestamp_sec`). Bridge silently stored 0/null for time fields. Fixing JSON + re-POSTing did NOT update properties because old upsert returned early on existing-row match. This PR makes the upsert truly idempotent in both directions.

## Test plan
- [x] tsc --noEmit passes
- [x] jest tests/unit/ontology/v2-bridge.test.ts (7 tests pass)
- [ ] Prod re-POST sample to verify UPDATE branch fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)