### PR TITLE
fix(stream): reset SSE card buffer on mandala switch — prevents stale-card bleed

### DIFF
--- a/frontend/src/features/recommendation-feed/model/useVideoStream.ts
+++ b/frontend/src/features/recommendation-feed/model/useVideoStream.ts
@@ -66,10 +66,17 @@ export function useVideoStream(mandalaId: string | null | undefined): UseVideoSt
   const lastEventIdRef = useRef<string | null>(null);
 
   useEffect(() => {
+    // mandalaId changed (or first mount) → this is a fresh stream. Drop any
+    // cards / seen-ids / lastEventId accumulated for the PREVIOUS mandala.
+    // Without this, switching A→B appends B's stream onto A's leftover cards,
+    // and useCardOrchestrator.streamMandalaCards force-relabels them with the
+    // current mandalaId — so the previous mandala's cards leak into the new
+    // one (count inflates until a hard refresh remounts this hook).
+    setCards([]);
+    seenRef.current = new Set();
+    lastEventIdRef.current = null;
+
     if (!mandalaId) {
-      setCards([]);
-      seenRef.current = new Set();
-      lastEventIdRef.current = null;
       setStatus('idle');
       setError(null);
       return;


### PR DESCRIPTION
## Summary

**Serious bug, prod-visible:** the same mandala showed 94 cards vs 32 (correct, after a hard refresh) — switching mandalas accumulated the previous mandala's cards into the new one's grid.

**Root cause:** `useVideoStream` only reset its `cards` / `seenRef` / `lastEventIdRef` when `mandalaId` became *null*. Switching A→B (both non-null) left A's streamed cards in state; B's `card_added` SSE events were appended on top. `useCardOrchestrator.streamMandalaCards` then force-relabels every buffered card with the *current* mandalaId (`recommendationToInsightCard(r, mandalaId)`), so the previous mandala's cards leaked into the new mandala — the count inflated on every switch until a hard refresh remounted the hook.

Pre-existing bug — not introduced by #643; #643 (skeleton-grace) only removed the brief skeleton that partly masked the transition.

**Fix:** move the buffer reset to the top of the effect so it runs on every `mandalaId` change, not only the null transition. `lastEventId` is per-mandala, so resetting it on switch is also correct.

## Test plan

- [x] `tsc --noEmit` (frontend) — pass
- [x] `vitest run` — 34 files / 309 tests pass (incl. `insertByScoreDesc`)
- [x] `npm run build` — pass
- [x] browser smoke — `/` + `/mandalas/new` → 200, dev log clean
- [ ] manual: switch between mandalas repeatedly → card count stays correct without a hard refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)