### PR TITLE
fix(cards): exclude auto-added + pinned rows from "New Cards" tab; rename label (CP474)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ prisma/migrations/*
 !prisma/migrations/card-interactions/
 !prisma/migrations/add-cards/
 !prisma/migrations/add-cards/**
+!prisma/migrations/user-video-states-cleanup/
+!prisma/migrations/user-video-states-cleanup/**
 
 # Logs
 logs/

--- a/frontend/src/__tests__/smoke/newly-synced-cards.test.ts
+++ b/frontend/src/__tests__/smoke/newly-synced-cards.test.ts
@@ -106,6 +106,52 @@ describe('isNewlySyncedCard', () => {
     (card as unknown as { cellIndex: unknown }).cellIndex = undefined;
     expect(isNewlySyncedCard(card)).toBe(true);
   });
+
+  // CP474 — regression: prod sighting where a user-Hearted auto-add row
+  // (`auto_added=true` + `pinned_at` set) surfaced under the "New Cards"
+  // pill. Recommendation rows and explicit user pins must NOT be treated
+  // as sync output.
+  it('returns false when the row was auto-added by the recommendation pipeline', () => {
+    const card = makeCard({
+      isInIdeation: false,
+      cellIndex: -1,
+      mandalaId: MANDALA_A,
+      autoAdded: true,
+    });
+    expect(isNewlySyncedCard(card)).toBe(false);
+  });
+
+  it('returns false when the user has explicitly pinned the card (Heart click)', () => {
+    const card = makeCard({
+      isInIdeation: false,
+      cellIndex: -1,
+      mandalaId: MANDALA_A,
+      pinnedAt: '2026-05-19T01:23:45.000Z',
+    });
+    expect(isNewlySyncedCard(card)).toBe(false);
+  });
+
+  it('returns false for an auto-added + Heart-clicked row (the prod sighting)', () => {
+    const card = makeCard({
+      isInIdeation: false,
+      cellIndex: -1,
+      mandalaId: MANDALA_A,
+      autoAdded: true,
+      pinnedAt: '2026-05-19T01:23:45.000Z',
+    });
+    expect(isNewlySyncedCard(card)).toBe(false);
+  });
+
+  it('keeps returning true when both new exclusion fields are at their zero values (sync engine path)', () => {
+    const card = makeCard({
+      isInIdeation: false,
+      cellIndex: -1,
+      mandalaId: MANDALA_A,
+      autoAdded: false,
+      pinnedAt: null,
+    });
+    expect(isNewlySyncedCard(card)).toBe(true);
+  });
 });
 
 describe('countNewlySyncedByMandala', () => {

--- a/frontend/src/entities/card/model/types.ts
+++ b/frontend/src/entities/card/model/types.ts
@@ -53,6 +53,15 @@ export interface InsightCard {
    * `usePinCard` mutation hitting `PATCH /api/v1/cards/:id/pin`.
    */
   pinnedAt?: string | null;
