### PR TITLE
fix(chatbot): read v2 layered rich-summary fields (core/analysis)

### DIFF
--- a/frontend/src/__tests__/smoke/chat-layer.test.ts
+++ b/frontend/src/__tests__/smoke/chat-layer.test.ts
@@ -90,15 +90,53 @@ describe('computeChatLayer (CP446+1, region awareness flag)', () => {
 describe('buildInstructions — video-summary fallback', () => {
   const VIDEO_ID = 'abc123XYZ_0';
 
-  it('uses rich summary content when present', () => {
+  it('uses v1 structured content when present', () => {
     const out = buildInstructions(
       VIDEO_ID,
-      { title: 'Asset Allocation 101', structured: { core_argument: 'Diversify early.' } },
+      {
+        videoId: VIDEO_ID,
+        oneLiner: 'Asset Allocation 101',
+        structured: { core_argument: 'Diversify early.', actionables: ['Open an IRA'] },
+        qualityScore: 0.9,
+        model: 'test',
+        updatedAt: '2026-05-15T00:00:00Z',
+      } as never,
       null,
       'ko'
     );
     expect(out).toContain('Asset Allocation 101');
     expect(out).toContain('Diversify early.');
+    expect(out).toContain('Open an IRA');
+    expect(out).not.toContain('transcript is provided below');
+  });
+
+  it('uses v2 layered content (core/analysis) when structured is null — CP461 fix', () => {
+    const out = buildInstructions(
+      VIDEO_ID,
+      {
+        videoId: VIDEO_ID,
+        oneLiner: null,
+        structured: null,
+        templateVersion: 'v2',
+        core: { one_liner: 'MZ세대가 원하는 배우자', domain: 'finance' },
+        analysis: {
+          core_argument: '결혼 통계는 시대의 변화를 보여준다',
+          key_concepts: [{ term: '자본소득', definition: '자본에서 발생하는 소득' }],
+          actionables: ['결혼 관련 통계와 부동산 지표를 함께 살펴 시대 흐름을 직접 파악하라'],
+        },
+        qualityScore: 0.85,
+        model: 'test',
+        updatedAt: '2026-05-15T00:00:00Z',
+      } as never,
+      null,
+      'ko'
+    );
+    expect(out).toContain('MZ세대가 원하는 배우자');
+    expect(out).toContain('결혼 통계는 시대의 변화를 보여준다');
+    expect(out).toContain('자본소득');
+    expect(out).toContain('결혼 관련 통계');
+    // Must NOT fall back to refusal or transcript paths.
+    expect(out).not.toContain('Do NOT fabricate a summary');
     expect(out).not.toContain('transcript is provided below');
   });
 
@@ -117,6 +155,28 @@ describe('buildInstructions — video-summary fallback', () => {
     const out = buildInstructions(VIDEO_ID, null, longTranscript, 'en');
     expect(out).toContain('Transcript truncated for length');
     expect(out.length).toBeLessThan(longTranscript.length + 2000);
+  });
+
+  it('falls back to refusal when rich summary row exists but every field is empty', () => {
+    // Mirrors a degraded row (e.g. quality_flag='low') where Prisma returns
+    // an object but every content field is null/empty. Must not pretend to
+    // summarize.
+    const out = buildInstructions(
+      VIDEO_ID,
+      {
+        videoId: VIDEO_ID,
+        oneLiner: null,
+        structured: null,
+        core: null,
+        analysis: null,
+        qualityScore: null,
+        model: null,
+        updatedAt: '2026-05-15T00:00:00Z',
+      } as never,
+      null,
+      'ko'
+    );
+    expect(out).toContain('Do NOT fabricate a summary');
   });
 
   it('falls back to a non-fabrication refusal when neither summary nor transcript exists', () => {

--- a/frontend/src/pages/learning/ui/ChatAssistant.tsx
+++ b/frontend/src/pages/learning/ui/ChatAssistant.tsx
@@ -10,6 +10,7 @@ import '@copilotkit/react-ui/styles.css';
 import { toast } from 'sonner';
 import { useRichSummary } from '@/features/video-side-panel/model/useRichSummary';
 import { useCaptions } from '@/features/video-side-panel/model/useCaptions';
+import type { VideoRichSummaryResponse } from '@/shared/lib/api-client';
 import { useMandalaQuery } from '@/features/mandala';
 import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import { useLearningStore } from '@/pages/learning/model/useLearningStore';
@@ -102,36 +103,68 @@ function linkifyTimestamps(root: Node) {
   }
 }
 
+/**
+ * Returns true when `richSummary` carries any usable content for the prompt
+ * — across v2 layered fields (`core`/`analysis`, CP437) AND v1 (`structured`,
+ * pre-CP437). PanelAISummary uses the same split (`hasNewV2`/`hasLegacyRich`).
+ */
+export function summaryHasUsableContent(rs: VideoRichSummaryResponse | null): boolean {
+  if (!rs) return false;
+  if (rs.core?.one_liner) return true;
+  if (rs.analysis?.core_argument) return true;
+  if (rs.analysis?.key_concepts && rs.analysis.key_concepts.length > 0) return true;
+  if (rs.analysis?.actionables && rs.analysis.actionables.length > 0) return true;
+  if (rs.oneLiner) return true;
+  if (rs.structured?.core_argument) return true;
+  if (rs.structured?.key_points && rs.structured.key_points.length > 0) return true;
+  if (rs.structured?.actionables && rs.structured.actionables.length > 0) return true;
+  return false;
+}
+
 export function buildInstructions(
   videoId: string,
-  richSummary: {
-    title?: string;
-    structured?: { key_points?: string[]; core_argument?: string; actionables?: string[] };
-  } | null,
+  richSummary: VideoRichSummaryResponse | null,
   transcript: string | null,
   language: string
 ): string {
   const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
-  const hasContent =
-    richSummary != null &&
-    (richSummary.title ||
-      richSummary.structured?.core_argument ||
-      richSummary.structured?.key_points?.length ||
-      richSummary.structured?.actionables?.length);
+  const hasContent = summaryHasUsableContent(richSummary);
 
   let videoSection: string;
   let noContentRule: string;
   let timestampRule: string;
 
-  if (hasContent) {
+  if (hasContent && richSummary) {
+    // Prefer v2 layered fields, fall back to v1 `structured` field-by-field.
+    const oneLiner = richSummary.core?.one_liner ?? richSummary.oneLiner ?? null;
+    const coreArg =
+      richSummary.analysis?.core_argument ?? richSummary.structured?.core_argument ?? null;
+    const keyConcepts = richSummary.analysis?.key_concepts ?? [];
+    const keyPoints = richSummary.structured?.key_points ?? [];
+    const actionables =
+      richSummary.analysis?.actionables ?? richSummary.structured?.actionables ?? [];
+    const sections = richSummary.segments?.sections ?? richSummary.structured?.chapters ?? null;
+
     videoSection = `\n\n## Current Video\n- URL: ${videoUrl}`;
-    if (richSummary!.title) videoSection += `\n- Title: ${richSummary!.title}`;
-    if (richSummary!.structured?.core_argument)
-      videoSection += `\n- Core argument: ${richSummary!.structured.core_argument}`;
-    if (richSummary!.structured?.key_points?.length)
-      videoSection += `\n- Key points:\n${richSummary!.structured.key_points.map((p) => `  - ${p}`).join('\n')}`;
-    if (richSummary!.structured?.actionables?.length)
-      videoSection += `\n- Actionable takeaways:\n${richSummary!.structured.actionables.map((a) => `  - ${a}`).join('\n')}`;
+    if (oneLiner) videoSection += `\n- One-liner: ${oneLiner}`;
+    if (coreArg) videoSection += `\n- Core argument: ${coreArg}`;
+    if (keyPoints.length)
+      videoSection += `\n- Key points:\n${keyPoints.map((p) => `  - ${p}`).join('\n')}`;
+    if (keyConcepts.length)
+      videoSection += `\n- Key concepts:\n${keyConcepts.map((c) => `  - ${c.term}: ${c.definition}`).join('\n')}`;
+    if (actionables.length)
+      videoSection += `\n- Actionable takeaways:\n${actionables.map((a) => `  - ${a}`).join('\n')}`;
+    if (Array.isArray(sections) && sections.length)
+      videoSection += `\n- Sections (with timestamps):\n${sections
+        .map((s) => {
+          const t =
+            'from_sec' in s && typeof s.from_sec === 'number'
+              ? ` (${Math.floor(s.from_sec / 60)}:${String(s.from_sec % 60).padStart(2, '0')})`
+              : '';
+          const title = 'title' in s ? s.title : '';
+          return `  - ${title}${t}`;
+        })
+        .join('\n')}`;
     noContentRule = '';
     timestampRule =
       '\n- When summarizing or referencing the video, include timestamps (e.g. 0:47) tied to actual sections in the content above to help the user navigate.';
@@ -224,10 +257,14 @@ function ChatPanel({
 }) {
   const { t, i18n } = useTranslation();
   const { richSummary, isLoading: richSummaryLoading } = useRichSummary(videoId);
-  // Transcript fallback: only fetched once rich-summary resolves to "absent",
-  // so videos that already have a structured summary never hit the captions
-  // endpoint.
-  const { captions } = useCaptions(videoId, !richSummaryLoading && !richSummary);
+  // Transcript fallback: only fetched once rich-summary resolves AND has no
+  // usable content (covers (a) row missing entirely and (b) row present but
+  // empty across both v2 and v1 fields — e.g. quality_flag=low). Videos with
+  // any usable rich-summary content never hit the captions endpoint.
+  const { captions } = useCaptions(
+    videoId,
+    !richSummaryLoading && !summaryHasUsableContent(richSummary ?? null)
+  );
   const suggestions = buildSuggestions(t, richSummary?.structured ?? null);
   const wrapperRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
## Summary
Follow-up to #647. The first PR still left **v2 rich-summary rows** broken in the chatbot, which is the prod-majority case:

- `video_rich_summaries` rows authored after CP437 store content in `core` / `analysis` / `segments` (`template_version='v2'`) and leave `structured` NULL.
- `buildInstructions` only inspected `richSummary.structured.*`, so for any v2 row it treated the summary as empty.
- AND the `useCaptions` enable gate was `!richSummary` — true only when the row is null. A v2 row IS non-null, so the transcript fallback also skipped.
- Result: a video with a working v2 rich summary (visible in AI 요약 panel) still gave "콘텐츠를 로드할 수 없습니다" in the chatbot. Confirmed end-to-end on prod for video `L-iAk7VPVuk` (`template_version=v2`, `quality_flag=pass`, `core/analysis` populated, `structured` NULL).

## Fix
- New `summaryHasUsableContent()` mirrors `PanelAISummary`'s `hasNewV2`/`hasLegacyRich` split. Used both to gate `useCaptions` (only fetch when no usable rich content exists) and as the precondition inside `buildInstructions`.
- Rich-summary prompt section prefers v2 fields (`core.one_liner`, `analysis.core_argument`, `analysis.key_concepts`, `analysis.actionables`, `segments.sections`) and falls back to v1 (`oneLiner`, `structured.*`) field-by-field. No behavior change for legacy v1 rows.

## Verification
- BE: no change.
- FE: tsc ✅ / vitest 316/316 (+2 new) ✅ / build ✅.
- New tests:
  - v2-only row (mirrors `L-iAk7VPVuk` shape) produces a real summary section, no refusal/transcript path.
  - degraded row (all content fields null) keeps the no-fabrication refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)