### PR TITLE
fix(chatbot): summarize video from transcript when no rich summary exists

### DIFF
--- a/frontend/src/__tests__/smoke/chat-layer.test.ts
+++ b/frontend/src/__tests__/smoke/chat-layer.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { computeChatLayer, buildInstructions } from '@/pages/learning/ui/ChatAssistant';
+
+const base = {
+  regionAware: false,
+  noteSelectionText: null as string | null,
+  playerState: 'unstarted',
+  playerTimeSec: 0,
+  currentSection: null as string | null,
+  selectedCellIndex: null as number | null,
+  videoId: '',
+  mandalaId: '',
+};
+
+describe('computeChatLayer (CP446+1, region awareness flag)', () => {
+  it('returns "global" when nothing is set', () => {
+    expect(computeChatLayer({ ...base })).toBe('global');
+  });
+
+  it('returns "mandala" when only mandalaId is present', () => {
+    expect(computeChatLayer({ ...base, mandalaId: 'm-1' })).toBe('mandala');
+  });
+
+  it('returns "video" when videoId is present without cell', () => {
+    expect(computeChatLayer({ ...base, mandalaId: 'm-1', videoId: 'v-1' })).toBe('video');
+  });
+
+  it('returns "cell" when section or cell is selected', () => {
+    expect(
+      computeChatLayer({ ...base, mandalaId: 'm-1', videoId: 'v-1', selectedCellIndex: 3 })
+    ).toBe('cell');
+    expect(
+      computeChatLayer({ ...base, mandalaId: 'm-1', videoId: 'v-1', currentSection: 'Ch1 > S1' })
+    ).toBe('cell');
+  });
+
+  it('does NOT promote to "video-time" when regionAware is false', () => {
+    expect(
+      computeChatLayer({
+        ...base,
+        regionAware: false,
+        mandalaId: 'm-1',
+        videoId: 'v-1',
+        playerState: 'playing',
+        playerTimeSec: 30,
+      })
+    ).toBe('video');
+  });
+
+  it('promotes to "video-time" when regionAware AND playing AND time > 0', () => {
+    expect(
+      computeChatLayer({
+        ...base,
+        regionAware: true,
+        mandalaId: 'm-1',
+        videoId: 'v-1',
+        playerState: 'playing',
+        playerTimeSec: 30,
+      })
+    ).toBe('video-time');
+  });
+
+  it('"note" wins over "video-time" when both conditions hold', () => {
+    expect(
+      computeChatLayer({
+        ...base,
+        regionAware: true,
+        mandalaId: 'm-1',
+        videoId: 'v-1',
+        playerState: 'playing',
+        playerTimeSec: 30,
+        noteSelectionText: 'selected paragraph',
+      })
+    ).toBe('note');
+  });
+
+  it('does NOT return "note" when regionAware is false even if selection exists', () => {
+    expect(
+      computeChatLayer({
+        ...base,
+        regionAware: false,
+        mandalaId: 'm-1',
+        videoId: 'v-1',
+        noteSelectionText: 'selected paragraph',
+      })
+    ).toBe('video');
+  });
+});
+
+describe('buildInstructions — video-summary fallback', () => {
+  const VIDEO_ID = 'abc123XYZ_0';
+
+  it('uses rich summary content when present', () => {
+    const out = buildInstructions(
+      VIDEO_ID,
+      { title: 'Asset Allocation 101', structured: { core_argument: 'Diversify early.' } },
+      null,
+      'ko'
+    );
+    expect(out).toContain('Asset Allocation 101');
+    expect(out).toContain('Diversify early.');
+    expect(out).not.toContain('transcript is provided below');
+  });
+
+  it('feeds the transcript and authorizes summarizing when no rich summary exists', () => {
+    const transcript = 'This video explains how to build retirement wealth through ETFs.';
+    const out = buildInstructions(VIDEO_ID, null, transcript, 'ko');
+    expect(out).toContain('### Transcript');
+    expect(out).toContain(transcript);
+    expect(out).toContain('SHOULD summarize the video');
+    // The hard refusal instruction must NOT be present in the transcript path.
+    expect(out).not.toContain('Do NOT fabricate a summary');
+  });
+
+  it('truncates an over-long transcript and notes the truncation', () => {
+    const longTranscript = 'word '.repeat(10000); // 50000 chars > 20000 cap
+    const out = buildInstructions(VIDEO_ID, null, longTranscript, 'en');
+    expect(out).toContain('Transcript truncated for length');
+    expect(out.length).toBeLessThan(longTranscript.length + 2000);
+  });
+
+  it('falls back to a non-fabrication refusal when neither summary nor transcript exists', () => {
+    const out = buildInstructions(VIDEO_ID, null, null, 'ko');
+    expect(out).toContain('Do NOT fabricate a summary');
+    expect(out).toContain('No transcript or AI analysis is available');
+  });
+
+  it('always keeps the language rule regardless of content path', () => {
+    for (const args of [
+      buildInstructions(VIDEO_ID, null, null, 'en'),
+      buildInstructions(VIDEO_ID, null, 'some transcript', 'en'),
+    ]) {
+      expect(args).toContain('respond in the same language as the user');
+    }
+  });
+});

