### PR TITLE
fix(v2): regen description-only rows on next Heart click (CP474)

### DIFF
--- a/prisma/migrations/rich-summary-v2/006_add_transcript_used.sql
+++ b/prisma/migrations/rich-summary-v2/006_add_transcript_used.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- CP474 — Add `transcript_used` flag to video_rich_summaries (v2 regen gate)
+-- ============================================================================
+-- Context:
+--   generateRichSummaryV2 used to skip when `template_version='v2' AND
+--   mandala_relevance_pct IS NOT NULL`, treating the existence of a v2 row
+--   as proof of an accurate v2. But that gate ignored the actual quality
+--   determinant — whether the LLM saw the transcript. A first Heart click
+--   whose captioner failed produces a description-only v2 row that still
+--   has both flags set, and every subsequent Heart click (including ones
+--   whose captioner succeeds) hit the skip branch and never refreshed the
+--   row.
+--
+-- Fix:
+--   Make the gate test for "transcript-grounded v2", not just "v2 exists".
+--   Add a boolean column the generator stamps on every successful update.
+--   Backfill conservatively: rows with non-null segments must have come
+--   from a transcript path (segments require real timestamps; the LLM is
+--   instructed not to fabricate them when the transcript is empty).
+--
+-- IMPORTANT (CLAUDE.md "prisma db push silent fail" Hard Rule):
+--   Apply via psql (or apply-custom-sql.sh), NOT via `prisma db push`.
+--   After apply, verify the column lands on prod:
+--     psql "$DIRECT_URL" -c "\d video_rich_summaries" | grep transcript_used
+--   Then NOTIFY pgrst, 'reload schema'.
+--
+-- Idempotency: ADD COLUMN IF NOT EXISTS + UPDATE WHERE transcript_used IS
+-- DISTINCT FROM ... — re-running after the first apply is a no-op.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.video_rich_summaries
+  ADD COLUMN IF NOT EXISTS transcript_used boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.video_rich_summaries.transcript_used IS
+  'CP474 — true when the v2 row was generated with a transcript. Used by generateRichSummaryV2 to decide whether to skip or regenerate on a Heart-triggered re-enrich.';
+
+-- Conservative backfill: only flip to true when segments[] is populated.
+-- description-only generations produce a single catch-all segment with
+-- from_sec=to_sec=0, which leaves segments JSON non-null but obviously
+-- non-transcript-derived. Detect that shape and keep transcript_used=false.
+UPDATE public.video_rich_summaries
+   SET transcript_used = true
+ WHERE template_version = 'v2'
+   AND segments IS NOT NULL
+   AND jsonb_typeof(segments->'sections') = 'array'
+   AND (
+     SELECT bool_or(
+       COALESCE((s->>'to_sec')::int, 0) > 0
+     )
+     FROM jsonb_array_elements(segments->'sections') s
+   )
+   AND transcript_used = false;
+
+COMMIT;
+
+-- Validation:
+--   SELECT COUNT(*) FILTER (WHERE transcript_used) AS transcript_grounded,
+--          COUNT(*) FILTER (WHERE NOT transcript_used) AS desc_only_or_legacy,
+--          COUNT(*) AS total
+--     FROM public.video_rich_summaries
+--    WHERE template_version = 'v2';
+--
+-- Rollback (dev only):
+--   ALTER TABLE public.video_rich_summaries
+--     DROP COLUMN IF EXISTS transcript_used;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1596,6 +1596,13 @@ model video_rich_summaries {
   /// segments[].relevance_pct which is intra-video chapter metric.
   /// Raw SQL DDL: prisma/migrations/rich-summary-v2/005_mandala_relevance_pct.sql
   mandala_relevance_pct   Int?
+  /// CP474 — true when the v2 row was generated with a transcript in scope.
+  /// description-only generations leave this false, which makes them eligible
+  /// for re-generation on a subsequent Heart click whose captioner succeeds.
+  /// Backfilled to true on rows where segments IS NOT NULL (transcript-derived
+  /// timestamps are the only realistic source of segments).
+  /// Raw SQL DDL: prisma/migrations/rich-summary-v2/006_add_transcript_used.sql
+  transcript_used         Boolean  @default(false)
   created_at              DateTime @default(now()) @db.Timestamptz(6)
   updated_at              DateTime @default(now()) @updatedAt @db.Timestamptz(6)
 

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -77,6 +77,9 @@ APPLY_FILES=(
   # re-application is safe.
   "prisma/migrations/card-interactions/001_create_table.sql"
   "prisma/migrations/rich-summary-v2/005_mandala_relevance_pct.sql"
+  # CP474 — v2 regen gate based on transcript_used (boolean). ADD COLUMN
+  # IF NOT EXISTS + idempotent backfill (WHERE transcript_used = false).
+  "prisma/migrations/rich-summary-v2/006_add_transcript_used.sql"
   # CP466 — Add Cards Phase 1 (surfacing). `surfaced_at` column + partial
   # index on user_video_states for Layer 1 Coverage dedup. ADD COLUMN IF
   # NOT EXISTS / CREATE INDEX IF NOT EXISTS — idempotent.

--- a/src/modules/queue/handlers/enrich-rich-summary.ts
+++ b/src/modules/queue/handlers/enrich-rich-summary.ts
@@ -137,12 +137,14 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
     });
   }
 
