### PR TITLE
feat(video-pool): auto-promote v2 summaries → video_pool (CP438)

### DIFF
--- a/mac-mini/openclaw-handlers/run-promote.sh
+++ b/mac-mini/openclaw-handlers/run-promote.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# OpenClaw /promote handler (CP438).
+# Calls /api/v1/internal/video-pool/promote-from-v2 with batch limit
+# (default 100). Returns the JSON shape the agent quotes back to Telegram.
+#
+# Usage:
+#   bash run-promote.sh           # default limit 100
+#   bash run-promote.sh 50        # limit 50
+#   PROMOTE_DRY_RUN=1 bash run-promote.sh   # show counts without writes
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_bootstrap.sh
+source "$DIR/_bootstrap.sh"
+
+LIMIT="${1:-100}"
+DRY_RUN="${PROMOTE_DRY_RUN:-0}"
+
+PAYLOAD=$(printf '{"limit":%d,"dry_run":%s}' "$LIMIT" "$([ "$DRY_RUN" = "1" ] && echo true || echo false)")
+
+echo "[run-promote] limit=$LIMIT dry_run=$DRY_RUN"
+
+curl -sS \
+  -X POST "${INSIGHTA_API_URL%/}/api/v1/internal/video-pool/promote-from-v2" \
+  -H "x-internal-token: ${INTERNAL_BATCH_TOKEN:?missing}" \
+  -H 'content-type: application/json' \
+  -d "$PAYLOAD" \
+  -w "\nHTTP %{http_code}\n"

--- a/src/api/routes/internal/video-pool-promote.ts
+++ b/src/api/routes/internal/video-pool-promote.ts
@@ -1,0 +1,69 @@
+/**
+ * Internal video-pool promotion endpoint (CP438, 2026-04-29).
+ *
+ *   POST /api/v1/internal/video-pool/promote-from-v2
+ *   Body: { limit?: number; dry_run?: boolean }
+ *   Auth: x-internal-token (same secret as bulk-upsert + transcript).
+ *
+ * Promotes up to `limit` (default 100) v2-summary rows into `video_pool`.
+ * Quality tier from completeness (≥0.9 gold else silver). Embedding via
+ * Mac Mini Ollama (qwen3-embedding:8b, fail-open if unreachable).
+ *
+ * Hard Rule (CP438):
+ *   - No LLM API call in this path (embedding is local Ollama, not paid API).
+ *   - Inserts only — no UPDATE, no DELETE on video_pool / video_pool_embeddings.
+ */
+
+import type { FastifyPluginAsync } from 'fastify';
+
+import { getInternalBatchToken } from '@/config/internal-auth';
+import { promoteV2ToVideoPool } from '@/modules/video-pool/promote-from-v2';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'api/internal/video-pool-promote' });
+
+interface PromoteBody {
+  limit?: number;
+  dry_run?: boolean;
+}
+
+const MAX_LIMIT = 500;
+
+export const internalVideoPoolPromoteRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post<{ Body: PromoteBody }>('/video-pool/promote-from-v2', async (request, reply) => {
+    const expected = getInternalBatchToken();
+    if (!expected) {
+      return reply.code(503).send({ error: 'internal trigger not configured' });
+    }
+    const got = request.headers['x-internal-token'];
+    if (typeof got !== 'string' || got !== expected) {
+      return reply.code(401).send({ error: 'invalid internal token' });
+    }
+
+    const limit = Math.max(
+      1,
+      Math.min(MAX_LIMIT, typeof request.body?.limit === 'number' ? request.body.limit : 100)
+    );
+    const dryRun = request.body?.dry_run === true;
+
+    try {
+      const result = await promoteV2ToVideoPool({ limit, dryRun });
+      log.info('promote-from-v2 endpoint done', {
+        limit,
+        dry_run: dryRun,
+        ...result,
+        errors: result.errors.length,
+      });
+      return reply.code(200).send({
+        limit,
+        dry_run: dryRun,
+        ...result,
+        errors_sample: result.errors.slice(0, 5),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error('promote-from-v2 endpoint failed', { err: msg });
+      return reply.code(500).send({ error: msg.slice(0, 300) });
+    }
+  });
+};

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -30,6 +30,7 @@ import { internalBatchVideoCollectorRoutes } from './routes/internal/batch-video
 import { internalTrendCollectorRoutes } from './routes/internal/trend-collector';
 import { internalTranscriptRoutes } from './routes/internal/transcript';
 import { internalVideosBulkUpsertRoutes } from './routes/internal/videos-bulk-upsert';
+import { internalVideoPoolPromoteRoutes } from './routes/internal/video-pool-promote';
 import { createErrorResponse, ErrorCode } from './schemas/common.schema';
 import { registerBotWriteGuard } from './plugins/bot-write-guard';
 import { registerBotUsageLogger } from './plugins/bot-usage-logger';
@@ -307,6 +308,11 @@ export async function buildServer() {
       });
       // CP438 — Mac Mini new-collector bulk video metadata upsert.
       await instance.register(internalVideosBulkUpsertRoutes, {
+        prefix: '/internal',
+      });
+      // CP438 — promote v2 layered summaries into video_pool (batched,
+      // embedding via Mac Mini Ollama, INSERT only).
+      await instance.register(internalVideoPoolPromoteRoutes, {
         prefix: '/internal',
       });
     },

