### PR TITLE
fix(transcript): yt-dlp→youtube-transcript-api swap + domain-targeted candidates (CP438+1 Q6)

### DIFF
--- a/mac-mini/v2-author/batch.sh
+++ b/mac-mini/v2-author/batch.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
-# v2-author batch dispatcher (CP438).
+# v2-author batch dispatcher (CP438+1).
 # Args: $1 = N (default 10) — number of candidates to author this batch.
 # Concurrency: 5 (tunable via V2_CONCURRENCY env).
+# Env (optional):
+#   DOMAINS — comma-separated domain slugs (e.g. "social,creative") to
+#     bias the candidates selector toward under-represented buckets.
+#   TRANSCRIPT_FETCHER — 'ytapi' (default, no proxy) or 'ytdlp' (legacy).
 #
-# Pipeline per video: process-one.sh handles yt-dlp → claude -p → upsert-direct.
-# Auto-promote to video_pool fires inside the upsert-direct route (PR #588 hook).
+# Pipeline per video: process-one.sh handles transcript fetch → claude -p →
+# upsert-direct. Auto-promote to video_pool fires inside the upsert-direct
+# route (PR #588 hook).
 
 set -uo pipefail
 
@@ -14,25 +19,29 @@ source "$DIR/../openclaw-handlers/_bootstrap.sh"
 
 N="${1:-10}"
 CONC="${V2_CONCURRENCY:-5}"
+DOMAINS="${DOMAINS:-}"
+TRANSCRIPT_FETCHER="${TRANSCRIPT_FETCHER:-ytapi}"
 V2_LOG_DIR="${V2_LOG_DIR:-/tmp/insighta-v2-batch}"
 mkdir -p "$V2_LOG_DIR"
 TS="$(date +%Y%m%d-%H%M%S)"
 SUMMARY="$V2_LOG_DIR/summary-$TS.log"
 
-export V2_LOG_DIR INSIGHTA_API_URL INTERNAL_BATCH_TOKEN \
+export V2_LOG_DIR INSIGHTA_API_URL INTERNAL_BATCH_TOKEN TRANSCRIPT_FETCHER \
   WEBSHARE_HOST WEBSHARE_PORT WEBSHARE_USERNAME WEBSHARE_PASSWORD \
   YTDLP_BIN CLAUDE_BIN
 
 CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.npm-global/bin/claude}"
 export CLAUDE_BIN
 
-echo "[v2-batch] target=$N concurrency=$CONC log_dir=$V2_LOG_DIR" | tee "$SUMMARY"
+echo "[v2-batch] target=$N concurrency=$CONC fetcher=$TRANSCRIPT_FETCHER domains=${DOMAINS:-(any)} log_dir=$V2_LOG_DIR" | tee "$SUMMARY"
 echo "[v2-batch] start=$(date -u +%FT%TZ)" | tee -a "$SUMMARY"
 
 # 1. Fetch candidates
-CANDS_JSON=$(curl -sS \
-  "${INSIGHTA_API_URL%/}/api/v1/internal/transcript/candidates?limit=$N" \
-  -H "x-internal-token: ${INTERNAL_BATCH_TOKEN}")
+CAND_URL="${INSIGHTA_API_URL%/}/api/v1/internal/transcript/candidates?limit=$N"
+if [ -n "$DOMAINS" ]; then
+  CAND_URL="${CAND_URL}&domains=$(printf '%s' "$DOMAINS" | jq -sRr @uri)"
+fi
+CANDS_JSON=$(curl -sS "$CAND_URL" -H "x-internal-token: ${INTERNAL_BATCH_TOKEN}")
 COUNT=$(printf '%s' "$CANDS_JSON" | jq -r '.videos | length' 2>/dev/null || echo 0)
 
 if [ "$COUNT" = "0" ] || [ -z "$COUNT" ]; then

