### PR TITLE
fix(v3): semantic cell assignment — replace lexically-biased Jaccard

### DIFF
--- a/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_RECENCY_HALF_LIFE_MONTHS,
   MIN_SUB_RELEVANCE,
   SEMANTIC_MIN_COSINE,
+  SEMANTIC_MIN_CELL_COSINE,
   type FilterCandidate,
 } from '../mandala-filter';
 
@@ -631,6 +632,10 @@ describe('applyMandalaFilter — centerGateMode: "semantic"', () => {
     expect(stats.droppedByCenterGate).toBeGreaterThanOrEqual(1);
   });
 
+  test('SEMANTIC_MIN_CELL_COSINE is exported and equals 0.25', () => {
+    expect(SEMANTIC_MIN_CELL_COSINE).toBeCloseTo(0.25, 5);
+  });
+
   test('EN fixture: paraphrase admitted, off-domain dropped', () => {
     const enInput = {
       centerGoal: 'Master React hooks in 30 days',
@@ -664,5 +669,114 @@ describe('applyMandalaFilter — centerGateMode: "semantic"', () => {
     );
     expect(stats.centerGateMode).toBe('semantic');
     expect(stats.droppedByCenterGate).toBe(1); // noise only; paraphrase passes
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Semantic cell assignment (Part A — subGoalEmbeddings)
+// ---------------------------------------------------------------------------
+
+describe('applyMandalaFilter — semantic cell assignment via subGoalEmbeddings', () => {
+  // Mandala: AI 마케팅 (mirrors the production trace 8a272317).
+  // Sub-goal embeddings are synthetic 4-dim vectors, each aligned with a
+  // different axis so the argmax is unambiguous in tests.
+  const centerGoal = 'AI 마케팅 전략';
+  const subGoals = [
+    'AI 마케팅 도구 및 플랫폼 학습', // cell 0 — axis [1, 0, 0, 0]
+    '데이터 분석 및 인사이트 도출', // cell 1 — axis [0, 1, 0, 0]
+    '콘텐츠 생성 및 최적화', // cell 2 — axis [0, 0, 1, 0]
+    '고객 타겟팅 전략', // cell 3 — axis [0, 0, 0, 1]
+    'ROI 측정 및 성과 관리', // cell 4 — axis [0.7, 0.7, 0, 0]
+    '소셜 미디어 채널 운영', // cell 5 — axis [0, 0, 0.7, 0.7]
+    '검색 엔진 최적화', // cell 6 — axis [0.5, 0, 0.5, 0]
+    '이메일 마케팅 자동화', // cell 7 — axis [0, 0.5, 0, 0.5]
+  ];
+  // Sub-goal embedding vectors — each axis-aligned per above.
+  const subGoalEmbeddings: number[][] = [
+    [1, 0, 0, 0],
+    [0, 1, 0, 0],
+    [0, 0, 1, 0],
+    [0, 0, 0, 1],
+    [0.7, 0.7, 0, 0],
+    [0, 0, 0.7, 0.7],
+    [0.5, 0, 0.5, 0],
+    [0, 0.5, 0, 0.5],
+  ];
+  const centerVec = [0.8, 0.6, 0, 0]; // near cells 0 + 1 axis
+
+  // Input template — semantic center gate so all center-matched candidates pass gate 1.
+  const baseInput = {
+    centerGoal,
+    subGoals,
+    language: 'ko' as const,
+    centerGateMode: 'semantic' as const,
+    centerEmbedding: centerVec,
+    subGoalEmbeddings,
+  };
+
+  test('(1) semantic cell assignment: candidate assigned to cell with highest cosine, even without title token overlap', () => {
+    // Cell 2 (콘텐츠 생성) embedding: [0, 0, 1, 0].
+    // Candidate title shares NO tokens with "콘텐츠 생성 및 최적화" — pure semantic.
+    const candidateVec: number[] = [0, 0, 0.95, 0.1]; // closest to cell 2 axis
+    const candidate = cand('sem1', '영상 제작 워크플로우 자동화', '');
+    // We need the candidate to pass the center gate too — give it a non-zero cosine vs centerVec.
+    // Override: use centerGateMode='off' so center gate is bypassed; we're testing cell routing only.
+    const { byCell } = applyMandalaFilterWithStats([candidate], {
+      ...baseInput,
+      centerGateMode: 'off',
+      candidateEmbeddings: new Map([['sem1', candidateVec]]),
+    });
+    // Must land in cell 2 (highest cosine with [0,0,1,0]).
+    const cell2 = byCell.get(2) ?? [];
+    expect(cell2).toHaveLength(1);
+    expect(cell2[0]!.candidate.videoId).toBe('sem1');
+    // All other cells must be empty.
+    for (const [idx, list] of byCell) {
+      if (idx !== 2) expect(list).toHaveLength(0);
+    }
+  });
+
+  test('(2) lexical fallback when subGoalEmbeddings absent — existing Jaccard path unchanged', () => {
+    // Without subGoalEmbeddings, the lexical path must behave identically to
+    // the pre-fix implementation. "Reading 만점" has clear token overlap with
+    // subGoal[0] of this separate TOEFL mandala.
+    const toeflInput = {
+      centerGoal: '토플 100점 달성',
+      subGoals: [
+        'Reading 25점 이상',
+        'Listening 25점 이상',
+        'Speaking 23점 이상',
+        'Writing 25점 이상',
+        'Grammar 복습',
+        '학습 루틴 관리',
+        '오답노트 작성',
+        '시험일 컨디션 관리',
+      ],
+      language: 'ko' as const,
+      // subGoalEmbeddings intentionally omitted → lexical path
+    };
+    const candidate = cand('lex1', '토플 Reading 만점 전략', '토플 Reading 25점');
+    const { byCell, stats } = applyMandalaFilterWithStats([candidate], toeflInput);
+    // droppedByCellScoreBelowThreshold must be 0 (semantic path not taken).
+    expect(stats.droppedByCellScoreBelowThreshold).toBe(0);
+    // Candidate routed to Reading cell (0) via Jaccard.
+    const cell0 = byCell.get(0) ?? [];
+    expect(cell0).toHaveLength(1);
+  });
+
+  test('(3) candidate below SEMANTIC_MIN_CELL_COSINE on all cells is dropped', () => {
+    // Use a zero-magnitude vector — cosineSimilarity returns 0 (zero-magnitude guard).
+    // 0 < SEMANTIC_MIN_CELL_COSINE (0.25) so the candidate must be dropped.
+    const zeroCandVec: number[] = [0, 0, 0, 0];
+    const candidate = cand('drop1', '완전히 다른 주제의 영상', '전혀 관련 없는 설명');
+    const { byCell, stats } = applyMandalaFilterWithStats([candidate], {
+      ...baseInput,
+      centerGateMode: 'off', // bypass center gate — test only cell assignment drop
+      candidateEmbeddings: new Map([['drop1', zeroCandVec]]),
+    });
+    expect(stats.droppedByCellScoreBelowThreshold).toBeGreaterThanOrEqual(1);
+    for (const list of byCell.values()) {
+      expect(list).toHaveLength(0);
+    }
   });
 });

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -89,6 +89,8 @@ const MAX_PER_CHANNEL_PER_CELL = 2;
 export interface HydratedState {
   centerGoal: string;
   subGoals: string[]; // length 8
+  /** Sub_goal embedding vectors (same 4096d space as candidate embeddings). */
+  subGoalEmbeddings: number[][]; // length 8, indexed by sub_goal_index
   language: KeywordLanguage;
   focusTags: string[];
   targetLevel: string;
@@ -158,21 +160,30 @@ export const executor: SkillExecutor = {
       };
     }
 
-    // Also load sub_goal text so Tier 2 can build per-cell queries. The
-    // embedding comparison itself runs in SQL so we don't load vectors here.
+    // Load sub_goal text AND embeddings. Embeddings are used for semantic
+    // cell assignment in applyMandalaFilterWithStats (replaces lexical
+    // jaccard+bigram path — see mandala-filter.ts SEMANTIC_MIN_CELL_COSINE).
     const subGoalRows = await db.$queryRaw<
-      { sub_goal_index: number; sub_goal: string | null; center_goal: string | null }[]
+      {
+        sub_goal_index: number;
+        sub_goal: string | null;
+        center_goal: string | null;
+        embedding: string | null;
+      }[]
     >(
-      Prisma.sql`SELECT sub_goal_index, sub_goal, center_goal FROM public.mandala_embeddings
+      Prisma.sql`SELECT sub_goal_index, sub_goal, center_goal, embedding::text AS embedding
+                 FROM public.mandala_embeddings
                  WHERE mandala_id = ${ctx.mandalaId} AND level = 1
                  ORDER BY sub_goal_index ASC`
     );
     const subGoals: string[] = new Array(V3_NUM_CELLS).fill('');
+    const subGoalEmbeddings: number[][] = new Array(V3_NUM_CELLS).fill([]);
     let centerGoal = mandala.title ?? '';
     for (const r of subGoalRows) {
       const idx = r.sub_goal_index;
       if (idx < 0 || idx >= V3_NUM_CELLS) continue;
       subGoals[idx] = r.sub_goal ?? '';
+      if (r.embedding) subGoalEmbeddings[idx] = parseVectorLiteral(r.embedding);
       if (r.center_goal && !centerGoal) centerGoal = r.center_goal;
     }
 
@@ -180,6 +191,7 @@ export const executor: SkillExecutor = {
     const hydrated: HydratedState = {
       centerGoal,
       subGoals,
+      subGoalEmbeddings,
       language,
       focusTags: mandala.focus_tags ?? [],
       targetLevel: mandala.target_level ?? 'standard',
@@ -334,6 +346,7 @@ async function executeImpl(ctx: ExecuteContext): Promise<ExecuteResult> {
             centerEmbedding,
             candidateEmbeddings,
             semanticMinCosine: v3Config.semanticMinCosine,
+            subGoalEmbeddings: state.subGoalEmbeddings,
           });
           const keptIds = new Set<string>();
           for (const assignments of byCell.values()) {
@@ -1018,6 +1031,7 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
       centerEmbedding,
       candidateEmbeddings,
       semanticMinCosine: v3Config.semanticMinCosine,
+      subGoalEmbeddings: input.state.subGoalEmbeddings,
     });
     debug.timing.mandalaFilterMs = Date.now() - tMandalaFilterStart;
 
@@ -1705,6 +1719,9 @@ async function runDiscoverEphemeralImpl(
       state: {
         centerGoal: input.centerGoal,
         subGoals: input.subGoals,
+        // Ephemeral path has no mandala in DB → no sub_goal embeddings.
+        // Semantic cell assignment falls back to lexical jaccard+bigram.
+        subGoalEmbeddings: [],
         language: input.language,
         focusTags: input.focusTags,
         targetLevel: input.targetLevel,
@@ -1890,4 +1907,20 @@ async function runDiscoverEphemeralImpl(
     duration_ms: Date.now() - t0,
     debug: tier2Debug,
   };
+}
+
+/**
+ * Parse a pgvector literal (`[f1,f2,...]`) into a `number[]`.
+ * Mirrors the identical helper in v2/executor.ts — kept local so v3 has
+ * no runtime dependency on v2's private scope.
+ */
+function parseVectorLiteral(literal: string): number[] {
+  if (!literal || literal.length < 2) return [];
+  const inner = literal.startsWith('[') && literal.endsWith(']') ? literal.slice(1, -1) : literal;
+  const parts = inner.split(',');
+  const out = new Array<number>(parts.length);
+  for (let i = 0; i < parts.length; i++) {
+    out[i] = parseFloat(parts[i] ?? '0');
+  }
+  return out;
 }

--- a/src/skills/plugins/video-discover/v3/mandala-filter.ts
+++ b/src/skills/plugins/video-discover/v3/mandala-filter.ts
@@ -42,6 +42,20 @@ import type { CenterGateMode } from './config';
 export const MIN_SUB_RELEVANCE = 0.05;
 
 /**
+ * Cosine-similarity floor for semantic cell assignment.
+ * When `subGoalEmbeddings` are provided, each candidate is assigned to the
+ * sub_goal cell whose embedding has the highest cosine with the candidate's
+ * own embedding. If the best cosine is below this threshold the candidate
+ * is dropped — mirror of MIN_SUB_RELEVANCE for the lexical path.
+ *
+ * 0.25 is a permissive floor: in-domain qwen3-embedding pairs typically
+ * run 0.3-0.8 (see SEMANTIC_MIN_COSINE comment above), so 0.25 admits
+ * nearly all genuine sub-domain matches while filtering clear off-domain
+ * noise. Can be tightened once telemetry lands.
+ */
+export const SEMANTIC_MIN_CELL_COSINE = 0.25;
+
+/**
  * Cosine-similarity threshold for the `'semantic'` center-gate mode.
  * A candidate passes when cosine(centerEmbedding, titleEmbedding) ≥ this.
  *
@@ -120,6 +134,18 @@ export interface MandalaFilterInput {
    * threshold without code changes. Clamped to [0, 1].
    */
   semanticMinCosine?: number;
+  /**
+   * Per-sub_goal embeddings (same 4096d qwen3-embedding:8b space as
+   * `centerEmbedding` / `candidateEmbeddings`). Length must equal
+   * `subGoals.length` (8). Entries may be undefined/empty for sub_goals
+   * that lack an embedding.
+   *
+   * When present AND a candidate has an entry in `candidateEmbeddings`,
+   * cell assignment uses `argmax_i cosineSimilarity(candidateEmb, subGoalEmb[i])`
+   * instead of the lexical jaccard+bigram path. Callers that omit this field
+   * get bit-identical lexical behavior (backward compatible).
+   */
+  subGoalEmbeddings?: ReadonlyArray<ReadonlyArray<number>>;
 }
 
 export interface ScoreWeights {
@@ -162,6 +188,13 @@ export interface MandalaFilterStats {
   output: number;
   droppedByCenterGate: number;
   droppedByJaccardBelowThreshold: number;
+  /**
+   * Candidates dropped because their best semantic cell cosine was below
+   * `SEMANTIC_MIN_CELL_COSINE`. Only populated when `subGoalEmbeddings` are
+   * provided; otherwise 0. Backward compatible — callers that read only the
+   * old fields are unaffected.
+   */
+  droppedByCellScoreBelowThreshold: number;
   centerTokens: string[];
   subGoalTokenCounts: number[];
   /** How many candidates passed the gate via focusTag match (2026-04-18). */
@@ -240,6 +273,7 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
     output: 0,
     droppedByCenterGate: 0,
     droppedByJaccardBelowThreshold: 0,
+    droppedByCellScoreBelowThreshold: 0,
     centerTokens: [...centerTokens],
     subGoalTokenCounts: subGoalTokens.map((s) => s.size),
     passedByFocusTag: 0,
@@ -302,26 +336,54 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
     }
 
     const bodyTokens = tokenize(`${c.title} ${c.description ?? ''}`, input.language);
-    const bodyGrams = new Set<string>();
-    for (const t of bodyTokens) for (const g of charBigrams(t)) bodyGrams.add(g);
+
+    // Cell assignment: semantic path when subGoalEmbeddings + candidate
+    // embedding are both present; lexical jaccard+bigram path otherwise.
+    const candidateVec = input.candidateEmbeddings?.get(c.videoId);
+    const useSemanticCell =
+      input.subGoalEmbeddings != null &&
+      input.subGoalEmbeddings.length > 0 &&
+      candidateVec != null &&
+      candidateVec.length > 0;
 
     let bestCell = -1;
     let bestScore = 0;
-    for (let i = 0; i < subGoalTokens.length; i++) {
-      const sg = subGoalTokens[i];
-      if (!sg) continue;
-      const exact = jaccard(bodyTokens, sg);
-      const sgGrams = subGoalGrams[i];
-      const bigram = sgGrams && sgGrams.size > 0 ? bigramOverlap(bodyGrams, sgGrams) : 0;
-      const s = Math.max(exact, bigram);
-      if (s > bestScore) {
-        bestScore = s;
-        bestCell = i;
+
+    if (useSemanticCell) {
+      // Semantic cell assignment: argmax cosine(candidateVec, subGoalEmb[i]).
+      for (let i = 0; i < input.subGoalEmbeddings!.length; i++) {
+        const sgEmb = input.subGoalEmbeddings![i];
+        if (!sgEmb || sgEmb.length === 0) continue;
+        const s = cosineSimilarity(candidateVec, sgEmb);
+        if (s > bestScore) {
+          bestScore = s;
+          bestCell = i;
+        }
       }
-    }
-    if (bestCell === -1 || bestScore < MIN_SUB_RELEVANCE) {
-      stats.droppedByJaccardBelowThreshold++;
-      continue;
+      if (bestCell === -1 || bestScore < SEMANTIC_MIN_CELL_COSINE) {
+        stats.droppedByCellScoreBelowThreshold++;
+        continue;
+      }
+    } else {
+      // Lexical cell assignment: max(jaccard, bigramOverlap).
+      const bodyGrams = new Set<string>();
+      for (const t of bodyTokens) for (const g of charBigrams(t)) bodyGrams.add(g);
+      for (let i = 0; i < subGoalTokens.length; i++) {
+        const sg = subGoalTokens[i];
+        if (!sg) continue;
+        const exact = jaccard(bodyTokens, sg);
+        const sgGrams = subGoalGrams[i];
+        const bigram = sgGrams && sgGrams.size > 0 ? bigramOverlap(bodyGrams, sgGrams) : 0;
+        const s = Math.max(exact, bigram);
+        if (s > bestScore) {
+          bestScore = s;
+          bestCell = i;
+        }
+      }
+      if (bestCell === -1 || bestScore < MIN_SUB_RELEVANCE) {
+        stats.droppedByJaccardBelowThreshold++;
+        continue;
+      }
     }
 
     const recencyScore =


### PR DESCRIPTION
## Summary
**Root cause (verified against code + prod trace):** `mandala-filter` assigned each candidate to a cell via `argmax Jaccard(titleTokens, subGoalTokens)`. Every candidate is searched with centerGoal-derived queries → all titles carry centerGoal vocabulary → sub_goals sharing words with the centerGoal absorbed every candidate; sub_goals with distinct vocabulary got nothing. Prod trace (mandala `8a272317`): cell distribution `[20,11,4,0,0,0,0,12]` — **4 of 8 cells empty** despite search queries running for all 8.

**Fix:** when `subGoalEmbeddings` + `candidateEmbeddings` are present, cell assignment uses `argmax cosine(candidateVec, subGoalEmb[i])` with a `SEMANTIC_MIN_CELL_COSINE=0.25` floor. Falls back to the unchanged Jaccard+bigram path when embeddings are absent (wizard-precompute ephemeral path). v3 executor now loads sub_goal embedding vectors and passes them to both main-path filter call sites.

## Test plan
- [x] `tsc --noEmit` clean
- [x] jest `mandala-filter` + `v3-upsert-slots` 50/50
- [ ] post-deploy: re-trace a mandala, confirm cell distribution is no longer half-empty

## Follow-up (not in this PR)
Ephemeral wizard-precompute path still uses lexical fallback (no DB sub_goal embeddings) — semantic path there is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)