### PR TITLE
feat(trend-collector): OpenRouter fallback for llm-extract (Phase D1-b)

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -137,6 +137,12 @@ const envSchema = z.object({
   // Pipeline events — round id stamped on each measurement event (paper §6.2).
   // Increment when starting a new measurement batch.
   PIPELINE_EVENTS_ROUND: z.coerce.number().int().min(1).default(1),
+
+  // Trend collector keyword extraction (D1-b, 2026-05-13).
+  //   'ollama'     → Mac-mini Ollama first, OpenRouter race fallback.
+  //   'openrouter' → skip Mac Mini, OpenRouter only.
+  // See docs/design/mac-mini-deprecation-2026-05-13.md.
+  TREND_EXTRACT_PROVIDER: z.enum(['ollama', 'openrouter']).default('ollama'),
 });
 
 type Env = z.infer<typeof envSchema>;
@@ -313,6 +319,11 @@ export const config = {
   // Pipeline events (paper §6.2 measurement)
   pipelineEvents: {
     round: env.PIPELINE_EVENTS_ROUND,
+  },
+
+  // Trend collector keyword extraction (D1-b)
+  trendExtract: {
+    provider: env.TREND_EXTRACT_PROVIDER,
   },
 
   // YouTube API costs (in quota units)

--- a/src/skills/plugins/trend-collector/sources/llm-extract.ts
+++ b/src/skills/plugins/trend-collector/sources/llm-extract.ts
@@ -28,6 +28,29 @@ const DEFAULT_OLLAMA_URL = 'http://100.91.173.17:11434';
 // keyword extraction.
 const DEFAULT_MODEL = 'llama3.1:latest';
 const REQUEST_TIMEOUT_MS = 60000; // per-chunk timeout
+
+// OpenRouter fallback path (Mac Mini deprecation Phase D1-b, 2026-05-13).
+// Mirrors the llm-query-generator OpenRouter constants. Used when
+// TREND_EXTRACT_PROVIDER=openrouter, or as fallback when Ollama call fails
+// while provider='ollama'.
+const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
+const OPENROUTER_REQUEST_TIMEOUT_MS = 30_000;
+const OPENROUTER_DEFAULT_MODEL = 'qwen/qwen3-30b-a3b';
+
+/**
+ * Selects which LLM provider to hit per chunk.
+ *
+ *   'ollama'     → Mac-mini Ollama first, OpenRouter fallback on transport/HTTP failure
+ *                  (default — pre-D1-b behaviour with added safety net)
+ *   'openrouter' → skip Mac Mini entirely, OpenRouter only
+ *
+ * Switch via env `TREND_EXTRACT_PROVIDER` at runtime (no code change).
+ */
+export type TrendExtractProvider = 'ollama' | 'openrouter';
+
+function resolveProvider(envVal: string | undefined): TrendExtractProvider {
+  return envVal === 'openrouter' ? 'openrouter' : 'ollama';
+}
 /**
  * Chunk size for batched extraction. llama3.1 8B handles 5 titles in ~30s
  * comfortably; 40 titles in one shot exceeds 120s on Mac Mini M4.
@@ -58,12 +81,23 @@ export interface ExtractKeywordsOptions {
   titles: string[];
   /** Override Ollama base URL. Defaults to Mac Mini. */
   baseUrl?: string;
-  /** Override model. Defaults to llama3.1:latest. */
+  /** Override Ollama model. Defaults to llama3.1:latest. */
   model?: string;
   /** Override chunk size. Defaults to 5 (proven safe on llama3.1 8B). */
   chunkSize?: number;
   /** Injectable fetch for testability. */
   fetchImpl?: typeof fetch;
+
+  // D1-b: OpenRouter fallback path overrides + provider switch.
+  /**
+   * Which provider to call per chunk. When omitted, read from
+   * `process.env.TREND_EXTRACT_PROVIDER` (defaults to 'ollama').
+   */
+  provider?: TrendExtractProvider;
+  /** OpenRouter API key. Falls back to `process.env.OPENROUTER_API_KEY`. */
+  openRouterApiKey?: string;
+  /** OpenRouter model id. Defaults to {@link OPENROUTER_DEFAULT_MODEL}. */
+  openRouterModel?: string;
 }
 
 const SYSTEM_PROMPT = `너는 학습 콘텐츠 발굴 엔진을 위한 키워드 추출 시스템이다.
@@ -164,10 +198,42 @@ export async function extractKeywordsBatch(
 }
 
 /**
- * Single Ollama call for one chunk. Throws LlmExtractError on any failure;
+ * Single chunk extraction — dispatches to Ollama or OpenRouter based on
+ * `opts.provider` (or `process.env.TREND_EXTRACT_PROVIDER`).
+ *
+ * Provider='ollama' (default): try Ollama → on LlmExtractError fall back
+ * to OpenRouter when API key is configured. Provider='openrouter': skip
+ * Ollama entirely.
+ *
+ * Throws LlmExtractError on any unrecoverable failure;
  * extractKeywordsBatch catches and pads.
  */
 async function extractOneChunk(
+  titles: string[],
+  opts: ExtractKeywordsOptions
+): Promise<ExtractedKeyword[]> {
+  const provider = opts.provider ?? resolveProvider(process.env['TREND_EXTRACT_PROVIDER']);
+  const openRouterApiKey = opts.openRouterApiKey ?? process.env['OPENROUTER_API_KEY'] ?? '';
+
+  if (provider === 'openrouter') {
+    return extractOneChunkViaOpenRouter(titles, opts, openRouterApiKey);
+  }
+
+  // provider='ollama' — try Mac Mini first, OpenRouter fallback on error.
+  try {
+    return await extractOneChunkViaOllama(titles, opts);
+  } catch (ollamaErr) {
+    if (!openRouterApiKey) {
+      // No fallback available — rethrow original error.
+      throw ollamaErr;
+    }
+    // Mac Mini unreachable / failing — try OpenRouter once.
+    return extractOneChunkViaOpenRouter(titles, opts, openRouterApiKey);
+  }
+}
+
+/** Ollama (Mac Mini) call path. Original D1-b extraction pre-refactor. */
+async function extractOneChunkViaOllama(
   titles: string[],
   opts: ExtractKeywordsOptions
 ): Promise<ExtractedKeyword[]> {
@@ -221,6 +287,81 @@ async function extractOneChunk(
   const content = data.message?.content;
   if (!content) {
     throw new LlmExtractError('Ollama chat returned empty content');
+  }
+
+  return parseExtractionResponse(content, titles);
+}
+
+/**
+ * OpenRouter call path. Mirrors `llm-query-generator.generateSearchQueriesViaOpenRouter`
+ * convention (Qwen3 reasoning disabled to prevent empty content, JSON-only
+ * prompt enforcement since OpenRouter Qwen3 doesn't support `format: json`).
+ */
+async function extractOneChunkViaOpenRouter(
+  titles: string[],
+  opts: ExtractKeywordsOptions,
+  apiKey: string
+): Promise<ExtractedKeyword[]> {
+  if (!apiKey) {
+    throw new LlmExtractError('OpenRouter API key not configured');
+  }
+  const fetchFn = opts.fetchImpl ?? fetch;
+  const model = opts.openRouterModel ?? OPENROUTER_DEFAULT_MODEL;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), OPENROUTER_REQUEST_TIMEOUT_MS);
+
+  let res: Response;
+  try {
+    const body: Record<string, unknown> = {
+      model,
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: buildUserPrompt(titles) },
+      ],
+      temperature: 0.2,
+      max_tokens: 1024,
+    };
+    // OpenRouter Qwen3 default to reasoning mode which drains the content
+    // token budget. Disable for the qwen-family models (same convention
+    // as OpenRouterGenerationProvider + llm-query-generator).
+    if (model.toLowerCase().includes('qwen')) {
+      body['reasoning'] = { enabled: false };
+    }
+
+    res = await fetchFn(OPENROUTER_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timer);
+    throw new LlmExtractError(
+      `OpenRouter chat failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  clearTimeout(timer);
+
+  if (!res.ok) {
+    let body = '';
+    try {
+      body = (await res.text()).slice(0, 200);
+    } catch {
+      // ignore
+    }
+    throw new LlmExtractError(`OpenRouter chat HTTP ${res.status}: ${body}`, res.status);
+  }
+
+  const data = (await res.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new LlmExtractError('OpenRouter chat returned empty content');
   }
 
   return parseExtractionResponse(content, titles);

