### PR TITLE
feat(metrics): pipeline_events table + v2 quality metrics (paper §6.2)

### DIFF
--- a/prisma/migrations/pipeline-events/001_create_pipeline_events.sql
+++ b/prisma/migrations/pipeline-events/001_create_pipeline_events.sql
@@ -1,0 +1,45 @@
+-- CP437 (2026-04-29) — pipeline_events table for paper measurement (§6.2).
+--
+-- Records per-event quality metrics for v2 rich-summary upserts (and any
+-- future pipeline stages). Round-keyed for batch-to-batch comparison.
+--
+-- Spec (user-provided 2026-04-29):
+--   stage   = 'rich_summary_v2' | (future stages)
+--   payload jsonb = {
+--     M1: number,            -- title-word recall ratio in atoms (0..1)
+--     M3_class: text,        -- all_null | uniform_fake | insufficient | mixed | real
+--     M3_score: number,      -- 0 / 0.5 / (1 - null_ratio)
+--     S: number,             -- 0.55 * M1 + 0.45 * M3_score
+--     round: int             -- batch round id
+--   }
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS + indexes IF NOT EXISTS.
+-- Hard Rule §raw-SQL-DDL: this file is the source of truth alongside the
+-- Prisma model — `prisma db push` may silent-fail on Supabase (auth schema
+-- ownership), so this script is applied by `scripts/apply-migrations.sh` in
+-- CI Database Schema Sync step.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.pipeline_events (
+  id          uuid          PRIMARY KEY DEFAULT gen_random_uuid(),
+  stage       text          NOT NULL,
+  video_id    text          NOT NULL,
+  payload     jsonb         NOT NULL DEFAULT '{}'::jsonb,
+  created_at  timestamptz   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS pipeline_events_stage_video_idx
+  ON public.pipeline_events (stage, video_id);
+
+CREATE INDEX IF NOT EXISTS pipeline_events_round_idx
+  ON public.pipeline_events ((payload ->> 'round'));
+
+CREATE INDEX IF NOT EXISTS pipeline_events_created_at_idx
+  ON public.pipeline_events (created_at DESC);
+
+COMMIT;
+
+-- Validation:
+-- SELECT COUNT(*) FROM public.pipeline_events;             -- 0 on first apply
+-- \d public.pipeline_events                                -- expects 5 columns

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1861,3 +1861,17 @@ model llm_call_logs {
   @@index([model])
   @@schema("public")
 }
+
+/// Per-event quality measurement (CP437 paper §6.2).
+/// payload shape (rich_summary_v2 stage): { M1, M3_class, M3_score, S, round }
+model pipeline_events {
+  id         String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  stage      String
+  video_id   String
+  payload    Json     @default("{}")
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+
+  @@index([stage, video_id])
+  @@index([created_at(sort: Desc)])
+  @@schema("public")
+}

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -61,6 +61,7 @@ APPLY_FILES=(
   "prisma/migrations/video_chunk_embeddings/001_create_table.sql"
   "prisma/migrations/video_rich_summaries/001_add_user_id.sql"
   "prisma/migrations/wizard-precompute/001_table.sql"
+  "prisma/migrations/pipeline-events/001_create_pipeline_events.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "

--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -32,6 +32,15 @@ import {
 import { bridgeV2ToOntology } from '@/modules/ontology/v2-bridge';
 import { Prisma as PrismaCli } from '@prisma/client';
 import { logger } from '@/utils/logger';
+import { computeV2Quality } from '@/modules/metrics/v2-quality-metrics';
+import { recordPipelineEvent } from '@/modules/metrics/pipeline-events';
+
+/**
+ * Round id stamped onto every pipeline_events payload — must be incremented
+ * when starting a new measurement batch (Round 1 = initial 20 CC-direct
+ * samples; Round 2 = first 1,507-video Mac-Mini-driven batch; etc).
+ */
+const PIPELINE_EVENTS_ROUND = Number(process.env['PIPELINE_EVENTS_ROUND'] ?? '1') || 1;
 
 const log = logger.child({ module: 'api/internal/transcript' });
 
@@ -205,6 +214,38 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
         });
       } catch (err) {
         log.warn('v2-bridge failed (non-fatal)', {
+          videoId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      // CP437 — paper §6.2 measurement: per-event quality metrics. Pulls
+      // the title from youtube_videos so M1 (title-word recall in atoms)
+      // can be computed; falls back to summary.core.one_liner when absent.
+      try {
+        const segments = body.segments as
+          | { atoms?: Array<{ text?: string; timestamp_sec?: number | null }> }
+          | undefined;
+        const titleRow = await prisma.$queryRaw<{ title: string | null }[]>(Prisma.sql`
+          SELECT title FROM youtube_videos WHERE youtube_video_id = ${videoId} LIMIT 1
+        `);
+        const title = titleRow[0]?.title ?? summary.core.one_liner ?? '';
+        const quality = computeV2Quality({ title, atoms: segments?.atoms ?? [] });
+        await recordPipelineEvent({
+          stage: 'rich_summary_v2',
+          videoId,
+          payload: {
+            M1: quality.M1,
+            M3_class: quality.M3_class,
+            M3_score: quality.M3_score,
+            S: quality.S,
+            null_ratio: quality.null_ratio,
+            round: PIPELINE_EVENTS_ROUND,
+            meta: quality.meta,
+          },
+        });
+      } catch (err) {
+        log.warn('pipeline_events emit failed (non-fatal)', {
           videoId,
           error: err instanceof Error ? err.message : String(err),
         });

--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -34,13 +34,14 @@ import { Prisma as PrismaCli } from '@prisma/client';
 import { logger } from '@/utils/logger';
 import { computeV2Quality } from '@/modules/metrics/v2-quality-metrics';
 import { recordPipelineEvent } from '@/modules/metrics/pipeline-events';
+import { config } from '@/config/index';
 
 /**
- * Round id stamped onto every pipeline_events payload — must be incremented
- * when starting a new measurement batch (Round 1 = initial 20 CC-direct
- * samples; Round 2 = first 1,507-video Mac-Mini-driven batch; etc).
+ * Round id stamped onto every pipeline_events payload — sourced from the
+ * zod-validated `PIPELINE_EVENTS_ROUND` env via `src/config/`. Increment
+ * the env value when starting a new measurement batch.
  */
-const PIPELINE_EVENTS_ROUND = Number(process.env['PIPELINE_EVENTS_ROUND'] ?? '1') || 1;
+const PIPELINE_EVENTS_ROUND = config.pipelineEvents.round;
 
 const log = logger.child({ module: 'api/internal/transcript' });
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -113,6 +113,10 @@ const envSchema = z.object({
   GMAIL_SMTP_HOST: z.string().default('smtp-relay.gmail.com'),
   GMAIL_SMTP_PORT: z.coerce.number().default(587),
   GMAIL_SMTP_FROM: z.string().default('noreply@insighta.one'),
+
+  // Pipeline events — round id stamped on each measurement event (paper §6.2).
+  // Increment when starting a new measurement batch.
+  PIPELINE_EVENTS_ROUND: z.coerce.number().int().min(1).default(1),
 });
 
 type Env = z.infer<typeof envSchema>;
@@ -263,6 +267,11 @@ export const config = {
     smtpHost: env.GMAIL_SMTP_HOST,
     smtpPort: env.GMAIL_SMTP_PORT,
     smtpFrom: env.GMAIL_SMTP_FROM,
+  },
+
+  // Pipeline events (paper §6.2 measurement)
+  pipelineEvents: {
+    round: env.PIPELINE_EVENTS_ROUND,
   },
 
   // YouTube API costs (in quota units)

--- a/src/modules/metrics/pipeline-events.ts
+++ b/src/modules/metrics/pipeline-events.ts
@@ -1,0 +1,40 @@
+/**
+ * pipeline_events insert helper (CP437 paper §6.2).
+ *
+ * Stage-stamps a per-event metric row. Currently used by the v2-summary
+ * upsert-direct route but the table is generic enough to host any future
+ * pipeline stage (kg-bridge, video-discover etc).
+ */
+
+import { Prisma } from '@prisma/client';
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'metrics/pipeline-events' });
+
+export interface PipelineEventRow {
+  stage: string;
+  videoId: string;
+  payload: Record<string, unknown>;
+}
+
+/**
+ * INSERT a pipeline_events row. Failures are logged but not thrown — this
+ * is a non-blocking telemetry path and must never regress the upstream
+ * caller (v2-summary upsert).
+ */
+export async function recordPipelineEvent(row: PipelineEventRow): Promise<void> {
+  try {
+    const prisma = getPrismaClient();
+    await prisma.$executeRaw(Prisma.sql`
+      INSERT INTO public.pipeline_events (stage, video_id, payload)
+      VALUES (${row.stage}, ${row.videoId}, ${JSON.stringify(row.payload)}::jsonb)
+    `);
+  } catch (err) {
+    log.warn('pipeline_events insert failed (non-fatal)', {
+      stage: row.stage,
+      videoId: row.videoId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/src/modules/metrics/v2-quality-metrics.ts
+++ b/src/modules/metrics/v2-quality-metrics.ts
@@ -1,0 +1,214 @@
+/**
+ * v2 Rich-Summary Quality Metrics — paper §6.2 measurement (CP437).
+ *
+ * Per-event per-video metrics emitted to `pipeline_events` table. Round-keyed
+ * for batch-to-batch comparison (Round 1 = initial 20 CC-direct samples;
+ * Round 2+ = subsequent batches over the 1,507 v1-only videos).
+ *
+ * Spec (user-provided 2026-04-29):
+ *   M1       — title-word recall in atom texts. Stopword-stripped, ratio of
+ *              title content tokens that appear anywhere across the
+ *              concatenated atoms text. 0..1.
+ *   M3_class — quality classification of segments.atoms:
+ *              all_null      — atoms missing or all timestamp_sec === null
+ *              uniform_fake  — all atom.text identical or near-identical
+ *              insufficient  — fewer than MIN_ATOMS_REAL atoms
+ *              mixed         — partial coverage (some null timestamps + some real)
+ *              real          — ≥ MIN_ATOMS_REAL atoms with varied text
+ *   M3_score — { all_null:0, uniform_fake:0, insufficient:0, mixed:0.5,
+ *                real: 1 - null_ratio }
+ *   S        — 0.55 * M1 + 0.45 * M3_score (composite quality)
+ *
+ * Hard Rule: pure function. No I/O, no LLM call, no embedding. Deterministic
+ * and side-effect-free so it's safe to call from the upsert-direct route or
+ * a backfill script.
+ */
+
+export const STOPWORDS_KO: ReadonlySet<string> = new Set([
+  // Korean particles (조사) commonly attached to title content words
+  '은',
+  '는',
+  '이',
+  '가',
+  '을',
+  '를',
+  '에',
+  '에서',
+  '에게',
+  '에겐',
+  '한테',
+  '께',
+  '와',
+  '과',
+  '의',
+  '도',
+  '로',
+  '으로',
+  '만',
+  '까지',
+  '부터',
+  '같이',
+  '처럼',
+  '보다',
+  '마저',
+  '조차',
+  '뿐',
+  '마다',
+  '씩',
+  '이나',
+  '나',
+  '이며',
+  '며',
+  '이자',
+  '와의',
+  '과의',
+]);
+
+const MIN_ATOMS_REAL = 3;
+const TITLE_MIN_TOKEN_LEN = 2;
+
+export type M3Class = 'all_null' | 'uniform_fake' | 'insufficient' | 'mixed' | 'real';
+
+export interface V2QualityResult {
+  M1: number;
+  M3_class: M3Class;
+  M3_score: number;
+  S: number;
+  null_ratio: number;
+  /** Diagnostic counts so audits can re-derive the score. */
+  meta: {
+    title_tokens: number;
+    atoms_total: number;
+    atoms_with_ts: number;
+    unique_text_count: number;
+  };
+}
+
+export interface V2Atom {
+  text?: string;
+  timestamp_sec?: number | null;
+  [k: string]: unknown;
+}
+
+export interface V2QualityInput {
+  title: string;
+  atoms: V2Atom[];
+}
+
+/**
+ * Strip a Korean particle suffix from a token if exactly one of STOPWORDS_KO
+ * is the longest matching suffix. Tokens shorter than 2 chars are returned
+ * as-is. Returns null when the post-strip stem is too short to count.
+ */
+function stripKoreanParticle(token: string): string | null {
+  if (token.length < TITLE_MIN_TOKEN_LEN) return null;
+  // Sort stopwords by length desc so '으로' wins over '로'
+  const candidates = [...STOPWORDS_KO].sort((a, b) => b.length - a.length);
+  for (const sw of candidates) {
+    if (token.length > sw.length && token.endsWith(sw)) {
+      const stem = token.slice(0, token.length - sw.length);
+      // If the stripped stem is too short (e.g. '의도' → '도'), the suffix
+      // was likely the second character of a content word, not a particle.
+      // Keep the original token in that case so we don't drop content.
+      if (stem.length < TITLE_MIN_TOKEN_LEN) return token;
+      return stem;
+    }
+  }
+  return token;
+}
+
+/**
+ * Tokenize title into content tokens. Splits on whitespace + Korean/Latin
+ * boundary characters, lowercases Latin, drops single-char tokens, strips
+ * particles from each.
+ */
+export function extractTitleTokens(title: string): string[] {
+  if (!title) return [];
+  const raw = title
+    .toLowerCase()
+    .split(/[\s\-_·,/()[\]{}<>!?@#$%^&*+=|\\~`"'.;:]+/u)
+    .filter((t) => t.length >= TITLE_MIN_TOKEN_LEN);
+  const out = new Set<string>();
+  for (const t of raw) {
+    const stem = stripKoreanParticle(t);
+    if (stem && !STOPWORDS_KO.has(stem)) out.add(stem);
+  }
+  return [...out];
+}
+
+/**
+ * Compute M1: fraction of title tokens that appear (substring match) in the
+ * concatenated atom text. Returns 0 when title yields no tokens.
+ */
+export function computeM1(input: V2QualityInput): number {
+  const tokens = extractTitleTokens(input.title);
+  if (tokens.length === 0) return 0;
+  const blob = (input.atoms ?? [])
+    .map((a) => (typeof a.text === 'string' ? a.text.toLowerCase() : ''))
+    .join('\n');
+  if (blob.length === 0) return 0;
+  let hit = 0;
+  for (const t of tokens) {
+    if (blob.includes(t)) hit += 1;
+  }
+  return hit / tokens.length;
+}
+
+function computeM3(input: V2QualityInput): {
+  cls: M3Class;
+  score: number;
+  null_ratio: number;
+  unique_text_count: number;
+  atoms_with_ts: number;
+} {
+  const atoms = input.atoms ?? [];
+  if (atoms.length === 0) {
+    return {
+      cls: 'all_null',
+      score: 0,
+      null_ratio: 1,
+      unique_text_count: 0,
+      atoms_with_ts: 0,
+    };
+  }
+  const atoms_with_ts = atoms.filter((a) => typeof a.timestamp_sec === 'number').length;
+  const null_ratio = (atoms.length - atoms_with_ts) / atoms.length;
+  const texts = atoms.map((a) => (typeof a.text === 'string' ? a.text.trim() : ''));
+  const uniqueTexts = new Set(texts.filter((t) => t.length > 0));
+  const unique_text_count = uniqueTexts.size;
+
+  if (atoms_with_ts === 0) {
+    return { cls: 'all_null', score: 0, null_ratio, unique_text_count, atoms_with_ts };
+  }
+  if (uniqueTexts.size <= 1) {
+    return { cls: 'uniform_fake', score: 0, null_ratio, unique_text_count, atoms_with_ts };
+  }
+  if (atoms.length < MIN_ATOMS_REAL) {
+    return { cls: 'insufficient', score: 0, null_ratio, unique_text_count, atoms_with_ts };
+  }
+  if (atoms_with_ts < atoms.length) {
+    return { cls: 'mixed', score: 0.5, null_ratio, unique_text_count, atoms_with_ts };
+  }
+  return { cls: 'real', score: 1 - null_ratio, null_ratio, unique_text_count, atoms_with_ts };
+}
+
+/** Compose the full V2QualityResult including S = 0.55*M1 + 0.45*M3_score. */
+export function computeV2Quality(input: V2QualityInput): V2QualityResult {
+  const tokens = extractTitleTokens(input.title);
+  const M1 = computeM1(input);
+  const m3 = computeM3(input);
+  const S = 0.55 * M1 + 0.45 * m3.score;
+  return {
+    M1,
+    M3_class: m3.cls,
+    M3_score: m3.score,
+    S,
+    null_ratio: m3.null_ratio,
+    meta: {
+      title_tokens: tokens.length,
+      atoms_total: (input.atoms ?? []).length,
+      atoms_with_ts: m3.atoms_with_ts,
+      unique_text_count: m3.unique_text_count,
+    },
+  };
+}

--- a/tests/unit/modules/v2-quality-metrics.test.ts
+++ b/tests/unit/modules/v2-quality-metrics.test.ts
@@ -1,0 +1,167 @@
+/**
+ * v2 Rich-Summary Quality Metrics — paper §6.2 (CP437).
+ */
+
+import {
+  extractTitleTokens,
+  computeM1,
+  computeV2Quality,
+} from '@/modules/metrics/v2-quality-metrics';
+
+describe('extractTitleTokens — Korean particle stripping', () => {
+  test('strips trailing 은/는/이/가/을/를 etc', () => {
+    const t = extractTitleTokens('수능 출제자의 의도 파악');
+    expect(t).toEqual(expect.arrayContaining(['수능', '출제자', '의도', '파악']));
+    expect(t).not.toContain('의'); // particle removed, not a content token
+  });
+
+  test('handles English mixed lowercase', () => {
+    const t = extractTitleTokens('Introducing Claude Code');
+    expect(t).toEqual(expect.arrayContaining(['introducing', 'claude', 'code']));
+  });
+
+  test('drops single-char tokens', () => {
+    const t = extractTitleTokens('A B 가 나');
+    expect(t).toEqual([]);
+  });
+
+  test("'으로' and '로' both stripped (longest-suffix wins)", () => {
+    const t = extractTitleTokens('어원으로 푸는 삼각함수');
+    expect(t).toContain('어원');
+    expect(t).toContain('푸는');
+    expect(t).toContain('삼각함수');
+  });
+});
+
+describe('computeM1 — title-word recall in atoms', () => {
+  test('all title tokens hit → 1.0', () => {
+    const m1 = computeM1({
+      title: '영어 리스닝 4원칙',
+      atoms: [{ text: '영어 리스닝 4원칙의 첫째' }, { text: '4원칙 - 발음 노출' }],
+    });
+    expect(m1).toBeCloseTo(1, 3); // 영어, 리스닝, 4원칙 → all literal hit
+  });
+
+  test('zero hits → 0', () => {
+    const m1 = computeM1({
+      title: '수능 출제자',
+      atoms: [{ text: 'something completely different' }],
+    });
+    expect(m1).toBe(0);
+  });
+
+  test('empty atoms → 0', () => {
+    const m1 = computeM1({ title: '시간 관리', atoms: [] });
+    expect(m1).toBe(0);
+  });
+
+  test('partial recall — half tokens hit', () => {
+    const m1 = computeM1({
+      title: '시간 관리 우선순위 핵심',
+      atoms: [{ text: '시간 관리에 대한 이야기 (우선순위 미언급)' }],
+    });
+    // tokens: [시간, 관리, 우선순위, 핵심] → 시간/관리/우선순위 hit, 핵심 miss → 3/4
+    expect(m1).toBeCloseTo(0.75, 3);
+  });
+});
+
+describe('computeV2Quality — full pipeline', () => {
+  test('all_null when atoms array empty', () => {
+    const r = computeV2Quality({ title: 't', atoms: [] });
+    expect(r.M3_class).toBe('all_null');
+    expect(r.M3_score).toBe(0);
+    expect(r.S).toBe(0);
+  });
+
+  test('all_null when every timestamp_sec is null', () => {
+    const r = computeV2Quality({
+      title: '리스닝',
+      atoms: [
+        { text: 'a', timestamp_sec: null },
+        { text: 'b', timestamp_sec: null },
+        { text: 'c', timestamp_sec: null },
+      ],
+    });
+    expect(r.M3_class).toBe('all_null');
+    expect(r.M3_score).toBe(0);
+  });
+
+  test('uniform_fake when all atom texts identical', () => {
+    const r = computeV2Quality({
+      title: 't',
+      atoms: [
+        { text: 'placeholder', timestamp_sec: 10 },
+        { text: 'placeholder', timestamp_sec: 20 },
+        { text: 'placeholder', timestamp_sec: 30 },
+      ],
+    });
+    expect(r.M3_class).toBe('uniform_fake');
+    expect(r.M3_score).toBe(0);
+  });
+
+  test('insufficient when fewer than 3 atoms (with timestamps + varied text)', () => {
+    const r = computeV2Quality({
+      title: '시간 관리',
+      atoms: [
+        { text: '첫 원칙', timestamp_sec: 10 },
+        { text: '둘째 원칙', timestamp_sec: 20 },
+      ],
+    });
+    expect(r.M3_class).toBe('insufficient');
+    expect(r.M3_score).toBe(0);
+  });
+
+  test('mixed when some atoms have null timestamp', () => {
+    const r = computeV2Quality({
+      title: '시간 관리',
+      atoms: [
+        { text: '원칙 A', timestamp_sec: 10 },
+        { text: '원칙 B', timestamp_sec: null },
+        { text: '원칙 C', timestamp_sec: 30 },
+      ],
+    });
+    expect(r.M3_class).toBe('mixed');
+    expect(r.M3_score).toBe(0.5);
+  });
+
+  test('real with 0 null_ratio → M3_score=1', () => {
+    const r = computeV2Quality({
+      title: '시간 관리',
+      atoms: [
+        { text: '원칙 A', timestamp_sec: 10 },
+        { text: '원칙 B', timestamp_sec: 20 },
+        { text: '원칙 C', timestamp_sec: 30 },
+      ],
+    });
+    expect(r.M3_class).toBe('real');
+    expect(r.M3_score).toBe(1);
+  });
+
+  test('S = 0.55 * M1 + 0.45 * M3_score', () => {
+    const r = computeV2Quality({
+      title: '리스닝 원칙',
+      atoms: [
+        { text: '리스닝 원칙 A', timestamp_sec: 10 },
+        { text: '리스닝 원칙 B', timestamp_sec: 20 },
+        { text: '리스닝 원칙 C', timestamp_sec: 30 },
+      ],
+    });
+    expect(r.M1).toBeCloseTo(1, 3);
+    expect(r.M3_score).toBe(1);
+    expect(r.S).toBeCloseTo(1, 3);
+  });
+
+  test('meta diagnostic counts populated', () => {
+    const r = computeV2Quality({
+      title: '리스닝 원칙',
+      atoms: [
+        { text: 'A', timestamp_sec: 10 },
+        { text: 'B', timestamp_sec: null },
+      ],
+    });
+    expect(r.meta.atoms_total).toBe(2);
+    expect(r.meta.atoms_with_ts).toBe(1);
+    expect(r.meta.unique_text_count).toBe(2);
+    expect(r.null_ratio).toBe(0.5);
+  });
+});


### PR DESCRIPTION
## Summary
- New `pipeline_events` table for Round-keyed batch comparison telemetry
- Per-event metric emission on `/v2-summary/upsert-direct` POST
- Pure metric computation (M1 / M3_class / M3_score / S) — zero LLM, zero embedding
- Round 1 baseline backfilled out-of-band (n=20, avg_S=0.523)

## Spec
| metric | meaning |
|---|---|
| M1 | title-word recall in atom texts (Korean particle-stripped) |
| M3_class | all_null / uniform_fake / insufficient / mixed / real |
| M3_score | 0 / 0 / 0 / 0.5 / (1 - null_ratio) |
| S | 0.55 × M1 + 0.45 × M3_score |
| round | env `PIPELINE_EVENTS_ROUND` (default 1) |

## Round 1 baseline (post-backfill)
- n=20, avg_M1=0.133, avg_M3_score=1.000, avg_S=0.523
- M3_class: all 20 = `real`
- 20개 CC-direct sample 모두 timestamp_sec + 다양한 atom text 보유 확인

## Hard Rule
- 모든 metric 함수 = 순수 함수 (텍스트 매칭만)
- pipeline_events INSERT = Prisma `$executeRaw` 만 사용
- LLM API / embedding 호출 0건

## Test plan
- [x] 16 unit tests pass (Korean particle / M1 recall / M3 classification / S compose)
- [x] tsc --noEmit
- [x] DDL applied to prod (table + 3 indexes verified)
- [x] Round 1 backfill complete (20 rows in pipeline_events)
- [ ] Prod smoke after deploy — re-POST a v2 sample, verify auto-INSERT row

🤖 Generated with [Claude Code](https://claude.com/claude-code)