### PR TITLE
fix(prod): raise Prisma pool 5 → 15 (wizard tx connection wait)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -217,6 +217,21 @@ services:
       # code. Uncomment + override here ONLY if the exact OpenRouter
       # model id string differs (verify at https://openrouter.ai/models).
       # - OPENROUTER_EMBED_MODEL=qwen/qwen3-embedding-8b
+      # CP451 (2026-05-12) — raise Prisma pool 5 → 15 to fix wizard
+      # tx_total bimodal gap (p50 3.9s, max 8.3s) caused by Supabase
+      # transaction pooler slot exhaustion. Background hot path
+      # (`UPDATE youtube_videos SET transcript_fetched_at`) takes 3-5s
+      # per call × 10+ concurrent, saturating the default 5-slot pool;
+      # wizard `$transaction` then waits for a free slot.
+      # Evidence: same user 60s gap delta = 12×, `pool_limit=5` in
+      # `[prisma-init]` log, `[prisma-slow-query]` shows 10× UPDATE 3-5s.
+      # Code default is `DEFAULT_POOL_LIMIT=5` (src/modules/database/
+      # connection-url.ts:21) — this env override raises ceiling to 15.
+      # Safety: `MAX_POOL_LIMIT=50` enforced at connection-url.ts:23,
+      # Supabase transaction pool quota ≫ 15. Tuning knob, not a secret
+      # (CP392 2-question test: pool size is stdout-safe / OSS-safe).
+      # Revert: delete this line → code default 5 takes over on redeploy.
+      - PRISMA_POOL_LIMIT=15
     volumes:
       - cache_data:/app/cache
       - logs_data:/app/logs


### PR DESCRIPTION
## Summary

- Add `PRISMA_POOL_LIMIT=15` to `docker-compose.prod.yml` (api service)
- Fixes wizard `$transaction` connection-acquire wait causing tx_total bimodal 3-8s spikes

## Root cause (data-anchored)

`mandala_create_timings` n=49 (2026-04-23 ~ 2026-05-11):
- `tx_total` p50 **3867ms**, p95 7980ms, max 8283ms
- Measured inner sum only ~216ms (`tx_mandala_create` 101ms + `tx_levels_createMany` 98ms + `tx_find_unique` 17ms)
- **Gap p50 = 3677ms is unmeasured** → `$transaction` connection-acquire time

Distribution is **bimodal**: min 10ms / p10 524ms / **p50 3677ms** / max 8283ms.  
Same user 60s apart: gap 4185ms → 329ms (12× delta) confirming external contention, not code/SQL issue.

`[prisma-slow-query]` log shows the contention source: `UPDATE youtube_videos SET transcript_fetched_at = ...` taking 3110~5295ms × 10 concurrent — saturating the default 5-slot pool.

## Fix

- File: `docker-compose.prod.yml` (api service env)
- Diff: 1 line added (`- PRISMA_POOL_LIMIT=15`) + 14-line rationale comment
- Code default: `DEFAULT_POOL_LIMIT=5` (`src/modules/database/connection-url.ts:21`)
- Ceiling: `MAX_POOL_LIMIT=50` (line 23)
- Supabase transaction pool quota ≫ 15

## Test plan

- [ ] Deploy via CI/CD
- [ ] Confirm `[prisma-init]` log shows `"pool_limit":15`
- [ ] Run `/mandala-perf --block=timings --timings-n=20` 1h post-deploy
- [ ] Expected: gap p50 3677ms → < 500ms

## Rollback

Three paths, fastest first:

1. **Emergency SSH (~2 min)**: `bash scripts/ssh-connect.sh "cd /opt/tubearchive && sed -i '/PRISMA_POOL_LIMIT/d' docker-compose.prod.yml && docker compose up -d api"`
2. **PR revert (~5-10 min)**: `git revert <this-commit>` on main → CI/CD auto-deploy → default 5 restored on container restart
3. **Container restart only**: not viable (env can't be unset on running container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)