### PR TITLE
fix(v3): exclude user's already-owned videos at the source

### DIFF
--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -304,6 +304,27 @@ async function executeImpl(ctx: ExecuteContext): Promise<ExecuteResult> {
   }
   const existingVideoIds = new Set(slots.map((s) => s.videoId));
 
+  // Exclude videos the user already owns in ANY mandala. user_video_states
+  // has @@unique([user_id, videoId]) — a video lives in one mandala per
+  // user — so a video owned elsewhere can never be inserted here anyway.
+  // Filtering it at the source (before Tier 1 + Tier 2) stops the pipeline
+  // from computing + SSE-streaming candidates that auto-add would silently
+  // drop, which is what made the dashboard count shrink on refresh.
+  try {
+    const owned = await getPrismaClient().youtube_videos.findMany({
+      where: { userState: { some: { user_id: ctx.userId } } },
+      select: { youtube_video_id: true },
+    });
+    for (const v of owned) existingVideoIds.add(v.youtube_video_id);
+    log.info(`[exclude] user owns ${owned.length} videos across mandalas — excluded from this run`);
+  } catch (err) {
+    log.warn(
+      `[exclude] failed to load user-owned video ids (continuing unfiltered): ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+
   const tier1Matches = v3Config.enableTier1Cache
     ? await matchFromVideoPool({
         mandalaId,


### PR DESCRIPTION
## Problem

The dashboard card count shrank when the user refreshed. Diagnosed via prod traces on two freshly-created mandalas:

- ko `0ee995bd`: `recommendation_cache` = 50 → `auto_add` inserted **33** → `user_video_states` = 33
- en `2f2773f9`: `recommendation_cache` = 28 → `auto_add` inserted **25** → `user_video_states` = 25

The gap (50 → 33) is videos the user **already owns in another mandala**. `user_video_states` has `@@unique([user_id, videoId])` — a video lives in exactly one mandala per user — so `auto_add` silently drops them. During creation the SSE stream showed the pre-drop count; on refresh the dashboard re-fetched `user_video_states` and settled to the smaller persisted count → visible "decrease".

(The 6 current test mandalas are all coding/AI-themed, so overlap is unusually high — 34% for the ko one. Normal cross-theme usage overlaps far less, e.g. the en mandala only lost 3.)

## Fix

Load the user's owned `youtube_video_id`s once and seed them into `existingVideoIds` **before** Tier 1 and Tier 2 run. Both tiers already filter candidates against this set, so owned videos are excluded at the source:

- The pipeline only ever computes genuinely-new candidates → SSE matches the DB → no shrink on refresh.
- The over-fetch budget from #640 is spent on fresh content instead of un-insertable duplicates.

Non-fatal: a failed lookup logs a warning and continues unfiltered (falls back to prior behaviour).

### File
- `v3/executor.ts` — +21 lines, a `try/catch` block right after `existingVideoIds` is declared.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Post-deploy: create two same-theme mandalas in sequence; confirm the 2nd one's `recommendation_cache` count ≈ `auto_add rowsInserted` ≈ `user_video_states` (no gap), and the dashboard count is stable across refresh
- [ ] Confirm `[exclude] user owns N videos` appears in logs

## Notes
- Follow-up to #640 (Tier 2 overfetch). Branch is off `main` post-#640-merge.
- No unit test added: `video-discover/__tests__/executor.test.ts` is pre-broken (`logger.info is not a function` mock-shape rot — confirmed identical with/without this branch). Verified by prod trace instead, same as #640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)