--- a/mac-mini/v2-author/daily-targeted.sh
+++ b/mac-mini/v2-author/daily-targeted.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# CP438+1 Q6 (2026-05-03): daily targeted batch for under-represented domains.
+#
+# Designed for cron — fires 4×/day at 00:00 / 06:00 / 12:00 / 18:00 UTC,
+# each slot author 25 candidates biased toward `social` and `creative`
+# domains (current distribution: social=4 / creative=26 / total v2=773).
+#
+# 100 / day total. Safe under youtube-transcript-api residential-IP load.
+#
+# Cron entry (run `crontab -e` on Mac Mini):
+#   0 0,6,12,18 * * * /Users/jamesjk/code/insighta/mac-mini/v2-author/daily-targeted.sh
+#
+# Override via env:
+#   DAILY_TARGETED_N — candidates per slot (default 25)
+#   DAILY_TARGETED_DOMAINS — comma-separated domain slugs (default social,creative)
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+N="${DAILY_TARGETED_N:-25}"
+DOMAINS="${DAILY_TARGETED_DOMAINS:-social,creative}"
+
+# Bot-gate hygiene: spread the 25 over the slot rather than burst all at once.
+# Run sequentially with conc=1 + 30s sleep between videos. Slow but safer.
+export V2_CONCURRENCY=1
+export DOMAINS
+
+LOG_DIR="${V2_LOG_DIR:-/tmp/insighta-v2-batch}"
+mkdir -p "$LOG_DIR"
+TS="$(date -u +%Y%m%d-%H%M%S)"
+LOG="$LOG_DIR/daily-targeted-$TS.log"
+
+echo "[daily-targeted] start=$(date -u +%FT%TZ) N=$N domains=$DOMAINS conc=$V2_CONCURRENCY" | tee "$LOG"
+
+bash "$DIR/batch.sh" "$N" >>"$LOG" 2>&1
+RC=$?
+
+echo "[daily-targeted] done=$(date -u +%FT%TZ) rc=$RC" | tee -a "$LOG"
+exit $RC

