### PR TITLE
revert: restore mandala-switch skeleton grace (revert #643)

### DIFF
--- a/frontend/src/features/card-management/model/useLocalCards.ts
+++ b/frontend/src/features/card-management/model/useLocalCards.ts
@@ -271,7 +271,6 @@ export function useLocalCards() {
 
     // Loading states
     isLoading: listQuery.isLoading,
-    isFetching: listQuery.isFetching,
     isAdding: addCard.isPending,
     isUpdating: updateCard.isPending,
     isDeleting: deleteCard.isPending,

--- a/frontend/src/pages/index/model/useCardOrchestrator.ts
+++ b/frontend/src/pages/index/model/useCardOrchestrator.ts
@@ -64,9 +64,6 @@ export interface UseCardOrchestratorReturn {
   pendingLocalCards: InsightCard[];
   // Loading state
   isLoading: boolean;
-  // True while either underlying card query is fetching (incl. background
-  // refetch with keepPreviousData) — distinct from isLoading (first load only).
-  isFetching: boolean;
   // Card actions
   handleCardClick: (card: InsightCard) => void;
   handleCardDrop: (
@@ -117,11 +114,7 @@ export function useCardOrchestrator(
   const queryClient = useQueryClient();
 
   // YouTube sync
-  const {
-    data: allVideoStates,
-    isLoading: isVideoStatesLoading,
-    isFetching: isVideoStatesFetching,
-  } = useAllVideoStates();
+  const { data: allVideoStates, isLoading: isVideoStatesLoading } = useAllVideoStates();
   const updateVideoState = useUpdateVideoState();
   const { autoSummaryEnabled } = useYouTubeAuth();
 
@@ -130,7 +123,6 @@ export function useCardOrchestrator(
     cards: persistedLocalCards,
     subscription,
     isLoading: isLocalCardsLoading,
-    isFetching: isLocalCardsFetching,
     addCard: addLocalCard,
     updateCard: updateLocalCard,
     deleteCard: deleteLocalCard,
@@ -1472,7 +1464,6 @@ export function useCardOrchestrator(
     displayCards,
     displayTitle,
     isLoading: isLocalCardsLoading || isVideoStatesLoading,
-    isFetching: isLocalCardsFetching || isVideoStatesFetching,
     syncedCards,
     newlySyncedCards,
     newlySyncedCountByMandala,

--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -252,33 +252,16 @@ function AuthenticatedApp() {
 
   // 5c'. Mandala-switch grace period: prevents the "0 cards" empty-state flash
   // that surfaced on every mandala switch because keepPreviousData + client-side
-  // mandala_id filter yields cards.length=0 for a brief moment while a card
-  // query is in flight. During the grace window we force isLoading downstream
-  // (skeleton instead of empty-state).
+  // mandala_id filter yields cards.length=0 for a brief moment before the next
+  // useAllVideoStates fetch lands. During the grace window we force isLoading
+  // downstream (skeleton instead of empty-state).
   const [mandalaSwitchGrace, setMandalaSwitchGrace] = useState(false);
-  // Render-assigned ref so the switch effect can read the current fetching
-  // state without re-running on every isFetching toggle.
-  const cardsFetchingRef = useRef(cards.isFetching);
-  cardsFetchingRef.current = cards.isFetching;
   useEffect(() => {
     if (!effectiveMandalaId) return;
-    // Only enter the grace if a card fetch is actually in flight at switch
-    // time. For a cached / genuinely-empty mandala the client-side filter
-    // resolves synchronously, so entering the grace would just flash the
-    // skeleton for one render (visible blink) with nothing to wait for.
-    if (!cardsFetchingRef.current) return;
     setMandalaSwitchGrace(true);
-    // 3s is a hard cap for a hung fetch; the effect below clears it earlier.
     const timer = setTimeout(() => setMandalaSwitchGrace(false), 3000);
     return () => clearTimeout(timer);
   }, [effectiveMandalaId]);
-  // Clear the grace as soon as the in-flight card fetch settles, so the
-  // skeleton never lingers past the actual load.
-  useEffect(() => {
-    if (mandalaSwitchGrace && !cards.isFetching) {
-      setMandalaSwitchGrace(false);
-    }
-  }, [mandalaSwitchGrace, cards.isFetching]);
 
   useEffect(() => {
     if (!isNewMandalaActive) return;


### PR DESCRIPTION
## Summary

Reverts `85e6309b` (#643 "fix(dashboard): skip mandala-switch skeleton grace when no fetch is in flight").

#643 removed the skeleton on mandala switch when no card fetch was in flight. But card data dribbles in from multiple async sources (synced video states, SSE stream, pending) at different times with a fluctuating count — without the skeleton the grid visibly jitters as cards pop in. The skeleton grace was masking that.

Restoring the original behaviour at the user's request while the underlying card-count non-determinism is investigated and fixed properly. `#645` (SSE buffer reset on mandala switch) is intentionally **not** reverted — it fixes a separate, confirmed stale-card-bleed bug.

## Test plan

- [x] `tsc --noEmit` (frontend) — pass
- [x] `vitest run` — 32 files / 296 tests pass
- [x] `npm run build` — pass
- [x] browser smoke — `/` + `/mandalas/new` → 200, dev log clean
- [x] pure inverse of an already-production-verified commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)