### PR TITLE
feat(v2-prompt): validateV2Segments — strict key whitelist (SSOT enforcement)

### DIFF
--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -25,6 +25,7 @@ import { getPrismaClient } from '@/modules/database/client';
 import { generateRichSummaryV2 } from '@/modules/skills/rich-summary-v2-generator';
 import {
   validateV2Layered,
+  validateV2Segments,
   scoreCompleteness,
   V2ValidationError,
 } from '@/modules/skills/rich-summary-v2-prompt';
@@ -135,6 +136,10 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
     let summary;
     try {
       summary = validateV2Layered({ core: body.core, analysis: body.analysis, lora: body.lora });
+      // Strict key whitelist on segments — catches start_sec/end_sec/ts_sec
+      // class typos at the API boundary so the bridge never silently stores
+      // 0/null (CP437 incident).
+      validateV2Segments(body.segments);
     } catch (err) {
       const path = err instanceof V2ValidationError ? err.path : '';
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/modules/skills/rich-summary-v2-prompt.ts
+++ b/src/modules/skills/rich-summary-v2-prompt.ts
@@ -367,6 +367,109 @@ export function validateV2Layered(parsed: unknown): RichSummaryV2Layered {
 }
 
 // ============================================================================
+// Segments validator — strict key whitelist (CP437 SSOT enforcement)
+// ============================================================================
+
+/**
+ * Allowed keys for segments.sections[i] and segments.atoms[i].
+ *
+ * SSOT (insighta-ontology-data-architecture.md §5.4):
+ *   sections — `idx`, `title`, `from_sec`, `to_sec`, `summary`, `key_points` (optional)
+ *   atoms    — `idx`, `type`, `text`, `timestamp_sec`, `entity_refs` (optional)
+ *
+ * Common typos are explicitly listed in `FORBIDDEN_*` so the error message
+ * tells the author exactly what to rename. The previous incident had bridge
+ * silently storing 0/null when the JSON used `start_sec`/`end_sec`/`ts_sec`
+ * because bridge accepted unknown keys without erroring.
+ */
+const ALLOWED_SECTION_KEYS = new Set([
+  'idx',
+  'title',
+  'from_sec',
+  'to_sec',
+  'summary',
+  'key_points',
+  'relevance_pct',
+]);
+const ALLOWED_ATOM_KEYS = new Set(['idx', 'type', 'text', 'timestamp_sec', 'entity_refs']);
+const FORBIDDEN_SECTION_RENAMES: Record<string, string> = {
+  start_sec: 'from_sec',
+  end_sec: 'to_sec',
+};
+const FORBIDDEN_ATOM_RENAMES: Record<string, string> = {
+  ts_sec: 'timestamp_sec',
+};
+
+/**
+ * Validate `segments` (optional, when present in `upsert-direct` body) —
+ * throws `V2ValidationError` on first unknown key. Pass-through when null
+ * or undefined (segments are optional).
+ *
+ * Catches the field-name mismatch class of bugs at the API boundary so
+ * downstream bridge code never sees `start_sec`/`ts_sec` etc.
+ */
+export function validateV2Segments(segments: unknown): void {
+  if (segments === null || segments === undefined) return;
+  if (typeof segments !== 'object') {
+    throw new V2ValidationError('segments must be an object', 'segments');
+  }
+  const seg = segments as Record<string, unknown>;
+
+  if (seg['sections'] !== undefined) {
+    if (!Array.isArray(seg['sections'])) {
+      throw new V2ValidationError('segments.sections must be an array', 'segments.sections');
+    }
+    seg['sections'].forEach((s, i) => {
+      if (!s || typeof s !== 'object') {
+        throw new V2ValidationError(
+          'segments.sections[i] must be an object',
+          `segments.sections[${i}]`
+        );
+      }
+      for (const key of Object.keys(s as Record<string, unknown>)) {
+        if (FORBIDDEN_SECTION_RENAMES[key]) {
+          throw new V2ValidationError(
+            `forbidden key '${key}' — SSOT requires '${FORBIDDEN_SECTION_RENAMES[key]}' (insighta-ontology-data-architecture.md §5.4)`,
+            `segments.sections[${i}].${key}`
+          );
+        }
+        if (!ALLOWED_SECTION_KEYS.has(key)) {
+          throw new V2ValidationError(
+            `unknown key '${key}' (allowed: ${[...ALLOWED_SECTION_KEYS].join(', ')})`,
+            `segments.sections[${i}].${key}`
+          );
+        }
+      }
+    });
+  }
+
+  if (seg['atoms'] !== undefined) {
+    if (!Array.isArray(seg['atoms'])) {
+      throw new V2ValidationError('segments.atoms must be an array', 'segments.atoms');
+    }
+    seg['atoms'].forEach((a, i) => {
+      if (!a || typeof a !== 'object') {
+        throw new V2ValidationError('segments.atoms[i] must be an object', `segments.atoms[${i}]`);
+      }
+      for (const key of Object.keys(a as Record<string, unknown>)) {
+        if (FORBIDDEN_ATOM_RENAMES[key]) {
+          throw new V2ValidationError(
+            `forbidden key '${key}' — SSOT requires '${FORBIDDEN_ATOM_RENAMES[key]}' (insighta-ontology-data-architecture.md §5.4)`,
+            `segments.atoms[${i}].${key}`
+          );
+        }
+        if (!ALLOWED_ATOM_KEYS.has(key)) {
+          throw new V2ValidationError(
+            `unknown key '${key}' (allowed: ${[...ALLOWED_ATOM_KEYS].join(', ')})`,
+            `segments.atoms[${i}].${key}`
+          );
+        }
+      }
+    });
+  }
+}
+
+// ============================================================================
 // Completeness scorer (10 × 0.1 weights, total 1.0; ≥ 0.7 = pass)
 // ============================================================================
 

--- a/tests/unit/skills/rich-summary-v2.test.ts
+++ b/tests/unit/skills/rich-summary-v2.test.ts
@@ -5,6 +5,7 @@
 import {
   buildV2Prompt,
   validateV2Layered,
+  validateV2Segments,
   scoreCompleteness,
   V2ValidationError,
   PASS_THRESHOLD,
@@ -247,5 +248,65 @@ describe('readRichSummary template_version branch', () => {
     );
     expect(adapted.core).toBeNull();
     expect(adapted.analysis).not.toBeNull();
+  });
+});
+
+describe('validateV2Segments — strict key whitelist (CP437 SSOT)', () => {
+  test('accepts null/undefined segments (optional field)', () => {
+    expect(() => validateV2Segments(null)).not.toThrow();
+    expect(() => validateV2Segments(undefined)).not.toThrow();
+  });
+
+  test('accepts valid sections + atoms shape', () => {
+    expect(() =>
+      validateV2Segments({
+        sections: [{ idx: 0, title: 's0', from_sec: 0, to_sec: 60, summary: 'x' }],
+        atoms: [{ idx: 0, type: 'fact', text: 'a0', timestamp_sec: 30 }],
+      })
+    ).not.toThrow();
+  });
+
+  test("rejects forbidden 'start_sec' with rename hint", () => {
+    expect(() =>
+      validateV2Segments({
+        sections: [{ idx: 0, title: 's', start_sec: 0, to_sec: 60 }],
+      })
+    ).toThrow(/forbidden key 'start_sec'.*from_sec/);
+  });
+
+  test("rejects forbidden 'end_sec' with rename hint", () => {
+    expect(() =>
+      validateV2Segments({
+        sections: [{ idx: 0, title: 's', from_sec: 0, end_sec: 60 }],
+      })
+    ).toThrow(/forbidden key 'end_sec'.*to_sec/);
+  });
+
+  test("rejects forbidden 'ts_sec' on atom with rename hint", () => {
+    expect(() =>
+      validateV2Segments({
+        atoms: [{ idx: 0, type: 'fact', text: 'a', ts_sec: 30 }],
+      })
+    ).toThrow(/forbidden key 'ts_sec'.*timestamp_sec/);
+  });
+
+  test('rejects unknown section key', () => {
+    expect(() =>
+      validateV2Segments({
+        sections: [{ idx: 0, title: 's', from_sec: 0, to_sec: 60, weird_field: 1 }],
+      })
+    ).toThrow(/unknown key 'weird_field'/);
+  });
+
+  test('throws V2ValidationError with structured path', () => {
+    try {
+      validateV2Segments({
+        atoms: [{ idx: 0, type: 'fact', text: 'a', ts_sec: 30 }],
+      });
+      throw new Error('expected to throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(V2ValidationError);
+      expect((e as V2ValidationError).path).toBe('segments.atoms[0].ts_sec');
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Add `validateV2Segments` with strict key whitelist (SSOT: `from_sec`/`to_sec`/`timestamp_sec`/`idx`)
- Wire into `/v2-summary/upsert-direct` route — bad payload now 422-rejected before bridge
- Explicit rename hints for `start_sec` → `from_sec`, `end_sec` → `to_sec`, `ts_sec` → `timestamp_sec`

## Background
3 of 20 v2 samples were authored with wrong keys; bridge silently dropped them as 0/null. This validator catches the typo class at the API boundary.

## Test plan
- [x] tsc --noEmit
- [x] jest tests/unit/skills/rich-summary-v2.test.ts (21 tests pass — 14 existing + 7 new)
- [ ] Prod smoke — POST a payload with `start_sec` → expect 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)