### PR TITLE
feat(api): internal videos bulk-upsert endpoint (CP438)

### DIFF
--- a/src/api/routes/internal/videos-bulk-upsert.ts
+++ b/src/api/routes/internal/videos-bulk-upsert.ts
@@ -1,0 +1,219 @@
+/**
+ * Internal videos bulk-upsert endpoint (CP438, 2026-04-29).
+ *
+ * Mac Mini new-collector posts batches of YouTube video metadata here. The
+ * endpoint applies a server-side quality gate, dedupes against existing
+ * youtube_videos rows via `ON CONFLICT (youtube_video_id) DO NOTHING`,
+ * and reports per-batch counts.
+ *
+ *   POST /api/v1/internal/videos/bulk-upsert
+ *   Body: { videos: VideoMeta[] } — max 500 per call
+ *   Auth: x-internal-token header (same pattern as transcript routes).
+ *
+ * Hard Rule (CP438 spec):
+ *   - No LLM API call from this path.
+ *   - No yt-dlp execution server-side (Mac Mini is the truth source).
+ *     The Mac Mini collector MUST route yt-dlp traffic through the
+ *     WebShare rotating proxy pool — direct YouTube hits bot-gate within
+ *     minutes (CP401/CP411 LEVEL-2 pattern). The endpoint cannot enforce
+ *     this server-side; it is a collector-side contract.
+ *   - Mandala-derived collection is permanently excluded — Mac Mini
+ *     collector enforces source taxonomy; the endpoint is source-agnostic
+ *     and trusts the caller's pipeline.
+ */
+
+import type { FastifyPluginAsync } from 'fastify';
+import { Prisma } from '@prisma/client';
+
+import { getInternalBatchToken } from '@/config/internal-auth';
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'api/internal/videos-bulk-upsert' });
+
+const MAX_BATCH = 500;
+
+/** Quality gate constants (CP438 spec §2 품질 게이트). */
+const DURATION_MIN_SEC = 180;
+const DURATION_MAX_SEC = 3600;
+const TITLE_MIN_LEN = 5;
+
+/**
+ * Title blocklist — drop entries whose title contains any of these
+ * substrings (case-insensitive). Per CP438 spec: 광고/PPL/협찬/sponsored
+ * /드라마/팬편집. Kept as a single set so future tuning lives in one place.
+ */
+const BLOCKLIST_TOKENS: readonly string[] = [
+  '광고',
+  'ppl',
+  '협찬',
+  'sponsored',
+  '드라마',
+  '팬편집',
+];
+
+interface VideoMeta {
+  youtube_video_id?: string;
+  title?: string;
+  channel_title?: string | null;
+  duration_seconds?: number | null;
+  view_count?: number | null;
+  like_count?: number | null;
+  thumbnail_url?: string | null;
+  published_at?: string | null;
+  default_language?: string | null;
+}
+
+interface BulkUpsertBody {
+  videos?: VideoMeta[];
+}
+
+interface FilterResult {
+  pass: VideoMeta[];
+  filtered: { id: string; reason: string }[];
+}
+
+function applyQualityGate(videos: VideoMeta[]): FilterResult {
+  const pass: VideoMeta[] = [];
+  const filtered: { id: string; reason: string }[] = [];
+  const seen = new Set<string>();
+
+  for (const v of videos) {
+    const id = typeof v.youtube_video_id === 'string' ? v.youtube_video_id.trim() : '';
+    const title = typeof v.title === 'string' ? v.title.trim() : '';
+
+    if (!id) {
+      filtered.push({ id: '<missing>', reason: 'no_video_id' });
+      continue;
+    }
+    if (seen.has(id)) {
+      filtered.push({ id, reason: 'duplicate_in_batch' });
+      continue;
+    }
+    seen.add(id);
+
+    if (title.length < TITLE_MIN_LEN) {
+      filtered.push({ id, reason: 'title_too_short' });
+      continue;
+    }
+    const titleLower = title.toLowerCase();
+    const blocked = BLOCKLIST_TOKENS.find((t) => titleLower.includes(t));
+    if (blocked) {
+      filtered.push({ id, reason: `blocklist:${blocked}` });
+      continue;
+    }
+    if (typeof v.duration_seconds === 'number') {
+      if (v.duration_seconds < DURATION_MIN_SEC) {
+        filtered.push({ id, reason: 'too_short' });
+        continue;
+      }
+      if (v.duration_seconds > DURATION_MAX_SEC) {
+        filtered.push({ id, reason: 'too_long' });
+        continue;
+      }
+    }
+    pass.push({ ...v, youtube_video_id: id, title });
+  }
+  return { pass, filtered };
+}
+
+export const internalVideosBulkUpsertRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post<{ Body: BulkUpsertBody }>('/videos/bulk-upsert', async (request, reply) => {
+    const expected = getInternalBatchToken();
+    if (!expected) {
+      return reply.code(503).send({ error: 'internal trigger not configured' });
+    }
+    const got = request.headers['x-internal-token'];
+    if (typeof got !== 'string' || got !== expected) {
+      return reply.code(401).send({ error: 'invalid internal token' });
+    }
+    const videos = Array.isArray(request.body?.videos) ? request.body.videos : [];
+    if (videos.length === 0) {
+      return reply.code(400).send({ error: 'videos[] required' });
+    }
+    if (videos.length > MAX_BATCH) {
+      return reply.code(400).send({
+        error: `batch too large (max ${MAX_BATCH}, got ${videos.length})`,
+      });
+    }
+
+    const { pass, filtered } = applyQualityGate(videos);
+
+    let inserted = 0;
+    let skippedDuplicate = 0;
+    const dbErrors: { id: string; error: string }[] = [];
+
+    if (pass.length > 0) {
+      const prisma = getPrismaClient();
+      // ON CONFLICT (youtube_video_id) DO NOTHING — the table has the
+      // unique constraint already. RETURNING xmax = 0 distinguishes
+      // freshly-inserted vs no-op rows so we can report inserted vs
+      // skipped accurately in a single round-trip per video.
+      for (const v of pass) {
+        try {
+          const result = await prisma.$queryRaw<{ inserted: boolean }[]>(Prisma.sql`
+              INSERT INTO youtube_videos (
+                youtube_video_id,
+                title,
+                channel_title,
+                duration_seconds,
+                view_count,
+                like_count,
+                thumbnail_url,
+                published_at,
+                default_language
+              )
+              VALUES (
+                ${v.youtube_video_id},
+                ${v.title},
+                ${v.channel_title ?? null},
+                ${v.duration_seconds ?? null},
+                ${v.view_count ?? null},
+                ${v.like_count ?? null},
+                ${v.thumbnail_url ?? null},
+                ${v.published_at ? new Date(v.published_at) : null},
+                ${v.default_language ?? null}
+              )
+              ON CONFLICT (youtube_video_id) DO NOTHING
+              RETURNING (xmax = 0) AS inserted
+            `);
+          if (result.length > 0 && result[0]!.inserted) {
+            inserted += 1;
+          } else {
+            skippedDuplicate += 1;
+          }
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          dbErrors.push({ id: v.youtube_video_id!, error: msg.slice(0, 200) });
+        }
+      }
+    }
+
+    log.info('videos bulk-upsert done', {
+      received: videos.length,
+      passed_filter: pass.length,
+      inserted,
+      skipped_duplicate: skippedDuplicate,
+      skipped_filter: filtered.length,
+      db_errors: dbErrors.length,
+    });
+
+    return reply.code(200).send({
+      received: videos.length,
+      inserted,
+      skipped_duplicate: skippedDuplicate,
+      skipped_filter: filtered.length,
+      db_errors: dbErrors.length,
+      ...(filtered.length > 0 ? { filter_breakdown: aggregateReasons(filtered) } : {}),
+      ...(dbErrors.length > 0 ? { db_errors_sample: dbErrors.slice(0, 5) } : {}),
+    });
+  });
+};
+
+function aggregateReasons(items: { reason: string }[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const it of items) {
+    out[it.reason] = (out[it.reason] ?? 0) + 1;
+  }
+  return out;
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -29,6 +29,7 @@ import { copilotKitRoutes } from './routes/copilotkit';
 import { internalBatchVideoCollectorRoutes } from './routes/internal/batch-video-collector';
 import { internalTrendCollectorRoutes } from './routes/internal/trend-collector';
 import { internalTranscriptRoutes } from './routes/internal/transcript';
+import { internalVideosBulkUpsertRoutes } from './routes/internal/videos-bulk-upsert';
 import { createErrorResponse, ErrorCode } from './schemas/common.schema';
 import { registerBotWriteGuard } from './plugins/bot-write-guard';
 import { registerBotUsageLogger } from './plugins/bot-usage-logger';
@@ -302,6 +303,10 @@ export async function buildServer() {
       });
       // CP437 — Mac Mini transcript pipeline (yt-dlp memory-only).
       await instance.register(internalTranscriptRoutes, {
+        prefix: '/internal',
+      });
+      // CP438 — Mac Mini new-collector bulk video metadata upsert.
+      await instance.register(internalVideosBulkUpsertRoutes, {
         prefix: '/internal',
       });
     },

