### PR TITLE
fix(transcript): candidates LEFT JOIN + upsert-direct upsert (CP438)

### DIFF
--- a/mac-mini/v2-author/process-one.sh
+++ b/mac-mini/v2-author/process-one.sh
@@ -79,8 +79,14 @@ Rules:
 
 CLAUDE_BIN="${CLAUDE_BIN:-$(which claude 2>/dev/null || echo "$HOME/.npm-global/bin/claude")}"
 
+# `claude -p` MUST authenticate via the user's CC subscription (OAuth in
+# keychain). If ANTHROPIC_API_KEY is set in the environment, claude CLI
+# uses that API key path instead — and the prod ANTHROPIC_API_KEY env on
+# Mac Mini has no active billing → "Invalid API key · Fix external API
+# key" returned and every call silently fails. Strip the env so OAuth
+# wins (CP438 — 2026-04-30 batch incident: 1,527/1,540 invalid_json).
 V2_JSON=$(printf '%s\n\nVideo: %s\nLanguage: %s\nTranscript:\n%s\n' "$PROMPT_HEADER" "$VID" "$LANG" "$TRANSCRIPT" \
-  | "$CLAUDE_BIN" -p 2>"$LOG_DIR/$VID.claude.err")
+  | env -u ANTHROPIC_API_KEY "$CLAUDE_BIN" -p 2>"$LOG_DIR/$VID.claude.err")
 
 # Strip optional markdown fences if claude added them despite instructions.
 V2_JSON=$(printf '%s' "$V2_JSON" | sed -e 's/^```json//' -e 's/^```//' -e 's/```$//' | sed '/^$/d')

--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -72,16 +72,15 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
       );
 
       // Candidate selector (CP438 — v2-author batch driver):
-      //   vrs.template_version = 'v1'       — needs v2 upgrade
-      //   transcript_fetched_at: NOT a filter (CP437 left it as gate, but
-      //     legacy transcript-collector cron stamped 1,520/1,521 v1 rows
-      //     without producing v2 — gating on it eliminated them as
-      //     candidates and dropped the pool to 1. Removed so CC v2-author
-      //     can revisit them. process-one.sh will re-run yt-dlp; if no
-      //     captions it skips and the row stays as v1).
-      //   has_caption tolerance: not enforced (column is NULL on the
-      //     entire prod table because the YT-API backfill cron is OFF per
-      //     the no-API Hard Rule).
+      //   LEFT JOIN video_rich_summaries — include yv rows w/ no summary at
+      //     all (newly collected by Mac Mini collect-trending.ts since
+      //     CP438; in prod 5,462 / 7,009 rows on 2026-04-30). INNER JOIN
+      //     was the original CP437 bug — only 1,503 v1 rows surfaced as
+      //     candidates while 5,462 fresh videos were silently invisible.
+      //   vrs.video_id IS NULL    — fresh yv with no summary → author v2 fresh
+      //   vrs.template_version='v1' — existing v1 row → upgrade to v2
+      //   transcript_fetched_at: NOT a filter (CP437/CP438 both dropped it).
+      //   has_caption: NOT a filter (column always NULL — YT-API backfill OFF).
       //   ordered by bookmark presence then view_count (high-engagement first).
       const prisma = getPrismaClient();
       const rows = await prisma.$queryRaw<CandidateRow[]>(Prisma.sql`
@@ -90,14 +89,14 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
         yv.default_language,
         yv.has_caption
       FROM youtube_videos yv
-      JOIN video_rich_summaries vrs ON vrs.video_id = yv.youtube_video_id
+      LEFT JOIN video_rich_summaries vrs ON vrs.video_id = yv.youtube_video_id
       LEFT JOIN (
         SELECT yv2.youtube_video_id, COUNT(*) AS bookmark_count
         FROM user_video_states uvs
         JOIN youtube_videos yv2 ON yv2.id = uvs.video_id
         GROUP BY yv2.youtube_video_id
       ) book ON book.youtube_video_id = yv.youtube_video_id
-      WHERE vrs.template_version = 'v1'
+      WHERE vrs.video_id IS NULL OR vrs.template_version = 'v1'
       ORDER BY
         (COALESCE(book.bookmark_count, 0) > 0) DESC,
         yv.view_count DESC NULLS LAST
@@ -176,9 +175,12 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
     const prisma = getPrismaClient();
     const now = new Date();
     try {
-      await prisma.video_rich_summaries.update({
+      // upsert (not update) — selector (LEFT JOIN, vrs.video_id IS NULL)
+      // surfaces newly-collected yv rows that have no summary yet, so this
+      // path must INSERT as well as UPDATE.
+      await prisma.video_rich_summaries.upsert({
         where: { video_id: videoId },
-        data: {
+        update: {
           template_version: 'v2',
           core: summary.core as unknown as PrismaCli.InputJsonValue,
           analysis: summary.analysis as unknown as PrismaCli.InputJsonValue,
@@ -190,6 +192,23 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
           ...(body.sourceLanguage === 'ko' || body.sourceLanguage === 'en'
             ? { source_language: body.sourceLanguage }
             : {}),
+          updated_at: now,
+        },
+        create: {
+          video_id: videoId,
+          tier_required: 'free',
+          template_version: 'v2',
+          core: summary.core as unknown as PrismaCli.InputJsonValue,
+          analysis: summary.analysis as unknown as PrismaCli.InputJsonValue,
+          lora: summary.lora as unknown as PrismaCli.InputJsonValue,
+          ...(body.segments ? { segments: body.segments as PrismaCli.InputJsonValue } : {}),
+          completeness: score.score,
+          quality_flag: 'pass',
+          model: 'claude-code-direct',
+          ...(body.sourceLanguage === 'ko' || body.sourceLanguage === 'en'
+            ? { source_language: body.sourceLanguage }
+            : {}),
+          created_at: now,
           updated_at: now,
         },
       });


### PR DESCRIPTION
## Summary
- Selector: INNER JOIN → LEFT JOIN; WHERE adds `vrs.video_id IS NULL`. PR #579 introduced the INNER JOIN; 5,462 / 7,009 fresh yt videos were silently invisible.
- `upsert-direct` route: `update` → `upsert` (must INSERT for new yv rows surfaced by the fixed selector).

## Prod evidence (2026-04-30)
```
yv_total=7009  vrs_v1=1503  vrs_v2=44  yv_no_vrs=5462
```

## Test plan
- [ ] CI tsc + jest + build pass
- [ ] Deploy → smoke `/transcript/candidates?limit=3` returns rows for both v1 + null cases
- [ ] Mac Mini batch run → v2 count grows beyond +44 against the 5,462 fresh pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)