### PR TITLE
fix(cards): tone-down hover vignette + reject channel URL on D&D

### DIFF
--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -973,6 +973,29 @@ function AuthenticatedApp() {
                       onDeleteCards={cards.handleDeleteCards}
                       onAddCard={navigation.selectedCellIndex != null ? handleAddCard : undefined}
                       onExternalUrlDrop={(url) => {
+                        // CP463+ Issue #649 follow-up — reject YouTube
+                        // channel/playlist URLs that have no video id. The
+                        // add path silently stores a placeholder row when
+                        // video_id can't be extracted (user reported case:
+                        // dropping the channel home `youtube.com/@xxx` →
+                        // "YouTube Video" placeholder + /placeholder.svg).
+                        const isYouTubeHost = /(?:^|\.)(?:youtube\.com|youtu\.be)$/i.test(
+                          (() => {
+                            try {
+                              return new URL(url).hostname;
+                            } catch {
+                              return '';
+                            }
+                          })()
+                        );
+                        if (isYouTubeHost && !getYouTubeVideoId(url)) {
+                          toast({
+                            title: t('cards.dropError.notVideoUrlTitle'),
+                            description: t('cards.dropError.notVideoUrlDescription'),
+                            variant: 'destructive',
+                          });
+                          return;
+                        }
                         // Read via render-assigned ref, not the closure — the
                         // closure can be stale on the first drop after a cell
                         // selection, silently routing to Idea Spot.

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -629,6 +629,10 @@
     "archive": {
       "toastSuccess": "Archived",
       "undoLabel": "Undo"
+    },
+    "dropError": {
+      "notVideoUrlTitle": "Video URL required",
+      "notVideoUrlDescription": "Channel and playlist URLs cannot be added. Please drag the URL of the video page itself."
     }
   },
   "contextHeader": {

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -637,6 +637,10 @@
     "archive": {
       "toastSuccess": "보관됨",
       "undoLabel": "되돌리기"
+    },
+    "dropError": {
+      "notVideoUrlTitle": "영상 URL 이 필요합니다",
+      "notVideoUrlDescription": "채널/플레이리스트 URL 은 추가할 수 없습니다. 영상 페이지의 URL 을 드래그해주세요."
     }
   },
   "contextHeader": {

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -349,7 +349,7 @@ export function InsightCardItemV2({
       )}
 
       {/* ── Thumbnail ── */}
-      <div className="relative aspect-video overflow-hidden rounded-[10px] bg-gradient-to-br from-[#1a1c28] to-[#13141c] group-hover:brightness-105 transition-[filter] duration-200">
+      <div className="relative aspect-video overflow-hidden rounded-[10px] bg-gradient-to-br from-[#1a1c28] to-[#13141c] transition-[filter] duration-300 group-hover:brightness-[0.96] group-hover:contrast-[1.04]">
         <img
           src={upgradeYouTubeThumbnail(card.thumbnail) ?? card.thumbnail}
           alt={card.title}
@@ -360,8 +360,12 @@ export function InsightCardItemV2({
           onLoad={handleThumbnailLoad}
         />
 
-        {/* Hover dim overlay */}
-        <div className="absolute inset-0 bg-black/10 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
+        {/* CP463+ — vignette-only hover: darken top + bottom edges so
+            the white drop-shadowed icons (grip TL / Heart TR / Archive BL /
+            progress dot BL) read clearly. via-transparent keeps the
+            middle of the thumbnail untouched so the original artwork
+            stays alive (user feedback: "전체가 시커멓게 되면 원본이 죽는 느낌"). */}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-black/30 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
 
         {/* Glass-morphism Play badge */}
         <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">


### PR DESCRIPTION
## Summary

Two follow-up fixes after CP463 (#653) verification feedback:

1. **Hover overlay was killing the original thumbnail.** Full-frame
   `brightness-[0.78] saturate-[0.92]` + `bg-black/55→/15→/35` darkened the
   whole frame, so the artwork felt dead. Replaced with:
   - thumbnail: `brightness-[0.96] contrast-[1.04]` (almost untouched)
   - overlay: `bg-gradient-to-t from-black/40 via-transparent to-black/30`
     → vignette only on the top and bottom edges where the icons sit
     (grip TL / Heart TR / Archive BL / progress dot BL); the middle of
     the artwork stays alive.

2. **Dropping a YouTube channel/playlist URL produced a placeholder row.**
   Repro: drag `youtube.com/@oziozi000` (channel home) into the grid →
   `user_local_cards` row with `title='YouTube Video'`,
   `thumbnail=/placeholder.svg`, `video_id=NULL`. The add path silently
   defaults when no `video_id` can be extracted. Now reject at the FE
   drop handler with a destructive toast pointing the user at the
   per-video URL — no DB row written when no video id is present.

   i18n: `cards.dropError.notVideoUrl{Title,Description}` (ko + en).

## Test plan

- [x] `npx tsc --noEmit` — PASS
- [ ] Manual: hover a card in the grid → top + bottom edges darken, middle stays vivid, white icons visible
- [ ] Manual: drag `youtube.com/@<channel>` → destructive toast, no row added
- [ ] Manual: drag `youtube.com/watch?v=<id>` → card added as before
- [ ] Manual: drag a non-YouTube URL → still routed to Idea Spot (no regression)

## Refs

- Builds on #653 (CP463 Issue #649 Phase 1-3)
- DB fact (latest D&D row): `8c81bdf8…|YouTube Video|/placeholder.svg||https://www.youtube.com/@oziozi000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)