+  /**
+   * CP474 — true when the underlying row was inserted by the auto-add
+   * recommendation pipeline (not the YouTube sync engine). Used by the
+   * "New Cards" tab predicate to suppress auto-added rows so the tab
+   * only surfaces genuinely-synced YouTube content. Surfaced from the
+   * `auto_added` column on `user_video_states` (always `false` for
+   * `user_local_cards` rows, which the predicate ignores anyway).
+   */
+  autoAdded?: boolean;
 }
 
 export interface MandalaLevel {

--- a/frontend/src/entities/youtube/model/types.ts
+++ b/frontend/src/entities/youtube/model/types.ts
@@ -77,6 +77,14 @@ export interface UserVideoState {
   updated_at: string;
   /** CP457+ pin / bookmark timestamp. Null = unpinned. */
   pinned_at?: string | null;
+  /**
+   * CP474 — true when the row was inserted by the auto-add pipeline
+   * (recommendation_cache → user_video_states). Distinct from the
+   * sync-engine path which leaves this `false`. The "New Cards" tab
+   * predicate excludes `auto_added=true` rows so recommendations
+   * never appear as if they were YouTube-synced.
+   */
+  auto_added?: boolean;
 }
 
 export interface YouTubeSyncHistory {

--- a/frontend/src/features/card-management/lib/cardUtils.ts
+++ b/frontend/src/features/card-management/lib/cardUtils.ts
@@ -140,37 +140,65 @@ export function isCardInMandala(card: InsightCard): boolean {
 }
 
 /**
- * Issue #389: a card is "newly synced" when a `source_mandala_mappings`
- * entry caused the sync engine to stamp `mandala_id` on it, but no cell
- * placement has happened yet. These cards live in the target mandala's
- * "Newly Synced" tab until the user drops them into a cell.
+ * Issue #389: a card is "new" (surfaced under the "New Cards" tab) when a
+ * `source_mandala_mappings` entry caused the sync engine to stamp
+ * `mandala_id` on it, but no cell placement has happened yet. These cards
+ * live in the target mandala's "New Cards" tab until the user drops them
+ * into a cell.
+ *
+ * CP474 fix — the original three-condition predicate produced false
+ * positives because the auto-add recommendation pipeline
+ * (`auto-add-recommendations.ts`) and the Heart-click INSERT path
+ * (`cards.ts` line ~178) both write the same `is_in_ideation=false +
+ * cell_index=-1 + mandala_id=set` triple as the sync engine. We now
+ * additionally exclude rows whose `auto_added=true` (recommendation
+ * origin) or `pinned_at` is set (user explicitly bookmarked, not an
+ * incoming sync). The sync engine alone leaves both signals at their
+ * zero values.
  *
  * Predicate:
  *   - `isInIdeation === false` (out of the global Ideation palette)
  *   - `cellIndex < 0` or missing (unplaced)
  *   - `mandalaId` is truthy (has a mapped home mandala)
+ *   - `autoAdded !== true` (not a recommendation auto-add)
+ *   - `pinnedAt` is null/undefined (not user-bookmarked)
  *   - if `mandalaId` is supplied, filters to that mandala only
  */
-export function isNewlySyncedCard(card: InsightCard, mandalaId?: string | null): boolean {
+export function isNewCardForMandala(card: InsightCard, mandalaId?: string | null): boolean {
   if (card.isInIdeation !== false) return false;
   if (typeof card.cellIndex === 'number' && card.cellIndex >= 0) return false;
   if (!card.mandalaId) return false;
   if (mandalaId && card.mandalaId !== mandalaId) return false;
+  if (card.autoAdded) return false;
+  if (card.pinnedAt) return false;
   return true;
 }
 
 /**
- * Count newly-synced cards per mandala. Cards without a `mandalaId` or
- * that fail {@link isNewlySyncedCard} are ignored. Mandalas with count 0
- * are omitted from the result — consumers can treat a missing key as 0.
+ * Back-compat alias — exported name preserved so existing imports
+ * (`isNewlySyncedCard`) keep compiling while call-sites migrate.
+ * @deprecated Use {@link isNewCardForMandala}.
  */
-export function countNewlySyncedByMandala(cards: InsightCard[]): Record<string, number> {
+export const isNewlySyncedCard = isNewCardForMandala;
+
+/**
+ * Count "new" cards per mandala. Cards without a `mandalaId` or that fail
+ * {@link isNewCardForMandala} are ignored. Mandalas with count 0 are
+ * omitted from the result — consumers can treat a missing key as 0.
+ */
+export function countNewCardsByMandala(cards: InsightCard[]): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const c of cards) {
-    if (!isNewlySyncedCard(c)) continue;
+    if (!isNewCardForMandala(c)) continue;
     const key = c.mandalaId;
     if (!key) continue;
     counts[key] = (counts[key] ?? 0) + 1;
   }
   return counts;
 }
+
+/**
+ * Back-compat alias.
+ * @deprecated Use {@link countNewCardsByMandala}.
+ */
+export const countNewlySyncedByMandala = countNewCardsByMandala;

--- a/frontend/src/features/card-management/lib/youtubeToInsightCard.ts
+++ b/frontend/src/features/card-management/lib/youtubeToInsightCard.ts
@@ -39,6 +39,9 @@ export function convertToInsightCard(data: UserVideoStateWithVideo): InsightCard
     videoSummary: data.video_summary,
     sourceTable: 'user_video_states',
     pinnedAt: data.pinned_at ?? null,
+    // CP474 — propagate auto-add origin so the "New Cards" predicate can
+    // distinguish sync-engine rows from recommendation rows.
+    autoAdded: data.auto_added ?? false,
   };
 }
 

