### PR TITLE
fix(v3): dedupe rerank candidates by videoId, not (cell, videoId)

### DIFF
--- a/src/skills/plugins/video-discover/v3/__tests__/hybrid-rerank.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/hybrid-rerank.test.ts
@@ -34,7 +34,7 @@ jest.mock('@/modules/database/client', () => ({
 
 import {
   applyHybridRerank,
-  groupByCellVideo,
+  groupByVideo,
   normalizeScores0to100,
   type RerankSlot,
 } from '../hybrid-rerank';
@@ -69,17 +69,20 @@ describe('normalizeScores0to100', () => {
   });
 });
 
-describe('groupByCellVideo', () => {
-  it('keeps highest score per (cell, video) pair', () => {
+describe('groupByVideo', () => {
+  it('collapses a video to one slot across cells, keeping its highest score', () => {
+    // Same videoId in cells 0, 0, 1 — recommendation_cache's
+    // @@unique([user, mandala, video]) would collapse these anyway, so
+    // the rerank dedupes by videoId (not cell:video) to avoid spending
+    // the top-N budget on duplicates.
     const slots: RerankSlot[] = [
       baseSlot({ videoId: 'a', cellIndex: 0, rec_score: 0.4 }),
       baseSlot({ videoId: 'a', cellIndex: 0, rec_score: 0.9 }),
       baseSlot({ videoId: 'a', cellIndex: 1, rec_score: 0.3 }),
     ];
-    const out = groupByCellVideo(slots);
-    expect(out.length).toBe(2);
+    const out = groupByVideo(slots);
+    expect(out.length).toBe(1);
     expect(out[0]!.rec_score).toBe(0.9);
-    expect(out[1]!.rec_score).toBe(0.3);
   });
 
   it('returns slots sorted by rec_score desc', () => {
@@ -88,7 +91,7 @@ describe('groupByCellVideo', () => {
       baseSlot({ videoId: 'b', cellIndex: 0, rec_score: 0.9 }),
       baseSlot({ videoId: 'c', cellIndex: 0, rec_score: 0.5 }),
     ];
-    const out = groupByCellVideo(slots);
+    const out = groupByVideo(slots);
     expect(out.map((s) => s.videoId)).toEqual(['b', 'c', 'a']);
   });
 });

--- a/src/skills/plugins/video-discover/v3/hybrid-rerank.ts
+++ b/src/skills/plugins/video-discover/v3/hybrid-rerank.ts
@@ -112,24 +112,25 @@ export function normalizeScores0to100(raw: ReadonlyArray<number>): number[] {
 }
 
 /**
- * Group slots by videoId, keep the highest-scored slot per video.
- * Returns slots sorted by rec_score desc. Pattern borrowed from
- * YT-Navigator's `Counter(...).most_common(5)` + group_by_video.
+ * Group slots by videoId, keeping the highest-scored slot per video (its
+ * best-fit cell). Returns slots sorted by rec_score desc.
  *
- * Note: in the Insighta model each card is a (mandala, cell, video) tuple,
- * so dedupe by videoId might collapse cards across cells. To preserve cell
- * diversity, we group by (cellIndex, videoId) — keeping per-cell top scored.
+ * The dedupe key is videoId, NOT (cellIndex, videoId): recommendation_cache
+ * has @@unique([user_id, mandala_id, video_id]) — cell_index is not in the
+ * key — so upsertSlots' `ON CONFLICT` collapses a video to one row per
+ * mandala regardless of cell anyway. Keeping per-cell copies here only
+ * inflated the Cohere document list and let cross-cell duplicates eat the
+ * top-N budget (measured: a 124-doc rerank → top-N 96 → 50 distinct rows).
  */
-export function groupByCellVideo<S extends RerankSlot>(slots: ReadonlyArray<S>): S[] {
-  const byKey = new Map<string, S>();
+export function groupByVideo<S extends RerankSlot>(slots: ReadonlyArray<S>): S[] {
+  const byVideo = new Map<string, S>();
   for (const s of slots) {
-    const key = `${s.cellIndex}:${s.videoId}`;
-    const existing = byKey.get(key);
+    const existing = byVideo.get(s.videoId);
     if (!existing || s.rec_score > existing.rec_score) {
-      byKey.set(key, s);
+      byVideo.set(s.videoId, s);
     }
   }
-  return Array.from(byKey.values()).sort((a, b) => b.rec_score - a.rec_score);
+  return Array.from(byVideo.values()).sort((a, b) => b.rec_score - a.rec_score);
 }
 
 export interface KeywordCandidate {
@@ -380,12 +381,12 @@ export async function applyHybridRerank<S extends RerankSlot>(
     return { slots: [], stats };
   }
 
-  const cellVideoDeduped = groupByCellVideo(semanticPool);
+  const videoDeduped = groupByVideo(semanticPool);
 
   // Build the document list for Cohere — title is the dominant signal (matches
   // YT-Navigator's `doc.page_content`); cell-context is added so the cross-encoder
   // distinguishes the same title across cells.
-  const documents = cellVideoDeduped.map((s) => s.title);
+  const documents = videoDeduped.map((s) => s.title);
   stats.afterDedupe = documents.length;
 
   let cohereRes: Awaited<ReturnType<typeof rerank>>;
@@ -410,14 +411,14 @@ export async function applyHybridRerank<S extends RerankSlot>(
       reason: stats.reason,
       err: stats.cohereError,
     });
-    return { slots: cellVideoDeduped, stats };
+    return { slots: videoDeduped, stats };
   }
 
   stats.cohereLatencyMs = cohereRes.latencyMs;
 
   if (cohereRes.results.length === 0) {
     stats.reason = 'no-candidates';
-    return { slots: cellVideoDeduped, stats };
+    return { slots: videoDeduped, stats };
   }
 
   // Normalize Cohere relevance_scores to 0–100 within this batch, then
@@ -437,7 +438,7 @@ export async function applyHybridRerank<S extends RerankSlot>(
   for (let i = 0; i < cohereRes.results.length; i++) {
     const r = cohereRes.results[i];
     if (!r) continue;
-    const slot = cellVideoDeduped[r.index];
+    const slot = videoDeduped[r.index];
     if (!slot) continue;
     const normScore = normalized[i] != null ? normalized[i]! / 100 : slot.rec_score;
     reorderedSlots.push({


### PR DESCRIPTION
## Problem (quality / card count — item #1 from the goal audit)

Analysis of prod traces showed Cohere rerank itself is **healthy** — on a well-matched mandala it scores top candidates at 0.99 with a clean distribution. The earlier "relevanceScore ≈ 0" reading was a single weak-candidate-pool run, not a rerank fault.

The real defect: `groupByCellVideo` keyed its dedupe map by `${cellIndex}:${videoId}`, keeping a separate copy of a video for **every cell** the mandala filter routed it to. But `recommendation_cache` has `@@unique([user_id, mandala_id, video_id])` — `cell_index` is not in the key — so `upsertSlots`' `ON CONFLICT` collapses a video to one row per mandala anyway.

The per-cell copies never reached the user. They only:
- inflated the Cohere document list (extra rerank cost), and
- let cross-cell duplicates consume the `top_n` budget.

**Measured on prod** (mandala `0ee995bd`): a **124-document** rerank → `top_n: 96` → only **50 distinct** `recommendation_cache` rows. ~46 of the 96 reranked slots were cross-cell duplicates of the other 50 — nearly half the budget wasted.

## Fix

Rename `groupByCellVideo` → `groupByVideo` and key the dedupe map by `videoId` only, keeping each video's highest-scored (best-fit) cell. The Cohere document list is now distinct, so `top_n` maps ~1:1 to delivered cards.

### Files
- `v3/hybrid-rerank.ts` — dedupe key `cellIndex:videoId` → `videoId`; rename function + the `videoDeduped` variable; comment explains the alignment with the `recommendation_cache` unique key
- `v3/__tests__/hybrid-rerank.test.ts` — updated the `groupByVideo` describe block: same video across cells now collapses to one slot

## Test plan
- [x] `tsc --noEmit` clean
- [x] `hybrid-rerank.test.ts` 8/8 pass
- [ ] Post-deploy: create a mandala, confirm the `hybrid_rerank.cohere` trace's `document_count` ≈ distinct videos, and `recommendation_cache` distinct count rises toward `top_n`

## Notes
- Follow-up to #640 / #641. Branch off `main` post-merge.
- Cohere rerank, the candidate-supply quality for abstract goals (keyword-builder query quality), and the 12s SLO are separate items — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)