### PR TITLE
fix(v3): Tier 1 100s→3s — eligible-CTE restructure + drop batch_trend

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -253,14 +253,18 @@ services:
       - V3_ENABLE_QUALITY_GATE=true
       - V3_MIN_VIEWS_PER_DAY=33
       # CP457 (2026-05-13) — domain idempotency fix per ssh-connect prod
-      # measurement: travel mandala 94d713f0 v2_promoted only = 13 rows
-      # across 8 cells; +batch_trend = 372 rows; cosine ≥ 0.5 admits 43.
-      # batch_trend ko gold+silver = 7,465 vs v2_promoted ko = 1,156
-      # (6.5x volume). Quality bar raise to 0.5 filters cross-domain
-      # near-matches (CP455 cell 6 = 28 토익스피킹 at cosine 0.55+).
-      # Rollback: remove both lines or comment out — backward compat
-      # defaults (['v2_promoted'], 0.35) restore CP456 behavior.
-      - V3_TIER1_SOURCES=v2_promoted,batch_trend
+      # CP458: batch_trend REMOVED from Tier 1 sources. EXPLAIN ANALYZE +
+      # per-mandala measurement on prod: with batch_trend the matchFromVideoPool
+      # cosine scans ~8.5k ko embeddings × 8 cells → 45-100s per run (the
+      # dominant wizard→dashboard latency). v2_promoted alone (1,156 ko rows)
+      # → ~0.3-2.7s for the SAME effective coverage: ko mandala 079148c3
+      # measured 37 rows/8 cells (v2_promoted) vs 40 rows/8 cells (+batch_trend)
+      # — +batch_trend bought 3 extra rows at a 16x latency cost. v2_promoted
+      # is also the cache-matcher.ts code default (batch_trend = untriaged
+      # cross-domain noise). Restructured query (eligible CTE first) makes the
+      # source filter actually shrink the cosine scan.
+      # Rollback: append ,batch_trend — but expect 45-100s Tier 1.
+      - V3_TIER1_SOURCES=v2_promoted
       - V3_SEMANTIC_MIN_COSINE=0.5
       # CP457+ — per-step request/response capture for video-discovery
       # (LLM prompts, YouTube search, Cohere rerank, embeddings, results).

--- a/src/skills/plugins/video-discover/v3/cache-matcher.ts
+++ b/src/skills/plugins/video-discover/v3/cache-matcher.ts
@@ -86,8 +86,24 @@ export async function matchFromVideoPool(opts: MatchFromVideoPoolOpts): Promise<
   const db = getPrismaClient();
   const t0 = Date.now();
 
