### PR TITLE
feat(book): mandala_books PoC — sidebar book index from generated chapters (CP438+1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ prisma/migrations/*
 !prisma/migrations/llm_call_logs/
 !prisma/migrations/quality_metrics/
 !prisma/migrations/transcript-attempted/
+!prisma/migrations/book-poc/
 
 # Logs
 logs/

--- a/frontend/src/features/mandala/model/useMandalaBook.ts
+++ b/frontend/src/features/mandala/model/useMandalaBook.ts
@@ -1,0 +1,36 @@
+/**
+ * useMandalaBook — fetch the PoC book index for a mandala.
+ *
+ * CP438+1 — wraps `GET /api/v1/mandalas/:id/book`. 404 → null (book
+ * not yet generated; sidebar shows "보고서 작성 준비중..." placeholder).
+ *
+ * Read-only. Generation runs offline via scripts/book-poc/* — endpoint
+ * never triggers it.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { apiClient, type MandalaBookResponse } from '@/shared/lib/api-client';
+
+const MANDALA_BOOK_STALE_MS = 5 * 60 * 1000;
+
+export interface UseMandalaBookResult {
+  book: MandalaBookResponse | null;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export function useMandalaBook(mandalaId: string | null | undefined): UseMandalaBookResult {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: mandalaId ? ['mandala', 'book', mandalaId] : ['mandala', 'book', 'disabled'],
+    queryFn: () => apiClient.getMandalaBook(mandalaId as string),
+    enabled: Boolean(mandalaId),
+    staleTime: MANDALA_BOOK_STALE_MS,
+    retry: false,
+  });
+
+  return {
+    book: data ?? null,
+    isLoading,
+    isError,
+  };
+}

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -186,6 +186,53 @@ export interface VideoRichSummaryResponse {
   updatedAt: string;
 }
 
+/**
+ * CP438+1 PoC — Mandala book index response shape.
+ * Server stores the entire generated book as a single jsonb blob keyed
+ * by mandala_id. PoC schema; will split into normalized tables in P5.
+ */
+export interface MandalaBookAtom {
+  vid: string;
+  ts: number;
+  text: string;
+  type?: string;
+}
+
+export interface MandalaBookSection {
+  title: string;
+  narrative?: string;
+  atoms?: MandalaBookAtom[];
+  qa?: Array<{ q: string; a: string }>;
+}
+
+export interface MandalaBookChapter {
+  ch: number;
+  title: string;
+  intro?: string;
+  sections: MandalaBookSection[];
+}
+
+export interface MandalaBookData {
+  mandala_id: string;
+  mandala_title: string;
+  generated_at: string;
+  source_videos: number;
+  source_atoms: number;
+  estimated_pages?: number;
+  chapters: MandalaBookChapter[];
+  stats?: Record<string, unknown>;
+}
+
+export interface MandalaBookResponse {
+  mandalaId: string;
+  version: number;
+  sourceVideos: number;
+  sourceAtoms: number;
+  generatedAt: string;
+  updatedAt: string;
+  book: MandalaBookData;
+}
+
 interface ClawbotConfig {
   cronExpression: string;
   threshold: number;
@@ -634,6 +681,23 @@ class ApiClient {
       const res = await this.request<{ data: VideoRichSummaryResponse }>(
         `/videos/${videoId}/rich-summary`
       );
+      return res.data;
+    } catch (err) {
+      if (err instanceof ApiHttpError && err.statusCode === 404) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * CP438+1 PoC — fetch the generated book index for a mandala.
+   * Returns null on 404 (book has not been generated yet — sidebar
+   * fallback to "보고서 작성 준비중...").
+   */
+  async getMandalaBook(mandalaId: string): Promise<MandalaBookResponse | null> {
+    try {
+      const res = await this.request<{ data: MandalaBookResponse }>(`/mandalas/${mandalaId}/book`);
       return res.data;
     } catch (err) {
       if (err instanceof ApiHttpError && err.statusCode === 404) {

--- a/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
@@ -2,8 +2,10 @@ import { useState } from 'react';
 import { ChevronRight, BookOpen, Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useMandalaQuery } from '@/features/mandala';
+import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import { useMandalaCards } from '@/pages/learning/model/useMandalaCards';
 import type { InsightCard } from '@/entities/card/model/types';
+import type { MandalaBookChapter } from '@/shared/lib/api-client';
 import { cn } from '@/shared/lib/utils';
 
 interface SidebarLearningSectionProps {
@@ -22,6 +24,14 @@ export function SidebarLearningSection({ mandalaId, collapsed }: SidebarLearning
   const subGoals = rootLevel?.subjects ?? [];
 
   const { cards: mandalaCards } = useMandalaCards(mandalaId);
+  // CP438+1 — book index PoC; non-null when a book has been generated.
+  const { book: bookResponse } = useMandalaBook(mandalaId);
+  const bookChaptersByIdx = new Map<number, MandalaBookChapter>();
+  if (bookResponse?.book?.chapters) {
+    for (const ch of bookResponse.book.chapters) {
+      bookChaptersByIdx.set(ch.ch, ch);
+    }
+  }
 
   const cardsByCell = new Map<number, InsightCard[]>();
   for (const card of mandalaCards) {
@@ -62,6 +72,9 @@ export function SidebarLearningSection({ mandalaId, collapsed }: SidebarLearning
         {subGoals.map((goal, idx) => {
           const cellCards = cardsByCell.get(idx + 1) ?? [];
           const isExpanded = selectedCell === idx + 1;
+          // CP438+1 — book chapter `ch` is 0-based but cellIndex is 1-based.
+          const bookChapter = bookChaptersByIdx.get(idx);
+          const sectionCount = bookChapter?.sections?.length ?? 0;
 
           return (
             <div key={idx}>
@@ -78,29 +91,107 @@ export function SidebarLearningSection({ mandalaId, collapsed }: SidebarLearning
                   className={cn('h-3 w-3 shrink-0 transition-transform', isExpanded && 'rotate-90')}
                 />
                 <span className="flex-1 truncate text-[12px] font-medium">{goal}</span>
-                {cellCards.length > 0 && (
-                  <span className="shrink-0 rounded-full bg-sidebar-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-sidebar-primary">
-                    {cellCards.length}
+                {sectionCount > 0 ? (
+                  <span className="shrink-0 rounded-full bg-[rgba(45,212,191,0.15)] px-1.5 py-0.5 text-[10px] font-semibold text-[#2dd4bf]">
+                    📖 {sectionCount}
                   </span>
+                ) : (
+                  cellCards.length > 0 && (
+                    <span className="shrink-0 rounded-full bg-sidebar-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-sidebar-primary">
+                      {cellCards.length}
+                    </span>
+                  )
                 )}
               </button>
 
               {isExpanded && (
                 <div className="px-3 pl-8 py-2">
-                  <div className="flex items-center gap-1.5 text-[11px] text-sidebar-foreground/40">
-                    <Sparkles className="w-3 h-3 shrink-0" />
-                    <span>
-                      {cellCards.length > 0
-                        ? t('learning.reportPreparing', '보고서 작성 준비중 ...')
-                        : t('learning.contentCollecting', '콘텐츠 수집 중...')}
-                    </span>
-                  </div>
+                  {bookChapter ? (
+                    <BookChapterPreview chapter={bookChapter} />
+                  ) : (
+                    <div className="flex items-center gap-1.5 text-[11px] text-sidebar-foreground/40">
+                      <Sparkles className="w-3 h-3 shrink-0" />
+                      <span>
+                        {cellCards.length > 0
+                          ? t('learning.reportPreparing', '보고서 작성 준비중 ...')
+                          : t('learning.contentCollecting', '콘텐츠 수집 중...')}
+                      </span>
+                    </div>
+                  )}
                 </div>
               )}
             </div>
           );
         })}
       </div>
+    </div>
+  );
+}
+
+/**
+ * CP438+1 — In-sidebar preview of a book chapter (PoC).
+ * Shows section titles + atom count + jump-to-video links. Click on an
+ * atom timestamp opens the YouTube source at the moment in a new tab.
+ */
+function BookChapterPreview({ chapter }: { chapter: MandalaBookChapter }) {
+  const sections = chapter.sections ?? [];
+
+  return (
+    <div className="space-y-2">
+      {chapter.intro && (
+        <p className="text-[11px] leading-[1.5] text-sidebar-foreground/50">{chapter.intro}</p>
+      )}
+      <ul className="space-y-2">
+        {sections.map((sec, sIdx) => {
+          const atoms = sec.atoms ?? [];
+          return (
+            <li
+              key={sIdx}
+              className="rounded-[6px] border border-sidebar-border bg-sidebar-accent/30 px-2 py-2"
+            >
+              <p className="text-[11px] font-semibold text-sidebar-foreground/80">{sec.title}</p>
+              {sec.narrative && (
+                <p className="mt-1 text-[10px] leading-[1.45] text-sidebar-foreground/55">
+                  {sec.narrative}
+                </p>
+              )}
+              {atoms.length > 0 && (
+                <ul className="mt-1.5 space-y-0.5">
+                  {atoms.slice(0, 5).map((atom, aIdx) => (
+                    <li
+                      key={aIdx}
+                      className="flex gap-1 text-[10px] leading-[1.4] text-sidebar-foreground/60"
+                    >
+                      <span className="shrink-0 text-sidebar-foreground/40">·</span>
+                      <span className="flex-1">
+                        {atom.text.slice(0, 60)}
+                        {atom.text.length > 60 ? '…' : ''}
+                        {atom.vid && Number.isFinite(atom.ts) && (
+                          <a
+                            href={`https://www.youtube.com/watch?v=${atom.vid}&t=${Math.floor(atom.ts ?? 0)}s`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="ml-1 inline-block rounded-[3px] bg-[rgba(129,140,248,0.15)] px-1 font-mono text-[9px] text-[#818cf8]"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            ▶ {Math.floor((atom.ts ?? 0) / 60)}:
+                            {String(Math.floor((atom.ts ?? 0) % 60)).padStart(2, '0')}
+                          </a>
+                        )}
+                      </span>
+                    </li>
+                  ))}
+                  {atoms.length > 5 && (
+                    <li className="text-[10px] text-sidebar-foreground/40">
+                      +{atoms.length - 5} more
+                    </li>
+                  )}
+                </ul>
+              )}
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }

--- a/prisma/migrations/book-poc/001_add_table.sql
+++ b/prisma/migrations/book-poc/001_add_table.sql
@@ -1,0 +1,29 @@
+-- CP438+1 (2026-05-06): mandala_books PoC table.
+-- Single-table storage for the generated book index (chapters + sections
+-- + atoms + qa pairs as one jsonb blob). PoC keeps schema minimal so the
+-- generator + reader can iterate quickly. Section-level confirm flow +
+-- cross-video atom split (book_chapters/book_sections/book_atoms) is
+-- deferred to P5.
+--
+-- Apply order:
+--   1. Local: psql "$DATABASE_URL" -f prisma/migrations/book-poc/001_add_table.sql
+--   2. Local: prisma db push --skip-generate (sync with Prisma)
+--   3. Local: psql "$DATABASE_URL" -c "NOTIFY pgrst, 'reload schema'"
+--   4. Prod: deploy.yml CI runs prisma db push (LEVEL-3 silent-fail risk!)
+--   5. Prod: ssh + docker exec psql apply this raw DDL too (defensive)
+--   6. Prod: Supabase Dashboard → Settings → API → "Reload schema"
+
+CREATE TABLE IF NOT EXISTS mandala_books (
+  mandala_id     UUID PRIMARY KEY REFERENCES user_mandalas(id) ON DELETE CASCADE,
+  book_json      JSONB NOT NULL,
+  version        INTEGER NOT NULL DEFAULT 1,
+  source_videos  INTEGER NOT NULL DEFAULT 0,
+  source_atoms   INTEGER NOT NULL DEFAULT 0,
+  generated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mandala_books_updated_at
+  ON mandala_books(updated_at DESC);
+
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -606,6 +606,25 @@ model mandala_activity_log {
   @@schema("public")
 }
 
+/// CP438+1 (2026-05-06) — Mandala "book index" PoC.
+/// Stores a generated book (chapters + sections + atoms + qa pairs) as a
+/// single jsonb blob keyed by mandala_id. PoC keeps the schema minimal —
+/// section-level confirm flow + cross-video dedup are deferred to P5
+/// (book_chapters/book_sections/book_atoms split tables).
+/// Raw SQL DDL: prisma/migrations/book-poc/001_add_table.sql
+model mandala_books {
+  mandala_id   String        @id @db.Uuid
+  book_json    Json          @db.JsonB
+  version      Int           @default(1)
+  source_videos Int          @default(0)
+  source_atoms Int           @default(0)
+  generated_at DateTime      @default(now()) @db.Timestamptz(6)
+  updated_at   DateTime      @default(now()) @updatedAt @db.Timestamptz(6)
+  mandala      user_mandalas @relation(fields: [mandala_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@schema("public")
+}
+
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model user_local_cards {
   id                   String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -440,6 +440,7 @@ model user_mandalas {
   recommendation_cache recommendation_cache[]
   pipeline_runs        mandala_pipeline_runs[]
   create_timings       mandala_create_timings[]
+  book                 mandala_books?
 
   source_template_id String?  @db.Uuid
   focus_tags         String[] @default([])

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -2376,5 +2376,86 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     }
   );
 
+  /**
+   * GET /api/v1/mandalas/:id/book — CP438+1 PoC.
+   *
+   * Returns the generated book index (chapters + sections + atoms + qa)
+   * for the mandala. PoC stores the entire book as a single jsonb blob
+   * keyed by mandala_id (mandala_books table). Read-only for now —
+   * generation is offline (CC console authored, then upserted via
+   * scripts/book-poc/import-eng-mandala.ts or similar).
+   *
+   * Auth: mandala owner OR public mandala (is_public=true).
+   * Response:
+   *   200 { status: 'ok', data: { mandalaId, version, sourceVideos,
+   *         sourceAtoms, generatedAt, updatedAt, book: <jsonb> } }
+   *   404 RICH_SUMMARY_NOT_FOUND when no book row exists yet
+   */
+  fastify.get<{ Params: { id: string } }>(
+    '/:id/book',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const userId = getUserId(request, reply);
+      if (!userId) return;
+
+      const { id: mandalaId } = request.params;
+
+      // Auth: owner or public mandala.
+      const mandala = await getPrismaClient().user_mandalas.findFirst({
+        where: {
+          id: mandalaId,
+          OR: [{ user_id: userId }, { is_public: true }],
+        },
+        select: { id: true, title: true },
+      });
+      if (!mandala) {
+        return reply.code(404).send({ status: 'error', error: 'Mandala not found' });
+      }
+
+      // Raw query — Prisma client model name `mandala_books` may not be
+      // present in every deploy if regen lags behind.
+      const rows = await getPrismaClient().$queryRawUnsafe<
+        Array<{
+          mandala_id: string;
+          book_json: unknown;
+          version: number;
+          source_videos: number;
+          source_atoms: number;
+          generated_at: Date;
+          updated_at: Date;
+        }>
+      >(
+        `SELECT mandala_id, book_json, version, source_videos, source_atoms,
+                generated_at, updated_at
+         FROM mandala_books
+         WHERE mandala_id = $1::uuid
+         LIMIT 1`,
+        mandalaId
+      );
+
+      if (!rows[0]) {
+        return reply.code(404).send({
+          status: 'error',
+          code: 'BOOK_NOT_FOUND',
+          message: 'No book has been generated for this mandala yet',
+        });
+      }
+
+      const row = rows[0];
+      return reply.code(200).send({
+        status: 'ok',
+        data: {
+          mandalaId: row.mandala_id,
+          version: row.version,
+          sourceVideos: row.source_videos,
+          sourceAtoms: row.source_atoms,
+          generatedAt: row.generated_at.toISOString(),
+          updatedAt: row.updated_at.toISOString(),
+          book: row.book_json,
+        },
+      });
+    }
+  );
+
   done();
 };


### PR DESCRIPTION
## Summary
- PoC: 만다라당 1개의 책(JSON blob)을 좌측 sidebar 의 chapter expansion 자리에 렌더링 ("보고서 작성 준비중..." 텍스트가 실제 chapter content 로 대체).
- "영어로 말하고 싶다" 만다라용 24-page book (26 v2 / 213 atoms / 23 sections) 이 prod DB 에 이미 upsert됨.

## Why
- v2 atoms 가 풍부히 누적됐으나 만다라 단위 aggregation/큐레이션 view 부재.
- 사용자 비전 = "내 책 평생 완성" — 만다라 = 책 표지, sub_goals = 8 chapters, atoms = paragraphs.

## Architecture (PoC)
| Layer | Item |
|-------|------|
| DB | `mandala_books (mandala_id PK, book_json jsonb, version, source_*, generated_at, updated_at)` — 단일 jsonb blob (chapters/sections/atoms/qa) |
| BE | `GET /api/v1/mandalas/:id/book` (auth: owner OR public). raw `$queryRawUnsafe` 으로 client regen 지연 회피 |
| FE | `useMandalaBook` hook + `BookChapterPreview` in `SidebarLearningSection`. atom timestamp click → `youtube.com/watch?v=X&t=Ns` 새 탭 |

## DDL pre-applied
prod 에 raw DDL 이미 실행 (LEVEL-3 prisma db push silent-fail trap 회피):
- `mandala_books` 테이블 + `idx_mandala_books_updated_at` 인덱스
- Postgrest schema reload notify
- Verified via `information_schema.columns`

## Deferred (P5)
- Section-level confirm flow
- Cross-video atom dedup automation
- Auto-regen on new v2 video

## Test plan
- [x] BE tsc + jest 117/117
- [x] FE tsc + vitest 275/275 + build
- [x] Browser smoke `/` `/learning` → 200
- [x] /verify PASS marker
- [ ] Post-deploy: visit "영어로 말하고 싶다" 만다라 (`72d5fe52-2f35-4a9e-8ef6-cd21629173ef`) → 좌측 sidebar 의 "어휘 범위 확대" 등 chapter expand 시 책 내용 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)