### PR TITLE
fix(settings): surface YouTube source-list fetch errors instead of silent empty state

### DIFF
--- a/frontend/src/pages/settings/ui/AddSourceModalV2.tsx
+++ b/frontend/src/pages/settings/ui/AddSourceModalV2.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Loader2, Youtube, X as XIcon, ChevronRight } from 'lucide-react';
+import { Loader2, Youtube, X as XIcon, ChevronRight, AlertTriangle, RefreshCw } from 'lucide-react';
 import { useToast } from '@/shared/lib/use-toast';
 import { apiClient } from '@/shared/lib/api-client';
 import { cn } from '@/shared/lib/utils';
@@ -217,6 +217,11 @@ export function AddSourceModalV2({
 
   const isLoading = activeTab === 'pl' ? pls.isLoading : subs.isLoading;
   const activeQuery = activeTab === 'pl' ? pls : subs;
+  // A fetch failure that is NOT "not connected" — quota/5xx/network/etc.
+  // Without this the modal silently falls through to the empty-list view,
+  // hiding the failure (and blocking source registration, which the card
+  // push cron depends on).
+  const isError = activeQuery.isError && !isNotConnected;
 
   const FILTER_OPTIONS = [
     { id: 'all', label: t('common.all', 'All') },
@@ -398,6 +403,27 @@ export function AddSourceModalV2({
           ) : isLoading ? (
             <div className="flex items-center justify-center py-16">
               <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : isError && items.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <AlertTriangle className="w-10 h-10 text-muted-foreground/30 mb-3" />
+              <p className="text-sm text-muted-foreground mb-1">{t('youtube.loadFailed')}</p>
+              <p className="text-xs text-muted-foreground/60 mb-3">
+                {(activeQuery.error as { code?: string } | null)?.code ??
+                  t('youtube.loadFailedHint')}
+              </p>
+              <button
+                onClick={() => activeQuery.refetch()}
+                disabled={activeQuery.isFetching}
+                className="bg-foreground/10 hover:bg-foreground/15 text-foreground px-4 py-2 rounded-[7px] text-sm font-semibold flex items-center gap-1.5 transition-colors"
+              >
+                {activeQuery.isFetching ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                ) : (
+                  <RefreshCw className="w-3.5 h-3.5" />
+                )}
+                {t('common.retry')}
+              </button>
             </div>
           ) : items.length === 0 ? (
             <p className="text-sm text-muted-foreground text-center py-16">

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -517,6 +517,8 @@
     "channelHashtagSoon": "Channel & hashtag sources — coming soon",
     "noPlaylists": "No registered playlists.",
     "noPlaylistsHint": "Add a YouTube playlist URL above to get started.",
+    "loadFailed": "Couldn't load the list",
+    "loadFailedHint": "Something went wrong fetching from YouTube. Try again.",
     "syncSettings": "Sync Settings",
     "autoSyncInterval": "Auto Sync Interval",
     "autoSyncIntervalDesc": "Choose how often to sync playlists automatically",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -525,6 +525,8 @@
     "channelHashtagSoon": "채널 · 해시태그 소스 — 준비 중",
     "noPlaylists": "등록된 플레이리스트가 없습니다.",
     "noPlaylistsHint": "위에서 YouTube 플레이리스트 URL을 추가해보세요.",
+    "loadFailed": "목록을 불러오지 못했습니다",
+    "loadFailedHint": "YouTube에서 가져오는 중 문제가 발생했습니다. 다시 시도해 주세요.",
     "syncSettings": "동기화 설정",
     "autoSyncInterval": "자동 동기화 간격",
     "autoSyncIntervalDesc": "플레이리스트를 자동으로 동기화할 주기를 선택하세요",


### PR DESCRIPTION
## Summary

The Settings → Source Management "Add Source" modal only handled the `YOUTUBE_NOT_CONNECTED` error code. Any other fetch failure (quota / 5xx / network / rate limit) fell through to the "No playlists" empty view, silently hiding the failure and offering no retry.

This matters because the registered source list feeds the **card-push cron** — a silent empty list blocks source registration and breaks the content loop with no user-visible signal. Reported as an intermittent "Add Source lists don't show" bug.

- Add `isError = activeQuery.isError && !isNotConnected` — catches every fetch failure that isn't "not connected".
- New error branch in the render chain (after `isLoading`, before the empty state): when the active tab's query errors **and** there is no cached data, render an error state with the failure code (for diagnosis) + a Retry button (`refetch()`).
- Stale cached data still renders, so a background-refetch failure does not blank an already-populated list.
- i18n: `youtube.loadFailed` / `youtube.loadFailedHint` (en/ko); reuses `common.retry`.

This is a FE-only resilience fix — it does not change the underlying YouTube fetch path; it makes failures visible and recoverable instead of indistinguishable from "genuinely empty".

## Test plan

- [x] `tsc --noEmit` (frontend) — pass
- [x] `vitest run` — 34 files / 309 tests pass
- [x] `npm run build` — pass
- [x] browser smoke — `/` + `/settings` → 200, dev server log clean
- [ ] manual: trigger a source-list fetch failure (offline / 5xx) → modal shows error + Retry instead of "No playlists"

🤖 Generated with [Claude Code](https://claude.com/claude-code)