### PR TITLE
feat(v2-author): batch.sh + process-one.sh (CP438)

### DIFF
--- a/mac-mini/openclaw-handlers/run-v2.sh
+++ b/mac-mini/openclaw-handlers/run-v2.sh
@@ -1,18 +1,12 @@
 #!/bin/bash
-# OpenClaw /v2 N handler (CP438 — placeholder).
+# OpenClaw /v2 N handler (CP438).
+# Dispatches mac-mini/v2-author/batch.sh — yt-dlp → claude -p → upsert-direct.
+# Auto-promote to video_pool fires inside upsert-direct (PR #588 hook).
 #
-# Spec (handoff §5):
-#   1. Fetch top N transcript-ready candidates from EC2
-#      (GET /api/v1/internal/transcript/candidates?limit=N).
-#   2. Mac Mini yt-dlp transcript collection (mac-mini/transcript-collector/collect.ts).
-#   3. CC (Claude Code session) authors v2 layered JSON per video.
-#   4. POST upsert-direct to EC2.
-#   5. Trigger ontology bridge.
-#   6. Telegram report: "v2 완료 N개, S=0.xxx".
-#
-# Step 3 requires Claude Code session on Mac Mini; not yet wired. This
-# handler currently runs only step 1 + step 2 and leaves transcripts in
-# the staging dir for manual CC review.
+# Usage:
+#   bash run-v2.sh           # default N=10
+#   bash run-v2.sh 50        # author 50 v2 summaries this batch
+#   V2_CONCURRENCY=3 bash run-v2.sh 50
 
 set -euo pipefail
 
@@ -21,15 +15,4 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$DIR/_bootstrap.sh"
 
 N="${1:-10}"
-
-echo "[run-v2] phase 1 — fetch transcript candidates (N=$N)"
-TRANSCRIPT_BATCH_SIZE="$N" npx tsx mac-mini/transcript-collector/collect.ts 2>&1 | tail -20
-
-echo ""
-echo "[run-v2] phase 2 — staging dir contents"
-STAGE_DIR="${TRANSCRIPT_OUTPUT_DIR:-/tmp/insighta-transcripts}"
-ls -la "$STAGE_DIR" 2>/dev/null | head -20 || echo "(staging dir empty or missing: $STAGE_DIR)"
-
-echo ""
-echo "[run-v2] CC v2 author + upsert + ontology = manual step (not yet automated)."
-echo "Operator next: open CC session on Mac Mini, run ${INSIGHTA_REPO}/scripts/v2-author-batch.ts (TBD)."
+exec bash "$INSIGHTA_REPO/mac-mini/v2-author/batch.sh" "$N"