--- a/src/modules/video-pool/promote-from-v2.ts
+++ b/src/modules/video-pool/promote-from-v2.ts
@@ -1,0 +1,275 @@
+/**
+ * Promote v2 layered summaries to video_pool (CP438, 2026-04-29).
+ *
+ * After CC authors a v2 layered JSON via `/internal/v2-summary/upsert-direct`,
+ * the row sits in `video_rich_summaries` with `template_version='v2'` but
+ * is NOT yet in `video_pool` (the table the recommender reads from).
+ * This module promotes those v2-summaries into video_pool in batches:
+ *
+ *   1. SELECT 100 candidates: video_rich_summaries WHERE template_version='v2'
+ *      AND video_id NOT IN (SELECT video_id FROM video_pool)
+ *   2. JOIN youtube_videos for the canonical metadata (title, channel, ...)
+ *   3. INSERT video_pool with quality_tier from completeness:
+ *        completeness >= 0.9 → 'gold'
+ *        else                → 'silver'
+ *      source = 'v2_promoted'
+ *   4. Generate embedding via Mac Mini Ollama (qwen3-embedding:8b) over
+ *      a compact text_input (one_liner + analysis.core_argument + title).
+ *   5. INSERT video_pool_embeddings on success; DO NOTHING on conflict.
+ *
+ * Filter strategy (CP438 spec, this iteration):
+ *   - **No filter**: every v2 row is promoted regardless of completeness
+ *     band. Future iterations will gate on user-action signals
+ *     (dismiss/bookmark/watch dwell-time) — see `quality_tier` redefinition
+ *     plan in the CP438 handoff.
+ *
+ * Blast radius: video_pool + video_pool_embeddings INSERT only. No
+ * UPDATE, no DELETE, no impact on existing rows.
+ */
+
+import { Prisma } from '@prisma/client';
+
+import { getPrismaClient } from '@/modules/database/client';
+import {
+  embedBatch,
+  isOllamaReachable,
+  vectorToLiteral,
+  QWEN3_EMBED_MODEL,
+  MAC_MINI_OLLAMA_DEFAULT_URL,
+} from '@/skills/plugins/iks-scorer/embedding';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'modules/video-pool/promote-from-v2' });
+
+const SOURCE_TAG = 'v2_promoted';
+const COMPLETENESS_GOLD_THRESHOLD = 0.9;
+const DEFAULT_BATCH_LIMIT = 100;
+const TEXT_INPUT_MAX_CHARS = 2000;
+
+export interface PromoteResult {
+  candidates: number;
+  promoted: number;
+  embedded: number;
+  gold: number;
+  silver: number;
+  embeddings_skipped_unreachable: boolean;
+  errors: { video_id: string; error: string }[];
+}
+
+interface CandidateRow {
+  video_id: string;
+  one_liner: string | null;
+  completeness: number | null;
+  source_language: string | null;
+  core: unknown;
+  analysis: unknown;
+  // joined from youtube_videos
+  yv_title: string | null;
+  yv_description: string | null;
+  yv_channel_title: string | null;
+  yv_channel_id: string | null;
+  yv_view_count: bigint | null;
+  yv_like_count: bigint | null;
+  yv_duration_seconds: number | null;
+  yv_published_at: Date | null;
+  yv_thumbnail_url: string | null;
+  yv_default_language: string | null;
+}
+
+function quality(completeness: number | null): 'gold' | 'silver' {
+  return (completeness ?? 0) >= COMPLETENESS_GOLD_THRESHOLD ? 'gold' : 'silver';
+}
+
+function buildEmbedText(row: CandidateRow): string {
+  const parts: string[] = [];
+  if (row.yv_title) parts.push(row.yv_title);
+  if (row.one_liner) parts.push(row.one_liner);
+  // analysis.core_argument is a hand-authored summary sentence; useful
+  // for embedding-based retrieval. Other analysis fields tend to be
+  // bullet lists which dilute the embedding signal.
+  if (row.analysis && typeof row.analysis === 'object') {
+    const argument = (row.analysis as { core_argument?: unknown }).core_argument;
+    if (typeof argument === 'string' && argument.length > 0) {
+      parts.push(argument);
+    }
+  }
+  return parts.join('\n').slice(0, TEXT_INPUT_MAX_CHARS);
+}
+
+export interface PromoteOptions {
+  /** Max candidates to promote per call (default 100). */
+  limit?: number;
+  /** When true, skip writes and return planned action counts only. */
+  dryRun?: boolean;
+  /** Override the Ollama URL (default Mac Mini Tailscale). */
+  ollamaUrl?: string;
+}
+
+export async function promoteV2ToVideoPool(opts: PromoteOptions = {}): Promise<PromoteResult> {
+  const limit = Math.max(1, Math.min(500, opts.limit ?? DEFAULT_BATCH_LIMIT));
+  const ollamaUrl = opts.ollamaUrl ?? MAC_MINI_OLLAMA_DEFAULT_URL;
+  const prisma = getPrismaClient();
+
+  // 1+2. Fetch candidates joined with youtube_videos metadata.
+  const candidates = await prisma.$queryRaw<CandidateRow[]>(Prisma.sql`
+    SELECT
+      vrs.video_id          AS video_id,
+      vrs.one_liner         AS one_liner,
+      vrs.completeness      AS completeness,
+      vrs.source_language   AS source_language,
+      vrs.core              AS core,
+      vrs.analysis          AS analysis,
+      yv.title              AS yv_title,
+      yv.description        AS yv_description,
+      yv.channel_title      AS yv_channel_title,
+      yv.channel_id         AS yv_channel_id,
+      yv.view_count         AS yv_view_count,
+      yv.like_count         AS yv_like_count,
+      yv.duration_seconds   AS yv_duration_seconds,
+      yv.published_at       AS yv_published_at,
+      yv.thumbnail_url      AS yv_thumbnail_url,
+      yv.default_language   AS yv_default_language
+    FROM video_rich_summaries vrs
+    LEFT JOIN youtube_videos yv ON yv.youtube_video_id = vrs.video_id
+    WHERE vrs.template_version = 'v2'
+      AND NOT EXISTS (
+        SELECT 1 FROM video_pool vp WHERE vp.video_id = vrs.video_id
+      )
+    ORDER BY vrs.updated_at DESC
+    LIMIT ${limit}
+  `);
+
+  if (candidates.length === 0) {
+    return {
+      candidates: 0,
+      promoted: 0,
+      embedded: 0,
+      gold: 0,
+      silver: 0,
+      embeddings_skipped_unreachable: false,
+      errors: [],
+    };
+  }
+
+  if (opts.dryRun) {
+    let gold = 0;
+    let silver = 0;
+    for (const c of candidates) {
+      if (quality(c.completeness) === 'gold') gold += 1;
+      else silver += 1;
+    }
+    return {
+      candidates: candidates.length,
+      promoted: 0,
+      embedded: 0,
+      gold,
+      silver,
+      embeddings_skipped_unreachable: false,
+      errors: [],
+    };
+  }
+
+  // 4. Generate embeddings up-front via Mac Mini Ollama (parallel batch).
+  const reachable = await isOllamaReachable({ baseUrl: ollamaUrl });
+  let embeddings: number[][] = [];
+  if (reachable) {
+    try {
+      const inputs = candidates.map(buildEmbedText);
+      embeddings = await embedBatch(inputs, { baseUrl: ollamaUrl });
+      if (embeddings.length !== candidates.length) {
+        log.warn('embed_count_mismatch', {
+          got: embeddings.length,
+          expected: candidates.length,
+        });
+        embeddings = [];
+      }
+    } catch (err) {
+      log.warn('embedBatch failed — continuing without embeddings', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      embeddings = [];
+    }
+  } else {
+    log.warn('Ollama unreachable — promoting without embeddings');
+  }
+
+  // 3+5. Insert video_pool + video_pool_embeddings.
+  const errors: { video_id: string; error: string }[] = [];
+  let promoted = 0;
+  let embedded = 0;
+  let gold = 0;
+  let silver = 0;
+
+  for (let i = 0; i < candidates.length; i += 1) {
+    const c = candidates[i]!;
+    if (!c.yv_title) {
+      // No matching youtube_videos row — skip with explicit error so we
+      // don't insert an orphan pool row that the recommender can't show.
+      errors.push({ video_id: c.video_id, error: 'youtube_videos missing' });
+      continue;
+    }
+    const tier = quality(c.completeness);
+    try {
+      // Cap title/description column lengths to match existing schema use
+      // (batch-video-collector slices to 5000).
+      const titleSafe = c.yv_title.slice(0, 5000);
+      const descSafe = c.yv_description ? c.yv_description.slice(0, 5000) : null;
+      const channelSafe = c.yv_channel_title ? c.yv_channel_title.slice(0, 200) : null;
+      const channelIdSafe = c.yv_channel_id ? c.yv_channel_id.slice(0, 30) : null;
+      const langSafe = (c.yv_default_language ?? c.source_language ?? 'ko').slice(0, 5);
+
+      await prisma.video_pool.create({
+        data: {
+          video_id: c.video_id,
+          title: titleSafe,
+          description: descSafe,
+          channel_name: channelSafe,
+          channel_id: channelIdSafe,
+          view_count: c.yv_view_count ?? BigInt(0),
+          like_count: c.yv_like_count ?? BigInt(0),
+          duration_seconds: c.yv_duration_seconds,
+          published_at: c.yv_published_at,
+          thumbnail_url: c.yv_thumbnail_url,
+          language: langSafe,
+          quality_tier: tier,
+          source: SOURCE_TAG,
+        },
+      });
+      promoted += 1;
+      if (tier === 'gold') gold += 1;
+      else silver += 1;
+
+      const vec = embeddings[i];
+      if (vec && vec.length > 0) {
+        await prisma.$executeRaw(Prisma.sql`
+          INSERT INTO public.video_pool_embeddings (video_id, embedding, text_input, model_version)
+          VALUES (${c.video_id}, ${vectorToLiteral(vec)}::vector, ${buildEmbedText(c)}, ${QWEN3_EMBED_MODEL})
+          ON CONFLICT (video_id, model_version) DO NOTHING
+        `);
+        embedded += 1;
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push({ video_id: c.video_id, error: msg.slice(0, 200) });
+    }
+  }
+
+  log.info('promote-from-v2 done', {
+    candidates: candidates.length,
+    promoted,
+    embedded,
+    gold,
+    silver,
+    errors: errors.length,
+  });
+
+  return {
+    candidates: candidates.length,
+    promoted,
+    embedded,
+    gold,
+    silver,
+    embeddings_skipped_unreachable: !reachable,
+    errors,
+  };
+}

--- a/tests/unit/modules/video-pool/promote-from-v2.test.ts
+++ b/tests/unit/modules/video-pool/promote-from-v2.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for promote-from-v2 (CP438).
+ *
+ * Mocks Prisma + the embedding helpers so we can exercise the tier
+ * mapping, error handling, and dry-run path without touching DB or
+ * the Mac Mini Ollama box.
+ */
+
+const mockQueryRaw = jest.fn();
+const mockExecuteRaw = jest.fn();
+const mockVideoPoolCreate = jest.fn();
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
+    $executeRaw: (...args: unknown[]) => mockExecuteRaw(...args),
+    video_pool: { create: (...args: unknown[]) => mockVideoPoolCreate(...args) },
+  }),
+}));
+
+const mockEmbedBatch = jest.fn();
+const mockIsOllamaReachable = jest.fn();
+jest.mock('@/skills/plugins/iks-scorer/embedding', () => ({
+  embedBatch: (...args: unknown[]) => mockEmbedBatch(...args),
+  isOllamaReachable: (...args: unknown[]) => mockIsOllamaReachable(...args),
+  vectorToLiteral: (vec: number[]) => `[${vec.join(',')}]`,
+  QWEN3_EMBED_MODEL: 'qwen3-embedding:8b',
+  MAC_MINI_OLLAMA_DEFAULT_URL: 'http://test',
+}));
+
+import { promoteV2ToVideoPool } from '@/modules/video-pool/promote-from-v2';
+
+const baseRow = {
+  yv_title: 'Title',
+  yv_description: null,
+  yv_channel_title: null,
+  yv_channel_id: null,
+  yv_view_count: BigInt(100),
+  yv_like_count: BigInt(10),
+  yv_duration_seconds: 600,
+  yv_published_at: null,
+  yv_thumbnail_url: null,
+  yv_default_language: 'ko',
+  one_liner: 'concise summary',
+  source_language: 'ko',
+  core: null,
+  analysis: { core_argument: 'argument' },
+};
+
+beforeEach(() => {
+  mockQueryRaw.mockReset();
+  mockExecuteRaw.mockReset();
+  mockVideoPoolCreate.mockReset();
+  mockEmbedBatch.mockReset();
+  mockIsOllamaReachable.mockReset();
+});
+
+describe('promoteV2ToVideoPool', () => {
+  test('zero candidates returns counts of zero', async () => {
+    mockQueryRaw.mockResolvedValueOnce([]);
+    const r = await promoteV2ToVideoPool({ limit: 100 });
+    expect(r.candidates).toBe(0);
+    expect(r.promoted).toBe(0);
+    expect(mockVideoPoolCreate).not.toHaveBeenCalled();
+    expect(mockIsOllamaReachable).not.toHaveBeenCalled();
+  });
+
+  test('quality_tier from completeness ≥0.9 (gold) else silver', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { ...baseRow, video_id: 'g1', completeness: 0.95 },
+      { ...baseRow, video_id: 'g2', completeness: 0.9 },
+      { ...baseRow, video_id: 's1', completeness: 0.7 },
+      { ...baseRow, video_id: 's2', completeness: null },
+    ]);
+    mockIsOllamaReachable.mockResolvedValueOnce(true);
+    mockEmbedBatch.mockResolvedValueOnce([[0.1], [0.2], [0.3], [0.4]]);
+    const r = await promoteV2ToVideoPool({ limit: 100 });
+    expect(r.candidates).toBe(4);
+    expect(r.promoted).toBe(4);
+    expect(r.gold).toBe(2);
+    expect(r.silver).toBe(2);
+    expect(r.embedded).toBe(4);
+    expect(mockVideoPoolCreate).toHaveBeenCalledTimes(4);
+    const tiers = mockVideoPoolCreate.mock.calls.map(
+      (c) => (c[0] as { data: { quality_tier: string } }).data.quality_tier
+    );
+    expect(tiers.filter((t) => t === 'gold')).toHaveLength(2);
+    expect(tiers.filter((t) => t === 'silver')).toHaveLength(2);
+  });
+
+  test('source field always = v2_promoted', async () => {
+    mockQueryRaw.mockResolvedValueOnce([{ ...baseRow, video_id: 'a1', completeness: 0.95 }]);
+    mockIsOllamaReachable.mockResolvedValueOnce(false);
+    const r = await promoteV2ToVideoPool({ limit: 100 });
+    expect(r.promoted).toBe(1);
+    expect(r.embeddings_skipped_unreachable).toBe(true);
+    expect(
+      (mockVideoPoolCreate.mock.calls[0]![0] as { data: { source: string } }).data.source
+    ).toBe('v2_promoted');
+  });
+
+  test('Ollama unreachable → promote without embeddings', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { ...baseRow, video_id: 'a', completeness: 0.95 },
+      { ...baseRow, video_id: 'b', completeness: 0.5 },
+    ]);
+    mockIsOllamaReachable.mockResolvedValueOnce(false);
+    const r = await promoteV2ToVideoPool({ limit: 100 });
+    expect(r.promoted).toBe(2);
+    expect(r.embedded).toBe(0);
+    expect(r.embeddings_skipped_unreachable).toBe(true);
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
+  });
+
+  test('skips rows where youtube_videos metadata missing', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { ...baseRow, video_id: 'orphan', yv_title: null, completeness: 0.9 },
+    ]);
+    mockIsOllamaReachable.mockResolvedValueOnce(false);
+    const r = await promoteV2ToVideoPool({ limit: 100 });
+    expect(r.candidates).toBe(1);
+    expect(r.promoted).toBe(0);
+    expect(r.errors).toEqual([{ video_id: 'orphan', error: 'youtube_videos missing' }]);
+  });
+
+  test('dry-run returns gold/silver counts without writes', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { ...baseRow, video_id: 'g', completeness: 0.95 },
+      { ...baseRow, video_id: 's', completeness: 0.5 },
+    ]);
+    const r = await promoteV2ToVideoPool({ limit: 100, dryRun: true });
+    expect(r.candidates).toBe(2);
+    expect(r.promoted).toBe(0);
+    expect(r.gold).toBe(1);
+    expect(r.silver).toBe(1);
+    expect(mockVideoPoolCreate).not.toHaveBeenCalled();
+    expect(mockIsOllamaReachable).not.toHaveBeenCalled();
+  });
+
+  test('embed count mismatch falls back to no embeddings', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { ...baseRow, video_id: 'a', completeness: 0.5 },
+      { ...baseRow, video_id: 'b', completeness: 0.5 },
+    ]);
+    mockIsOllamaReachable.mockResolvedValueOnce(true);
+    mockEmbedBatch.mockResolvedValueOnce([[0.1]]); // mismatch — only 1 vec for 2 candidates
+    const r = await promoteV2ToVideoPool({ limit: 100 });
+    expect(r.promoted).toBe(2);
+    expect(r.embedded).toBe(0);
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
After CC authors a v2 layered JSON via `/internal/v2-summary/upsert-direct`, the row sits in `video_rich_summaries` (template_version='v2') but is NOT in `video_pool` — so the recommender (PoolProvider) can't surface it. This PR closes that gap with a batched promotion endpoint.

