### PR TITLE
fix(quota,ef): honor null=unlimited in local-cards Edge Function (Phase 2)

### DIFF
--- a/supabase/functions/local-cards/index.ts
+++ b/supabase/functions/local-cards/index.ts
@@ -75,7 +75,11 @@ async function checkCardLimit(supabase: ReturnType<typeof createClient>, userId:
   return {
     limit: subscription.local_cards_limit,
     used: count || 0,
-    canAdd: (count || 0) < subscription.local_cards_limit,
+    // `null = unlimited` per docs/policies/quota-policy.md + skill-quota-policy.md:96.
+    // Lifetime/admin tiers store null in local_cards_limit. Without this guard,
+    // `(count || 0) < null` coerces to `< 0` and blocks every add.
+    canAdd: subscription.local_cards_limit === null
+      || (count || 0) < subscription.local_cards_limit,
     tier: subscription.tier
   };
 }
@@ -87,7 +91,8 @@ async function verifyCardLimitAfterInsert(
   insertedCardIds: string[]
 ): Promise<{ exceeded: boolean; limitInfo?: { tier: string; limit: number; used: number } }> {
   const limitInfo = await checkCardLimit(supabase, userId);
-  if (limitInfo.used <= limitInfo.limit) {
+  // `null = unlimited` — never trigger rollback for unlimited tiers.
+  if (limitInfo.limit === null || limitInfo.used <= limitInfo.limit) {
     return { exceeded: false };
   }
 
@@ -598,9 +603,9 @@ Deno.serve(async (req) => {
             }
           }
 
-          // Check limit for inserts
+          // Check limit for inserts — `null = unlimited` per policy.
           const limitInfo = await checkCardLimit(supabase, user.id);
-          if (limitInfo.used + inserts.length > limitInfo.limit) {
+          if (limitInfo.limit !== null && limitInfo.used + inserts.length > limitInfo.limit) {
             return new Response(
               JSON.stringify({
                 error: 'LIMIT_EXCEEDED',
@@ -735,9 +740,9 @@ Deno.serve(async (req) => {
         const playlistThumbnail = plMeta.snippet.thumbnails?.medium?.url || plMeta.snippet.thumbnails?.default?.url || '';
         const playlistItemCount = plMeta.contentDetails?.itemCount || 0;
 
-        // 2. Card limit pre-check
+        // 2. Card limit pre-check — `null = unlimited` per policy.
         const limitInfo = await checkCardLimit(supabase, user.id);
-        if (limitInfo.used + playlistItemCount > limitInfo.limit) {
+        if (limitInfo.limit !== null && limitInfo.used + playlistItemCount > limitInfo.limit) {
           const available = Math.max(0, limitInfo.limit - limitInfo.used);
           return new Response(
             JSON.stringify({


### PR DESCRIPTION
## Summary

Companion / Phase 2 to PR #651 (frontend). Reporter confirmed Phase 1 alone wasn't enough — lifetime user (`jamesjk4242@`) still got "저장한도 초과" because the backend `add` action returns 403 LIMIT_EXCEEDED, which the frontend catch surfaces with the same toast.

Same JS gotcha as the frontend: `(count || 0) < null` coerces to `< 0`; `used + N > null` evaluates true. So every add / batch-move / playlist-import was blocked for lifetime users (`local_cards_limit = null` per policy).

> "If limit is `null`: unlimited, always allowed." — `docs/policies/skill-quota-policy.md:96`

## Changes (single file)

`supabase/functions/local-cards/index.ts` — four sites, all `null` guards:

| Line | Function | Predicate |
|---|---|---|
| 78 | `checkCardLimit` | `canAdd` |
| 90 | `verifyCardLimitAfterInsert` | post-insert rollback gate |
| 603 | `batch-move` | bulk pre-check |
| 740 | `import-playlist` | playlist pre-check |

Existing numeric-limit paths behave identically (mathematically). diff: +11/−6.

## Scope honesty (per user 추측-금지 standard)

- ✅ Verified by direct read: the 4 edited sites, the policy doc, the JS coercion rule.
- ⚠️ NOT exhaustively re-read: the full 1900-line EF, other EFs, `src/api/` routes for parallel limit checks, DB triggers. Backend Explore agent's grep found these 4 — completeness for other limit-check sites is **agent-assumed, not first-person fact-verified**.
- ⚠️ `verifyCardLimitAfterInsert` return type still declares `{ limit: number }` even though it can now be null — left untouched (no observed downstream consumer breaks).
- 🛡 Real signal = reporter's manual prod test, not automated tests (paste/D&D not covered by regression suite).

## Test plan

- [x] EF file diff reviewed (+11/−6, 4 guards added, zero other changes)
- [ ] **After deploy — reporter manual test on `jamesjk4242@`** (lifetime account):
  - URL paste → succeeds (no 한도 toast)
  - D&D drop onto sector → card lands in sector
  - D&D drop onto Idea Spot → card lands in Idea Spot
- [ ] Free account (if available) — limit enforcement still works (regression)

Worktree-isolated (`/tmp/insighta-limit-fix`) — shared working dir + other sessions' uncommitted work untouched. Local-dev dispatcher (`/Users/jeonhokim/cursor/superbase/...`) carries the same pattern; prod-unaffected, separate-repo sync in follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)