### PR TITLE
docs(spec): hybrid retrieval design + session diagnosis (Issue #610 spec)

### DIFF
--- a/docs/design/insighta-hybrid-retrieval-2026-05-12.md
+++ b/docs/design/insighta-hybrid-retrieval-2026-05-12.md
@@ -1,0 +1,259 @@
+# Insighta Hybrid Retrieval — 2026-05-12 디자인 초안
+
+**Status**: Locked (사용자 directive 2026-05-12 "활용가능한 기능은 최대한 도입해서 활용")
+**Adoption scope**: A + B + C + D 전수 도입. E (channel scan) 만 보류 (mandala-centric 모델과 conceptual 충돌).
+
+**Origin**:
+- 본 세션 진단 결과 (`docs/reports/wizard-dashboard-diagnosis-2026-05-12.md`) — 카드 품질 (Issue #610), 카드 수량, 챗봇 컨텍스트 부재
+- 사용자 제안 (2026-05-12): "오픈소스 분석 + 적용 가능한 부분 도입" → YT-Navigator (MIT, 593★, https://github.com/wassim249/YT-Navigator) 분석 → Insighta 재서술
+
+**비-목표 (Non-goals)**: Insighta 의 mandala/cell/user_video_states 모델 변경 X. 챗봇 / wizard discover / 카드 ranking 만 영향.
+
+---
+
+## 1. 무엇이 부족한가 (Insighta 현 상태)
+
+| 부족 영역 | 현 prod 동작 | 데이터 |
+|----------|------------|--------|
+| 카드 quality | cosine (mandala_embeddings ↔ video_pool/YouTube ranking) 단일 게이트 + PR #555 mandala-filter bypass | mandala 7b99f68c top rec_score 1.0 = "의료영어회화 002" |
+| 카드 quantity | shorts cutoff 180s + LLM query gen 편향 + cell 분배 불균등 | 5/8 cells 채움, droppedShortsDuration=137/290 |
+| Reranking | 없음 (rec_score = mandala_embeddings cosine 그대로) | `video_chunk_embeddings` 2,641 rows dormant |
+| 시간 anchor | 카드는 전체 영상 단위, 사용자가 "어디부터 의미 있나" 모름 | `video_chunk_embeddings.start_sec` 컬럼 미사용 |
+| 챗봇 컨텍스트 | `ontology/chat.ts` 가 매 호출마다 graph traversal | `PLACED_IN` 8 rows = card→sector 그래프 미반영 |
+| LLM cost | 매 응답마다 tool call (graph 조회) | route 분기 없음 |
+
+---
+
+## 2. YT-Navigator 의 어떤 패턴이 직접 응답하는가
+
+### Pattern P1 — Hybrid retrieval + cross-encoder rerank
+
+YT-Navigator `app/services/vector_database/tools/vector_tool.py:similarity_videos_search` 의 11-stage pipeline:
+
+```
+1. semantic search   (asimilarity_search, k=20)
+2. keyword search    (BM25 또는 tsvector 자체 구현)
+3. concat + bulk fetch metadata (single query)
+4. dedupe by content
+5. cross-encoder rerank  (BAAI/bge-reranker-v2-m3 등)
+6. valid filter
+7. Counter → top 5 video_ids
+8. minimise_chunks (representative chunk per video)
+9. MinMaxScaler 0-100 score 표준화
+10. group by video + avg_score
+11. sort desc, return
+```
+
+**우리 Insighta 의 카드 quality 문제 (Issue #610) 의 디자인 옵션 (c) "two-stage retrieval + rerank top-N" 과 사실상 동일.**
+
+### Pattern P2 — VideoChunk 모델 + timestamp anchor
+
+YT-Navigator `app/models/video_chunk.py`:
+```python
+class VideoChunk:
+    video: FK
+    start: TimeField    # 시간 anchor
+    end: TimeField
+    text: TextField
+```
+
+**우리는 이미 `video_chunk_embeddings(video_id, embedding vector(4096))` 존재 (2,641 rows). 그러나 시간 컬럼 없음.** 시간 anchor 추가 시:
+- 카드 click 시 "0:45 부터 의미 있음" deep-link
+- semantic rerank 의 결과를 segment-level 로 사용자에게 제시 → 체감 시간 ↓
+
+### Pattern P3 — LangGraph ReAct + route 분기
+
+YT-Navigator `app/services/agent/react_graph.py` 의 2-node 사이클:
+```
+agent (call_model with tools)
+  ↓ tool_calls? continue : END
+tools (execute)
+  ↓
+agent  ← loop
+```
+
+상위 `main_graph.py` (분석 미진행) 가 추가로 3-way route 한다:
+- (a) direct reply (cost-cheap LLM)
+- (b) static "not relevant" reply
+- (c) tool_calls reply (heavier LLM)
+
+**현재 우리 챗봇은 모든 query 에 graph traversal 수행 → cost + latency 낭비.** Route 가 있으면 "안녕하세요" 같은 trivial query 가 graph 안 탐.
+
+---
+
+## 3. Insighta 스택 재서술
+
+| 영역 | YT-Navigator | Insighta 대응 | 비용 |
+|------|------------|-------------|------|
+| Vector store | PGVector (Django ORM) | PGVector (Prisma + `pgvector` extension, 이미 5 테이블 운영 중) | 0 — 동일 인프라 |
+| Semantic search | `asimilarity_search(k=20)` | `prisma.$queryRaw` + `<=>` cosine operator (이미 v3 cache-matcher 등에서 사용 중) | 0 |
+| Keyword search | BM25 (Postgres `ts_rank` 또는 외부 lib) | Postgres `to_tsvector` + `ts_rank` (TS-side: SQL 1줄) | 낮음 — 자체 구현 |
+| Cross-encoder rerank | `sentence-transformers` (BAAI/bge-reranker-v2-m3) Python 직접 inference | OpenRouter 모델 호스팅 확인 필요. 없으면 Mac Mini Ollama 또는 별도 HF inference endpoint | 중간 — 모델 호스팅 결정 |
+| LangGraph | `langgraph` Python | `@langchain/langgraph` (공식 TS 포팅 있음) 또는 자체 구현 | 중간 — 학습 곡선 |
+| Score 표준화 | sklearn MinMaxScaler | 자체 구현 (max-min normalize, 10 줄) | 0 |
+
+---
+
+## 4. 차용 후보 5개 (재정렬)
+
+### A. **Hybrid retrieval + cross-encoder rerank** — P0
+- **대응**: Issue #610 (카드 quality)
+- **범위**:
+  - 신규 `src/skills/plugins/video-discover/v3/hybrid-rerank.ts` (모듈)
+  - 입력: query, candidate list (mandala-filter 결과 + YouTube ranking)
+  - 단계: BM25 search → concat → dedupe → rerank → top-N
+  - mandala-filter 와 병행 도입, A/B flag
+- **모델 결정 필요**:
+  - OpenRouter 에 `BAAI/bge-reranker-v2-m3` 있는지 확인
+  - 없으면 Mac Mini Ollama 자체 호스팅 (Ollama 가 cross-encoder 안 함 → llama.cpp / TEI server 별도)
+  - 또는 Cohere `rerank-multilingual-v3.0` (유료 API, 1000 query 당 $1)
+- **추정 비용**: 100 query 처리당 rerank latency +200-500ms (모델 의존). cost: Cohere 의 경우 무시 가능 ($0.001/100)
+- **롤백**: A/B flag off
+
+### B. **VideoChunk timestamp anchor** — P0 (P2 patterns)
+- **대응**: video_chunk_embeddings dormancy + M3 사용자 체감
+- **범위**:
+  - DDL: `video_chunk_embeddings` 에 `start_sec INT, end_sec INT, text TEXT` 컬럼 추가
+  - transcript 처리 코드 (`internal/transcript.ts`) 가 segment 단위로 chunk + embed + insert
+  - FE: 카드 click 시 `youtube.com/watch?v=<id>&t=<start_sec>s` deep-link
+- **추정 비용**: 영상당 ~10-30 chunks × embed (qwen3-embedding:8b). 기존 transcript pipeline 에 segment loop 추가
+- **롤백**: 컬럼 그대로 두고 FE link 만 비활성
+
+### C. **LangGraph ReAct + 3-way route (챗봇)** — P1
+- **대응**: 챗봇 cost / latency + route 결정
+- **범위**:
+  - 신규 `src/modules/ontology/chat-graph.ts`
+  - 3 노드: `route_message` (cheap LLM) / `tool_call_agent` (powerful LLM) / `static_reply`
+  - 기존 `ontology/chat.ts` 와 병행 (flag)
+- **추정 비용**: 학습 곡선 (LangGraph TS) — ~1-2 day. cost 절감 분명 (cheap LLM route 우선)
+- **롤백**: flag
+
+### D. **Score 표준화 (MinMaxScaler) + group by video** — P2
+- **대응**: 현재 rec_score 분포가 너무 평탄 (top 0.99 → 0.88 → 0.95 등 unreliable)
+- **범위**: rec_score 를 0-100 표준화 + cell 별이 아니라 video 별 group + avg_score
+- **추정 비용**: SQL view + FE 정렬 한 번. 작음
+- **롤백**: view 삭제
+
+### E. **Channel-level scan 모드** — P3 (보류)
+- **대응**: 신규 user flow ("이 채널 깊이 학습")
+- **비용**: 큼 — endpoint + UI + scan worker
+- **위험**: mandala-centric 모델과 conceptual 충돌
+- **결정**: P0/P1 효과 확인 후 재검토
+
+---
+
+## 5. 단계별 도입 plan
+
+### Phase 1 — 자료 / 결정 (코드 변경 0)
+1. **OpenRouter `BAAI/bge-reranker-v2-m3` 호스팅 여부 확인** (또는 alternatives — Cohere, Voyage)
+2. **LangGraph TS 도입 비용 평가** — POC 1개 (route_message 단일 노드)
+3. **본 디자인 문서를 Issue #610 의 (c) 옵션 spec 으로 lock**
+
+### Phase 2 — Hybrid rerank shadow (Pattern A, flag-off)
+1. `hybrid-rerank.ts` 모듈 구현 (BM25 + concat + dedupe + rerank)
+2. `V3_ENABLE_HYBRID_RERANK=false` env 도입, shadow 모드 — recommendation_cache 에 두 set 저장
+3. 5+ mandala (finance / health / hobby / education / career) 의 A/B 비교 1주일
+4. 결과: hybrid 가 control 보다 top-5 cosine 평균 ≥ 0.1 높으면 활성화
+
+### Phase 3 — VideoChunk timestamp (Pattern B)
+1. DDL 추가 (`start_sec`, `end_sec`, `text`)
+2. transcript pipeline (`internal/transcript.ts`) 에 segment loop
+3. 기존 2,641 rows 는 `start_sec=NULL` 그대로, 신규만 시간 anchor
+4. FE deep-link 한 줄
+
+### Phase 4 — LangGraph chatbot (Pattern C)
+1. `@langchain/langgraph` 도입 + `chat-graph.ts` POC
+2. 기존 `ontology/chat.ts` 와 병행
+3. cost / latency 비교 후 flip
+
+### Phase 5 — Score 표준화 + group by video (Pattern D)
+- Phase 2 hybrid 안정화 후 적용
+
+---
+
+## 6. 결정 — Lock-in (2026-05-12)
+
+| 항목 | 결정 | 근거 |
+|------|-----|-----|
+| Reranker 모델 | **Mac Mini self-host: `BAAI/bge-reranker-v2-m3` via TEI server** | OpenRouter 에 reranker 없음 (확인 완료, 0 hits). Cohere/Voyage 는 신규 API key + 비용. Mac Mini 는 기존 Tailscale 인프라 재사용, CLAUDE.md LLM-API 금지 규칙과 무관 |
+| LangGraph | **`@langchain/langgraph@1.3.0` TS 도입** | 공식 TS 포팅 안정. 자체 구현 (~200 lines) 대비 ecosystem (HITL, checkpointing, streaming) 가치 큼 |
+| Keyword search | **Postgres `to_tsvector` + `ts_rank`** | 외부 lib 0. BM25 와 정확히 같지 않지만 keyword recall 효과 충분. 추가 인덱스 1개 |
+| Rerank 호출 빈도 | **매 wizard 시 1회, 결과는 `recommendation_cache.rec_score` 저장 (재호출 X)** | 추가 LLM 호출 없음. recompute 만이 갱신 |
+| Score 표준화 | **자체 구현 (max-min normalize, 10 줄)** | sklearn 의존 X |
+
+---
+
+## 7. 본 디자인의 메타-원칙 (CLAUDE.md alignment)
+
+- **단편 fix 금지** (Rule F) — flag flip 아니라 spec-level 통합
+- **측정 가능성** — Phase 2 shadow 모드로 A/B 정량 비교 (Rule G "valid rate + p95 + failure modes" 적용)
+- **롤백 즉시성** — 모든 Phase 가 flag-off 로 환원
+- **Plan→Approve→Execute** — 본 문서가 Plan, 사용자 승인 후 Phase 1 진행
+- **단일 PR 안 3 hotfix 누적 시 stop** — Phase 2 가 1주일 안에 ≥ 2 rollback 발생 시 디자인 iter reset
+
+---
+
+## 8. 실행 시퀀스 (lock-in)
+
+각 Phase 가 독립 PR. PR 머지 후 다음 Phase 진입. 4 PR / ~1-2 주 estimate.
+
+### PR1 — Pattern B (timestamp anchor + segment loop) — Foundation
+- **이유**: Pattern A 가 segment-level chunks 를 의미있게 활용하려면 chunk 가 시간 anchor 있어야. 다른 PR 의 prerequisite.
+- **범위**:
+  - DDL: `prisma/migrations/hybrid-retrieval/001_video_chunk_time.sql` — `ALTER TABLE video_chunk_embeddings ADD COLUMN start_sec INT, end_sec INT, text TEXT`
+  - Code: `internal/transcript.ts` 의 segment loop 추가
+  - FE: 카드 click 시 `&t=<start_sec>s` deep-link
+  - 기존 2,641 rows = `start_sec NULL` 그대로
+- **검증**: 신규 transcript 처리 1건 → chunk 10+ row, 모두 시간 채워짐
+
+### PR2 — Mac Mini TEI server (BGE-reranker) — Infrastructure
+- **이유**: Pattern A 의 rerank step 의 prerequisite
+- **범위**:
+  - Mac Mini 에 `text-embeddings-inference` server 띄움 (HF TEI, Docker)
+  - 모델: `BAAI/bge-reranker-v2-m3` (multilingual, 4-lang Korean OK)
+  - Tailscale 포트 노출, 신규 env `MANDALA_RERANK_URL=http://100.91.173.17:<port>`
+  - Insighta TS client: `src/modules/rerank/client.ts` (POST /rerank, body {query, texts[]})
+- **검증**: localhost 에서 sample (query, 10 texts) → score 배열 반환
+
+### PR3 — Pattern A (Hybrid retrieval + rerank) — Main quality fix
+- **이유**: Issue #610 의 spec 옵션 (c) 의 본체. 가장 큰 user-facing 효과.
+- **범위**:
+  - `src/skills/plugins/video-discover/v3/hybrid-rerank.ts` (모듈)
+  - 단계: candidate list → BM25 search → concat → dedupe → rerank → top-N → score 표준화 → group by video → return
+  - 통합 위치: `v3/executor.ts` 의 기존 mandala-filter 결과를 입력으로 받음
+  - flag: `V3_ENABLE_HYBRID_RERANK=true` (PR 머지 시 default ON)
+  - PR #555 `V3_USE_YOUTUBE_RANKING_ONLY=true` 의 cell-quality 문제를 hybrid+rerank 가 대체
+- **검증**: 동일 mandala (7b99f68c, 영어 학습) 에서 의료영어 oversaturation 사라지는지 (top 5 카드 manual 검증). Issue #610 close.
+
+### PR4 — Pattern D (Score 표준화 + group by video) — Polish
+- **이유**: rec_score 분포 평탄성 개선 + UX 정렬 합리화
+- **범위**:
+  - rec_score 0-100 normalize (PR3 안에 통합 가능하면 흡수)
+  - cell-별 정렬에 video group-avg 보조 score 추가
+- **검증**: 동일 video 다중 chunk 가 분산되지 않고 1 video 가 1 슬롯에 응집
+
+### PR5 — Pattern C (LangGraph ReAct + 3-way route) — Chatbot
+- **이유**: 챗봇 cost / latency / 응답 품질. PR3 와 독립적.
+- **범위**:
+  - `npm i @langchain/langgraph @langchain/core`
+  - `src/modules/ontology/chat-graph.ts` 신규
+  - 3 노드: `route_message` (cheap LLM cheap, e.g. Qwen 7B local) / `static_reply` / `tool_call_agent` (powerful, Haiku/Gemini)
+  - 도구 2개: `vectorSearchTool` (PR3 의 hybrid-rerank.ts wrapping) + `sqlTool` (user_video_states / mandala_levels select)
+  - 기존 `ontology/chat.ts` flag-off, 신규 path flag-on (`CHAT_USE_LANGGRAPH=true`)
+- **검증**: trivial query ("안녕") → route 가 cheap LLM 만 호출 (LLM cost 측정). 복잡 query → tool_call agent 가 적절히 도구 호출.
+
+---
+
+## 9. Cross-references
+
+- Source: [YT-Navigator](https://github.com/wassim249/YT-Navigator) (MIT, 593★, last updated 2026-05-10)
+- 본 세션 진단: `docs/reports/wizard-dashboard-diagnosis-2026-05-12.md`
+- 관련 Issue: #610 (Card quality medical-English flooding)
+- 관련 PR: #555 (mandala-filter bypass), #556 (Tier 1 cache disable), #609 (Prisma pool fix)
+- 기존 디자인:
+  - `docs/design/v3-semantic-center-gate.md`
+  - `docs/design/v3-semantic-cell-gate.md`
+  - `docs/design/progressive-relevance-stream.md`
+  - `docs/design/card-refresh-strategy.md`
+  - `docs/design/realtime-search-pipeline.md`
+  - `docs/design/quality-gate.md`

--- a/docs/design/insighta-hybrid-retrieval-2026-05-12.md
+++ b/docs/design/insighta-hybrid-retrieval-2026-05-12.md
@@ -175,7 +175,7 @@ agent  ← loop
 
 | 항목 | 결정 | 근거 |
 |------|-----|-----|
-| Reranker 모델 | **Mac Mini self-host: `BAAI/bge-reranker-v2-m3` via TEI server** | OpenRouter 에 reranker 없음 (확인 완료, 0 hits). Cohere/Voyage 는 신규 API key + 비용. Mac Mini 는 기존 Tailscale 인프라 재사용, CLAUDE.md LLM-API 금지 규칙과 무관 |
+| Reranker 모델 | **Cohere Rerank API (`rerank-multilingual-v3.0`)** | (1) Mac Mini 는 production-critical inference 의 *임시 scaffold* 이지 영구 위치 아님 — 단일 머신 / SLA 불가 / Seoul↔us-west-2 latency. 더 키우지 않음. (2) OpenRouter 에 reranker 없음 (확인). (3) Cohere = zero ops, 100-200ms latency, multilingual (Korean), traffic 에서 cost < $10/mo. (4) 신규 API key + credentials.md 업데이트는 일회성 비용. **별 track 으로 Mac Mini 의 기존 LoRA 는 RunPod Serverless 로 마이그레이션 (CP449 챗봇 패턴 복제) 예정.** |
 | LangGraph | **`@langchain/langgraph@1.3.0` TS 도입** | 공식 TS 포팅 안정. 자체 구현 (~200 lines) 대비 ecosystem (HITL, checkpointing, streaming) 가치 큼 |
 | Keyword search | **Postgres `to_tsvector` + `ts_rank`** | 외부 lib 0. BM25 와 정확히 같지 않지만 keyword recall 효과 충분. 추가 인덱스 1개 |
 | Rerank 호출 빈도 | **매 wizard 시 1회, 결과는 `recommendation_cache.rec_score` 저장 (재호출 X)** | 추가 LLM 호출 없음. recompute 만이 갱신 |
@@ -193,54 +193,60 @@ agent  ← loop
 
 ---
 
-## 8. 실행 시퀀스 (lock-in)
+## 8. 실행 시퀀스 (lock-in, 2026-05-12 amendment)
 
-각 Phase 가 독립 PR. PR 머지 후 다음 Phase 진입. 4 PR / ~1-2 주 estimate.
+**Amendment 근거**:
+- 사용자 directive: "Mac Mini 는 임시 패턴, 향후 BE 통합되어야" → reranker 를 Mac Mini TEI 에 올리지 않고 처음부터 BE-native (Cohere) 로
+- 데이터 점검: `video_chunk_embeddings` schema 에 `text/start_time/end_time/chunk_idx` **이미 존재** + 2,641 rows 적재 (Mac Mini A1→A4 batch 가 채움). 우리 BE 에서 INSERT 코드 0건
+- → 원래 PR1 (DDL + transcript segment loop) 의 가정이 부분 무효. 시퀀스 축소.
 
-### PR1 — Pattern B (timestamp anchor + segment loop) — Foundation
-- **이유**: Pattern A 가 segment-level chunks 를 의미있게 활용하려면 chunk 가 시간 anchor 있어야. 다른 PR 의 prerequisite.
+### 새 시퀀스 (3 PR)
+
+#### PR1 — Pattern A + D (Hybrid retrieval + Cohere rerank + score normalize) — Issue #610 fix
+- **이유**: 가장 큰 user-facing 효과, prerequisite 없음 (chunk data + schema 이미 있음, reranker = Cohere API)
 - **범위**:
-  - DDL: `prisma/migrations/hybrid-retrieval/001_video_chunk_time.sql` — `ALTER TABLE video_chunk_embeddings ADD COLUMN start_sec INT, end_sec INT, text TEXT`
-  - Code: `internal/transcript.ts` 의 segment loop 추가
-  - FE: 카드 click 시 `&t=<start_sec>s` deep-link
-  - 기존 2,641 rows = `start_sec NULL` 그대로
-- **검증**: 신규 transcript 처리 1건 → chunk 10+ row, 모두 시간 채워짐
-
-### PR2 — Mac Mini TEI server (BGE-reranker) — Infrastructure
-- **이유**: Pattern A 의 rerank step 의 prerequisite
-- **범위**:
-  - Mac Mini 에 `text-embeddings-inference` server 띄움 (HF TEI, Docker)
-  - 모델: `BAAI/bge-reranker-v2-m3` (multilingual, 4-lang Korean OK)
-  - Tailscale 포트 노출, 신규 env `MANDALA_RERANK_URL=http://100.91.173.17:<port>`
-  - Insighta TS client: `src/modules/rerank/client.ts` (POST /rerank, body {query, texts[]})
-- **검증**: localhost 에서 sample (query, 10 texts) → score 배열 반환
-
-### PR3 — Pattern A (Hybrid retrieval + rerank) — Main quality fix
-- **이유**: Issue #610 의 spec 옵션 (c) 의 본체. 가장 큰 user-facing 효과.
-- **범위**:
-  - `src/skills/plugins/video-discover/v3/hybrid-rerank.ts` (모듈)
-  - 단계: candidate list → BM25 search → concat → dedupe → rerank → top-N → score 표준화 → group by video → return
-  - 통합 위치: `v3/executor.ts` 의 기존 mandala-filter 결과를 입력으로 받음
-  - flag: `V3_ENABLE_HYBRID_RERANK=true` (PR 머지 시 default ON)
+  - `src/modules/rerank/cohere-client.ts` — `POST https://api.cohere.com/v2/rerank` wrapper (axios, retry, timeout)
+  - `credentials.md` — `COHERE_API_KEY` 등록 + `.env` 에 추가 절차 명시 (실제 키는 .env 만, repo X)
+  - `src/skills/plugins/video-discover/v3/hybrid-rerank.ts` — pipeline:
+    - 입력: mandala-filter 결과 candidate list
+    - 단계: tsvector keyword search → concat → dedupe → cohere rerank → top-N → score 0-100 normalize → group by video (avg) → sort
+  - `v3/executor.ts` 통합 — `V3_ENABLE_HYBRID_RERANK=true` env (default ON after merge)
   - PR #555 `V3_USE_YOUTUBE_RANKING_ONLY=true` 의 cell-quality 문제를 hybrid+rerank 가 대체
-- **검증**: 동일 mandala (7b99f68c, 영어 학습) 에서 의료영어 oversaturation 사라지는지 (top 5 카드 manual 검증). Issue #610 close.
+- **검증**:
+  - 단위 테스트: cohere-client mock + hybrid-rerank.ts (5+ test)
+  - 회귀 mandala (7b99f68c, 영어 학습): 의료영어 oversaturation 사라지는지 manual 확인 → Issue #610 close
+  - cost telemetry: 일 1주일 cohere 호출 수 + cost 로그
+- **롤백**: `V3_ENABLE_HYBRID_RERANK=false`
 
-### PR4 — Pattern D (Score 표준화 + group by video) — Polish
-- **이유**: rec_score 분포 평탄성 개선 + UX 정렬 합리화
-- **범위**:
-  - rec_score 0-100 normalize (PR3 안에 통합 가능하면 흡수)
-  - cell-별 정렬에 video group-avg 보조 score 추가
-- **검증**: 동일 video 다중 chunk 가 분산되지 않고 1 video 가 1 슬롯에 응집
-
-### PR5 — Pattern C (LangGraph ReAct + 3-way route) — Chatbot
-- **이유**: 챗봇 cost / latency / 응답 품질. PR3 와 독립적.
+#### PR2 — Pattern C (LangGraph ReAct + 3-way route 챗봇)
+- **이유**: 챗봇 cost / latency / 응답 품질. PR1 와 독립적 (vectorSearchTool 은 PR1 의 hybrid-rerank.ts wrapping 으로 재사용 가능, 그러나 PR1 머지 전에도 기존 v3 path wrap 가능)
 - **범위**:
   - `npm i @langchain/langgraph @langchain/core`
   - `src/modules/ontology/chat-graph.ts` 신규
-  - 3 노드: `route_message` (cheap LLM cheap, e.g. Qwen 7B local) / `static_reply` / `tool_call_agent` (powerful, Haiku/Gemini)
-  - 도구 2개: `vectorSearchTool` (PR3 의 hybrid-rerank.ts wrapping) + `sqlTool` (user_video_states / mandala_levels select)
-  - 기존 `ontology/chat.ts` flag-off, 신규 path flag-on (`CHAT_USE_LANGGRAPH=true`)
-- **검증**: trivial query ("안녕") → route 가 cheap LLM 만 호출 (LLM cost 측정). 복잡 query → tool_call agent 가 적절히 도구 호출.
+  - 3 노드:
+    - `route_message` — cheap LLM (Haiku 또는 Qwen 7B RunPod) 으로 분류: (a) direct (b) static_not_relevant (c) tool_call
+    - `static_reply` — 정해진 응답
+    - `tool_call_agent` — powerful LLM (Haiku 4.5 또는 Gemini 2.5) + tools (vectorSearch + sql)
+  - 도구 2개: `vectorSearchTool` (hybrid-rerank wrapping), `sqlTool` (user_video_states / mandala_levels select-only)
+  - 기존 `ontology/chat.ts` flag-off, 신규 path `CHAT_USE_LANGGRAPH=true`
+- **검증**:
+  - trivial query ("안녕") → cheap LLM 만 호출, cost 측정
+  - 복잡 query → tool_call agent 가 도구 호출
+  - 응답 latency p50/p95 vs 기존 chat.ts
+
+#### PR3 — FE timestamp deep-link (Pattern B 부분 — 카드 click)
+- **이유**: video_chunk_embeddings 의 start_time data 가 이미 있으나 사용자에게 노출 X. PR1 의 rerank 결과에 chunk start_time 도 전파되도록 보강 후 FE 단순 추가.
+- **범위**:
+  - PR1 의 hybrid-rerank 결과 schema 에 `start_sec` 포함
+  - FE 카드 click 시 `youtube.com/watch?v=<id>&t=<start_sec>s` deep-link (한 줄)
+  - chunk → card 매핑: 한 video 의 top-scored chunk 의 start_time 을 카드의 anchor 로
+- **검증**: 카드 click 시 시간 anchor 적용 youtube 페이지 열림
+
+### 보류
+
+- **Pattern B 의 transcript.ts segment loop 부분**: write path 가 Mac Mini batch (외부) — 별도 spec
+- **Pattern E (channel scan)**: mandala-centric 모델 충돌 — backlog
+- **Mac Mini deprecation 전체 roadmap**: 별 spec doc 으로 분리 (LoRA action-fill → RunPod 이동, etc.)
 
 ---
 

--- a/docs/reports/wizard-dashboard-diagnosis-2026-05-12.md
+++ b/docs/reports/wizard-dashboard-diagnosis-2026-05-12.md
@@ -1,0 +1,407 @@
+# Wizard → Dashboard 진단 보고 — 2026-05-12 세션
+
+**Purpose**: 2026-05-12 단일 세션에서 진행한 위저드 → 대시보드 arc 의 전수 진단 결과 누적. 코드 + log + DB + ledger 3-축 교차 검증 데이터만 수록. 추측 X.
+
+**Scope**:
+- 위저드 응답 속도 (M7 / tx_total)
+- 카드 품질 (rec_score top picks)
+- 카드 수량 (per-cell rec_count + drop stages)
+- 버려진 카드의 운명 (video_pool 정책)
+- Rich Summary trigger timing
+- 벡터 / 그래프 데이터 인벤토리
+- Shorts cutoff
+
+**기준 mandala (trace 대상)**: `7b99f68c-93d7-4851-83aa-99f4ef418f20` "한달 안에 영어로 의사 표현하기" (2026-05-12T08:44:41Z 생성)
+
+---
+
+## 1. 위저드 응답 속도 — Pool exhaustion → Fix shipped
+
+### 진단 데이터 (`mandala_create_timings` n=49, 2026-04-23 ~ 2026-05-11)
+
+| 측정 | p50 | p95 | max |
+|------|-----|-----|-----|
+| `tx_mandala_create` | 101ms | 301ms | 397ms |
+| `tx_levels_createMany` | 98ms | 2489ms | 5027ms |
+| `tx_find_unique` | 17ms | 39ms | 157ms |
+| 측정 내부 합 | ~216ms | ~2.8s | — |
+| **`tx_total`** | **3867ms** | 7980ms | 9233ms |
+| **미발견 gap** | **~3.65s** | ~5.2s | ~4.2s |
+
+### 갭의 정체 — Bimodal
+
+```
+min  10ms · p10  524ms · p50 3677ms · p90 4862ms · max 8283ms
+under_500ms: 5  ·  500-2000: 7  ·  over_2000ms: 37
+```
+
+동일 user 60초 간격에 gap 12배 변동 (4185ms → 329ms). 코드 동일 → **외부 contention**.
+
+### Root cause (3-축 일치)
+
+| 축 | 증거 |
+|----|------|
+| Code | `connection-url.ts:21` `DEFAULT_POOL_LIMIT = 5`. `PRISMA_POOL_LIMIT` env 미설정 → 5 적용 |
+| Log | `[prisma-init] {"pool_limit":5,"host":"aws-0-us-west-2.pooler.supabase.com:6543"}` |
+| Log | `[prisma-slow-query]` 의 `UPDATE youtube_videos SET transcript_fetched_at` 3110~5295ms × 10건 연속 — pool slot 점유 |
+| DB | 동일 user 12× variance, gap 분포 bimodal |
+
+→ Supabase **transaction pooler (port 6543)** + Prisma `pool_limit=5` + background hot path 가 슬롯 점유 → wizard `$transaction` 진입 시 connection acquire 대기 3-7s.
+
+### Fix — PR #609 (commit `e1fa6c71`, deployed 2026-05-12T08:40Z)
+
+```yaml
+# docker-compose.prod.yml (api service env)
+- PRISMA_POOL_LIMIT=15
+```
+
+Deploy 검증:
+- `[prisma-init] {"pool_limit":15, ...}` (post-deploy 49s uptime)
+- `[prisma-slow-query]` 첫 2분간 0건 (직전 10건 연속 → 0)
+
+검증 측정 대기: n=20 trickle 후 `/mandala-perf γ`. 예상 gap p50 3677ms → < 500ms.
+
+### 부수 발견 — `transcript_fetched_at` UPDATE 도 같은 근본 원인
+
+`[prisma-slow-query]` 의 4404ms duration 은 Prisma 측정값 = **connection acquire + 실제 SQL**. 실제 SQL <100ms 로 추정. Pool=15 적용 후 자동으로 빨라질 가능성 높음 → **Fix #2 (transcript batch 화) 는 보류**, deploy 후 측정으로 결정.
+
+### 롤백 매트릭스
+
+1. SSH sed (~2분): `bash scripts/ssh-connect.sh "cd /opt/tubearchive && sed -i '/PRISMA_POOL_LIMIT/d' docker-compose.prod.yml && docker compose up -d api"`
+2. `git revert <e1fa6c71>` → CI/CD redeploy (~5-10분)
+3. 즉시 unset 불가 (env는 컨테이너 재기동 필요)
+
+---
+
+## 2. 카드 품질 — 의료영어 oversaturation (Issue #610)
+
+### 증상
+
+mandala 7b99f68c (영어 학습) cell 0 의 top rec_score 1.0 카드 = **"기초문진에 필요한 영어, 쉽게 말하기 part 1 [의료영어회화 002]"**. 그 외 cell 0 카드:
+- "[병원영어] 아플때 병원가서 쓰는 필수 영어표현" (rec_score 0.95)
+- "혹시 임신 가능성이 있으신가요?+ ... [의료영어회화 007]" (rec_score 0.94)
+- "영어의사 알렉스" 채널 × 3건
+- ~50% 의료영어 채널 점유
+
+### 진단 (3-축)
+
+| 축 | 증거 |
+|----|------|
+| LLM | sub_goals 정확함: "1분 스피치로 자신의 의견 표현하기" — LLM 이 "의사" → "의견" 올바르게 변환 |
+| Git | PR #555 / commit `e4a48e46` (2026-05-04) 가 `V3_USE_YOUTUBE_RANKING_ONLY=true` 도입 → mandala-filter bypass |
+| DB | `mandalaFilterInput: 135 → Output: 135 (drop 0)` — 필터 효과 0 |
+
+→ YouTube 인기 ranking 그대로 신뢰 → "영어 의견 표현" 검색에서 의료영어회화 (인기 채널) 가 1위 점유.
+
+### 왜 단일 flag flip 금지
+
+- PR #555 도입 사유 = mandala-filter 자체 false-positive 해결 목적. revert 시 그 problem 재현.
+- CP418 `V3_CENTER_GATE_MODE` oscillation 패턴 (semantic → subword → semantic → ...) 의 cell-level 재현 위험.
+- **CLAUDE.md Active Rule F** ("Multi-layer PR 3 hotfix patch-on-patch stop") 적용 대상.
+
+### 등록 위치 — Issue #610 (spec ticket)
+
+해결 전제 (issue body 명시):
+1. PR #555 의 도입 의도 / 원래 false-positive 케이스 확인
+2. 5+ mandala (finance / health / hobby / education / career) cross-regime 비교
+3. 세 옵션 중 결정:
+   - (a) cell-level semantic filter + 튜닝된 threshold
+   - (b) per-domain ranking strategy
+   - (c) two-stage retrieval + cosine rerank top-N
+4. 디자인 문서 cross-ref: `v3-semantic-center-gate.md`, `v3-semantic-cell-gate.md`, `progressive-relevance-stream.md`, `card-refresh-strategy.md`
+
+---
+
+## 3. 카드 수량 — 5/8 cells 만 채워짐
+
+### 증상 (mandala 7b99f68c)
+
+```
+8 cells 중 :
+  cell 0  →  rec 12,  user_video_states ~12
+  cell 1  →  rec 0   ← 빈 셀
+  cell 2  →  rec 9
+  cell 3  →  rec 0   ← 빈 셀
+  cell 4  →  rec 12
+  cell 5  →  rec 4
+  cell 6  →  rec 12
+  cell 7  →  rec 0   ← 빈 셀
+총: 49 cards (사용자 목표 "최소 40-50" 경계)
+```
+
+### Stage breakdown (mandala_pipeline_runs.step2_result.debug)
+
+| 단계 | 값 | 해석 |
+|------|-----|------|
+| rule queries (cell-specific) | 거의 0 hit | cell 별 query "한달 안에 영어로 의사 표현하기 + sub_goal" → YouTube 매칭 X |
+| LLM queries | 4건 hit (46+46+46+38), 1건 0 hit | LLM 이 cell-별 query 안 만들고 generic English 검색 |
+| poolAfterDedupe | 290 | raw 합 |
+| **droppedShortsDuration** | **137 drop** | duration ≤ 180s = drop |
+| scoredCandidates | 135 | dedupe + filter 후 |
+| droppedBlocklist | 18 | channel block |
+| mandalaFilterInput → Output | 135 → 135 | **drop 0 (PR #555 bypass)** |
+| perCellAssigned | 5 cells | 8 cells 중 3 cells (1/3/7) empty |
+
+### 원인 3-layer (단일 fix 불가)
+
+1. **Shorts cutoff 180s 가 영어 학습 도메인에 공격적** — 30초~3분 짧은 영상 많음
+2. **LLM query gen 이 cell-별 query 안 만듦** — generic English query 만 생성 → cell 1/3/7 sub_goal text 가 query 풀에 미반영
+3. **Cell 분배 알고리즘 편향** — 135 candidate 가 5 cells 에만 들어감
+
+### 권장 (단편 fix 금지)
+
+issue 등록 권장. 도메인별 shorts cutoff + cell-별 query gen 보장 + 분배 fairness 통합 spec.
+
+---
+
+## 4. 버려진 카드의 운명 — Video pool 미보관
+
+### `video_pool` source 분포
+
+| source | n |
+|--------|---|
+| `batch_trend` | 9,553 |
+| `v2_promoted` | 1,200 |
+
+→ **v3 discover search 가 drop 한 후보는 어디에도 저장 안 됨**.
+
+### 정책 (현재)
+
+```
+batch-video-collector (cron, 매일 07:30 UTC, fresh quota 직후)
+        ↓
+   video_pool (10,753 rows)
+        ↓
+   v3 cache-matcher / search
+        ↓
+   recommendation_cache → user_video_states
+        ↓
+   drop된 후보 → 사라짐 (one-way, history 없음)
+```
+
+→ "drop 사유 + score 보존하는 candidate_history 테이블" 같은 spec 이 있어야 재사용 가능.
+
+---
+
+## 5. Rich Summary 발화 시점
+
+### 두 경로
+
+**A. 위저드 직후 auto (현재 활성)**:
+```
+wizard 완료 → mandala-post-creation (setImmediate)
+            → pipeline-runner step 3 (maybeAutoAddRecommendations) 완료
+            → setImmediate 으로 enqueueRichSummaryForMandalaCards (pipeline-runner.ts:251)
+            → OpenRouter 호출 → video_rich_summaries 테이블
+```
+- Gate: `RICH_SUMMARY_ENABLED=true` (prod ON)
+- Quota 게이트: free=30 / pro=200 / lifetime=admin=unlimited
+- LLM 직렬 처리 (1 in-flight) — 모든 카드 즉시 X
+
+**B. 일일 cron (현재 OFF)**:
+- Env: `RICH_SUMMARY_V2_CRON_ENABLED=false` (prod startup log 확인)
+- 의도: 17:00 UTC = 02:00 KST daily tick, batch 50개 v2 처리
+- 현재 비활성, 경로 A만 작동
+
+### 일반 vs 상세
+
+같은 v2 layered prompt 의 single LLM call 로 **동시 생성**:
+- `core` (일반) + `analysis` / `lora` / `segments` (상세)
+- "일반 즉시 → 상세 나중" 흐름 아님
+
+### Prod 누적
+
+video_rich_summaries 79 rows (prod, 2026-05-12 시점). 자연 traffic 누적.
+
+---
+
+## 6. 벡터 데이터 인벤토리 (5 테이블)
+
+| 테이블 | 차원 | rows | 저장 | 활용 | 상태 |
+|--------|-----|------|------|------|------|
+| `mandala_embeddings` | 4096 | 19,137 | 각 mandala sub_goal text (cell당 1 row) | v3 mandala-filter, `searchMandalasByGoal` (template floor 0.4), cache-matcher | 활성 |
+| `video_pool_embeddings` | 4096 | 10,645 | video_pool 의 video title embedding | cache-matcher cosine 매칭 (rec_reason='cache') | 비활성 (PR #556 "noise > signal", 2026-05-06) |
+| `video_chunk_embeddings` | 4096 | 2,641 | 비디오 transcript chunk embedding | semantic-rank.ts rerank | 비활성 (`V3_ENABLE_SEMANTIC_RERANK=false`) |
+| `keyword_scores` | 4096 | 1,253 | trend keyword embedding + IKS score | iks-scorer Phase 2b goal_relevance | 활성 |
+| `ontology.embeddings` | **768** | 26 | ontology 노드 title embedding (다른 모델) | ontology.search semantic | 실험적, 사실상 dead |
+
+**모델**: 활성 4개 = qwen3-embedding:8b (4096d). `ontology.embeddings` 만 768d (별도 모델).
+
+### 미진단 약점
+
+- `video_pool_embeddings` 10,645 적재 비용 vs prod 비활성 (효용 0)
+- `video_chunk_embeddings` 2,641 적재 비용 vs 비활성 (Phase 3A 대기 1년+)
+- `ontology.embeddings` 26 rows = schema artifact
+
+---
+
+## 7. 그래프 데이터 인벤토리 (ontology schema)
+
+### Tables
+
+`nodes, edges, embeddings, action_log, action_types, object_types, relation_types`
+
+### Nodes — 10 type, 총 ~177K rows
+
+| Type | Count | 의미 |
+|------|-------|------|
+| `topic` | 103,304 | sub_goal 의 각 subject (셀당 8 항목) |
+| `atom_node` | 15,014 | rich-summary v2 atom 단위 |
+| `goal` | 13,466 | mandala center_goal |
+| `mandala_sector` | 13,456 | mandala 의 8 cell (sector) |
+| `concept` | 10,107 | rich-summary core 개념 |
+| `section_node` | 9,936 | rich-summary section |
+| `action_node` | 6,695 | 실행 가능 action |
+| `resource` | 2,655 | 학습 리소스 |
+| `mandala` | 1,501 | mandala 자체 |
+| `video_resource` | 1,311 | video reference |
+
+### Edges — 8 relation, 총 ~146K rows
+
+| Relation | Count | 방향 |
+|----------|-------|------|
+| `CONTAINS` | 103,520 | mandala→sector / sector→topic (압도적, 위계) |
+| `HAS_ATOM` | 15,014 | video → atom |
+| `COVERS` | 10,937 | concept → topic |
+| `HAS_SECTION` | 9,933 | video → section |
+| `SUGGESTS` | 6,695 | → action |
+| `RELEVANT_TO` | 106 | cross-mandala (실험) |
+| `MENTIONS` | 9 | video → topic (거의 미작동) |
+| `PLACED_IN` | **8** | **card → sector (CP415 trigger 거의 실패)** |
+
+### 활용 경로
+
+| 시점 | 코드 | 그래프 작업 |
+|------|------|------------|
+| wizard 저장 | `sync-edges.ts` | mandala / sector / goal / topic 노드 upsert + CONTAINS 엣지 |
+| auto-add | `mandala-post-creation.ts` | PLACED_IN trigger 거의 실패 (8 rows) |
+| rich-summary v2 | `kg-bridge.ts`, `v2-bridge.ts` | atom / section / concept 노드 + HAS_ATOM / HAS_SECTION / COVERS |
+| 챗봇 | `ontology/chat.ts`, `context-builder.ts` | 그래프 traversal → user knowledge 컨텍스트 |
+| 비디오 enrich | `enrich-worker.ts` | video_resource 노드 |
+| 그래프 검색 | `ontology/search.ts` | 위계 + 768d embedding |
+
+### 미진단 약점
+
+**`PLACED_IN` 8 rows** — `card → sector` trigger 사실상 실패. 사용자 카드 배치가 그래프에 미반영 → 챗봇이 "사용자가 어떤 카드 봤는지" 모름.
+
+---
+
+## 8. Shorts cutoff — 180s
+
+### 현재 활성 path
+
+prod env: `VIDEO_DISCOVER_V3=1` → v3 executor.
+
+### 함수
+
+```ts
+// src/skills/plugins/video-discover/v2/youtube-client.ts:435
+export function isShortsByDuration(durationSec: number | null): boolean {
+  return durationSec === null || durationSec <= 180;
+}
+```
+
+v3 / v2 / youtube-provider 모두 같은 함수 import.
+
+### 근거
+
+- PR #401 (2026-04-17): YouTube 2024-10 정책으로 shorts 길이 60→180s 확장 반영
+- prod 사고: 110s shorts "한의대수석 #공부 #공부잘하는방법" 가 60s gate 통과해 wizard 결과 오염
+- `durationSec === null` → 방어적 drop (Videos.list API 가 shorts duration 누락하는 케이스 방어)
+
+### 부작용 (mandala 7b99f68c)
+
+`droppedShortsDuration: 137` — 영어 학습 채널의 30초~3분 짧은 영상이 cutoff 에 걸려 카드 부족의 한 축. 도메인별 분기 spec 필요.
+
+---
+
+## 9. Meta — 18일 ledger 정지 + oscillation 패턴
+
+### Ledger drift (`docs/reports/wizard-dashboard-perf-log.md`)
+
+- **Last updated: 2026-04-23** (CP419) — 본 진단 시점 2026-05-12 까지 19일 stale
+- 그 동안 PR 7+ 건 (CP426~451) 이 v3 discover / wizard path 에 변경 가했으나 ledger 미반영
+
+### 18일간의 변화 (git log on `docker-compose.prod.yml`)
+
+```
+2026-04-25  f0aa3ffd  precompute poll budget 15s→1s + conditional pipeline   (M3 60s → 12s claim)
+2026-04-25  60f49d63  semantic center gate 재활성 (subword → semantic)
+2026-04-26  1b19271f  rollback semantic gate + parallelize
+2026-04-30  9b64885f  YOUTUBE_SEARCH_TIMEOUT 1000→3000 + bigram fallback
+2026-05-02  be8d2af0  Tier 1 video_pool semantic match in prod
+2026-05-03  d497ee7d  semantic center gate ON + candidate cap (V3_SEMANTIC_MAX_CANDIDATES=30)
+2026-05-04  e4a48e46  mandala-filter bypass (V3_USE_YOUTUBE_RANKING_ONLY=true)   ← Issue #610 의 원인
+2026-05-05  8d161467  Tier 1 cache disable (noise > signal)
+2026-05-06  12fac681  Tier 0 Redis kill (lexical OFF)
+```
+
+### Oscillation 패턴 (CP418 → 본 세션)
+
+```
+CP418  semantic gate 켰다가 → subword 롤백 → 다시 semantic ON ...
+2026-05-04  mandala-filter bypass (cell-level) 도입
+                                  ↓
+2026-05-12  bypass 가 카드 품질 망가뜨림 (Issue #610)
+                                  ↓
+유혹: V3_USE_YOUTUBE_RANKING_ONLY=false 단일 flip
+                                  ↓
+이전에 bypass 가 해결했던 false-positive 재현
+                                  ↓
+다시 flip ON → cell quality 망가짐 → ...
+```
+
+→ **CLAUDE.md Active Rule F** (patch-on-patch stop) 발동. 단일 env flip 금지 명시.
+
+---
+
+## 10. 본 세션 산출물 + 미해결
+
+### Shipped
+
+- **PR #609** (`e1fa6c71`) — `PRISMA_POOL_LIMIT=15`. deploy 검증 완료. Trickle 측정 대기.
+
+### Filed (spec ticket, 코드 변경 보류)
+
+- **Issue #610** — Card quality medical-English flooding (post PR #555). 디자인 문서 결정 의무.
+
+### 미파일 (issue 화 여부 사용자 결정 대기)
+
+- 카드 수량 부족 (3 layer: shorts cutoff + LLM query gen + cell 분배)
+- `video_pool_embeddings` 적재 비용 vs 비활성 (10,645 rows × embed cost dormant)
+- `video_chunk_embeddings` 동일 (2,641 rows dormant)
+- `ontology.embeddings` (26 rows, 사실상 dead schema)
+- `PLACED_IN` 8 rows (card→sector trigger 실패)
+- `RICH_SUMMARY_V2_CRON_ENABLED=false` 의도된 비활성인지 미확인
+- `ledger drift 18+일` 자체가 process issue
+
+### M3 telemetry 제안 (보류)
+
+본 세션 중반에 client-side first-card timing endpoint 구현 제안 (~115 라인, 5 파일). 사용자 답변 없이 다른 진단 라인으로 전환.
+
+---
+
+## 11. Cross-references
+
+- **Ledger**: `docs/reports/wizard-dashboard-perf-log.md` (CP419 stale)
+- **Anatomy**: `docs/reports/wizard-dashboard-flow-anatomy.md` (CP416 stale)
+- **Design SSOT**:
+  - `docs/design/precompute-pipeline.md` (Phase 2 SLO-1)
+  - `docs/design/v3-semantic-center-gate.md`
+  - `docs/design/v3-semantic-cell-gate.md`
+  - `docs/design/progressive-relevance-stream.md`
+  - `docs/design/card-refresh-strategy.md`
+  - `docs/design/realtime-search-pipeline.md`
+  - `docs/design/quality-gate.md`
+  - `docs/design/video-pool-growth.md`
+  - `docs/design/wizard-service-redesign-2026-04-22.md`
+- **본 세션 origin**: 사용자 질문 "위저드에서 대시보드로 이어지는 플로우에서 너무 큰 지연이 발생하고 있고 찾지 못하는데..." (2026-04-29) → 2026-05-12 후속 진단
+
+---
+
+## 12. 행동 원칙 — 본 세션의 메타 결론
+
+1. **단일 env flag flip 금지** — Rule F enforce, CP418 oscillation 회피
+2. **모든 fix 는 측정 가능해야** — M3 telemetry 부재가 carryover 의 영속 원인
+3. **Ledger 와 ssh source 의 일치 의무** — `docs/reports/wizard-dashboard-perf-log.md` 갱신 책임을 commit 단위 또는 CP 단위로 강제
+4. **단편 fix 누적 시 stop + spec 재설계** — 본 세션의 모든 미해결 항목이 이 원칙 적용 대상


### PR DESCRIPTION
## Summary

Docs-only PR with two artifacts from the 2026-05-12 wizard→dashboard investigation session.

**Report**: `docs/reports/wizard-dashboard-diagnosis-2026-05-12.md`
- Single-document session diagnosis (response speed / card quality / card quantity / video_pool / rich-summary / vector+graph inventory / shorts cutoff)
- Closes the 18-day ledger gap (wizard-dashboard-perf-log.md last update 2026-04-23)

**Spec**: `docs/design/insighta-hybrid-retrieval-2026-05-12.md`
- Spec ticket for Issue #610 (mandala-filter bypass quality regression)
- Adopts retrieval patterns from YT-Navigator (MIT, 593★)
- **Locked decisions**:
  - Reranker = Mac Mini self-host `BAAI/bge-reranker-v2-m3` via TEI (OpenRouter has no reranker; Cohere requires new API key)
  - LangGraph = `@langchain/langgraph@1.3.0` TS
  - Keyword search = Postgres `to_tsvector` + `ts_rank` (no external lib)
- **5-PR execution sequence**:
  | # | Pattern | Purpose |
  |---|---------|---------|
  | PR1 | video_chunk timestamp + segment loop | Foundation |
  | PR2 | Mac Mini TEI server (BGE-reranker) | Infrastructure |
  | PR3 | Hybrid retrieval + rerank | Issue #610 fix |
  | PR4 | Score normalize + group by video | Polish |
  | PR5 | LangGraph ReAct + 3-way chatbot route | Independent track |

## Cross-references

- Issue #610 (Card quality medical-English flooding)
- PR #555 (mandala-filter bypass — root cause this spec addresses)
- PR #609 (Prisma pool fix — shipped this session, orthogonal to this spec)

## Pre-flight

- Docs-only, no code changes.
- tsc / vitest skipped (no source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)