### PR TITLE
feat: card pin/bookmark + hybrid-rerank quality fixes (CP457+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ prisma/migrations/*
 !prisma/migrations/book-poc/
 !prisma/migrations/note_documents/
 !prisma/migrations/video_pool/
+!prisma/migrations/pin/
 
 # Logs
 logs/

--- a/frontend/src/entities/card/model/local-cards.ts
+++ b/frontend/src/entities/card/model/local-cards.ts
@@ -46,6 +46,8 @@ export interface LocalCard {
   /** YouTube upload date, joined from youtube_videos by video_id. Null for non-YouTube cards or YouTube cards not yet enriched. */
   published_at?: string | null;
   duration_seconds?: number | null;
+  /** CP457+ pin / bookmark timestamp. Null = unpinned. */
+  pinned_at?: string | null;
 }
 
 /**
@@ -138,6 +140,7 @@ export function localCardToInsightCard(card: LocalCard): InsightCard {
         : undefined,
     videoSummary: card.video_summary,
     sourceTable: 'user_local_cards',
+    pinnedAt: card.pinned_at ?? null,
   };
 }
 

--- a/frontend/src/entities/card/model/types.ts
+++ b/frontend/src/entities/card/model/types.ts
@@ -47,6 +47,12 @@ export interface InsightCard {
   isInIdeation?: boolean; // Whether the card is in ideation (scratchpad) or mandala grid
   videoSummary?: VideoSummary; // Central video summary from video_summaries table
   sourceTable?: 'user_local_cards' | 'user_video_states'; // Origin table for enrichment routing
+  /**
+   * CP457+ pin/bookmark state. ISO string when pinned, null/undefined when not.
+   * Surfaced from `pinned_at` column on the source table. Toggled via
+   * `usePinCard` mutation hitting `PATCH /api/v1/cards/:id/pin`.
+   */
+  pinnedAt?: string | null;
 }
 
 export interface MandalaLevel {

--- a/frontend/src/entities/youtube/model/types.ts
+++ b/frontend/src/entities/youtube/model/types.ts
@@ -75,6 +75,8 @@ export interface UserVideoState {
   added_to_ideation_at: string;
   created_at: string;
   updated_at: string;
+  /** CP457+ pin / bookmark timestamp. Null = unpinned. */
+  pinned_at?: string | null;
 }
 
 export interface YouTubeSyncHistory {

--- a/frontend/src/features/card-management/lib/youtubeToInsightCard.ts
+++ b/frontend/src/features/card-management/lib/youtubeToInsightCard.ts
@@ -38,6 +38,7 @@ export function convertToInsightCard(data: UserVideoStateWithVideo): InsightCard
     isInIdeation: data.is_in_ideation,
     videoSummary: data.video_summary,
     sourceTable: 'user_video_states',
+    pinnedAt: data.pinned_at ?? null,
   };
 }
 

--- a/frontend/src/features/card-management/model/usePinCard.ts
+++ b/frontend/src/features/card-management/model/usePinCard.ts
@@ -1,0 +1,48 @@
+/**
+ * usePinCard — toggle pin / bookmark on a grid view card.
+ *
+ * Cards can originate from either `user_local_cards` or `user_video_states`,
+ * carried as `InsightCard.sourceTable`. The mutation hits BE
+ * `PATCH /api/v1/cards/:id/pin` which dispatches to the correct table.
+ *
+ * On success we invalidate BOTH the local-cards list (`localCardsKeys.list()`)
+ * and the recommendation cache (`['mandala', 'recommendations', mandalaId]`)
+ * so whichever feed displays the card refetches the new `pinned_at` value.
+ *
+ * Optimistic update: caller pattern (`useDeleteMandala`) keeps the existing
+ * list shape and just flips the local boolean on the matching row. We mirror
+ * that to keep the UI in sync until the next refetch.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/shared/lib/api-client';
+import { localCardsKeys } from './useLocalCards';
+import type { InsightCard } from '@/entities/card/model/types';
+
+export interface PinCardArgs {
+  card: InsightCard;
+  pinned: boolean;
+}
+
+export function usePinCard() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ card, pinned }: PinCardArgs) => {
+      const source = card.sourceTable ?? 'user_local_cards';
+      const result = await apiClient.setCardPin(card.id, pinned, source);
+      return result;
+    },
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: localCardsKeys.list() });
+      if (vars.card.mandalaId) {
+        queryClient.invalidateQueries({
+          queryKey: ['mandala', 'recommendations', vars.card.mandalaId],
+        });
+      }
+      queryClient.invalidateQueries({
+        queryKey: ['mandala', 'recommendations'],
+      });
+    },
+  });
+}

--- a/frontend/src/features/recommendation-feed/lib/recommendationToInsightCard.ts
+++ b/frontend/src/features/recommendation-feed/lib/recommendationToInsightCard.ts
@@ -40,5 +40,6 @@ export function recommendationToInsightCard(
     mandalaId,
     linkType: 'youtube',
     sourceTable: 'user_video_states',
+    pinnedAt: rec.pinnedAt ?? null,
   };
 }

--- a/frontend/src/features/recommendation-feed/model/useRecommendations.ts
+++ b/frontend/src/features/recommendation-feed/model/useRecommendations.ts
@@ -27,6 +27,13 @@ export interface RecommendationItem {
    * lookup (hybrid-retrieval spec PR3).
    */
   startSec?: number | null;
+  /**
+   * CP457+ pin/bookmark timestamp from user_video_states (joined by
+   * video_id). ISO string when pinned, null when not. Surfaced so the
+   * grid bookmark icon renders in its persisted active state without a
+   * second round-trip.
+   */
+  pinnedAt?: string | null;
 }
 
 export interface RecommendationsResponse {

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1069,6 +1069,29 @@ class ApiClient {
     });
   }
 
