### PR TITLE
feat(transcript): post-upsert auto-promote v2 → video_pool (CP438)

### DIFF
--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -35,6 +35,7 @@ import { logger } from '@/utils/logger';
 import { computeV2Quality } from '@/modules/metrics/v2-quality-metrics';
 import { recordPipelineEvent } from '@/modules/metrics/pipeline-events';
 import { config } from '@/config/index';
+import { promoteV2ToVideoPool } from '@/modules/video-pool/promote-from-v2';
 
 /**
  * Round id stamped onto every pipeline_events payload — sourced from the
@@ -258,6 +259,31 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
           error: err instanceof Error ? err.message : String(err),
         });
       }
+
+      // CP438 — auto-promote this v2 row into video_pool so the recommender
+      // can surface it. Non-blocking: any error here is logged + recorded
+      // to pipeline_events (`stage='promote_from_v2'`) but never breaks
+      // the upsert response. Limit=1 so a single upsert triggers a single
+      // promotion (subsequent v2 backlog is drained by the cron path).
+      setImmediate(() => {
+        promoteV2ToVideoPool({ limit: 1, dryRun: false })
+          .then((result) => {
+            log.info('post-upsert promote done', {
+              videoId,
+              ...result,
+              errors: result.errors.length,
+            });
+          })
+          .catch(async (err) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            log.warn('post-upsert promote failed (non-fatal)', { videoId, error: msg });
+            await recordPipelineEvent({
+              stage: 'promote_from_v2',
+              videoId,
+              payload: { error: msg.slice(0, 500), round: PIPELINE_EVENTS_ROUND },
+            }).catch(() => {});
+          });
+      });
 
       return reply.code(200).send({
         kind: 'pass',


### PR DESCRIPTION
## Summary
Wires upsert-direct success → \`promoteV2ToVideoPool({limit:1})\` hook so each CC-authored v2 row auto-enters the recommender pool without a separate manual call.

## Pattern
- \`setImmediate\` fire-and-forget — non-blocking
- Any failure logs warn + emits \`pipeline_events\` row (\`stage='promote_from_v2'\`)
- Never affects upsert response shape or status
- limit=1 (per-request cost bounded; cron path drains backlog separately)

## Test plan
- [x] \`npx tsc --noEmit\` PASS (no new tests — covered by promoteV2ToVideoPool 7-test suite + transcript-route mock cost)
- [ ] Post-merge smoke: re-run /promote dry-run → expect 0 candidates (already promoted by manual /promote 19)
- [ ] CC v2 author 1 sample → upsert-direct → verify post-upsert auto-promote in logs + video_pool +1 row

## Hard Rules
- INSERT only on video_pool / video_pool_embeddings (no UPDATE / DELETE)
- No paid-LLM API call (embedding via Mac Mini Ollama)
- Failure non-fatal (no impact on upsert success path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)