### PR TITLE
fix(video-discover): detect input language so YouTube search matches it

### DIFF
--- a/src/modules/mandala/manager.ts
+++ b/src/modules/mandala/manager.ts
@@ -4,6 +4,7 @@ import { logger } from '../../utils/logger';
 import { user_mandalas, Prisma } from '@prisma/client';
 import { nanoid } from 'nanoid';
 import { DEFAULT_TIER, getMandalaLimit, type Tier } from '@/config/quota';
+import { detectLanguage } from '@/utils/detect-language';
 import {
   EXPLORE_PAGE_LIMIT,
   EXPLORE_DEFAULT_PAGE_SIZE,
@@ -479,6 +480,9 @@ export class MandalaManager {
             data: {
               user_id: userId,
               title,
+              // CP458: persist the input language so video-discover searches
+              // in the right language/region instead of defaulting to 'ko'.
+              language: detectLanguage(title),
               is_default: isDefault,
               position,
             },
@@ -838,6 +842,7 @@ export class MandalaManager {
             data: {
               user_id: userId,
               title,
+              language: detectLanguage(title),
               is_default: true,
               position: 0,
             },
@@ -1172,6 +1177,7 @@ export class MandalaManager {
       data: {
         user_id: targetUserId,
         title: clonedTitle,
+        language: detectLanguage(clonedTitle),
         is_default: existingCount === 0,
         is_public: false,
         source_template_id: options?.sourceTemplateId ?? null,

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -48,6 +48,7 @@ import { filterByQualityGate } from './quality-gate';
 import { applyHybridRerank } from './hybrid-rerank';
 import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
 import { withTraceContext, recordTrace } from '@/modules/discover-tracing';
+import { resolveLanguage } from '@/utils/detect-language';
 
 import {
   buildRuleBasedQueriesSync,
@@ -187,7 +188,12 @@ export const executor: SkillExecutor = {
       if (r.center_goal && !centerGoal) centerGoal = r.center_goal;
     }
 
-    const language: KeywordLanguage = mandala.language === 'en' ? 'en' : 'ko';
+    // CP458: a stored 'ko'/'en' wins; otherwise detect from the goal text
+    // rather than blind-defaulting NULL → 'ko'. This is the chokepoint that
+    // feeds runSearchTraced's regionCode/relevanceLanguage AND the
+    // keyword-builder extraction path — getting it right here makes the
+    // YouTube search match the input language end-to-end.
+    const language: KeywordLanguage = resolveLanguage(mandala.language, centerGoal);
     const hydrated: HydratedState = {
       centerGoal,
       subGoals,

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -1,0 +1,55 @@
+/**
+ * detect-language — deterministic script detection for goal/title text.
+ *
+ * CP458: the wizard never stored `user_mandalas.language`, and the v3
+ * executor's `mandala.language === 'en' ? 'en' : 'ko'` silently defaulted
+ * every NULL-language mandala to 'ko' — so an English goal ("Build
+ * retirement assets via ETF investing") was searched with regionCode=KR +
+ * relevanceLanguage=ko and the Korean keyword-extraction path, surfacing
+ * Korean results. This helper recovers the input language from the text
+ * itself so the YouTube search is issued in the right language/region.
+ *
+ * Zero-dependency, deterministic — pure character-class counting.
+ */
+
+export type DetectedLanguage = 'ko' | 'en';
+
+/** Hangul Syllables block (U+AC00–U+D7A3) — Korean pre-composed syllables. */
+const HANGUL_RE = /[가-힣]/gu;
+/** Basic Latin letters — the English signal. */
+const LATIN_RE = /[A-Za-z]/g;
+
+/**
+ * Detect the dominant script of `text`.
+ *
+ *   - Any Hangul that is at least as frequent as Latin letters → 'ko'.
+ *   - Latin letters present, little/no Hangul → 'en'.
+ *   - No script signal at all (digits/symbols only, or empty) → 'ko',
+ *     preserving the pre-CP458 default so this is never *more* surprising
+ *     than the behavior it replaces.
+ *
+ * "Input language priority" (per product spec): the goal text the user
+ * typed wins. A caller may still fall back to an explicit language
+ * setting when it has one and wants to override an ambiguous detection.
+ */
+export function detectLanguage(text: string | null | undefined): DetectedLanguage {
+  if (!text) return 'ko';
+  const hangulCount = (text.match(HANGUL_RE) ?? []).length;
+  const latinCount = (text.match(LATIN_RE) ?? []).length;
+  if (hangulCount === 0 && latinCount === 0) return 'ko';
+  return hangulCount >= latinCount ? 'ko' : 'en';
+}
+
+/**
+ * Resolve the effective language for a mandala: a stored `'ko' | 'en'`
+ * value wins (it was detected at creation time), otherwise detect from
+ * the goal text. Anything that is not exactly 'ko'/'en' (NULL, '', stray
+ * values) falls through to text detection rather than defaulting to 'ko'.
+ */
+export function resolveLanguage(
+  stored: string | null | undefined,
+  goalText: string | null | undefined
+): DetectedLanguage {
+  if (stored === 'ko' || stored === 'en') return stored;
+  return detectLanguage(goalText);
+}

--- a/tests/unit/utils/detect-language.test.ts
+++ b/tests/unit/utils/detect-language.test.ts
@@ -1,0 +1,53 @@
+/**
+ * detect-language — script detection for goal/title text (CP458).
+ *
+ * Pins the fix for the English-mandala-searched-as-Korean bug: an English
+ * goal must resolve to 'en' so YouTube search uses regionCode=US +
+ * relevanceLanguage=en instead of the NULL→'ko' default.
+ */
+
+import { detectLanguage, resolveLanguage } from '@/utils/detect-language';
+
+describe('detectLanguage', () => {
+  it('detects an English goal as en (the reported bug case)', () => {
+    expect(detectLanguage('Build retirement assets via ETF investing')).toBe('en');
+  });
+
+  it('detects a Korean goal as ko', () => {
+    expect(detectLanguage('ETF 투자로 노후 자산 만들기')).toBe('ko');
+  });
+
+  it('treats Korean-dominant mixed text as ko', () => {
+    // "AI" is Latin but Hangul dominates → ko
+    expect(detectLanguage('AI 마케팅으로 비즈니스 성장 시키기')).toBe('ko');
+  });
+
+  it('treats English-dominant mixed text as en', () => {
+    expect(detectLanguage('Complete an AI/ML project portfolio 만들기')).toBe('en');
+  });
+
+  it('defaults to ko for empty / null / no-script input (preserves pre-CP458 default)', () => {
+    expect(detectLanguage('')).toBe('ko');
+    expect(detectLanguage(null)).toBe('ko');
+    expect(detectLanguage(undefined)).toBe('ko');
+    expect(detectLanguage('2026 — 100%')).toBe('ko');
+  });
+});
+
+describe('resolveLanguage', () => {
+  it('a stored ko/en value wins over text detection (input-language priority)', () => {
+    expect(resolveLanguage('en', '한국어 제목')).toBe('en');
+    expect(resolveLanguage('ko', 'English title')).toBe('ko');
+  });
+
+  it('falls through to text detection when stored is NULL', () => {
+    expect(resolveLanguage(null, 'Build retirement assets via ETF investing')).toBe('en');
+    expect(resolveLanguage(null, 'ETF 투자로 노후 자산')).toBe('ko');
+  });
+
+  it('falls through to text detection for empty or stray stored values', () => {
+    expect(resolveLanguage('', 'English text')).toBe('en');
+    expect(resolveLanguage('EN', '한국어')).toBe('ko'); // case-sensitive — 'EN' is not 'en'
+    expect(resolveLanguage('garbage', 'English text')).toBe('en');
+  });
+});


### PR DESCRIPTION
## Root cause (Tier 2 integrated diagnosis #1, CP458)

The wizard never stored `user_mandalas.language` — `mandala/manager.ts`'s 3 `create` sites omit the field — and `v3/executor.ts:190` resolved language as `mandala.language === 'en' ? 'en' : 'ko'`, so every NULL-language mandala (the default state) became `'ko'`.

An English goal ("Build retirement assets via ETF investing") was then searched with `regionCode=KR` + `relevanceLanguage=ko` **and** run through the Korean keyword-extraction path → Korean results for an English query (user-reported consistency bug, screenshot).

## Fix
- **`src/utils/detect-language.ts`** (new) — `detectLanguage(text)` (Hangul vs Latin char count, deterministic, zero-dep) + `resolveLanguage(stored, text)`: a stored `'ko'/'en'` wins (input-language priority), else detect from text.
- **`v3/executor.ts:190`** — `resolveLanguage(mandala.language, centerGoal)`. This is the chokepoint feeding `runSearchTraced`'s `regionCode`/`relevanceLanguage` and the keyword-builder extraction — fixing it here corrects both **new and legacy** NULL-language mandalas.
- **`mandala/manager.ts`** — the 3 `user_mandalas.create` sites now persist `language: detectLanguage(title)`.

## Test plan
- [x] `tsc --noEmit` clean
- [x] jest `detect-language` 8/8 (English/Korean/mixed/empty + resolveLanguage priority)
- [x] v3 regression — cache-matcher / hybrid-rerank / mandala-filter / quality-gate / config / v3-semantic-cap all green
- [ ] post-deploy: create an English-goal mandala → confirm cards come back English

## Pre-existing, NOT in this PR (verified via `git stash`)
`mandala-manager.test.ts` + `mandala-post-creation.test.ts` (18 test failures) and the v3 `executor-semantic-rerank`/`executor-whitelist-gate` suites fail on stale mocks — present on HEAD without this change. The codebase has accumulated test-mock rot across several suites; worth a dedicated cleanup pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)