### PR TITLE
feat(v3): domain idempotency — V3_TIER1_SOURCES + V3_SEMANTIC_MIN_COSINE + ephemeral Tier 1 (CP457)

### DIFF
--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -6,10 +6,15 @@ import {
   DEFAULT_MIN_VIEW_COUNT,
   DEFAULT_MIN_VIEWS_PER_DAY,
   DEFAULT_PUBLISHED_AFTER_DAYS,
+  DEFAULT_TIER1_SOURCES,
   DEFAULT_YOUTUBE_SEARCH_TIMEOUT_MS,
   loadV3Config,
 } from '../config';
-import { DEFAULT_RECENCY_HALF_LIFE_MONTHS, DEFAULT_RECENCY_WEIGHT } from '../mandala-filter';
+import {
+  DEFAULT_RECENCY_HALF_LIFE_MONTHS,
+  DEFAULT_RECENCY_WEIGHT,
+  SEMANTIC_MIN_COSINE,
+} from '../mandala-filter';
 
 describe('loadV3Config', () => {
   test('empty env → activated defaults (Tier 1 off, recency on, 3yr cutoff, semantic off, yt timeout 1s, center-gate substring, quality gate off)', () => {
@@ -31,6 +36,8 @@ describe('loadV3Config', () => {
       semanticMaxCandidates: 30, // PR-Y0b2 default
       useYoutubeRankingOnly: false, // PR-Y0d default
       enableRedisProvider: false, // PR-Y0g default (kill switch)
+      tier1Sources: [...DEFAULT_TIER1_SOURCES], // CP457 default ['v2_promoted']
+      semanticMinCosine: SEMANTIC_MIN_COSINE, // CP457 default 0.35 (mandala-filter.ts const)
     });
   });
 
@@ -102,6 +109,8 @@ describe('loadV3Config', () => {
       semanticMaxCandidates: 30, // PR-Y0b2 default
       useYoutubeRankingOnly: false, // PR-Y0d default
       enableRedisProvider: false, // PR-Y0g default (kill switch)
+      tier1Sources: [...DEFAULT_TIER1_SOURCES], // CP457 default ['v2_promoted']
+      semanticMinCosine: SEMANTIC_MIN_COSINE, // CP457 default 0.35 (mandala-filter.ts const)
     });
   });
 
