### PR TITLE
fix(v3): port lang post-filter to Tier-2; raise shorts threshold 60s→75s

### DIFF
--- a/src/skills/plugins/video-discover/__tests__/v2-youtube-client.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v2-youtube-client.test.ts
@@ -102,20 +102,16 @@ describe('parseIsoDuration', () => {
 });
 
 describe('filters', () => {
-  test('isShortsByDuration — duration-based (60s threshold, CP358 original)', () => {
+  test('isShortsByDuration — duration-based (75s threshold, 2026-05-15)', () => {
     expect(isShortsByDuration(30)).toBe(true);
     expect(isShortsByDuration(60)).toBe(true);
-    // 2026-05-14 revert from 180s back to 60s: trace analysis of the
-    // "8구단 드래프트 1순위" mandala showed 24% of YouTube candidates
-    // (50/206) were KBO/MLB draft NEWS CLIPS from SBS/KBS/YTN/MBN
-    // (281k, 136k, 111k views) — exactly the mandala-relevant content
-    // — that fell in the 61-180s bucket and got incorrectly killed by
-    // the 180s gate. `titleIndicatesShorts` still catches explicit
-    // `#shorts` hashtag cases in this range.
-    expect(isShortsByDuration(61)).toBe(false);
+    // 2026-05-15: raised from 60s to 75s — outputs still surfaced cards
+    // slightly over the 60s line; 75s clears that band.
+    expect(isShortsByDuration(61)).toBe(true);
+    expect(isShortsByDuration(75)).toBe(true);
+    expect(isShortsByDuration(76)).toBe(false);
     expect(isShortsByDuration(110)).toBe(false);
     expect(isShortsByDuration(180)).toBe(false);
-    expect(isShortsByDuration(181)).toBe(false);
     expect(isShortsByDuration(600)).toBe(false);
   });
 

--- a/src/skills/plugins/video-discover/__tests__/v3-lang-filter.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v3-lang-filter.test.ts
@@ -1,0 +1,220 @@
+/**
+ * v3 language post-filter — unit tests
+ *
+ * Verifies that Tier-2 YouTube candidates are dropped when their title
+ * language does not match the mandala language. YouTube's
+ * `relevanceLanguage` parameter is a ranking hint, not a hard filter,
+ * so Korean-titled videos can leak into English mandalas and
+ * Latin-only-titled videos can leak into Korean mandalas.
+ *
+ * These tests exercise the filter logic directly (the regex predicate)
+ * and via the YouTubeProvider.match() integration path.
+ */
+
+// ─── Logger mock ──────────────────────────────────────────────────────────────
+const noopFn = jest.fn();
+interface NoopLogger {
+  info: jest.Mock;
+  warn: jest.Mock;
+  error: jest.Mock;
+  debug: jest.Mock;
+  child: () => NoopLogger;
+}
+const noopLogger: NoopLogger = {
+  info: noopFn,
+  warn: noopFn,
+  error: noopFn,
+  debug: noopFn,
+  child: (): NoopLogger => noopLogger,
+};
+jest.mock('@/utils/logger', () => ({ logger: noopLogger }));
+
+// ─── v3 config — minimal stub ─────────────────────────────────────────────────
+jest.mock('@/skills/plugins/video-discover/v3/config', () => ({
+  v3Config: {
+    maxQueries: 3,
+    publishedAfterDays: 0,
+    youtubeSearchTimeoutMs: 5000,
+  },
+}));
+
+// ─── keyword-builder — return one fixed query ─────────────────────────────────
+jest.mock('@/skills/plugins/video-discover/v2/keyword-builder', () => ({
+  buildRuleBasedQueriesSync: jest.fn().mockReturnValue([{ query: 'test query', cellIndex: 0 }]),
+}));
+
+// ─── tracing — no-op ──────────────────────────────────────────────────────────
+jest.mock('@/modules/discover-tracing', () => ({
+  recordTrace: jest.fn(),
+}));
+
+// ─── YouTube client — mocked at module level ──────────────────────────────────
+const mockSearchVideos = jest.fn();
+const mockVideosBatch = jest.fn();
+jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
+  searchVideos: mockSearchVideos,
+  videosBatch: mockVideosBatch,
+  parseIsoDuration: jest.requireActual('@/skills/plugins/video-discover/v2/youtube-client')
+    .parseIsoDuration,
+  isShortsByDuration: jest.requireActual('@/skills/plugins/video-discover/v2/youtube-client')
+    .isShortsByDuration,
+  titleIndicatesShorts: jest.requireActual('@/skills/plugins/video-discover/v2/youtube-client')
+    .titleIndicatesShorts,
+  titleHitsBlocklist: jest.requireActual('@/skills/plugins/video-discover/v2/youtube-client')
+    .titleHitsBlocklist,
+}));
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+import { YouTubeProvider } from '../v3/providers/youtube-provider';
+import type { MatchRequest } from '../v3/providers/types';
+
+// ─── Unit tests: language predicate ──────────────────────────────────────────
+
+describe('hasKoreanTitle predicate (inline)', () => {
+  const hasKorean = (text: string): boolean => /[가-힣]/.test(text);
+
+  test('returns true for titles containing Hangul', () => {
+    expect(hasKorean('기타 코드 배우기')).toBe(true);
+    expect(hasKorean('Learn 기타 Chords')).toBe(true);
+    expect(hasKorean('공부 방법')).toBe(true);
+  });
+
+  test('returns false for purely Latin/ASCII titles', () => {
+    expect(hasKorean('Learn Guitar Chords Beginner')).toBe(false);
+    expect(hasKorean('How to play A minor chord')).toBe(false);
+    expect(hasKorean('')).toBe(false);
+    expect(hasKorean('KBO MLB draft highlights 2024')).toBe(false);
+  });
+});
+
+// ─── Integration: YouTubeProvider.match() language post-filter ───────────────
+
+/** Build a minimal MatchRequest for YouTubeProvider.match(). */
+function makeRequest(language: 'en' | 'ko'): MatchRequest {
+  return {
+    mandalaId: 'test-mandala',
+    userId: 'test-user',
+    centerGoal: 'Learn guitar',
+    cells: [{ cellIndex: 0, subGoal: 'Chords', keywords: ['guitar chords', 'beginner'] }],
+    focusTags: [],
+    language,
+    budget: 20,
+    excludeVideoIds: new Set(),
+  };
+}
+
+/** Build a fake search item with the given videoId and title. */
+function makeSearchItem(
+  videoId: string,
+  title: string
+): {
+  id: { videoId: string };
+  snippet: {
+    title: string;
+    description: string;
+    channelTitle: string;
+    channelId: string;
+    publishedAt: string;
+    thumbnails: { high: { url: string } };
+  };
+} {
+  return {
+    id: { videoId },
+    snippet: {
+      title,
+      description: 'test description',
+      channelTitle: 'Test Channel',
+      channelId: 'channel-1',
+      publishedAt: '2024-01-01T00:00:00Z',
+      thumbnails: { high: { url: `https://img/${videoId}.jpg` } },
+    },
+  };
+}
+
+/** Build a fake stats item with a safe long duration (default 5 min). */
+function makeStatsItem(
+  videoId: string,
+  durationIso = 'PT5M'
+): {
+  id: string;
+  statistics: { viewCount: string; likeCount: string };
+  contentDetails: { duration: string };
+} {
+  return {
+    id: videoId,
+    statistics: { viewCount: '50000', likeCount: '1000' },
+    contentDetails: { duration: durationIso },
+  };
+}
+
+describe('YouTubeProvider.match() — language post-filter', () => {
+  let provider: YouTubeProvider;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    provider = new YouTubeProvider(['test-key']);
+  });
+
+  test('en mandala: drops a Korean-titled candidate, keeps English-titled one', async () => {
+    const koreanVideo = makeSearchItem('vid-ko', '기타 코드 배우기 초보자');
+    const englishVideo = makeSearchItem('vid-en', 'Guitar Chords for Beginners');
+
+    mockSearchVideos.mockResolvedValueOnce([koreanVideo, englishVideo]);
+    mockVideosBatch.mockResolvedValueOnce([makeStatsItem('vid-ko'), makeStatsItem('vid-en')]);
+
+    const result = await provider.match(makeRequest('en'));
+
+    expect(result.candidates.map((c) => c.videoId)).toEqual(['vid-en']);
+    expect(result.candidates).toHaveLength(1);
+  });
+
+  test('ko mandala: drops a Latin-only-titled candidate, keeps Korean-titled one', async () => {
+    const koreanVideo = makeSearchItem('vid-ko', '기타 코드 배우기 초보자');
+    const englishVideo = makeSearchItem('vid-en', 'Guitar Chords for Beginners');
+
+    mockSearchVideos.mockResolvedValueOnce([koreanVideo, englishVideo]);
+    mockVideosBatch.mockResolvedValueOnce([makeStatsItem('vid-ko'), makeStatsItem('vid-en')]);
+
+    const result = await provider.match(makeRequest('ko'));
+
+    expect(result.candidates.map((c) => c.videoId)).toEqual(['vid-ko']);
+    expect(result.candidates).toHaveLength(1);
+  });
+
+  test('en mandala: matching-language (English-title) candidate survives', async () => {
+    const englishVideo = makeSearchItem('vid-en', 'Beginner Guitar Lesson Part 1');
+
+    mockSearchVideos.mockResolvedValueOnce([englishVideo]);
+    mockVideosBatch.mockResolvedValueOnce([makeStatsItem('vid-en')]);
+
+    const result = await provider.match(makeRequest('en'));
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]?.videoId).toBe('vid-en');
+  });
+
+  test('ko mandala: matching-language (Korean-title) candidate survives', async () => {
+    const koreanVideo = makeSearchItem('vid-ko', '기초 기타 강의 1편');
+
+    mockSearchVideos.mockResolvedValueOnce([koreanVideo]);
+    mockVideosBatch.mockResolvedValueOnce([makeStatsItem('vid-ko')]);
+
+    const result = await provider.match(makeRequest('ko'));
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]?.videoId).toBe('vid-ko');
+  });
+
+  test('shorts (PT1M = 60s) are dropped before the language filter', async () => {
+    // A Korean-titled short in a ko mandala — dropped by duration (60 <= 75).
+    const shortKorean = makeSearchItem('vid-short-ko', '기타 코드 1분 강의');
+
+    mockSearchVideos.mockResolvedValueOnce([shortKorean]);
+    // PT1M = 60s → isShortsByDuration(60) = true (60 <= SHORTS_MAX_DURATION_SEC=75)
+    mockVideosBatch.mockResolvedValueOnce([makeStatsItem('vid-short-ko', 'PT1M')]);
+
+    const result = await provider.match(makeRequest('ko'));
+
+    expect(result.candidates).toHaveLength(0);
+  });
+});