--- a/tests/unit/api/videos-bulk-upsert.test.ts
+++ b/tests/unit/api/videos-bulk-upsert.test.ts
@@ -1,0 +1,164 @@
+/**
+ * videos-bulk-upsert quality gate (CP438).
+ *
+ * The route registers a Fastify handler that hits Prisma; integration
+ * coverage lives in prod smoke. This file exercises the in-handler
+ * filter logic by invoking the same route function with a mocked Prisma
+ * client. The pure-filter cases (duration / title length / blocklist /
+ * batch dedupe) need no DB at all.
+ */
+
+import Fastify, { type FastifyInstance } from 'fastify';
+
+jest.mock('@/config/internal-auth', () => ({
+  getInternalBatchToken: () => 'test-token',
+}));
+
+const mockExecuteRaw = jest.fn();
+const mockQueryRaw = jest.fn();
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    $executeRaw: (...args: unknown[]) => mockExecuteRaw(...args),
+    $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
+  }),
+}));
+
+import { internalVideosBulkUpsertRoutes } from '@/api/routes/internal/videos-bulk-upsert';
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify();
+  await app.register(internalVideosBulkUpsertRoutes, { prefix: '/internal' });
+  return app;
+}
+
+const HEADERS = { 'x-internal-token': 'test-token', 'content-type': 'application/json' };
+
+describe('POST /internal/videos/bulk-upsert', () => {
+  beforeEach(() => {
+    mockQueryRaw.mockReset();
+    mockExecuteRaw.mockReset();
+  });
+
+  test('rejects without internal token', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/videos/bulk-upsert',
+      headers: { 'content-type': 'application/json' },
+      payload: { videos: [] },
+    });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  test('rejects empty videos array', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/videos/bulk-upsert',
+      headers: HEADERS,
+      payload: { videos: [] },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  test('rejects batch >500', async () => {
+    const app = await buildApp();
+    const videos = Array.from({ length: 501 }, (_, i) => ({
+      youtube_video_id: `id${i}`,
+      title: 'a long enough title here',
+      duration_seconds: 600,
+    }));
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/videos/bulk-upsert',
+      headers: HEADERS,
+      payload: { videos },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  test('quality gate filters short titles + duration + blocklist + dedupe', async () => {
+    mockQueryRaw.mockResolvedValue([{ inserted: true }]);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/videos/bulk-upsert',
+      headers: HEADERS,
+      payload: {
+        videos: [
+          { youtube_video_id: 'ok1', title: 'a long enough title', duration_seconds: 600 },
+          { youtube_video_id: 'short', title: 'hi', duration_seconds: 600 }, // title_too_short
+          { youtube_video_id: 'tooshort', title: 'normal title', duration_seconds: 30 }, // too_short
+          { youtube_video_id: 'toolong', title: 'normal title', duration_seconds: 7200 }, // too_long
+          { youtube_video_id: 'ad', title: '광고로 보는 신상품', duration_seconds: 600 }, // blocklist:광고
+          { youtube_video_id: 'sponsor', title: 'sponsored video here', duration_seconds: 600 }, // blocklist:sponsored
+          { youtube_video_id: 'dup', title: 'duplicate test title', duration_seconds: 600 },
+          { youtube_video_id: 'dup', title: 'duplicate test title', duration_seconds: 600 }, // duplicate_in_batch
+          { title: 'no id title', duration_seconds: 600 }, // no_video_id
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as {
+      inserted: number;
+      skipped_filter: number;
+      filter_breakdown: Record<string, number>;
+    };
+    // ok1 + dup = 2 pass to DB; mockQueryRaw returns inserted=true for both
+    expect(body.inserted).toBe(2);
+    expect(body.skipped_filter).toBe(7);
+    expect(body.filter_breakdown).toEqual({
+      title_too_short: 1,
+      too_short: 1,
+      too_long: 1,
+      'blocklist:광고': 1,
+      'blocklist:sponsored': 1,
+      duplicate_in_batch: 1,
+      no_video_id: 1,
+    });
+    await app.close();
+  });
+
+  test('counts duplicate-by-DB conflict as skipped_duplicate', async () => {
+    mockQueryRaw.mockResolvedValueOnce([{ inserted: true }]).mockResolvedValueOnce([]); // conflict — RETURNING produces 0 rows on DO NOTHING
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/videos/bulk-upsert',
+      headers: HEADERS,
+      payload: {
+        videos: [
+          { youtube_video_id: 'newone', title: 'fresh row title', duration_seconds: 600 },
+          { youtube_video_id: 'existed', title: 'already in db', duration_seconds: 600 },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as { inserted: number; skipped_duplicate: number };
+    expect(body.inserted).toBe(1);
+    expect(body.skipped_duplicate).toBe(1);
+    await app.close();
+  });
+
+  test('duration filter not applied when duration is null/undefined', async () => {
+    mockQueryRaw.mockResolvedValue([{ inserted: true }]);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/videos/bulk-upsert',
+      headers: HEADERS,
+      payload: {
+        videos: [
+          { youtube_video_id: 'noduration', title: 'a long enough title' }, // no duration → pass
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as { inserted: number };
+    expect(body.inserted).toBe(1);
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- New `POST /api/v1/internal/videos/bulk-upsert` for Mac Mini video collector batches (max 500/call).
- Server-side quality gate (duration / title length / blocklist / in-batch dedupe) + `ON CONFLICT DO NOTHING` per-row counting.
- Pure-handler logic with no LLM calls and no yt-dlp execution server-side — Mac Mini collector remains the truth source and **must** route yt-dlp through WebShare rotating proxy (CP401/CP411 LEVEL-2 enforcement; cannot be enforced server-side).

## Scope
- Pure additive: new route + new test file. No existing endpoint behavior changes.
- Mandala-derived collection permanently excluded by collector-side taxonomy. Endpoint is source-agnostic and trusts the caller's pipeline.

## Why
- CP438 video collection pipeline redesign — existing Redis 32,840 entries have unverifiable quality (quality_flags scaffolding never wired, no view_count, mandala goal slugs instead of trendy topics). New collector posts here directly; no Redis intermediary.

## Test plan
- [x] `npx tsc --noEmit` — PASS
- [x] `npx jest tests/unit/api/videos-bulk-upsert.test.ts` — 6/6 PASS
  - rejects without internal token (401)
  - rejects empty `videos[]` (400)
  - rejects batch > 500 (400)
  - quality gate filters short titles + duration + blocklist + dedupe (filter_breakdown verified)
  - duplicate-by-DB conflict counted as `skipped_duplicate`
  - duration filter not applied when duration is null/undefined
- [ ] Post-merge: prod deploy + 1 sample batch from Mac Mini collector → verify `inserted` / `skipped_filter` / `filter_breakdown` shape in response.

## Hard Rule reminders
- NO LLM API call from this path (Anthropic / OpenRouter forbidden in non-prod-runtime per 2026-04-15 incident).
- WebShare proxy is **collector-side contract** — endpoint cannot enforce.
- `.env` 불변 — config via `INTERNAL_BATCH_TOKEN` env (already in deploy.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)