--- a/src/skills/plugins/trend-collector/sources/llm-extract.ts
+++ b/src/skills/plugins/trend-collector/sources/llm-extract.ts
@@ -21,6 +21,8 @@
  * pipeline runs against all 40+ titles.
  */
 
+import { config } from '@/config/index';
+
 const DEFAULT_OLLAMA_URL = 'http://100.91.173.17:11434';
 // Mac Mini installed models (verified 2026-04-07): llama3.1:latest (8B),
 // qwen3-embedding:8b (embed-only, can't chat), mandala-gen (mandala-tuned).
@@ -48,9 +50,6 @@ const OPENROUTER_DEFAULT_MODEL = 'qwen/qwen3-30b-a3b';
  */
 export type TrendExtractProvider = 'ollama' | 'openrouter';
 
-function resolveProvider(envVal: string | undefined): TrendExtractProvider {
-  return envVal === 'openrouter' ? 'openrouter' : 'ollama';
-}
 /**
  * Chunk size for batched extraction. llama3.1 8B handles 5 titles in ~30s
  * comfortably; 40 titles in one shot exceeds 120s on Mac Mini M4.
@@ -91,10 +90,11 @@ export interface ExtractKeywordsOptions {
   // D1-b: OpenRouter fallback path overrides + provider switch.
   /**
    * Which provider to call per chunk. When omitted, read from
-   * `process.env.TREND_EXTRACT_PROVIDER` (defaults to 'ollama').
+   * `config.trendExtract.provider` (sourced from `TREND_EXTRACT_PROVIDER`
+   * env, defaults to 'ollama').
    */
   provider?: TrendExtractProvider;
