### PR TITLE
fix(v2-author): sync process-one.sh prompt to SSOT + duration filter (CP438)

### DIFF
--- a/mac-mini/v2-author/process-one.sh
+++ b/mac-mini/v2-author/process-one.sh
@@ -43,38 +43,49 @@ if [ ${#TRANSCRIPT} -lt 200 ]; then
 fi
 
 # 3. Build prompt + invoke claude -p
+# Schema synced to src/modules/skills/rich-summary-v2-prompt.ts SSOT (CP438):
+#   content_type:  tutorial | lecture | vlog | interview | documentary | review (NOT explainer/case_study/discussion/news)
+#   one_liner:     ≤ 20 chars (NOT 40)
+#   qa context:    video | mandala_cell | mandala_mesh (NOT general)
+#   PASS_THRESHOLD = 0.7; MIN_KEY_CONCEPTS=3, MIN_ACTIONABLES=3, MIN_QA_PAIRS_L1=5
+# Drift prior to this fix caused completeness penalty + occasional 422 reject.
 PROMPT_HEADER='You are a JSON authoring tool for Insighta. Author a strict v2 layered JSON for the YouTube video below from its transcript.
 
 Schema (no extra keys, no markdown fences, JSON only):
 {
   "core": {
-    "one_liner": string (under 40 chars, ko or en),
+    "one_liner": string (≤ 20 chars, in source language),
     "domain": "tech"|"learning"|"health"|"business"|"finance"|"social"|"creative"|"lifestyle"|"mind",
     "depth_level": "beginner"|"intermediate"|"advanced",
-    "content_type": "tutorial"|"explainer"|"case_study"|"review"|"discussion"|"vlog"|"news",
+    "content_type": "tutorial"|"lecture"|"vlog"|"interview"|"documentary"|"review",
     "target_audience": string
   },
   "analysis": {
-    "core_argument": string (1 sentence, hand-authored summary),
-    "key_concepts": [{"term": string, "definition": string}, ...],
-    "actionables": [string, ...],
-    "mandala_fit": {"suggested_goals": [string, ...], "relevance_rationale": string},
+    "core_argument": string (2-3 sentences capturing the central thesis),
+    "key_concepts": [{"term": string, "definition": string}, ... 3-5 entries],
+    "actionables": [string, ... 3-5 entries, each a single imperative sentence],
+    "mandala_fit": {"suggested_goals": [string, ... 2-4 phrases], "relevance_rationale": string},
     "bias_signals": {"has_ad": bool, "is_sponsored": bool, "subjectivity_level": "low"|"medium"|"high", "notes": string},
     "prerequisites": string
   },
   "segments": {
-    "sections": [{"idx": int, "title": string, "from_sec": int, "to_sec": int, "summary": string}, ...],
-    "atoms": [{"idx": int, "type": "fact"|"tip"|"argument", "text": string, "timestamp_sec": int}, ...]
+    "sections": [{"idx": int, "title": string, "from_sec": int, "to_sec": int, "summary": string}, ... 4+ entries],
+    "atoms": [{"idx": int, "type": "fact"|"tip"|"argument", "text": string, "timestamp_sec": int}, ... 4+ entries]
   },
   "lora": {
-    "qa_pairs": [{"level": 1|2|3, "q": string, "a": string, "context": "video"|"general"}, ...]
+    "qa_pairs": [{"level": 1, "q": string, "a": string, "context": "video"}, ... 5-7 entries, all level=1, all context="video"]
   }
 }
 
 Rules:
-- completeness must be ≥0.9: 4+ key_concepts, 4+ actionables, 4+ sections, 4+ atoms, 4+ qa_pairs.
+- core.one_liner: ≤ 20 chars, no quotes, no trailing punctuation.
+- core.domain MUST be one of the 9 slugs above.
+- core.content_type MUST be one of the 6 enum values above.
+- analysis.actionables: each a single imperative sentence the viewer can do today.
+- lora.qa_pairs: 5-7 entries, all level=1, all context="video".
 - timestamp_sec / from_sec / to_sec are integers in seconds (NOT mm:ss).
-- Output JSON only — no preamble, no markdown.
+- Use the source language consistently across every string field.
+- Output JSON only — no preamble, no markdown fences, no commentary.
 '
 
 CLAUDE_BIN="${CLAUDE_BIN:-$(which claude 2>/dev/null || echo "$HOME/.npm-global/bin/claude")}"

--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -79,6 +79,11 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
       //     candidates while 5,462 fresh videos were silently invisible.
       //   vrs.video_id IS NULL    — fresh yv with no summary → author v2 fresh
       //   vrs.template_version='v1' — existing v1 row → upgrade to v2
+      //   duration_seconds > 180  — drop YouTube Shorts / music clips. Top
+      //     view_count rows skew heavily to <60s viral content with no
+      //     captions or only [Music]/[Applause] fillers; first MacBook batch
+      //     (CP438 2026-04-30) hit 7/11 no_caption from these. NULL allowed
+      //     (collector batches that did not capture duration get a pass).
       //   transcript_fetched_at: NOT a filter (CP437/CP438 both dropped it).
       //   has_caption: NOT a filter (column always NULL — YT-API backfill OFF).
       //   ordered by bookmark presence then view_count (high-engagement first).
@@ -96,7 +101,8 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
         JOIN youtube_videos yv2 ON yv2.id = uvs.video_id
         GROUP BY yv2.youtube_video_id
       ) book ON book.youtube_video_id = yv.youtube_video_id
-      WHERE vrs.video_id IS NULL OR vrs.template_version = 'v1'
+      WHERE (vrs.video_id IS NULL OR vrs.template_version = 'v1')
+        AND (yv.duration_seconds IS NULL OR yv.duration_seconds > 180)
       ORDER BY
         (COALESCE(book.bookmark_count, 0) > 0) DESC,
         yv.view_count DESC NULLS LAST


### PR DESCRIPTION
## Summary
- `mac-mini/v2-author/process-one.sh`: sync prompt header to `src/modules/skills/rich-summary-v2-prompt.ts` SSOT (content_type 6-enum, one_liner ≤20, qa context strict, MIN values).
- `transcript/candidates`: add `duration_seconds > 180 OR IS NULL` to drop high-view Shorts/music clips (CP438 first batch hit 7/11 no_caption from these).

## Evidence (2026-04-30)
- Pool size with filter: 6,964 → 6,799 (165 sub-180s shorts dropped, 186 NULL preserved).
- First MacBook agent sample (KrF3cYdcT1A) passed completeness=0.9 with the OLD prompt — confirms the schema mismatch was a degradation, not a hard reject. SSOT-sync should lift baseline pass rate from ~12% (CP438 batch) to ~25-35%.

## Test plan
- [ ] CI tsc + jest + build pass
- [ ] Deploy → smoke `/transcript/candidates?limit=10` returns no rows with `duration_seconds < 180`
- [ ] Mac Mini batch (`bash batch.sh 10`) → completeness scores skew ≥ 0.9 with new prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)