--- a/mac-mini/v2-author/batch.sh
+++ b/mac-mini/v2-author/batch.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# v2-author batch dispatcher (CP438).
+# Args: $1 = N (default 10) — number of candidates to author this batch.
+# Concurrency: 5 (tunable via V2_CONCURRENCY env).
+#
+# Pipeline per video: process-one.sh handles yt-dlp → claude -p → upsert-direct.
+# Auto-promote to video_pool fires inside the upsert-direct route (PR #588 hook).
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../openclaw-handlers/_bootstrap.sh
+source "$DIR/../openclaw-handlers/_bootstrap.sh"
+
+N="${1:-10}"
+CONC="${V2_CONCURRENCY:-5}"
+V2_LOG_DIR="${V2_LOG_DIR:-/tmp/insighta-v2-batch}"
+mkdir -p "$V2_LOG_DIR"
+TS="$(date +%Y%m%d-%H%M%S)"
+SUMMARY="$V2_LOG_DIR/summary-$TS.log"
+
+export V2_LOG_DIR INSIGHTA_API_URL INTERNAL_BATCH_TOKEN \
+  WEBSHARE_HOST WEBSHARE_PORT WEBSHARE_USERNAME WEBSHARE_PASSWORD \
+  YTDLP_BIN CLAUDE_BIN
+
+CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.npm-global/bin/claude}"
+export CLAUDE_BIN
+
+echo "[v2-batch] target=$N concurrency=$CONC log_dir=$V2_LOG_DIR" | tee "$SUMMARY"
+echo "[v2-batch] start=$(date -u +%FT%TZ)" | tee -a "$SUMMARY"
+
+# 1. Fetch candidates
+CANDS_JSON=$(curl -sS \
+  "${INSIGHTA_API_URL%/}/api/v1/internal/transcript/candidates?limit=$N" \
+  -H "x-internal-token: ${INTERNAL_BATCH_TOKEN}")
+COUNT=$(printf '%s' "$CANDS_JSON" | jq -r '.videos | length' 2>/dev/null || echo 0)
+
+if [ "$COUNT" = "0" ] || [ -z "$COUNT" ]; then
+  echo "[v2-batch] no candidates available — done" | tee -a "$SUMMARY"
+  exit 0
+fi
+echo "[v2-batch] candidates fetched: $COUNT" | tee -a "$SUMMARY"
+
+# 2. Dispatch concurrently via xargs -P. Each worker = process-one.sh.
+PAIRS=$(printf '%s' "$CANDS_JSON" | jq -r '.videos[] | "\(.youtube_video_id) \(.default_language // "ko")"')
+echo "$PAIRS" | xargs -n 2 -P "$CONC" -I {} bash -c 'eval set -- {}; "'"$DIR"'/process-one.sh" "$1" "$2"' || true
+
+# 3. Aggregate per-video result lines.
+PASS=$(grep -h ' pass ' "$V2_LOG_DIR"/*.log 2>/dev/null | wc -l | tr -d ' ')
+NO_CAP=$(grep -h ' no_caption' "$V2_LOG_DIR"/*.log 2>/dev/null | wc -l | tr -d ' ')
+INV_JSON=$(grep -h ' claude_invalid_json' "$V2_LOG_DIR"/*.log 2>/dev/null | wc -l | tr -d ' ')
+UP_FAIL=$(grep -h ' upsert_failed' "$V2_LOG_DIR"/*.log 2>/dev/null | wc -l | tr -d ' ')
+
+cat <<EOF | tee -a "$SUMMARY"
+[v2-batch] done=$(date -u +%FT%TZ)
+[v2-batch] candidates=$COUNT pass=$PASS no_caption=$NO_CAP claude_invalid_json=$INV_JSON upsert_failed=$UP_FAIL
+EOF

--- a/mac-mini/v2-author/process-one.sh
+++ b/mac-mini/v2-author/process-one.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Process ONE video: yt-dlp transcript → claude -p (v2 schema) → POST upsert-direct.
+# Args: $1 = youtube_video_id  $2 = source_language (ko|en)
+# Env: INSIGHTA_API_URL / INTERNAL_BATCH_TOKEN / WEBSHARE_* (sourced by caller)
+# Exit 0 = pass, 1 = no_caption, 2 = claude_invalid_json, 3 = upsert_failed
+# stdout: single line "[<vid>] <result>" suitable for batch.sh aggregation.
+
+set -uo pipefail
+
+VID="$1"
+LANG="${2:-ko}"
+LOG_DIR="${V2_LOG_DIR:-/tmp/insighta-v2-batch}"
+mkdir -p "$LOG_DIR"
+
+YTDLP_BIN="${YTDLP_BIN:-/opt/homebrew/bin/yt-dlp}"
+PROXY="http://${WEBSHARE_USERNAME}:${WEBSHARE_PASSWORD}@${WEBSHARE_HOST}:${WEBSHARE_PORT}"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# 1. yt-dlp auto-subs
+"$YTDLP_BIN" \
+  --write-auto-subs --sub-format vtt --sub-lang "$LANG" --skip-download \
+  --proxy "$PROXY" --socket-timeout 20 \
+  -o "$TMP/%(id)s.%(ext)s" \
+  "https://www.youtube.com/watch?v=$VID" >"$TMP/ytdlp.log" 2>&1 || true
+
+VTT=$(ls "$TMP"/*.vtt 2>/dev/null | head -1)
+if [ -z "$VTT" ]; then
+  echo "[$VID] no_caption" | tee "$LOG_DIR/$VID.log"
+  exit 1
+fi
+
+# 2. Strip VTT timing → plain text. Dedupe consecutive identical lines (auto-caps cue artifacts).
+TRANSCRIPT=$(awk '
+  /^WEBVTT/ || /^Kind:/ || /^Language:/ || /^[0-9]+:[0-9]+/ || /-->/ || /^align:/ || /^position:/ { next }
+  /^$/ { next }
+  { gsub(/<[^>]*>/, ""); gsub(/&nbsp;/, " "); print }
+' "$VTT" | awk '!seen[$0]++' | head -c 30000)
+
+if [ ${#TRANSCRIPT} -lt 200 ]; then
+  echo "[$VID] no_caption (transcript too short: ${#TRANSCRIPT} chars)" | tee "$LOG_DIR/$VID.log"
+  exit 1
+fi
+
+# 3. Build prompt + invoke claude -p
+PROMPT_HEADER='You are a JSON authoring tool for Insighta. Author a strict v2 layered JSON for the YouTube video below from its transcript.
+
+Schema (no extra keys, no markdown fences, JSON only):
+{
+  "core": {
+    "one_liner": string (under 40 chars, ko or en),
+    "domain": "tech"|"learning"|"health"|"business"|"finance"|"social"|"creative"|"lifestyle"|"mind",
+    "depth_level": "beginner"|"intermediate"|"advanced",
+    "content_type": "tutorial"|"explainer"|"case_study"|"review"|"discussion"|"vlog"|"news",
+    "target_audience": string
+  },
+  "analysis": {
+    "core_argument": string (1 sentence, hand-authored summary),
+    "key_concepts": [{"term": string, "definition": string}, ...],
+    "actionables": [string, ...],
+    "mandala_fit": {"suggested_goals": [string, ...], "relevance_rationale": string},
+    "bias_signals": {"has_ad": bool, "is_sponsored": bool, "subjectivity_level": "low"|"medium"|"high", "notes": string},
+    "prerequisites": string
+  },
+  "segments": {
+    "sections": [{"idx": int, "title": string, "from_sec": int, "to_sec": int, "summary": string}, ...],
+    "atoms": [{"idx": int, "type": "fact"|"tip"|"argument", "text": string, "timestamp_sec": int}, ...]
+  },
+  "lora": {
+    "qa_pairs": [{"level": 1|2|3, "q": string, "a": string, "context": "video"|"general"}, ...]
+  }
+}
+
+Rules:
+- completeness must be ≥0.9: 4+ key_concepts, 4+ actionables, 4+ sections, 4+ atoms, 4+ qa_pairs.
+- timestamp_sec / from_sec / to_sec are integers in seconds (NOT mm:ss).
+- Output JSON only — no preamble, no markdown.
+'
+
+CLAUDE_BIN="${CLAUDE_BIN:-$(which claude 2>/dev/null || echo "$HOME/.npm-global/bin/claude")}"
+
+V2_JSON=$(printf '%s\n\nVideo: %s\nLanguage: %s\nTranscript:\n%s\n' "$PROMPT_HEADER" "$VID" "$LANG" "$TRANSCRIPT" \
+  | "$CLAUDE_BIN" -p 2>"$LOG_DIR/$VID.claude.err")
+
+# Strip optional markdown fences if claude added them despite instructions.
+V2_JSON=$(printf '%s' "$V2_JSON" | sed -e 's/^```json//' -e 's/^```//' -e 's/```$//' | sed '/^$/d')
+
+if ! printf '%s' "$V2_JSON" | jq -e . >/dev/null 2>&1; then
+  echo "[$VID] claude_invalid_json" | tee "$LOG_DIR/$VID.log"
+  printf '%s' "$V2_JSON" | head -c 500 > "$LOG_DIR/$VID.invalid.json"
+  exit 2
+fi
+
+# 4. POST upsert-direct
+PAYLOAD=$(printf '%s' "$V2_JSON" | jq -c \
+  --arg vid "$VID" --arg lang "$LANG" \
+  '{videoId: $vid, sourceLanguage: $lang, stampTranscriptFetchedAt: true, core, analysis, lora, segments}')
+
+RESP=$(printf '%s' "$PAYLOAD" | curl -sS \
+  -X POST "${INSIGHTA_API_URL%/}/api/v1/internal/v2-summary/upsert-direct" \
+  -H "x-internal-token: ${INTERNAL_BATCH_TOKEN}" \
+  -H 'content-type: application/json' \
+  --data-binary @-)
+
+if printf '%s' "$RESP" | jq -e '.kind == "pass"' >/dev/null 2>&1; then
+  COMP=$(printf '%s' "$RESP" | jq -r '.completeness')
+  echo "[$VID] pass completeness=$COMP" | tee "$LOG_DIR/$VID.log"
+  exit 0
+else
+  ERR=$(printf '%s' "$RESP" | jq -r '.error // "unknown"' 2>/dev/null || echo "unparseable")
+  echo "[$VID] upsert_failed err=$ERR" | tee "$LOG_DIR/$VID.log"
+  printf '%s' "$RESP" | head -c 500 >> "$LOG_DIR/$VID.log"
+  exit 3
+fi


### PR DESCRIPTION
Mac Mini v2 author pipeline:

- `process-one.sh` — yt-dlp (WebShare) → `claude -p` (v2 schema) → POST upsert-direct. Auto-promote via PR #588 hook.
- `batch.sh` — concurrent dispatcher (5 workers). Returns pass/no_caption/invalid_json/upsert_failed summary.
- `run-v2.sh` — OpenClaw handler replaces phase-1 stub.

Telegram `/v2 N` → OpenClaw agent → batch.sh → N v2 rows authored + auto-promoted to video_pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)