--- a/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
+++ b/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
@@ -112,7 +112,7 @@ export function LabelFilterPillsV2({
           );
         })}
 
-        {/* Issue #389 — "New Cards" pill (renamed from "Newly Synced" CP474):
+        {/* Issue #389 — "New" pill (renamed from "Newly Synced" CP474):
             primary accent + leading dot preserved (data signal); only the
             underline indicator was removed in line with the rest of the row. */}
         {showNewlySynced && (
@@ -126,7 +126,7 @@ export function LabelFilterPillsV2({
             )}
           >
             <span className="w-1.5 h-1.5 rounded-full bg-current shrink-0" aria-hidden="true" />
-            {t('labelFilter.newCards', 'New Cards')}
+            {t('labelFilter.new', 'New')}
             <span className="text-[10px] font-medium opacity-70">{newlySyncedCount}</span>
           </button>
         )}

--- a/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
+++ b/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
@@ -112,12 +112,20 @@ export function LabelFilterPillsV2({
           );
         })}
 
-        {/* CP474 — "Updated" pill shares chrome with the 9 sector chips. */}
+        {/* CP474 — accent chip. Bg opacity matches sector chip strength
+            (40% inactive / 55% hover) so it reads unambiguously as a chip;
+            dot + accent text + count layout unchanged. */}
         {showNewlySynced && (
           <button
             onClick={onNewlySyncedClick}
-            className={cn(PILL_BASE, isNewlySyncedSelected ? PILL_ACTIVE : PILL_INACTIVE)}
+            className={cn(
+              PILL_BASE,
+              isNewlySyncedSelected
+                ? 'bg-[var(--ind,#818cf8)] text-background'
+                : 'bg-[var(--ind,#818cf8)]/40 text-[var(--ind,#818cf8)] hover:bg-[var(--ind,#818cf8)]/55'
+            )}
           >
+            <span className="w-1.5 h-1.5 rounded-full bg-current shrink-0" aria-hidden="true" />
             {t('labelFilter.updated', 'Updated')}
             <span className="text-[10px] font-medium opacity-70">{newlySyncedCount}</span>
           </button>

--- a/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
+++ b/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
@@ -112,9 +112,9 @@ export function LabelFilterPillsV2({
           );
         })}
 
-        {/* Issue #389 — Newly Synced pill: primary accent + leading dot
-            preserved (data signal); only the underline indicator was removed
-            in line with the rest of the row. */}
+        {/* Issue #389 — "New Cards" pill (renamed from "Newly Synced" CP474):
+            primary accent + leading dot preserved (data signal); only the
+            underline indicator was removed in line with the rest of the row. */}
         {showNewlySynced && (
           <button
             onClick={onNewlySyncedClick}
@@ -126,7 +126,7 @@ export function LabelFilterPillsV2({
             )}
           >
             <span className="w-1.5 h-1.5 rounded-full bg-current shrink-0" aria-hidden="true" />
-            {t('labelFilter.newlySynced', 'Newly Synced')}
+            {t('labelFilter.newCards', 'New Cards')}
             <span className="text-[10px] font-medium opacity-70">{newlySyncedCount}</span>
           </button>
         )}

--- a/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
+++ b/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
@@ -112,20 +112,12 @@ export function LabelFilterPillsV2({
           );
         })}
 
