### PR TITLE
fix(add-cards): v2-priority blockquote + chip DB removal + client timeout

### DIFF
--- a/frontend/src/features/card-management/model/useV2Summaries.ts
+++ b/frontend/src/features/card-management/model/useV2Summaries.ts
@@ -64,6 +64,9 @@ export function useV2Summaries(videoIds: string[] | null | undefined) {
   return {
     summariesByVideoId: map,
     isLoading: query.isLoading,
+    // Covers initial load + background refetch. Consumers suppress v1
+    // fallback while this is true to avoid the v1->v2 swap flicker.
+    isFetching: query.isFetching,
     isError: query.isError,
   };
 }

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1227,6 +1227,16 @@ class ApiClient {
     });
   }
 
+  // Replace the mandala's focus_tags array. Called when the user X-removes
+  // a chip in the Add Cards panel so the change persists across reload
+  // (FE-only veto was getting clobbered by the wizard-meta seed).
+  async updateMandalaFocusTags(id: string, focusTags: string[]): Promise<{ focusTags: string[] }> {
+    return this.request(`/mandalas/${id}/focus-tags`, {
+      method: 'PATCH',
+      body: JSON.stringify({ focusTags }),
+    });
+  }
+
   async deleteMandala(id: string): Promise<void> {
     return this.request<void>(`/mandalas/${id}`, {
       method: 'DELETE',
@@ -1363,6 +1373,14 @@ class ApiClient {
     return this.request(`/mandalas/${mandalaId}/add-cards`, {
       method: 'POST',
       body: JSON.stringify(body),
+      // BE runs Tier 1 (video_pool KNN) + Tier 2 (runDiscoverEphemeral
+      // → YouTube API, 9 cells × 60 buffer with 6-key rotation) in
+      // parallel. Default 15s client timeout aborts before BE can
+      // assemble + filter the cohort on mandalas with a cold video_pool
+      // (prod incident 2026-05-18 — "Request timeout (15s)"). Match the
+      // wizard 60s budget; BE remains the source of truth for actual
+      // upper bound.
+      timeoutMs: 60_000,
     });
   }
 

--- a/frontend/src/widgets/add-cards-panel/ui/KeywordChipInput.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/KeywordChipInput.tsx
@@ -22,6 +22,7 @@ import { useState, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X } from 'lucide-react';
 import { useAddCardsPanelStore } from '../model/useAddCardsPanelStore';
+import { apiClient } from '@/shared/lib/api-client';
 
 const MAX_CHIP_LEN = 200;
 
@@ -30,8 +31,27 @@ export function KeywordChipInput() {
   const extraKeywords = useAddCardsPanelStore((s) => s.extraKeywords);
   const addKeyword = useAddCardsPanelStore((s) => s.addKeyword);
   const removeKeyword = useAddCardsPanelStore((s) => s.removeKeyword);
+  const mandalaId = useAddCardsPanelStore((s) => s.mandalaId);
   const [draft, setDraft] = useState('');
   const isComposingRef = useRef(false);
+
+  // Persist chip removal at the DB layer. FE-only veto was lost on
+  // reload + clobbered by the wizard-meta seed in the next search
+  // response, causing removed chips (e.g. "박문호") to come back.
+  const persistRemoval = useCallback(
+    (kw: string) => {
+      removeKeyword(kw);
+      if (!mandalaId) return;
+      const next = extraKeywords.filter((k) => k !== kw);
+      void apiClient.updateMandalaFocusTags(mandalaId, next).catch(() => {
+        // Non-fatal — the local store already removed the chip. If the
+        // DB write fails the wizard-meta seed may re-add it on next
+        // panel open, but that is a recoverable annoyance, not data
+        // loss.
+      });
+    },
+    [extraKeywords, mandalaId, removeKeyword]
+  );
 
   const commitDraft = useCallback(() => {
     const trimmed = draft.trim().slice(0, MAX_CHIP_LEN);
@@ -50,7 +70,7 @@ export function KeywordChipInput() {
           {kw}
           <button
             type="button"
-            onClick={() => removeKeyword(kw)}
+            onClick={() => persistRemoval(kw)}
             className="hover:bg-primary/15 rounded-full transition-colors"
             aria-label={t('addCards.panel.removeKeyword', {
               keyword: kw,
@@ -82,7 +102,7 @@ export function KeywordChipInput() {
             commitDraft();
           } else if (e.key === 'Backspace' && draft === '' && extraKeywords.length > 0) {
             const last = extraKeywords[extraKeywords.length - 1];
-            if (last) removeKeyword(last);
+            if (last) persistRemoval(last);
           }
         }}
         onBlur={() => {

--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -110,7 +110,8 @@ export function CardList({
     }
     return Array.from(ids);
   }, [cards]);
-  const { summariesByVideoId: v2SummariesMap } = useV2Summaries(videoIdsForV2);
+  const { summariesByVideoId: v2SummariesMap, isFetching: v2IsFetching } =
+    useV2Summaries(videoIdsForV2);
 
   // CP462+ Issue #649 Phase 3 — archive: client-side hide + 5-second
   // undo. The BE archive endpoint only records the signal (it does NOT
@@ -446,6 +447,7 @@ export function CardList({
                   const vid = safeVideoId(card.videoUrl);
                   return vid ? (v2SummariesMap.get(vid)?.oneLiner ?? null) : null;
                 })()}
+                isV2Loading={v2IsFetching}
                 sectorLabel={
                   sectorSubjects && card.cellIndex >= 0 && card.cellIndex < sectorSubjects.length
                     ? sectorSubjects[card.cellIndex]

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -135,6 +135,13 @@ interface InsightCardItemV2Props {
    */
   oneLiner?: string | null;
   /**
+   * True while the batch v2-summaries query is fetching (initial load or
+   * background refetch). When true the card suppresses the v1 fallback so
+   * the blockquote stays empty until v2 arrives — prevents the
+   * v1 (long) → v2 (short) text-shrink flicker on grid mutation refetch.
+   */
+  isV2Loading?: boolean;
+  /**
    * Optional archive callback. The card calls this AFTER the archive
    * mutation succeeds so the parent can present a 5-second undo
    * toast (handoff decision #6 — soft hide). When omitted, the card
@@ -163,6 +170,7 @@ export function InsightCardItemV2({
   onRetryEnrich,
   mandalaRelevancePct,
   oneLiner,
+  isV2Loading = false,
   onArchived,
   sectorLabel,
 }: InsightCardItemV2Props) {
@@ -293,17 +301,19 @@ export function InsightCardItemV2({
   const views = formatViewCount(ytMeta.viewCount);
   const relDate = formatRelativeDate(ytMeta.publishedAt ?? card.createdAt?.toISOString());
   const hasNote = !!card.userNote?.trim();
-  // CP464+ — blockquote source priority:
-  //   1. v2 `core.one_liner` (Heart-triggered v2 enrichment, ≤ 20 chars
-  //      mandala-fit one-liner — most precise).
-  //   2. v1 `video_summaries.summary_ko` (Clawbot cron auto-summary —
-  //      already populated for every D&D card with a transcript,
-  //      regardless of Heart click).
-  // PR #653 originally bound this slot to oneLiner only, which silently
-  // dropped the v1 summary that the legacy auto-pipeline still produces.
-  // Falling back to summary_ko restores the "drop a card → auto summary
-  // appears" behaviour while preserving the v2 precision on Heart'd cards.
-  const trimmedOneLiner = (oneLiner ?? card.videoSummary?.summary_ko)?.trim();
+  // Blockquote source priority (v2 wins; v1 only when v2 is settled-absent):
+  //   1. v2 `core.one_liner` if the row exists.
+  //   2. v1 `video_summaries.summary_ko` only when the v2 query has
+  //      FINISHED and produced no row for this video. While v2 is in
+  //      flight the slot stays empty — this prevents the v1 (long
+  //      paragraph) -> v2 (short one-liner) shrink flicker the user
+  //      reported on grid mutation refetch.
+  const trimmedOneLiner = (() => {
+    const v2 = oneLiner?.trim();
+    if (v2) return v2;
+    if (isV2Loading) return undefined;
+    return card.videoSummary?.summary_ko?.trim();
+  })();
 
   const footerLeft = relDate || null;
   const footerRight = views || null;

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -2127,6 +2127,56 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
   );
 
   /**
+   * PATCH /api/v1/mandalas/:id/focus-tags - Replace the mandala's focus_tags
+   * array. Used by the Add Cards panel chip-X button so removing a chip
+   * persists at the DB layer (FE-only state was lost on reload + re-seeded
+   * by subsequent search responses, causing the chip to "come back").
+   * Body: { focusTags: string[] }
+   */
+  fastify.patch<{ Params: { id: string }; Body: { focusTags: unknown } }>(
+    '/:id/focus-tags',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const userId = getUserId(request, reply);
+      if (!userId) return;
+
+      const { focusTags } = request.body ?? {};
+      if (!Array.isArray(focusTags) || focusTags.some((t) => typeof t !== 'string')) {
+        return reply.code(400).send({
+          status: 400,
+          code: 'INVALID_BODY',
+          message: 'focusTags must be a string array',
+        });
+      }
+      const sanitized = (focusTags as string[])
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0 && t.length <= 200);
+
+      try {
+        const updated = await getPrismaClient().user_mandalas.update({
+          where: { id: request.params.id, user_id: userId },
+          data: { focus_tags: sanitized, updated_at: new Date() },
+          select: { focus_tags: true },
+        });
+        return reply.send({ focusTags: updated.focus_tags ?? [] });
+      } catch (err: any) {
+        if (err?.code === 'P2025') {
+          return reply.code(404).send({ error: 'Mandala not found' });
+        }
+        request.log.error(
+          { err, userId, mandalaId: request.params.id },
+          'Failed to update focus_tags'
+        );
+        return reply.code(500).send({
+          status: 500,
+          code: 'UPDATE_FAILED',
+          message: 'Failed to update focus_tags',
+        });
+      }
+    }
+  );
+
+  /**
    * DELETE /api/v1/mandalas/:id - Delete a mandala (cascade deletes levels)
    */
   fastify.delete<{ Params: { id: string } }>(


### PR DESCRIPTION
## Summary

Three related Add Cards / card grid fixes shipped together (same domain follow-up to PR #660):

1. **Card grid v1→v2 blockquote flicker** (user report: text shrinks on grid mutation refetch). `InsightCardItemV2` fell back to v1 `summary_ko` while `useV2Summaries` batch was still fetching, then swapped to the v2 `one_liner` once resolved — a paragraph → one-liner shrink read as a bug. Thread `useV2Summaries.isFetching` through `CardList` → `InsightCardItemV2` and suppress v1 fallback while v2 is in flight; v1 still renders when v2 is settled-absent.

2. **Add Cards chip "comes back" after X-removal** (user diagnosis: FE-only veto, needs DB-level removal). Chip removal only mutated the Zustand store, so reload cleared the veto and the wizard-meta seed re-added the chip from `user_mandalas.focus_tags`. New `PATCH /api/v1/mandalas/:id/focus-tags` persists the new array; `KeywordChipInput` calls it on chip-X + Backspace removal.

3. **Prod incident "Request timeout (15s)"**. `apiClient.request` `DEFAULT_TIMEOUT_MS = 15_000` and `addCards()` did not override. BE runs Tier 1 (`video_pool` KNN) + Tier 2 (`runDiscoverEphemeral` → YouTube API, 9 cells × 60 buffer, 6-key rotation) in parallel; cold-pool mandalas exceed 15s. `addCards()` → `timeoutMs: 60_000`, matching the wizard budget. BE remains the source of truth for the actual upper bound.

## Test plan

- [x] backend `tsc --noEmit -p tsconfig.json` clean
- [x] frontend `tsc --noEmit` clean
- [x] vitest 316/316 passed
- [x] frontend production build clean (12.21s)
- [x] hardcode audit `ms-per-day-redeclared = 0` (baseline unchanged)
- [x] jest smoke (add-cards.test.ts, card-interactions.test.ts) — auth gate cases skip without JWT env, no regressions
- [ ] Prod verification: Add Cards search returns within new 60s budget for cold-pool mandala (this incident: "스마트 스토어로 온라인 비즈니스 시작하기")
- [ ] Prod verification: removed chip stays removed across reload
- [ ] Prod verification: card grid no longer shows v1→v2 paragraph→one-liner shrink on refetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)