### PR TITLE
fix(cards): halve idle Heart icon size for thumbnail legibility

### DIFF
--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -463,7 +463,8 @@ export function InsightCardItemV2({
           >
             <Heart
               className={cn(
-                'w-[22px] h-[22px]',
+                'w-[22px] h-[22px] transition-transform duration-200',
+                liked && 'scale-[0.5] group-hover:scale-100',
                 liked
                   ? 'text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.7)]'
                   : 'text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.85)]'


### PR DESCRIPTION
## Summary
- CP466 user directive — liked Heart icon stays visible after hover-out at full 22px and dominates the thumbnail. Halve idle icon size while preserving hit area + hover scale.
- Add `scale-[0.5] group-hover:scale-100` on the Heart icon. `transition-transform duration-200` for smooth animation. unliked behavior unchanged.

## Behavior
| State | Before | After |
|---|---|---|
| liked + idle (no hover) | 22px icon, dominates thumbnail | ~11px icon (half), thumbnail legibility improved |
| liked + card hover (`group-hover`) | 22px | 22px (restored) |
| liked + button hover | 22px × `scale-125` = ~27px | 22px × `scale-125` = ~27px (unchanged) |
| unliked | hover-only opacity-100, 22px | unchanged |
| Hit area (button wrapper) | 28px | 28px (touch target preserved) |

## Test plan
- [x] tsc `--noEmit` clean
- [x] vitest 316/316 PASS
- [x] `npm run build` PASS (PWA SW generated)
- [x] Browser smoke: GET `/` 200, GET `/mandalas/new` 200 (dev server :8081)
- [ ] Visual check on main grid: hover-in Heart restores to 22px, hover-out shrinks to ~11px

🤖 Generated with [Claude Code](https://claude.com/claude-code)