### PR TITLE
fix(embedding): retry OpenRouter transient 404 + Ollama fallback

### DIFF
--- a/src/skills/plugins/iks-scorer/embedding.ts
+++ b/src/skills/plugins/iks-scorer/embedding.ts
@@ -37,6 +37,14 @@ const EMBED_TIMEOUT_MS = 60000;
 /** OpenRouter cost-logger module label (Issue #543 fallback path). */
 const OPENROUTER_FALLBACK_MODULE = 'iks-embed-fallback';
 /**
+ * OpenRouter embed transient-error retry policy (CP458).
+ * OpenRouter's /embeddings endpoint returns an intermittent HTTP 404
+ * — measured ~11% (8 err / 71 calls in 12h). The 404 is transient (the
+ * other 89% succeed), so 404 / 5xx / network errors are retried.
+ */
+const OPENROUTER_EMBED_MAX_RETRIES = 2;
+const OPENROUTER_EMBED_RETRY_BASE_MS = 500;
+/**
  * Embed chunk size — Mac Mini M4 handles ~50 texts in ~10s comfortably.
  * 456 texts in one call exceeds 60s timeout. Chunking gives predictable
  * per-call latency.
@@ -46,7 +54,13 @@ const DEFAULT_EMBED_CHUNK_SIZE = 50;
 export class EmbeddingError extends Error {
   constructor(
     message: string,
-    public readonly httpStatus?: number
+    public readonly httpStatus?: number,
+    /**
+     * True when the error is transient and a retry may succeed (network
+     * failure, HTTP 404 — see OPENROUTER_EMBED_* note — or 5xx). False for
+     * deterministic failures (auth, count/dimension mismatch).
+     */
+    public readonly retryable: boolean = false
   ) {
     super(message);
     this.name = 'EmbeddingError';
@@ -158,9 +172,21 @@ export async function embedBatch(
 async function embedOneChunk(texts: string[], opts: EmbeddingClientOptions): Promise<number[][]> {
   const provider = config.iksEmbed.provider;
   if (provider === 'openrouter') {
-    return embedOneChunkViaOpenRouter(texts, opts);
+    // OpenRouter primary (retry on transient errors) → Ollama fallback once
+    // retries are exhausted. Both produce 4096-d qwen3-embedding-8b vectors
+    // so a fallback chunk stays co-comparable with the rest of the batch.
+    try {
+      return await embedOneChunkViaOpenRouterRetrying(texts, opts);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      log.warn(
+        `OpenRouter embed failed after retries (chunk size=${texts.length}), falling back to Ollama: ${reason}`
+      );
+      return embedOneChunkViaOllama(texts, opts);
+    }
   }
-  // 'ollama' (default): Mac-mini first, OpenRouter fallback on transport/HTTP error.
+  // 'ollama' (default): Mac-mini first, OpenRouter (retrying) fallback on
+  // transport/HTTP error.
   try {
     return await embedOneChunkViaOllama(texts, opts);
   } catch (err) {
@@ -168,7 +194,7 @@ async function embedOneChunk(texts: string[], opts: EmbeddingClientOptions): Pro
     log.warn(
       `Ollama embed failed (chunk size=${texts.length}), falling back to OpenRouter: ${reason}`
     );
-    return embedOneChunkViaOpenRouter(texts, opts);
+    return embedOneChunkViaOpenRouterRetrying(texts, opts);
   }
 }
 
@@ -281,7 +307,8 @@ async function embedOneChunkViaOpenRouter(
       status: 'error',
       errorMessage: reason,
     });
-    throw new EmbeddingError(`OpenRouter embed call failed: ${reason}`);
+    // Network / timeout / abort — transient, safe to retry.
+    throw new EmbeddingError(`OpenRouter embed call failed: ${reason}`, undefined, true);
   }
   clearTimeout(timer);
 
@@ -300,7 +327,11 @@ async function embedOneChunkViaOpenRouter(
       status: 'error',
       errorMessage: errMsg,
     });
-    throw new EmbeddingError(errMsg, res.status);
+    // 404 is intermittent on OpenRouter /embeddings (~11%, CP458); 5xx is
+    // standard-transient. Both are retryable. 4xx-other (auth/bad request)
+    // is deterministic — not retryable.
+    const retryable = res.status === 404 || res.status >= 500;
+    throw new EmbeddingError(errMsg, res.status, retryable);
   }
 
   const data = (await res.json()) as {
@@ -339,6 +370,52 @@ async function embedOneChunkViaOpenRouter(
   });
 
   return vectors;
