### PR TITLE
fix(dashboard): skip mandala-switch skeleton grace when no fetch is in flight

### DIFF
--- a/frontend/src/features/card-management/model/useLocalCards.ts
+++ b/frontend/src/features/card-management/model/useLocalCards.ts
@@ -271,6 +271,7 @@ export function useLocalCards() {
 
     // Loading states
     isLoading: listQuery.isLoading,
+    isFetching: listQuery.isFetching,
     isAdding: addCard.isPending,
     isUpdating: updateCard.isPending,
     isDeleting: deleteCard.isPending,

--- a/frontend/src/pages/index/model/useCardOrchestrator.ts
+++ b/frontend/src/pages/index/model/useCardOrchestrator.ts
@@ -64,6 +64,9 @@ export interface UseCardOrchestratorReturn {
   pendingLocalCards: InsightCard[];
   // Loading state
   isLoading: boolean;
+  // True while either underlying card query is fetching (incl. background
+  // refetch with keepPreviousData) — distinct from isLoading (first load only).
+  isFetching: boolean;
   // Card actions
   handleCardClick: (card: InsightCard) => void;
   handleCardDrop: (
@@ -114,7 +117,11 @@ export function useCardOrchestrator(
   const queryClient = useQueryClient();
 
   // YouTube sync
-  const { data: allVideoStates, isLoading: isVideoStatesLoading } = useAllVideoStates();
+  const {
+    data: allVideoStates,
+    isLoading: isVideoStatesLoading,
+    isFetching: isVideoStatesFetching,
+  } = useAllVideoStates();
   const updateVideoState = useUpdateVideoState();
   const { autoSummaryEnabled } = useYouTubeAuth();
 
@@ -123,6 +130,7 @@ export function useCardOrchestrator(
     cards: persistedLocalCards,
     subscription,
     isLoading: isLocalCardsLoading,
+    isFetching: isLocalCardsFetching,
     addCard: addLocalCard,
     updateCard: updateLocalCard,
     deleteCard: deleteLocalCard,
@@ -1464,6 +1472,7 @@ export function useCardOrchestrator(
     displayCards,
     displayTitle,
     isLoading: isLocalCardsLoading || isVideoStatesLoading,
+    isFetching: isLocalCardsFetching || isVideoStatesFetching,
     syncedCards,
     newlySyncedCards,
     newlySyncedCountByMandala,

--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -252,16 +252,33 @@ function AuthenticatedApp() {
 
   // 5c'. Mandala-switch grace period: prevents the "0 cards" empty-state flash
   // that surfaced on every mandala switch because keepPreviousData + client-side
-  // mandala_id filter yields cards.length=0 for a brief moment before the next
-  // useAllVideoStates fetch lands. During the grace window we force isLoading
-  // downstream (skeleton instead of empty-state).
+  // mandala_id filter yields cards.length=0 for a brief moment while a card
+  // query is in flight. During the grace window we force isLoading downstream
+  // (skeleton instead of empty-state).
   const [mandalaSwitchGrace, setMandalaSwitchGrace] = useState(false);
+  // Render-assigned ref so the switch effect can read the current fetching
+  // state without re-running on every isFetching toggle.
+  const cardsFetchingRef = useRef(cards.isFetching);
+  cardsFetchingRef.current = cards.isFetching;
   useEffect(() => {
     if (!effectiveMandalaId) return;
+    // Only enter the grace if a card fetch is actually in flight at switch
+    // time. For a cached / genuinely-empty mandala the client-side filter
+    // resolves synchronously, so entering the grace would just flash the
+    // skeleton for one render (visible blink) with nothing to wait for.
+    if (!cardsFetchingRef.current) return;
     setMandalaSwitchGrace(true);
+    // 3s is a hard cap for a hung fetch; the effect below clears it earlier.
     const timer = setTimeout(() => setMandalaSwitchGrace(false), 3000);
     return () => clearTimeout(timer);
   }, [effectiveMandalaId]);
+  // Clear the grace as soon as the in-flight card fetch settles, so the
+  // skeleton never lingers past the actual load.
+  useEffect(() => {
+    if (mandalaSwitchGrace && !cards.isFetching) {
+      setMandalaSwitchGrace(false);
+    }
+  }, [mandalaSwitchGrace, cards.isFetching]);
 
   useEffect(() => {
     if (!isNewMandalaActive) return;


### PR DESCRIPTION
## Summary

Switching to an empty (or fully cached) mandala showed the card skeleton with nothing to actually load — originally a fixed 3s dead wait, and after a first gate-on-settle attempt, a one-render visible blink.

`mandalaSwitchGrace` exists to mask the `keepPreviousData` flicker **while a card query is in flight**. It was being entered unconditionally on every mandala switch.

- Enter the grace **only if a card fetch is actually in flight** at switch time — read via a render-assigned ref so the effect does not re-run on every `isFetching` toggle.
- Clear the grace as soon as the in-flight fetch settles; the 3s timeout is kept purely as a hard cap for a hung fetch.
- Expose `isFetching` from `useCardOrchestrator` / `useLocalCards` (both back React Query `useQuery` instances) to drive this.

Net: empty / cached mandala → empty state shows immediately, no skeleton, no blink. Mandala switch with a real in-flight fetch → skeleton still masks the flicker, cleared the moment the fetch lands.

## Test plan

- [x] `tsc --noEmit` (frontend) — pass
- [x] `vitest run` — 34 files / 309 tests pass
- [x] `npm run build` — pass
- [x] browser smoke — `/` + `/mandalas/new` → 200, dev log clean
- [x] manual: switching to an empty mandala no longer flashes the skeleton (reporter-confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)