### PR TITLE
feat(rich-summary): expose v2 layered jsonb + V2NewBlock FE renderer (CP438+1)

### DIFF
--- a/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
@@ -1,17 +1,26 @@
 /**
  * AI summary read-only view for the side panel.
  *
- * Renders two layers:
- *  1. Rich AI summary (CP425 / `video_rich_summaries`) — tl_dr, key_points,
- *     actionables, chapters. Fetched via `useRichSummary`. Empty-state on
- *     404 (not yet generated / quota exceeded).
- *  2. Short metadata summary (`videoSummary.summary_ko|en` + tags) —
+ * Renders three layers (in priority order — first non-empty wins for the
+ * "rich" block):
+ *  1. CP438+1 v2 layered jsonb (`core` + `analysis` + `segments` + `lora`)
+ *     — full v2 schema with atom timestamps, key_concepts, qa_pairs.
+ *  2. Legacy CP425 v2 / v1 (`structured` jsonb) — tl_dr, key_points,
+ *     actionables, chapters. Fallback for rows authored before CP437.
+ *  3. Short metadata summary (`videoSummary.summary_ko|en` + tags) —
  *     existing path, always renders when available.
  *
  * Design tokens: insighta-side-editor-mockup-v3.html
  */
 import type { VideoSummary } from '@/entities/card/model/types';
 import { getYouTubeVideoId } from '@/widgets/video-player/model/youtube-api';
