### PR TITLE
fix(cards): show channel/views/duration on D&D-added cards

### DIFF
--- a/frontend/src/entities/card/model/local-cards.ts
+++ b/frontend/src/entities/card/model/local-cards.ts
@@ -48,6 +48,9 @@ export interface LocalCard {
   /** YouTube upload date, joined from youtube_videos by video_id. Null for non-YouTube cards or YouTube cards not yet enriched. */
   published_at?: string | null;
   duration_seconds?: number | null;
+  /** Joined from youtube_videos by video_id (CP463+ /local-cards/list LEFT JOIN extension). */
+  channel_title?: string | null;
+  view_count?: number | null;
   /** CP457+ pin / bookmark timestamp. Null = unpinned. */
   pinned_at?: string | null;
 }
@@ -109,10 +112,16 @@ export interface LimitExceededError {
 export function localCardToInsightCard(card: LocalCard): InsightCard {
   const publishedAt = card.published_at ? new Date(card.published_at) : null;
   const hasMetadataTitle = !!card.metadata_title;
-  const hasVideoExtras = card.published_at != null || card.duration_seconds != null;
+  const hasVideoExtras =
+    card.published_at != null ||
+    card.duration_seconds != null ||
+    card.channel_title != null ||
+    card.view_count != null;
   const metadataExtras: Record<string, unknown> = {};
   if (card.published_at) metadataExtras['published_at'] = card.published_at;
   if (card.duration_seconds != null) metadataExtras['duration_seconds'] = card.duration_seconds;
+  if (card.channel_title) metadataExtras['channel_title'] = card.channel_title;
+  if (card.view_count != null) metadataExtras['view_count'] = Number(card.view_count);
 
   return {
     id: card.id,

--- a/supabase/functions/local-cards/index.ts
+++ b/supabase/functions/local-cards/index.ts
@@ -276,7 +276,12 @@ Deno.serve(async (req) => {
           .filter((id): id is string => !!id);
 
         let summaryMap = new Map<string, Record<string, unknown>>();
-        let videoMetaMap = new Map<string, { published_at: string | null; duration_seconds: number | null }>();
+        let videoMetaMap = new Map<string, {
+          published_at: string | null;
+          duration_seconds: number | null;
+          channel_title: string | null;
+          view_count: number | null;
+        }>();
         if (youtubeUrls.length > 0 || youtubeVideoIds.length > 0) {
           const [summariesRes, videosRes] = await Promise.all([
             youtubeUrls.length > 0
@@ -288,7 +293,7 @@ Deno.serve(async (req) => {
             youtubeVideoIds.length > 0
               ? supabase
                   .from('youtube_videos')
-                  .select('youtube_video_id, published_at, duration_seconds')
+                  .select('youtube_video_id, published_at, duration_seconds, channel_title, view_count')
                   .in('youtube_video_id', youtubeVideoIds)
               : Promise.resolve({ data: [] as Record<string, unknown>[] }),
           ]);
@@ -301,6 +306,8 @@ Deno.serve(async (req) => {
             videoMetaMap.set(v.youtube_video_id as string, {
               published_at: (v.published_at as string | null) ?? null,
               duration_seconds: (v.duration_seconds as number | null) ?? null,
+              channel_title: (v.channel_title as string | null) ?? null,
+              view_count: (v.view_count as number | null) ?? null,
             });
           }
         }
@@ -315,6 +322,8 @@ Deno.serve(async (req) => {
               ? {
                   published_at: videoMeta.published_at,
                   duration_seconds: videoMeta.duration_seconds,
+                  channel_title: videoMeta.channel_title,
+                  view_count: videoMeta.view_count,
                 }
               : {}),
           };
@@ -443,6 +452,56 @@ Deno.serve(async (req) => {
               }),
               { status: 403, headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' } }
             );
+          }
+        }
+
+        // CP463+ Issue #649 — populate youtube_videos cache for this video
+        // so subsequent /local-cards/list (and Heart→v2 enrichment) returns
+        // channel_title / view_count / duration_seconds / published_at
+        // instead of falling back to the user-supplied placeholder. Synchronous
+        // so the first list refetch after add already has full metadata. Silent
+        // skip on cache hit, missing API key, or YouTube API failure (the card
+        // still saves successfully — D&D add path remains unblocked).
+        if (
+          card?.id &&
+          (body.link_type === 'youtube' || body.link_type === 'youtube-shorts') &&
+          body.video_id
+        ) {
+          try {
+            const { data: cached } = await supabase
+              .from('youtube_videos')
+              .select('youtube_video_id')
+              .eq('youtube_video_id', body.video_id)
+              .maybeSingle();
+            if (!cached) {
+              const apiKey = Deno.env.get('YOUTUBE_API_KEY');
+              if (apiKey) {
+                const vUrl = `${YOUTUBE_API_BASE}/videos?part=snippet,contentDetails,statistics&id=${body.video_id}`;
+                const vResp = await youtubeRequest(vUrl, null, apiKey);
+                if (vResp.ok) {
+                  const vData = await vResp.json();
+                  const video = vData.items?.[0];
+                  if (video) {
+                    await supabase.from('youtube_videos').upsert({
+                      youtube_video_id: body.video_id,
+                      title: video.snippet?.title || '',
+                      description: video.snippet?.description || '',
+                      thumbnail_url: video.snippet?.thumbnails?.medium?.url
+                        || video.snippet?.thumbnails?.default?.url
+                        || '',
+                      channel_title: video.snippet?.channelTitle || '',
+                      published_at: video.snippet?.publishedAt || null,
+                      duration_seconds: parseDuration(video.contentDetails?.duration || 'PT0S'),
+                      view_count: Number(video.statistics?.viewCount) || 0,
+                      like_count: Number(video.statistics?.likeCount) || 0,
+                      source: 'user-d-and-d',
+                    }, { onConflict: 'youtube_video_id' });
+                  }
+                }
+              }
+            }
+          } catch (e) {
+            console.error('[local-cards] youtube_videos cache populate failed:', e);
           }
         }
 


### PR DESCRIPTION
## Summary

D&D-added cards were missing channel name, view count, duration badge, and the real upload date — they only showed a bare "just now · <sector>" footer (see CP463 bug report for the screenshot side-by-side with recommendation cards).

**Root cause** (two-part):
1. `/local-cards/list` joined `youtube_videos` only for `published_at` + `duration_seconds`, dropping `channel_title` + `view_count`.
2. The add path never populated `youtube_videos` for D&D videos, so any video outside the trending pool was a permanent cache miss (real case: dragging `youtube.com/watch?v=eUGlonGv2EY` 빙하 라면 → cache miss → bare row even after the JOIN fix).

## Changes

| File | Change |
|---|---|
| `supabase/functions/local-cards/index.ts` list path | also `select channel_title, view_count` from `youtube_videos`; surface on returned card |
| same file add path | on YouTube cache miss, synchronously fetch `videos?part=snippet,contentDetails,statistics` via the existing `YOUTUBE_API_KEY` and upsert. Add stays unblocked on any failure |
| `superbase/volumes/functions/main/index.ts` mirror | same two changes (list path derives video_id from URL; add path falls back to url-derived id when `body.video_id` absent) |
| `frontend/src/entities/card/model/local-cards.ts` | extend `LocalCard` + `localCardToInsightCard` with `channel_title` / `view_count` metadata extras so `InsightCardItemV2`'s existing footer renders them |

## Test plan

- [x] `npx tsc --noEmit` — PASS
- [x] supabase-functions-dev restarted, mirror synced
- [ ] Manual (dev): refresh grid → previously-cached D&D cards (`uvd-ZXOU1fg`, `aircAruvnKk`, `KyA-NywDwSY`) now show channel name + view count + duration badge
- [ ] Manual (prod after deploy): drag a fresh YouTube video URL → first list refetch shows full metadata (cache populate succeeds with `YOUTUBE_API_KEY` injected)
- [ ] Manual (dev): drag a non-YouTube URL → still routed to Idea Spot (no regression)

## Notes

- Dev container does NOT inject `YOUTUBE_API_KEY` (only `YOUTUBE_CLIENT_*` for OAuth). Cache populate silently skips locally — D&D card still added, but no channel/views until the row is cached by other means. Prod uses the secret already wired into `import-playlist`.
- API quota cost: 1 unit per D&D add (videos endpoint). Negligible.

## Refs

- Follow-up to #654 (CP463+1)
- DB fact (bug repro row): `a57aeaf1…|해발 5,000m 빙하 앞에서 라면…|eUGlonGv2EY|https://www.youtube.com/watch?v=eUGlonGv2EY` — and `youtube_videos` row absent at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)