### PR TITLE
fix(feed): drop status filter from recommendation feed queries

### DIFF
--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -21,7 +21,6 @@ import {
 } from '../../config/explore';
 import {
   RECOMMENDATION_FETCH_LIMIT,
-  RECOMMENDATION_DEFAULT_STATUS,
   RECOMMENDATION_DEFAULT_MODE,
 } from '../../config/recommendations';
 import { config } from '../../config';
@@ -1754,11 +1753,16 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     // invalidate) could shuffle visually identical cards. uuid asc is
     // arbitrary but stable across refetches, so the grid no longer
     // re-arranges on background polling.
+    // No `status` filter: `status` is auto_add's bookkeeping (pending = not
+    // yet promoted to user_video_states, shown = promoted) — NOT a display
+    // gate. Filtering on status='pending' here made the feed empty itself
+    // the instant auto_add flipped its rows to 'shown', so cards "appeared
+    // then disappeared". The feed shows the mandala's non-expired
+    // recommendations regardless of promotion state.
     const rows = await prisma.recommendation_cache.findMany({
       where: {
         user_id: userId,
         mandala_id: mandalaId,
-        status: RECOMMENDATION_DEFAULT_STATUS,
         expires_at: { gt: new Date() },
         ...(cellIndexFilter !== undefined ? { cell_index: cellIndexFilter } : {}),
       },
@@ -2494,11 +2498,14 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         }
       }
 
+      // No `status` filter — see the /recommendations REST handler above:
+      // `status` is auto_add bookkeeping, not a display gate. Filtering it
+      // here made the SSE reconnect backlog come back empty once auto_add
+      // ran, wiping the feed.
       const backlogRows = await getPrismaClient().recommendation_cache.findMany({
         where: {
           user_id: userId,
           mandala_id: mandalaId,
-          status: RECOMMENDATION_DEFAULT_STATUS,
           expires_at: { gt: new Date() },
         },
         // CP457+ deterministic tie-break to match the REST endpoint.

--- a/tests/smoke/mandalas-recommendations.test.ts
+++ b/tests/smoke/mandalas-recommendations.test.ts
@@ -259,7 +259,10 @@ describeIfSigning('GET /api/v1/mandalas/:id/recommendations — authenticated', 
     expect(call?.where?.cell_index).toBe(2);
     expect(call?.where?.user_id).toBe(TEST_USER_ID);
     expect(call?.where?.mandala_id).toBe(TEST_MANDALA_ID);
-    expect(call?.where?.status).toBe('pending');
+    // No `status` filter: it is auto_add bookkeeping, not a display gate —
+    // filtering it made the feed empty when auto_add flipped rows to 'shown'.
+    expect(call?.where?.status).toBeUndefined();
+    expect(call?.where?.expires_at).toBeDefined();
     expect(call?.take).toBe(80);
   });
 });


### PR DESCRIPTION
## Problem — cards "appear then suddenly disappear"

The recommendation feed showed cards that vanished without warning (user: "2차로 들어온 카드들이 예고없이 갑자기 사라짐"). Traced end-to-end through code + prod data.

### Root cause

`/recommendations` (REST, 8s poll) and the `/videos/stream` SSE backlog **both** filtered `recommendation_cache` on `status = 'pending'` (`RECOMMENDATION_DEFAULT_STATUS`).

But `status` is **auto_add's bookkeeping**, not a display gate:
- post-creation step 2 (`upsertSlots`) writes ~36 rec_cache rows `status='pending'` + streams them all via SSE `card_added` → feed fills.
- post-creation step 3 (`maybeAutoAddRecommendations`) copies recs into `user_video_states`, then runs `UPDATE recommendation_cache SET status='shown' WHERE status='pending'` for **every** row (auto-add-recommendations.ts:358-367).
- The instant step 3 finishes, the feed's `status='pending'` source → **0 rows**. Next 8s poll / SSE reconnect backlog returns empty → the ~36 just-streamed cards disappear.

**Prod trace confirmed**: mandala `74fa314a` — `recommendation_cache` 36 rows, **all already `status='shown'`** by query time. Feed source = 0. Same path explains the English-mandala "Korean cards appeared then disappeared".

## Fix

The feed should show the mandala's non-expired recommendations **regardless of promotion state**. Remove the `status` filter from both feed-facing queries; keep `expires_at > now`.

`auto_add`'s own `status='pending'` read (to find un-promoted recs) is **unchanged** — `status` still does its real job in the promotion pipeline.

### Files
- `src/api/routes/mandalas.ts` — `/recommendations` REST + `/videos/stream` SSE backlog: drop `status` filter; remove now-unused `RECOMMENDATION_DEFAULT_STATUS` import
- `tests/smoke/mandalas-recommendations.test.ts` — assert `where.status` is undefined + `where.expires_at` is still set

## Test plan
- [x] `tsc --noEmit` clean
- [ ] `mandalas-recommendations.test.ts` — env-conditionally skipped locally (`canBootServer`); runs in CI
- [ ] Post-deploy: create a mandala, confirm the feed cards stay after the post-creation pipeline finishes (do not vanish on the next poll)

## Notes
- Part of the v3 "돌려막기 / disappearing cards" investigation series (#640 overfetch, #641 owned-video exclusion, #642 rerank dedup). This one addresses card **stability**.
- Separate still-open items from the same investigation: wizard precompute is dead weight (6s consume poll vs ~40s ephemeral run, 0/3 rows ever consumed); English-mandala Korean leak via `tsvectorKeywordCandidates` (no language filter); 12s SLO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)