--- a/frontend/src/features/video-side-panel/model/useCaptions.ts
+++ b/frontend/src/features/video-side-panel/model/useCaptions.ts
@@ -1,0 +1,48 @@
+/**
+ * useCaptions — fetch YouTube captions (transcript) for a video on demand.
+ *
+ * Powers the chatbot's video-summary fallback: when no rich summary exists
+ * yet, the transcript is fed to the model so it can still produce a real
+ * summary instead of refusing. Caller gates `enabled` (typically
+ * `!richSummary`) so transcript is only fetched when actually needed.
+ *
+ * Transcript extraction can fail (no public captions, bot-gate) — that
+ * surfaces as `captions === null`, and the chatbot degrades to its
+ * "analysis in progress" message rather than fabricating content.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { apiClient, type VideoCaptionResponse } from '@/shared/lib/api-client';
+import { queryKeys } from '@/shared/config/query-client';
+
+// Transcript text is immutable for a given video — cache aggressively.
+const CAPTIONS_STALE_MS = 60 * 60 * 1000;
+
+export interface UseCaptionsResult {
+  captions: VideoCaptionResponse | null;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export function useCaptions(
+  videoId: string | null | undefined,
+  enabled: boolean
+): UseCaptionsResult {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: videoId
+      ? queryKeys.video.captions(videoId, 'auto')
+      : ['video', 'captions', 'disabled'],
+    // No explicit language — the server tries en then ko, maximising hit
+    // rate. Output language is controlled by the chatbot's own language rule.
+    queryFn: () => apiClient.getVideoCaptions(videoId as string),
+    enabled: Boolean(videoId) && enabled,
+    staleTime: CAPTIONS_STALE_MS,
+    retry: false,
+  });
+
+  return {
+    captions: data ?? null,
+    isLoading,
+    isError,
+  };
+}

--- a/frontend/src/pages/learning/ui/ChatAssistant.tsx
+++ b/frontend/src/pages/learning/ui/ChatAssistant.tsx
@@ -9,6 +9,7 @@ import { CopilotChat } from '@copilotkit/react-ui';
 import '@copilotkit/react-ui/styles.css';
 import { toast } from 'sonner';
 import { useRichSummary } from '@/features/video-side-panel/model/useRichSummary';
+import { useCaptions } from '@/features/video-side-panel/model/useCaptions';
 import { useMandalaQuery } from '@/features/mandala';
 import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import { useLearningStore } from '@/pages/learning/model/useLearningStore';
@@ -26,6 +27,11 @@ export interface ChatContext {
 }
 
 const REGION_AWARENESS_ENABLED = import.meta.env.VITE_CHATBOT_REGION_AWARENESS === 'true';
+
+// Upper bound on raw transcript text injected into the chatbot prompt when
+// no structured rich summary exists. Long enough to cover most videos
+// substantially; bounded to keep prompt tokens and latency in check.
+const TRANSCRIPT_PROMPT_MAX_CHARS = 20000;
 
 export function computeChatLayer(input: {
   regionAware: boolean;
@@ -96,12 +102,13 @@ function linkifyTimestamps(root: Node) {
   }
 }
 
-function buildInstructions(
+export function buildInstructions(
   videoId: string,
   richSummary: {
     title?: string;
     structured?: { key_points?: string[]; core_argument?: string; actionables?: string[] };
   } | null,
+  transcript: string | null,
   language: string
 ): string {
   const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
@@ -113,6 +120,9 @@ function buildInstructions(
       richSummary.structured?.actionables?.length);
 
   let videoSection: string;
+  let noContentRule: string;
+  let timestampRule: string;
+
   if (hasContent) {
     videoSection = `\n\n## Current Video\n- URL: ${videoUrl}`;
     if (richSummary!.title) videoSection += `\n- Title: ${richSummary!.title}`;
@@ -122,17 +132,27 @@ function buildInstructions(
       videoSection += `\n- Key points:\n${richSummary!.structured.key_points.map((p) => `  - ${p}`).join('\n')}`;
     if (richSummary!.structured?.actionables?.length)
       videoSection += `\n- Actionable takeaways:\n${richSummary!.structured.actionables.map((a) => `  - ${a}`).join('\n')}`;
+    noContentRule = '';
+    timestampRule =
+      '\n- When summarizing or referencing the video, include timestamps (e.g. 0:47) tied to actual sections in the content above to help the user navigate.';
+  } else if (transcript) {
+    // Fallback: no structured rich summary yet, but the raw transcript is
+    // available. Feed it so the model can still produce a real summary
+    // instead of refusing — grounded strictly in the transcript text.
+    const clipped = transcript.slice(0, TRANSCRIPT_PROMPT_MAX_CHARS);
+    const truncatedNote =
+      transcript.length > TRANSCRIPT_PROMPT_MAX_CHARS
+        ? '\n\n[Transcript truncated for length — summarize what is available above.]'
+        : '';
+    videoSection = `\n\n## Current Video\n- URL: ${videoUrl}\n- Source: raw transcript (a structured AI analysis has not been generated yet)\n\n### Transcript\n${clipped}${truncatedNote}`;
+    noContentRule =
+      '\n- A structured AI summary is not available yet, but the raw video transcript is provided below. Base every answer strictly on that transcript. You MAY and SHOULD summarize the video from it when asked. Do NOT invent content, claims, or timestamps that are not present in the transcript.';
+    timestampRule = '';
   } else {
-    videoSection = `\n\n## Current Video\n- URL: ${videoUrl}\n- Content status: AI analysis for this video is currently being prepared and will be available shortly.`;
+    videoSection = `\n\n## Current Video\n- URL: ${videoUrl}\n- Content status: No transcript or AI analysis is available for this video yet.`;
+    noContentRule = `\n- IMPORTANT: Neither an AI analysis nor a transcript is available for this video. Do NOT fabricate a summary. Do NOT invent timestamps. Do NOT guess or infer the video's topic or content from any other context (including the user's learning goal or mandala). When the user asks about the video, tell them warmly that the content could not be loaded yet, and offer to help in the meantime with general questions about their learning goal.`;
+    timestampRule = '';
   }
-
-  const noContentRule = hasContent
-    ? ''
-    : `\n- IMPORTANT: The AI analysis for this video is still being prepared — no summary, transcript, or structured content is available yet. Do NOT fabricate a summary. Do NOT invent timestamps. Do NOT guess or infer the video's topic or content from any other context (including the user's learning goal or mandala). When the user asks about the video, tell them warmly that the analysis is in progress and will be ready soon, and offer to help in the meantime with general questions about their learning goal.`;
-
-  const timestampRule = hasContent
-    ? '\n- When summarizing or referencing the video, include timestamps (e.g. 0:47) tied to actual sections in the content above to help the user navigate.'
-    : '';
 
   return `You are Insighta's learning assistant. You help users learn from the YouTube video they are currently watching.
 
@@ -203,7 +223,11 @@ function ChatPanel({
   onSeek?: (seconds: number) => void;
 }) {
   const { t, i18n } = useTranslation();
-  const { richSummary } = useRichSummary(videoId);
+  const { richSummary, isLoading: richSummaryLoading } = useRichSummary(videoId);
+  // Transcript fallback: only fetched once rich-summary resolves to "absent",
+  // so videos that already have a structured summary never hit the captions
+  // endpoint.
+  const { captions } = useCaptions(videoId, !richSummaryLoading && !richSummary);
   const suggestions = buildSuggestions(t, richSummary?.structured ?? null);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -267,8 +291,9 @@ function ChatPanel({
   ]);
 
   const instructions = useMemo(
-    () => buildInstructions(videoId, richSummary ?? null, i18n.language),
-    [videoId, richSummary, i18n.language]
+    () =>
+      buildInstructions(videoId, richSummary ?? null, captions?.fullText ?? null, i18n.language),
+    [videoId, richSummary, captions, i18n.language]
   );
 
   useCopilotReadable({

--- a/frontend/src/shared/config/query-client.ts
+++ b/frontend/src/shared/config/query-client.ts
@@ -92,6 +92,8 @@ export const queryKeys = {
   video: {
     all: ['video'] as const,
     richSummary: (videoId: string) => [...queryKeys.video.all, 'rich-summary', videoId] as const,
+    captions: (videoId: string, language: string) =>
+      [...queryKeys.video.all, 'captions', videoId, language] as const,
   },
   billing: {
     all: ['billing'] as const,

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -226,6 +226,18 @@ export interface VideoRichSummaryResponse {
 }
 
 /**
+ * YouTube captions (transcript) response shape.
+ * Transcript text is fetched on demand and never persisted server-side;
+ * only `fullText` is consumed by the chatbot's summary fallback.
+ */
+export interface VideoCaptionResponse {
+  videoId: string;
+  language: string;
+  fullText: string;
+  segments: { text: string; start: number; duration: number }[];
+}
+
+/**
  * CP438+1 PoC — Mandala book index response shape.
  * Server stores the entire generated book as a single jsonb blob keyed
  * by mandala_id. PoC schema; will split into normalized tables in P5.
@@ -763,6 +775,28 @@ class ApiClient {
         `/videos/${videoId}/rich-summary`
       );
       return res.data;
+    } catch (err) {
+      if (err instanceof ApiHttpError && err.statusCode === 404) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Fetch publicly available YouTube captions (transcript) for a video.
+   *
+   * Used as the chatbot's video-summary fallback when no rich summary
+   * exists yet. Returns null on 404 (no public captions / extraction
+   * failed) so callers can degrade gracefully. Other errors propagate.
+   */
+  async getVideoCaptions(videoId: string, language?: string): Promise<VideoCaptionResponse | null> {
+    const query = language ? `?language=${encodeURIComponent(language)}` : '';
+    try {
+      const res = await this.request<{ caption: VideoCaptionResponse }>(
+        `/videos/${videoId}/captions${query}`
+      );
+      return res.caption;
     } catch (err) {
       if (err instanceof ApiHttpError && err.statusCode === 404) {
         return null;

--- a/src/api/schemas/video.schema.ts
+++ b/src/api/schemas/video.schema.ts
@@ -13,6 +13,15 @@ import { errorResponseSchema } from './common.schema';
 // ============================================================================
 
 /**
+ * Video id route param accepts EITHER form, because the video manager
+ * (`getVideo().getVideo(id)`) resolves both: an internal UUID (36 chars)
+ * or a YouTube video id (11 chars of [A-Za-z0-9_-]). A `format: 'uuid'`
+ * constraint here wrongly 400s the YouTube-id callers (e.g. the learning
+ * page chatbot fetching captions by YouTube id).
+ */
+export const VIDEO_ID_PATTERN = '^[A-Za-z0-9_-]{11,64}$';
+
+/**
  * List videos query parameters
  */
 export const ListVideosQuerySchema = z.object({
@@ -32,7 +41,7 @@ export type ListVideosQuery = z.infer<typeof ListVideosQuerySchema>;
  * Get video params
  */
 export const GetVideoParamsSchema = z.object({
-  id: z.string().uuid('Invalid video ID format'),
+  id: z.string().regex(new RegExp(VIDEO_ID_PATTERN), 'Invalid video ID format'),
 });
 
 export type GetVideoParams = z.infer<typeof GetVideoParamsSchema>;
@@ -40,8 +49,11 @@ export type GetVideoParams = z.infer<typeof GetVideoParamsSchema>;
 /**
  * Get captions query parameters
  */
+// No default language: when omitted, the extractor falls back through its
+// own en→ko priority list (extractor.ts). Forcing 'en' here would make
+// Korean-only videos fail caption extraction.
 export const GetCaptionsQuerySchema = z.object({
-  language: z.string().optional().default('en'),
+  language: z.string().optional(),
 });
 
 export type GetCaptionsQuery = z.infer<typeof GetCaptionsQuerySchema>;
@@ -305,7 +317,11 @@ export const getVideoSchema: FastifySchema = {
     type: 'object',
     required: ['id'],
     properties: {
-      id: { type: 'string', format: 'uuid', description: 'Video ID' },
+      id: {
+        type: 'string',
+        pattern: VIDEO_ID_PATTERN,
+        description: 'Video ID (internal UUID or YouTube id)',
+      },
     },
   },
   response: {
@@ -334,7 +350,11 @@ export const getCaptionsSchema: FastifySchema = {
     type: 'object',
     required: ['id'],
     properties: {
-      id: { type: 'string', format: 'uuid', description: 'Video ID' },
+      id: {
+        type: 'string',
+        pattern: VIDEO_ID_PATTERN,
+        description: 'Video ID (internal UUID or YouTube id)',
+      },
     },
   },
   querystring: {
@@ -342,8 +362,8 @@ export const getCaptionsSchema: FastifySchema = {
     properties: {
       language: {
         type: 'string',
-        default: 'en',
-        description: 'Caption language code (e.g., en, ko, ja)',
+        description:
+          'Caption language code (e.g., en, ko, ja). Omit to let the extractor try en then ko.',
       },
     },
   },
@@ -373,7 +393,11 @@ export const getCaptionLanguagesSchema: FastifySchema = {
     type: 'object',
     required: ['id'],
     properties: {
-      id: { type: 'string', format: 'uuid', description: 'Video ID' },
+      id: {
+        type: 'string',
+        pattern: VIDEO_ID_PATTERN,
+        description: 'Video ID (internal UUID or YouTube id)',
+      },
     },
   },
   response: {
@@ -403,7 +427,11 @@ export const getSummarySchema: FastifySchema = {
     type: 'object',
     required: ['id'],
     properties: {
-      id: { type: 'string', format: 'uuid', description: 'Video ID' },
+      id: {
+        type: 'string',
+        pattern: VIDEO_ID_PATTERN,
+        description: 'Video ID (internal UUID or YouTube id)',
+      },
     },
   },
   response: {
@@ -442,7 +470,11 @@ export const generateSummarySchema: FastifySchema = {
     type: 'object',
     required: ['id'],
     properties: {
-      id: { type: 'string', format: 'uuid', description: 'Video ID' },
+      id: {
+        type: 'string',
+        pattern: VIDEO_ID_PATTERN,
+        description: 'Video ID (internal UUID or YouTube id)',
+      },
     },
   },
   body: {

--- a/src/modules/caption/extractor.ts
+++ b/src/modules/caption/extractor.ts
@@ -9,9 +9,13 @@
  * may be returned to the client for local caching only.
  */
 
-// Dynamic import: youtube-transcript is ESM-only, CJS require() fails in production
+// Dynamic import of the ESM build subpath.
+// The package `main` (youtube-transcript.common.js) is CJS-bodied yet the
+// package.json declares `"type": "module"`, so importing the bare package
+// name throws "exports is not defined in ES module scope". Importing the
+// `.esm.js` build directly sidesteps the broken main entry.
 async function loadFetchTranscript() {
-  const mod = await import('youtube-transcript');
+  const mod = await import('youtube-transcript/dist/youtube-transcript.esm.js');
   return mod.fetchTranscript;
 }
 import { logger } from '../../utils/logger';

--- a/src/modules/video/manager.ts
+++ b/src/modules/video/manager.ts
@@ -17,6 +17,10 @@ import { logger } from '../../utils/logger';
 import { RecordNotFoundError } from '../../utils/errors';
 import { youtube_v3 } from 'googleapis';
 
+/** Standard UUID v1-v5 shape — used to decide whether an id can be matched
+ *  against the `youtube_videos.id` uuid column without a DB type error. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * Video Manager
  *
@@ -109,13 +113,17 @@ export class VideoManager {
   }
 
   /**
-   * Get video by ID or YouTube ID
+   * Get video by internal UUID or YouTube video id.
+   *
+   * `id` (the internal PK) is a Postgres `uuid` column — comparing it
+   * against a non-UUID string (e.g. an 11-char YouTube id) raises a DB
+   * "invalid input syntax for type uuid" error. So only include the
+   * `{ id }` clause when the input actually looks like a UUID.
    */
   public async getVideo(id: string): Promise<youtube_videos> {
+    const isUuid = UUID_RE.test(id);
     const video = await db.youtube_videos.findFirst({
-      where: {
-        OR: [{ id }, { youtube_video_id: id }],
-      },
+      where: isUuid ? { OR: [{ id }, { youtube_video_id: id }] } : { youtube_video_id: id },
     });
 
     if (!video) {

--- a/src/types/youtube-transcript.d.ts
+++ b/src/types/youtube-transcript.d.ts
@@ -1,0 +1,20 @@
+/**
+ * Type declarations for the `youtube-transcript` ESM build subpath.
+ *
+ * The package ships no usable types and its `main` entry is broken under
+ * ESM (CJS body + `"type": "module"`), so `extractor.ts` imports the
+ * `.esm.js` build directly — which has no `.d.ts`. This declaration
+ * mirrors the runtime shape of `parseTranscriptXml`'s output.
+ */
+declare module 'youtube-transcript/dist/youtube-transcript.esm.js' {
+  export interface TranscriptItem {
+    text: string;
+    duration: number;
+    offset: number;
+    lang?: string;
+  }
+  export function fetchTranscript(
+    videoId: string,
+    options?: { lang?: string }
+  ): Promise<TranscriptItem[]>;
+}


### PR DESCRIPTION
## Summary
The learning-page chatbot refused to summarize **any** video that didn't already have a generated rich summary ("죄송합니다... AI 분석이 진행 중"). Fixing the transcript path surfaced **5 distinct bugs** — all confirmed by code/data, not guesswork:

1. **`ChatAssistant.buildInstructions`** now feeds the YouTube transcript into the chatbot prompt (via new `useCaptions` hook + `getVideoCaptions` api-client method) so Gemini-2.5 (OpenRouter) can summarize even before the structured rich summary exists. Falls back to a non-fabrication refusal **only** when no transcript is available.
2. **`video.schema.ts`** — dropped `format: 'uuid'` on video-id route params (5 routes) + the Zod `.uuid()`. They returned **400** for YouTube-id callers, even though `getVideo()` resolves both id forms. Replaced with `VIDEO_ID_PATTERN`.
3. **`video.schema.ts`** — dropped `default: 'en'` on the captions `language` query so the extractor's en→ko fallback works for Korean-only videos.
4. **`VideoManager.getVideo`** — only matches the uuid `id` column when the input is actually a UUID; a non-UUID string raised a Postgres type error (**500**).
5. **`caption/extractor.ts`** — imports the `youtube-transcript` ESM build subpath directly. The package `main` is CJS-bodied under `"type": "module"`, so `import('youtube-transcript')` threw `"exports is not defined"`, **silently failing all caption extraction**.

## Verification
- `/verify` gate: BE tsc ✅ / BE jest 151 pass ✅ / FE tsc ✅ / FE vitest 314/314 ✅ / FE build ✅ / browser smoke ✅
- BE endpoint measured: `GET /api/v1/videos/u-L-JjTu44I/captions` → `200`, ko transcript 8135 chars / 666 segments
- New unit tests (`chat-layer.test.ts`): 5 cases covering all 4 `buildInstructions` branches + language rule
- Prod DB already has the columns the routes select (verified via `DIRECT_URL`) — no migration needed

## Notes
- Local dev DB had schema drift (`video_rich_summaries` / `youtube_videos` missing columns) — fixed by applying the existing idempotent DDL files to the **local** DB only; prod was already in sync.
- Not browser-verified for the full interactive chatbot render (OAuth login required).

## Test plan
- [ ] Open a learning page video with no rich summary but with captions → chatbot produces a real summary in the request language
- [ ] Open a video with no captions → chatbot gives the honest "content unavailable" reply (no fabrication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)