-  /** OpenRouter API key. Falls back to `process.env.OPENROUTER_API_KEY`. */
+  /** OpenRouter API key. Falls back to `config.openrouter.apiKey`. */
   openRouterApiKey?: string;
   /** OpenRouter model id. Defaults to {@link OPENROUTER_DEFAULT_MODEL}. */
   openRouterModel?: string;
@@ -199,7 +199,7 @@ export async function extractKeywordsBatch(
 
 /**
  * Single chunk extraction — dispatches to Ollama or OpenRouter based on
- * `opts.provider` (or `process.env.TREND_EXTRACT_PROVIDER`).
+ * `opts.provider` (or `config.trendExtract.provider`).
  *
  * Provider='ollama' (default): try Ollama → on LlmExtractError fall back
  * to OpenRouter when API key is configured. Provider='openrouter': skip
@@ -212,8 +212,8 @@ async function extractOneChunk(
   titles: string[],
   opts: ExtractKeywordsOptions
 ): Promise<ExtractedKeyword[]> {
-  const provider = opts.provider ?? resolveProvider(process.env['TREND_EXTRACT_PROVIDER']);
-  const openRouterApiKey = opts.openRouterApiKey ?? process.env['OPENROUTER_API_KEY'] ?? '';
+  const provider = opts.provider ?? config.trendExtract.provider;
+  const openRouterApiKey = opts.openRouterApiKey ?? config.openrouter.apiKey ?? '';
 
   if (provider === 'openrouter') {
     return extractOneChunkViaOpenRouter(titles, opts, openRouterApiKey);

--- a/tests/smoke/llm-extract-openrouter-fallback.test.ts
+++ b/tests/smoke/llm-extract-openrouter-fallback.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests — trend-collector llm-extract.ts OpenRouter fallback path
+ * (Mac Mini deprecation Phase D1-b, 2026-05-13).
+ *
+ * Verifies the dispatcher contract:
+ *   provider='ollama' (default) → Ollama first, OpenRouter fallback on failure
+ *   provider='openrouter'       → skip Ollama, OpenRouter only
+ *   no OpenRouter API key       → no fallback, rethrow Ollama error
+ *
+ * The actual HTTP layer is mocked via fetchImpl injection.
+ */
+
+import {
+  extractKeywordsBatch,
+  LlmExtractError,
+  type ExtractedKeyword,
+  type ExtractKeywordsOptions,
+} from '@/skills/plugins/trend-collector/sources/llm-extract';
+
+/**
+ * Build a mock fetch that produces a successful Ollama-shape response.
+ * Echoes 1 keyword per title with constant learning_score.
+ */
+function makeOllamaOkFetch(titles: string[]): typeof fetch {
+  return (async (_url: unknown) => {
+    const results = titles.map((t) => ({
+      title: t,
+      keywords: [`kw-${t}`],
+      learning_score: 0.6,
+    }));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        message: { content: JSON.stringify({ results }) },
+      }),
+    } as Response;
+  }) as unknown as typeof fetch;
+}
+
+/** Mock fetch that produces a successful OpenRouter-shape response. */
+function makeOpenRouterOkFetch(titles: string[]): typeof fetch {
+  return (async (_url: unknown) => {
+    const results = titles.map((t) => ({
+      title: t,
+      keywords: [`or-${t}`],
+      learning_score: 0.7,
+    }));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [{ message: { content: JSON.stringify({ results }) } }],
+      }),
+    } as Response;
+  }) as unknown as typeof fetch;
+}
+
+/** Mock fetch that fails with a transport error for the FIRST call, succeeds after. */
+function makeFailThenSucceedFetch(titles: string[]): typeof fetch {
+  let calls = 0;
+  return (async (_url: unknown) => {
+    calls += 1;
+    if (calls === 1) {
+      // Simulate Ollama unreachable (e.g. Tailscale down).
+      throw new Error('ECONNREFUSED');
+    }
+    // Second call = OpenRouter — return OR-shape response.
+    const results = titles.map((t) => ({
+      title: t,
+      keywords: [`or-${t}`],
+      learning_score: 0.7,
+    }));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [{ message: { content: JSON.stringify({ results }) } }],
+      }),
+    } as Response;
+  }) as unknown as typeof fetch;
+}
+
+/** Mock fetch that always fails — no recovery. */
+function makeAlwaysFailFetch(): typeof fetch {
+  return (async () => {
+    throw new Error('ECONNREFUSED');
+  }) as unknown as typeof fetch;
+}
+
+describe('llm-extract OpenRouter fallback', () => {
+  const titles = ['파이썬 입문 강의', 'AI 동향 정리'];
+
+  describe("provider='openrouter' — skip Mac Mini", () => {
+    it('calls OpenRouter only when provider is openrouter + API key present', async () => {
+      const opts: ExtractKeywordsOptions = {
+        titles,
+        provider: 'openrouter',
+        openRouterApiKey: 'sk-or-test',
+        fetchImpl: makeOpenRouterOkFetch(titles),
+      };
+      const out: ExtractedKeyword[] = await extractKeywordsBatch(opts);
+      expect(out).toHaveLength(2);
+      expect(out[0]!.keywords).toEqual(['or-파이썬 입문 강의']);
+      expect(out[1]!.keywords).toEqual(['or-AI 동향 정리']);
+    });
+
+    it('throws when provider=openrouter but no API key', async () => {
+      const opts: ExtractKeywordsOptions = {
+        titles,
+        provider: 'openrouter',
+        openRouterApiKey: '',
+        fetchImpl: makeOpenRouterOkFetch(titles),
+      };
+      await expect(extractKeywordsBatch(opts)).rejects.toThrow(LlmExtractError);
+    });
+  });
+
+  describe("provider='ollama' (default) — Mac Mini first, OpenRouter fallback", () => {
+    it('uses Ollama when Ollama succeeds (no OpenRouter call)', async () => {
+      const opts: ExtractKeywordsOptions = {
+        titles,
+        provider: 'ollama',
+        fetchImpl: makeOllamaOkFetch(titles),
+      };
+      const out = await extractKeywordsBatch(opts);
+      // Ollama's mock prefixes with 'kw-', OpenRouter's with 'or-'.
+      expect(out[0]!.keywords).toEqual(['kw-파이썬 입문 강의']);
+    });
+
+    it('falls back to OpenRouter when Ollama throws + API key present', async () => {
+      const opts: ExtractKeywordsOptions = {
+        titles,
+        provider: 'ollama',
+        openRouterApiKey: 'sk-or-test',
+        fetchImpl: makeFailThenSucceedFetch(titles),
+      };
+      const out = await extractKeywordsBatch(opts);
+      // Result came from OpenRouter — prefix 'or-'.
+      expect(out[0]!.keywords).toEqual(['or-파이썬 입문 강의']);
+    });
+
+    it('rethrows Ollama error when no OpenRouter API key', async () => {
+      const opts: ExtractKeywordsOptions = {
+        titles,
+        provider: 'ollama',
+        openRouterApiKey: '',
+        fetchImpl: makeAlwaysFailFetch(),
+      };
+      await expect(extractKeywordsBatch(opts)).rejects.toThrow(LlmExtractError);
+    });
+  });
+
+  describe('env-based provider resolution', () => {
+    const prev = process.env['TREND_EXTRACT_PROVIDER'];
+    afterEach(() => {
+      if (prev === undefined) delete process.env['TREND_EXTRACT_PROVIDER'];
+      else process.env['TREND_EXTRACT_PROVIDER'] = prev;
+    });
+
+    it('TREND_EXTRACT_PROVIDER=openrouter routes through OpenRouter', async () => {
+      process.env['TREND_EXTRACT_PROVIDER'] = 'openrouter';
+      const opts: ExtractKeywordsOptions = {
+        titles,
+        openRouterApiKey: 'sk-or-test',
+        fetchImpl: makeOpenRouterOkFetch(titles),
+      };
+      const out = await extractKeywordsBatch(opts);
+      expect(out[0]!.keywords).toEqual(['or-파이썬 입문 강의']);
+    });
+
+    it('TREND_EXTRACT_PROVIDER absent defaults to ollama (Mac Mini)', async () => {
+      delete process.env['TREND_EXTRACT_PROVIDER'];
+      const opts: ExtractKeywordsOptions = {
+        titles,
+        fetchImpl: makeOllamaOkFetch(titles),
+      };
+      const out = await extractKeywordsBatch(opts);
+      expect(out[0]!.keywords).toEqual(['kw-파이썬 입문 강의']);
+    });
+  });
+});