--- a/src/skills/plugins/video-discover/executor.ts
+++ b/src/skills/plugins/video-discover/executor.ts
@@ -49,6 +49,7 @@ import {
 } from '@/prompts/search-query-generator';
 import { rerankBatch, type RerankCandidate } from './sources/llm-reranker';
 import { MS_PER_DAY } from '@/utils/time-constants';
+import { SHORTS_MAX_DURATION_SEC } from './v2/youtube-client';
 
 const log = logger.child({ module: 'video-discover' });
 const YOUTUBE_API_BASE = 'https://www.googleapis.com/youtube/v3';
@@ -362,8 +363,6 @@ const TITLE_BLOCKLIST: readonly string[] = [
   '#광고',
 ];
 
-/** Minimum duration in seconds (Fix 3, CP358) — anything shorter is a Short. */
-const MIN_DURATION_SEC = 60;
 /**
  * Channel diversity cap (Fix 3, CP358). If a single channel contributes
  * `>= GLOBAL_CHANNEL_CAP_THRESHOLD` videos to the final 24, collapse it to
@@ -977,7 +976,7 @@ export const executor: SkillExecutor = {
     let droppedLangMismatch = 0;
     const hasKorean = (text: string) => /[가-힣]/.test(text);
     const survivedFix3 = allCandidates.filter((c) => {
-      if (c.durationSec !== null && c.durationSec < MIN_DURATION_SEC) {
+      if (c.durationSec !== null && c.durationSec <= SHORTS_MAX_DURATION_SEC) {
         droppedShorts += 1;
         return false;
       }

--- a/src/skills/plugins/video-discover/v2/youtube-client.ts
+++ b/src/skills/plugins/video-discover/v2/youtube-client.ts
@@ -502,13 +502,17 @@ export const V2_TITLE_BLOCKLIST: ReadonlyArray<string> = [
  *     mandala-relevant content. The 180s gate was killing the news
  *     and highlights domain. `titleIndicatesShorts` still catches
  *     explicit `#shorts` hashtag cases in the 60-180s range.
+ *   - 2026-05-15: raised 60s → 75s. Outputs still surfaced cards
+ *     slightly over the 60s line; 75s clears that band.
  *
  * Null duration is treated as shorts (defensive drop). Videos.list
  * occasionally omits `contentDetails.duration` for shorts specifically,
  * so null → drop prevents that hole.
  */