+}
+
+/** Promise-based sleep for retry backoff. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * `embedOneChunkViaOpenRouter` with bounded retry on transient errors.
+ *
+ * OpenRouter's /embeddings endpoint returns an intermittent HTTP 404
+ * ("404 page not found") — measured ~11% (8 err / 71 calls, 12h, CP458).
+ * It is transient, not endpoint-absent (the other 89% succeed), so
+ * `EmbeddingError.retryable` is set for 404 / 5xx / network errors and we
+ * retry up to OPENROUTER_EMBED_MAX_RETRIES with exponential backoff.
+ * Non-retryable errors (auth, count / dimension mismatch) throw at once.
+ *
+ * Rationale: a single un-retried 404 on any chunk used to fail the entire
+ * `embedBatch` — promote-from-playlists imported 197 rows with 0 embeddings
+ * because one of its 4 chunks hit the 404.
+ */
+async function embedOneChunkViaOpenRouterRetrying(
+  texts: string[],
+  opts: EmbeddingClientOptions
+): Promise<number[][]> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= OPENROUTER_EMBED_MAX_RETRIES; attempt++) {
+    try {
+      return await embedOneChunkViaOpenRouter(texts, opts);
+    } catch (err) {
+      lastErr = err;
+      const retryable = err instanceof EmbeddingError && err.retryable;
+      if (!retryable || attempt === OPENROUTER_EMBED_MAX_RETRIES) {
+        throw err;
+      }
+      const backoffMs = OPENROUTER_EMBED_RETRY_BASE_MS * 2 ** attempt;
+      log.warn(
+        `OpenRouter embed transient error (attempt ${attempt + 1}/${
+          OPENROUTER_EMBED_MAX_RETRIES + 1
+        }), retrying in ${backoffMs}ms: ${err instanceof Error ? err.message : String(err)}`
+      );
+      await sleep(backoffMs);
+    }
+  }
+  // Unreachable: the loop above either returns or throws. Satisfies TS.
+  throw lastErr;
 }
 
 // ============================================================================

--- a/tests/unit/modules/embedding-openrouter-retry.test.ts
+++ b/tests/unit/modules/embedding-openrouter-retry.test.ts
@@ -1,0 +1,138 @@
+/**
+ * embedBatch — OpenRouter transient-404 retry + Ollama fallback (CP458).
+ *
+ * OpenRouter's /embeddings endpoint returns an intermittent ~11% HTTP 404
+ * (measured: 8 err / 71 calls in 12h). A single un-retried 404 on any chunk
+ * used to fail the entire embedBatch — promote-from-playlists imported 197
+ * rows with 0 embeddings because one of its 4 chunks hit the 404.
+ *
+ * These tests pin: retry on transient (404/5xx/network), no retry on
+ * deterministic (4xx-other), and Ollama fallback once retries are exhausted.
+ */
+
+const mockConfig = {
+  iksEmbed: { provider: 'openrouter' as 'openrouter' | 'ollama' },
+  openrouter: { apiKey: 'test-key' },
+  mandalaEmbed: {
+    openRouterBaseUrl: 'https://openrouter.test/api/v1',
+    openRouterModel: 'qwen/qwen3-embedding-8b',
+    openRouterDimension: 4096,
+  },
+};
+
+jest.mock('@/config/index', () => ({ config: mockConfig }));
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+  },
+}));
+jest.mock('@/modules/llm/call-logger', () => ({ logLLMCall: jest.fn() }));
+jest.mock('@/modules/discover-tracing', () => ({ recordTrace: jest.fn() }));
+jest.mock('@/modules/database', () => ({ getPrismaClient: jest.fn() }));
+
+import { embedBatch, EmbeddingError } from '@/skills/plugins/iks-scorer/embedding';
+
+const DIM = 4096;
+const vec = (): number[] => new Array(DIM).fill(0.01);
+
+const openRouterOk = (n: number): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      data: Array.from({ length: n }, () => ({ embedding: vec() })),
+      usage: {},
+    }),
+  }) as unknown as Response;
+
+const ollamaOk = (n: number): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({ embeddings: Array.from({ length: n }, () => vec()) }),
+  }) as unknown as Response;
+
+const httpErr = (status: number): Response =>
+  ({ ok: false, status, text: async () => `${status} error` }) as unknown as Response;
+
+beforeEach(() => {
+  mockConfig.iksEmbed.provider = 'openrouter';
+});
+
+describe('embedBatch — OpenRouter transient-404 retry + Ollama fallback', () => {
+  it('retries a transient 404 and succeeds on the next attempt', async () => {
+    const orCalls: string[] = [];
+    const fetchImpl = jest.fn(async (url: string) => {
+      if (!url.includes('/embeddings')) return ollamaOk(2);
+      orCalls.push(url);
+      return orCalls.length === 1 ? httpErr(404) : openRouterOk(2);
+    }) as unknown as typeof fetch;
+
+    const out = await embedBatch(['a', 'b'], { fetchImpl });
+
+    expect(out).toHaveLength(2);
+    expect(out[0]).toHaveLength(DIM);
+    expect(orCalls).toHaveLength(2); // 1 transient 404 + 1 successful retry
+  });
+
+  it('does NOT retry a deterministic 400 — falls straight to Ollama', async () => {
+    const orCalls: string[] = [];
+    const ollamaCalls: string[] = [];
+    const fetchImpl = jest.fn(async (url: string) => {
+      if (url.includes('/embeddings')) {
+        orCalls.push(url);
+        return httpErr(400);
+      }
+      ollamaCalls.push(url);
+      return ollamaOk(2);
+    }) as unknown as typeof fetch;
+
+    const out = await embedBatch(['a', 'b'], { fetchImpl });
+
+    expect(out).toHaveLength(2);
+    expect(orCalls).toHaveLength(1); // 400 is non-retryable — exactly one attempt
+    expect(ollamaCalls).toHaveLength(1); // then Ollama fallback
+  });
+
+  it('exhausts retries on persistent 404 then falls back to Ollama', async () => {
+    const orCalls: string[] = [];
+    const ollamaCalls: string[] = [];
+    const fetchImpl = jest.fn(async (url: string) => {
+      if (url.includes('/embeddings')) {
+        orCalls.push(url);
+        return httpErr(404);
+      }
+      ollamaCalls.push(url);
+      return ollamaOk(2);
+    }) as unknown as typeof fetch;
+
+    const out = await embedBatch(['a', 'b'], { fetchImpl });
+
+    expect(out).toHaveLength(2);
+    expect(orCalls).toHaveLength(3); // initial + 2 retries (OPENROUTER_EMBED_MAX_RETRIES)
+    expect(ollamaCalls).toHaveLength(1); // fallback after exhaustion
+  });
+
+  it('throws when OpenRouter retries exhaust AND the Ollama fallback also fails', async () => {
+    const fetchImpl = jest.fn(async (url: string) =>
+      url.includes('/embeddings') ? httpErr(404) : httpErr(500)
+    ) as unknown as typeof fetch;
+
+    await expect(embedBatch(['a', 'b'], { fetchImpl })).rejects.toThrow(EmbeddingError);
+  });
+
+  it('ollama-provider branch: Ollama down → OpenRouter fallback also retries transient 404', async () => {
+    mockConfig.iksEmbed.provider = 'ollama';
+    const orCalls: string[] = [];
+    const fetchImpl = jest.fn(async (url: string) => {
+      if (url.includes('/api/embed')) return httpErr(500); // Mac Mini Ollama down
+      orCalls.push(url);
+      return orCalls.length === 1 ? httpErr(404) : openRouterOk(2);
+    }) as unknown as typeof fetch;
+
+    const out = await embedBatch(['a', 'b'], { fetchImpl });
+
+    expect(out).toHaveLength(2);
+    expect(orCalls).toHaveLength(2); // fallback path retries the transient 404 too
+  });
+});