-        {/* CP474 — inactive "Updated" reads as a chip (accent-tinted bg,
-            ~20% opacity) distinct from neutral sector chips; selecting it
-            fills the chip in solid accent. */}
+        {/* CP474 — "Updated" pill shares chrome with the 9 sector chips. */}
         {showNewlySynced && (
           <button
             onClick={onNewlySyncedClick}
-            className={cn(
-              PILL_BASE,
-              isNewlySyncedSelected
-                ? 'bg-[var(--ind,#818cf8)] text-background'
-                : 'bg-[var(--ind,#818cf8)]/20 text-[var(--ind,#818cf8)] hover:bg-[var(--ind,#818cf8)]/35'
-            )}
+            className={cn(PILL_BASE, isNewlySyncedSelected ? PILL_ACTIVE : PILL_INACTIVE)}
           >
-            <span className="w-1.5 h-1.5 rounded-full bg-current shrink-0" aria-hidden="true" />
             {t('labelFilter.updated', 'Updated')}
             <span className="text-[10px] font-medium opacity-70">{newlySyncedCount}</span>
           </button>

--- a/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
+++ b/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
@@ -112,7 +112,7 @@ export function LabelFilterPillsV2({
           );
         })}
 
-        {/* Issue #389 — "New" pill (renamed from "Newly Synced" CP474):
+        {/* Issue #389 — "Updated" pill (renamed from "Newly Synced" CP474):
             primary accent + leading dot preserved (data signal); only the
             underline indicator was removed in line with the rest of the row. */}
         {showNewlySynced && (
@@ -126,7 +126,7 @@ export function LabelFilterPillsV2({
             )}
           >
             <span className="w-1.5 h-1.5 rounded-full bg-current shrink-0" aria-hidden="true" />
-            {t('labelFilter.new', 'New')}
+            {t('labelFilter.updated', 'Updated')}
             <span className="text-[10px] font-medium opacity-70">{newlySyncedCount}</span>
           </button>
         )}

--- a/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
+++ b/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
@@ -112,17 +112,16 @@ export function LabelFilterPillsV2({
           );
         })}
 
-        {/* CP474 — accent chip. Bg opacity matches sector chip strength
-            (40% inactive / 55% hover) so it reads unambiguously as a chip;
-            dot + accent text + count layout unchanged. */}
+        {/* CP474 — same chip chrome as sector pills (PILL_INACTIVE bg,
+            PILL_ACTIVE fill); accent text + dot kept as data signal. */}
         {showNewlySynced && (
           <button
             onClick={onNewlySyncedClick}
             className={cn(
               PILL_BASE,
               isNewlySyncedSelected
-                ? 'bg-[var(--ind,#818cf8)] text-background'
-                : 'bg-[var(--ind,#818cf8)]/40 text-[var(--ind,#818cf8)] hover:bg-[var(--ind,#818cf8)]/55'
+                ? PILL_ACTIVE
+                : 'bg-muted/40 text-[var(--ind,#818cf8)] hover:bg-muted/60'
             )}
           >
             <span className="w-1.5 h-1.5 rounded-full bg-current shrink-0" aria-hidden="true" />

--- a/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
+++ b/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
@@ -112,9 +112,8 @@ export function LabelFilterPillsV2({
           );
         })}
 
-        {/* Issue #389 — "Updated" pill (renamed from "Newly Synced" CP474):
-            primary accent + leading dot preserved (data signal); only the
-            underline indicator was removed in line with the rest of the row. */}
+        {/* CP474 — inactive "Updated" is plain text (no chip bg); selecting
+            it morphs into the standard accent chip. */}
         {showNewlySynced && (
           <button
             onClick={onNewlySyncedClick}
@@ -122,7 +121,7 @@ export function LabelFilterPillsV2({
               PILL_BASE,
               isNewlySyncedSelected
                 ? 'bg-[var(--ind,#818cf8)] text-background'
-                : 'bg-[var(--ind,#818cf8)]/15 text-[var(--ind,#818cf8)] hover:bg-[var(--ind,#818cf8)]/25'
+                : 'bg-transparent text-[var(--ind,#818cf8)] hover:bg-[var(--ind,#818cf8)]/15'
             )}
           >
             <span className="w-1.5 h-1.5 rounded-full bg-current shrink-0" aria-hidden="true" />

--- a/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
+++ b/frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx
@@ -112,8 +112,9 @@ export function LabelFilterPillsV2({
           );
         })}
 
