### PR TITLE
fix(v3): Tier 2 overfetch — always run live YouTube search, ignore pool fill

### DIFF
--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -38,6 +38,7 @@ describe('loadV3Config', () => {
       enableRedisProvider: false, // PR-Y0g default (kill switch)
       tier1Sources: [...DEFAULT_TIER1_SOURCES], // CP457 default ['v2_promoted']
       semanticMinCosine: SEMANTIC_MIN_COSINE, // CP457 default 0.35 (mandala-filter.ts const)
+      tier2Overfetch: true, // overfetch default — Tier 2 always runs a full per-cell budget
     });
   });
 
@@ -111,6 +112,7 @@ describe('loadV3Config', () => {
       enableRedisProvider: false, // PR-Y0g default (kill switch)
       tier1Sources: [...DEFAULT_TIER1_SOURCES], // CP457 default ['v2_promoted']
       semanticMinCosine: SEMANTIC_MIN_COSINE, // CP457 default 0.35 (mandala-filter.ts const)
+      tier2Overfetch: true, // overfetch default — Tier 2 always runs a full per-cell budget
     });
   });
 
@@ -250,5 +252,17 @@ describe('loadV3Config', () => {
     // Explicit off / empty / unset all collapse to default false
     expect(loadV3Config({ V3_ENABLE_REDIS_PROVIDER: 'false' }).enableRedisProvider).toBe(false);
     expect(loadV3Config({ V3_ENABLE_REDIS_PROVIDER: '' }).enableRedisProvider).toBe(false);
+  });
+
+  test('V3_TIER2_OVERFETCH defaults true; explicit false reverts to deficit-fill', () => {
+    // Default unset → overfetch ON (Tier 2 always runs a full per-cell budget)
+    expect(loadV3Config({}).tier2Overfetch).toBe(true);
+    // Explicit re-affirm
+    expect(loadV3Config({ V3_TIER2_OVERFETCH: 'true' }).tier2Overfetch).toBe(true);
+    expect(loadV3Config({ V3_TIER2_OVERFETCH: '  TRUE  ' }).tier2Overfetch).toBe(true);
+    // Explicit false → rollback to deficit-fill behaviour
+    expect(loadV3Config({ V3_TIER2_OVERFETCH: 'false' }).tier2Overfetch).toBe(false);
+    // Empty string → booleanFlag treats as false (matches other flags' contract)
+    expect(loadV3Config({ V3_TIER2_OVERFETCH: '' }).tier2Overfetch).toBe(false);
   });
 });

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -305,6 +305,7 @@ export const v3EnvSchema = z.object({
   V3_ENABLE_REDIS_PROVIDER: booleanFlag.optional().default(false as unknown as string),
   V3_TIER1_SOURCES: tier1Sources,
   V3_SEMANTIC_MIN_COSINE: semanticMinCosine,
+  V3_TIER2_OVERFETCH: booleanFlag.optional().default(true as unknown as string),
 });
 
 export interface V3Config {
@@ -327,6 +328,13 @@ export interface V3Config {
   enableRedisProvider: boolean;
   tier1Sources: ReadonlyArray<string>;
   semanticMinCosine: number;
+  /**
+   * When true (default), Tier 2 always runs and fetches a full per-cell
+   * budget of fresh YouTube candidates regardless of Tier 1 fill — live
+   * search is the main source, the pool is a minimal device. When false,
+   * Tier 2 reverts to deficit-fill (`need = V3_TARGET_PER_CELL - have`).
+   */
+  tier2Overfetch: boolean;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -350,6 +358,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_ENABLE_REDIS_PROVIDER: env['V3_ENABLE_REDIS_PROVIDER'],
     V3_TIER1_SOURCES: env['V3_TIER1_SOURCES'],
     V3_SEMANTIC_MIN_COSINE: env['V3_SEMANTIC_MIN_COSINE'],
+    V3_TIER2_OVERFETCH: env['V3_TIER2_OVERFETCH'],
   });
   if (!parsed.success) {
     return {
@@ -372,6 +381,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       enableRedisProvider: DEFAULT_ENABLE_REDIS_PROVIDER,
       tier1Sources: [...DEFAULT_TIER1_SOURCES],
       semanticMinCosine: SEMANTIC_MIN_COSINE,
+      tier2Overfetch: true,
     };
   }
   return {
@@ -394,6 +404,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     enableRedisProvider: parsed.data.V3_ENABLE_REDIS_PROVIDER,
     tier1Sources: parsed.data.V3_TIER1_SOURCES,
     semanticMinCosine: parsed.data.V3_SEMANTIC_MIN_COSINE,
+    tier2Overfetch: parsed.data.V3_TIER2_OVERFETCH,
   };
 }
 

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -416,12 +416,19 @@ async function executeImpl(ctx: ExecuteContext): Promise<ExecuteResult> {
     }
   }
 
