### PR TITLE
fix(cards): blockquote fallback to v1 summary_ko when v2 oneLiner absent

### DIFF
--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -285,7 +285,17 @@ export function InsightCardItemV2({
   const views = formatViewCount(ytMeta.viewCount);
   const relDate = formatRelativeDate(ytMeta.publishedAt ?? card.createdAt?.toISOString());
   const hasNote = !!card.userNote?.trim();
-  const trimmedOneLiner = oneLiner?.trim();
+  // CP464+ — blockquote source priority:
+  //   1. v2 `core.one_liner` (Heart-triggered v2 enrichment, ≤ 20 chars
+  //      mandala-fit one-liner — most precise).
+  //   2. v1 `video_summaries.summary_ko` (Clawbot cron auto-summary —
+  //      already populated for every D&D card with a transcript,
+  //      regardless of Heart click).
+  // PR #653 originally bound this slot to oneLiner only, which silently
+  // dropped the v1 summary that the legacy auto-pipeline still produces.
+  // Falling back to summary_ko restores the "drop a card → auto summary
+  // appears" behaviour while preserving the v2 precision on Heart'd cards.
+  const trimmedOneLiner = (oneLiner ?? card.videoSummary?.summary_ko)?.trim();
 
   const footerLeft = relDate || null;
   const footerRight = views || null;


### PR DESCRIPTION
## Summary

D&D-added cards never showed the description blockquote even though the legacy auto-pipeline (Clawbot) **was still populating** v1 \`video_summaries.summary_ko\` for them. The patch tower (PR #655, #657) attacked the wrong layers.

**True root cause (CP464 diagnosis)**: PR #653 (#649 Phase 3) rebound the blockquote in \`InsightCardItemV2\` to read **only** v2 \`core.one_liner\`, which is populated only after a Heart click. For non-Heart'd cards the binding fell through to \`null\` and the slot rendered empty — even when the v1 summary was sitting on the card object.

DB fact for the user-reported 빙하 라면 D&D card (\`eUGlonGv2EY\`):
| Source | State |
|---|---|
| \`video_rich_summaries\` (v2) | no row (Heart not clicked) |
| \`video_summaries.summary_ko\` (v1) | **232 chars present** (Clawbot already processed) |
| \`/local-cards/list\` response | \`card.video_summary\` already in JSON |
| \`localCardToInsightCard\` | \`videoSummary\` already on the InsightCard |
| UI binding | **broken** — read oneLiner only |

## Fix

Single line in \`frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx:288\`:

\`\`\`ts
// Before
const trimmedOneLiner = oneLiner?.trim();
// After
const trimmedOneLiner = (oneLiner ?? card.videoSummary?.summary_ko)?.trim();
\`\`\`

Priority: v2 oneLiner first (Heart-precision), v1 summary_ko fallback (Clawbot auto-pipeline).

## Patch tower retired

- **PR #655** (channel/views/duration JOIN): kept — verified correct
- **PR #657** (description fallback at BE): **closed** — wrong layer, blockquote never reads \`metadata.description\`
- **This PR**: 1-line FE binding fix that restores the Clawbot auto-summary display

## Test plan

- [x] tsc --noEmit PASS
- [ ] Manual (dev): refresh grid → 빙하 카드 blockquote 표시 (summary_ko 232 chars)
- [ ] No regression: Heart'd cards still show oneLiner (v2 wins)
- [ ] Manual (prod): same after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)