### PR TITLE
fix(quota): honor null=unlimited policy in frontend canAddCard guard

### DIFF
--- a/frontend/src/entities/card/model/local-cards.ts
+++ b/frontend/src/entities/card/model/local-cards.ts
@@ -17,8 +17,10 @@ export type SubscriptionTier = 'free' | 'premium' | 'admin';
  */
 export interface UserSubscription {
   tier: SubscriptionTier;
-  limit: number;
-  mandalaLimit: number;
+  /** Card limit. `null` = unlimited (lifetime/admin tiers — see quota-policy.md). */
+  limit: number | null;
+  /** Mandala limit. `null` = unlimited (lifetime/admin tiers). */
+  mandalaLimit: number | null;
   used: number;
 }
 

--- a/frontend/src/features/card-management/model/useLocalCards.ts
+++ b/frontend/src/features/card-management/model/useLocalCards.ts
@@ -278,9 +278,17 @@ export function useLocalCards() {
     // Error states
     error: listQuery.error || addCard.error || updateCard.error || deleteCard.error,
 
-    // Limit check
-    canAddCard: listQuery.subscription.used < listQuery.subscription.limit,
-    remainingSlots: listQuery.subscription.limit - listQuery.subscription.used,
+    // Limit check — per docs/policies/quota-policy.md + skill-quota-policy.md:96
+    // "If limit is null: unlimited, always allowed." Lifetime/admin tiers store
+    // null in user_subscriptions.local_cards_limit (TIER_LIMITS.lifetime.cards = null).
+    // Without the null guard, `used < null` coerces to `used < 0` and blocks every add.
+    canAddCard:
+      listQuery.subscription.limit === null ||
+      listQuery.subscription.used < listQuery.subscription.limit,
+    remainingSlots:
+      listQuery.subscription.limit === null
+        ? Number.POSITIVE_INFINITY
+        : listQuery.subscription.limit - listQuery.subscription.used,
 
     // Actions
     addCard: addCard.mutateAsync,


### PR DESCRIPTION
## Summary

**Policy violation**, not just a bug. Lifetime / admin users have `local_cards_limit = null` in `user_subscriptions` per the documented contract:

> "If limit is `null`: unlimited, always allowed." — `docs/policies/skill-quota-policy.md:96`
> "Resource limits per tier. `null` means unlimited." — `src/config/quota.ts:77`

The frontend `canAddCard` predicate was `used < limit`. Without a null guard, `used < null` coerces to `used < 0` and evaluates **false**, so every paste / D&D add was blocked for lifetime users with an empty-interpolated "저장 한도(개) 초과" toast.

The matching `mandala` path was already null-guarded (`MandalaWizardPage.tsx:73`, `SubscriptionSettingsTab.tsx:55`); only the card path was out of sync with the policy.

## Changes

- `useLocalCards.ts:282-283` — `canAddCard` / `remainingSlots`: explicit `=== null` guard.
- `entities/card/model/local-cards.ts:20-21` — `UserSubscription.limit` / `mandalaLimit`: type widened to `number | null` so consumers can no longer assume non-null.

Five downstream block sites (`useCardDragDrop.ts:173`, `useCardOrchestrator.ts:781/842/1097`, `useLocalCards.ts:282`) are fixed transitively via the `canAddCard` derivation — no D&D-protected files (`useCardDragDrop.ts`, `IndexPage.tsx`, etc.) are touched directly.

The matching Edge Function fix (`supabase/functions/local-cards/index.ts` — `checkCardLimit`, `verifyCardLimitAfterInsert`, batch-move, import-playlist) lands in a follow-up PR for isolated rollback.

## Test plan

- [x] `tsc --noEmit` (frontend) — pass (type widening caused 0 downstream errors)
- [x] `vitest run` — 33 files / 311 tests pass
- [x] `npm run build` — pass
- [x] browser smoke — `/` + `/mandalas/new` → 200, dev log clean
- [ ] **manual after deploy**: lifetime account — URL paste / D&D drop succeed (no "한도 초과" toast). free account — still blocked when over limit (regression check).
- [ ] `/test-dnd` Playwright — paste case isn't covered by the regression suite; manual verification is the real signal.

Worktree isolation used (`git worktree add ...`) — shared working dir + parallel session uncommitted work untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)