+export const SHORTS_MAX_DURATION_SEC = 75;
+
 export function isShortsByDuration(durationSec: number | null): boolean {
-  return durationSec === null || durationSec <= 60;
+  return durationSec === null || durationSec <= SHORTS_MAX_DURATION_SEC;
 }
 
 /**

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -72,6 +72,14 @@ import type { CellDefinition } from './providers/types';
 
 const log = logger.child({ module: 'video-discover/v3/executor' });
 
+/**
+ * Returns true if the text contains at least one Hangul syllable block.
+ * Used by the Tier-2 language post-filter: YouTube's `relevanceLanguage`
+ * is a ranking hint, not a hard filter, so Korean videos can leak into
+ * English mandalas and Latin-only titles can leak into Korean mandalas.
+ */
+const hasKoreanTitle = (text: string): boolean => /[가-힣]/.test(text);
+
 const TTL_DAYS = 7;
 const RECOMMENDATION_STATUS_PENDING = 'pending';
 const WEIGHT_VERSION = 3;
@@ -683,6 +691,7 @@ interface Tier2Debug {
   droppedShortsDuration: number;
   droppedShortsTitle: number;
   droppedBlocklist: number;
+  droppedLangMismatch: number;
   droppedQuality: number;
   afterFilter: number;
   existingExcluded: number;
@@ -733,6 +742,7 @@ function makeEmptyDebug(input: Tier2Input): Tier2Debug {
     droppedShortsDuration: 0,
     droppedShortsTitle: 0,
     droppedBlocklist: 0,
+    droppedLangMismatch: 0,
     droppedQuality: 0,
     afterFilter: 0,
     existingExcluded: 0,
@@ -882,6 +892,15 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     }
     if (titleHitsBlocklist(p.title)) {
       debug.droppedBlocklist++;
+      continue;
+    }
+    // Title-based language post-filter (ported from legacy executor.ts §978-996).
+    // YouTube's relevanceLanguage is a ranking hint, not a hard filter — Korean
+    // videos leak into English mandalas (and vice versa). Only applied to Tier-2
+    // live YouTube candidates; Tier-1 video_pool is already language-filtered at
+    // the DB level.
+    if (hasKoreanTitle(p.title) !== (input.state.language === 'ko')) {
+      debug.droppedLangMismatch++;
       continue;
     }
     enriched.push({

--- a/src/skills/plugins/video-discover/v3/providers/youtube-provider.ts
+++ b/src/skills/plugins/video-discover/v3/providers/youtube-provider.ts
@@ -255,6 +255,7 @@ export class YouTubeProvider implements VideoProvider {
     const validCellIndices = new Set(request.cells.map((c) => c.cellIndex));
 
     const candidates: VideoCandidate[] = [];
+    let droppedLangMismatch = 0;
     for (const p of rawPool) {
       // Skip already-excluded videos before doing any heavier work.
       if (request.excludeVideoIds.has(p.videoId)) continue;
@@ -265,6 +266,18 @@ export class YouTubeProvider implements VideoProvider {
       if (isShortsByDuration(durationSec)) continue;
       if (titleIndicatesShorts(p.title)) continue;
       if (titleHitsBlocklist(p.title)) continue;
+      // Title-based language post-filter. YouTube's relevanceLanguage is a
+      // ranking hint, not a hard filter — Korean videos can leak into English
+      // mandalas and vice versa. This mirrors the legacy executor.ts post-filter.
+      const titleHasKorean = /[가-힣]/.test(p.title);
+      if (request.language === 'en' && titleHasKorean) {
+        droppedLangMismatch++;
+        continue;
+      }
+      if (request.language === 'ko' && !titleHasKorean) {
+        droppedLangMismatch++;
+        continue;
+      }
 
       const viewCount =
         s?.statistics?.viewCount != null ? parseInt(s.statistics.viewCount, 10) : null;
@@ -302,7 +315,7 @@ export class YouTubeProvider implements VideoProvider {
     const latencyMs = Date.now() - t0;
 
     log.info(
-      `[YouTubeProvider] mandala=${request.mandalaId} queries=${queries.length} rawPool=${rawPool.length} candidates=${candidates.length} quota=${totalQuota} latencyMs=${latencyMs}`
+      `[YouTubeProvider] mandala=${request.mandalaId} queries=${queries.length} rawPool=${rawPool.length} droppedLangMismatch=${droppedLangMismatch} candidates=${candidates.length} quota=${totalQuota} latencyMs=${latencyMs}`
     );
 
     return {


### PR DESCRIPTION
## Summary

- **FIX 1 — Language post-filter ported to v3 Tier-2**: YouTube's `relevanceLanguage` is a ranking *hint*, not a hard filter. Korean-titled videos leak into English mandalas (and Latin-only-titled videos leak into Korean mandalas) via the v3 live-search path. The legacy `executor.ts` had a `/[가-힣]/` title guard (~line 978-996) that v3 was missing entirely. This PR ports the filter to both the `runTier2` filter block in `v3/executor.ts` (primary production path) and to `YouTubeProvider.match()` Step 5 in `v3/providers/youtube-provider.ts` (provider abstraction). Adds a `droppedLangMismatch` debug counter alongside the existing `droppedShortsDuration` / `droppedShortsTitle` / `droppedBlocklist` counters. The filter is applied only to Tier-2 live YouTube candidates; Tier-1 `video_pool` matches are already language-filtered at the DB level.

- **FIX 2 — Shorts threshold 60s → 75s; consolidate duplicate constant**: User feedback indicated outputs still surfaced cards slightly over the 60s line; 75s clears that band. Added `export const SHORTS_MAX_DURATION_SEC = 75` to `v2/youtube-client.ts` as the single source of truth. The legacy `executor.ts` previously had a local `const MIN_DURATION_SEC = 60` that was a duplicate; it is now deleted and replaced with an import of `SHORTS_MAX_DURATION_SEC`. Threshold-history doc-comment block in `youtube-client.ts` updated with 2026-05-15 entry. Tests updated: `isShortsByDuration(61)` and `isShortsByDuration(75)` now correctly return `true`; `isShortsByDuration(76)` returns `false`.

## Root causes

- **FIX 1**: `relevanceLanguage=en` is a ranking signal, not a filter contract. YouTube returns Korean-titled results ranked lower but still present. The v3 Tier-2 pipeline had no post-search title check; legacy executor.ts did.
- **FIX 2**: The 60s threshold was a local constant duplicated across two files. Centralizing to `SHORTS_MAX_DURATION_SEC` in `youtube-client.ts` satisfies the CLAUDE.md "no magic numbers, consolidate duplicates in same PR" rule.

## Files changed

| File | Change |
|------|--------|
| `v2/youtube-client.ts` | Add `SHORTS_MAX_DURATION_SEC = 75`; update `isShortsByDuration`; add threshold-history entry |
| `v3/executor.ts` | Add `hasKoreanTitle` helper; add `droppedLangMismatch` to `Tier2Debug` interface + `makeEmptyDebug`; apply lang filter in `runTier2` filter block |
| `v3/providers/youtube-provider.ts` | Apply lang filter in Step 5; add `droppedLangMismatch` counter to log line |
| `executor.ts` (legacy) | Delete `MIN_DURATION_SEC = 60`; import `SHORTS_MAX_DURATION_SEC`; update filter comparison to `<=` |
| `__tests__/v2-youtube-client.test.ts` | Update `isShortsByDuration` assertions for 75s threshold |
| `__tests__/v3-lang-filter.test.ts` | New — 7 tests covering en/ko mandala drops, matching-language survival, shorts-before-lang ordering |

## Test plan

- [x] `npx tsc --noEmit` — clean (0 errors)
- [x] `v3-lang-filter.test.ts` — 7/7 pass (new test file)
- [x] `v2-youtube-client.test.ts` — all new assertions pass; 1 pre-existing failure (`does NOT rotate on non-quota 403`) confirmed present on `main` before this PR
- [x] `v3-upsert-slots.test.ts` — passes (mocks `isShortsByDuration`, no change needed; verified compiles)
- [ ] Deploy blocked per brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)