### PR TITLE
chore(deploy): sync YOUTUBE_METADATA_BACKFILL_ENABLED to prod .env (CP474)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,11 +228,22 @@ jobs:
           # state (config/rich-summary.ts:39). Set GitHub Variable
           # RICH_SUMMARY_ENABLED to "true" to activate.
           RICH_SUMMARY_ENABLED: ${{ vars.RICH_SUMMARY_ENABLED }}
+          # CP474 — YouTube metadata backfill cron activation.
+          # Non-secret per CP392: boolean toggle, not a credential. Default
+          # empty ⇒ startYouTubeMetadataCron() exits early per
+          # src/modules/scheduler/youtube-metadata-cron.ts:111 (cron never
+          # registered, no API calls). Set GitHub Variable
+          # YOUTUBE_METADATA_BACKFILL_ENABLED to "true" to activate the
+          # backfill of tags / topic_categories / has_caption /
+          # default_language / comment_count for the ~11K youtube_videos
+          # rows that were created with snippet-only data and never
+          # received the full videos.list metadata enrichment.
+          YOUTUBE_METADATA_BACKFILL_ENABLED: ${{ vars.YOUTUBE_METADATA_BACKFILL_ENABLED }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED
+          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED
           script: |
             set -e
             cd /opt/tubearchive
@@ -260,6 +271,17 @@ jobs:
             # redeploy. Non-secret per CP392 (boolean tuning knob).
             if [ -n "${RICH_SUMMARY_ENABLED}" ]; then
               grep -q '^RICH_SUMMARY_ENABLED=' .env 2>/dev/null && sed -i "s|^RICH_SUMMARY_ENABLED=.*|RICH_SUMMARY_ENABLED=${RICH_SUMMARY_ENABLED}|" .env || echo "RICH_SUMMARY_ENABLED=${RICH_SUMMARY_ENABLED}" >> .env
+            fi
+            # CP474 — YouTube metadata backfill cron activation. Same
+            # idempotent grep/sed/echo pattern as RICH_SUMMARY_ENABLED.
+            # When the Variable is unset/empty the conditional skips,
+            # leaving the youtube-metadata config default (false) in
+            # effect (src/config/youtube-metadata.ts:32) and the cron
+            # logs "metadata cron disabled (...)" at startup. Activate
+            # via `gh variable set YOUTUBE_METADATA_BACKFILL_ENABLED
+            # --body true` then redeploy.
+            if [ -n "${YOUTUBE_METADATA_BACKFILL_ENABLED}" ]; then
+              grep -q '^YOUTUBE_METADATA_BACKFILL_ENABLED=' .env 2>/dev/null && sed -i "s|^YOUTUBE_METADATA_BACKFILL_ENABLED=.*|YOUTUBE_METADATA_BACKFILL_ENABLED=${YOUTUBE_METADATA_BACKFILL_ENABLED}|" .env || echo "YOUTUBE_METADATA_BACKFILL_ENABLED=${YOUTUBE_METADATA_BACKFILL_ENABLED}" >> .env
             fi
             # 2026-04-18 — sync DB URLs from GitHub Secrets so password
             # rotations propagate to prod .env without manual SSH. Was


### PR DESCRIPTION
## Summary
- Mirror the `RICH_SUMMARY_ENABLED` activation pattern for `YOUTUBE_METADATA_BACKFILL_ENABLED` so that the GitHub Variable (already set: `true`) actually propagates to `/opt/tubearchive/.env` on EC2 on the next deploy.
- 3-line idempotent `grep -q / sed -i / echo >>` block + `envs:` list append + `env:` mapping. Single file, single workflow.
- Activates the `youtube-metadata` cron (`src/modules/scheduler/youtube-metadata-cron.ts`) which has been gated off (default `false` @ `src/config/youtube-metadata.ts:32`) since CP437. Code path itself is unchanged.

## Why
- Prod measurement (2026-05-19): **0 / 10,881** `youtube_videos` rows have `metadata_fetched_at` populated. `tags`, `topic_categories`, `has_caption`, `default_language`, `comment_count` are 100% empty. YouTube API returns this data on `videos.list?part=snippet,contentDetails,statistics,topicDetails` and `metadata-collector.ts:118` already maps it — only the activation flag was missing.
- Same `feature flag default-off → silent skip` pattern as CP465 (`RICH_SUMMARY_ENABLED`). Treated as LEVEL-1 troubleshooting family.

## Cost
- One-time backfill: ~218 `videos.list` calls × 1 unit = ~200 units total. ~2% of the 10K daily quota.
- Cron schedule (default `*/30 * * * *`, batch 2000) processes the 11K backlog in ~3 sweeps then idles on new-row-only ticks.

## Test plan
- [ ] Merge → automatic deploy.
- [ ] After deploy completes: `bash scripts/ssh-connect.sh "docker logs insighta-api --tail 200 2>&1 | grep -E 'metadata cron|YOUTUBE_METADATA'"` — expect `metadata cron started schedule=...` instead of `metadata cron disabled (...)`.
- [ ] First cron tick (within 30 minutes of deploy): expect `metadata cron batch start picked=...` followed by `metadata cron batch done picked=N fetched=N upserted=N errors=0`.
- [ ] After ~3 sweeps (~1.5 hours): `SELECT COUNT(*) FROM youtube_videos WHERE metadata_fetched_at IS NOT NULL` should reach ~10,881 (full backfill). `array_length(tags, 1)` should be non-null for most rows (creator-provided tags are not universally present, but the column is now populated when the API returns them).

## Rollback
- `gh variable delete YOUTUBE_METADATA_BACKFILL_ENABLED` + redeploy → cron exits early on next boot. No DB rollback needed (the new column values are additive and not consumed yet by any active query path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)