@@ -190,6 +199,46 @@ describe('loadV3Config', () => {
     expect(loadV3Config({ V3_MAX_QUERIES: '-3' }).maxQueries).toBe(DEFAULT_MAX_QUERIES);
     expect(loadV3Config({ V3_MAX_QUERIES: 'garbage' }).maxQueries).toBe(DEFAULT_MAX_QUERIES);
     expect(loadV3Config({ V3_MAX_QUERIES: '' }).maxQueries).toBe(DEFAULT_MAX_QUERIES);
+  });
+
+  test('V3_TIER1_SOURCES parses comma-separated list (CP457)', () => {
+    // Default unset → ['v2_promoted']
+    expect(loadV3Config({}).tier1Sources).toEqual(['v2_promoted']);
+    // Single value
+    expect(loadV3Config({ V3_TIER1_SOURCES: 'v2_promoted' }).tier1Sources).toEqual(['v2_promoted']);
+    // Two values (prod CP457 setting)
+    expect(loadV3Config({ V3_TIER1_SOURCES: 'v2_promoted,batch_trend' }).tier1Sources).toEqual([
+      'v2_promoted',
+      'batch_trend',
+    ]);
+    // Whitespace trimming + empty filter
+    expect(
+      loadV3Config({ V3_TIER1_SOURCES: '  v2_promoted , batch_trend , ' }).tier1Sources
+    ).toEqual(['v2_promoted', 'batch_trend']);
+    // Empty string → default fallback (parses as empty array, schema rejects via .min(1) → fallback)
+    expect(loadV3Config({ V3_TIER1_SOURCES: '' }).tier1Sources).toEqual([...DEFAULT_TIER1_SOURCES]);
+  });
+
+  test('V3_SEMANTIC_MIN_COSINE parses valid [0,1] values (CP457)', () => {
+    // Default unset → 0.35 (mandala-filter.ts SEMANTIC_MIN_COSINE)
+    expect(loadV3Config({}).semanticMinCosine).toBe(SEMANTIC_MIN_COSINE);
+    // Prod CP457 setting
+    expect(loadV3Config({ V3_SEMANTIC_MIN_COSINE: '0.5' }).semanticMinCosine).toBe(0.5);
+    expect(loadV3Config({ V3_SEMANTIC_MIN_COSINE: '0.55' }).semanticMinCosine).toBeCloseTo(0.55, 6);
+    // Bounds
+    expect(loadV3Config({ V3_SEMANTIC_MIN_COSINE: '0' }).semanticMinCosine).toBe(0);
+    expect(loadV3Config({ V3_SEMANTIC_MIN_COSINE: '1' }).semanticMinCosine).toBe(1);
+    // Empty / invalid → default
+    expect(loadV3Config({ V3_SEMANTIC_MIN_COSINE: '' }).semanticMinCosine).toBe(
+      SEMANTIC_MIN_COSINE
+    );
+    // Out of range → entire schema falls back to baseline
+    expect(loadV3Config({ V3_SEMANTIC_MIN_COSINE: '1.5' }).semanticMinCosine).toBe(
+      SEMANTIC_MIN_COSINE
+    );
+    expect(loadV3Config({ V3_SEMANTIC_MIN_COSINE: '-0.1' }).semanticMinCosine).toBe(
+      SEMANTIC_MIN_COSINE
+    );
   });
 
   test('V3_ENABLE_REDIS_PROVIDER kill switch (PR-Y0g, default false)', () => {

--- a/src/skills/plugins/video-discover/v3/cache-matcher.ts
+++ b/src/skills/plugins/video-discover/v3/cache-matcher.ts
@@ -150,6 +150,154 @@ export async function matchFromVideoPool(opts: MatchFromVideoPoolOpts): Promise<
 }
 
 /**
+ * Options for `matchFromVideoPoolByCenterGoal` (CP457).
+ *
+ * Used by the ephemeral / wizard-precompute path where no `mandala_id`
+ * exists yet — so `mandala_embeddings` table is unavailable. Instead the
+ * caller embeds `centerGoal` once and we run pgvector cosine against
+ * `video_pool_embeddings` with that single vector.
+ *
+ * Cell assignment falls back to argmax token-overlap over `subGoals`,
+ * the same pattern used by `tsvectorKeywordCandidates` in
+ * `hybrid-rerank.ts:212-224`. When centerGateMode='semantic' in the
+ * downstream executor the post-Tier-1 mandala-filter may reassign cells;
+ * we still need a meaningful initial value because non-semantic modes
+ * (substring/subword/off) skip that reassignment.
+ */
+export interface MatchByCenterGoalOpts {
+  /** 4096-d qwen3-embedding:8b vector of the wizard `centerGoal`. */
+  centerEmbedding: ReadonlyArray<number>;
+  /** Eight sub_goal strings; argmax token overlap drives cellIndex. */
+  subGoals: ReadonlyArray<string>;
+  language: 'ko' | 'en';
+  limit?: number;
+  /** Minimum cosine to admit. Caller passes `v3Config.semanticMinCosine`. */
+  threshold?: number;
+  /** Same default + override semantics as `matchFromVideoPool`. */
+  sources?: ReadonlyArray<string>;
+}
+
+interface CenterMatchRow {
+  video_id: string;
+  title: string;
+  description: string | null;
+  channel_name: string | null;
+  channel_id: string | null;
+  thumbnail_url: string | null;
+  view_count: bigint | null;
+  like_count: bigint | null;
+  duration_seconds: number | null;
+  published_at: Date | null;
+  score: number;
+}
+
+/**
+ * Tier 1 cache match against a single center-goal embedding (no mandala_id).
+ *
+ * Returns up to `limit` rows from `video_pool`, sorted by cosine desc
+ * against `centerEmbedding`, restricted to gold+silver, language match,
+ * is_active=true, and `sources` whitelist (default `['v2_promoted']`).
+ *
+ * Cell index is assigned per-row via argmax token-overlap with `subGoals`
+ * (lower-case tokenisation on title). Mirrors the tsvector-keyword-path
+ * cell-assignment so ephemeral Tier 1 + Tier 2 hybrid candidates share
+ * an identical distribution rule.
+ *
+ * Returns `[]` when the pool has zero gold+silver rows for the language
+ * or `centerEmbedding.length === 0` (defensive — caller should never).
+ */
+export async function matchFromVideoPoolByCenterGoal(
+  opts: MatchByCenterGoalOpts
+): Promise<CachedMatch[]> {
+  if (opts.centerEmbedding.length === 0) return [];
+  const limit = opts.limit ?? 64;
+  const threshold = opts.threshold ?? DEFAULT_RELEVANCE_THRESHOLD;
+  const sources = opts.sources ?? ['v2_promoted'];
+  const db = getPrismaClient();
+
+  // pgvector requires the literal vector cast — `${array}::vector` doesn't
+  // resolve a JS array through Prisma's template parameter binding, so we
+  // serialise to the `[v1,v2,...]` text form and let Postgres cast.
+  const vectorLiteral = `[${opts.centerEmbedding.join(',')}]`;
+
+  const rows = await db.$queryRaw<CenterMatchRow[]>(Prisma.sql`
+    SELECT
+      vp.video_id,
+      vp.title,
+      vp.description,
+      vp.channel_name,
+      vp.channel_id,
+      vp.thumbnail_url,
+      vp.view_count,
+      vp.like_count,
+      vp.duration_seconds,
+      vp.published_at,
+      1 - (vpe.embedding <=> ${vectorLiteral}::vector) AS score
+    FROM public.video_pool vp
+    JOIN public.video_pool_embeddings vpe
+      ON vp.video_id = vpe.video_id
+    WHERE vp.is_active = true
+      AND vp.language = ${opts.language}
+      AND vp.quality_tier IN ('gold', 'silver')
+      AND vp.source = ANY(${sources}::text[])
+      AND 1 - (vpe.embedding <=> ${vectorLiteral}::vector) >= ${threshold}
+    ORDER BY vpe.embedding <=> ${vectorLiteral}::vector ASC
+    LIMIT ${limit}
+  `);
+
+  const subTokens = opts.subGoals.map((sg) => tokenizeLower(sg ?? ''));
+  const matches: CachedMatch[] = rows.map((r) => {
+    const titleTokens = tokenizeLower(r.title);
+    let bestCell = 0;
+    let bestOverlap = -1;
+    for (let i = 0; i < subTokens.length; i++) {
+      const overlap = countTokenOverlap(titleTokens, subTokens[i] ?? []);
+      if (overlap > bestOverlap) {
+        bestOverlap = overlap;
+        bestCell = i;
+      }
+    }
+    return {
+      videoId: r.video_id,
+      title: r.title,
+      description: r.description,
+      channelName: r.channel_name,
+      channelId: r.channel_id,
+      thumbnail: r.thumbnail_url,
+      viewCount: r.view_count == null ? null : Number(r.view_count),
+      likeCount: r.like_count == null ? null : Number(r.like_count),
+      durationSec: r.duration_seconds,
+      publishedAt: r.published_at,
+      cellIndex: bestCell,
+      score: r.score,
+    };
+  });
+
+  log.info(
+    `cache match (by center-goal): lang=${opts.language} sources=[${sources.join(',')}] threshold=${threshold} matches=${matches.length}`
+  );
+
+  return matches;
+}
+
+function tokenizeLower(s: string): string[] {
+  return s
+    .toLowerCase()
+    .split(/[\s.,;:!?()[\]{}'"`#~^$%&*+=\-_/\\|<>]+/u)
+    .filter((t) => t.length > 0);
+}
+
+function countTokenOverlap(a: ReadonlyArray<string>, b: ReadonlyArray<string>): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  const bSet = new Set(b);
+  let n = 0;
+  for (const t of a) {
+    if (bSet.has(t)) n++;
+  }
+  return n;
+}
+
+/**
  * Distribute cached matches into 8 cell buckets (cellIndex 0..7). Already
  * sorted per cell by score desc. Caller is responsible for merging with
  * Tier 2 fallback and upserting to recommendation_cache.

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -2,7 +2,11 @@ import { z } from 'zod';
 
 import { DEFAULT_SEMANTIC_ALPHA, DEFAULT_SEMANTIC_BETA } from '@/modules/video-dictionary';
 
-import { DEFAULT_RECENCY_HALF_LIFE_MONTHS, DEFAULT_RECENCY_WEIGHT } from './mandala-filter';
+import {
+  DEFAULT_RECENCY_HALF_LIFE_MONTHS,
+  DEFAULT_RECENCY_WEIGHT,
+  SEMANTIC_MIN_COSINE,
+} from './mandala-filter';
 
 export const DEFAULT_PUBLISHED_AFTER_DAYS = 0;
 
@@ -206,6 +210,60 @@ export const DEFAULT_USE_YOUTUBE_RANKING_ONLY = false;
  */
 export const DEFAULT_ENABLE_REDIS_PROVIDER = false;
 
+/**
+ * Tier 1 video_pool source filter (CP457 domain idempotency fix).
+ *
+ * Comma-separated list of `video_pool.source` values that Tier 1 + hybrid-
+ * rerank keyword-expansion are allowed to draw from. Default
+ * `['v2_promoted']` preserves CP456 behavior (CC-authored v2 summaries
+ * with completeness ≥ 0.7, structurally on-topic).
+ *
+ * Set `V3_TIER1_SOURCES=v2_promoted,batch_trend` in prod to expand
+ * coverage to travel / hobby / language / cooking domains where
+ * v2_promoted alone is sparse (CP457 prod measurement: travel mandala
+ * v2_promoted=13 rows vs +batch_trend=372 rows top-50 per cell, cosine
+ * ≥ 0.5 batch=38 + v2=5 = 43 rows pass).
+ *
+ * Trade-off: batch_trend rows are untriaged trend-cron output and admit
+ * cross-domain near-matches (CP455 cell 6 = 28 토익스피킹 at cosine 0.55+).
+ * Companion env `V3_SEMANTIC_MIN_COSINE` (default 0.35, raise to 0.5 in
+ * prod) gates noise via the post-Tier-1 mandala-filter semantic gate.
+ *
+ * Rollback: unset the env var or set back to `v2_promoted` only —
+ * no code change required.
+ */
+export const DEFAULT_TIER1_SOURCES: ReadonlyArray<string> = ['v2_promoted'];
+
+const tier1Sources = z
+  .preprocess((v) => {
+    if (typeof v !== 'string') return undefined;
+    const parts = v
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    return parts.length > 0 ? parts : undefined;
+  }, z.array(z.string()).min(1).optional())
+  .transform((v) => v ?? [...DEFAULT_TIER1_SOURCES]);
+
+/**
+ * Semantic-mode center-gate cosine threshold (CP457 domain idempotency).
+ *
+ * Default 0.35 matches `mandala-filter.ts::SEMANTIC_MIN_COSINE` (CP416
+ * permissive floor) for backward compat. Set `V3_SEMANTIC_MIN_COSINE=0.5`
+ * in prod when V3_TIER1_SOURCES admits batch_trend — raises quality bar
+ * so cross-domain near-matches (CP455 cell 6 토익스피킹 cosine 0.55+) are
+ * filtered while in-domain matches (0.5-0.8 range per CP416 measurement)
+ * survive.
+ *
+ * Rollback: unset env to revert to 0.35 floor — no code change.
+ */
+const semanticMinCosine = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().min(0).max(1).optional()
+  )
+  .transform((v) => v ?? SEMANTIC_MIN_COSINE);
+
 const minViewCount = z
   .preprocess(
     (v) => (v == null || v === '' ? undefined : Number(v)),
@@ -245,6 +303,8 @@ export const v3EnvSchema = z.object({
   V3_SEMANTIC_MAX_CANDIDATES: semanticMaxCandidates,
   V3_USE_YOUTUBE_RANKING_ONLY: booleanFlag.optional().default(false as unknown as string),
   V3_ENABLE_REDIS_PROVIDER: booleanFlag.optional().default(false as unknown as string),
+  V3_TIER1_SOURCES: tier1Sources,
+  V3_SEMANTIC_MIN_COSINE: semanticMinCosine,
 });
 
 export interface V3Config {
@@ -265,6 +325,8 @@ export interface V3Config {
   semanticMaxCandidates: number;
   useYoutubeRankingOnly: boolean;
   enableRedisProvider: boolean;
+  tier1Sources: ReadonlyArray<string>;
+  semanticMinCosine: number;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -286,6 +348,8 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_SEMANTIC_MAX_CANDIDATES: env['V3_SEMANTIC_MAX_CANDIDATES'],
     V3_USE_YOUTUBE_RANKING_ONLY: env['V3_USE_YOUTUBE_RANKING_ONLY'],
     V3_ENABLE_REDIS_PROVIDER: env['V3_ENABLE_REDIS_PROVIDER'],
+    V3_TIER1_SOURCES: env['V3_TIER1_SOURCES'],
+    V3_SEMANTIC_MIN_COSINE: env['V3_SEMANTIC_MIN_COSINE'],
   });
   if (!parsed.success) {
     return {
@@ -306,6 +370,8 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       semanticMaxCandidates: DEFAULT_SEMANTIC_MAX_CANDIDATES,
       useYoutubeRankingOnly: DEFAULT_USE_YOUTUBE_RANKING_ONLY,
       enableRedisProvider: DEFAULT_ENABLE_REDIS_PROVIDER,
+      tier1Sources: [...DEFAULT_TIER1_SOURCES],
+      semanticMinCosine: SEMANTIC_MIN_COSINE,
     };
   }
   return {
@@ -326,6 +392,8 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     semanticMaxCandidates: parsed.data.V3_SEMANTIC_MAX_CANDIDATES,
     useYoutubeRankingOnly: parsed.data.V3_USE_YOUTUBE_RANKING_ONLY,
     enableRedisProvider: parsed.data.V3_ENABLE_REDIS_PROVIDER,
+    tier1Sources: parsed.data.V3_TIER1_SOURCES,
+    semanticMinCosine: parsed.data.V3_SEMANTIC_MIN_COSINE,
   };
 }
 

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -37,7 +37,7 @@ import {
 import { notifyCardAdded, type CardPayload } from '@/modules/recommendations/publisher';
 import { MS_PER_DAY } from '@/utils/time-constants';
 import { manifest, V3_TARGET_PER_CELL, V3_NUM_CELLS, V3_TARGET_TOTAL } from './manifest';
-import { matchFromVideoPool } from './cache-matcher';
+import { matchFromVideoPool, matchFromVideoPoolByCenterGoal } from './cache-matcher';
 import {
   applyMandalaFilterWithStats,
   MIN_SUB_RELEVANCE,
@@ -266,6 +266,7 @@ export const executor: SkillExecutor = {
           mandalaId,
           language: state.language,
           perCell: V3_TARGET_PER_CELL,
+          sources: v3Config.tier1Sources,
         })
       : [];
 
@@ -306,6 +307,7 @@ export const executor: SkillExecutor = {
               centerGateMode: v3Config.centerGateMode,
               centerEmbedding,
               candidateEmbeddings,
+              semanticMinCosine: v3Config.semanticMinCosine,
             });
             const keptIds = new Set<string>();
             for (const assignments of byCell.values()) {
@@ -418,6 +420,7 @@ export const executor: SkillExecutor = {
       enableKeywordExpansion: true,
       topN: V3_TARGET_TOTAL,
       requestId: mandalaId,
+      sources: v3Config.tier1Sources,
     });
     const hybridSlots: AssembledSlot[] = hybridResult.slots
       .map((r) => {
@@ -970,6 +973,7 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
       centerGateMode: v3Config.centerGateMode,
       centerEmbedding,
       candidateEmbeddings,
+      semanticMinCosine: v3Config.semanticMinCosine,
     });
     debug.timing.mandalaFilterMs = Date.now() - tMandalaFilterStart;
 
@@ -1448,6 +1452,8 @@ export interface EphemeralDiscoverResult {
   slots: AssembledSlot[];
   queriesUsed: number;
   tier0_matches: number;
+  /** CP457 — video_pool Tier 1 matches via centerGoal embedding. */
+  tier1_matches: number;
   tier2_matches: number;
   duration_ms: number;
   debug?: Tier2Debug;
@@ -1531,16 +1537,72 @@ export async function runDiscoverEphemeral(
     log.info(`[redis][ephemeral] disabled by V3_ENABLE_REDIS_PROVIDER=false (Y0g)`);
   }
 
-  // ── Compute per-cell deficit after Redis ─
-  const redisByCell = new Map<number, number>();
-  for (const s of redisSlots) {
-    redisByCell.set(s.cellIndex, (redisByCell.get(s.cellIndex) ?? 0) + 1);
-  }
+  // ── Tier 1: video_pool cache by center-goal embedding (CP457) ─
+  // Ephemeral path has no mandala_id → cannot use mandala_embeddings table.
+  // Instead we embed centerGoal once and query video_pool_embeddings cosine
+  // directly. Cell index is assigned via subGoal token-overlap argmax inside
+  // matchFromVideoPoolByCenterGoal (same pattern as tsvectorKeywordCandidates).
+  // Gated by V3_ENABLE_TIER1_CACHE (same flag as mandala-id Tier 1).
+  const tier1Slots: AssembledSlot[] = [];
   const existingVideoIds = new Set(redisSlots.map((s) => s.videoId));
+  if (v3Config.enableTier1Cache) {
+    try {
+      const [centerVec] = await embedBatch([input.centerGoal]);
+      if (centerVec && centerVec.length > 0) {
+        const tier1Matches = await matchFromVideoPoolByCenterGoal({
+          centerEmbedding: centerVec,
+          subGoals: input.subGoals,
+          language: input.language,
+          limit: V3_TARGET_TOTAL,
+          threshold: v3Config.semanticMinCosine,
+          sources: v3Config.tier1Sources,
+        });
+        for (const m of tier1Matches) {
+          if (existingVideoIds.has(m.videoId)) continue;
+          tier1Slots.push({
+            videoId: m.videoId,
+            title: m.title,
+            description: m.description,
+            channelName: m.channelName,
+            channelId: m.channelId,
+            thumbnail: m.thumbnail,
+            viewCount: m.viewCount,
+            likeCount: m.likeCount,
+            durationSec: m.durationSec,
+            publishedAt: m.publishedAt,
+            cellIndex: m.cellIndex,
+            score: m.score,
+            tier: 'cache',
+          });
+          existingVideoIds.add(m.videoId);
+        }
+        log.info(
+          `[tier1][ephemeral] matches=${tier1Matches.length} admitted=${tier1Slots.length} ` +
+            `sources=[${v3Config.tier1Sources.join(',')}] threshold=${v3Config.semanticMinCosine}`
+        );
+      } else {
+        log.warn(`[tier1][ephemeral] centerGoal embed returned empty — skipping Tier 1`);
+      }
+    } catch (err) {
+      log.warn(
+        `[tier1][ephemeral] threw — skipping Tier 1: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  } else {
+    log.info(`[tier1][ephemeral] disabled by V3_ENABLE_TIER1_CACHE=false`);
+  }
+
+  // ── Compute per-cell deficit after Redis + Tier 1 ─
+  const cacheByCell = new Map<number, number>();
+  for (const s of [...redisSlots, ...tier1Slots]) {
+    cacheByCell.set(s.cellIndex, (cacheByCell.get(s.cellIndex) ?? 0) + 1);
+  }
 
   const deficitCells: { cellIndex: number; need: number }[] = [];
   for (let i = 0; i < V3_NUM_CELLS; i++) {
-    const have = redisByCell.get(i) ?? 0;
+    const have = cacheByCell.get(i) ?? 0;
     const need = V3_TARGET_PER_CELL - have;
     if (need > 0) {
       deficitCells.push({ cellIndex: i, need });
@@ -1572,7 +1634,7 @@ export async function runDiscoverEphemeral(
     tier2Debug = tier2.debug;
   }
 
-  const allSlots = [...redisSlots, ...tier2Slots];
+  const allSlots = [...redisSlots, ...tier1Slots, ...tier2Slots];
 
   let filteredSlots = allSlots;
   if (allSlots.length > 0 && v3Config.centerGateMode === 'semantic') {
@@ -1607,6 +1669,7 @@ export async function runDiscoverEphemeral(
           centerGateMode: v3Config.centerGateMode,
           centerEmbedding,
           candidateEmbeddings,
+          semanticMinCosine: v3Config.semanticMinCosine,
         });
         const slotById = new Map(allSlots.map((s) => [s.videoId, s]));
         const flattened: AssembledSlot[] = [];
@@ -1653,6 +1716,7 @@ export async function runDiscoverEphemeral(
       enableKeywordExpansion: true,
       topN: V3_TARGET_TOTAL,
       requestId: 'ephemeral-precompute',
+      sources: v3Config.tier1Sources,
     });
     rerankedSlots = hybridResult.slots
       .map((r) => {
@@ -1714,6 +1778,7 @@ export async function runDiscoverEphemeral(
     slots: rerankedSlots,
     queriesUsed,
     tier0_matches: redisSlots.length,
+    tier1_matches: tier1Slots.length,
     tier2_matches: tier2Slots.length,
     duration_ms: Date.now() - t0,
     debug: tier2Debug,

--- a/src/skills/plugins/video-discover/v3/hybrid-rerank.ts
+++ b/src/skills/plugins/video-discover/v3/hybrid-rerank.ts
@@ -69,6 +69,13 @@ export interface HybridRerankInput<S extends RerankSlot> {
   keywordExpansionLimit?: number;
   topN?: number;
   requestId?: string;
+  /**
+   * `video_pool.source` whitelist for the tsvector keyword-expansion path
+   * (CP457). Default `['v2_promoted']` preserves CP456 behavior — gates out
+   * batch_trend cross-domain noise. Caller passes `v3Config.tier1Sources`
+   * to share the same filter as Tier 1 cache matching.
+   */
+  sources?: ReadonlyArray<string>;
 }
 
 export interface HybridRerankStats {
@@ -296,7 +303,13 @@ export async function applyHybridRerank<S extends RerankSlot>(
   if (input.enableKeywordExpansion === true && input.subGoals && input.subGoals.length > 0) {
     const excludeIds = semanticPool.map((s) => s.videoId);
     const limit = input.keywordExpansionLimit ?? 20;
-    const kw = await tsvectorKeywordCandidates(input.centerGoal, input.subGoals, excludeIds, limit);
+    const kw = await tsvectorKeywordCandidates(
+      input.centerGoal,
+      input.subGoals,
+      excludeIds,
+      limit,
+      input.sources
+    );
     const kwSlots = kw.map((k) => ({
       videoId: k.videoId,
       title: k.title,


### PR DESCRIPTION
## Summary

Three flag-gated env additions to fix the v2_promoted-only source filter
gap that left travel/hobby/language mandalas with **cache=0**. All defaults
preserve CP456 behavior — no behavior change without explicit env set.

**Prod env to set after merge** (rollback = unset, no code revert):
```
V3_TIER1_SOURCES=v2_promoted,batch_trend
V3_SEMANTIC_MIN_COSINE=0.5
```

## Components

### [F] `V3_TIER1_SOURCES` (default `['v2_promoted']`)
Comma-separated `video_pool.source` whitelist. Expands Tier 1 cache +
hybrid-rerank keyword expansion beyond CC-authored v2 summaries.

### [G] `V3_SEMANTIC_MIN_COSINE` (default `0.35`)
Override for semantic center-gate cosine floor. Raises quality bar when
`batch_trend` is admitted — filters cross-domain near-matches.

### [H] Ephemeral Tier 1 — `matchFromVideoPoolByCenterGoal` (new)
Wizard precompute path had no `mandala_id` → no Tier 1 → 100% YouTube
Tier 2 burn. New function embeds `centerGoal` once + queries
`video_pool_embeddings` cosine direct. Cell index assigned via argmax
sub_goal token-overlap. Gated by existing `V3_ENABLE_TIER1_CACHE`.

## Prod Measurement (CP457, ssh-connect to insighta-api via prisma)

| Probe | Result |
|-------|--------|
| U1 video_pool ko gold+silver | v2_promoted 1,156 vs batch_trend 7,465 |
| U2 batch_trend embeddings coverage | 99% (Tier 1 matching feasible) |
| U3 해외여행 mandala (`94d713f0`) | exists in prod (2026-05-13) |
| U4 top-50/cell × 8 cells, v2_promoted only | **13 rows** total (cell 4 = 6, others 0-2) |
| U4 top-50/cell × 8 cells, +batch_trend | **372 rows** total |
| U4 cosine ≥ 0.5 admits | batch=38 + v2=5 = **43 rows** |
| U5 명상 mandala (CP456 baseline) cosine 0.5 | v2 91 + batch_trend 533 (regression-free) |

## Verification

- ✅ `tsc --noEmit` PASS
- ✅ jest v3 suites (cache-matcher, config, hybrid-rerank, mandala-filter, quality-gate, v3-semantic-cap) — 6/6 suites, **91/91 tests PASS**
- ⚠️ `executor-whitelist-gate.test.ts` + `executor-semantic-rerank.test.ts` fail at module-load (`logger.info is not a function`) — **pre-existing**, reproducible on base `4f3aef15`, not introduced by this PR
- 0 LLM API calls / 0 prod DB writes / 0 .env edits / 0 EC2 SSH outside canonical wrapper

## Test plan
- [ ] CI green
- [ ] Deploy succeeds
- [ ] Prod env set (`V3_TIER1_SOURCES=v2_promoted,batch_trend` + `V3_SEMANTIC_MIN_COSINE=0.5`)
- [ ] Local wizard test — 해외여행 mandala cache count > 0
- [ ] Local wizard test — 명상 mandala cache count maintains (regression-free)
- [ ] Cohere hybrid-rerank cell distribution log check
- [ ] Rollback drill — unset env vars + verify CP456 behavior restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)