### PR TITLE
fix(youtube): auto-refresh expired OAuth token in getAccessToken

### DIFF
--- a/src/modules/youtube/api.ts
+++ b/src/modules/youtube/api.ts
@@ -5,7 +5,10 @@
  * user's subscriptions and playlists.
  */
 
+import { google } from 'googleapis';
 import { getPrismaClient } from '../database';
+import { config } from '@/config/index';
+import { logger } from '@/utils/logger';
 import { MS_PER_HOUR } from '@/utils/time-constants';
 
 const YOUTUBE_API_BASE = 'https://www.googleapis.com/youtube/v3';
@@ -64,28 +67,66 @@ interface YouTubePlaylist {
 
 /**
  * Get user's YouTube access token from DB.
- * Returns null if not connected or token expired.
+ * If the stored access token is expired and a refresh token is present,
+ * performs an OAuth2 refresh, persists the new token, and returns it.
+ * Returns null if not connected or if the refresh fails.
  */
-async function getAccessToken(userId: string): Promise<string | null> {
+export async function getAccessToken(userId: string): Promise<string | null> {
   const prisma = getPrismaClient();
   const settings = await prisma.youtube_sync_settings.findUnique({
     where: { user_id: userId },
     select: {
       youtube_access_token: true,
       youtube_token_expires_at: true,
+      youtube_refresh_token: true,
     },
   });
 
   if (!settings?.youtube_access_token) return null;
 
-  if (
-    settings.youtube_token_expires_at &&
-    new Date(settings.youtube_token_expires_at) < new Date()
-  ) {
-    return null; // Token expired — frontend should trigger refresh via youtube-auth Edge Function
+  const isExpired =
+    settings.youtube_token_expires_at != null &&
+    new Date(settings.youtube_token_expires_at) < new Date();
+
+  if (!isExpired) {
+    return settings.youtube_access_token;
   }
 
-  return settings.youtube_access_token;
+  // Token is expired — attempt silent refresh if a refresh token is available.
+  if (!settings.youtube_refresh_token) {
+    return null; // Genuinely disconnected; no refresh possible.
+  }
+
+  try {
+    const oauth2Client = new google.auth.OAuth2(
+      config.youtube.clientId,
+      config.youtube.clientSecret,
+      config.youtube.redirectUri
+    );
+    oauth2Client.setCredentials({ refresh_token: settings.youtube_refresh_token });
+
+    const { credentials } = await oauth2Client.refreshAccessToken();
+    const newAccessToken = credentials.access_token ?? null;
+    const newExpiryDate = credentials.expiry_date ? new Date(credentials.expiry_date) : null;
+
+    if (!newAccessToken) {
+      logger.warn('YouTube token refresh returned no access_token', { userId });
+      return null;
+    }
+
+    await prisma.youtube_sync_settings.update({
+      where: { user_id: userId },
+      data: {
+        youtube_access_token: newAccessToken,
+        youtube_token_expires_at: newExpiryDate,
+      },
+    });
+
+    return newAccessToken;
+  } catch (err) {
+    logger.warn('YouTube OAuth token refresh failed', { userId, error: err });
+    return null;
+  }
 }
 
 /**

--- a/tests/unit/modules/youtube-api-token.test.ts
+++ b/tests/unit/modules/youtube-api-token.test.ts
@@ -1,0 +1,219 @@
+/**
+ * youtube/api.ts — getAccessToken unit tests
+ *
+ * Covers:
+ *   (a) valid (non-expired) token returned as-is, no refresh triggered
+ *   (b) expired token + refresh_token present → refresh called, new token
+ *       persisted to DB, new token returned
+ *   (c) expired token + no refresh_token → null returned
+ *   (d) expired token + refresh_token present, but refresh throws → null returned
+ */
+
+// ── Mock: Prisma ──────────────────────────────────────────────────────────────
+const mockFindUnique = jest.fn();
+const mockUpdate = jest.fn();
+
+jest.mock('@/modules/database', () => ({
+  getPrismaClient: () => ({
+    youtube_sync_settings: {
+      findUnique: mockFindUnique,
+      update: mockUpdate,
+    },
+  }),
+}));
+
+// ── Mock: googleapis ─────────────────────────────────────────────────────────
+const mockSetCredentials = jest.fn();
+const mockRefreshAccessToken = jest.fn();
+const MockOAuth2 = jest.fn().mockImplementation(() => ({
+  setCredentials: mockSetCredentials,
+  refreshAccessToken: mockRefreshAccessToken,
+}));
+
+jest.mock('googleapis', () => ({
+  google: {
+    auth: {
+      OAuth2: MockOAuth2,
+    },
+  },
+}));
+
+// ── Mock: config ──────────────────────────────────────────────────────────────
+jest.mock('@/config/index', () => ({
+  config: {
+    youtube: {
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+      redirectUri: 'http://localhost/callback',
+    },
+  },
+}));
+
+// ── Mock: logger ──────────────────────────────────────────────────────────────
+const mockLoggerWarn = jest.fn();
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    warn: mockLoggerWarn,
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+import { getAccessToken } from '../../../src/modules/youtube/api';
+
+const USER_ID = 'user-uuid-001';
+const VALID_TOKEN = 'ya29.valid-access-token';
+const REFRESH_TOKEN = 'refresh-token-abc';
+const NEW_ACCESS_TOKEN = 'ya29.new-access-token';
+const FUTURE_DATE = new Date(Date.now() + 3_600_000); // 1 h from now
+const PAST_DATE = new Date(Date.now() - 3_600_000); // 1 h ago
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── (a) Valid token — no refresh ──────────────────────────────────────────────
+describe('getAccessToken — valid token (not expired)', () => {
+  it('returns the stored token without calling refresh', async () => {
+    mockFindUnique.mockResolvedValue({
+      youtube_access_token: VALID_TOKEN,
+      youtube_token_expires_at: FUTURE_DATE,
+      youtube_refresh_token: REFRESH_TOKEN,
+    });
+
+    const result = await getAccessToken(USER_ID);
+
+    expect(result).toBe(VALID_TOKEN);
+    expect(MockOAuth2).not.toHaveBeenCalled();
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns the stored token when expires_at is null (no expiry set)', async () => {
+    mockFindUnique.mockResolvedValue({
+      youtube_access_token: VALID_TOKEN,
+      youtube_token_expires_at: null,
+      youtube_refresh_token: null,
+    });
+
+    const result = await getAccessToken(USER_ID);
+
+    expect(result).toBe(VALID_TOKEN);
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+  });
+});
+
+// ── (b) Expired token + refresh_token → refresh succeeds ─────────────────────
+describe('getAccessToken — expired token with refresh_token', () => {
+  it('calls OAuth2 refresh, persists new token, returns new token', async () => {
+    const newExpiry = Date.now() + 3_600_000;
+
+    mockFindUnique.mockResolvedValue({
+      youtube_access_token: 'ya29.old-expired',
+      youtube_token_expires_at: PAST_DATE,
+      youtube_refresh_token: REFRESH_TOKEN,
+    });
+    mockRefreshAccessToken.mockResolvedValue({
+      credentials: {
+        access_token: NEW_ACCESS_TOKEN,
+        expiry_date: newExpiry,
+      },
+    });
+    mockUpdate.mockResolvedValue({});
+
+    const result = await getAccessToken(USER_ID);
+
+    // OAuth2 client constructed with correct config values
+    expect(MockOAuth2).toHaveBeenCalledWith(
+      'test-client-id',
+      'test-client-secret',
+      'http://localhost/callback'
+    );
+    // Credentials set with stored refresh token
+    expect(mockSetCredentials).toHaveBeenCalledWith({ refresh_token: REFRESH_TOKEN });
+    // Refresh was performed
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1);
+    // New token persisted to DB
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { user_id: USER_ID },
+      data: {
+        youtube_access_token: NEW_ACCESS_TOKEN,
+        youtube_token_expires_at: new Date(newExpiry),
+      },
+    });
+    // New token returned to caller
+    expect(result).toBe(NEW_ACCESS_TOKEN);
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+});
+
+// ── (c) Expired token + no refresh_token → null ───────────────────────────────
+describe('getAccessToken — expired token without refresh_token', () => {
+  it('returns null without attempting refresh', async () => {
+    mockFindUnique.mockResolvedValue({
+      youtube_access_token: 'ya29.old-expired',
+      youtube_token_expires_at: PAST_DATE,
+      youtube_refresh_token: null,
+    });
+
+    const result = await getAccessToken(USER_ID);
+
+    expect(result).toBeNull();
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// ── (d) Refresh throws → null (caller not crashed) ───────────────────────────
+describe('getAccessToken — refresh throws', () => {
+  it('logs a warning and returns null when refreshAccessToken rejects', async () => {
+    mockFindUnique.mockResolvedValue({
+      youtube_access_token: 'ya29.old-expired',
+      youtube_token_expires_at: PAST_DATE,
+      youtube_refresh_token: REFRESH_TOKEN,
+    });
+    mockRefreshAccessToken.mockRejectedValue(new Error('invalid_grant'));
+
+    const result = await getAccessToken(USER_ID);
+
+    expect(result).toBeNull();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'YouTube OAuth token refresh failed',
+      expect.objectContaining({ userId: USER_ID })
+    );
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no access_token in refresh response', async () => {
+    mockFindUnique.mockResolvedValue({
+      youtube_access_token: 'ya29.old-expired',
+      youtube_token_expires_at: PAST_DATE,
+      youtube_refresh_token: REFRESH_TOKEN,
+    });
+    mockRefreshAccessToken.mockResolvedValue({
+      credentials: { access_token: null, expiry_date: null },
+    });
+
+    const result = await getAccessToken(USER_ID);
+
+    expect(result).toBeNull();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'YouTube token refresh returned no access_token',
+      expect.objectContaining({ userId: USER_ID })
+    );
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// ── No settings row → null ────────────────────────────────────────────────────
+describe('getAccessToken — no settings row', () => {
+  it('returns null when settings row does not exist', async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    const result = await getAccessToken(USER_ID);
+
+    expect(result).toBeNull();
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
`getAccessToken` returned `null` on token expiry → the playlist-import pipeline and every `youtube/api.ts` caller threw `YOUTUBE_NOT_CONNECTED` once a token aged past ~1h. Now it refreshes via the stored `youtube_refresh_token` (OAuth2 client → `refreshAccessToken()`), persists the new token + expiry to `youtube_sync_settings`, and returns the fresh token. No refresh token / failed refresh → `null` (graceful, unchanged).

## Test plan
- [x] `tsc --noEmit` clean
- [x] jest `youtube-api-token` 7/7 (valid passthrough / expired+refresh / expired+no-refresh / refresh-throws)

🤖 Generated with [Claude Code](https://claude.com/claude-code)