### PR DESCRIPTION
## Problem
OpenRouter's `/embeddings` endpoint returns an intermittent HTTP 404 — measured **~11%** (8 err / 71 calls in 12h, CP458). It is transient (the other 89% succeed), but `embedOneChunk` with `provider='openrouter'` had **no retry and no fallback** — so a single 404 on any chunk failed the whole `embedBatch`.

`promote-from-playlists` imported **197 `video_pool` rows with 0 embeddings** because one of its 4 chunks hit the 404 → those rows are invisible to the v3 recommender (`JOIN video_pool_embeddings`).

## Fix
- `EmbeddingError` gains a `retryable` flag — set for network errors, HTTP 404 and 5xx; false for deterministic failures (auth, count/dimension mismatch).
- `embedOneChunkViaOpenRouterRetrying` — bounded retry (2 retries, 500ms→1000ms backoff) on retryable errors only.
- `embedOneChunk`'s `openrouter` branch now falls back to Ollama once retries exhaust (symmetric with the existing `ollama` branch). Both produce 4096-d qwen3-embedding-8b vectors → a fallback chunk stays co-comparable.

Keeps `IKS_EMBED_PROVIDER=openrouter` (Mac Mini deprecation Phase D1 intent) — fixes the reliability gap, not the provider choice.

## Test plan
- [x] `tsc --noEmit` clean
- [x] jest `embedding-openrouter-retry` 5/5 (retry-success / no-retry-on-400 / retry-exhaust→ollama / both-fail→throw / ollama-branch fallback retries)
- [ ] post-deploy: `DELETE FROM video_pool WHERE source='user_playlist'` (197 unembedded rows) → re-run playlist import → verify `video_pool_embeddings` rows created

## Pre-existing (not in this PR)
`iks-scorer/__tests__/embedding-fallback.test.ts` + `executor.test.ts` fail to run — their `@/config` mock lacks `discoverTracing` (broken since CP457 added the `recordTrace` import). Verified pre-existing by stashing this change. Needs a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)