### PR TITLE
fix(embedding): OpenRouter baseURL leak + per-chunk batch isolation

### DIFF
--- a/src/modules/mandala/ensure-mandala-embeddings.ts
+++ b/src/modules/mandala/ensure-mandala-embeddings.ts
@@ -165,7 +165,7 @@ export async function ensureMandalaEmbeddings(mandalaId: string): Promise<Ensure
   // ── Step 4: generate via Mac Mini Ollama (only missing/stale) ─────
   const subjectsToEmbed = indexesToGenerate.map((i) => currentSubjects[i]!);
   const t0 = Date.now();
-  let vectors: number[][];
+  let vectors: (number[] | null)[];
   try {
     vectors = await embedBatch(subjectsToEmbed);
   } catch (err) {

--- a/src/modules/video-pool/promote-from-playlists.ts
+++ b/src/modules/video-pool/promote-from-playlists.ts
@@ -190,7 +190,7 @@ export async function promotePlaylistsToVideoPool(
 
   // 7. Generate embeddings (fail-open if Ollama unreachable).
   const reachable = await isOllamaReachable({ baseUrl: ollamaUrl });
-  let embeddings: number[][] = [];
+  let embeddings: (number[] | null)[] = [];
   if (reachable) {
     try {
       const inputs = validMeta.map(buildEmbedText);

--- a/src/modules/video-pool/promote-from-v2.ts
+++ b/src/modules/video-pool/promote-from-v2.ts
@@ -169,7 +169,7 @@ export async function promoteV2ToVideoPool(opts: PromoteOptions = {}): Promise<P
 
   // 4. Generate embeddings up-front via Mac Mini Ollama (parallel batch).
   const reachable = await isOllamaReachable({ baseUrl: ollamaUrl });
-  let embeddings: number[][] = [];
+  let embeddings: (number[] | null)[] = [];
   if (reachable) {
     try {
       const inputs = candidates.map(buildEmbedText);

--- a/src/skills/plugins/batch-video-collector/executor.ts
+++ b/src/skills/plugins/batch-video-collector/executor.ts
@@ -257,7 +257,7 @@ export const executor: SkillExecutor = {
 
       // 7. Embeddings (Qwen3 via Mac Mini Ollama) — optional
       const embedReachable = await isOllamaReachable({ baseUrl: state.ollamaUrl });
-      let embeddings: number[][] = [];
+      let embeddings: (number[] | null)[] = [];
       if (embedReachable && enriched.length > 0) {
         try {
           const inputs = enriched.map((v) => buildEmbedText(v));
@@ -427,7 +427,9 @@ async function searchAllKeywords(
 
 async function upsertAll(
   enriched: EnrichedVideo[],
-  embeddings: number[][]
+  // One slot per `enriched` video; `null` where that video's embed chunk
+  // failed (embedBatch per-chunk isolation, CP458). Body skips null entries.
+  embeddings: (number[] | null)[]
 ): Promise<{ videosNew: number; videosUpdated: number; domainTagsWritten: number }> {
   const db = getPrismaClient();
   let videosNew = 0;

--- a/src/skills/plugins/iks-scorer/__tests__/embedding-fallback.test.ts
+++ b/src/skills/plugins/iks-scorer/__tests__/embedding-fallback.test.ts
@@ -56,6 +56,11 @@ jest.mock('@/modules/database', () => ({
   getPrismaClient: () => ({}),
 }));
 
+// embedding.ts imports recordTrace from discover-tracing, whose module-load
+// reads config.discoverTracing.enabled — the config mock above doesn't
+// provide it, so stub the tracer directly.
+jest.mock('@/modules/discover-tracing', () => ({ recordTrace: jest.fn() }));
+
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 function makeOllamaResponse(count: number, vector: number[] = FAKE_OLLAMA_VECTOR): Response {
@@ -83,7 +88,7 @@ function makeErrorResponse(status: number, body = 'server error'): Response {
 
 // ─── Import after mocks ─────────────────────────────────────────────────────
 
-import { embedBatch, EmbeddingError } from '../embedding';
+import { embedBatch } from '../embedding';
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
@@ -140,14 +145,16 @@ describe('embedBatch — IKS_EMBED_PROVIDER fallback (Issue #543)', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
-  it('provider=ollama: ollama fail + OpenRouter fail → throw EmbeddingError', async () => {
+  it('provider=ollama: ollama fail + OpenRouter fail → null slot, no throw (CP458 per-chunk isolation)', async () => {
     const fetchImpl = jest
       .fn()
       .mockRejectedValueOnce(new TypeError('fetch failed'))
       .mockResolvedValueOnce(makeErrorResponse(429, 'rate limited'));
 
-    await expect(embedBatch(['t1'], { fetchImpl })).rejects.toBeInstanceOf(EmbeddingError);
-    // logLLMCall fired with status=error for the failed OpenRouter attempt
+    // embedBatch isolates chunk failure — the chunk yields `null`, not a throw.
+    const out = await embedBatch(['t1'], { fetchImpl });
+    expect(out).toEqual([null]);
+    // logLLMCall still fired with status=error for the failed OpenRouter attempt
     expect(logLLMCallMock).toHaveBeenCalledTimes(1);
     const callArg = logLLMCallMock.mock.calls[0]?.[0] as { status: string };
     expect(callArg.status).toBe('error');
@@ -166,13 +173,16 @@ describe('embedBatch — IKS_EMBED_PROVIDER fallback (Issue #543)', () => {
     expect(url0).toContain('openrouter.ai');
   });
 
-  it('OpenRouter dimension mismatch → throws (no silent acceptance)', async () => {
+  it('OpenRouter dimension mismatch → null slot (no silent bad-dim acceptance, no throw)', async () => {
     const wrongDim = new Array(2048).fill(0.5);
     const fetchImpl = jest
       .fn()
       .mockRejectedValueOnce(new TypeError('fetch failed'))
       .mockResolvedValueOnce(makeOpenRouterResponse(1, wrongDim));
 
-    await expect(embedBatch(['t1'], { fetchImpl })).rejects.toBeInstanceOf(EmbeddingError);
+    // Dimension mismatch is non-retryable; embedOneChunk throws, embedBatch
+    // isolates it to a null slot rather than accepting the wrong-dim vector.
+    const out = await embedBatch(['t1'], { fetchImpl });
+    expect(out).toEqual([null]);
   });
 });

--- a/src/skills/plugins/iks-scorer/embedding.ts
+++ b/src/skills/plugins/iks-scorer/embedding.ts
@@ -111,49 +111,60 @@ export async function isOllamaReachable(opts: EmbeddingClientOptions = {}): Prom
  * into chunks of DEFAULT_EMBED_CHUNK_SIZE so no single call exceeds the
  * timeout.
  *
- * Returns vectors in the same order as inputs. Throws EmbeddingError if
- * ANY chunk fails — callers MUST decide whether to fall back to placeholder
- * mode (recommended) or fail the whole execute() call.
+ * Returns one slot per input, in order. Per-chunk isolation (CP458): a
+ * chunk whose embed call fails yields `null` for each of its inputs rather
+ * than failing the whole batch — a single bad chunk used to throw away
+ * every embedding (promote-from-playlists imported 197 rows with 0
+ * embeddings because one of its 4 chunks failed). The returned array length
+ * always equals `texts.length`; callers MUST null-check each entry.
+ * Does not throw for chunk-level failures.
  */
 export async function embedBatch(
   texts: string[],
   opts: EmbeddingClientOptions = {}
-): Promise<number[][]> {
+): Promise<(number[] | null)[]> {
   if (texts.length === 0) return [];
   const chunkSize = opts.chunkSize ?? DEFAULT_EMBED_CHUNK_SIZE;
-  const out: number[][] = [];
-
+  const out: (number[] | null)[] = [];
   const t0 = Date.now();
-  try {
-    for (let i = 0; i < texts.length; i += chunkSize) {
-      const chunk = texts.slice(i, i + chunkSize);
+  let failedChunks = 0;
+
+  for (let i = 0; i < texts.length; i += chunkSize) {
+    const chunk = texts.slice(i, i + chunkSize);
+    try {
       const vectors = await embedOneChunk(chunk, opts);
       out.push(...vectors);
+    } catch (err) {
+      failedChunks += 1;
+      log.warn(
+        `embedBatch chunk [${i}, ${i + chunk.length}) failed — continuing without it: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      for (let j = 0; j < chunk.length; j += 1) out.push(null);
     }
-    // CP457+ trace — text inputs + vector counts (skip the 4096d vectors
-    // themselves to keep payload sane; record first-3-dim sample per vec).
-    recordTrace({
-      step: 'embed.batch',
-      status: 'ok',
-      request: { text_count: texts.length, chunk_size: chunkSize, texts: texts.slice(0, 50) },
-      response: {
-        vector_count: out.length,
-        dim: out[0]?.length ?? 0,
-        samples: out.slice(0, 3).map((v) => v.slice(0, 3)),
-      },
-      latencyMs: Date.now() - t0,
-    });
-    return out;
-  } catch (err) {
-    recordTrace({
-      step: 'embed.batch',
-      status: 'error',
-      request: { text_count: texts.length, chunk_size: chunkSize, texts: texts.slice(0, 50) },
-      errorMessage: err instanceof Error ? err.message : String(err),
-      latencyMs: Date.now() - t0,
-    });
-    throw err;
   }
+
+  const okCount = out.reduce((n, v) => (v ? n + 1 : n), 0);
+  const firstVec = out.find((v): v is number[] => v != null);
+  // CP457+ trace — text inputs + vector counts (skip the 4096d vectors
+  // themselves to keep payload sane; record first-3-dim sample per vec).
+  recordTrace({
+    step: 'embed.batch',
+    status: okCount > 0 ? 'ok' : 'error',
+    request: { text_count: texts.length, chunk_size: chunkSize, texts: texts.slice(0, 50) },
+    response: {
+      vector_count: okCount,
+      failed_chunks: failedChunks,
+      dim: firstVec?.length ?? 0,
+      samples: out
+        .filter((v): v is number[] => v != null)
+        .slice(0, 3)
+        .map((v) => v.slice(0, 3)),
+    },
+    latencyMs: Date.now() - t0,
+  });
+  return out;
 }
 
 /**
@@ -277,8 +288,14 @@ async function embedOneChunkViaOpenRouter(
     throw new EmbeddingError('OPENROUTER_API_KEY not configured (cannot fall back from Ollama)');
   }
 
-  const baseUrl = opts.baseUrl ?? config.mandalaEmbed.openRouterBaseUrl;
-  const model = opts.model ?? config.mandalaEmbed.openRouterModel;
+  // NOTE: `opts.baseUrl` / `opts.model` are the *Ollama* overrides (see
+  // EmbeddingClientOptions JSDoc — they default to MAC_MINI_OLLAMA_DEFAULT_URL
+  // / QWEN3_EMBED_MODEL). They MUST NOT leak into the OpenRouter call. CP458:
+  // promote-from-* passed `{ baseUrl: ollamaUrl }`, which made this function
+  // POST to `http://<mac-mini>:11434/embeddings` — a route Ollama doesn't have
+  // — yielding a deterministic "HTTP 404 page not found" on every call.
+  const baseUrl = config.mandalaEmbed.openRouterBaseUrl;
+  const model = config.mandalaEmbed.openRouterModel;
   const expectedDim = config.mandalaEmbed.openRouterDimension;
   const fetchFn = opts.fetchImpl ?? fetch;
 

--- a/src/skills/plugins/video-discover/v2/video-embedder.ts
+++ b/src/skills/plugins/video-discover/v2/video-embedder.ts
@@ -68,7 +68,7 @@ export async function embedVideos(
   }
 
   const texts = videos.map(buildEmbeddingText);
-  let vectors: number[][];
+  let vectors: (number[] | null)[];
   try {
     vectors = await embedBatch(texts, opts);
   } catch (err) {

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -321,7 +321,7 @@ async function executeImpl(ctx: ExecuteContext): Promise<ExecuteResult> {
         const texts = [state.centerGoal, ...capped.map((m) => m.title)];
         const vectors = await embedBatch(texts);
         if (vectors.length === texts.length) {
-          const centerEmbedding = vectors[0];
+          const centerEmbedding = vectors[0] ?? undefined;
           const candidateEmbeddings = new Map<string, number[]>();
           for (let i = 0; i < capped.length; i++) {
             const vec = vectors[i + 1];
@@ -962,7 +962,7 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     try {
       const vectors = await embedBatch(texts);
       if (vectors.length === texts.length) {
-        centerEmbedding = vectors[0];
+        centerEmbedding = vectors[0] ?? undefined;
         candidateEmbeddings = new Map<string, number[]>();
         for (let i = 0; i < cappedFilterInputs.length; i++) {
           const vec = vectors[i + 1];
@@ -1748,7 +1748,7 @@ async function runDiscoverEphemeralImpl(
       const vectors = await embedBatch(texts);
       const embedMs = Date.now() - embedT0;
       if (vectors.length === texts.length) {
-        const centerEmbedding = vectors[0];
+        const centerEmbedding = vectors[0] ?? undefined;
         const candidateEmbeddings = new Map<string, number[]>();
         for (let i = 0; i < cappedSlots.length; i++) {
           const vec = vectors[i + 1];

--- a/tests/unit/modules/embedding-openrouter-retry.test.ts
+++ b/tests/unit/modules/embedding-openrouter-retry.test.ts
@@ -30,7 +30,7 @@ jest.mock('@/modules/llm/call-logger', () => ({ logLLMCall: jest.fn() }));
 jest.mock('@/modules/discover-tracing', () => ({ recordTrace: jest.fn() }));
 jest.mock('@/modules/database', () => ({ getPrismaClient: jest.fn() }));
 
-import { embedBatch, EmbeddingError } from '@/skills/plugins/iks-scorer/embedding';
+import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
 
 const DIM = 4096;
 const vec = (): number[] => new Array(DIM).fill(0.01);
@@ -113,12 +113,15 @@ describe('embedBatch — OpenRouter transient-404 retry + Ollama fallback', () =
     expect(ollamaCalls).toHaveLength(1); // fallback after exhaustion
   });
 
-  it('throws when OpenRouter retries exhaust AND the Ollama fallback also fails', async () => {
+  it('returns null slots when OpenRouter retries exhaust AND the Ollama fallback also fails', async () => {
     const fetchImpl = jest.fn(async (url: string) =>
       url.includes('/embeddings') ? httpErr(404) : httpErr(500)
     ) as unknown as typeof fetch;
 
-    await expect(embedBatch(['a', 'b'], { fetchImpl })).rejects.toThrow(EmbeddingError);
+    // per-chunk isolation (CP458): both providers fail → the chunk's inputs
+    // become null and embedBatch returns rather than throwing.
+    const out = await embedBatch(['a', 'b'], { fetchImpl });
+    expect(out).toEqual([null, null]);
   });
 
   it('ollama-provider branch: Ollama down → OpenRouter fallback also retries transient 404', async () => {


### PR DESCRIPTION
## Root cause (code + prod-data confirmed)

promote-from-playlists imported **197 video_pool rows with 0 embeddings** — same silent failure in `promote-from-v2` and `batch-video-collector` all day (CP458). Two causes:

**1. baseURL leak — the actual "404".** `embedOneChunkViaOpenRouter` used `opts.baseUrl`, but `EmbeddingClientOptions.baseUrl` is the *Ollama* override (JSDoc: "Defaults to MAC_MINI_OLLAMA_DEFAULT_URL"). `promote-from-*` pass `{ baseUrl: ollamaUrl }`, so the OpenRouter path POSTed to `http://<mac-mini>:11434/embeddings` — a route Ollama doesn't have → deterministic `HTTP 404 page not found` on every call. The wizard path never passes `baseUrl`, which is exactly why it always worked (`llm_call_logs`: 63 wizard success / 8 promote-* error). → `embedOneChunkViaOpenRouter` now always uses `config.mandalaEmbed.openRouterBaseUrl` / `openRouterModel`.

**2. all-or-nothing batch.** `embedBatch` threw if ANY chunk failed → one bad chunk discarded every embedding. → `embedBatch` is now **per-chunk isolated**: returns `(number[] | null)[]` (length always == input length, `null` where a chunk failed), never throws for chunk-level failures. All 8 callers already null-check per index; type annotations widened to match.

(Note: PR #635's retry+fallback was treating a symptom — it retried a *deterministic* 404. The retry infra stays — valid for genuine transient OpenRouter errors — but this PR fixes the actual bug.)

## Test plan
- [x] `tsc --noEmit` clean
- [x] jest: embedding-openrouter-retry 5/5, embedding-fallback 6/6, promote-from-v2/playlists, video-embedder, batch-video-collector, v3 (mandala-filter/cache-matcher/hybrid-rerank/quality-gate/config/semantic-cap) — **all green, 197/197 across the sweep**
- [x] `embedding-fallback.test.ts` un-broken (config mock lacked `discoverTracing` since CP457) + 2 throw-expectations updated to the null-slot contract
- [ ] post-deploy: `DELETE FROM video_pool WHERE source='user_playlist'` → re-run playlist import → verify `video_pool_embeddings` rows created

## Pre-existing, NOT in this PR (verified via `git stash` — fail on HEAD too)
`iks-scorer/executor.test.ts` + `v3/executor-semantic-rerank.test.ts` + `v3/executor-whitelist-gate.test.ts` fail at suite-load on a `@/utils/logger` mock missing `.info`. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)