### PR TITLE
fix(filter): shorts threshold 180s → 60s

### DIFF
--- a/src/skills/plugins/video-discover/__tests__/v2-youtube-client.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v2-youtube-client.test.ts
@@ -102,14 +102,19 @@ describe('parseIsoDuration', () => {
 });
 
 describe('filters', () => {
-  test('isShortsByDuration — duration-based (180s threshold per 2024 YouTube policy)', () => {
+  test('isShortsByDuration — duration-based (60s threshold, CP358 original)', () => {
     expect(isShortsByDuration(30)).toBe(true);
     expect(isShortsByDuration(60)).toBe(true);
-    // Prod bug 2026-04-17: 110s video "한의대수석으로 만들어준 공부법
-    // #공부" slipped past the old 60s gate because YouTube widened Shorts
-    // from 60s to 180s in October 2024. Now caught.
-    expect(isShortsByDuration(110)).toBe(true);
-    expect(isShortsByDuration(180)).toBe(true);
+    // 2026-05-14 revert from 180s back to 60s: trace analysis of the
+    // "8구단 드래프트 1순위" mandala showed 24% of YouTube candidates
+    // (50/206) were KBO/MLB draft NEWS CLIPS from SBS/KBS/YTN/MBN
+    // (281k, 136k, 111k views) — exactly the mandala-relevant content
+    // — that fell in the 61-180s bucket and got incorrectly killed by
+    // the 180s gate. `titleIndicatesShorts` still catches explicit
+    // `#shorts` hashtag cases in this range.
+    expect(isShortsByDuration(61)).toBe(false);
+    expect(isShortsByDuration(110)).toBe(false);
+    expect(isShortsByDuration(180)).toBe(false);
     expect(isShortsByDuration(181)).toBe(false);
     expect(isShortsByDuration(600)).toBe(false);
   });

--- a/src/skills/plugins/video-discover/v2/youtube-client.ts
+++ b/src/skills/plugins/video-discover/v2/youtube-client.ts
@@ -489,19 +489,26 @@ export const V2_TITLE_BLOCKLIST: ReadonlyArray<string> = [
  * Shorts are excluded from AI recommendations — users can add them
  * manually, but the discovery pipeline recommends long-form only.
  *
- * Threshold is 180 seconds (YouTube extended Shorts from 60s to 180s
- * in October 2024). Prod 2026-04-17: a 110-second shorts titled
- * "한의대수석으로 만들어준 공부법 #공부 #공부잘하는방법" surfaced in
- * a "효율적인 학습법 탐색" mandala — duration passed the old 60s gate
- * even though the video is clearly a short. The hashtag pattern also
- * missed it because the title tagged `#공부` rather than `#shorts`.
+ * Threshold history:
+ *   - Original: 60s (CP358 Fix 3) — YouTube's pre-2024 Shorts cutoff.
+ *   - 2026-04-17: raised to 180s after a 110s `#공부` short surfaced
+ *     in a learning mandala. The intent was to align with YouTube's
+ *     2024-10 Shorts format extension (60s → 180s).
+ *   - 2026-05-14: REVERTED to 60s. Trace analysis of the "8구단
+ *     드래프트 1순위" mandala showed 24% of the YouTube candidates
+ *     (50/206) fell into the 61-180s bucket — and inspection revealed
+ *     those were KBO/MLB draft news clips from SBS/KBS/YTN/MBN/MBC
+ *     official news channels (281k, 136k, 111k views), exactly the
+ *     mandala-relevant content. The 180s gate was killing the news
+ *     and highlights domain. `titleIndicatesShorts` still catches
+ *     explicit `#shorts` hashtag cases in the 60-180s range.
  *
  * Null duration is treated as shorts (defensive drop). Videos.list
  * occasionally omits `contentDetails.duration` for shorts specifically,
  * so null → drop prevents that hole.
  */
 export function isShortsByDuration(durationSec: number | null): boolean {
-  return durationSec === null || durationSec <= 180;
+  return durationSec === null || durationSec <= 60;
 }
 
 /**


### PR DESCRIPTION
## Summary

Reverts the 2026-04-17 widening of the shorts duration gate (60s→180s) that aligned with YouTube's 2024-10 Shorts format extension. Trace analysis on the "8구단 드래프트 1순위" mandala revealed the 180s gate was killing the news-and-highlights domain.

## Evidence

Direct YouTube API dump (`docs/reports/yt-search-dumps/8gudan-draft-2026-05-14.txt`):

| Duration bucket | Count | % | Disposition |
|---|---:|---:|---|
| null | 0 | 0% | DROP (defensive) |
| ≤ 60s (true shorts) | 86 | 41.7% | DROP (correct) |
| **61-180s** | **50** | **24.3%** | **INCORRECTLY DROPPED** |
| 181-600s | 19 | 9.2% | PASS |
| 601-1800s | 22 | 10.7% | PASS |
| > 1800s | 29 | 14.1% | PASS |

Manual review of the 50 incorrectly-dropped: SBS/KBS/YTN/MBN/MBC/연합뉴스TV official news clips reporting on KBO/MLB drafts (281k/136k/111k views) — exactly the content the mandala needs.

## Change

```diff
-  return durationSec === null || durationSec <= 180;
+  return durationSec === null || durationSec <= 60;
```

The legacy 2026-04-17 case (`110s + #공부 hashtag`) is still caught by `titleIndicatesShorts`, which fires regardless of duration when explicit shorts hashtag markers are present.

## Risk

- Some "extended Shorts" (60-180s with no hashtag marker) may now surface. Acceptable: these were the same gate state from CP358 through 2026-04-17 and never caused user complaints.
- `null` duration still defensively dropped.

## Test plan

- [x] Unit test updated: `isShortsByDuration(61|110|180)` now expects `false`
- [ ] CI green
- [ ] After deploy, recreate the "8구단 드래프트 1순위" mandala — expected: 6 cards → +N news clips admitted (subject to mandala_filter pass rate)

## Future

If 60-180s noise becomes a concern again, expose this via `system_settings.shorts_threshold_seconds` (admin-editable per `T2-2` pattern).