### PR TITLE
feat(ops): Mac Mini deprecation Phase D1 — flip iks-scorer embed to OpenRouter

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -59,6 +59,15 @@ services:
       # Revert: delete this line and redeploy — code default 'ollama'
       # restores the pre-Phase-1 behavior bit-identically.
       - MANDALA_EMBED_PROVIDER=openrouter
+      # Mac Mini deprecation Phase D1 (2026-05-13) — flip iks-scorer
+      # embedBatch from Mac-mini-first-with-OpenRouter-fallback to
+      # OpenRouter-only. Removes a Mac Mini dependency for ~4 call sites
+      # (ensureMandalaEmbeddings, v3 semantic gate, iks-scorer Phase 2b
+      # goal_relevance, batch-video-collector, v2 video-embedder).
+      # Already-supported flag (connection-url.ts comment for full spec).
+      # Revert: delete this line → falls back to ollama-first behaviour.
+      # See docs/design/mac-mini-deprecation-2026-05-13.md §4 Phase D1.
+      - IKS_EMBED_PROVIDER=openrouter
       # CP416 (2026-04-22) — restore the LoRA action-fill path. Without
       # this, generateMandala() called config.mandalaGen.model=undefined,
       # Ollama /api/generate returned 400, LoRA threw, and the Haiku


### PR DESCRIPTION
## Summary

Phase D1 of [Mac Mini deprecation roadmap (PR #615)](https://github.com/JK42JJ/insighta/pull/615).

Single env flag flip: `IKS_EMBED_PROVIDER=openrouter` added to `docker-compose.prod.yml`.

## Effect

Switches the `embedBatch()` path for 4 hot-path call sites:
- `ensureMandalaEmbeddings` (mandala wizard)
- v3 executor semantic gate
- iks-scorer Phase 2b goal_relevance
- batch-video-collector + v2 video-embedder

**Before**: try Mac Mini first → fallback to OpenRouter on transport error
**After**: skip Mac Mini entirely → OpenRouter only

## Why scope reduced from spec doc §4

After code review against the actual call sites:

| Spec doc claim | Reality |
|---|---|
| `llm-query-generator` needs migration | Already has OpenRouter race orchestrator (line 42-44). No-op. |
| `video-discover/executor.ts:501` needs OLLAMA_URL fallback removal | V2 dead path (prod `VIDEO_DISCOVER_V3=1`). Defer. |
| `iks-scorer` embed | ✅ env flip only |
| `trend-collector llm-extract.ts` | Pure Ollama, no race — needs real code (split into D1-b PR). |

So actual D1 minimum = 1-line env flip + Phase D1-b follow-up for trend-collector.

## Test plan

- [x] `python3 -c "yaml.safe_load(...)"` parse OK
- [x] No code changes; `tsc --noEmit` unchanged
- [ ] After deploy: confirm `[prisma-init]` shows the new env
- [ ] 1-week trickle: Mac Mini Tailscale traffic should drop on embed paths

## Rollback

- Delete the env line → next deploy reverts to `ollama` default (Mac Mini first, OpenRouter fallback)
- ~5-10min deploy roundtrip

## Cross-references

- Spec: PR #615 (Mac Mini deprecation roadmap)
- Companion: PR #611 (hybrid-retrieval spec — reranker already off Mac Mini)
- Supported flag: `src/skills/plugins/iks-scorer/embedding.ts:123-138` documents the `'openrouter'` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)