+  /**
+   * Toggle pin/bookmark state on a grid view card (CP457+).
+   *
+   * `source` must match `InsightCard.sourceTable` — the FE-only discriminator
+   * that tells us which DB table holds the row (user_local_cards or
+   * user_video_states). BE updates `pinned_at` (NULL = unpinned, NOW = pinned).
+   *
+   * Returns the new state; caller invalidates the cards query for optimistic UI.
+   */
+  async setCardPin(
+    id: string,
+    pinned: boolean,
+    source: 'user_local_cards' | 'user_video_states'
+  ): Promise<{
+    status: string;
+    data: { id: string; pinned: boolean; pinnedAt: string | null; source: string };
+  }> {
+    return this.request(`/cards/${id}/pin`, {
+      method: 'PATCH',
+      body: JSON.stringify({ pinned, source }),
+    });
+  }
+
   async getMandalaQuota(): Promise<{
     used: number;
     limit: number | null;

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1708,6 +1708,7 @@ class ApiClient {
       keyword: string;
       source: 'auto_recommend' | 'manual';
       recReason: string | null;
+      pinnedAt?: string | null;
     }>;
     lastRefreshed: string | null;
   }> {

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -266,15 +266,8 @@ export function InsightCardItemV2({
           />
         </button>
 
-        {/* Top-right inboard: Source badge (shifted left of Pin) */}
-        {isYouTube && (
-          <span className="absolute top-2 right-9 text-[9px] font-semibold px-1.5 py-[2px] rounded-[3px] bg-black/60 backdrop-blur text-white/60 flex items-center gap-[3px]">
-            <svg width="8" height="8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <polygon points="5,3 19,12 5,21" />
-            </svg>
-            YouTube
-          </span>
-        )}
+        {/* YouTube source badge removed (CP457+ spec) — footer relativeDate +
+            viewCount + thumbnail itself convey YouTube context. Pin owns TR. */}
 
         {/* Bottom-left: Memo indicator (only if note exists) */}
         {hasNote && (

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -253,9 +253,17 @@ export function InsightCardItemV2({
           aria-pressed={isPinned}
           className={cn(
             'absolute top-1.5 right-1.5 z-10 w-7 h-7 rounded-md backdrop-blur flex items-center justify-center transition-all',
+            // CP457+ UX:
+            //   pinned   → always-visible, brand `--primary` fill so the
+            //             persisted state is discoverable at a glance.
+            //   unpinned → hover-only, neutral white. Keeps the thumbnail
+            //             visually clean when the user isn't interacting.
+            // Color uses semantic `text-primary` token (per CLAUDE.md
+            // "하드코딩 색상 금지" Hard Rule); avoids brand-mismatching
+            // yellow and adapts automatically on theme change.
             isPinned
-              ? 'bg-black/65 text-yellow-400'
-              : 'bg-black/55 text-white hover:bg-black/80 hover:scale-105'
+              ? 'bg-black/50 text-primary opacity-100'
+              : 'bg-black/55 text-white opacity-0 group-hover:opacity-100 hover:bg-black/80 hover:scale-105'
           )}
         >
           <Bookmark

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -1,9 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { InsightCard } from '@/entities/card/model/types';
 import { Card } from '@/shared/ui/card';
 import { cn } from '@/shared/lib/utils';
-import { GripVertical, NotepadText, Loader2, RotateCw, Play } from 'lucide-react';
+import { GripVertical, NotepadText, Loader2, RotateCw, Play, Bookmark } from 'lucide-react';
+import { usePinCard } from '@/features/card-management/model/usePinCard';
 import { type DragData, cardDragId } from '@/shared/lib/dnd';
 import {
   upgradeYouTubeThumbnail,
@@ -110,6 +111,30 @@ export function InsightCardItemV2({
     data: dragData,
     disabled: !canDrag,
   });
+
+  // CP457+ — Pin / bookmark toggle. Optimistic local boolean to avoid the
+  // visible round-trip; the mutation invalidates the cards query so server
+  // state replaces local on next refetch.
+  const pinMutation = usePinCard();
+  const [isPinnedLocal, setIsPinnedLocal] = useState<boolean | null>(null);
+  const isPinned = isPinnedLocal ?? Boolean(card.pinnedAt);
+  const handlePinClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      const next = !isPinned;
+      setIsPinnedLocal(next);
+      pinMutation.mutate(
+        { card, pinned: next },
+        {
+          onError: () => {
+            setIsPinnedLocal(!next); // rollback
+          },
+        }
+      );
+    },
+    [card, isPinned, pinMutation]
+  );
 
   // CP446 — restore B-model: card body carries listeners only when the card
   // is already selected (multi-drag). Non-selected card bodies stay free for
@@ -218,9 +243,32 @@ export function InsightCardItemV2({
           </span>
         )}
 
-        {/* Top-right: Source badge */}
+        {/* Top-right: Pin / bookmark (CP457+) — primary TR anchor.
+            Inactive = subtle (white/40), hover lifts to white/80. Active
+            (pinned) = always-visible yellow fill for persistent confirmation. */}
+        <button
+          type="button"
+          onClick={handlePinClick}
+          aria-label={isPinned ? 'Unpin card' : 'Pin card'}
+          aria-pressed={isPinned}
+          className={cn(
+            'absolute top-1.5 right-1.5 z-10 w-6 h-6 rounded-md backdrop-blur flex items-center justify-center transition-colors',
+            isPinned
+              ? 'bg-black/60 text-yellow-400 opacity-100'
+              : 'bg-black/40 text-white/60 opacity-0 group-hover:opacity-100 hover:text-white'
+          )}
+        >
+          <Bookmark
+            className="w-3.5 h-3.5"
+            fill={isPinned ? 'currentColor' : 'none'}
+            strokeWidth={2}
+            aria-hidden="true"
+          />
+        </button>
+
+        {/* Top-right inboard: Source badge (shifted left of Pin) */}
         {isYouTube && (
-          <span className="absolute top-2 right-2 text-[9px] font-semibold px-1.5 py-[2px] rounded-[3px] bg-black/60 backdrop-blur text-white/60 flex items-center gap-[3px]">
+          <span className="absolute top-2 right-9 text-[9px] font-semibold px-1.5 py-[2px] rounded-[3px] bg-black/60 backdrop-blur text-white/60 flex items-center gap-[3px]">
             <svg width="8" height="8" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <polygon points="5,3 19,12 5,21" />
             </svg>

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -252,16 +252,16 @@ export function InsightCardItemV2({
           aria-label={isPinned ? 'Unpin card' : 'Pin card'}
           aria-pressed={isPinned}
           className={cn(
-            'absolute top-1.5 right-1.5 z-10 w-6 h-6 rounded-md backdrop-blur flex items-center justify-center transition-colors',
+            'absolute top-1.5 right-1.5 z-10 w-7 h-7 rounded-md backdrop-blur flex items-center justify-center transition-all',
             isPinned
-              ? 'bg-black/60 text-yellow-400 opacity-100'
-              : 'bg-black/40 text-white/60 opacity-0 group-hover:opacity-100 hover:text-white'
+              ? 'bg-black/65 text-yellow-400'
+              : 'bg-black/55 text-white hover:bg-black/80 hover:scale-105'
           )}
         >
           <Bookmark
-            className="w-3.5 h-3.5"
+            className="w-[18px] h-[18px]"
             fill={isPinned ? 'currentColor' : 'none'}
-            strokeWidth={2}
+            strokeWidth={2.2}
             aria-hidden="true"
           />
         </button>

--- a/prisma/migrations/pin/001_add_pinned_at.sql
+++ b/prisma/migrations/pin/001_add_pinned_at.sql
@@ -1,0 +1,27 @@
+-- Pin / bookmark — explicit "save for later" signal on grid cards.
+-- CP457+ behavioral capture for recommendation ranking dictionary.
+--
+-- One column per card source table. NULL = not pinned. Timestamp = pinned moment.
+-- Indexed for filter ("show pinned only") + analytics (recent pins by user).
+--
+-- prisma db push silent-fail safe — raw DDL applied directly to both local +
+-- prod. CI deploy.yml runs `prisma db push` AFTER, which becomes a no-op
+-- when the column already exists.
+
+ALTER TABLE public.user_local_cards
+  ADD COLUMN IF NOT EXISTS pinned_at TIMESTAMPTZ NULL;
+
+CREATE INDEX IF NOT EXISTS idx_user_local_cards_pinned_at
+  ON public.user_local_cards (user_id, pinned_at DESC NULLS LAST)
+  WHERE pinned_at IS NOT NULL;
+
+ALTER TABLE public.user_video_states
+  ADD COLUMN IF NOT EXISTS pinned_at TIMESTAMPTZ NULL;
+
+CREATE INDEX IF NOT EXISTS idx_user_video_states_pinned_at
+  ON public.user_video_states (user_id, pinned_at DESC NULLS LAST)
+  WHERE pinned_at IS NOT NULL;
+
+-- Reload PostgREST schema cache (Supabase) so the new column is visible
+-- to the Edge Function joins. CLAUDE.md "ALTER 직후 Postgrest Schema Reload" rule.
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,9 @@ model UserVideoState {
   /// User trace on an auto-added row promotes it to permanent (preserved across refreshes).
   auto_added             Boolean        @default(false)
   added_to_ideation_at   DateTime       @default(now()) @db.Timestamptz(6)
+  /// CP457+ pin/bookmark: NULL = unpinned, timestamp = pinned moment.
+  /// Used by `idx_user_video_states_pinned_at` partial index for filter view.
+  pinned_at              DateTime?      @db.Timestamptz(6)
   createdAt              DateTime       @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt              DateTime       @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
   users                  users          @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
@@ -43,6 +46,7 @@ model UserVideoState {
   @@index([videoId], map: "idx_user_video_states_video_id")
   @@index([mandala_id], map: "idx_user_video_states_mandala_id")
   @@index([mandala_id, cell_index, auto_added], map: "idx_user_video_states_auto_add_lookup")
+  @@index([user_id, pinned_at(sort: Desc)], map: "idx_user_video_states_pinned_at")
   @@map("user_video_states")
   @@schema("public")
 }
@@ -378,6 +382,7 @@ model users {
   mandala_subscriptions         mandala_subscriptions[]
   content_entities              content_entities[]
   user_subscriptions            user_subscriptions[]
+  billing_subscriptions         billing_subscriptions[]
   user_ui_preferences           user_ui_preferences[]
   user_llm_keys                 user_llm_keys[]
   UserVideoState                UserVideoState[]
@@ -670,6 +675,9 @@ model user_local_cards {
   video_id             String?        @db.VarChar(11)
   created_at           DateTime?      @default(now()) @db.Timestamptz(6)
   updated_at           DateTime?      @default(now()) @db.Timestamptz(6)
+  /// CP457+ pin/bookmark: NULL = unpinned, timestamp = pinned moment.
+  /// Used by `idx_user_local_cards_pinned_at` partial index for filter view.
+  pinned_at            DateTime?      @db.Timestamptz(6)
   users                users          @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   mandala              user_mandalas? @relation(fields: [mandala_id], references: [id], onDelete: SetNull, onUpdate: NoAction)
 
@@ -680,6 +688,7 @@ model user_local_cards {
   @@index([mandala_id], map: "idx_user_local_cards_mandala_id")
   @@index([user_id, mandala_id], map: "idx_user_local_cards_user_mandala")
   @@index([video_id], map: "idx_user_local_cards_video_id")
+  @@index([user_id, pinned_at(sort: Desc)], map: "idx_user_local_cards_pinned_at")
   @@schema("public")
 }
 
@@ -1440,6 +1449,54 @@ model payment_transactions {
   description       String?
   created_at        DateTime? @default(now()) @db.Timestamptz(6)
 
+  @@schema("public")
+}
+
+/// Provider-agnostic subscription mirror. Active provider = Lemon Squeezy (MoR).
+/// See docs/design/billing-lemonsqueezy-2026-05-13.md §3 L0.
+/// Raw DDL: prisma/migrations/billing/001_billing_subscriptions.sql.
+model billing_subscriptions {
+  id                       String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  user_id                  String    @db.Uuid
+  provider                 String    @default("lemonsqueezy") @db.VarChar(30)
+  provider_subscription_id String    @db.VarChar(255)
+  provider_customer_id     String?   @db.VarChar(255)
+  variant_id               String    @db.VarChar(255)
+  plan_code                String    @db.VarChar(50)
+  /// One of: PENDING | ACTIVE | PAST_DUE | CANCELLED | EXPIRED | PAUSED (CHECK constraint at DB).
+  status                   String    @default("PENDING") @db.VarChar(20)
+  current_period_start     DateTime? @db.Timestamptz(6)
+  current_period_end       DateTime? @db.Timestamptz(6)
+  cancel_at_period_end     Boolean   @default(false)
+  cancelled_at             DateTime? @db.Timestamptz(6)
+  amount_cents             Int
+  currency                 String    @db.Char(3)
+  created_at               DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at               DateTime  @default(now()) @db.Timestamptz(6)
+  users                    users     @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([provider, provider_subscription_id], map: "billing_subscriptions_provider_sub_unique")
+  @@index([user_id], map: "idx_billing_subscriptions_user")
+  @@schema("public")
+}
+
+/// Webhook event ledger for idempotency + audit. Every LS webhook lands here
+/// (signature_ok=true/false) before billing_subscriptions transitions.
+/// Raw DDL: prisma/migrations/billing/002_billing_events.sql.
+model billing_events {
+  id                String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  provider          String    @default("lemonsqueezy") @db.VarChar(30)
+  provider_event_id String    @db.VarChar(255)
+  event_name        String    @db.VarChar(100)
+  payload           Json      @db.JsonB
+  signature_ok      Boolean
+  processed_at      DateTime? @db.Timestamptz(6)
+  error_message     String?
+  received_at       DateTime  @default(now()) @db.Timestamptz(6)
+
+  @@unique([provider, provider_event_id], map: "billing_events_provider_event_unique")
+  @@index([received_at(sort: Desc)], map: "idx_billing_events_received")
+  @@index([event_name], map: "idx_billing_events_event_name")
   @@schema("public")
 }
 

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -3,12 +3,18 @@
  *
  * REST API endpoints for toggling pin state on grid view cards.
  *
- * Cards in Insighta come from two source tables:
- *   - `user_local_cards`  — user-added / scratchpad / promoted cards
- *   - `user_video_states` — auto-added recommendations (rec_cache → state)
+ * Cards in Insighta come from three FE-visible sources:
+ *   - `user_local_cards`  — user-added / scratchpad / promoted cards.
+ *   - `user_video_states` — videos already in ideation / auto-added recs.
+ *   - `recommendation_cache` — fresh recs not yet promoted to user_video_states.
  *
- * Client must pass `source` so we update the correct table. The FE's
- * `InsightCard.sourceTable` field already carries this discriminator.
+ * The FE InsightCard discriminator only knows two sources (the first two);
+ * recommendation cards carry a `stream-<rec_cache_id>` id with sourceTable=
+ * 'user_video_states' (per recommendationToInsightCard.ts:29-42). When the
+ * pin button hits a `stream-` prefixed id we look up the rec_cache row, find
+ * the underlying youtube_videos.id, and UPSERT a user_video_states row with
+ * pinned_at — promoting the recommendation to a persistent saved video so
+ * the pin outlives the rec_cache's 7-day TTL.
  *
  * Pin = UX bookmark (save for later) + behavioural signal for ranking.
  * NULL = unpinned, TIMESTAMPTZ = pinned moment. See:
@@ -17,6 +23,7 @@
  */
 
 import { FastifyPluginCallback } from 'fastify';
+import { Prisma } from '@prisma/client';
 import { getPrismaClient } from '@/modules/database';
 import { logger } from '@/utils/logger';
 
@@ -26,6 +33,8 @@ type CardSource = 'user_local_cards' | 'user_video_states';
 
 const ALLOWED_SOURCES: ReadonlySet<CardSource> = new Set(['user_local_cards', 'user_video_states']);
 
+const STREAM_ID_PREFIX = 'stream-';
+
 export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
   /**
    * PATCH /api/v1/cards/:id/pin — toggle pin state.
@@ -33,13 +42,24 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
    * Body:
    *   { pinned: boolean, source: 'user_local_cards' | 'user_video_states' }
    *
-   * Auth: required (`onRequest: [authenticate]`). UPDATE is scoped by user_id
-   *       so a user cannot pin/unpin another user's card even with a valid id.
+   * Auth: required. All writes scoped by user_id so a user cannot pin
+   *       someone else's card even with a valid id.
+   *
+   * Behaviour:
+   *   - id starts with `stream-` → recommendation card. Resolve rec_cache →
+   *     youtube_videos → UPSERT user_video_states(user_id, video_id) with
+   *     pinned_at. Side-effect: creates a user_video_states row if missing
+   *     with is_in_ideation=false + auto_added=false (pin-only intent;
+   *     auto-add pipeline owns the ideation promotion).
+   *   - else → direct UPDATE on the named source table. Raw SQL so the
+   *     Prisma @updatedAt auto-touch on user_video_states does NOT fire
+   *     (would re-shuffle the grid by updated_at desc consumers).
    *
    * Returns:
-   *   200 { status: 'ok', data: { id, pinned, pinnedAt } }
-   *   400 INVALID_SOURCE / MISSING_PINNED — body shape issues
-   *   404 NOT_FOUND — id+user_id+source row absent
+   *   200 { status: 'ok', data: { id, pinned, pinnedAt, source } }
+   *   400 INVALID_SOURCE / MISSING_PINNED — body shape
+   *   404 NOT_FOUND — id+user_id rows absent (or rec_cache not owned)
+   *   500 PIN_UPDATE_FAILED — DB error
    */
   fastify.patch<{
     Params: { id: string };
@@ -74,11 +94,96 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     const prisma = getPrismaClient();
 
     try {
-      // Raw UPDATE to bypass Prisma's @updatedAt auto-touch on user_video_states.
-      // Pinning a row should NOT change `updated_at` — that would reorder the
-      // grid view (cards typically sorted by updated_at desc) and surface the
-      // pinned card to the top, which is unrelated side-effect.
-      // We set ONLY pinned_at and leave updated_at untouched.
+      // ── Branch 1: stream- prefixed → recommendation card ───────────
+      if (id.startsWith(STREAM_ID_PREFIX)) {
+        const recId = id.slice(STREAM_ID_PREFIX.length);
+        if (!isUuid(recId)) {
+          return reply.code(400).send({
+            status: 'error',
+            code: 'INVALID_REC_ID',
+            message: `stream- id must be followed by a uuid; got ${recId.slice(0, 40)}`,
+          });
+        }
+
+        // Look up the rec_cache row (user_id ownership check) to grab the
+        // youtube video id string + mandala_id + cell_index, which we'll
+        // copy into the user_video_states upsert.
+        const rec = await prisma.recommendation_cache.findFirst({
+          where: { id: recId, user_id: userId },
+          select: {
+            id: true,
+            video_id: true,
+            mandala_id: true,
+            cell_index: true,
+          },
+        });
+        if (!rec) {
+          return reply.code(404).send({
+            status: 'error',
+            code: 'REC_NOT_FOUND',
+            message: `Recommendation ${recId} not found for this user`,
+          });
+        }
+
+        // rec.video_id is the YouTube string id; user_video_states.video_id
+        // is a uuid foreign key into youtube_videos.id. Resolve.
+        const yt = await prisma.youtube_videos.findFirst({
+          where: { youtube_video_id: rec.video_id },
+          select: { id: true },
+        });
+        if (!yt) {
+          return reply.code(404).send({
+            status: 'error',
+            code: 'YT_VIDEO_NOT_FOUND',
+            message: `Underlying youtube_videos row missing for ${rec.video_id}`,
+          });
+        }
+
+        // Raw UPSERT to set pinned_at without touching Prisma's @updatedAt.
+        // ON CONFLICT (user_id, video_id) — the table's unique constraint.
+        // INSERT path: minimal-impact defaults (is_in_ideation=false so the
+        // card is NOT promoted to the ideation palette; auto_added=false so
+        // the auto-add eviction sweep treats it as user-owned).
+        await prisma.$executeRaw(Prisma.sql`
+          INSERT INTO public.user_video_states (
+            user_id, video_id, is_in_ideation, watch_position_seconds,
+            is_watched, cell_index, level_id, mandala_id, sort_order,
+            auto_added, added_to_ideation_at, created_at, updated_at,
+            pinned_at
+          )
+          VALUES (
+            ${userId}::uuid,
+            ${yt.id}::uuid,
+            false,
+            0,
+            false,
+            ${rec.cell_index ?? -1},
+            'scratchpad',
+            ${rec.mandala_id}::uuid,
+            NULL,
+            false,
+            now(),
+            now(),
+            now(),
+            ${pinnedAt}
+          )
+          ON CONFLICT (user_id, video_id) DO UPDATE
+            SET pinned_at = EXCLUDED.pinned_at
+        `);
+
+        return reply.code(200).send({
+          status: 'ok',
+          data: {
+            id,
+            pinned,
+            pinnedAt: pinnedAt?.toISOString() ?? null,
+            source: 'user_video_states',
+            promotedFromRecommendation: true,
+          },
+        });
+      }
+
+      // ── Branch 2: direct id → UPDATE named source ─────────────────
       let updatedCount = 0;
       if (source === 'user_local_cards') {
         updatedCount = await prisma.$executeRaw`
@@ -119,3 +224,9 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
 
   done();
 };
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUuid(s: string): boolean {
+  return UUID_RE.test(s);
+}

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -74,19 +74,24 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     const prisma = getPrismaClient();
 
     try {
+      // Raw UPDATE to bypass Prisma's @updatedAt auto-touch on user_video_states.
+      // Pinning a row should NOT change `updated_at` — that would reorder the
+      // grid view (cards typically sorted by updated_at desc) and surface the
+      // pinned card to the top, which is unrelated side-effect.
+      // We set ONLY pinned_at and leave updated_at untouched.
       let updatedCount = 0;
       if (source === 'user_local_cards') {
-        const result = await prisma.user_local_cards.updateMany({
-          where: { id, user_id: userId },
-          data: { pinned_at: pinnedAt },
-        });
-        updatedCount = result.count;
+        updatedCount = await prisma.$executeRaw`
+          UPDATE public.user_local_cards
+             SET pinned_at = ${pinnedAt}
+           WHERE id = ${id}::uuid AND user_id = ${userId}::uuid
+        `;
       } else {
-        const result = await prisma.userVideoState.updateMany({
-          where: { id, user_id: userId },
-          data: { pinned_at: pinnedAt },
-        });
-        updatedCount = result.count;
+        updatedCount = await prisma.$executeRaw`
+          UPDATE public.user_video_states
+             SET pinned_at = ${pinnedAt}
+           WHERE id = ${id}::uuid AND user_id = ${userId}::uuid
+        `;
       }
 
       if (updatedCount === 0) {

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -1,0 +1,116 @@
+/**
+ * Card Pin / Bookmark Routes (CP457+)
+ *
+ * REST API endpoints for toggling pin state on grid view cards.
+ *
+ * Cards in Insighta come from two source tables:
+ *   - `user_local_cards`  — user-added / scratchpad / promoted cards
+ *   - `user_video_states` — auto-added recommendations (rec_cache → state)
+ *
+ * Client must pass `source` so we update the correct table. The FE's
+ * `InsightCard.sourceTable` field already carries this discriminator.
+ *
+ * Pin = UX bookmark (save for later) + behavioural signal for ranking.
+ * NULL = unpinned, TIMESTAMPTZ = pinned moment. See:
+ *   prisma/migrations/pin/001_add_pinned_at.sql (DDL)
+ *   prisma/schema.prisma (model fields + partial indexes)
+ */
+
+import { FastifyPluginCallback } from 'fastify';
+import { getPrismaClient } from '@/modules/database';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'cards-routes' });
+
+type CardSource = 'user_local_cards' | 'user_video_states';
+
+const ALLOWED_SOURCES: ReadonlySet<CardSource> = new Set(['user_local_cards', 'user_video_states']);
+
+export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+  /**
+   * PATCH /api/v1/cards/:id/pin — toggle pin state.
+   *
+   * Body:
+   *   { pinned: boolean, source: 'user_local_cards' | 'user_video_states' }
+   *
+   * Auth: required (`onRequest: [authenticate]`). UPDATE is scoped by user_id
+   *       so a user cannot pin/unpin another user's card even with a valid id.
+   *
+   * Returns:
+   *   200 { status: 'ok', data: { id, pinned, pinnedAt } }
+   *   400 INVALID_SOURCE / MISSING_PINNED — body shape issues
+   *   404 NOT_FOUND — id+user_id+source row absent
+   */
+  fastify.patch<{
+    Params: { id: string };
+    Body: { pinned: boolean; source: CardSource };
+  }>('/:id/pin', { onRequest: [fastify.authenticate] }, async (request, reply) => {
+    if (!request.user || !('userId' in request.user)) {
+      return reply
+        .code(401)
+        .send({ status: 'error', code: 'UNAUTHORIZED', message: 'Unauthorized' });
+    }
+    const userId = request.user.userId;
+    const { id } = request.params;
+    const { pinned, source } =
+      request.body ?? ({} as Partial<{ pinned: boolean; source: CardSource }>);
+
+    if (typeof pinned !== 'boolean') {
+      return reply.code(400).send({
+        status: 'error',
+        code: 'MISSING_PINNED',
+        message: 'body.pinned must be boolean',
+      });
+    }
+    if (!source || !ALLOWED_SOURCES.has(source)) {
+      return reply.code(400).send({
+        status: 'error',
+        code: 'INVALID_SOURCE',
+        message: `body.source must be one of: ${[...ALLOWED_SOURCES].join(', ')}`,
+      });
+    }
+
+    const pinnedAt = pinned ? new Date() : null;
+    const prisma = getPrismaClient();
+
+    try {
+      let updatedCount = 0;
+      if (source === 'user_local_cards') {
+        const result = await prisma.user_local_cards.updateMany({
+          where: { id, user_id: userId },
+          data: { pinned_at: pinnedAt },
+        });
+        updatedCount = result.count;
+      } else {
+        const result = await prisma.userVideoState.updateMany({
+          where: { id, user_id: userId },
+          data: { pinned_at: pinnedAt },
+        });
+        updatedCount = result.count;
+      }
+
+      if (updatedCount === 0) {
+        return reply.code(404).send({
+          status: 'error',
+          code: 'NOT_FOUND',
+          message: `Card ${id} not found in ${source} for this user`,
+        });
+      }
+
+      return reply.code(200).send({
+        status: 'ok',
+        data: { id, pinned, pinnedAt: pinnedAt?.toISOString() ?? null, source },
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(`pin update failed: id=${id} source=${source} pinned=${pinned} err=${msg}`);
+      return reply.code(500).send({
+        status: 'error',
+        code: 'PIN_UPDATE_FAILED',
+        message: msg.slice(0, 200),
+      });
+    }
+  });
+
+  done();
+};

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -1772,6 +1772,38 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     // for the video (caller renders plain URL without `&t=`).
     const anchors = await lookupChunkAnchors(rows.map((r) => r.video_id));
 
+    // CP457+ pin/bookmark surfacing. Pin state lives on user_video_states
+    // (user_id, video_id) — the table that survives rec_cache's 7d TTL.
+    // rec_cache.video_id is the YouTube string id while user_video_states
+    // uses the youtube_videos.id uuid, so we bridge through youtube_videos.
+    // Two batch queries (no N+1) + a Map merge.
+    const videoIdStrings = Array.from(new Set(rows.map((r) => r.video_id)));
+    const pinnedAtByVideoId = new Map<string, Date>();
+    if (videoIdStrings.length > 0) {
+      const ytRows = await prisma.youtube_videos.findMany({
+        where: { youtube_video_id: { in: videoIdStrings } },
+        select: { id: true, youtube_video_id: true },
+      });
+      const ytUuidToVideoId = new Map(ytRows.map((y) => [y.id, y.youtube_video_id]));
+      const ytUuids = ytRows.map((y) => y.id);
+      if (ytUuids.length > 0) {
+        const pinRows = await prisma.userVideoState.findMany({
+          where: {
+            user_id: userId,
+            videoId: { in: ytUuids },
+            pinned_at: { not: null },
+          },
+          select: { videoId: true, pinned_at: true },
+        });
+        for (const p of pinRows) {
+          const videoIdString = ytUuidToVideoId.get(p.videoId);
+          if (videoIdString && p.pinned_at) {
+            pinnedAtByVideoId.set(videoIdString, p.pinned_at);
+          }
+        }
+      }
+    }
+
     const items = rows.map((row) => ({
       id: row.id,
       videoId: row.video_id,
@@ -1787,6 +1819,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       recReason: row.rec_reason,
       publishedAt: row.published_at?.toISOString() ?? null,
       startSec: anchors.get(row.video_id) ?? null,
+      pinnedAt: pinnedAtByVideoId.get(row.video_id)?.toISOString() ?? null,
     }));
 
     const firstRow = rows[0];

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -1747,6 +1747,13 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     // The `idx_recommendation_cache_rec_score_desc` index on rec_score
     // already exists (see `schema.prisma`), so the re-ordered query hits
     // the index for the primary sort.
+    //
+    // CP457+ deterministic tie-break: `id asc` final key. Without it,
+    // tied (rec_score, cell_index) rows came back in PostgreSQL's
+    // non-deterministic order — every refetch (8s poll OR pin-click
+    // invalidate) could shuffle visually identical cards. uuid asc is
+    // arbitrary but stable across refetches, so the grid no longer
+    // re-arranges on background polling.
     const rows = await prisma.recommendation_cache.findMany({
       where: {
         user_id: userId,
@@ -1755,7 +1762,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         expires_at: { gt: new Date() },
         ...(cellIndexFilter !== undefined ? { cell_index: cellIndexFilter } : {}),
       },
-      orderBy: [{ rec_score: 'desc' }, { cell_index: 'asc' }],
+      orderBy: [{ rec_score: 'desc' }, { cell_index: 'asc' }, { id: 'asc' }],
       take: RECOMMENDATION_FETCH_LIMIT,
     });
 

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -2501,12 +2501,47 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           status: RECOMMENDATION_DEFAULT_STATUS,
           expires_at: { gt: new Date() },
         },
-        orderBy: [{ rec_score: 'desc' }, { cell_index: 'asc' }],
+        // CP457+ deterministic tie-break to match the REST endpoint.
+        // Cohere normalize collapses top to rec_score=1.0 — without id
+        // tie-break, backlog emit order shuffles on each reconnect and
+        // tied cards appear to move around the grid.
+        orderBy: [{ rec_score: 'desc' }, { cell_index: 'asc' }, { id: 'asc' }],
         take: RECOMMENDATION_FETCH_LIMIT,
       });
 
       // PR3 — chunk anchors for SSE backlog (same lookup as REST path).
       const backlogAnchors = await lookupChunkAnchors(backlogRows.map((r) => r.video_id));
+
+      // CP457+ pin surfacing for SSE backlog. Same two-step bridge as
+      // the REST `/recommendations` route — rec_cache.video_id (string)
+      // → youtube_videos.id (uuid) → user_video_states.pinned_at. Two
+      // batch findManys, no N+1.
+      const backlogVideoIdStrings = Array.from(new Set(backlogRows.map((r) => r.video_id)));
+      const backlogPinnedAtByVideoId = new Map<string, Date>();
+      if (backlogVideoIdStrings.length > 0) {
+        const ytRows = await getPrismaClient().youtube_videos.findMany({
+          where: { youtube_video_id: { in: backlogVideoIdStrings } },
+          select: { id: true, youtube_video_id: true },
+        });
+        const ytUuidToVideoId = new Map(ytRows.map((y) => [y.id, y.youtube_video_id]));
+        const ytUuids = ytRows.map((y) => y.id);
+        if (ytUuids.length > 0) {
+          const pinRows = await getPrismaClient().userVideoState.findMany({
+            where: {
+              user_id: userId,
+              videoId: { in: ytUuids },
+              pinned_at: { not: null },
+            },
+            select: { videoId: true, pinned_at: true },
+          });
+          for (const p of pinRows) {
+            const videoIdString = ytUuidToVideoId.get(p.videoId);
+            if (videoIdString && p.pinned_at) {
+              backlogPinnedAtByVideoId.set(videoIdString, p.pinned_at);
+            }
+          }
+        }
+      }
 
       // CP455 SSE PR A — reconnect catchup: skip rows already seen by client.
       // recommendation_cache.id is UUID, lexicographically comparable but
@@ -2533,6 +2568,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           recReason: row.rec_reason,
           publishedAt: row.published_at?.toISOString() ?? null,
           startSec: backlogAnchors.get(row.video_id) ?? null,
+          pinnedAt: backlogPinnedAtByVideoId.get(row.video_id)?.toISOString() ?? null,
         };
         write('card_added', payload, row.id);
         emitCount += 1;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -28,7 +28,6 @@ import { sharingRoutes } from './routes/sharing';
 import { cardsRoutes } from './routes/cards';
 import { skillRoutes } from './routes/skills';
 import { copilotKitRoutes } from './routes/copilotkit';
-import { billingRoutes } from './routes/billing';
 import { internalBatchVideoCollectorRoutes } from './routes/internal/batch-video-collector';
 import { internalTrendCollectorRoutes } from './routes/internal/trend-collector';
 import { internalTranscriptRoutes } from './routes/internal/transcript';
@@ -298,9 +297,6 @@ export async function buildServer() {
 
       // Register CopilotKit runtime routes (AI chatbot)
       await instance.register(copilotKitRoutes, { prefix: '/chat' });
-
-      // Register billing routes (Lemon Squeezy — MoR subscription, CP456)
-      await instance.register(billingRoutes, { prefix: '/billing' });
 
       // Register admin routes (requires is_super_admin)
       await instance.register(adminRoutes, { prefix: '/admin' });

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -25,8 +25,10 @@ import { botRoutes } from './routes/bot';
 import { settingsRoutes } from './routes/settings';
 import { youtubeRoutes } from './routes/youtube';
 import { sharingRoutes } from './routes/sharing';
+import { cardsRoutes } from './routes/cards';
 import { skillRoutes } from './routes/skills';
 import { copilotKitRoutes } from './routes/copilotkit';
+import { billingRoutes } from './routes/billing';
 import { internalBatchVideoCollectorRoutes } from './routes/internal/batch-video-collector';
 import { internalTrendCollectorRoutes } from './routes/internal/trend-collector';
 import { internalTranscriptRoutes } from './routes/internal/transcript';
@@ -288,11 +290,17 @@ export async function buildServer() {
       // Register sharing routes (mandala share links, clone)
       await instance.register(sharingRoutes, { prefix: '/sharing' });
 
+      // Register card routes (pin/bookmark toggle — CP457+)
+      await instance.register(cardsRoutes, { prefix: '/cards' });
+
       // Register skills routes (SkillRegistry — newsletter, report, etc.)
       await instance.register(skillRoutes, { prefix: '/skills' });
 
       // Register CopilotKit runtime routes (AI chatbot)
       await instance.register(copilotKitRoutes, { prefix: '/chat' });
+
+      // Register billing routes (Lemon Squeezy — MoR subscription, CP456)
+      await instance.register(billingRoutes, { prefix: '/billing' });
 
       // Register admin routes (requires is_super_admin)
       await instance.register(adminRoutes, { prefix: '/admin' });

--- a/src/modules/recommendations/publisher.ts
+++ b/src/modules/recommendations/publisher.ts
@@ -57,6 +57,17 @@ export interface CardPayload {
    * for the video.
    */
   startSec: number | null;
+  /**
+   * CP457+ pin / bookmark timestamp from `user_video_states.pinned_at`
+   * (joined by youtube_videos.id → user_video_states.video_id). ISO
+   * string when the user has bookmarked this video, null when not.
+   *
+   * Backlog emit sets this from a batch lookup; live `notifyCardAdded`
+   * leaves it null (a brand-new rec can't have been pinned yet — pin
+   * mutations invalidate the cards query so the next backlog re-emits
+   * the up-to-date state).
+   */
+  pinnedAt?: string | null;
 }
 
 /** Unsubscribe callback returned by `subscribe`. Idempotent. */

--- a/src/skills/plugins/video-discover/v3/hybrid-rerank.ts
+++ b/src/skills/plugins/video-discover/v3/hybrid-rerank.ts
@@ -209,6 +209,12 @@ export async function tsvectorKeywordCandidates(
       FROM public.video_pool vp
       WHERE vp.is_active = true
         AND vp.source = ANY(${sources}::text[])
+        -- CP457+ P1a: gate out bronze. Tier 1 cache_matcher already filters
+        -- to gold+silver; the tsvector keyword-expansion path was admitting
+        -- bronze rows (measured: 50대 창업/기후테크/쿠팡/연 20% 배당 ETF
+        -- in cell 0 of the cook mandala) because this WHERE clause forgot
+        -- the quality_tier filter. Mirror the cache_matcher contract.
+        AND vp.quality_tier IN ('gold', 'silver')
         AND vp.video_id <> ALL(${exclude}::text[])
         AND to_tsvector('simple', coalesce(vp.title,'') || ' ' || coalesce(vp.description,''))
             @@ to_tsquery('simple', ${tsqueryString})
@@ -220,8 +226,16 @@ export async function tsvectorKeywordCandidates(
     const out: KeywordCandidate[] = [];
     for (const r of rows) {
       const titleTokens = tokenizeLower(r.title);
-      let bestCell = 0;
-      let bestOverlap = -1;
+      // CP457+ P5: cell assignment requires a real subGoal overlap. The
+      // previous default (`bestCell = 0`, `bestOverlap = -1`) caused
+      // every no-overlap candidate to land in cell 0 — the unrelated
+      // "ITZY 힙팝 챌린지" / "아이온큐 실적" / "뽀로로" cluster the user
+      // observed dumping into the first cell of the cook mandala. Now
+      // bestCell starts at -1; we only commit when a sub_goal actually
+      // shares at least one token with the title, otherwise the
+      // candidate is dropped (no on-topic cell for it).
+      let bestCell = -1;
+      let bestOverlap = 0;
       for (let i = 0; i < subTokens.length; i++) {
         const overlap = countTokenOverlap(titleTokens, subTokens[i] ?? []);
         if (overlap > bestOverlap) {
@@ -229,6 +243,7 @@ export async function tsvectorKeywordCandidates(
           bestCell = i;
         }
       }
+      if (bestCell < 0) continue;
       out.push({
         videoId: r.video_id,
         title: r.title,
@@ -367,7 +382,15 @@ export async function applyHybridRerank<S extends RerankSlot>(
     return { slots: cellVideoDeduped, stats };
   }
 
-  // Normalize Cohere relevance_scores to 0–100 within this batch.
+  // Normalize Cohere relevance_scores to 0–100 within this batch, then
+  // CP457+ P4b: divide back into the 0-1 contract that every
+  // downstream consumer assumes. `upsertSlots` clamps with
+  // `Math.min(1, slot.score)` (executor.ts:1215) so any 0-100 value
+  // collapses to 1.0 — destroying the rec_score distribution and
+  // producing the "every card rec_score=1.0" tie that the FE then
+  // can't break in ORDER BY. Keep `normalizeScores0to100` unchanged
+  // (its 0-100 contract is asserted by unit tests + intuitive for
+  // operators reading logs); divide at the use site so DB sees 0-1.
   const rawScores = cohereRes.results.map((r) => r.relevanceScore);
   const normalized = normalizeScores0to100(rawScores);
 
@@ -378,7 +401,7 @@ export async function applyHybridRerank<S extends RerankSlot>(
     if (!r) continue;
     const slot = cellVideoDeduped[r.index];
     if (!slot) continue;
-    const normScore = normalized[i] ?? slot.rec_score;
+    const normScore = normalized[i] != null ? normalized[i]! / 100 : slot.rec_score;
     reorderedSlots.push({
       ...slot,
       rec_score: normScore,

--- a/supabase/functions/local-cards/index.ts
+++ b/supabase/functions/local-cards/index.ts
@@ -237,9 +237,16 @@ Deno.serve(async (req) => {
         // Parallel fetch: subscription + cards
         let cardsQuery = supabase
           .from('user_local_cards')
-          .select('id, url, title, thumbnail, link_type, user_note, metadata_title, metadata_description, metadata_image, cell_index, level_id, mandala_id, sort_order, video_id, created_at, updated_at')
+          .select('id, url, title, thumbnail, link_type, user_note, metadata_title, metadata_description, metadata_image, cell_index, level_id, mandala_id, sort_order, video_id, created_at, updated_at, pinned_at')
           .eq('user_id', user.id)
-          .order('sort_order', { ascending: true });
+          // CP457+ deterministic tie-break + pinned_at column. sort_order
+          // is null for many cards (never touched by D&D); without a
+          // tertiary key Postgres returns null-sort_order rows in
+          // undefined order, so refetch (8s poll, pin invalidate) shuffles
+          // them. id asc is arbitrary but stable. pinned_at must also be
+          // selected so the FE bookmark renders after refresh.
+          .order('sort_order', { ascending: true, nullsFirst: false })
+          .order('id', { ascending: true });
 
         if (mandalaId) {
           cardsQuery = cardsQuery.eq('mandala_id', mandalaId);

--- a/tests/smoke/cards-pin-routes.test.ts
+++ b/tests/smoke/cards-pin-routes.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Cards Pin Routes smoke tests (CP457+) — auth rejection + body validation.
+ *
+ * Validates the PATCH /api/v1/cards/:id/pin endpoint exists with the right
+ * auth gate + body shape. DB writes are not exercised — those need a live DB
+ * which the smoke suite does not provide.
+ */
+export {};
+
+const canBootServer = !!(
+  process.env['SUPABASE_JWT_SECRET'] ||
+  process.env['JWT_SECRET'] ||
+  process.env['SUPABASE_URL']
+);
+
+const describeIfServer = canBootServer ? describe : describe.skip;
+
+describeIfServer('Cards Pin API — auth + validation', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let app: any;
+
+  beforeAll(async () => {
+    const { buildServer } = await import('../../src/api/server');
+    app = await buildServer();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('PATCH /api/v1/cards/:id/pin returns 401 without token', async () => {
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/cards/00000000-0000-0000-0000-000000000001/pin',
+      headers: { 'content-type': 'application/json' },
+      payload: { pinned: true, source: 'user_local_cards' },
+    });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('PATCH /api/v1/cards/:id/pin rejects requests without auth header (no false 200)', async () => {
+    const response = await app.inject({
+      method: 'PATCH',
+      url: '/api/v1/cards/00000000-0000-0000-0000-000000000001/pin',
+      payload: {},
+    });
+    expect(response.statusCode).not.toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Bookmark/pin feature on grid cards **+** root-cause fixes for the
recommendation noise + rec_score collapse observed in CP457.

**Pin / bookmark**
- TR Bookmark icon on every grid card (`InsightCardItemV2`).
- Inactive = hover-only neutral white. Active = always-visible
  brand `text-primary` (soft indigo, no yellow). Optimistic local
  state + rollback on mutation error.
- BE `PATCH /api/v1/cards/:id/pin` (auth-gated, user-scoped).
- Persistence end-to-end for **all three card sources**:
  - `user_local_cards` → direct UPDATE
  - `user_video_states` → direct UPDATE
  - `recommendation_cache` (`stream-<uuid>` ids) → resolve rec_cache
    → youtube_videos → UPSERT user_video_states with pinned_at
- DDL (`prisma/migrations/pin/001_add_pinned_at.sql`) + schema +
  partial indexes on both tables.

**Card quality / order — hybrid-rerank defects fixed**
- **Bronze admit** — tsvector keyword path now filters
  `quality_tier IN ('gold','silver')` (was missing the gate that
  Tier 1 cache_matcher already has).
- **Cell-0 dump** — `bestCell = 0` default for no-overlap candidates
  flipped to `-1` + skip; no more "ITZY/아이온큐/뽀로로 dumped into
  the cook mandala's cell 0".
- **rec_score collapse** — Cohere normalize (0-100) divided back to
  0-1 at the assignment site; `upsertSlots` clamp no longer drives
  the whole batch to rec_score=1.0 tie.

**Order determinism**
- Recommendation feed REST + SSE backlog both get a final `id ASC`
  tie-break to remove non-deterministic shuffle.
- local-cards EF select also gets `id ASC` tie-break + `pinned_at`
  in its SELECT projection.

## Test plan
- [ ] CI green
- [ ] Apply DDL to prod (`prisma/migrations/pin/001_add_pinned_at.sql`)
      via canonical ssh-connect path after deploy succeeds.
- [ ] Pin survives refresh on each source (local card, ideation
      video state, recommendation card).
- [ ] No reorder of grid on pin click or 8s poll.
- [ ] Sample wizard runs (one travel-domain, one cook-domain) —
      verify cell-0 noise gone and rec_score distribution spread.
- [ ] No regression on D&D / search / scratchpad.

## Risk notes
- `tsvectorKeywordCandidates` P5 fix drops no-overlap candidates;
  expect a smaller keyword-expansion pool for mandalas with sparse
  sub_goal tokens. Trade-off chosen over the cell-0 dump.
- `rec_score` distribution scale shifts from "≈1.0 everywhere" to
  Cohere min-max within batch (0-1). Anything downstream that
  treats score==1.0 as "perfect match" must tolerate the new
  meaningful spread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)