## Pipeline
1. SELECT 100 candidates: `video_rich_summaries WHERE template_version='v2' AND video_id NOT IN (SELECT video_id FROM video_pool)`
2. JOIN youtube_videos for canonical metadata (title, channel, view_count, ...)
3. INSERT video_pool with quality_tier from completeness:
   - completeness ≥ 0.9 → `gold`
   - else → `silver`
   - source = `'v2_promoted'`
4. Generate embedding via Mac Mini Ollama (`qwen3-embedding:8b`, fail-open if unreachable)
5. INSERT video_pool_embeddings ON CONFLICT DO NOTHING

## Filter strategy (this iteration)
**No filter** — every v2 row is promoted. Future iteration will gate on user-action signals (dismiss/bookmark/watch dwell-time) and redefine the gold/silver thresholds. Spec: CP438 handoff §filter 기준.

## Files
- `src/modules/video-pool/promote-from-v2.ts` — module
- `src/api/routes/internal/video-pool-promote.ts` — POST `/api/v1/internal/video-pool/promote-from-v2`
- `src/api/server.ts` — route registration
- `tests/unit/modules/video-pool/promote-from-v2.test.ts` — 7 unit tests
- `mac-mini/openclaw-handlers/run-promote.sh` — Telegram /promote handler

## Hard Rules
- INSERT only on `video_pool` / `video_pool_embeddings` — no UPDATE, no DELETE
- No paid-LLM API call; embedding is local Mac Mini Ollama
- yt-dlp not invoked from this path (collector-side only)

## Test plan
- [x] `npx tsc --noEmit` PASS
- [x] `npx jest tests/unit/modules/video-pool/promote-from-v2.test.ts` 7/7 PASS
  - zero candidates / gold-silver mapping / source='v2_promoted' / Ollama-down / orphan yt_videos / dry-run / embed count mismatch
- [ ] Post-merge dry-run: `bash run-promote.sh 50` with `PROMOTE_DRY_RUN=1` — expect candidates count, no writes
- [ ] Live: `bash run-promote.sh 100` — verify `video_pool +N` and `video_pool_embeddings +M` (M ≤ N if Ollama reachable)
- [ ] OpenClaw cron decision (every 30min vs after-upsert hook) — defer to next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)