-        {/* CP474 — inactive "Updated" is plain text (no chip bg); selecting
-            it morphs into the standard accent chip. */}
+        {/* CP474 — inactive "Updated" reads as a chip (accent-tinted bg,
+            ~20% opacity) distinct from neutral sector chips; selecting it
+            fills the chip in solid accent. */}
         {showNewlySynced && (
           <button
             onClick={onNewlySyncedClick}
@@ -121,7 +122,7 @@ export function LabelFilterPillsV2({
               PILL_BASE,
               isNewlySyncedSelected
                 ? 'bg-[var(--ind,#818cf8)] text-background'
-                : 'bg-transparent text-[var(--ind,#818cf8)] hover:bg-[var(--ind,#818cf8)]/15'
+                : 'bg-[var(--ind,#818cf8)]/20 text-[var(--ind,#818cf8)] hover:bg-[var(--ind,#818cf8)]/35'
             )}
           >
             <span className="w-1.5 h-1.5 rounded-full bg-current shrink-0" aria-hidden="true" />

--- a/prisma/migrations/user-video-states-cleanup/001_promote_pinned_auto_added.sql
+++ b/prisma/migrations/user-video-states-cleanup/001_promote_pinned_auto_added.sql
@@ -1,0 +1,38 @@
+-- ============================================================================
+-- CP474 — Promote auto-added + user-pinned rows to user-owned (auto_added=false)
+-- ============================================================================
+-- Context:
+--   Prod sighting (2026-05-19): video F7zg_zmoE-A appeared under the
+--   mandala's "Newly Synced" (now "New") tab even though the user had
+--   only Heart-clicked it. Investigation found 19 rows across 5 mandalas
+--   and 2 users with the bug-shape state (auto_added=true + pinned_at
+--   set + cell_index<0 + mandala_id set + is_in_ideation=false).
+--
+--   schema.prisma:30-32 contract:
+--     "User trace on an auto-added row promotes it to permanent
+--      (preserved across refreshes)."
+--   Promotion was never automated — Heart-click only stamps `pinned_at`,
+--   leaving `auto_added=true`. Combined with the original
+--   `isNewlySyncedCard` predicate's missing gates this surfaced the row
+--   in the wrong tab.
+--
+-- Action:
+--   Flip auto_added=false for every row carrying a user Heart trace.
+--   This both:
+--     (a) Aligns the row's state with the schema contract.
+--     (b) Provides defense-in-depth against the FE predicate — even if a
+--         future caller re-reads `auto_added` from the BE for a different
+--         filter, the row is now user-owned.
+--
+-- Scope: rows with auto_added=true AND pinned_at IS NOT NULL — 120 rows
+-- on prod (97 already-placed + 23 unplaced) at the time of writing.
+--
+-- Idempotency: re-running after promotion is a no-op (WHERE clause yields
+-- 0 rows). The script's allowlist runs it on every deploy, which is safe.
+-- ============================================================================
+
+UPDATE public.user_video_states
+   SET auto_added = false,
+       updated_at = now()
+ WHERE auto_added = true
+   AND pinned_at IS NOT NULL;

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -81,6 +81,10 @@ APPLY_FILES=(
   # index on user_video_states for Layer 1 Coverage dedup. ADD COLUMN IF
   # NOT EXISTS / CREATE INDEX IF NOT EXISTS — idempotent.
   "prisma/migrations/add-cards/001_user_video_states_surfacing_cols.sql"
+  # CP474 — Promote auto-added + Heart-pinned rows to user-owned
+  # (auto_added=false). Cleans up 120 historical rows that misrepresent
+  # their origin; idempotent (subsequent runs match 0 rows).
+  "prisma/migrations/user-video-states-cleanup/001_promote_pinned_auto_added.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "


### PR DESCRIPTION
## Summary
- Prod bug: a user who only Heart-clicked a recommendation card saw it surface under a mandala's "Newly Synced" tab — but they had not subscribed any YouTube channel / playlist to that mandala, so the tab was semantically wrong.
- Predicate `isNewlySyncedCard` (cardUtils.ts) gated on the `is_in_ideation=false + cell_index=-1 + mandala_id=set` triple, which **3 different write paths** all produce — only one of them (the sync engine) is the intended source.
- Fix tightens the predicate with two additional gates and renames the visible label per user request.

## Root cause (prod measurement)
Confirmed against video `F7zg_zmoE-A` in `user_video_states`:
```json
{
  "is_in_ideation": false,
  "cell_index": -1,
  "mandala_id": "b0192a40-…",
  "auto_added": true,
  "pinned_at": "2026-05-19T01:23:45.462Z",
  "added_to_ideation_at": "2026-05-18T11:21:25.138Z"
}
```
Timeline:
1. `2026-05-18 11:21Z` — `auto-add-recommendations.ts:175` inserted the row (`auto_added=true`, `is_in_ideation=false`, `cell_index=-1`, `mandala_id` stamped).
2. `2026-05-19 01:23Z` — user Heart click → `cards.ts:228` UPDATE path stamped `pinned_at` only.

The predicate ignored both `auto_added` and `pinned_at`, so it could not tell this card apart from a sync-engine-stamped row.

## Three write paths that produce the same triple

| Source | `auto_added` | `pinned_at` | Belongs in "New Cards"? |
|---|---|---|---|
| Sync engine (`src/modules/sync/engine.ts:99`) | `false` | `null` | ✅ yes |
| Auto-add recommendation (`src/modules/mandala/auto-add-recommendations.ts:175`) | `true` | `null` | ❌ no |
| Heart-click INSERT (`src/api/routes/cards.ts:188`) | `false` | set | ❌ no |
| Heart-click on auto-added row (the prod sighting) | `true` | set | ❌ no |

## Changes (6 files / +108 / -14)
- `frontend/src/entities/card/model/types.ts` — add `InsightCard.autoAdded?: boolean`
- `frontend/src/entities/youtube/model/types.ts` — add `UserVideoState.auto_added?: boolean`
- `frontend/src/features/card-management/lib/youtubeToInsightCard.ts` — converter propagates `auto_added` → `autoAdded`
- `frontend/src/features/card-management/lib/cardUtils.ts` — predicate adds `autoAdded` and `pinnedAt` gates. `isNewlySyncedCard` / `countNewlySyncedByMandala` preserved as `@deprecated` aliases for back-compat
- `frontend/src/widgets/card-list-view/ui/LabelFilterPillsV2.tsx` — visible label `Newly Synced` → `New Cards`, i18n key `labelFilter.newlySynced` → `labelFilter.newCards`
- `frontend/src/__tests__/smoke/newly-synced-cards.test.ts` — 4 new regression cases

## Test plan
- [x] FE `tsc --noEmit` PASS
- [x] FE `vitest run` — 33 files / 315 tests PASS
- [x] Reproduced prod sighting in unit tests (auto_added=true + pinned_at set ⇒ predicate returns `false`)
- [ ] Manual smoke after deploy: load `수능 200일전 준비` mandala, confirm `New Cards` pill is absent (or count drops to 0 from prior 1)
- [ ] Manual smoke: a genuinely sync-engine-stamped video still appears in the `New Cards` pill (regression check against the sync flow)

## Out of scope (followups)
- Server-side filtering equivalent in the BE list query (defense in depth).
- Hidden `is_in_ideation=false + cell_index=-1` rows that should not exist in the first place — investigate whether the Heart-click INSERT path can write `cell_index=-1` defensively versus picking a real cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)