-  // Step 3 — v2 upgrade + mandala_relevance_pct, transcript-aware.
+  // Step 3 — v2 upgrade. forceRegen when a transcript arrived so a prior
+  // description-only v2 row is replaced with transcript-grounded content.
   const v2Outcome = await generateRichSummaryV2({
     videoId,
     userId,
     mandalaCenterGoal: centerGoal,
     transcript,
+    forceRegen: transcript !== undefined,
   });
 
   logger.info('enrich-rich-summary: completed', {

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -69,6 +69,9 @@ export interface V2GenerationInput {
    * cron-driven backfill which does not know which user triggered the video.
    */
   mandalaCenterGoal?: string;
+  /** CP474 — bypass the "complete v2" skip gate so a description-only row
+   *  can be regenerated when a transcript becomes available. */
+  forceRegen?: boolean;
 }
 
 export async function generateRichSummaryV2(
@@ -84,16 +87,23 @@ export async function generateRichSummaryV2(
       template_version: true,
       source_language: true,
       quality_flag: true,
-      // CP462+ Issue #649 — legacy v2 rows have NULL here; Lazy backfill
-      // regenerates them on the first Heart click so the score is populated.
       mandala_relevance_pct: true,
+      // CP474 — only "transcript-grounded v2" is skip-worthy.
+      transcript_used: true,
     },
   });
   if (!row) {
     return { kind: 'skip', videoId: input.videoId, reason: 'no_rich_summary_row' };
   }
-  if (row.template_version === 'v2' && row.mandala_relevance_pct != null) {
-    return { kind: 'skip', videoId: input.videoId, reason: 'already_v2' };
+  // CP474 — description-only v2 rows fall through so a later Heart click
+  // with a successful captioner can regenerate them. forceRegen overrides.
+  if (
+    !input.forceRegen &&
+    row.template_version === 'v2' &&
+    row.mandala_relevance_pct != null &&
+    row.transcript_used
+  ) {
+    return { kind: 'skip', videoId: input.videoId, reason: 'already_v2_with_transcript' };
   }
 
   const ytRow = await prisma.youtube_videos.findUnique({
@@ -175,6 +185,8 @@ export async function generateRichSummaryV2(
           quality_flag: 'pass',
           model: provider.model,
           mandala_relevance_pct: summary.analysis.mandala_fit.mandala_relevance_pct,
+          // CP474 — true only when the LLM actually saw a transcript.
+          transcript_used: Boolean(input.transcript && input.transcript.length > 0),
           ...(input.userId ? { user_id: input.userId } : {}),
           updated_at: new Date(),
         },


### PR DESCRIPTION
## Problem
`generateRichSummaryV2` skip gate gated on row existence alone (`template_version='v2' AND mandala_relevance_pct IS NOT NULL`). A first Heart click whose captioner failed produced a description-only v2 row that satisfied both flags, so every subsequent Heart click — even ones whose captioner succeeded — hit the skip branch and the row never refreshed. User-visible symptom: cards stay stuck with the low-quality v2 forever.

## Fix
1. **Schema** — add `video_rich_summaries.transcript_used boolean NOT NULL DEFAULT false`. Generator stamps true only when the LLM call actually had a transcript in scope.
2. **Skip gate** — now requires `transcript_used=true` in addition to the previous two conditions. Description-only rows fall through.
3. **`forceRegen` option** — Heart worker passes `true` whenever `transcript !== undefined`, so regen is unconditional once captions are available.
4. **Backfill** (migration 006): flip `transcript_used=true` on rows whose segments[] carries at least one chapter with `to_sec > 0` (catch-all description-only segments use `from_sec=to_sec=0` and stay false).

## Files (5, +96 / -5)
- `prisma/schema.prisma` — `transcript_used` column
- `prisma/migrations/rich-summary-v2/006_add_transcript_used.sql` — ADD COLUMN IF NOT EXISTS + conditional backfill (idempotent)
- `scripts/apply-custom-sql.sh` — allowlist 006
- `src/modules/skills/rich-summary-v2-generator.ts` — skip gate + forceRegen + transcript_used stamp
- `src/modules/queue/handlers/enrich-rich-summary.ts` — pass `forceRegen: transcript !== undefined`

## Test plan
- [x] Prisma generate PASS, BE `tsc --noEmit` PASS
- [x] BE Jest 21 PASS (rich-summary-v2 — existing tests still green)
- [ ] Local DB apply 006 → confirm column present, backfill row count matches expectation
- [ ] Manual smoke after deploy: Heart-click a card whose existing v2 has `transcript_used=false`, watch SSE `scored`, confirm `video_rich_summaries.transcript_used` flipped to true and `updated_at` advanced
- [ ] Manual smoke: Heart-click a card whose v2 is already transcript-grounded — confirm skip path (`already_v2_with_transcript`), no LLM call

## Related
- Pairs with #671 (segments + entities + core_argument card render). When this lands first, segments-aware v2 also benefits — every description-only legacy row gets a chance to grow segments on the next Heart.
- Pairs with #672 (FE predicate / "Updated" label / DB cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)