### PR TITLE
fix(migrations): idempotent RLS policies + approval-gate hook

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,6 +13,11 @@
             "type": "command",
             "command": "bash scripts/hooks/ssh-ec2-guard.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash scripts/hooks/approval-gate.sh",
+            "timeout": 5
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,8 @@ scripts/*
 !scripts/data/
 !scripts/dataset-v4/
 !scripts/apply-custom-sql.sh
+!scripts/hooks/
+!scripts/hooks/**
 prompt/
 
 # Dev tool configs

--- a/prisma/migrations/card-interactions/001_create_table.sql
+++ b/prisma/migrations/card-interactions/001_create_table.sql
@@ -70,14 +70,22 @@ CREATE INDEX IF NOT EXISTS idx_card_interactions_mandala
 -- (mandala_subscriptions). Users can only read/write their own rows.
 ALTER TABLE public.card_interactions ENABLE ROW LEVEL SECURITY;
 
+-- CP463+ — DROP-then-CREATE pattern so the file is idempotent across
+-- every `psql -f` reapply. PostgreSQL 15 has no `CREATE POLICY IF NOT
+-- EXISTS`, so on the second run a bare CREATE raises "policy ... already
+-- exists" and the whole Database Schema Sync deploy step fails with
+-- exit code 3 (see 2026-05-17 Deploy run 25989424141 against `65c3adef`).
+DROP POLICY IF EXISTS "Users can view their own card interactions" ON public.card_interactions;
 CREATE POLICY "Users can view their own card interactions"
   ON public.card_interactions FOR SELECT
   USING (user_id = auth.uid());
 
+DROP POLICY IF EXISTS "Users can insert their own card interactions" ON public.card_interactions;
 CREATE POLICY "Users can insert their own card interactions"
   ON public.card_interactions FOR INSERT
   WITH CHECK (user_id = auth.uid());
 
+DROP POLICY IF EXISTS "Users can delete their own card interactions" ON public.card_interactions;
 CREATE POLICY "Users can delete their own card interactions"
   ON public.card_interactions FOR DELETE
   USING (user_id = auth.uid());

--- a/scripts/hooks/approval-gate.sh
+++ b/scripts/hooks/approval-gate.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# PreToolUse hook — require explicit user approval marker before
+# `gh pr merge` and `git push --force` (and `--force-with-lease`).
+#
+# CP462 /retro 12th #2 → CP463 ship: memory-only "계획 → 승인 → 실행"
+# rule failed 5+ times across CP421~CP461 ("계획→승인→실행 위반 1건 PR #648
+# 명시 승인 없이 머지"). This hook adds a hard friction step that forces
+# Claude (or any caller) to surface the irreversible action one more
+# time before it commits.
+#
+# Allowed forms:
+#   • INSIGHTA_USER_OK=1 gh pr merge <N> --squash       (Claude must add env after user "ok")
+#   • INSIGHTA_USER_OK=1 git push --force-with-lease    (only after user 's typed "ok"/"approved"/"머지")
+#   • plain `git push` (non-force) is NOT blocked — verify-gate.sh handles FE marker
+#   • read-only `gh pr view / list / checks` not blocked
+#
+# Telemetry: every bypass appends a row to
+#   ~/.claude/projects/-Users-jeonhokim-cursor-insighta/memory/.approval-gate.log
+# so /retro can audit how often the env was used and whether the surrounding
+# user message actually contained an explicit approval token.
+
+set -euo pipefail
+
+INPUT=$(cat 2>/dev/null || echo '{}')
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+
+LOG="$HOME/.claude/projects/-Users-jeonhokim-cursor-insighta/memory/.approval-gate.log"
+
+# `gh pr merge <N>` (squash/rebase/merge) — irreversible to public main
+if echo "$CMD" | grep -qE '\bgh[[:space:]]+pr[[:space:]]+merge\b'; then
+  if [ "${INSIGHTA_USER_OK:-}" = "1" ]; then
+    printf '%s gh-pr-merge bypass cmd=%q\n' "$(date -u +%FT%TZ)" "$CMD" >> "$LOG" 2>/dev/null || true
+    exit 0
+  fi
+  cat <<'EOF' >&2
+🚫 BLOCKED: `gh pr merge` requires explicit user approval marker.
+
+CP462 /retro 12th #2 — memory-only "계획→승인→실행" enforcement failed
+5+ times. This hook makes irreversible merges visible.
+
+Re-run with the approval env:
+  INSIGHTA_USER_OK=1 gh pr merge <N> --squash --delete-branch
+
+Only do so after the user has typed an explicit "ok" / "approved" /
+"머지" / "진행" in chat for THIS specific PR. The bypass is logged to
+~/.claude/projects/-Users-jeonhokim-cursor-insighta/memory/.approval-gate.log
+for /retro audit.
+EOF
+  exit 1
+fi
+
+# Force push — irreversible to remote history
+if echo "$CMD" | grep -qE '\bgit[[:space:]]+push\b.*--force(-with-lease)?\b'; then
+  if [ "${INSIGHTA_USER_OK:-}" = "1" ]; then
+    printf '%s git-force-push bypass cmd=%q\n' "$(date -u +%FT%TZ)" "$CMD" >> "$LOG" 2>/dev/null || true
+    exit 0
+  fi
+  cat <<'EOF' >&2
+🚫 BLOCKED: `git push --force` requires explicit user approval marker.
+
+Re-run with:
+  INSIGHTA_USER_OK=1 git push --force-with-lease <remote> <branch>
+
+Force-push rewrites remote history. Only after user explicit "ok".
+EOF
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Two unrelated cleanup items bundled into one small PR.

### 1. Deploy Schema Sync regression — `card_interactions` RLS policies not idempotent

`deploy.yml` Database Schema Sync step re-applies every `prisma/migrations/**/*.sql` on every push to main. PG 15 has **no** `CREATE POLICY IF NOT EXISTS`, so the second run against `prisma/migrations/card-interactions/001_create_table.sql` raises:

```
ERROR: policy "Users can view their own card interactions" for table "card_interactions" already exists
Process completed with exit code 3.
```

→ **Deploy run [25989424141](https://github.com/JK42JJ/insighta/actions/runs/25989424141) failed** for `65c3adef` (PR #654 ship) and PR #655 deploy will fail the same way without this fix.

**Fix:** wrap each `CREATE POLICY` with `DROP POLICY IF EXISTS` so the file is idempotent across reapply (standard pattern).

### 2. `scripts/hooks/approval-gate.sh` — block `gh pr merge` / `git push --force` without explicit user approval marker

Memory-only "계획→승인→실행" rule failed 5+ times across CP421~CP461 (CP462 /retro 12th #2 carryover). PreToolUse hook checks `INSIGHTA_USER_OK=1`. Read-only `gh pr view/list/checks` are not blocked. Every bypass logs to `memory/.approval-gate.log` so /retro can audit pattern.

Updated `.gitignore` so `scripts/hooks/**` is tracked (was excluded by `scripts/*` blanket rule).

## Test plan

- [x] Smoke: `echo '{"tool_input":{"command":"gh pr merge 999 --squash"}}' | bash scripts/hooks/approval-gate.sh` → blocks (exit 1) + helpful stderr
- [x] Smoke: with `INSIGHTA_USER_OK=1` → passes (exit 0) + appends row to `.approval-gate.log`
- [x] Smoke: `gh pr view 655` payload → passes (not matched)
- [ ] Manual: deploy after merge → Database Schema Sync passes (run for this commit will be the proof)
- [ ] Manual: `gh pr merge` from this Claude session → hook blocks until env added

## Notes

- Migration #1 is **prod-safe**: every CREATE POLICY ran exactly once during PR #653 deploy (run 25988710468 SUCCESS). The DROP-then-CREATE re-creates the same policy text, no semantic change.
- Hook #2 only blocks at execution time inside Claude Code sessions; manual shell `gh pr merge` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)