### PR TITLE
fix(v2): atom timestamps — preserve markers + duration clamp (CP438+1)

### DIFF
--- a/mac-mini/v2-author/batch.sh
+++ b/mac-mini/v2-author/batch.sh
@@ -51,8 +51,10 @@ fi
 echo "[v2-batch] candidates fetched: $COUNT" | tee -a "$SUMMARY"
 
 # 2. Dispatch concurrently via xargs -P. Each worker = process-one.sh.
-PAIRS=$(printf '%s' "$CANDS_JSON" | jq -r '.videos[] | "\(.youtube_video_id) \(.default_language // "ko")"')
-echo "$PAIRS" | xargs -n 2 -P "$CONC" -I {} bash -c 'eval set -- {}; "'"$DIR"'/process-one.sh" "$1" "$2"' || true
+# CP438+1: forward duration_sec (3rd arg) so process-one.sh can inject it
+# into the prompt (timestamp ≤ duration rule).
+PAIRS=$(printf '%s' "$CANDS_JSON" | jq -r '.videos[] | "\(.youtube_video_id) \(.default_language // "ko") \(.duration_sec // 0)"')
+echo "$PAIRS" | xargs -n 3 -P "$CONC" -I {} bash -c 'eval set -- {}; "'"$DIR"'/process-one.sh" "$1" "$2" "$3"' || true
 
 # 3. Aggregate per-video result lines.
 PASS=$(grep -h ' pass ' "$V2_LOG_DIR"/*.log 2>/dev/null | wc -l | tr -d ' ')

--- a/mac-mini/v2-author/fetch-transcript.py
+++ b/mac-mini/v2-author/fetch-transcript.py
@@ -36,7 +36,18 @@ def main() -> int:
     lang = sys.argv[2] if len(sys.argv) > 2 else "ko"
     try:
         result = YouTubeTranscriptApi().fetch(vid, languages=[lang])
-        text = " ".join(s.text for s in result.snippets)
+        # CP438+1 fix: preserve cue start times so the LLM can use them as
+        # the source of `timestamp_sec`. Prior version dropped `s.start`
+        # entirely, forcing the model to hallucinate timestamps and
+        # produce values past the video duration (1103/7496 atoms = 14.7%
+        # were over-duration before this fix).
+        parts = []
+        for s in result.snippets:
+            sec = int(s.start) if hasattr(s, "start") else 0
+            mm = sec // 60
+            ss = sec % 60
+            parts.append(f"[{mm}:{ss:02d}] {s.text}")
+        text = "\n".join(parts)
     except Exception as e:  # noqa: BLE001 — surface every failure mode
         sys.stderr.write(f"{type(e).__name__}: {e}\n")
         return 1

--- a/mac-mini/v2-author/process-one.sh
+++ b/mac-mini/v2-author/process-one.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Process ONE video: transcript fetch → claude -p (v2 schema) → POST upsert-direct.
-# Args: $1 = youtube_video_id  $2 = source_language (ko|en)
+# Args: $1 = youtube_video_id  $2 = source_language (ko|en)  $3 = duration_sec (optional, for prompt + clamp)
 # Env: INSIGHTA_API_URL / INTERNAL_BATCH_TOKEN
 #      TRANSCRIPT_FETCHER (default 'ytapi'; 'ytdlp' for legacy WebShare path)
 #      For ytdlp path: WEBSHARE_* required.
@@ -11,6 +11,7 @@ set -uo pipefail
 
 VID="$1"
 LANG="${2:-ko}"
+DURATION_SEC="${3:-0}"
 LOG_DIR="${V2_LOG_DIR:-/tmp/insighta-v2-batch}"
 mkdir -p "$LOG_DIR"
 
@@ -57,10 +58,38 @@ else
     mark_attempted "$VID"
     exit 1
   fi
+  # CP438+1 fix: capture the cue start time and prefix the next text
+  # line with [mm:ss]. Prior version dropped both the timestamp line and
+  # the `-->` separator entirely, leaving the LLM with no timing source
+  # — which forced it to hallucinate timestamp_sec values past video
+  # duration (1103/7496 atoms = 14.7% over-duration on legacy data).
   TRANSCRIPT=$(awk '
-    /^WEBVTT/ || /^Kind:/ || /^Language:/ || /^[0-9]+:[0-9]+/ || /-->/ || /^align:/ || /^position:/ { next }
+    BEGIN { last_ts = "" }
+    /^WEBVTT/ || /^Kind:/ || /^Language:/ || /^align:/ || /^position:/ { next }
+    /-->/ {
+      # Cue header line: 00:01:23.456 --> 00:01:25.789
+      match($0, /^([0-9]+):([0-9]+):([0-9]+)/, m)
+      if (m[1] != "") {
+        sec = m[1] * 3600 + m[2] * 60 + m[3]
+      } else {
+        match($0, /^([0-9]+):([0-9]+)/, m2)
+        sec = m2[1] * 60 + m2[2]
+      }
+      mm = int(sec / 60); ss = sec % 60
+      last_ts = sprintf("[%d:%02d]", mm, ss)
+      next
+    }
+    /^[0-9]+$/ { next }
     /^$/ { next }
-    { gsub(/<[^>]*>/, ""); gsub(/&nbsp;/, " "); print }
+    {
+      gsub(/<[^>]*>/, ""); gsub(/&nbsp;/, " ")
+      if (last_ts != "") {
+        print last_ts " " $0
+        last_ts = ""
+      } else {
+        print $0
+      }
+    }
   ' "$VTT" | awk '!seen[$0]++' | head -c 30000)
 fi
 
@@ -112,6 +141,14 @@ Rules:
 - analysis.actionables: each a single imperative sentence the viewer can do today.
 - lora.qa_pairs: 5-7 entries, all level=1, all context="video".
 - timestamp_sec / from_sec / to_sec are integers in seconds (NOT mm:ss).
+- TIMESTAMP RULE (critical, CP438+1): The transcript below is annotated with
+  [mm:ss] markers at the start of every cue. Atom timestamp_sec MUST be
+  derived from the [mm:ss] marker that contains the source phrase — convert
+  to seconds (mm*60 + ss). Section from_sec/to_sec must come from the
+  earliest/latest [mm:ss] marker spanned. NEVER invent round numbers
+  (1:00, 5:00, 7:00, etc.) without a matching marker. Atom timestamp_sec
+  MUST be ≤ video duration ('"${DURATION_SEC}"' s); if a candidate exceeds
+  it, drop the atom rather than emit it.
 - Use the source language consistently across every string field.
 - Output JSON only — no preamble, no markdown fences, no commentary.
 '

--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -53,6 +53,7 @@ interface CandidateRow {
   youtube_video_id: string;
   default_language: string | null;
   has_caption: boolean | null;
+  duration_sec: number | null;
 }
 
 /**
@@ -165,7 +166,8 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
       SELECT
         yv.youtube_video_id,
         yv.default_language,
-        yv.has_caption
+        yv.has_caption,
+        yv.duration_seconds AS duration_sec
       FROM youtube_videos yv
       LEFT JOIN video_rich_summaries vrs ON vrs.video_id = yv.youtube_video_id
       LEFT JOIN (
@@ -289,6 +291,67 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
 
     const prisma = getPrismaClient();
     const now = new Date();
+
+    // CP438+1: clamp atom timestamp_sec / section from_sec/to_sec to video
+    // duration. Even with the new prompt rule + transcript [mm:ss] markers,
+    // the LLM occasionally still emits values past the duration. Silent
+    // clamp + log keeps the row useful (text + type stay) instead of 422
+    // rejecting the whole row.
+    let clampedAtomCount = 0;
+    let clampedSectionCount = 0;
+    let durationSec: number | null = null;
+    let mutatedSegments: unknown = body.segments;
+    try {
+      const yvRow = await prisma.$queryRawUnsafe<{ duration_seconds: number | null }[]>(
+        'SELECT duration_seconds FROM youtube_videos WHERE youtube_video_id = $1 LIMIT 1',
+        videoId
+      );
+      durationSec = yvRow[0]?.duration_seconds ?? null;
+    } catch {
+      // duration unknown — skip clamp; fall back to legacy behavior
+      durationSec = null;
+    }
+    if (
+      typeof durationSec === 'number' &&
+      durationSec > 0 &&
+      body.segments &&
+      typeof body.segments === 'object'
+    ) {
+      const cap = Math.max(0, durationSec - 1);
+      const segCopy = JSON.parse(JSON.stringify(body.segments)) as {
+        atoms?: Array<{ timestamp_sec?: number | null }>;
+        sections?: Array<{ from_sec?: number | null; to_sec?: number | null }>;
+      };
+      if (Array.isArray(segCopy.atoms)) {
+        for (const a of segCopy.atoms) {
+          if (typeof a.timestamp_sec === 'number' && a.timestamp_sec > cap) {
+            a.timestamp_sec = cap;
+            clampedAtomCount++;
+          }
+        }
+      }
+      if (Array.isArray(segCopy.sections)) {
+        for (const s of segCopy.sections) {
+          if (typeof s.from_sec === 'number' && s.from_sec > cap) {
+            s.from_sec = cap;
+            clampedSectionCount++;
+          }
+          if (typeof s.to_sec === 'number' && s.to_sec > cap) {
+            s.to_sec = cap;
+            clampedSectionCount++;
+          }
+        }
+      }
+      mutatedSegments = segCopy;
+      if (clampedAtomCount > 0 || clampedSectionCount > 0) {
+        log.warn('v2 timestamp clamp', {
+          videoId,
+          duration_seconds: durationSec,
+          clamped_atoms: clampedAtomCount,
+          clamped_sections: clampedSectionCount,
+        });
+      }
+    }
     try {
       // upsert (not update) — selector (LEFT JOIN, vrs.video_id IS NULL)
       // surfaces newly-collected yv rows that have no summary yet, so this
@@ -300,7 +363,7 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
           core: summary.core as unknown as PrismaCli.InputJsonValue,
           analysis: summary.analysis as unknown as PrismaCli.InputJsonValue,
           lora: summary.lora as unknown as PrismaCli.InputJsonValue,
-          ...(body.segments ? { segments: body.segments as PrismaCli.InputJsonValue } : {}),
+          ...(mutatedSegments ? { segments: mutatedSegments as PrismaCli.InputJsonValue } : {}),
           completeness: score.score,
           quality_flag: 'pass',
           model: 'claude-code-direct',
@@ -316,7 +379,7 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
           core: summary.core as unknown as PrismaCli.InputJsonValue,
           analysis: summary.analysis as unknown as PrismaCli.InputJsonValue,
           lora: summary.lora as unknown as PrismaCli.InputJsonValue,
-          ...(body.segments ? { segments: body.segments as PrismaCli.InputJsonValue } : {}),
+          ...(mutatedSegments ? { segments: mutatedSegments as PrismaCli.InputJsonValue } : {}),
           completeness: score.score,
           quality_flag: 'pass',
           model: 'claude-code-direct',


### PR DESCRIPTION
## Bug
북인덱스 atom timestamps showed values past video duration (5:58 video → atoms at 6:30 / 7:00). Sweep across DB found 1103/7496 atoms (14.7%) over-duration affecting 471/897 v2 videos (52.5%).

## Root cause (pipeline trace)
| Stage | Defect |
|-------|--------|
| `fetch-transcript.py` | `" ".join(s.text)` dropped `s.start` cue times |
| `process-one.sh` awk | `/^[0-9]+:[0-9]+/ \|\| /-->/ { next }` stripped both timestamp + separator |
| Prompt | asked for `timestamp_sec: int` but input had no timing source |
| LLM | hallucinated round numbers (1:00, 5:00, 7:00) as "logical" placeholders |
| `validateV2Segments` | enforced key whitelist only — no value range |
| `scoreCompleteness` | ignored M3 (timestamp quality) |

## Fix (3 layers, single PR)
**PR-A** — preserve timestamps + prompt rule
- `fetch-transcript.py` emits `[mm:ss] text` per snippet
- `process-one.sh` awk captures cue header → prefixes next text line
- prompt: new TIMESTAMP RULE — derive from markers, ≤ duration, no rounds
- `batch.sh` forwards `duration_sec` (3rd arg) from candidates response
- `transcript.ts` candidates SQL adds `duration_seconds AS duration_sec`

**PR-B** — defense-in-depth (silent clamp + log)
- `transcript.ts` upsert-direct: query `yv.duration_seconds`, clamp atoms + sections to `min(value, duration - 1)`, `log.warn` counts when clamp fires

**PR-C** — existing data cleanup (applied direct to prod via $executeRawUnsafe)
- `video_rich_summaries`: 616 rows / 1108 atoms / 2024 sections clamped
- `mandala_books.book_json`: 1 book / 4 atoms clamped (영어로 말하고 싶다 PoC)
- Verification SELECT: 0 over-duration atoms remaining

## Test plan
- [x] BE tsc + FE tsc + vitest 275/275 + FE build
- [x] Browser smoke / and /learning → 200
- [x] /verify PASS marker
- [x] Prod cleanup verified (over-duration: 1103 → 0)
- [ ] Post-deploy: visit 1g5HSh37atU video → atoms timestamps all ≤ 5:58 (no 6:30/7:00 surfacing)
- [ ] Next v2 batch: re-author one video, confirm new atoms have timestamps that map to actual transcript [mm:ss] markers (NOT round-number invents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)