### PR TITLE
feat(ontology): v2-bridge consumes analysis.entities[] (CP474)

### DIFF
--- a/src/modules/ontology/v2-bridge.ts
+++ b/src/modules/ontology/v2-bridge.ts
@@ -31,7 +31,22 @@ import { Prisma } from '@prisma/client';
 import { getPrismaClient } from '@/modules/database/client';
 import { logger } from '@/utils/logger';
 import { getInternalUserId } from '@/config/internal-auth';
-import type { RichSummaryV2Layered, KeyConcept } from '@/modules/skills/rich-summary-v2-prompt';
+import type {
+  RichSummaryV2Layered,
+  KeyConcept,
+  RichSummaryEntity,
+  EntityType,
+} from '@/modules/skills/rich-summary-v2-prompt';
+
+// CP474 — entity.type → ontology.nodes.type. `concept` shares the type slot
+// with key_concepts so dedup happens naturally on (type='concept', title).
+const ENTITY_TYPE_TO_NODE_TYPE: Record<EntityType, string> = {
+  concept: 'concept',
+  person: 'person',
+  tool: 'tool',
+  framework: 'framework',
+  organization: 'organization',
+};
 
 const log = logger.child({ module: 'OntologyV2Bridge' });
 
@@ -69,6 +84,8 @@ export interface V2BridgeResult {
   sectionNodeIds: string[];
   atomNodeIds: string[];
   actionNodeIds: string[];
+  /** CP474 — entities[] (5-type) → nodes, grouped by ontology.nodes.type. */
+  entityNodeIds: Record<EntityType, string[]>;
   edgeCount: {
     covers: number;
     has_section: number;
@@ -99,6 +116,23 @@ export async function bridgeV2ToOntology(input: V2BridgeInput): Promise<V2Bridge
   const conceptNameToId = new Map<string, string>(
     layered.analysis.key_concepts.map((c, i) => [c.term, conceptIds[i]!])
   );
+
+  // 2.5. CP474 — entities[] (5-type) → typed nodes. atoms.entity_refs prefers
+  // entities[].name match over key_concepts.term match when both exist.
+  const entities: RichSummaryEntity[] = layered.analysis.entities ?? [];
+  const entityNodeIds: Record<EntityType, string[]> = {
+    concept: [],
+    person: [],
+    tool: [],
+    framework: [],
+    organization: [],
+  };
+  const entityNameToId = new Map<string, string>();
+  for (const ent of entities) {
+    const id = await upsertEntity(prisma, userId, ent);
+    entityNodeIds[ent.type].push(id);
+    entityNameToId.set(ent.name, id);
+  }
 
   // 3. section_node (when segments present)
   const sectionIds: string[] = [];
@@ -147,7 +181,8 @@ export async function bridgeV2ToOntology(input: V2BridgeInput): Promise<V2Bridge
   for (let i = 0; i < atomIds.length; i++) {
     const refs = atomToEntityRefs[i] ?? [];
     for (const ref of refs) {
-      const target = conceptNameToId.get(ref);
+      // CP474 — entities[].name wins; key_concepts.term is fallback.
+      const target = entityNameToId.get(ref) ?? conceptNameToId.get(ref);
       if (target && (await upsertEdge(prisma, userId, atomIds[i]!, target, 'MENTIONS'))) {
         mentionsCount++;
       }
@@ -174,6 +209,7 @@ export async function bridgeV2ToOntology(input: V2BridgeInput): Promise<V2Bridge
     sectionNodeIds: sectionIds,
     atomNodeIds: atomIds,
     actionNodeIds: actionIds,
+    entityNodeIds,
     edgeCount: {
       covers: coversCount,
       has_section: hasSectionCount,
@@ -269,6 +305,48 @@ async function upsertConcept(
       'concept',
       ${concept.term},
       ${props}::jsonb,
+      ${sourceRef}::jsonb,
+      'service'
+    )
+    RETURNING id
+  `);
+  return inserted[0]!.id;
+}
+
+// CP474 — entities[] (5-type) lookup by (type, title) so key_concepts dedup
+// works for `concept` entries. Other types fall on their own type slot.
+async function upsertEntity(
+  prisma: ReturnType<typeof getPrismaClient>,
+  userId: string,
+  entity: RichSummaryEntity
+): Promise<string> {
+  const nodeType = ENTITY_TYPE_TO_NODE_TYPE[entity.type];
+  const sourceRef = JSON.stringify({
+    table: 'video_rich_summaries.entities',
+    type: entity.type,
+    name: entity.name,
+  });
+  const existing = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
+    SELECT id FROM ontology.nodes
+    WHERE type = ${nodeType} AND title = ${entity.name}
+    LIMIT 1
+  `);
+  if (existing.length > 0) {
+    await prisma.$executeRaw(Prisma.sql`
+      UPDATE ontology.nodes
+      SET source_ref = ${sourceRef}::jsonb,
+          updated_at = NOW()
+      WHERE id = ${existing[0]!.id}::uuid
+    `);
+    return existing[0]!.id;
+  }
+  const inserted = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
+    INSERT INTO ontology.nodes (user_id, type, title, properties, source_ref, domain)
+    VALUES (
+      ${userId}::uuid,
+      ${nodeType},
+      ${entity.name},
+      '{}'::jsonb,
       ${sourceRef}::jsonb,
       'service'
     )

--- a/tests/unit/ontology/v2-bridge.test.ts
+++ b/tests/unit/ontology/v2-bridge.test.ts
@@ -42,13 +42,18 @@ describe('v2-bridge module purity (Hard Rule no-API)', () => {
     }
   });
 
-  test('inserts the 5 expected node types exactly', () => {
+  test('declares the 9 expected node types (CP474 entities[] 5-type added)', () => {
     for (const nodeType of [
       'video_resource',
       'concept',
       'section_node',
       'atom_node',
       'action_node',
+      // CP474 — entities[] 5-type. 'concept' is shared with key_concepts.
+      'person',
+      'tool',
+      'framework',
+      'organization',
     ]) {
       expect(SOURCE).toContain(`'${nodeType}'`);
     }
@@ -60,11 +65,21 @@ describe('v2-bridge module purity (Hard Rule no-API)', () => {
   });
 
   test('node upserts UPDATE properties on existing match (not just return)', () => {
-    // Sections / atoms / actions / video_resource / concept upserts must
-    // refresh properties + source_ref when an existing row is found, not
-    // simply return the id (otherwise re-POST cannot correct field values).
+    // CP474: 6 upserters (video_resource / concept / entity / section /
+    // atom / action). Each must refresh on existing match.
     const updateMatches = SOURCE.match(/UPDATE ontology\.nodes\s+SET\s+/g) ?? [];
-    expect(updateMatches.length).toBeGreaterThanOrEqual(5);
+    expect(updateMatches.length).toBeGreaterThanOrEqual(6);
+  });
+
+  test('CP474 — atoms.entity_refs prefer entities[].name over key_concepts.term', () => {
+    // bridgeV2ToOntology MENTIONS edge fallback chain.
+    expect(SOURCE).toMatch(/entityNameToId\.get\(ref\)\s*\?\?\s*conceptNameToId\.get\(ref\)/);
+  });
+
+  test('CP474 — ENTITY_TYPE_TO_NODE_TYPE maps all 5 entity types', () => {
+    for (const t of ['concept', 'person', 'tool', 'framework', 'organization']) {
+      expect(SOURCE).toMatch(new RegExp(`${t}:\\s*'${t}'`));
+    }
   });
 
   test('findGoalNodesByExactTitle uses exact title match (no fuzzy)', () => {


### PR DESCRIPTION
## Summary
PR #671 added `analysis.entities[]` (5-type: concept/person/tool/framework/organization) to the layered v2 schema; the KG bridge ignored it and built only `key_concepts → concept` nodes. This wires entities into the ontology so person/tool/framework/organization references land as their own typed nodes and atoms can MENTION them.

## Changes (2 files / +100 / -7)
- `src/modules/ontology/v2-bridge.ts`
  - `ENTITY_TYPE_TO_NODE_TYPE` map: `concept | person | tool | framework | organization` → ontology.nodes.type
  - `upsertEntity()` mirrors `upsertConcept` (lookup by `(type, title)` → UPDATE or INSERT)
  - `bridgeV2ToOntology` iterates `layered.analysis.entities ?? []`, builds `entityNameToId` map
  - MENTIONS edge resolution: `entityNameToId.get(ref) ?? conceptNameToId.get(ref)` (entities wins, key_concepts is fallback)
  - `V2BridgeResult.entityNodeIds: Record<EntityType, string[]>` (grouped per type)

- `tests/unit/ontology/v2-bridge.test.ts`
  - Bumped expected node types 5 → 9
  - Bumped expected UPDATE count 5 → 6
  - New: MENTIONS fallback chain assertion
  - New: ENTITY_TYPE_TO_NODE_TYPE map completeness

## Why this doesn't need a schema migration
`ontology.nodes.type` is `VARCHAR(30)` free-form (no CHECK constraint, no enum). Adding `person`/`tool`/`framework`/`organization` is a write-time change only.

## Backward compat
Legacy v2 rows have `entities = []` (PR #671's adapter default for v1 → layered). Bridge handles empty array as zero-iteration, no edges, no side effects. New v2 generations from PR #671's Heart-click path will populate entities.

## Test plan
- [x] BE `tsc --noEmit` PASS
- [x] BE Jest 9/9 PASS (v2-bridge.test.ts) — includes 4 new CP474 assertions
- [ ] Post-merge prod smoke: Heart-click a card → SSE `scored` → `SELECT type, title FROM ontology.nodes WHERE source_ref->>'table' = 'video_rich_summaries.entities' LIMIT 20` should show person/tool/framework/organization rows (when the LLM emits them)
- [ ] Optional follow-up audit: confirm dedup across video sources — a tool like \"Notion\" referenced from two different videos should produce 1 node, 2 MENTIONS edges

## Pairs with
- #671 (segments + entities + core_argument) — already merged
- #672 (Updated label + predicate fix) — already merged
- #673 (transcript_used regen gate) — already merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)