-  // ── Tier 2: realtime fallback for deficit cells ────────────────────
+  // ── Tier 2: realtime YouTube search ────────────────────────────────
+  // V3_TIER2_OVERFETCH (default true): Tier 2 ALWAYS runs and fetches a
+  // full per-cell budget of *fresh* YouTube candidates regardless of how
+  // many the pool (Tier 1) supplied — the pool is a minimal device, live
+  // search is the main source. Pre-overfetch Tier 2 was budgeted as
+  // `need = V3_TARGET_PER_CELL - have`, so a pool-filled mandala fetched
+  // ~zero fresh videos ("돌려막기" — recycling pool cards). Set
+  // V3_TIER2_OVERFETCH=false to restore the deficit-fill behaviour.
   let tier2Count = 0;
   let tier2QueriesUsed = 0;
   let tier2Debug: Tier2Debug | null = null;
   const totalHave = slots.length;
-  if (totalHave < V3_TARGET_TOTAL) {
+  if (v3Config.tier2Overfetch || totalHave < V3_TARGET_TOTAL) {
     const slotsByCell = new Map<number, number>();
     for (const s of slots) {
       slotsByCell.set(s.cellIndex, (slotsByCell.get(s.cellIndex) ?? 0) + 1);
@@ -429,7 +436,11 @@ async function executeImpl(ctx: ExecuteContext): Promise<ExecuteResult> {
     const deficitCells: Array<{ cellIndex: number; need: number }> = [];
     for (let i = 0; i < V3_NUM_CELLS; i++) {
       const have = slotsByCell.get(i) ?? 0;
-      const need = Math.max(0, V3_TARGET_PER_CELL - have);
+      // Overfetch: target a full per-cell budget of fresh candidates,
+      // ignoring `have`. Deficit-fill: only top up to the per-cell target.
+      const need = v3Config.tier2Overfetch
+        ? V3_TARGET_PER_CELL
+        : Math.max(0, V3_TARGET_PER_CELL - have);
       if (need > 0) deficitCells.push({ cellIndex: i, need });
     }
 


### PR DESCRIPTION
## Problem (P0 — service-breaking)

The v3 video-discover pipeline was recycling pool cards instead of fetching fresh YouTube results ("돌려막기"). A user revisiting/creating a mandala saw the same frozen pool-derived cards and ~zero fresh YouTube content.

### Root cause (traced, not guessed)

Tier 2 (live YouTube `search.list`) was:
1. **Gated** behind `if (totalHave < V3_TARGET_TOTAL)` — skipped entirely once Tier 1 filled the target.
2. **Budgeted as deficit-fill**: `need = V3_TARGET_PER_CELL - have`. If the pool (Tier 1) supplied a cell, Tier 2 fetched only the gap.

Now that #638 made Tier 1 fast and reliable, the pool fills cells consistently → Tier 2 fetches almost nothing.

**Measured on prod traces:**
- ko mandala, 59 Tier-1 pool matches → only **8/60 (13%)** delivered cards were fresh YouTube.
- en mandala, sparse pool → 26/52 (50%) fresh.

This inverts the intended design — "the pool is a minimal device, live search is the main source."

## Fix

New `V3_TIER2_OVERFETCH` flag (**default `true`**):
- Tier 2 **always runs**, regardless of pool fill.
- Per-cell budget = full `V3_TARGET_PER_CELL` of *fresh* candidates (ignores `have`), so a pool-filled mandala still fetches a full budget of fresh YouTube videos.
- `V3_TIER2_OVERFETCH=false` → restores the old deficit-fill behaviour (rollback without code revert).

### Files
- `v3/config.ts` — add `tier2Overfetch` (env `V3_TIER2_OVERFETCH`, default true)
- `v3/executor.ts` — Tier 2 gate `tier2Overfetch || totalHave < target`; per-cell `need` = full `V3_TARGET_PER_CELL` when overfetch on
- `v3/__tests__/config.test.ts` — cover the new flag + update the two full-config `toEqual` assertions

## Test plan
- [x] `tsc --noEmit` clean
- [x] `config.test.ts` 22/22 pass (incl. new `V3_TIER2_OVERFETCH` test)
- [ ] Post-deploy: create a ko mandala (rich pool), confirm trace shows `tier2.search.list` running + fresh-YouTube share of delivered cards rises well above 13%
- [ ] Watch the 12s creation SLO — more Tier 2 = more YouTube quota + latency; revert via flag if it regresses

## Notes
- Not a regression from a prior PR — Tier 2 has always been deficit-fill; #638 (Tier 1 speedup) exposed the latent suppression.
- Pre-existing test rot (`video-discover/__tests__/executor.test.ts` — `logger.info is not a function` mock-shape bug) confirmed identical with/without this branch; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)