### PR TITLE
feat(collector): youtube_videos.source column + per-source tagging (CP438)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ openclaw/memory/
 # Hardcode audit — keep baseline.json, ignore per-run reports
 reports/hardcode-audit/report-*.json
 reports/hardcode-audit/latest.json
+!prisma/migrations/collector-source/

--- a/mac-mini/video-collector/collect-trending.ts
+++ b/mac-mini/video-collector/collect-trending.ts
@@ -251,22 +251,41 @@ async function main(): Promise<void> {
 
   // Insertion order = priority. s1+s3 first (full metadata, dedupe
   // basis); s2+s4 IDs filtered to non-overlap, then enriched.
+  // CP438: each video tagged with source — first-occurrence wins so
+  // priority order is S1 > S3 > S2 > S4 for cross-source overlaps.
   const seen = new Set<string>();
+  const idSourceMap = new Map<string, string>();
   const directVideos: VideoMeta[] = [];
-  for (const v of [...s1Videos, ...s3Videos]) {
+  for (const v of s1Videos) {
     if (seen.has(v.youtube_video_id)) continue;
     seen.add(v.youtube_video_id);
-    directVideos.push(v);
+    idSourceMap.set(v.youtube_video_id, 'category_mostpopular');
+    directVideos.push({ ...v, source: 'category_mostpopular' });
   }
-  const idsToEnrich = [...s2Take, ...s4Take].filter((id) => {
-    if (seen.has(id)) return false;
+  for (const v of s3Videos) {
+    if (seen.has(v.youtube_video_id)) continue;
+    seen.add(v.youtube_video_id);
+    idSourceMap.set(v.youtube_video_id, 'youtube_mostpopular');
+    directVideos.push({ ...v, source: 'youtube_mostpopular' });
+  }
+  const idsToEnrich: string[] = [];
+  for (const id of s2Take) {
+    if (seen.has(id)) continue;
     seen.add(id);
-    return true;
-  });
+    idSourceMap.set(id, 'naver_keyword');
+    idsToEnrich.push(id);
+  }
+  for (const id of s4Take) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    idSourceMap.set(id, 'domain_keyword');
+    idsToEnrich.push(id);
+  }
 
   let enriched: VideoMeta[] = [];
   if (idsToEnrich.length > 0) {
-    enriched = await fetchVideoMetadata(idsToEnrich, env.youtubeApiKey);
+    const rows = await fetchVideoMetadata(idsToEnrich, env.youtubeApiKey);
+    enriched = rows.map((r) => ({ ...r, source: idSourceMap.get(r.youtube_video_id) ?? null }));
   }
   const allVideos: VideoMeta[] = [...directVideos, ...enriched];
 

--- a/mac-mini/video-collector/sources/types.ts
+++ b/mac-mini/video-collector/sources/types.ts
@@ -16,6 +16,10 @@ export interface VideoMeta {
   thumbnail_url?: string | null;
   published_at?: string | null;
   default_language?: string | null;
+  /** CP438 collector pipeline source. The orchestrator tags each
+   *  video before POST; bulk-upsert endpoint stores it on the
+   *  youtube_videos.source column. */
+  source?: string | null;
 }
 
 export interface SourceResult {

--- a/prisma/migrations/collector-source/001_add_source.sql
+++ b/prisma/migrations/collector-source/001_add_source.sql
@@ -1,0 +1,29 @@
+-- CP438 (2026-04-29) — collector source tagging.
+--
+-- Adds youtube_videos.source so we can attribute each row to one of the
+-- 4 collector pipeline sources. Existing rows stay NULL (소급 불가 per
+-- CP438 plan). Going forward the bulk-upsert endpoint accepts a source
+-- field and stamps it on insert; ON CONFLICT DO UPDATE rewrites source
+-- on subsequent submissions so a video re-discovered via a different
+-- source path keeps the most-recent attribution.
+--
+-- Allowed values (informational — column is plain VARCHAR(30) with no
+-- DB CHECK constraint so future sources can be added without migration):
+--   'category_mostpopular'  — Source 1 (videoCategoryId × KR/US)
+--   'naver_keyword'         — Source 2 (Naver DataLab + yt-dlp search)
+--   'youtube_mostpopular'   — Source 3 (chart=mostPopular generic)
+--   'domain_keyword'        — Source 4 (9-domain × 10 templates)
+
+ALTER TABLE youtube_videos
+  ADD COLUMN IF NOT EXISTS source VARCHAR(30);
+
+CREATE INDEX IF NOT EXISTS idx_youtube_videos_source
+  ON youtube_videos (source)
+  WHERE source IS NOT NULL;
+
+COMMENT ON COLUMN youtube_videos.source IS
+  'CP438 collector pipeline source: category_mostpopular / naver_keyword / youtube_mostpopular / domain_keyword. NULL = pre-CP438 legacy row.';
+
+-- Postgrest schema reload (Supabase) — required so the new column is
+-- visible to PostgREST/REST clients. CP383 hard rule §ALTER 직후 reload.
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -893,6 +893,11 @@ model youtube_videos {
   /// CP437 transcript pipeline (Mac Mini yt-dlp). Stamped on summary
   /// success; transcript text itself is never persisted.
   transcript_fetched_at  DateTime?                @db.Timestamptz(6)
+  /// CP438 (2026-04-29) collector pipeline source.
+  /// Values: 'category_mostpopular' | 'naver_keyword' | 'youtube_mostpopular' | 'domain_keyword'.
+  /// Pre-CP438 legacy rows stay NULL (소급 불가).
+  /// Raw SQL DDL: prisma/migrations/collector-source/001_add_source.sql
+  source                 String?                  @db.VarChar(30)
   created_at             DateTime                 @default(now()) @db.Timestamptz(6)
   updated_at             DateTime                 @default(now()) @db.Timestamptz(6)
   userState              UserVideoState[]
@@ -904,6 +909,7 @@ model youtube_videos {
 
   @@index([metadata_fetched_at], map: "idx_youtube_videos_metadata_fetched_at")
   @@index([transcript_fetched_at], map: "idx_youtube_videos_transcript_fetched_at")
+  @@index([source], map: "idx_youtube_videos_source")
   @@schema("public")
 }
 

--- a/src/api/routes/internal/videos-bulk-upsert.ts
+++ b/src/api/routes/internal/videos-bulk-upsert.ts
@@ -62,6 +62,22 @@ interface VideoMeta {
   thumbnail_url?: string | null;
   published_at?: string | null;
   default_language?: string | null;
+  /** CP438 collector pipeline source (column added 2026-04-29). */
+  source?: string | null;
+}
+
+/** Whitelist of allowed values for `source` per CP438 spec. */
+const ALLOWED_SOURCES: ReadonlySet<string> = new Set([
+  'category_mostpopular',
+  'naver_keyword',
+  'youtube_mostpopular',
+  'domain_keyword',
+]);
+
+function normalizeSource(s: unknown): string | null {
+  if (typeof s !== 'string') return null;
+  const trimmed = s.trim();
+  return ALLOWED_SOURCES.has(trimmed) ? trimmed : null;
 }
 
 interface BulkUpsertBody {
@@ -112,7 +128,12 @@ function applyQualityGate(videos: VideoMeta[]): FilterResult {
         continue;
       }
     }
-    pass.push({ ...v, youtube_video_id: id, title });
+    pass.push({
+      ...v,
+      youtube_video_id: id,
+      title,
+      source: normalizeSource(v.source),
+    });
   }
   return { pass, filtered };
 }
@@ -145,10 +166,14 @@ export const internalVideosBulkUpsertRoutes: FastifyPluginAsync = async (fastify
 
     if (pass.length > 0) {
       const prisma = getPrismaClient();
-      // ON CONFLICT (youtube_video_id) DO NOTHING — the table has the
-      // unique constraint already. RETURNING xmax = 0 distinguishes
-      // freshly-inserted vs no-op rows so we can report inserted vs
-      // skipped accurately in a single round-trip per video.
+      // ON CONFLICT (youtube_video_id) DO UPDATE — CP438 introduced
+      // `source` and we want re-submits to update that attribution
+      // (a video re-discovered via a different pipeline path keeps the
+      // most-recent source). Everything else stays read-only on
+      // conflict so a stale collector dump can't overwrite freshly
+      // fetched metadata from another path. RETURNING (xmax = 0) AS
+      // inserted distinguishes a fresh INSERT (xmax=0) from an UPDATE
+      // (xmax!=0) in a single round-trip per video.
       for (const v of pass) {
         try {
           const result = await prisma.$queryRaw<{ inserted: boolean }[]>(Prisma.sql`
@@ -161,7 +186,8 @@ export const internalVideosBulkUpsertRoutes: FastifyPluginAsync = async (fastify
                 like_count,
                 thumbnail_url,
                 published_at,
-                default_language
+                default_language,
+                source
               )
               VALUES (
                 ${v.youtube_video_id},
@@ -172,9 +198,11 @@ export const internalVideosBulkUpsertRoutes: FastifyPluginAsync = async (fastify
                 ${v.like_count ?? null},
                 ${v.thumbnail_url ?? null},
                 ${v.published_at ? new Date(v.published_at) : null},
-                ${v.default_language ?? null}
+                ${v.default_language ?? null},
+                ${v.source ?? null}
               )
-              ON CONFLICT (youtube_video_id) DO NOTHING
+              ON CONFLICT (youtube_video_id) DO UPDATE
+                SET source = COALESCE(EXCLUDED.source, youtube_videos.source)
               RETURNING (xmax = 0) AS inserted
             `);
           if (result.length > 0 && result[0]!.inserted) {

--- a/tests/unit/api/videos-bulk-upsert.test.ts
+++ b/tests/unit/api/videos-bulk-upsert.test.ts
@@ -123,7 +123,11 @@ describe('POST /internal/videos/bulk-upsert', () => {
   });
 
   test('counts duplicate-by-DB conflict as skipped_duplicate', async () => {
-    mockQueryRaw.mockResolvedValueOnce([{ inserted: true }]).mockResolvedValueOnce([]); // conflict — RETURNING produces 0 rows on DO NOTHING
+    // CP438: ON CONFLICT DO UPDATE — RETURNING (xmax = 0) is now false
+    // for a conflict (formerly DO NOTHING returned []).
+    mockQueryRaw
+      .mockResolvedValueOnce([{ inserted: true }])
+      .mockResolvedValueOnce([{ inserted: false }]);
     const app = await buildApp();
     const res = await app.inject({
       method: 'POST',
@@ -140,6 +144,66 @@ describe('POST /internal/videos/bulk-upsert', () => {
     const body = JSON.parse(res.body) as { inserted: number; skipped_duplicate: number };
     expect(body.inserted).toBe(1);
     expect(body.skipped_duplicate).toBe(1);
+    await app.close();
+  });
+
+  test('source field passes through valid values + null on unknown', async () => {
+    mockQueryRaw.mockResolvedValue([{ inserted: true }]);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/videos/bulk-upsert',
+      headers: HEADERS,
+      payload: {
+        videos: [
+          {
+            youtube_video_id: 's1',
+            title: 'cat mostpop video',
+            duration_seconds: 600,
+            source: 'category_mostpopular',
+          },
+          {
+            youtube_video_id: 's2',
+            title: 'naver kw video',
+            duration_seconds: 600,
+            source: 'naver_keyword',
+          },
+          {
+            youtube_video_id: 's3',
+            title: 'mostpop video',
+            duration_seconds: 600,
+            source: 'youtube_mostpopular',
+          },
+          {
+            youtube_video_id: 's4',
+            title: 'domain kw video',
+            duration_seconds: 600,
+            source: 'domain_keyword',
+          },
+          {
+            youtube_video_id: 'sx',
+            title: 'unknown source video',
+            duration_seconds: 600,
+            source: 'bogus_value',
+          },
+          { youtube_video_id: 'sn', title: 'no source video', duration_seconds: 600 },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as { inserted: number };
+    expect(body.inserted).toBe(6);
+    // verify the SQL invocations bound the expected source values.
+    // mockQueryRaw is called once per pass — the 10th positional arg is `source`.
+    const calls = mockQueryRaw.mock.calls;
+    expect(calls.length).toBe(6);
+    // Prisma.sql template — first arg is the templated TemplateStringsArray
+    // followed by ordered values; we just check that 'bogus_value' was
+    // normalized to null and other valid values passed through.
+    const firstSql = JSON.stringify(calls[0]);
+    expect(firstSql).toContain('category_mostpopular');
+    const fifthSql = JSON.stringify(calls[4]);
+    expect(fifthSql).not.toContain('bogus_value');
     await app.close();
   });
 


### PR DESCRIPTION
## Summary
Adds `youtube_videos.source` VARCHAR(30) so each row can be attributed to one of the 4 collector pipeline sources. Required for accurate source-distribution stats; prior runs could only estimate.

## Tasks
- **DB schema**: ALTER ADD COLUMN + partial index + raw SQL DDL (`prisma/migrations/collector-source/001_add_source.sql`). Per Hard Rule §prisma db push silent fail — DDL applied via psql before / after merge.
- **bulk-upsert endpoint**: VideoMeta.source field with whitelist (category_mostpopular | naver_keyword | youtube_mostpopular | domain_keyword); unknown values → null. ON CONFLICT switched from DO NOTHING to DO UPDATE on source only.
- **collect-trending.ts**: Each source tagged at aggregation; idSourceMap stamps tag so enriched bare IDs receive correct source. Cross-source priority preserved (S1 > S3 > S2 > S4).
- **collection-stats-reporter SKILL.md**: Source distribution query #2 added; example table updated.

## Why
- Run 1-7 stats this session could only estimate source split. column makes it exact.
- ON CONFLICT DO UPDATE allows re-discovery via different path to update source attribution.

## Hard Rule
- Pre-CP438 rows stay NULL (소급 불가).
- Local → prod migration order (raw DDL via psql; `prisma db push` silent-fail risk per CLAUDE.md).
- NOTIFY pgrst on ALTER for Supabase REST visibility.

## Test plan
- [x] `npx tsc --noEmit` PASS
- [x] `npx jest tests/unit/api/videos-bulk-upsert.test.ts` 7/7 PASS (1 new test for source field whitelist)
- [ ] After merge: apply DDL to prod via `psql "$DIRECT_URL" -f prisma/migrations/collector-source/001_add_source.sql`
- [ ] Mac Mini: `git pull` + new collect run → verify `youtube_videos.source` populated
- [ ] Stats query #2 returns 4 source buckets (no nulls for new rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)