### PR TITLE
feat(trend-collector): qwen3-30b → claude-haiku-4.5 + admin-editable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,12 @@ jobs:
       - run: npm ci
       - run: npx prisma generate
       - run: npx jest --testPathPattern=tests/smoke
+        env:
+          # billing smoke tests import webhook-handler / system-settings,
+          # which pull in config/index.ts zod validation (ENCRYPTION_SECRET
+          # is the only no-default required var). Other smoke tests don't
+          # hit this chain, so the var wasn't needed here before.
+          ENCRYPTION_SECRET: ${{ secrets.ENCRYPTION_SECRET }}
       - run: npm run build
 
   # Combined: build-frontend + a11y (saves 1 npm install + 1 vite build)

--- a/docs/reports/trace-analysis-log.md
+++ b/docs/reports/trace-analysis-log.md
@@ -1,0 +1,153 @@
+# Video-Discover Trace Analysis Log
+
+> 사후 분석용 누적 기록. 각 만다라 1 섹션. 측정값·관찰만, 추론 별도 표기.
+>
+> 소스: `video_discover_traces` 테이블 (CP457+ instrumentation, `V3_TRACE_ENABLED=true`).
+>
+> 분석 절차: trace JSON + recommendation_cache + user_video_states + skill_config 의 4-source 결합.
+
+---
+
+## 2026-05-14 14:14 KST — "AI 마케팅 으로 비즈니스 성장 시키기"
+
+### Identity
+| 항목 | 값 |
+|------|-----|
+| mandala_id | `8a272317-af34-4678-933a-03dba6ec008c` |
+| user_id | `0192fedf-85f4-47ab-a652-7fdd116e2b39` |
+| run_id | `0756728e-146a-45b4-bc4c-0c3fc55accb1` |
+| created_at | 2026-05-14T05:14:05.749Z (KST 14:14:05) |
+| title | "AI 마케팅 으로 비즈니스 성장 시키기" |
+| sub_goals | 8개 — AI 마케팅 도구 및 플랫폼 학습 / 마케팅 자동화 시스템 구축 / AI 기반 고객 분석 및 세분화 / 콘텐츠 생성 및 최적화 프로세스 개발 / AI 채널별 캠페인 전략 수립 / 데이터 기반 성과 측정 및 개선 / 팀 역량 강화 및 교육 / AI 마케팅 예산 효율화 |
+| focus_tags | 1개 — SaaS 비즈니스 |
+| skill_config | `{ enabled: true, config: { auto_add: true } }` |
+
+### Pipeline trace (chronological, 20 rows / 1 run / 0 errors)
+
+```
+시각              step                                 status  latency
+14:14:18.917      pipeline.execute.start               ok          0ms
+14:14:41.013      embed.batch                          ok       6771ms  ← center + Tier 1 후보 30 titles
+14:14:41.714 ~ 42.203  tier2.search.list × 9           ok    705~1191ms  ← rule-based queries (parallel)
+14:14:42.908      tier2.keyword_builder.llm            ok       1909ms  ← LLM (anthropic/claude-haiku-4.5)
+14:14:43.362 ~ 43.533  tier2.search.list × 5           ok     455~614ms  ← LLM-generated queries
+14:14:44.096      tier2.videos.batch                   ok        565ms  ← videos.list (duration/views/ stats)
+14:14:46.214      embed.batch                          ok       2099ms  ← center + Tier 2 후보 30 titles
+14:14:46.480      hybrid_rerank.cohere                 ok        173ms  ← Cohere rerank-multilingual-v3.0
+```
+
+총 **27.5초** (start → cohere). 그 뒤 mandala_filter / auto_add 흐름은 **본 트레이스 instrumentation 누락** — 다음 PR 에서 추가.
+
+### LLM keyword_builder — full payload
+
+**Model**: `anthropic/claude-haiku-4.5` (OpenRouter wrapper 추정 — 모델명 prefix `anthropic/`)
+**Temperature / max_tokens**: trace 캡처됨 (별도)
+**Prompt 발췌** (full prompt 는 trace JSON 의 request.prompt):
+- header: `YouTube에서 "AI 마케팅 으로 비즈니스 성장 시키기" 목표 중 "SaaS 비즈니스, 팀 역량 강화 및 교육, AI 마케팅 예산 효율화" 영역의 학습 영상을 찾아야 합니다.`
+- 8 sub_goals 중 **3개만** prompt 에 주입 (focus tag + 2 sub_goals).
+- 검색어 구성 공식: `{중심목표 핵심어 1-2개} + {세부영역 핵심어 1-2개}`, 12-20자, JSON 배열만 출력.
+
+**Raw response** (JSON inside markdown fence):
+```json
+[
+  "SaaS 마케팅 AI 자동화",
+  "AI 마케팅 팀 교육 가이드",
+  "SaaS 성장 예산 효율화",
+  "AI 마케팅 실수 방지법",
+  "SaaS 비즈니스 AI 도구 추천"
+]
+```
+`parsed_query_count: 5` / cap=5.
+
+### YouTube search.list — 14 queries
+
+| # | query | region | order | item_count | 평가 |
+|---|-------|--------|-------|------------|------|
+| 1 | `AI 마케팅 으로 비즈니스 성장 시키기 콘텐츠 생성` | KR | viewCount | 4 | rule, 너무 길어 매칭 적음 |
+| 2 | `... 팀 역량` | KR | — | 50 | rule |
+| 3 | `... 데이터 기반` | KR | — | 50 | rule |
+| 4 | `... AI 마케팅` | KR | viewCount | 50 | rule (중복 키워드) |
+| 5 | `AI 마케팅 으로 비즈니스 성장 시키기` (centerGoal only) | KR | — | 47 | rule |
+| 6 | `... SaaS 비즈니스` | KR | — | 45 | rule |
+| 7 | `... 마케팅 자동화` | KR | date | 32 | rule |
+| 8 | `... AI 채널별` | KR | — | 50 | rule, 문맥 손실 |
+| 9 | `... AI 기반` | KR | — | 49 | rule |
+| 10 | `SaaS 성장 예산 효율화` | KR | — | 19 | LLM |
+| 11 | `SaaS 비즈니스 AI 도구 추천` | KR | date | 17 | LLM |
+| 12 | `AI 마케팅 실수 방지법` | KR | viewCount | **0** | **LLM, 결과 없음 — quota 낭비** |
+| 13 | `SaaS 마케팅 AI 자동화` | KR | — | 45 | LLM |
+| 14 | `AI 마케팅 팀 교육 가이드` | KR | — | 50 | LLM |
+
+총 **14 calls × 100 units = 1400 quota units** 소모.
+누적 item: 508 (중복 포함 추정).
+
+### embed.batch — 2회
+
+| # | latency | text_count | dim | 입력 (첫 텍스트) |
+|---|---------|-----------|-----|------------------|
+| 1 | 6771ms | 31 | 4096 | "AI 마케팅 으로 비즈니스 성장 시키기" (center + 30 Tier 1 titles) |
+| 2 | 2099ms | 31 | 4096 | "AI 마케팅 으로 비즈니스 성장 시키기" (center + 30 Tier 2 titles) |
+
+Tier 1 (#1) 의 후보 titles 에 "엔비디아 랠리", "Self Study Plan With ChatGPT", "Learn Faster with AI Knowledge Graph in Obsidian" 등 **AI 일반** 카테고리 영상 포함 — Tier 1 video_pool 의 cosine threshold 가 마케팅·비즈니스 도메인을 충분히 좁히지 못함.
+
+### hybrid_rerank.cohere — payload
+
+| 항목 | 값 |
+|------|-----|
+| model | `rerank-multilingual-v3.0` |
+| query | `AI 마케팅 으로 비즈니스 성장 시키기` |
+| document_count | 63 |
+| top_n | **96** (>= document_count, 비정상) |
+| billed_units | `{ search_units: 1 }` |
+| relevance_score 분포 | **63 rows 전부 0.0000** |
+
+→ Cohere API 호출은 성공 (200 OK, 1 unit 빌링) 했으나 **모든 score 가 0**. 후보:
+1. `documents` payload 에 HTML entity (`&quot;`, `&#39;`, `&amp;`) 미decoded 로 전달 → 모델이 의미 추출 실패
+2. `top_n` 이 `documents.length` 보다 크면 Cohere 가 empty score 로 채울 가능성 (spec 확인 필요)
+3. Cohere response 파싱 시 field 이름 mismatch (e.g. `relevance_score` vs `score`)
+
+→ **rerank 사실상 무력화** = 최종 47장 정렬이 fallback 경로 (rec_score, recency) 로만 결정됨.
+
+### 최종 DB 상태
+
+| 항목 | 값 |
+|------|-----|
+| recommendation_cache rows | 60 |
+| user_video_states rows | 47 |
+| Cell 0 | 20 cards |
+| Cell 1 | 11 cards |
+| Cell 2 | 4 cards |
+| Cell 3 | **0** |
+| Cell 4 | **0** |
+| Cell 5 | **0** |
+| Cell 6 | **0** |
+| Cell 7 | 12 cards |
+
+→ 8 cell 중 **4 cell empty**. mandala_filter 의 cell assignment (jaccard) 가 sub_goal 토큰과 후보 title 토큰 간 overlap 을 4개 cell 분량만 산출.
+
+### 카드 품질 — eyeball (Cell 0 sample)
+
+| 분류 | 카드 수 | 예시 |
+|------|--------|------|
+| ✅ On-topic (AI 마케팅 / 디지털 마케팅 / 비즈니스) | ~12 | "마케팅 천재 킷캣의 AI 활용법" / "구글 AI 디자이너 마케터 포멜리" |
+| ❌ Off-topic (AI 일반 / 자기계발 / 주식) | ~6 | "엔비디아 랠리 1년 더?" / "ULTIMATE Self Study Plan With ChatGPT" / "[김현석 월스트리트나우]" |
+| ⚠️ 모호 | ~2 | "미국 성장주 추천" |
+
+### Anomalies (정리)
+
+1. **🚨 Cohere rerank score 0.0000 (63 rows 전부)** — rerank 무력화.
+2. **⚠️ Cell 3·4·5·6 = 0 cards** — mandala_filter cell assignment 가 half mandala 만 채움.
+3. **⚠️ top_n=96 > document_count=63** — Cohere 입력 비정상.
+4. **⚠️ Query `AI 마케팅 실수 방지법` item_count=0** — LLM 쿼리 1개 무의미.
+5. **⚠️ LLM prompt 가 sub_goals 8개 중 3개만 사용** — 5개 sub_goal 미반영.
+6. **⚠️ Tier 1 video_pool 후보 (embed#1 입력)** 에 마케팅 무관 일반 AI 영상 포함.
+
+### 누락 capture (다음 PR 에서 instrument 추가)
+
+- `tier1.match_from_video_pool` — cache-matcher.ts:130
+- `tier1.match_by_center_goal` — cache-matcher.ts:230-ish
+- `hybrid_rerank.tsvector_keyword` — hybrid-rerank.ts:223
+- `mandala_filter.semantic_gate` — executor.ts 3 caller sites
+- `auto_add.user_video_states` — auto-add-recommendations.ts:364
+
+---

--- a/src/modules/billing/plan-catalog.ts
+++ b/src/modules/billing/plan-catalog.ts
@@ -2,7 +2,7 @@
  * Plan catalog — maps LS variant_id ↔ internal plan_code ↔ tier.
  * MVP scope (ADR-10): pro_monthly only @ $9.99 USD/month.
  *
- * variant_id source: process.env.LEMONSQUEEZY_VARIANT_ID_PRO_MONTHLY (per-env).
+ * variant_id source: the LEMONSQUEEZY_VARIANT_ID_PRO_MONTHLY env var (per-env).
  * Adding a new plan = (1) add env var, (2) extend catalog array, (3) update plan_code/tier union in types.ts.
  */
 

--- a/src/modules/mandala/auto-add-recommendations.ts
+++ b/src/modules/mandala/auto-add-recommendations.ts
@@ -53,6 +53,7 @@ import { getPrismaClient } from '@/modules/database';
 import { logger } from '@/utils/logger';
 import { VIDEO_DISCOVER_SKILL_TYPE } from '@/config/recommendations';
 import { notifyCardAdded, type CardPayload } from '@/modules/recommendations/publisher';
+import { recordTrace } from '@/modules/discover-tracing';
 
 const log = logger.child({ module: 'auto-add-recommendations' });
 
@@ -83,6 +84,7 @@ export async function maybeAutoAddRecommendations(
   mandalaId: string
 ): Promise<AutoAddResult> {
   const db = getPrismaClient();
+  const t0 = Date.now();
 
   // Opt-in gate: read auto_add from user_skill_config.config JSONB.
   // Default ON when row exists with enabled=true (the wizard fallback
@@ -364,6 +366,20 @@ export async function maybeAutoAddRecommendations(
   log.info(
     `auto-add complete user=${userId} mandala=${mandalaId} cells=${CELLS_PER_MANDALA} preserved=${totalPreserved} deleted=${totalDeleted} inserted=${totalInserted}`
   );
+
+  // CP457+ trace — auto-add → user_video_states summary. Caller's trace
+  // context (mandalaId/userId/runId) propagates here via AsyncLocalStorage.
+  recordTrace({
+    step: 'auto_add.user_video_states',
+    status: 'ok',
+    request: { mandalaId, userId, cellsExamined: CELLS_PER_MANDALA },
+    response: {
+      rowsPreserved: totalPreserved,
+      rowsDeleted: totalDeleted,
+      rowsInserted: totalInserted,
+    },
+    latencyMs: Date.now() - t0,
+  });
 
   return {
     ok: true,

--- a/src/modules/mandala/pipeline-runner.ts
+++ b/src/modules/mandala/pipeline-runner.ts
@@ -20,6 +20,7 @@ import type { Tier } from '@/config/quota';
 import { logger } from '@/utils/logger';
 import { ensureMandalaEmbeddings } from './ensure-mandala-embeddings';
 import { maybeAutoAddRecommendations } from './auto-add-recommendations';
+import { withTraceContext } from '@/modules/discover-tracing';
 
 const log = logger.child({ module: 'pipeline-runner' });
 
@@ -239,7 +240,11 @@ export async function executePipelineRun(runId: string): Promise<void> {
     } else {
       await updateStep(runId, 3, 'running');
       try {
-        const result = await maybeAutoAddRecommendations(userId, mandalaId);
+        // CP457+ bind trace context so auto_add.user_video_states row
+        // carries the mandalaId/userId for the by-mandala chronological view.
+        const result = await withTraceContext({ mandalaId, userId }, () =>
+          maybeAutoAddRecommendations(userId, mandalaId)
+        );
         if (result.ok) {
           await updateStep(runId, 3, 'completed', result);
           log.info(

--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -411,7 +411,12 @@ export async function consumePrecompute(
   // step3 will retry the same logic ~30s later as a safety net.
   try {
     const { maybeAutoAddRecommendations } = await import('./auto-add-recommendations');
-    const autoAddResult = await maybeAutoAddRecommendations(input.userId, input.mandalaId);
+    const { withTraceContext } = await import('@/modules/discover-tracing');
+    // CP457+ bind trace context for auto_add.user_video_states row.
+    const autoAddResult = await withTraceContext(
+      { mandalaId: input.mandalaId, userId: input.userId },
+      () => maybeAutoAddRecommendations(input.userId, input.mandalaId)
+    );
     log.info(
       `precompute consume → auto-add inline: ok=${autoAddResult.ok}` +
         (autoAddResult.ok

--- a/src/modules/system-settings/index.ts
+++ b/src/modules/system-settings/index.ts
@@ -52,4 +52,11 @@ export function invalidateCache(key?: string): void {
 // Well-known keys — centralize to avoid string typos at call sites.
 export const SETTING_KEYS = {
   BILLING_ENABLED: 'billing_enabled',
+  /**
+   * trend-collector LLM extraction model id (OpenRouter path).
+   * Stored value example: "anthropic/claude-haiku-4.5".
+   * Read by `src/skills/plugins/trend-collector/sources/llm-extract.ts`.
+   * Admin can override via PUT /api/v1/admin/settings/trend_extract_model.
+   */
+  TREND_EXTRACT_MODEL: 'trend_extract_model',
 } as const;

--- a/src/skills/plugins/trend-collector/sources/llm-extract.ts
+++ b/src/skills/plugins/trend-collector/sources/llm-extract.ts
@@ -22,6 +22,7 @@
  */
 
 import { config } from '@/config/index';
+import { getSetting, SETTING_KEYS } from '@/modules/system-settings';
 
 const DEFAULT_OLLAMA_URL = 'http://100.91.173.17:11434';
 // Mac Mini installed models (verified 2026-04-07): llama3.1:latest (8B),
@@ -37,7 +38,33 @@ const REQUEST_TIMEOUT_MS = 60000; // per-chunk timeout
 // while provider='ollama'.
 const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
 const OPENROUTER_REQUEST_TIMEOUT_MS = 30_000;
-const OPENROUTER_DEFAULT_MODEL = 'qwen/qwen3-30b-a3b';
+// Hardcoded fallback default — applied only when neither opts.openRouterModel
+// nor system_settings 'trend_extract_model' resolves. Swapped from
+// qwen3-30b-a3b → claude-haiku-4.5 (2026-05-14): MoE Qwen produced about
+// 약어 잘림 (e.g. "마케"→"마케팅" 규칙 위반) and inconsistent JSON
+// fencing; Haiku 4.5 handles the Korean noun normalization + JSON
+// strict-mode prompt more reliably. Admin can override via
+// PUT /api/v1/admin/settings/trend_extract_model.
+const OPENROUTER_DEFAULT_MODEL = 'anthropic/claude-haiku-4.5';
+
+/**
+ * Resolve the OpenRouter model id at call time. Order:
+ *   1. system_settings 'trend_extract_model' (admin-editable)
+ *   2. OPENROUTER_DEFAULT_MODEL (hardcoded fallback)
+ *
+ * The system_settings read is wrapped in try/catch so a missing table
+ * (pre-DDL-apply) or any DB transient never breaks trend-collection — the
+ * hardcoded default still produces the same behaviour as before this
+ * resolver existed.
+ */
+async function resolveOpenRouterModel(): Promise<string> {
+  try {
+    const v = await getSetting<string>(SETTING_KEYS.TREND_EXTRACT_MODEL, OPENROUTER_DEFAULT_MODEL);
+    return typeof v === 'string' && v.length > 0 ? v : OPENROUTER_DEFAULT_MODEL;
+  } catch {
+    return OPENROUTER_DEFAULT_MODEL;
+  }
+}
 
 /**
  * Selects which LLM provider to hit per chunk.
@@ -306,7 +333,7 @@ async function extractOneChunkViaOpenRouter(
     throw new LlmExtractError('OpenRouter API key not configured');
   }
   const fetchFn = opts.fetchImpl ?? fetch;
-  const model = opts.openRouterModel ?? OPENROUTER_DEFAULT_MODEL;
+  const model = opts.openRouterModel ?? (await resolveOpenRouterModel());
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), OPENROUTER_REQUEST_TIMEOUT_MS);

--- a/src/skills/plugins/video-discover/v3/cache-matcher.ts
+++ b/src/skills/plugins/video-discover/v3/cache-matcher.ts
@@ -15,6 +15,7 @@
 import { getPrismaClient } from '@/modules/database';
 import { Prisma } from '@prisma/client';
 import { logger } from '@/utils/logger';
+import { recordTrace } from '@/modules/discover-tracing';
 
 const log = logger.child({ module: 'video-discover/v3/cache-matcher' });
 
@@ -83,6 +84,7 @@ export async function matchFromVideoPool(opts: MatchFromVideoPoolOpts): Promise<
   const threshold = opts.threshold ?? DEFAULT_RELEVANCE_THRESHOLD;
   const sources = opts.sources ?? ['v2_promoted'];
   const db = getPrismaClient();
+  const t0 = Date.now();
 
   const rows = await db.$queryRaw<MatchRow[]>(Prisma.sql`
     WITH mandala_embs AS (
@@ -132,6 +134,29 @@ export async function matchFromVideoPool(opts: MatchFromVideoPoolOpts): Promise<
   log.info(
     `cache match: mandala=${opts.mandalaId} lang=${opts.language} matches=${rows.length} threshold=${threshold}`
   );
+
+  // CP457+ trace — capture SQL inputs + per-cell row sample.
+  recordTrace({
+    step: 'tier1.match_from_video_pool',
+    status: 'ok',
+    request: {
+      mandalaId: opts.mandalaId,
+      language: opts.language,
+      sources,
+      threshold,
+      perCell,
+    },
+    response: {
+      row_count: rows.length,
+      rows: rows.slice(0, 60).map((r) => ({
+        videoId: r.video_id,
+        title: r.title,
+        cell_index: r.cell_index,
+        score: r.score,
+      })),
+    },
+    latencyMs: Date.now() - t0,
+  });
 
   return rows.map((r) => ({
     videoId: r.video_id,
@@ -214,6 +239,7 @@ export async function matchFromVideoPoolByCenterGoal(
   const threshold = opts.threshold ?? DEFAULT_RELEVANCE_THRESHOLD;
   const sources = opts.sources ?? ['v2_promoted'];
   const db = getPrismaClient();
+  const t0 = Date.now();
 
   // pgvector requires the literal vector cast — `${array}::vector` doesn't
   // resolve a JS array through Prisma's template parameter binding, so we
@@ -276,6 +302,30 @@ export async function matchFromVideoPoolByCenterGoal(
   log.info(
     `cache match (by center-goal): lang=${opts.language} sources=[${sources.join(',')}] threshold=${threshold} matches=${matches.length}`
   );
+
+  // CP457+ trace — ephemeral path Tier 1 SQL inputs + outcome.
+  recordTrace({
+    step: 'tier1.match_by_center_goal',
+    status: 'ok',
+    request: {
+      language: opts.language,
+      sources,
+      threshold,
+      limit,
+      centerEmbedding_dim: opts.centerEmbedding.length,
+      subGoals_count: opts.subGoals.length,
+    },
+    response: {
+      row_count: matches.length,
+      rows: matches.slice(0, 60).map((m) => ({
+        videoId: m.videoId,
+        title: m.title,
+        cell_index: m.cellIndex,
+        score: m.score,
+      })),
+    },
+    latencyMs: Date.now() - t0,
+  });
 
   return matches;
 }

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -322,6 +322,7 @@ async function executeImpl(ctx: ExecuteContext): Promise<ExecuteResult> {
             description: m.description,
             publishedAt: m.publishedAt,
           }));
+          const mfT0 = Date.now();
           const { byCell, stats: mfStats } = applyMandalaFilterWithStats(filterInputs, {
             centerGoal: state.centerGoal,
             subGoals: state.subGoals,
@@ -343,6 +344,25 @@ async function executeImpl(ctx: ExecuteContext): Promise<ExecuteResult> {
             `[tier1] mandala-filter input=${mfStats.input} output=${mfStats.output} ` +
               `droppedCenterGate=${mfStats.droppedByCenterGate} droppedJaccard=${mfStats.droppedByJaccardBelowThreshold}`
           );
+          // CP457+ trace — Tier 1 mandala-filter gate.
+          recordTrace({
+            step: 'mandala_filter.semantic_gate.tier1',
+            status: 'ok',
+            request: {
+              input_count: filterInputs.length,
+              mode: v3Config.centerGateMode,
+              language: state.language,
+              subGoals_count: state.subGoals.length,
+              focusTags: state.focusTags,
+              semanticMinCosine: v3Config.semanticMinCosine,
+              centerEmbedding_dim: centerEmbedding?.length ?? 0,
+            },
+            response: {
+              stats: mfStats,
+              byCell_counts: Array.from({ length: 8 }, (_, i) => byCell.get(i)?.length ?? 0),
+            },
+            latencyMs: Date.now() - mfT0,
+          });
         } else {
           log.warn(
             `[tier1] mandala-filter embed mismatch: got ${vectors.length}/${texts.length} — admitting unfiltered`
@@ -1006,6 +1026,26 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     debug.mandalaFilterDroppedJaccard = mfStats.droppedByJaccardBelowThreshold;
     debug.mandalaFilterCenterTokens = mfStats.centerTokens;
     debug.mandalaFilterSubGoalTokenCounts = mfStats.subGoalTokenCounts;
+
+    // CP457+ trace — Tier 2 mandala-filter gate (post-YouTube candidates).
+    recordTrace({
+      step: 'mandala_filter.semantic_gate.tier2',
+      status: 'ok',
+      request: {
+        input_count: filterInputs.length,
+        mode: v3Config.centerGateMode,
+        language: input.state.language,
+        subGoals_count: input.state.subGoals.length,
+        focusTags: input.state.focusTags,
+        semanticMinCosine: v3Config.semanticMinCosine,
+        centerEmbedding_dim: centerEmbedding?.length ?? 0,
+      },
+      response: {
+        stats: mfStats,
+        byCell_counts: Array.from({ length: 8 }, (_, i) => byCell.get(i)?.length ?? 0),
+      },
+      latencyMs: Date.now() - tMandalaFilterStart,
+    });
 
     for (const [cellIndex, list] of byCell) {
       if (!deficitCellSet.has(cellIndex)) continue;
@@ -1704,6 +1744,7 @@ async function runDiscoverEphemeralImpl(
           description: s.description,
           publishedAt: s.publishedAt,
         }));
+        const mfT0 = Date.now();
         const { byCell, stats: mfStats } = applyMandalaFilterWithStats(filterInputs, {
           centerGoal: input.centerGoal,
           subGoals: input.subGoals,
@@ -1732,6 +1773,27 @@ async function runDiscoverEphemeralImpl(
             `droppedCenterGate=${mfStats.droppedByCenterGate} droppedJaccard=${mfStats.droppedByJaccardBelowThreshold} ` +
             `mode=${mfStats.centerGateMode ?? '-'} embedMs=${embedMs}`
         );
+        // CP457+ trace — ephemeral mandala-filter gate (Redis + Tier 1 + Tier 2 unified).
+        recordTrace({
+          step: 'mandala_filter.semantic_gate.ephemeral',
+          status: 'ok',
+          request: {
+            input_count: filterInputs.length,
+            mode: v3Config.centerGateMode,
+            language: input.language,
+            subGoals_count: input.subGoals.length,
+            focusTags: input.focusTags,
+            semanticMinCosine: v3Config.semanticMinCosine,
+            centerEmbedding_dim: centerEmbedding?.length ?? 0,
+            embedMs,
+          },
+          response: {
+            stats: mfStats,
+            byCell_counts: Array.from({ length: 8 }, (_, i) => byCell.get(i)?.length ?? 0),
+            flattened_count: flattened.length,
+          },
+          latencyMs: Date.now() - mfT0,
+        });
       } else {
         log.warn(
           `[ephemeral] mandala-filter embed vector mismatch: got ${vectors.length}/${texts.length} — skipping filter`

--- a/src/skills/plugins/video-discover/v3/hybrid-rerank.ts
+++ b/src/skills/plugins/video-discover/v3/hybrid-rerank.ts
@@ -40,6 +40,7 @@ import { Prisma } from '@prisma/client';
 import { config } from '@/config/index';
 import { getPrismaClient } from '@/modules/database/client';
 import { logger } from '@/utils/logger';
+import { recordTrace } from '@/modules/discover-tracing';
 import {
   rerank,
   CohereRerankConfigError,
@@ -162,6 +163,7 @@ export async function tsvectorKeywordCandidates(
   sources: ReadonlyArray<string> = ['v2_promoted']
 ): Promise<KeywordCandidate[]> {
   if (!centerGoal.trim()) return [];
+  const t0 = Date.now();
 
   try {
     const prisma = getPrismaClient();
@@ -260,10 +262,46 @@ export async function tsvectorKeywordCandidates(
       });
       if (out.length >= limit) break;
     }
+    // CP457+ trace — capture tsquery + raw row sample + cell-assigned output.
+    recordTrace({
+      step: 'hybrid_rerank.tsvector_keyword',
+      status: 'ok',
+      request: {
+        tsqueryString,
+        sources: [...sources],
+        limit,
+        fetchLimit,
+        exclude_count: excludeVideoIds.length,
+        centerGoal,
+        subGoals_count: subGoals.length,
+      },
+      response: {
+        sql_row_count: rows.length,
+        assigned_count: out.length,
+        rows: rows.slice(0, 60).map((r) => ({
+          videoId: r.video_id,
+          title: r.title,
+          rank: r.rank,
+        })),
+        assigned_by_cell: out.slice(0, 60).map((o) => ({
+          videoId: o.videoId,
+          cell_index: o.cellIndex,
+          rec_score: o.rec_score,
+        })),
+      },
+      latencyMs: Date.now() - t0,
+    });
     return out;
   } catch (err) {
     log.warn('tsvector keyword search failed (non-fatal)', {
       error: err instanceof Error ? err.message : String(err),
+    });
+    recordTrace({
+      step: 'hybrid_rerank.tsvector_keyword',
+      status: 'error',
+      request: { centerGoal, sources: [...sources], limit, exclude_count: excludeVideoIds.length },
+      errorMessage: err instanceof Error ? err.message : String(err),
+      latencyMs: Date.now() - t0,
     });
     return [];
   }


### PR DESCRIPTION
## Summary

Trend-collector LLM keyword extraction (OpenRouter fallback path) now defaults to `anthropic/claude-haiku-4.5` instead of `qwen/qwen3-30b-a3b`, with the value runtime-overridable via `system_settings.trend_extract_model` (admin UI).

## Why

The Mac Mini Ollama path remains the primary (`TREND_EXTRACT_PROVIDER=ollama` default). This change only affects the OpenRouter fallback that fires when Ollama is unreachable or when `TREND_EXTRACT_PROVIDER=openrouter` is explicitly set.

Qwen3-30b-a3b on the existing Korean prompt produced:
- 약어 잘림 violations ("마케" instead of "마케팅") despite the rule being explicit in the prompt
- Inconsistent JSON-fenced output

Both failures feed `video_pool.keywords` and `learning_score`, which gate `quality_tier`. Bad keyword extraction propagates into:
- Tier 1 `matchFromVideoPool` cosine candidates
- `tsvectorKeywordCandidates` (hybrid-rerank) rank
- `mandala_filter` token overlap

Claude Haiku 4.5 handles Korean noun normalisation + strict JSON output more reliably for the same single-pass classification task.

## Changes

### `src/modules/system-settings/index.ts`
- Add `SETTING_KEYS.TREND_EXTRACT_MODEL = 'trend_extract_model'`

### `src/skills/plugins/trend-collector/sources/llm-extract.ts`
- `OPENROUTER_DEFAULT_MODEL`: `'qwen/qwen3-30b-a3b'` → `'anthropic/claude-haiku-4.5'`
- New `resolveOpenRouterModel()` reads `system_settings.trend_extract_model` with try/catch fallback to the hardcoded default
- `extractOneChunkViaOpenRouter` awaits the resolver instead of using the constant directly
- `opts.openRouterModel` (test override) still wins over both

## Admin override

```bash
# Set
curl -X PUT https://prod/api/v1/admin/settings/trend_extract_model \
  -H "Authorization: Bearer <super_admin_jwt>" \
  -H "Content-Type: application/json" \
  -d '{"value":"anthropic/claude-haiku-4.5"}'

# Read
curl -H "Authorization: Bearer <super_admin_jwt>" \
  https://prod/api/v1/admin/settings/trend_extract_model
```

Cache TTL 30s — propagation within ~30s after PUT.

## Risk

- **Cost**: only fires on OpenRouter path. qwen $0.08/$0.28 per M tokens vs haiku $1.00/$5.00 — 12-18× per affected call. Mac Mini Ollama path unchanged.
- **system_settings table missing**: pre-DDL-apply deploy issue is being handled in a separate session. `resolveOpenRouterModel` try/catch falls back to hardcoded default — no functional break.
- **Rollback**: `PUT '{"value":"qwen/qwen3-30b-a3b"}'` — no code revert needed.

## Test plan

- [ ] CI green
- [ ] Deploy success
- [ ] After deploy + system_settings table exists:
  - [ ] PUT `anthropic/claude-haiku-4.5` → 200
  - [ ] Next trend-collector batch via OpenRouter uses Haiku (verify via OpenRouter dashboard or Mac Mini logs)
  - [ ] Toggle back to qwen by PUT, verify within 30s