### PR TITLE
fix(transcript): candidates selector — drop has_caption gate, target v1 only

### DIFF
--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -70,10 +70,16 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
         MAX_CANDIDATE_LIMIT
       );
 
-      // Candidate selector:
-      //   has_caption = true (YouTube reports captions exist)
-      //   transcript_fetched_at IS NULL
-      //   ordered by user_video_states presence (priority) then view_count
+      // Candidate selector (CP437 v2-driver — Round 2 expansion):
+      //   yv.transcript_fetched_at IS NULL  — not yet processed
+      //   vrs.template_version = 'v1'       — needs v2 upgrade (Round 2 target)
+      //   has_caption tolerance: not enforced. The column is NULL on the
+      //     entire prod table (5,875/5,875) because the YT-API backfill
+      //     cron is OFF per the no-API Hard Rule. yt-dlp on Mac Mini is
+      //     the truth source — it fetches successfully when captions exist
+      //     and writes a no_captions row otherwise. Filtering on the stale
+      //     has_caption column would zero out the candidate list.
+      //   ordered by bookmark presence then view_count (high-engagement first).
       const prisma = getPrismaClient();
       const rows = await prisma.$queryRaw<CandidateRow[]>(Prisma.sql`
       SELECT
@@ -81,14 +87,15 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
         yv.default_language,
         yv.has_caption
       FROM youtube_videos yv
+      JOIN video_rich_summaries vrs ON vrs.video_id = yv.youtube_video_id
       LEFT JOIN (
         SELECT yv2.youtube_video_id, COUNT(*) AS bookmark_count
         FROM user_video_states uvs
         JOIN youtube_videos yv2 ON yv2.id = uvs.video_id
         GROUP BY yv2.youtube_video_id
       ) book ON book.youtube_video_id = yv.youtube_video_id
-      WHERE yv.has_caption = true
-        AND yv.transcript_fetched_at IS NULL
+      WHERE yv.transcript_fetched_at IS NULL
+        AND vrs.template_version = 'v1'
       ORDER BY
         (COALESCE(book.bookmark_count, 0) > 0) DESC,
         yv.view_count DESC NULLS LAST


### PR DESCRIPTION
Round 2 (1,507) candidate query was empty because `has_caption=true` matches 0 rows (column NULL on all 5,875 — YT-API backfill cron OFF per Hard Rule). yt-dlp on Mac Mini is now the truth source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)