+  // CP458: materialise the eligible video_pool subset (index scan, fast)
+  // BEFORE joining video_pool_embeddings, so pgvector cosine runs only over
+  // the eligible rows — not the whole embeddings table. EXPLAIN ANALYZE on
+  // prod: pre-CP458 the planner hash-joined (mandala × Seq Scan ALL 11,123
+  // embeddings) → 89k cosine ops → 65-100s. With the eligible CTE first +
+  // sources=['v2_promoted'] (1,156 ko rows): ~9k cosine → ~2.9s.
   const rows = await db.$queryRaw<MatchRow[]>(Prisma.sql`
-    WITH mandala_embs AS (
+    WITH eligible AS (
+      SELECT
+        video_id, title, description, channel_name, channel_id,
+        thumbnail_url, view_count, like_count, duration_seconds, published_at
+      FROM public.video_pool
+      WHERE is_active = true
+        AND language = ${opts.language}
+        AND quality_tier IN ('gold', 'silver')
+        AND source = ANY(${sources}::text[])
+    ),
+    mandala_embs AS (
       SELECT sub_goal_index AS cell_index, embedding
         FROM public.mandala_embeddings
        WHERE mandala_id = ${opts.mandalaId}
@@ -96,26 +112,22 @@ export async function matchFromVideoPool(opts: MatchFromVideoPoolOpts): Promise<
     ),
     scored AS (
       SELECT
-        vp.video_id,
-        vp.title,
-        vp.description,
-        vp.channel_name,
-        vp.channel_id,
-        vp.thumbnail_url,
-        vp.view_count,
-        vp.like_count,
-        vp.duration_seconds,
-        vp.published_at,
+        e.video_id,
+        e.title,
+        e.description,
+        e.channel_name,
+        e.channel_id,
+        e.thumbnail_url,
+        e.view_count,
+        e.like_count,
+        e.duration_seconds,
+        e.published_at,
         me.cell_index,
         1 - (vpe.embedding <=> me.embedding) AS score
-      FROM public.video_pool vp
+      FROM eligible e
       JOIN public.video_pool_embeddings vpe
-        ON vp.video_id = vpe.video_id
+        ON vpe.video_id = e.video_id
       CROSS JOIN mandala_embs me
-      WHERE vp.is_active = true
-        AND vp.language = ${opts.language}
-        AND vp.quality_tier IN ('gold', 'silver')
-        AND vp.source = ANY(${sources}::text[])
     ),
     ranked AS (
       SELECT
@@ -246,27 +258,35 @@ export async function matchFromVideoPoolByCenterGoal(
   // serialise to the `[v1,v2,...]` text form and let Postgres cast.
   const vectorLiteral = `[${opts.centerEmbedding.join(',')}]`;
 
+  // CP458: same eligible-CTE-first restructure as matchFromVideoPool — cosine
+  // runs over the eligible video_pool subset, not the whole embeddings table.
   const rows = await db.$queryRaw<CenterMatchRow[]>(Prisma.sql`
+    WITH eligible AS (
+      SELECT
+        video_id, title, description, channel_name, channel_id,
+        thumbnail_url, view_count, like_count, duration_seconds, published_at
+      FROM public.video_pool
+      WHERE is_active = true
+        AND language = ${opts.language}
+        AND quality_tier IN ('gold', 'silver')
+        AND source = ANY(${sources}::text[])
+    )
     SELECT
-      vp.video_id,
-      vp.title,
-      vp.description,
-      vp.channel_name,
-      vp.channel_id,
-      vp.thumbnail_url,
-      vp.view_count,
-      vp.like_count,
-      vp.duration_seconds,
-      vp.published_at,
+      e.video_id,
+      e.title,
+      e.description,
+      e.channel_name,
+      e.channel_id,
+      e.thumbnail_url,
+      e.view_count,
+      e.like_count,
+      e.duration_seconds,
+      e.published_at,
       1 - (vpe.embedding <=> ${vectorLiteral}::vector) AS score
-    FROM public.video_pool vp
+    FROM eligible e
     JOIN public.video_pool_embeddings vpe
-      ON vp.video_id = vpe.video_id
-    WHERE vp.is_active = true
-      AND vp.language = ${opts.language}
-      AND vp.quality_tier IN ('gold', 'silver')
-      AND vp.source = ANY(${sources}::text[])
-      AND 1 - (vpe.embedding <=> ${vectorLiteral}::vector) >= ${threshold}
+      ON vpe.video_id = e.video_id
+    WHERE 1 - (vpe.embedding <=> ${vectorLiteral}::vector) >= ${threshold}
     ORDER BY vpe.embedding <=> ${vectorLiteral}::vector ASC
     LIMIT ${limit}
   `);


### PR DESCRIPTION
## Root cause (Tier 2 integrated diagnosis #2, CP458 — EXPLAIN ANALYZE verified)

`matchFromVideoPool`'s planner did `Nested Loop(mandala_embs × Seq Scan ALL 11,123 video_pool_embeddings)` **before** the video_pool filter → ~89k 4096-d cosine ops → **65-100s**. This is the dominant wizard→dashboard latency for ko mandalas (en is fast only because the en pool is near-empty). Trace-confirmed: recent ko runs 97-115s wall-clock, `tier1.match_from_video_pool` = 77-100s of it.

4096-d vectors can't be ANN-indexed in pgvector (vector 2000 / halfvec 4000 dim cap; the existing `idx_vpool_emb_cosine`/`idx_mandala_emb_cosine` IVFFlat indexes are `valid=false` stubs from a failed `CONCURRENTLY` build). Brute-force is structural — the only lever is the eligible-set size.

## Fix (both EXPLAIN-ANALYZE-verified on prod)
1. **`cache-matcher.ts`** — `matchFromVideoPool` + `matchFromVideoPoolByCenterGoal` now materialise an `eligible` CTE (video_pool filtered by language/tier/source via index scan) **first**, then join `video_pool_embeddings` for only those video_ids. Correctness-neutral.
2. **`docker-compose.prod.yml`** — `V3_TIER1_SOURCES` drops `batch_trend` (`v2_promoted` only = the `cache-matcher.ts` code default; batch_trend = "untriaged cross-domain noise" per the code comment).

## Measured on prod (restructured query, EXPLAIN ANALYZE)
| config | ko mandala 079148c3 | ko mandala 32573e5b |
|--------|---------------------|---------------------|
| `v2_promoted` only | **37 rows / 8 cells, 2.7s** | **31 rows / 7 cells, 0.3s** |
| `+batch_trend` | 40 rows / 8 cells, 44.6s | 38 rows / 7 cells, 66.2s |

batch_trend bought 3-7 extra rows at 16-255x the latency. **Net: ko Tier 1 ~100s → ~0.3-2.7s, ~same coverage.**

## Test plan
- [x] `tsc --noEmit` clean
- [x] jest cache-matcher / config / v3-semantic-cap — 32/32
- [ ] post-deploy: re-create a ko mandala, confirm trace `tier1.match_from_video_pool` < 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)