--- a/tests/smoke/llm-extract-openrouter-fallback.test.ts
+++ b/tests/smoke/llm-extract-openrouter-fallback.test.ts
@@ -8,7 +8,12 @@
  *   no OpenRouter API key       → no fallback, rethrow Ollama error
  *
  * The actual HTTP layer is mocked via fetchImpl injection.
+ *
+ * ENCRYPTION_SECRET is set below so config validation passes in CI — the
+ * SUT imports `@/config/index` (hardcode-audit fix, 2026-05-13).
  */
+process.env['ENCRYPTION_SECRET'] ??=
+  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
 import {
   extractKeywordsBatch,


### PR DESCRIPTION
## Summary

Phase D1-b of [Mac Mini deprecation roadmap (PR #615)](https://github.com/JK42JJ/insighta/pull/615). Companion to PR #616 (D1-a env flip).

Adds OpenRouter as fallback (and optional primary) to trend-collector's keyword extractor — removing the last hard Mac Mini dependency in general-LLM extraction.

## Behavior matrix

| `TREND_EXTRACT_PROVIDER` env | `OPENROUTER_API_KEY` | Behavior |
|------------------------------|---------------------|----------|
| unset (default) / `ollama` | absent | Ollama only, throws on failure (pre-D1-b) |
| unset (default) / `ollama` | present | Ollama first, OpenRouter fallback on error (**resilient**) |
| `openrouter` | present | OpenRouter only, skip Mac Mini |
| `openrouter` | absent | Throw (config error) |

Default behavior unchanged when no OpenRouter key set → safe merge, no regression.

## Files

| File | Change |
|------|--------|
| `src/skills/plugins/trend-collector/sources/llm-extract.ts` | +OpenRouter call path + dispatcher (~120 lines) |
| `tests/smoke/llm-extract-openrouter-fallback.test.ts` | NEW — 7 jest tests |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest --testPathPattern='llm-extract-openrouter'` — 7/7 PASS
- [ ] After merge + `OPENROUTER_API_KEY` already in prod env: behavior auto-resilient. Flip `TREND_EXTRACT_PROVIDER=openrouter` later for explicit primary swap.
- [ ] Monitor: trend-collector cron output. No empty-keyword burst on Mac Mini outage.

## Rollback

- Default unchanged when `OPENROUTER_API_KEY` env not set
- Setting `TREND_EXTRACT_PROVIDER=ollama` (or unset) reverts to Mac Mini primary
- `git revert <sha>` → exact pre-D1-b code path

## Phase D1 completion status

- ✅ D1-a (#616): `IKS_EMBED_PROVIDER=openrouter` env flip
- ✅ D1-b (this PR): trend-collector OpenRouter fallback + provider switch
- Together: 2 Mac Mini dependencies eliminated (embed + general LLM extraction)

Remaining Mac Mini dependencies (Phase D2+):
- mandala-gen LoRA (action-fill) — requires RunPod Serverless migration
- (V2 video-discover executor) — dead path, can be deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)