### PR TITLE
fix(ui): unify panel font + highlight active book section (CP438+1)

### DIFF
--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -263,6 +263,23 @@
 
   body {
     @apply bg-background text-foreground font-sans;
+    /* CP438+1: unify Korean rendering across panels (sidebar / center /
+     * chatbot). Korean glyphs were falling back inconsistently because
+     * Source Sans Pro is Latin-only — the chatbot panel uses system
+     * Korean while the sidebar/center used different fallbacks per
+     * browser. Pin the Korean-first stack so every panel renders the
+     * same Apple SD Gothic Neo / Pretendard family. */
+    font-family:
+      -apple-system,
+      BlinkMacSystemFont,
+      "Apple SD Gothic Neo",
+      Pretendard,
+      "Noto Sans KR",
+      "Source Sans Pro",
+      "Segoe UI",
+      Roboto,
+      system-ui,
+      sans-serif;
   }
 
   /* Skip navigation link — visible on focus only */

--- a/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { ChevronRight, BookOpen, Sparkles } from 'lucide-react';
+import { ChevronRight, BookOpen, Sparkles, PlayCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useMandalaQuery } from '@/features/mandala';
 import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
@@ -15,7 +15,11 @@ interface SidebarLearningSectionProps {
   collapsed: boolean;
 }
 
