### PR TITLE
hotfix(dashboard): revert sequential reveal queue — kills 메롱 flash + 5× slowdown (CP470)

### DIFF
--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -237,44 +237,25 @@ export function CardList({
     setVisibleCount(PAGE_SIZE);
   }, [cardListKey]);
 
-  // CP469.3 — strict top-down sequential reveal queue.
+  // CP469.3 sequential reveal queue REMOVED (CP470 hotfix).
   //
-  // Browser fetchPriority + loading="eager" only order the *fetch
-  // start* — bytes arrive in whatever order HTTP/2 multiplex / image
-  // size / CDN cache state decides. To match the user mental model
-  // ("상단부터 차례로 로드"), CardList owns a `readyIds` Set and only
-  // reveals idx N once 0..N-1 have all reached a terminal load state
-  // (real decoded thumb, fallback exhausted, or placeholder) — OR the
-  // per-idx timeout fires so one slow network never holds the rest of
-  // the grid hostage. Per-idx timeout = REVEAL_TIMEOUT_BASE_MS +
-  // idx * REVEAL_TIMEOUT_STAGGER_MS so the stagger trickles the
-  // forced advances in order even on a totally cold connection.
-  const REVEAL_TIMEOUT_BASE_MS = 1500;
-  const REVEAL_TIMEOUT_STAGGER_MS = 100;
-  const [readyIds, setReadyIds] = useState<Set<string>>(new Set());
-  const markReady = useCallback((cardId: string) => {
-    setReadyIds((prev) => {
-      if (prev.has(cardId)) return prev;
-      const next = new Set(prev);
-      next.add(cardId);
-      return next;
-    });
-  }, []);
-  useEffect(() => {
-    setReadyIds(new Set());
-  }, [cardListKey]);
-  useEffect(() => {
-    if (sortedCards.length === 0) return;
-    const timers = sortedCards.map((card, idx) =>
-      setTimeout(() => markReady(card.id), REVEAL_TIMEOUT_BASE_MS + idx * REVEAL_TIMEOUT_STAGGER_MS)
-    );
-    return () => timers.forEach(clearTimeout);
-  }, [cardListKey, sortedCards, markReady]);
-  const revealedPrefix = useMemo(() => {
-    let i = 0;
-    while (i < sortedCards.length && readyIds.has(sortedCards[i].id)) i++;
-    return i;
-  }, [sortedCards, readyIds]);
+  // The queue's `readyIds` Set was reset on every `cardListKey` change
+  // (= card ids list change). Background SSE / TanStack refetches add
+  // a card → ids list changes → reset → all revealed cards flip back
+  // to wrapper opacity-0 → user sees a "메롱" flash where thumbs that
+  // were already visible disappear behind shimmer and re-reveal.
+  //
+  // We rely instead on:
+  //   - image-utils' own opacity-0 → 1 fade-in (onLoad/onError chain).
+  //   - `loading="eager" + fetchPriority="high"` for idx < 6 so the
+  //     first row arrives near-simultaneously (mosaic minimized).
+  //   - `bg-muted` + shimmer overlay so the placeholder reads as a
+  //     YouTube-style gray loading state until each thumb settles.
+  //
+  // Sequential order across the entire grid is best-effort, not
+  // strict. Re-introducing strict order requires a race-free design
+  // (mandala-scoped reset key + monotonic ready set + safe
+  // sort-change handling) and lands in a separate PR.
 
   // Infinite scroll: observe sentinel at bottom of grid
   useEffect(() => {
@@ -501,8 +482,6 @@ export function CardList({
                 isEnrichFailed={failedEnrichCardIds?.has(card.id)}
                 onRetryEnrich={onRetryEnrich}
                 priority={idx < 6}
-                isRevealed={idx < revealedPrefix}
-                onImageReady={() => markReady(card.id)}
                 mandalaRelevancePct={(() => {
                   const vid = safeVideoId(card.videoUrl);
                   return vid ? (v2SummariesMap.get(vid)?.mandalaRelevancePct ?? null) : null;

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -121,29 +121,13 @@ interface InsightCardItemV2Props {
    */
   isV2Loading?: boolean;
   /**
-   * Above-the-fold hint (CP469 follow-up). When true the thumbnail
-   * <img> opts out of lazy loading and asks the browser to fetch with
-   * high priority. NOTE: priority is advisory — the browser may still
-   * deliver images out of order, which is why the parent CardList also
-   * sequences reveals via `isRevealed` / `onImageReady`.
+   * Above-the-fold hint. When true the thumbnail <img> opts out of
+   * lazy loading and asks the browser to fetch with high priority.
+   * NOTE: priority is advisory — bytes still arrive in whatever order
+   * HTTP/2 multiplex / image size / CDN cache state decides; the
+   * remaining mosaic is acceptable and intentional after CP470.
    */
   priority?: boolean;
-  /**
-   * Sequential reveal gate (CP469.3 — strict top-down). When false the
-   * thumbnail <img> stays hidden behind the muted shimmer placeholder;
-   * the <img> itself stays mounted so its onLoad / onError still fires
-   * to signal readiness upstream. CardList opens the gate idx-by-idx
-   * as each prior card lands or times out.
-   */
-  isRevealed?: boolean;
-  /**
-   * Fires after image-utils' onLoad / onError chain reaches a terminal
-   * state (real decoded thumb, fallback exhausted, or placeholder). The
-   * parent CardList uses this to advance the reveal prefix. Detected by
-   * `img.style.opacity === '1'` since that is exactly what image-utils'
-   * `revealThumbnail` sets on terminal states only.
-   */
-  onImageReady?: () => void;
   /**
    * Optional archive callback. The card calls this AFTER the archive
    * mutation succeeds so the parent can present a 5-second undo
@@ -175,8 +159,6 @@ export function InsightCardItemV2({
   oneLiner,
   isV2Loading = false,
   priority = false,
-  isRevealed = true,
-  onImageReady,
   onArchived,
   sectorLabel,
 }: InsightCardItemV2Props) {
@@ -400,34 +382,24 @@ export function InsightCardItemV2({
           }}
           aria-hidden="true"
         />
-        {/* Image wrapper opacity-gated by parent CardList's strict
-            top-down reveal queue (CP469.3). The inner <img> keeps its
-            own image-utils opacity-0 → 1 fade so progressive-decode
-            mid-frames stay hidden, and we forward the terminal-state
-            signal (img.style.opacity === '1') to CardList via
-            onImageReady so the next idx can reveal. */}
-        <div
-          className="absolute inset-0 transition-opacity duration-300"
-          style={{ opacity: isRevealed ? 1 : 0 }}
-        >
-          <img
-            src={upgradeYouTubeThumbnail(card.thumbnail) ?? card.thumbnail}
-            alt={card.title}
-            className="relative w-full h-full object-cover opacity-0 transition-opacity duration-200"
-            loading={priority ? 'eager' : 'lazy'}
-            fetchPriority={priority ? 'high' : 'auto'}
-            decoding="async"
-            draggable={false}
-            onError={(e) => {
-              handleThumbnailError(e);
-              if (e.currentTarget.style.opacity === '1') onImageReady?.();
-            }}
-            onLoad={(e) => {
-              handleThumbnailLoad(e);
-              if (e.currentTarget.style.opacity === '1') onImageReady?.();
-            }}
-          />
-        </div>
+        {/* CP470 — wrapper opacity gate removed. image-utils' own
+            opacity-0 → 1 onLoad chain (revealThumbnail sets
+            img.style.opacity = '1' on terminal load states) handles
+            the fade-in, so each thumb reveals the moment its own
+            bytes settle. No parent gate means background SSE /
+            refetches that change the cards list can no longer flash
+            already-revealed thumbs back behind the shimmer. */}
+        <img
+          src={upgradeYouTubeThumbnail(card.thumbnail) ?? card.thumbnail}
+          alt={card.title}
+          className="relative w-full h-full object-cover opacity-0 transition-opacity duration-200"
+          loading={priority ? 'eager' : 'lazy'}
+          fetchPriority={priority ? 'high' : 'auto'}
+          decoding="async"
+          draggable={false}
+          onError={handleThumbnailError}
+          onLoad={handleThumbnailLoad}
+        />
 
         {/* CP463+ — vignette-only hover: darken top + bottom edges so
             the white drop-shadowed icons (grip TL / Heart TR / Archive BL /


### PR DESCRIPTION
## Summary

CP469 prod test surfaced two critical bugs introduced by the strict top-down sequential reveal queue (`CP469.3`):

1. **5× slower card loading** — every background TanStack / SSE refetch that changed the cards list reset `readyIds` to an empty Set, which dropped `revealedPrefix` back to 0 and re-armed every per-idx timer (1500ms base + idx × 100ms). The cascade meant most cards waited the full timeout fallback before being marked ready.
2. **"메롱" flicker** — already-revealed thumbs (wrapper `opacity: 1`) flashed back behind the gray shimmer (wrapper `opacity: 0`) whenever the cards array got a new id (new SSE card, archive toggle, refetch returning a slightly different tail) because the same reset emptied `readyIds`. User direct quote: "이건 메롱 하는것도 아니고 ... 코드품질이 낮아서야".

Root cause:

```ts
const cardListKey = useMemo(() => cards.map((c) => c.id).join(','), [cards]);
useEffect(() => { setReadyIds(new Set()); }, [cardListKey]);
```

Any background mutation that changes the id list runs the reset. A race-free design needs a mandala-scoped reset key, a monotonic ready set, and sort-change-safe prefix math — that lands in a separate PR.

This hotfix removes the queue and the wrapper opacity gate but keeps every other CP468 → CP469 improvement intact:

- Full-card invisibility wrap + padding mid-grid: stay removed.
- `bg-muted` semantic-gray thumbnail placeholder: stays.
- Shimmer overlay (`@keyframes shimmer`): stays.
- `loading="eager"` + `fetchPriority="high"` for idx < 6: stays.

Each thumb fades in via image-utils' own `opacity-0 → 1` onLoad chain the moment its bytes settle, with the first row arriving near-simultaneously thanks to the priority hint. No background refetch can hide an already-revealed thumb.

## Files
- `frontend/src/widgets/card-list/ui/CardList.tsx`: remove `readyIds` state + `markReady` callback + reset useEffect + per-idx timeout useEffect + `revealedPrefix` memo; drop `isRevealed` + `onImageReady` props passed to `InsightCardItemV2`.
- `frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx`: drop `isRevealed` + `onImageReady` interface fields + destructure; remove the wrapper opacity gate; restore bare `onError={handleThumbnailError} onLoad={handleThumbnailLoad}`.

Net change: +41 / -90 lines.

## Verify
- tsc PASS (0 errors)
- vitest PASS (34 files / 316 tests)
- npm run build PASS (13.1s)
- Browser smoke (GET / + /login on dev :8081 = 200, HMR alive on changed files)
- `/verify` PASS marker `fa014e5f`

## Test plan
- [x] CI: tsc / vitest / build / lint / hardcode audit
- [ ] Post-deploy prod: refresh on a card-heavy mandala — no 5× slowdown, no thumbnail flash-then-hide pattern
- [ ] Post-deploy prod: open mandala, scroll past idx 6, watch background refetches without flicker
- [ ] D&D / heart / archive still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)