### PR TITLE
fix(book,v2): atom timestamp seeks in-page (no new YouTube tab)

### DIFF
--- a/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
@@ -12,6 +12,7 @@
  *
  * Design tokens: insighta-side-editor-mockup-v3.html
  */
+import { useParams, Link } from 'react-router-dom';
 import type { VideoSummary } from '@/entities/card/model/types';
 import { getYouTubeVideoId } from '@/widgets/video-player/model/youtube-api';
 import type {
@@ -29,6 +30,7 @@ export interface PanelAISummaryProps {
 }
 
 export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) {
+  const { mandalaId } = useParams<{ mandalaId: string }>();
   const youtubeId = videoUrl ? getYouTubeVideoId(videoUrl) : null;
   const { richSummary, isLoading: isRichLoading } = useRichSummary(youtubeId);
 
@@ -57,6 +59,7 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
           segments={richSummary.segments ?? null}
           lora={richSummary.lora ?? null}
           youtubeId={youtubeId}
+          mandalaId={mandalaId ?? null}
         />
       )}
       {hasLegacyRich && richSummary?.structured && (
@@ -322,6 +325,7 @@ interface RichSummaryV2NewBlockProps {
   segments: VideoRichSummarySegments | null;
   lora: VideoRichSummaryLora | null;
   youtubeId: string | null;
+  mandalaId: string | null;
 }
 
 function RichSummaryV2NewBlock({
@@ -330,6 +334,7 @@ function RichSummaryV2NewBlock({
   segments,
   lora,
   youtubeId,
+  mandalaId,
 }: RichSummaryV2NewBlockProps) {
   const oneLiner = core?.one_liner ?? null;
   const coreArg = analysis?.core_argument ?? null;
@@ -341,9 +346,12 @@ function RichSummaryV2NewBlock({
   const subjectivity = analysis?.bias_signals?.subjectivity_level ?? null;
   const hasAd = analysis?.bias_signals?.has_ad === true;
 
-  const tsUrl = (sec: number | undefined) =>
-    youtubeId && Number.isFinite(sec)
-      ? `https://www.youtube.com/watch?v=${youtubeId}&t=${Math.floor(sec ?? 0)}s`
+  // CP438+1: in-page seek via ?t=N param (LearningPage useEffect picks it up
+  // and calls playerRef.current.seekTo). Falls back to null if mandalaId
+  // missing (rare — side panel always renders inside Learning route).
+  const tsUrl = (sec: number | undefined): string | null =>
+    mandalaId && youtubeId && Number.isFinite(sec)
+      ? `/learning/${mandalaId}/${youtubeId}?t=${Math.floor(sec ?? 0)}`
       : null;
 
   return (
@@ -506,14 +514,12 @@ function AtomRow({ atom, jumpUrl }: { atom: VideoRichSummaryAtom; jumpUrl: strin
       <span className="flex-1">
         {atom.text}
         {jumpUrl && Number.isFinite(atom.timestamp_sec) && (
-          <a
-            href={jumpUrl}
-            target="_blank"
-            rel="noopener noreferrer"
+          <Link
+            to={jumpUrl}
             className="ml-2 inline-flex items-center gap-0.5 rounded-[3px] bg-[rgba(129,140,248,0.1)] px-[5px] py-[1px] font-mono text-[10px] text-[#818cf8] hover:bg-[rgba(129,140,248,0.2)]"
           >
             ▶ {formatSeconds(atom.timestamp_sec ?? 0)}
-          </a>
+          </Link>
         )}
       </span>
     </li>

--- a/frontend/src/pages/learning/ui/LearningPage.tsx
+++ b/frontend/src/pages/learning/ui/LearningPage.tsx
@@ -1,5 +1,5 @@
-import { useRef, useCallback, useState, useLayoutEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useRef, useCallback, useState, useLayoutEffect, useEffect } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { VideoStrip } from './VideoStrip';
 import { CenterPanel } from './CenterPanel';
 import { RightPanel } from './RightPanel';
@@ -7,6 +7,9 @@ import type { YTPlayer } from '@/widgets/video-player/model/youtube-api';
 
 export default function LearningPage() {
   const { mandalaId, videoId } = useParams<{ mandalaId: string; videoId: string }>();
+  const [searchParams] = useSearchParams();
+  const tParam = searchParams.get('t');
+  const targetSec = tParam ? Math.max(0, Math.floor(Number(tParam))) : null;
   const playerRef = useRef<YTPlayer | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
   const playbackMapRef = useRef(new Map<string, number>());
@@ -24,6 +27,26 @@ export default function LearningPage() {
     }
     prevVideoIdRef.current = videoId;
   }, [videoId]);
+
+  // CP438+1: ?t=N query param drives in-page seek. When the user clicks
+  // an atom timestamp link in the sidebar/panel, the same-video case
+  // doesn't unmount CenterPanel — useEffect on tParam fires seekTo on
+  // the live player. The different-video case loads via startTime below.
+  useEffect(() => {
+    if (targetSec === null || !Number.isFinite(targetSec)) return;
+    if (!videoId) return;
+    // Override resume position so reload-on-video-change also lands here.
+    playbackMapRef.current.set(videoId, targetSec);
+    const player = playerRef.current;
+    if (!player) return;
+    try {
+      player.seekTo(targetSec, true);
+      player.playVideo?.();
+      setIsPlaying(true);
+    } catch {
+      // player not ready yet — startTime fallback handles it on mount
+    }
+  }, [tParam, targetSec, videoId]);
 
   const handleUserPlayed = useCallback(() => {
     setIsPlaying(true);

--- a/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { ChevronRight, BookOpen, Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useMandalaQuery } from '@/features/mandala';
@@ -107,7 +108,7 @@ export function SidebarLearningSection({ mandalaId, collapsed }: SidebarLearning
               {isExpanded && (
                 <div className="px-3 pl-8 py-2">
                   {bookChapter ? (
-                    <BookChapterPreview chapter={bookChapter} />
+                    <BookChapterPreview chapter={bookChapter} mandalaId={mandalaId} />
                   ) : (
                     <div className="flex items-center gap-1.5 text-[11px] text-sidebar-foreground/40">
                       <Sparkles className="w-3 h-3 shrink-0" />
@@ -130,10 +131,17 @@ export function SidebarLearningSection({ mandalaId, collapsed }: SidebarLearning
 
 /**
  * CP438+1 — In-sidebar preview of a book chapter (PoC).
- * Shows section titles + atom count + jump-to-video links. Click on an
- * atom timestamp opens the YouTube source at the moment in a new tab.
+ * Shows section titles + atom count + jump-to-video links. Atom
+ * timestamp clicks navigate same-tab to /learning/:mandala/:vid?t=N
+ * which LearningPage handles via the seekTo effect (no new YouTube tab).
  */
-function BookChapterPreview({ chapter }: { chapter: MandalaBookChapter }) {
+function BookChapterPreview({
+  chapter,
+  mandalaId,
+}: {
+  chapter: MandalaBookChapter;
+  mandalaId: string;
+}) {
   const sections = chapter.sections ?? [];
 
   return (
@@ -167,16 +175,14 @@ function BookChapterPreview({ chapter }: { chapter: MandalaBookChapter }) {
                         {atom.text.slice(0, 60)}
                         {atom.text.length > 60 ? '…' : ''}
                         {atom.vid && Number.isFinite(atom.ts) && (
-                          <a
-                            href={`https://www.youtube.com/watch?v=${atom.vid}&t=${Math.floor(atom.ts ?? 0)}s`}
-                            target="_blank"
-                            rel="noopener noreferrer"
+                          <Link
+                            to={`/learning/${mandalaId}/${atom.vid}?t=${Math.floor(atom.ts ?? 0)}`}
                             className="ml-1 inline-block rounded-[3px] bg-[rgba(129,140,248,0.15)] px-1 font-mono text-[9px] text-[#818cf8]"
                             onClick={(e) => e.stopPropagation()}
                           >
                             ▶ {Math.floor((atom.ts ?? 0) / 60)}:
                             {String(Math.floor((atom.ts ?? 0) % 60)).padStart(2, '0')}
-                          </a>
+                          </Link>
                         )}
                       </span>
                     </li>


### PR DESCRIPTION
## Bug
북인덱스 / V2 상세 요약의 atom timestamp 클릭 시 새 탭으로 youtube.com 이동 → 사용자 흐름 단절. 기대 동작: 중앙 패널 video player 가 해당 구간으로 seek + play.

## Fix
| File | Change |
|------|--------|
| `LearningPage.tsx` | `?t=N` query param → `useEffect` 가 player.seekTo + playVideo. playbackMapRef 도 업데이트 (video remount 시 resume) |
| `SidebarLearningSection.tsx` | atom `<a target=_blank>` → `<Link to=/learning/:mandala/:vid?t=N>` |
| `PanelAISummary.tsx` | V2NewBlock atom 도 동일 패턴, `tsUrl` = in-app route |

## Test plan
- [x] BE tsc + vitest 275/275 + build
- [x] /verify PASS marker
- [ ] Post-deploy: 북인덱스 atom 클릭 → 같은 탭 video player seek 확인
- [ ] V2 상세 요약 atom 클릭 → 동일 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)