### PR TITLE
feat(v2): segments + entities + grid-card core_argument blockquote (CP474)

### DIFF
--- a/frontend/src/features/card-management/model/useV2Summaries.ts
+++ b/frontend/src/features/card-management/model/useV2Summaries.ts
@@ -23,6 +23,14 @@ import { apiClient } from '@/shared/lib/api-client';
 export interface V2SummaryItem {
   videoId: string;
   oneLiner: string | null;
+  /**
+   * CP474 — v2 `analysis.core_argument` (2-3 sentences capturing the
+   * central thesis). Grid card blockquote prefers this over `oneLiner`
+   * because oneLiner is capped at 20 chars and underfills the
+   * line-clamp-3 slot. NULL when the row is pre-v2 or `analysis` is
+   * absent.
+   */
+  coreArgument: string | null;
   mandalaRelevancePct: number | null;
   qualityFlag: string | null;
   templateVersion: string;

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1421,6 +1421,8 @@ class ApiClient {
       items: Array<{
         videoId: string;
         oneLiner: string | null;
+        /** CP474 — `analysis.core_argument`, the v2 essence (2-3 sentences). */
+        coreArgument: string | null;
         mandalaRelevancePct: number | null;
         qualityFlag: string | null;
         templateVersion: string;

--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -447,6 +447,10 @@ export function CardList({
                   const vid = safeVideoId(card.videoUrl);
                   return vid ? (v2SummariesMap.get(vid)?.oneLiner ?? null) : null;
                 })()}
+                coreArgument={(() => {
+                  const vid = safeVideoId(card.videoUrl);
+                  return vid ? (v2SummariesMap.get(vid)?.coreArgument ?? null) : null;
+                })()}
                 isV2Loading={v2IsFetching}
                 sectorLabel={
                   sectorSubjects && card.cellIndex >= 0 && card.cellIndex < sectorSubjects.length

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -114,6 +114,14 @@ interface InsightCardItemV2Props {
    */
   oneLiner?: string | null;
   /**
+   * CP474 — v2 `analysis.core_argument` (2-3 sentences capturing the
+   * central thesis). When present this is preferred over `oneLiner`
+   * for the grid-card blockquote because oneLiner's 20-char cap
+   * underfills the line-clamp-3 slot. Production p50=180 / p90=240
+   * chars — line-clamp-3 + "…" handles overflow.
+   */
+  coreArgument?: string | null;
+  /**
    * True while the batch v2-summaries query is fetching (initial load or
    * background refetch). When true the card suppresses the v1 fallback so
    * the blockquote stays empty until v2 arrives — prevents the
@@ -149,6 +157,7 @@ export function InsightCardItemV2({
   onRetryEnrich,
   mandalaRelevancePct,
   oneLiner,
+  coreArgument,
   isV2Loading = false,
   onArchived,
   sectorLabel,
@@ -280,16 +289,20 @@ export function InsightCardItemV2({
   const views = formatViewCount(ytMeta.viewCount);
   const relDate = formatRelativeDate(ytMeta.publishedAt ?? card.createdAt?.toISOString());
   const hasNote = !!card.userNote?.trim();
-  // Blockquote source priority (v2 wins; v1 only when v2 is settled-absent):
-  //   1. v2 `core.one_liner` if the row exists.
-  //   2. v1 `video_summaries.summary_ko` only when the v2 query has
+  // CP474 — blockquote source priority (v2 essence wins, then v2 head-
+  // line, then v1 fallback when v2 is settled-absent):
+  //   1. v2 `analysis.core_argument` (2-3 sentences, the actual thesis).
+  //   2. v2 `core.one_liner` (≤ 20 chars headline) — only when essence
+  //      is missing (legacy rows pre-CP474 or generation gaps).
+  //   3. v1 `video_summaries.summary_ko` — only when the v2 query has
   //      FINISHED and produced no row for this video. While v2 is in
-  //      flight the slot stays empty — this prevents the v1 (long
-  //      paragraph) -> v2 (short one-liner) shrink flicker the user
-  //      reported on grid mutation refetch.
-  const trimmedOneLiner = (() => {
-    const v2 = oneLiner?.trim();
-    if (v2) return v2;
+  //      flight the slot stays empty to prevent the v1 (long) -> v2
+  //      (short) shrink flicker on grid mutation refetch.
+  const cardSummary = (() => {
+    const essence = coreArgument?.trim();
+    if (essence) return essence;
+    const headline = oneLiner?.trim();
+    if (headline) return headline;
     if (isV2Loading) return undefined;
     return card.videoSummary?.summary_ko?.trim();
   })();
@@ -621,9 +634,9 @@ export function InsightCardItemV2({
             leftover space and the empty area sits flush at the card's
             bottom (YouTube-style: no empty line between meta and the
             absent summary). */}
-        {trimmedOneLiner && (
+        {cardSummary && (
           <blockquote className="mt-2 text-[10.5px] italic text-muted-foreground/75 leading-relaxed line-clamp-3 break-words">
-            {decodeHtmlEntities(trimmedOneLiner)}
+            {decodeHtmlEntities(cardSummary)}
           </blockquote>
         )}
       </div>

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -726,6 +726,12 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           select: {
             video_id: true,
             one_liner: true,
+            // CP474 — `analysis.core_argument` (2-3 sentences) is the v2
+            // essence/thesis. FE renders it as the grid-card blockquote
+            // (priority over the 20-char one_liner). Selecting the full
+            // `analysis` jsonb keeps the response shape stable if more
+            // fields surface to the card later.
+            analysis: true,
             mandala_relevance_pct: true,
             quality_flag: true,
             template_version: true,
@@ -734,13 +740,21 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         return reply.code(200).send({
           status: 'ok',
           data: {
-            items: rows.map((r) => ({
-              videoId: r.video_id,
-              oneLiner: r.one_liner,
-              mandalaRelevancePct: r.mandala_relevance_pct,
-              qualityFlag: r.quality_flag,
-              templateVersion: r.template_version,
-            })),
+            items: rows.map((r) => {
+              const analysis = (r.analysis ?? null) as { core_argument?: unknown } | null;
+              const coreArgument =
+                analysis && typeof analysis.core_argument === 'string'
+                  ? analysis.core_argument
+                  : null;
+              return {
+                videoId: r.video_id,
+                oneLiner: r.one_liner,
+                coreArgument,
+                mandalaRelevancePct: r.mandala_relevance_pct,
+                qualityFlag: r.quality_flag,
+                templateVersion: r.template_version,
+              };
+            }),
           },
         });
       } catch (err) {

--- a/src/modules/skills/rich-summary-reader.ts
+++ b/src/modules/skills/rich-summary-reader.ts
@@ -179,6 +179,7 @@ export function adaptV1ToLayered(
   const analysis: RichSummaryAnalysis = {
     core_argument: pickString(v1['core_argument']) ?? oneLiner,
     key_concepts: [], // v1 had no key_concepts
+    entities: [], // CP474 — legacy v1 has no typed entities; empty by design
     actionables,
     mandala_fit: {
       suggested_goals: suggested,

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -31,7 +31,11 @@ import {
 const log = logger.child({ module: 'RichSummaryV2Generator' });
 
 const MAX_RETRIES = 1; // 1 retry → spec §7-D
-const MAX_TOKENS = 4096;
+// CP474 — raised from 4096 to accommodate segments.sections (3-8 entries
+// with summary + key_points) and segments.atoms (5-15 entries). Empirical
+// upper bound for the full layered output is ~3000 tokens; 6144 leaves
+// safe buffer for verbose outputs without truncation.
+const MAX_TOKENS = 6144;
 const TEMPERATURE = 0.3;
 
 export type V2GenerationOutcome =
@@ -171,6 +175,13 @@ export async function generateRichSummaryV2(
           core: summary.core as unknown as Prisma.InputJsonValue,
           analysis: summary.analysis as unknown as Prisma.InputJsonValue,
           lora: summary.lora as unknown as Prisma.InputJsonValue,
+          // CP474 — persist segments emitted by the same LLM call.
+          // Optional: when the LLM omits segments (transcript absent or
+          // model declined), leave the column NULL via undefined so
+          // existing rows aren't accidentally cleared.
+          ...(summary.segments
+            ? { segments: summary.segments as unknown as Prisma.InputJsonValue }
+            : {}),
           completeness: score.score,
           quality_flag: 'pass',
           model: provider.model,

--- a/src/modules/skills/rich-summary-v2-prompt.ts
+++ b/src/modules/skills/rich-summary-v2-prompt.ts
@@ -43,6 +43,19 @@ export interface BiasSignals {
   notes: string;
 }
 
+// CP474 — entities are now emitted by the same single-LLM-call (was
+// previously only present in the legacy structured-jsonb v1 path). These
+// feed the KG bridge: each entity becomes a topic/concept/person/tool/
+// framework/organization node, and `atoms[].entity_refs` link insights
+// back to these names. The 5-type vocabulary mirrors
+// rich-summary-types.ts:18 RichSummaryEntity.
+export type EntityType = 'concept' | 'person' | 'tool' | 'framework' | 'organization';
+
+export interface RichSummaryEntity {
+  name: string;
+  type: EntityType;
+}
+
 export interface MandalaFit {
   suggested_goals: string[];
   relevance_rationale: string;
@@ -60,6 +73,15 @@ export interface MandalaFit {
 export interface RichSummaryAnalysis {
   core_argument: string;
   key_concepts: KeyConcept[];
+  /**
+   * CP474 — typed entities (concept / person / tool / framework /
+   * organization). Source of truth for KG bridge nodes and the target
+   * of `segments.atoms[].entity_refs`. Distinct from key_concepts:
+   * key_concepts.term carries a definition; entities[].name is a bare
+   * label with a type. The two arrays often overlap on `term ↔ name`
+   * for 'concept' entries.
+   */
+  entities: RichSummaryEntity[];
   actionables: string[];
   mandala_fit: MandalaFit;
   bias_signals: BiasSignals;
@@ -77,10 +99,41 @@ export interface RichSummaryLora {
   qa_pairs: QAPair[];
 }
 
+// CP474 — segments now emitted by the same single-LLM-call (was previously
+// only populated via the Mac Mini v2-author cron + upsert-direct path).
+// The shape mirrors validateV2Segments's allowed-key whitelist.
+export interface RichSummarySectionKeyPoint {
+  text: string;
+  timestamp_sec?: number;
+}
+export interface RichSummarySection {
+  idx?: number;
+  from_sec: number;
+  to_sec: number;
+  title: string;
+  summary?: string;
+  relevance_pct: number;
+  key_points?: RichSummarySectionKeyPoint[];
+}
+export interface RichSummaryAtom {
+  idx?: number;
+  type: string;
+  text: string;
+  timestamp_sec?: number;
+  entity_refs?: string[];
+}
+export interface RichSummarySegments {
+  sections?: RichSummarySection[];
+  atoms?: RichSummaryAtom[];
+}
+
 export interface RichSummaryV2Layered {
   core: RichSummaryCore;
   analysis: RichSummaryAnalysis;
   lora: RichSummaryLora;
+  /** CP474 — optional. Empty/undefined when the transcript was absent or
+   *  the LLM declined to emit segments. */
+  segments?: RichSummarySegments;
 }
 
 // ============================================================================
@@ -108,6 +161,13 @@ const VALID_DEPTH_LEVELS: ReadonlySet<DepthLevel> = new Set([
 ]);
 const VALID_SUBJECTIVITY: ReadonlySet<SubjectivityLevel> = new Set(['low', 'medium', 'high']);
 const VALID_DOMAIN_SET: ReadonlySet<string> = new Set(DOMAIN_SLUGS);
+const VALID_ENTITY_TYPES: ReadonlySet<EntityType> = new Set([
+  'concept',
+  'person',
+  'tool',
+  'framework',
+  'organization',
+]);
 
 // ============================================================================
 // Prompt template
@@ -141,6 +201,9 @@ Respond with this exact JSON structure (no extra keys, no comments):
     "key_concepts": [
       {{"term": "concept name", "definition": "short definition"}}
     ],
+    "entities": [
+      {{"name": "Entity label as it appears in the video", "type": "concept"}}
+    ],
     "actionables": ["concrete action item the viewer can do today"],
     "mandala_fit": {{
       "suggested_goals": ["goal phrase 1", "goal phrase 2"],
@@ -159,6 +222,24 @@ Respond with this exact JSON structure (no extra keys, no comments):
     "qa_pairs": [
       {{"level": 1, "q": "video-only Q", "a": "answer derived from the video", "context": "video"}}
     ]
+  }},
+  "segments": {{
+    "sections": [
+      {{
+        "idx": 0,
+        "from_sec": 0,
+        "to_sec": 102,
+        "title": "Section title (≤ 30 chars, no quotes)",
+        "summary": "What this section covers in 1 sentence",
+        "relevance_pct": 65,
+        "key_points": [
+          {{"text": "Key point grounded in the section", "timestamp_sec": 45}}
+        ]
+      }}
+    ],
+    "atoms": [
+      {{"idx": 0, "type": "fact", "text": "Standalone insight or claim", "timestamp_sec": 120, "entity_refs": ["Concept name"]}}
+    ]
   }}
 }}
 
@@ -166,17 +247,21 @@ Field rules:
 - core.one_liner: ≤ 20 chars, no quotes, no trailing punctuation.
 - core.domain: MUST be one of the 9 slugs above. No other values, no labels in Korean/English.
 - analysis.key_concepts: 3-5 entries.
+- analysis.entities: 3-10 entries. Each has a 'name' (bare label, no quotes) and a 'type' that MUST be one of: concept | person | tool | framework | organization. Use 'concept' for ideas/methods, 'person' for named individuals, 'tool' for software/products, 'framework' for named methodologies/processes, 'organization' for companies/institutions. When unsure, default to 'concept'. Entries should be distinct (no duplicate names). These are the KG bridge nodes — segments.atoms[].entity_refs should reference these names verbatim.
 - analysis.actionables: 3-5 entries, each a single imperative sentence.
 - analysis.mandala_fit.suggested_goals: 2-4 short phrases that align with the 9-domain SSOT taxonomy.
 - analysis.mandala_fit.mandala_relevance_pct: integer 0-100 reflecting how well this video fits the user's mandala center goal above. Score 0 when the center goal is empty or genuinely unrelated; higher values mean stronger alignment. Be conservative — 90+ only when the video clearly addresses the exact goal.
 - analysis.bias_signals.has_ad / is_sponsored: boolean. Only true when explicitly visible in the title/description.
 - lora.qa_pairs: 5-7 entries, all level=1, all context="video". Each Q is something a learner would ask AFTER watching this video; A is grounded in the video content.
 - prerequisites: empty string when none.
+- segments.sections: 3-8 entries dividing the video timeline. from_sec/to_sec integers in seconds, monotonically increasing, derived from transcript timestamps. relevance_pct (integer 0-100) is the intra-video metric for THIS section vs the user's mandala center goal — distinct from analysis.mandala_fit.mandala_relevance_pct (which is the whole-video score). Each section has 1-3 key_points; timestamp_sec is optional and falls within the section's [from_sec, to_sec] window.
+- segments.atoms: 5-15 standalone insights. type MUST be one of: fact | argument | tip | other. timestamp_sec is optional (use when derivable from the transcript). entity_refs is optional and links to analysis.entities[].name values (fallback: analysis.key_concepts[].term).
 
 Output rules:
 - Return JSON only — no markdown fences, no commentary, no chain-of-thought.
 - Use {language} consistently across every string field (Korean if 'ko', English if 'en').
-- When the Transcript block is non-empty, prefer transcript content over description/title for evidence in qa_pairs.a and analysis.core_argument. When empty, fall back to title + description.`;
+- When the Transcript block is non-empty, prefer transcript content over description/title for evidence in qa_pairs.a and analysis.core_argument. When empty, fall back to title + description.
+- When the Transcript block is empty (= "(no transcript)"): segments.sections should be a single catch-all entry (from_sec: 0, to_sec: 0, relevance_pct: 50) and segments.atoms entries should omit timestamp_sec — the LLM cannot infer real timestamps without transcript evidence. Do NOT fabricate timestamps.`;
 
 // ============================================================================
 // Prompt fill helper
@@ -314,6 +399,29 @@ export function validateV2Layered(parsed: unknown): RichSummaryV2Layered {
       definition: requireString(kk['definition'], `analysis.key_concepts[${i}].definition`),
     };
   });
+  // CP474 — entities are optional on the wire so pre-CP474 prompt
+  // responses (or LLMs that omit the field on retry) still validate.
+  // When present, every entry is strictly type-checked.
+  let entities: RichSummaryEntity[] = [];
+  const entitiesRaw = a['entities'];
+  if (Array.isArray(entitiesRaw)) {
+    entities = entitiesRaw.map((e, i) => {
+      if (!e || typeof e !== 'object') {
+        throw new V2ValidationError('entity must be object', `analysis.entities[${i}]`);
+      }
+      const ee = e as Record<string, unknown>;
+      const name = requireString(ee['name'], `analysis.entities[${i}].name`);
+      const type = String(ee['type'] ?? '');
+      if (!VALID_ENTITY_TYPES.has(type as EntityType)) {
+        throw new V2ValidationError(
+          `unknown entity type '${type}' (expected one of: ${[...VALID_ENTITY_TYPES].join(' | ')})`,
+          `analysis.entities[${i}].type`
+        );
+      }
+      return { name, type: type as EntityType };
+    });
+  }
+
   const actionablesRaw = requireArray<unknown>(a['actionables'], 'analysis.actionables');
   const actionables = actionablesRaw.map((s, i) => requireString(s, `analysis.actionables[${i}]`));
 
@@ -372,6 +480,7 @@ export function validateV2Layered(parsed: unknown): RichSummaryV2Layered {
   const analysis: RichSummaryAnalysis = {
     core_argument: coreArgument,
     key_concepts: keyConcepts,
+    entities,
     actionables,
     mandala_fit: mandalaFit,
     bias_signals: biasSignals,
@@ -408,7 +517,17 @@ export function validateV2Layered(parsed: unknown): RichSummaryV2Layered {
     };
   });
 
-  return { core, analysis, lora: { qa_pairs: qa } };
+  // CP474 — segments are optional. When present, run the strict key
+  // whitelist (validateV2Segments) and pass the raw object through so
+  // the generator can persist it to video_rich_summaries.segments as-is.
+  let segments: RichSummarySegments | undefined;
+  const segmentsRaw = obj['segments'];
+  if (segmentsRaw !== undefined && segmentsRaw !== null) {
+    validateV2Segments(segmentsRaw);
+    segments = segmentsRaw as RichSummarySegments;
+  }
+
+  return { core, analysis, lora: { qa_pairs: qa }, segments };
 }
 
 // ============================================================================

--- a/tests/unit/api/transcript-direct-upsert.test.ts
+++ b/tests/unit/api/transcript-direct-upsert.test.ts
@@ -35,6 +35,11 @@ function validPayload(): RichSummaryV2Layered {
         { term: '타임블로킹', definition: '시간대별 업무 고정 배치' },
         { term: '회고', definition: '하루 끝 5분 정리' },
       ],
+      entities: [
+        { name: '포모도로', type: 'concept' },
+        { name: '타임블로킹', type: 'concept' },
+        { name: '회고 노트', type: 'tool' },
+      ],
       actionables: ['오늘 저녁 내일 할 일 3가지 적기', '포모도로 앱 설치', '회고 노트 시작하기'],
       mandala_fit: {
         suggested_goals: ['생산성 향상', '루틴 만들기'],

--- a/tests/unit/skills/rich-summary-v2.test.ts
+++ b/tests/unit/skills/rich-summary-v2.test.ts
@@ -35,6 +35,11 @@ function validSummary(overrides: Partial<RichSummaryV2Layered> = {}): RichSummar
         { term: '타임블로킹', definition: '시간대별 업무 고정 배치' },
         { term: '회고', definition: '하루 끝 5분 정리' },
       ],
+      entities: [
+        { name: '포모도로', type: 'concept' },
+        { name: '타임블로킹', type: 'concept' },
+        { name: '회고 노트', type: 'tool' },
+      ],
       actionables: ['오늘 저녁 내일 할 일 3가지 적기', '포모도로 앱 설치', '회고 노트 시작하기'],
       mandala_fit: {
         suggested_goals: ['생산성 향상', '루틴 만들기'],


### PR DESCRIPTION
## Summary
Restores three v1 fields lost in the v2 layered migration and surfaces the v2 essence in the grid card.

1. **`analysis.entities[]` (5-type)** — `concept | person | tool | framework | organization`. The legacy single-jsonb v2 path produced these; the layered migration silently dropped them. KG bridge anchor points + `segments.atoms[].entity_refs` targets. Optional on the wire (validator tolerates omission); `adaptV1ToLayered` fills `[]` for v1 rows.
2. **`segments.sections[]` + `segments.atoms[]` (single LLM call)** — previously only filled by the Mac Mini v2-author cron via `/v2-summary/upsert-direct`. Now `generateRichSummaryV2` emits the full layered + segments JSON in one call. `sections[].relevance_pct` is the **intra-video chapter score** (distinct from `analysis.mandala_fit.mandala_relevance_pct` which is the whole-video score). `MAX_TOKENS` 4096 → 6144 to fit the larger payload.
3. **Grid-card blockquote source = `analysis.core_argument`** — the 20-char `core.one_liner` underfilled the line-clamp-3 slot (CP473 empty-line root cause). Prod measurement on 1320 v2 rows: p50=180, avg=188, p90=240 chars, user-friendly tone. Source chain: v2 `core_argument` → v2 `one_liner` → v1 `summary_ko` (only after v2 query settles empty — prevents v1→v2 shrink flicker).

## Files (10, +203/-21)
**BE**
- `src/api/routes/cards.ts` — `/v2-summaries` SELECT `analysis: true` + `coreArgument` mapping
- `src/modules/skills/rich-summary-v2-generator.ts` — MAX_TOKENS bump + segments persist
- `src/modules/skills/rich-summary-v2-prompt.ts` — types, prompt JSON schema, validator (entities + segments)
- `src/modules/skills/rich-summary-reader.ts` — v1→layered adapter fills `entities: []`

**FE**
- `frontend/src/shared/lib/api-client.ts` — `getV2Summaries` return type
- `frontend/src/features/card-management/model/useV2Summaries.ts` — `V2SummaryItem.coreArgument`
- `frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx` — Props + blockquote source priority
- `frontend/src/widgets/card-list/ui/CardList.tsx` — pass `coreArgument` prop

**Tests**
- `tests/unit/api/transcript-direct-upsert.test.ts` — entities fixture
- `tests/unit/skills/rich-summary-v2.test.ts` — entities fixture

## Why
- `entities[]` and `sections[].relevance_pct` were v1 fields the layered migration silently dropped. Reader/bridge paths still expected them.
- `core.one_liner` is a 20-char headline, not the essence — the grid card needed the actual thesis. Production measurement confirmed `core_argument` fits the 90-120 char visible window of `line-clamp-3 + text-[10.5px]` with `…` overflow.

## Test plan
- [x] BE `tsc --noEmit` PASS
- [x] FE `tsc --noEmit` PASS
- [x] BE `jest tests/unit/skills/rich-summary-v2.test.ts tests/unit/api/transcript-direct-upsert.test.ts` — 26 / 26 PASS
- [x] FE `vitest run` full — 316 / 316 PASS
- [x] Manual smoke: Heart-click → SSE `scored` → blockquote shows multi-sentence `core_argument`, user-confirmed
- [ ] Post-merge smoke: drag a card into a mandala on prod, Heart it, verify blockquote populates with 2-3 sentences after enrichment completes
- [ ] Post-merge: monitor `video_rich_summaries.segments` non-null growth on Heart-triggered rows
- [ ] Heart on a card that already has v1 only → blockquote keeps v1 `summary_ko` until v2 arrives

## Followups (separate PRs)
- v2-bridge (`src/modules/ontology/v2-bridge.ts`) consumes `entities[]` alongside `key_concepts` so the KG graph gets person / tool / framework / organization typing
- `entities[]` ↔ `analysis.key_concepts[]` de-dup policy
- Optional `core.essence` dedicated field if the 2-3 sentence `core_argument` tone proves too academic for card display

## Related
- Depends on `RICH_SUMMARY_ENABLED=true` GitHub Variable (already set 2026-05-17 CP463)
- Pairs with #670 — `YOUTUBE_METADATA_BACKFILL_ENABLED` activation, independent path

🤖 Generated with [Claude Code](https://claude.com/claude-code)