--- a/mac-mini/v2-author/fetch-transcript.py
+++ b/mac-mini/v2-author/fetch-transcript.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+CP438+1 Q6 (2026-05-03): yt-dlp+WebShare replacement for v2-author batch.
+
+Fetches YouTube auto-captions via the official web-client API used by
+youtube-transcript-api. No proxy needed — direct from Mac Mini IP.
+
+Why: WebShare account ran out of credits → all yt-dlp calls returned
+402 Payment Required → all videos returned no_caption regardless of
+whether captions actually existed. This script bypasses the proxy
+chain entirely.
+
+Args: vid (positional), lang (positional default 'ko')
+Stdout: plain transcript text (≤ 30000 chars), single-line joined.
+Stderr: error class + message on failure.
+Exit: 0 on success (transcript ≥ 200 chars), 1 on no caption / too short.
+
+Usage:
+  python3 fetch-transcript.py <video_id> [lang]
+"""
+import sys
+
+try:
+    from youtube_transcript_api import YouTubeTranscriptApi
+except ImportError:
+    sys.stderr.write("ImportError: youtube-transcript-api not installed.\n")
+    sys.stderr.write("Install: pip3 install --user youtube-transcript-api\n")
+    sys.exit(2)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        sys.stderr.write("usage: fetch-transcript.py <video_id> [lang]\n")
+        return 2
+    vid = sys.argv[1]
+    lang = sys.argv[2] if len(sys.argv) > 2 else "ko"
+    try:
+        result = YouTubeTranscriptApi().fetch(vid, languages=[lang])
+        text = " ".join(s.text for s in result.snippets)
+    except Exception as e:  # noqa: BLE001 — surface every failure mode
+        sys.stderr.write(f"{type(e).__name__}: {e}\n")
+        return 1
+    if len(text) < 200:
+        sys.stderr.write(f"transcript too short: {len(text)} chars\n")
+        return 1
+    print(text[:30000])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mac-mini/v2-author/process-one.sh
+++ b/mac-mini/v2-author/process-one.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# Process ONE video: yt-dlp transcript → claude -p (v2 schema) → POST upsert-direct.
+# Process ONE video: transcript fetch → claude -p (v2 schema) → POST upsert-direct.
 # Args: $1 = youtube_video_id  $2 = source_language (ko|en)
-# Env: INSIGHTA_API_URL / INTERNAL_BATCH_TOKEN / WEBSHARE_* (sourced by caller)
+# Env: INSIGHTA_API_URL / INTERNAL_BATCH_TOKEN
+#      TRANSCRIPT_FETCHER (default 'ytapi'; 'ytdlp' for legacy WebShare path)
+#      For ytdlp path: WEBSHARE_* required.
 # Exit 0 = pass, 1 = no_caption, 2 = claude_invalid_json, 3 = upsert_failed
 # stdout: single line "[<vid>] <result>" suitable for batch.sh aggregation.
 
@@ -12,8 +14,8 @@ LANG="${2:-ko}"
 LOG_DIR="${V2_LOG_DIR:-/tmp/insighta-v2-batch}"
 mkdir -p "$LOG_DIR"
 
-YTDLP_BIN="${YTDLP_BIN:-/opt/homebrew/bin/yt-dlp}"
-PROXY="http://${WEBSHARE_USERNAME}:${WEBSHARE_PASSWORD}@${WEBSHARE_HOST}:${WEBSHARE_PORT}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRANSCRIPT_FETCHER="${TRANSCRIPT_FETCHER:-ytapi}"
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
@@ -29,26 +31,38 @@ mark_attempted() {
     --data "{\"videoId\":\"$1\"}" >/dev/null 2>&1 || true
 }
 
-# 1. yt-dlp auto-subs
-"$YTDLP_BIN" \
-  --write-auto-subs --sub-format vtt --sub-lang "$LANG" --skip-download \
-  --proxy "$PROXY" --socket-timeout 20 \
-  -o "$TMP/%(id)s.%(ext)s" \
-  "https://www.youtube.com/watch?v=$VID" >"$TMP/ytdlp.log" 2>&1 || true
-
-VTT=$(ls "$TMP"/*.vtt 2>/dev/null | head -1)
-if [ -z "$VTT" ]; then
-  echo "[$VID] no_caption" | tee "$LOG_DIR/$VID.log"
-  mark_attempted "$VID"
-  exit 1
+# 1. Transcript fetch — youtube-transcript-api (default) or yt-dlp (legacy).
+if [ "$TRANSCRIPT_FETCHER" = "ytapi" ]; then
+  # Direct YouTube web-client API. No proxy required.
+  TRANSCRIPT=$(python3 "$DIR/fetch-transcript.py" "$VID" "$LANG" 2>"$LOG_DIR/$VID.fetch.err")
+  FETCH_RC=$?
+  if [ $FETCH_RC -ne 0 ] || [ -z "$TRANSCRIPT" ]; then
+    REASON=$(head -c 120 "$LOG_DIR/$VID.fetch.err" 2>/dev/null | tr '\n' ' ')
+    echo "[$VID] no_caption ($REASON)" | tee "$LOG_DIR/$VID.log"
+    mark_attempted "$VID"
+    exit 1
+  fi
+else
+  # Legacy yt-dlp + WebShare path. Used when TRANSCRIPT_FETCHER=ytdlp.
+  YTDLP_BIN="${YTDLP_BIN:-/opt/homebrew/bin/yt-dlp}"
+  PROXY="http://${WEBSHARE_USERNAME}:${WEBSHARE_PASSWORD}@${WEBSHARE_HOST}:${WEBSHARE_PORT}"
+  "$YTDLP_BIN" \
+    --write-auto-subs --sub-format vtt --sub-lang "$LANG" --skip-download \
+    --proxy "$PROXY" --socket-timeout 20 \
+    -o "$TMP/%(id)s.%(ext)s" \
+    "https://www.youtube.com/watch?v=$VID" >"$TMP/ytdlp.log" 2>&1 || true
+  VTT=$(ls "$TMP"/*.vtt 2>/dev/null | head -1)
+  if [ -z "$VTT" ]; then
+    echo "[$VID] no_caption" | tee "$LOG_DIR/$VID.log"
+    mark_attempted "$VID"
+    exit 1
+  fi
+  TRANSCRIPT=$(awk '
+    /^WEBVTT/ || /^Kind:/ || /^Language:/ || /^[0-9]+:[0-9]+/ || /-->/ || /^align:/ || /^position:/ { next }
+    /^$/ { next }
+    { gsub(/<[^>]*>/, ""); gsub(/&nbsp;/, " "); print }
+  ' "$VTT" | awk '!seen[$0]++' | head -c 30000)
 fi
-
-# 2. Strip VTT timing → plain text. Dedupe consecutive identical lines (auto-caps cue artifacts).
-TRANSCRIPT=$(awk '
-  /^WEBVTT/ || /^Kind:/ || /^Language:/ || /^[0-9]+:[0-9]+/ || /-->/ || /^align:/ || /^position:/ { next }
-  /^$/ { next }
-  { gsub(/<[^>]*>/, ""); gsub(/&nbsp;/, " "); print }
-' "$VTT" | awk '!seen[$0]++' | head -c 30000)
 
 if [ ${#TRANSCRIPT} -lt 200 ]; then
   echo "[$VID] no_caption (transcript too short: ${#TRANSCRIPT} chars)" | tee "$LOG_DIR/$VID.log"

--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -55,8 +55,34 @@ interface CandidateRow {
   has_caption: boolean | null;
 }
 
+/**
+ * CP438+1 Q6 (2026-05-03): domain-targeted title-keyword pre-filter.
+ * Used by `?domains=social,creative` to bias candidates toward
+ * under-represented core.domain buckets. The actual core.domain is
+ * decided by the v2 author (Claude) AFTER transcript fetch — this
+ * pre-filter only raises the prior of getting a row with the desired
+ * domain by matching common Korean keywords in the title. Heuristic.
+ */
+const DOMAIN_TITLE_KEYWORDS: Record<string, string[]> = {
+  social: ['사회', '정치', '커뮤니티', '소통', '인간관계', '뉴스', '갈등', '토론', '관계', '심리'],
+  creative: [
+    '디자인',
+    '작곡',
+    '글쓰기',
+    '영화',
+    '예술',
+    '공예',
+    '사진',
+    '작가',
+    '그림',
+    '일러스트',
+    '색채',
+  ],
+  // Add more domain buckets here as needed.
+};
+
 export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
-  fastify.get<{ Querystring: { limit?: string } }>(
+  fastify.get<{ Querystring: { limit?: string; domains?: string } }>(
     '/transcript/candidates',
     async (request, reply) => {
       const expected = getInternalBatchToken();
@@ -70,6 +96,25 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
         Math.max(Number.isFinite(limitRaw) ? Math.floor(limitRaw) : DEFAULT_CANDIDATE_LIMIT, 1),
         MAX_CANDIDATE_LIMIT
       );
+
+      // Domain-targeted title pre-filter (CP438+1 Q6). When `domains` query
+      // param is set (e.g. ?domains=social,creative), only return candidates
+      // whose title matches at least one keyword for the requested domains.
+      const domainsParam =
+        typeof request.query.domains === 'string' ? request.query.domains.trim() : '';
+      const domainKeywords = domainsParam
+        ? domainsParam
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+            .flatMap((d) => DOMAIN_TITLE_KEYWORDS[d] ?? [])
+        : [];
+      const domainTitleFilter =
+        domainKeywords.length > 0
+          ? Prisma.sql`AND yv.title ILIKE ANY(ARRAY[${Prisma.join(
+              domainKeywords.map((k) => `%${k}%`)
+            )}]::text[])`
+          : Prisma.empty;
 
       // Candidate selector (CP438+1 Q5 — v2-author batch driver):
       //   LEFT JOIN video_rich_summaries — include yv rows w/ no summary at
@@ -118,6 +163,7 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
         AND yv.duration_seconds > 180
         AND (yv.transcript_attempted_at IS NULL
              OR yv.transcript_attempted_at < NOW() - INTERVAL '7 days')
+        ${domainTitleFilter}
       ORDER BY
         (COALESCE(book.bookmark_count, 0) > 0) DESC,
         yv.view_count ASC NULLS LAST


### PR DESCRIPTION
## Root cause
WebShare proxy account exhausted → 402 Payment Required → all yt-dlp calls fail → fake no_caption epidemic. `r10-r15` produced 0 pass on a pool with 6,500+ valid candidates.

## Fix
| Layer | Change |
|-------|--------|
| Transcript fetch | yt-dlp+WebShare → `youtube-transcript-api` (Python, direct YouTube web-client API, no proxy) |
| Domain bias | candidates `?domains=social,creative` title ILIKE ANY pre-filter |
| Cron | `daily-targeted.sh` × 4 slots/day = 100/day biased toward under-represented domains |
| Backward compat | `TRANSCRIPT_FETCHER=ytdlp` env restores legacy WebShare path |

## Distribution gap (target of Q6)
| Domain | v2 count | % |
|--------|----------|---|
| learning | 196 | 25.4% |
| finance | 165 | 21.3% |
| tech | 131 | 17.0% |
| ... | | |
| creative | 26 | **3.4%** ⚠️ |
| **social** | **4** | **0.5%** 🚨 |

## Smoke
- youtube-transcript-api on `bK-J0j_O_hg` (기초수학) returned 4,939-char Korean transcript. Same vid yt-dlp+WebShare 402'd on.
- tsc --noEmit: PASS

## Mac Mini setup (post-merge, manual)
```bash
pip3 install --user youtube-transcript-api
crontab -e
# Add: 0 0,6,12,18 * * * /Users/jamesjk/code/insighta/mac-mini/v2-author/daily-targeted.sh
```

## Risks
- Mac Mini residential IP exposure. 100/day + spread is light → ~5%/month ban probability.
- Mitigation on ban: swap to `--cookies-from-browser` OR restore WebShare → `TRANSCRIPT_FETCHER=ytdlp`.

## Test plan
- [x] tsc PASS
- [x] Python lib smoke test
- [ ] CI green
- [ ] Manual smoke after deploy: `DOMAINS=social,creative bash mac-mini/v2-author/batch.sh 5` from Mac Mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)