### PR TITLE
fix(auth): SSE access_token query support (70s→6s wizard regression)

### DIFF
--- a/src/api/plugins/auth.ts
+++ b/src/api/plugins/auth.ts
@@ -155,6 +155,15 @@ export async function registerAuth(fastify: FastifyInstance) {
         }
       }
 
+      // SSE/EventSource browser API cannot send custom headers, so the
+      // frontend passes the JWT via `?access_token=<jwt>` query for the
+      // /videos/stream endpoint. Fall back to that when no Authorization
+      // header is present — Authorization-header path stays bit-identical.
+      const queryToken = (request.query as Record<string, string> | undefined)?.['access_token'];
+      if (!request.headers.authorization && queryToken) {
+        request.headers.authorization = `Bearer ${queryToken}`;
+      }
+
       const decoded = await request.jwtVerify<SupabaseJWTClaims>();
 
       const userMeta: Record<string, unknown> = decoded.user_metadata || {};


### PR DESCRIPTION
## Root cause (DB+log evidence)

- \`/api/v1/mandalas/:id/videos/stream\` returned **401 on 5/5 SSE attempts** in the last 24h (prod logs).
- \`src/api/plugins/auth.ts:158\` calls \`request.jwtVerify()\` which reads only the \`Authorization: Bearer\` header.
- Browser \`EventSource\` API cannot send custom headers → FE passes JWT via \`?access_token=<jwt>\` query.
- Result: SSE never connected → FE polling fallback → **70-80s perceived wait** despite BE pipeline completing in **6.1s** (DB-measured for mandala \`d155a979\`).

This is a **pre-existing bug** since SSE rollout (CP416 Phase B). Not introduced by today's perf PRs.

## Fix

Single-file change in \`src/api/plugins/auth.ts\`:
- When \`Authorization\` header is missing AND \`?access_token=\` query param is present, synthesize the header so the existing \`jwtVerify\` path runs unchanged.
- Authorization-header path stays bit-identical (only fires when header is absent).
- Token validity is verified the same way (Supabase ES256 JWKS or HS256 fallback) — no auth weakening.

## Test plan

- [x] tsc clean
- [x] hardcode-audit baseline (33 violations, unchanged)
- [x] tests/smoke/auth-guard.test.ts pass
- [ ] Post-deploy: fresh wizard → confirm \`/videos/stream\` returns 200 (not 401)
- [ ] Confirm FE receives \`card_added\` events as DB upserts (target end-to-end ~6s)

## Rollback

Single commit revert. No DB / schema / config change.