-export function SidebarLearningSection({ mandalaId, collapsed }: SidebarLearningSectionProps) {
+export function SidebarLearningSection({
+  mandalaId,
+  currentVideoId,
+  collapsed,
+}: SidebarLearningSectionProps) {
   const { t } = useTranslation();
   const [selectedCell, setSelectedCell] = useState<number | null>(null);
 
@@ -33,6 +37,27 @@ export function SidebarLearningSection({ mandalaId, collapsed }: SidebarLearning
       bookChaptersByIdx.set(ch.ch, ch);
     }
   }
+
+  // CP438+1: find which chapter+section contains an atom whose vid matches
+  // the currently-playing video. Used to highlight the active section in
+  // the sidebar AND auto-expand the chapter on first match.
+  const activeMatch: { chapterIdx: number; sectionIdx: number } | null = (() => {
+    if (!currentVideoId || !bookResponse?.book?.chapters) return null;
+    for (const ch of bookResponse.book.chapters) {
+      const sections = ch.sections ?? [];
+      for (let s = 0; s < sections.length; s++) {
+        const atoms = sections[s].atoms ?? [];
+        if (atoms.some((a) => a.vid === currentVideoId)) {
+          return { chapterIdx: ch.ch, sectionIdx: s };
+        }
+      }
+    }
+    return null;
+  })();
+
+  useEffect(() => {
+    if (activeMatch) setSelectedCell(activeMatch.chapterIdx + 1);
+  }, [activeMatch?.chapterIdx]);
 
   const cardsByCell = new Map<number, InsightCard[]>();
   for (const card of mandalaCards) {
@@ -76,6 +101,7 @@ export function SidebarLearningSection({ mandalaId, collapsed }: SidebarLearning
           // CP438+1 — book chapter `ch` is 0-based but cellIndex is 1-based.
           const bookChapter = bookChaptersByIdx.get(idx);
           const sectionCount = bookChapter?.sections?.length ?? 0;
+          const isActiveChapter = activeMatch?.chapterIdx === idx;
 
           return (
             <div key={idx}>
@@ -83,15 +109,18 @@ export function SidebarLearningSection({ mandalaId, collapsed }: SidebarLearning
                 onClick={() => setSelectedCell(isExpanded ? null : idx + 1)}
                 className={cn(
                   'flex w-full items-center gap-2 px-3 py-2 text-left rounded-lg transition-colors',
-                  isExpanded
-                    ? 'bg-sidebar-accent text-sidebar-foreground'
-                    : 'text-sidebar-foreground/70 hover:bg-sidebar-accent/50'
+                  isActiveChapter && !isExpanded
+                    ? 'bg-[rgba(129,140,248,0.10)] text-sidebar-foreground'
+                    : isExpanded
+                      ? 'bg-sidebar-accent text-sidebar-foreground'
+                      : 'text-sidebar-foreground/70 hover:bg-sidebar-accent/50'
                 )}
               >
                 <ChevronRight
                   className={cn('h-3 w-3 shrink-0 transition-transform', isExpanded && 'rotate-90')}
                 />
                 <span className="flex-1 truncate text-[12px] font-medium">{goal}</span>
+                {isActiveChapter && <PlayCircle className="h-3 w-3 shrink-0 text-[#818cf8]" />}
                 {sectionCount > 0 ? (
                   <span className="shrink-0 rounded-full bg-[rgba(45,212,191,0.15)] px-1.5 py-0.5 text-[10px] font-semibold text-[#2dd4bf]">
                     📖 {sectionCount}
@@ -108,7 +137,12 @@ export function SidebarLearningSection({ mandalaId, collapsed }: SidebarLearning
               {isExpanded && (
                 <div className="px-3 pl-8 py-2">
                   {bookChapter ? (
-                    <BookChapterPreview chapter={bookChapter} mandalaId={mandalaId} />
+                    <BookChapterPreview
+                      chapter={bookChapter}
+                      mandalaId={mandalaId}
+                      currentVideoId={currentVideoId}
+                      activeSectionIdx={isActiveChapter ? (activeMatch?.sectionIdx ?? null) : null}
+                    />
                   ) : (
                     <div className="flex items-center gap-1.5 text-[11px] text-sidebar-foreground/40">
                       <Sparkles className="w-3 h-3 shrink-0" />
@@ -138,9 +172,13 @@ export function SidebarLearningSection({ mandalaId, collapsed }: SidebarLearning
 function BookChapterPreview({
   chapter,
   mandalaId,
+  currentVideoId,
+  activeSectionIdx,
 }: {
   chapter: MandalaBookChapter;
   mandalaId: string;
+  currentVideoId?: string;
+  activeSectionIdx: number | null;
 }) {
   const sections = chapter.sections ?? [];
 
@@ -152,12 +190,30 @@ function BookChapterPreview({
       <ul className="space-y-2">
         {sections.map((sec, sIdx) => {
           const atoms = sec.atoms ?? [];
+          const isActiveSection = sIdx === activeSectionIdx;
           return (
             <li
               key={sIdx}
-              className="rounded-[6px] border border-sidebar-border bg-sidebar-accent/30 px-2 py-2"
+              className={cn(
+                'rounded-[6px] border px-2 py-2 transition-colors',
+                isActiveSection
+                  ? 'border-[#818cf8] bg-[rgba(129,140,248,0.08)] ring-1 ring-[rgba(129,140,248,0.3)]'
+                  : 'border-sidebar-border bg-sidebar-accent/30'
+              )}
             >
-              <p className="text-[11px] font-semibold text-sidebar-foreground/80">{sec.title}</p>
+              <div className="flex items-start gap-1.5">
+                {isActiveSection && (
+                  <PlayCircle className="mt-[1px] h-3 w-3 shrink-0 text-[#818cf8]" />
+                )}
+                <p
+                  className={cn(
+                    'text-[11px] font-semibold',
+                    isActiveSection ? 'text-[#818cf8]' : 'text-sidebar-foreground/80'
+                  )}
+                >
+                  {sec.title}
+                </p>
+              </div>
               {sec.narrative && (
                 <p className="mt-1 text-[10px] leading-[1.45] text-sidebar-foreground/55">
                   {sec.narrative}
@@ -165,28 +221,39 @@ function BookChapterPreview({
               )}
               {atoms.length > 0 && (
                 <ul className="mt-1.5 space-y-0.5">
-                  {atoms.slice(0, 5).map((atom, aIdx) => (
-                    <li
-                      key={aIdx}
-                      className="flex gap-1 text-[10px] leading-[1.4] text-sidebar-foreground/60"
-                    >
-                      <span className="shrink-0 text-sidebar-foreground/40">·</span>
-                      <span className="flex-1">
-                        {atom.text.slice(0, 60)}
-                        {atom.text.length > 60 ? '…' : ''}
-                        {atom.vid && Number.isFinite(atom.ts) && (
-                          <Link
-                            to={`/learning/${mandalaId}/${atom.vid}?t=${Math.floor(atom.ts ?? 0)}`}
-                            className="ml-1 inline-block rounded-[3px] bg-[rgba(129,140,248,0.15)] px-1 font-mono text-[9px] text-[#818cf8]"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            ▶ {Math.floor((atom.ts ?? 0) / 60)}:
-                            {String(Math.floor((atom.ts ?? 0) % 60)).padStart(2, '0')}
-                          </Link>
+                  {atoms.slice(0, 5).map((atom, aIdx) => {
+                    const isActiveAtom = atom.vid === currentVideoId;
+                    return (
+                      <li
+                        key={aIdx}
+                        className={cn(
+                          'flex gap-1 text-[10px] leading-[1.4]',
+                          isActiveAtom ? 'text-sidebar-foreground' : 'text-sidebar-foreground/60'
                         )}
-                      </span>
-                    </li>
-                  ))}
+                      >
+                        <span className="shrink-0 text-sidebar-foreground/40">·</span>
+                        <span className="flex-1">
+                          {atom.text.slice(0, 60)}
+                          {atom.text.length > 60 ? '…' : ''}
+                          {atom.vid && Number.isFinite(atom.ts) && (
+                            <Link
+                              to={`/learning/${mandalaId}/${atom.vid}?t=${Math.floor(atom.ts ?? 0)}`}
+                              className={cn(
+                                'ml-1 inline-block rounded-[3px] px-1 font-mono text-[9px]',
+                                isActiveAtom
+                                  ? 'bg-[rgba(129,140,248,0.3)] text-[#818cf8]'
+                                  : 'bg-[rgba(129,140,248,0.15)] text-[#818cf8]'
+                              )}
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              ▶ {Math.floor((atom.ts ?? 0) / 60)}:
+                              {String(Math.floor((atom.ts ?? 0) % 60)).padStart(2, '0')}
+                            </Link>
+                          )}
+                        </span>
+                      </li>
+                    );
+                  })}
                   {atoms.length > 5 && (
                     <li className="text-[10px] text-sidebar-foreground/40">
                       +{atoms.length - 5} more


### PR DESCRIPTION
## Summary
- 좌측/중앙/우측 패널 폰트 불일치 → 한글 우선 시스템 폰트 stack 으로 body 통일 (챗봇이 사용하는 시스템 폰트와 일치).
- 좌측 책 사이드바: 현재 재생 중인 video 와 매치되는 chapter/section 자동 expand + 강조 (indigo border + ring + ▶ icon).

## Test plan
- [x] BE tsc + FE tsc + vitest 275/275 + build
- [x] /verify PASS marker
- [ ] Post-deploy: 영어로 말하고 싶다 만다라 → "I bet" video 진입 시 좌측 6.2 의견 표현 5가지 강도 section 자동 highlight 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)