### PR TITLE
fix(security): gate admin/discover-traces with authenticateAdmin

### DIFF
--- a/src/api/routes/admin/discover-traces.ts
+++ b/src/api/routes/admin/discover-traces.ts
@@ -6,13 +6,15 @@
  * pipeline behaviour: LLM prompts, YouTube search queries, Cohere rerank
  * input/output, embedding batches, etc.
  *
- * Requires is_super_admin (parent plugin enforces).
+ * All routes guarded by fastify.authenticate + fastify.authenticateAdmin.
  */
 
 import { FastifyPluginCallback } from 'fastify';
 import { getPrismaClient } from '@/modules/database';
 
 export const adminDiscoverTracesRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
   /**
    * GET /api/v1/admin/discover-traces/by-mandala/:mandalaId
    *
@@ -20,6 +22,7 @@ export const adminDiscoverTracesRoutes: FastifyPluginCallback = (fastify, _opts,
    */
   fastify.get<{ Params: { mandalaId: string } }>(
     '/by-mandala/:mandalaId',
+    adminAuth,
     async (request, reply) => {
       const prisma = getPrismaClient();
       const rows = await prisma.video_discover_traces.findMany({
@@ -49,15 +52,19 @@ export const adminDiscoverTracesRoutes: FastifyPluginCallback = (fastify, _opts,
   /**
    * GET /api/v1/admin/discover-traces/by-run/:runId — fetch one execution.
    */
-  fastify.get<{ Params: { runId: string } }>('/by-run/:runId', async (request, reply) => {
-    const prisma = getPrismaClient();
-    const rows = await prisma.video_discover_traces.findMany({
-      where: { run_id: request.params.runId },
-      orderBy: { created_at: 'asc' },
-      take: 5000,
-    });
-    return reply.send({ runId: request.params.runId, count: rows.length, traces: rows });
-  });
+  fastify.get<{ Params: { runId: string } }>(
+    '/by-run/:runId',
+    adminAuth,
+    async (request, reply) => {
+      const prisma = getPrismaClient();
+      const rows = await prisma.video_discover_traces.findMany({
+        where: { run_id: request.params.runId },
+        orderBy: { created_at: 'asc' },
+        take: 5000,
+      });
+      return reply.send({ runId: request.params.runId, count: rows.length, traces: rows });
+    }
+  );
 
   /**
    * GET /api/v1/admin/discover-traces/recent?user_id=...&limit=N
@@ -65,6 +72,7 @@ export const adminDiscoverTracesRoutes: FastifyPluginCallback = (fastify, _opts,
    */
   fastify.get<{ Querystring: { user_id?: string; limit?: string } }>(
     '/recent',
+    adminAuth,
     async (request, reply) => {
       const userId = request.query.user_id;
       const limit = Math.min(Number(request.query.limit ?? '500') || 500, 5000);


### PR DESCRIPTION
## Summary

Routes in `src/api/routes/admin/discover-traces.ts` were registered without `onRequest: [fastify.authenticate, fastify.authenticateAdmin]`. The admin plugin only decorates the helper — each route must opt in.

**Verified open in prod**: `curl https://44.231.152.49/api/v1/admin/discover-traces/recent -k` → `HTTP 200 {"count":0,"traces":[]}` (no JWT supplied).

## Fix

Align with `admin/health.ts` and `admin/quality-metrics.ts`:
```ts
const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
fastify.get('/by-mandala/:mandalaId', adminAuth, async (...) => { ... });
```
applied to all 3 routes (`/by-mandala/:id`, `/by-run/:id`, `/recent`).

## Risk

- Pre-fix exposure: an unauthenticated caller could enumerate `video_discover_traces` rows (LLM prompts, YouTube queries, Cohere rerank input — potentially sensitive user query text).
- Window: from PR #624 deploy (~12:24 KST) to merge of this hotfix.
- Pre-merge mitigation: table is fresh and only fills when wizard runs. As of detection: count=0.

## Test plan

- [ ] CI green
- [ ] curl `/api/v1/admin/discover-traces/recent` post-merge returns 401 without JWT
- [ ] super_admin JWT returns 200