### PR TITLE
config(v3): raise V3_SEMANTIC_MAX_CANDIDATES 30 → 100

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -161,10 +161,16 @@ services:
       #
       # Revert: set to 'off' (or delete this line — code default 'substring').
       - V3_CENTER_GATE_MODE=semantic
-      # CP436 PR-Y0b2 — semantic gate candidate cap. ≤ 30 ensures the
-      # embedBatch call ([centerGoal, ...top30titles]) stays in a single
-      # OpenRouter/Ollama request. Cap > 50 would cross the chunk boundary.
-      - V3_SEMANTIC_MAX_CANDIDATES=30
+      # CP436 PR-Y0b2 — semantic gate candidate cap.
+      # 2026-05-14: raised 30 → 100 per direct user directive after "8구단
+      # 드래프트" mandala trace analysis revealed 750 raw → 30 cap → 18
+      # mandala_filter input → 6 final cards. Cap was the dominant
+      # bottleneck (1500 quota units yielded only 6 cards). Trade-off: the
+      # embedBatch single-chunk safety (DEFAULT_EMBED_CHUNK_SIZE=50) is now
+      # exceeded — embedding.ts will chunk into 2-3 batches, adding ~1-2s
+      # latency. Acceptable for the candidate-pool expansion gain.
+      # Rollback: set back to 30.
+      - V3_SEMANTIC_MAX_CANDIDATES=100
       # CP436 PR-Y0d (Issue #543) — bypass mandala-filter and trust YouTube's
       # search.list ranking. User feedback (2026-04-28): the 9-axis filter
       # actively degraded card quality vs the original YouTube-only path


### PR DESCRIPTION
## Summary

Single-line env config change. Raises V3_SEMANTIC_MAX_CANDIDATES from 30 to 100 to unblock the dominant funnel point identified by trace analysis of "8구단 드래프트 1순위" mandala.

## Evidence (from trace inspection)

Trace data (mandala 8359df45):
- 15 search.list calls = 1500 quota units
- 750 raw items returned
- **Cap=30 dropped to 30** ← bottleneck
- mandala_filter input: 18
- Final cards: 6

→ The 1500 quota units yielded only 6 cards because the cap (NOT the queries, NOT mandala_filter) cropped 720 candidates. Raising cap to 100 lets ~3× more candidates flow through.

## Expected impact

- Final card count: 6 → 15-25 (estimate, subject to mandala_filter pass rate)
- Cell distribution: currently [0,0,0,0,0,0,0,6] — expected to fill more cells
- YouTube quota: unchanged (no new search.list calls)
- Embed latency: +1-2s (100 texts crosses single-chunk boundary 50, goes to 2-3 chunks)

## Test plan

- [ ] CI green
- [ ] Deploy success
- [ ] Create a new wizard mandala on same niche domain (e.g. baseball/draft)
- [ ] Confirm `mandala_filter.semantic_gate.*` input_count > 30 in new trace
- [ ] Confirm card count > 6 on dashboard

## Rollback

- Revert this commit, or
- `PUT /api/v1/admin/settings/V3_SEMANTIC_MAX_CANDIDATES 30` (if exposed as runtime setting — not yet wired, requires future PR)