+import type {
+  VideoRichSummaryAnalysis,
+  VideoRichSummaryAtom,
+  VideoRichSummaryCore,
+  VideoRichSummaryLora,
+  VideoRichSummarySegments,
+} from '@/shared/lib/api-client';
 import { useRichSummary } from '../model/useRichSummary';
 
 export interface PanelAISummaryProps {
@@ -26,10 +35,12 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
   const short = videoSummary?.summary_ko || videoSummary?.summary_en || null;
   const tags = videoSummary?.tags ?? [];
 
-  const hasRich = Boolean(richSummary?.structured);
+  // CP438+1: prefer new layered v2 jsonb when present.
+  const hasNewV2 = Boolean(richSummary?.core);
+  const hasLegacyRich = !hasNewV2 && Boolean(richSummary?.structured);
   const hasShort = Boolean(short) || tags.length > 0;
 
-  if (!hasRich && !hasShort && !isRichLoading) {
+  if (!hasNewV2 && !hasLegacyRich && !hasShort && !isRichLoading) {
     return (
       <p className="py-8 text-center text-[13px] text-[#4e4f5c]">
         아직 AI 요약이 생성되지 않았어요
@@ -39,7 +50,16 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
 
   return (
     <div className="space-y-5">
-      {hasRich && richSummary?.structured && (
+      {hasNewV2 && richSummary && (
+        <RichSummaryV2NewBlock
+          core={richSummary.core ?? null}
+          analysis={richSummary.analysis ?? null}
+          segments={richSummary.segments ?? null}
+          lora={richSummary.lora ?? null}
+          youtubeId={youtubeId}
+        />
+      )}
+      {hasLegacyRich && richSummary?.structured && (
         <RichSummaryBlock structured={richSummary.structured} />
       )}
 
@@ -287,4 +307,215 @@ function formatSeconds(sec: number): string {
   const r = s % 60;
   if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(r).padStart(2, '0')}`;
   return `${m}:${String(r).padStart(2, '0')}`;
+}
+
+/**
+ * CP438+1: V2 layered jsonb renderer (CP437 schema).
+ * Layout: core_argument hero → actionables → key_concepts →
+ *         segments.sections (timeline) → segments.atoms (with timestamp
+ *         jump links) → lora.qa_pairs (collapsible).
+ * Atom timestamp click → opens YouTube tab at the moment via &t= param.
+ */
+interface RichSummaryV2NewBlockProps {
+  core: VideoRichSummaryCore | null;
+  analysis: VideoRichSummaryAnalysis | null;
+  segments: VideoRichSummarySegments | null;
+  lora: VideoRichSummaryLora | null;
+  youtubeId: string | null;
+}
+
+function RichSummaryV2NewBlock({
+  core,
+  analysis,
+  segments,
+  lora,
+  youtubeId,
+}: RichSummaryV2NewBlockProps) {
+  const oneLiner = core?.one_liner ?? null;
+  const coreArg = analysis?.core_argument ?? null;
+  const actionables = analysis?.actionables ?? [];
+  const keyConcepts = analysis?.key_concepts ?? [];
+  const sections = segments?.sections ?? [];
+  const atoms = segments?.atoms ?? [];
+  const qaPairs = lora?.qa_pairs ?? [];
+  const subjectivity = analysis?.bias_signals?.subjectivity_level ?? null;
+  const hasAd = analysis?.bias_signals?.has_ad === true;
+
+  const tsUrl = (sec: number | undefined) =>
+    youtubeId && Number.isFinite(sec)
+      ? `https://www.youtube.com/watch?v=${youtubeId}&t=${Math.floor(sec ?? 0)}s`
+      : null;
+
+  return (
+    <div className="space-y-4">
+      {oneLiner && (
+        <section>
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
+            한 줄 요약
+          </h3>
+          <p className="rounded-r-[6px] border-l-2 border-[#818cf8] bg-[rgba(99,102,241,0.06)] px-[14px] py-[10px] text-[13px] leading-[1.65] text-[#ededf0]">
+            {oneLiner}
+          </p>
+        </section>
+      )}
+
+      {coreArg && (
+        <section>
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
+            핵심 주장
+          </h3>
+          <p className="text-[13px] leading-[1.6] text-[rgba(237,237,240,0.84)]">{coreArg}</p>
+        </section>
+      )}
+
+      {(subjectivity === 'high' || hasAd) && (
+        <div className="flex flex-wrap gap-1.5">
+          {hasAd && (
+            <span className="rounded-[4px] bg-[rgba(248,113,113,0.12)] px-[7px] py-[2px] text-[10px] font-semibold text-[#f87171]">
+              광고 포함
+            </span>
+          )}
+          {subjectivity === 'high' && (
+            <span className="rounded-[4px] bg-[rgba(245,158,11,0.12)] px-[7px] py-[2px] text-[10px] font-semibold text-[#f59e0b]">
+              주관성 높음
+            </span>
+          )}
+        </div>
+      )}
+
+      {actionables.length > 0 && (
+        <section>
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#818cf8]">
+            실행 아이템
+          </h3>
+          <ul className="space-y-1.5 text-[13px] leading-[1.55] text-[rgba(237,237,240,0.84)]">
+            {actionables.map((item, idx) => (
+              <li key={idx} className="flex gap-2">
+                <span
+                  aria-hidden
+                  className="mt-[2px] flex h-[14px] w-[14px] shrink-0 items-center justify-center rounded-[3px] border border-[#818cf8] text-[10px] text-[#818cf8]"
+                >
+                  →
+                </span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {keyConcepts.length > 0 && (
+        <section>
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
+            주요 개념
+          </h3>
+          <ul className="space-y-2 text-[13px] leading-[1.5]">
+            {keyConcepts.map((kc, idx) => (
+              <li key={idx} className="rounded-[6px] bg-[rgba(255,255,255,0.02)] px-3 py-2">
+                <p className="text-[12px] font-semibold text-[#818cf8]">{kc.term}</p>
+                <p className="mt-[2px] text-[12px] text-[rgba(237,237,240,0.74)]">
+                  {kc.definition}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {sections.length > 0 && (
+        <section>
+          <h3 className="mb-[8px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
+            구간별 분석
+          </h3>
+          <div className="space-y-1">
+            {sections.map((sec, idx) => (
+              <div
+                key={idx}
+                className="rounded-[6px] px-3 py-[10px] transition-colors hover:bg-[rgba(255,255,255,0.02)]"
+              >
+                <div className="flex items-baseline gap-3">
+                  <span className="font-mono text-[10px] text-[#818cf8] shrink-0">
+                    {formatSeconds(sec.from_sec)} — {formatSeconds(sec.to_sec)}
+                  </span>
+                  <p className="text-[12px] font-semibold leading-[1.35] text-[rgba(237,237,240,0.92)]">
+                    {sec.title}
+                  </p>
+                </div>
+                {sec.summary && (
+                  <p className="mt-[3px] pl-[88px] text-[11px] text-[rgba(237,237,240,0.66)]">
+                    {sec.summary}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {atoms.length > 0 && (
+        <section>
+          <h3 className="mb-[8px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
+            핵심 atoms
+          </h3>
+          <ul className="space-y-[6px]">
+            {atoms.map((atom, idx) => (
+              <AtomRow key={idx} atom={atom} jumpUrl={tsUrl(atom.timestamp_sec)} />
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {qaPairs.length > 0 && (
+        <section>
+          <details className="rounded-[6px] bg-[rgba(255,255,255,0.02)] px-3 py-2">
+            <summary className="cursor-pointer text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
+              자가점검 ({qaPairs.length})
+            </summary>
+            <ul className="mt-[8px] space-y-2 text-[12px]">
+              {qaPairs.map((qa, idx) => (
+                <li key={idx} className="border-l-2 border-[rgba(129,140,248,0.4)] pl-3">
+                  <p className="font-semibold text-[#ededf0]">Q. {qa.q}</p>
+                  <p className="mt-[2px] text-[rgba(237,237,240,0.66)]">A. {qa.a}</p>
+                </li>
+              ))}
+            </ul>
+          </details>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function AtomRow({ atom, jumpUrl }: { atom: VideoRichSummaryAtom; jumpUrl: string | null }) {
+  const typeColor =
+    atom.type === 'fact'
+      ? 'text-[#2dd4bf]'
+      : atom.type === 'argument'
+        ? 'text-[#f59e0b]'
+        : atom.type === 'tip'
+          ? 'text-[#818cf8]'
+          : 'text-[#94a3b8]';
+  const typeMark =
+    atom.type === 'fact' ? '✓' : atom.type === 'argument' ? '!' : atom.type === 'tip' ? '★' : '·';
+
+  return (
+    <li className="flex items-start gap-2 text-[12px] leading-[1.5] text-[rgba(237,237,240,0.84)]">
+      <span aria-hidden className={`mt-[2px] shrink-0 font-mono text-[11px] ${typeColor}`}>
+        {typeMark}
+      </span>
+      <span className="flex-1">
+        {atom.text}
+        {jumpUrl && Number.isFinite(atom.timestamp_sec) && (
+          <a
+            href={jumpUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-2 inline-flex items-center gap-0.5 rounded-[3px] bg-[rgba(129,140,248,0.1)] px-[5px] py-[1px] font-mono text-[10px] text-[#818cf8] hover:bg-[rgba(129,140,248,0.2)]"
+          >
+            ▶ {formatSeconds(atom.timestamp_sec ?? 0)}
+          </a>
+        )}
+      </span>
+    </li>
+  );
 }

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -91,12 +91,96 @@ export interface VideoRichSummaryStructured {
   quotes?: VideoRichSummaryQuote[];
   tl_dr_ko?: string;
   tl_dr_en?: string;
+  // Legacy v2 (CP425) schema kept for backwards compat. New v2 (CP437+)
+  // uses the layered jsonb fields below.
+  sections?: Array<{
+    from_sec: number;
+    to_sec: number;
+    title: string;
+    summary?: string;
+    relevance_pct: number;
+    key_points?: Array<{ text: string; timestamp_sec?: number }>;
+  }>;
+  entities?: Array<{ name: string }>;
+}
+
+/**
+ * CP438+1: v2 layered jsonb schema (CP437 generator). Each is null for
+ * v1 rows or when the v2 author has not run yet.
+ */
+export interface VideoRichSummaryCore {
+  one_liner?: string;
+  domain?: string;
+  depth_level?: string;
+  content_type?: string;
+  target_audience?: string;
+}
+
+export interface VideoRichSummaryKeyConcept {
+  term: string;
+  definition: string;
+}
+
+export interface VideoRichSummaryAnalysis {
+  core_argument?: string;
+  key_concepts?: VideoRichSummaryKeyConcept[];
+  actionables?: string[];
+  mandala_fit?: {
+    suggested_goals?: string[];
+    relevance_rationale?: string;
+  };
+  bias_signals?: {
+    has_ad?: boolean;
+    is_sponsored?: boolean;
+    subjectivity_level?: string;
+    notes?: string;
+  };
+  prerequisites?: string;
+}
+
+export interface VideoRichSummarySection {
+  idx?: number;
+  title: string;
+  from_sec: number;
+  to_sec: number;
+  summary?: string;
+}
+
+export interface VideoRichSummaryAtom {
+  idx?: number;
+  type?: 'fact' | 'tip' | 'argument' | string;
+  text: string;
+  timestamp_sec?: number;
+}
+
+export interface VideoRichSummarySegments {
+  sections?: VideoRichSummarySection[];
+  atoms?: VideoRichSummaryAtom[];
+}
+
+export interface VideoRichSummaryQAPair {
+  level?: number;
+  q: string;
+  a: string;
+  context?: string;
+}
+
+export interface VideoRichSummaryLora {
+  qa_pairs?: VideoRichSummaryQAPair[];
 }
 
 export interface VideoRichSummaryResponse {
   videoId: string;
   oneLiner: string | null;
   structured: VideoRichSummaryStructured | null;
+  // CP438+1: layered v2 jsonb fields. Present when template_version='v2' AND
+  // CP437 generator authored the row. NULL on v1 rows.
+  templateVersion?: string | null;
+  completeness?: number | null;
+  core?: VideoRichSummaryCore | null;
+  analysis?: VideoRichSummaryAnalysis | null;
+  segments?: VideoRichSummarySegments | null;
+  lora?: VideoRichSummaryLora | null;
   qualityScore: number | null;
   model: string | null;
   updatedAt: string;

--- a/src/api/routes/videos.ts
+++ b/src/api/routes/videos.ts
@@ -543,6 +543,14 @@ export const videoRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           videoId: row.video_id,
           oneLiner: row.one_liner,
           structured: row.structured,
+          // CP438+1: expose v2 layered jsonb (CP437 schema). FE V2NewBlock
+          // renders these directly when `core` is non-null.
+          templateVersion: row.template_version ?? null,
+          completeness: row.completeness ?? null,
+          core: row.core ?? null,
+          analysis: row.analysis ?? null,
+          segments: row.segments ?? null,
+          lora: row.lora ?? null,
           qualityScore: row.quality_score,
           model: row.model,
           updatedAt: row.updated_at.toISOString(),


### PR DESCRIPTION
## Summary
- **BE** `/api/v1/videos/:id/rich-summary` 응답에 v2 layered jsonb (`core/analysis/segments/lora` + `templateVersion/completeness`) 추가. 기존 `structured` 응답 보존, additive 변경.
- **FE** `PanelAISummary` 에 `RichSummaryV2NewBlock` 신규 — `core` 가 non-null 일 때 우선 렌더. atom timestamp 클릭 → `youtube.com/watch?v=XXX&t=Ns` 새 탭.
- 기존 V2/V1 분기는 fallback 으로 보존 — v1 행 / pre-CP437 v2 행 영향 없음.

## Why
DB 에 894+ v2 row 가 작성됐으나 BE 응답에서 누락 + FE 타입/렌더 부재 → 사용자 화면에 보이지 않던 issue.

## Render priority
| Order | Trigger | Block |
|-------|---------|-------|
| 1 | `core` non-null | RichSummaryV2NewBlock (NEW) — atoms, actionables, key_concepts, qa_pairs |
| 2 | `structured.sections` | RichSummaryV2Block (legacy) |
| 3 | `structured.tl_dr_*` | RichSummaryV1Block |

## Test plan
- [x] BE tsc + jest smoke 117/117
- [x] FE tsc + vitest 275/275 + build
- [x] Browser smoke `/` `/learning` → 200
- [x] `/verify` PASS marker
- [ ] Post-deploy: visit a v2 video (예: `영어로 말하고 싶다` 만다라의 26 v2) → 새 V2NewBlock 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)