### PR TITLE
feat(v2): Key Moments + cell_index safeguards + entities/relevance UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           node-version: 20
       - name: Clean install (resolves platform-specific native binaries)
-        run: cd frontend && npm install --no-package-lock --no-audit
+        run: cd frontend && npm install --no-audit
       - run: cd frontend && npx vitest run
 
   hardcode-audit:
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: cd frontend && npm install --no-package-lock --no-audit
+      - run: cd frontend && npm install --no-audit
       - run: cd frontend && npx tsc --noEmit
       - run: cd frontend && npm run build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           node-version: 20
       - name: Clean install (resolves platform-specific native binaries)
-        run: cd frontend && npm install --no-audit
+        run: cd frontend && rm -rf node_modules package-lock.json && npm install --no-audit --legacy-peer-deps
       - run: cd frontend && npx vitest run
 
   hardcode-audit:
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: cd frontend && npm install --no-audit
+      - run: cd frontend && rm -rf node_modules package-lock.json && npm install --no-audit --legacy-peer-deps
       - run: cd frontend && npx tsc --noEmit
       - run: cd frontend && npm run build
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ prisma/migrations/*
 !prisma/migrations/add-cards/**
 !prisma/migrations/user-video-states-cleanup/
 !prisma/migrations/user-video-states-cleanup/**
+!prisma/migrations/user-video-states-guards/
+!prisma/migrations/user-video-states-guards/**
 !prisma/migrations/youtube-metadata-completeness/
 !prisma/migrations/youtube-metadata-completeness/**
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@copilotkit/react-core": "^1.56.3",
-    "@copilotkit/react-ui": "^1.56.3",
+    "@copilotkit/react-core": "~1.56.3",
+    "@copilotkit/react-ui": "~1.56.3",
     "@dicebear/collection": "^9.4.2",
     "@dicebear/core": "^9.4.2",
     "@dnd-kit/core": "^6.3.1",

--- a/frontend/src/features/card-management/model/useLikeCard.ts
+++ b/frontend/src/features/card-management/model/useLikeCard.ts
@@ -56,15 +56,12 @@ export function useLikeCard() {
       });
     },
     onSuccess: () => {
-      // CP463 flicker-fix — DO NOT invalidate the card-list queries
-      // (`localCards.list()` / `['mandala','recommendations']`). like only
-      // changes `pinned_at`, which the in-card `likedLocal` optimistic
-      // state already reflects; invalidating the list forces a full grid
-      // refetch + 60+ card reconcile per click, and triggers a visible
-      // flicker storm when multiple cards are enriched concurrently.
-      // Only v2-summaries needs an invalidate so the TL badge + footer
-      // one_liner appear when the score lands.
+      // Skip the recommendation feed invalidate — the optimistic flip
+      // covers the grid and a full refetch causes flicker storms.
       queryClient.invalidateQueries({ queryKey: ['cards', 'v2-summaries'] });
+      // localCards drives the sidebar book-index; refetch so the new
+      // pinned card surfaces under its sub-goal without a manual reload.
+      queryClient.invalidateQueries({ queryKey: localCardsKeys.list() });
     },
   });
 
@@ -73,10 +70,8 @@ export function useLikeCard() {
       await apiClient.unlikeCard(videoId);
     },
     onSuccess: () => {
-      // Same flicker-fix as `like` — the optimistic flip already covers
-      // the UI; the next natural refetch (`useRecommendations`
-      // refetchInterval 8s) propagates the server pinned_at=NULL.
       queryClient.invalidateQueries({ queryKey: ['cards', 'v2-summaries'] });
+      queryClient.invalidateQueries({ queryKey: localCardsKeys.list() });
     },
   });
 

--- a/frontend/src/features/card-management/model/useV2Summaries.ts
+++ b/frontend/src/features/card-management/model/useV2Summaries.ts
@@ -31,6 +31,12 @@ export interface V2SummaryItem {
    * absent.
    */
   coreArgument: string | null;
+  /** Top key-concept terms (≤ 3) used as book-index entries in the
+   *  sidebar. Empty when the row is pre-v2 or analysis is absent. */
+  keyConcepts: string[];
+  /** Fallback keyword source for videos without a v2 row yet — derived
+   *  from video_summaries.tags. Sidebar uses these when keyConcepts empty. */
+  fallbackTags: string[];
   mandalaRelevancePct: number | null;
   qualityFlag: string | null;
   templateVersion: string;

--- a/frontend/src/features/video-side-panel/model/useRichSummary.ts
+++ b/frontend/src/features/video-side-panel/model/useRichSummary.ts
@@ -29,6 +29,7 @@ export function useRichSummary(videoId: string | null | undefined): UseRichSumma
     queryFn: () => apiClient.getVideoRichSummary(videoId as string),
     enabled: Boolean(videoId),
     staleTime: RICH_SUMMARY_STALE_MS,
+    refetchOnMount: 'always',
     retry: false,
   });
 

--- a/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
@@ -12,10 +12,13 @@
  *
  * Design tokens: insighta-side-editor-mockup-v3.html
  */
+import { useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import type { VideoSummary } from '@/entities/card/model/types';
 import { getYouTubeVideoId } from '@/widgets/video-player/model/youtube-api';
+import { queryKeys } from '@/shared/config/query-client';
 import type {
   VideoRichSummaryAnalysis,
   VideoRichSummaryAtom,
@@ -33,7 +36,14 @@ export interface PanelAISummaryProps {
 export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) {
   const { t } = useTranslation();
   const { mandalaId } = useParams<{ mandalaId: string }>();
+  const queryClient = useQueryClient();
   const youtubeId = videoUrl ? getYouTubeVideoId(videoUrl) : null;
+  // Cache-bust on every mount + videoId change so freshly-backfilled v2
+  // rows surface immediately without a hard refresh.
+  useEffect(() => {
+    if (!youtubeId) return;
+    void queryClient.invalidateQueries({ queryKey: queryKeys.video.richSummary(youtubeId) });
+  }, [youtubeId, queryClient]);
   const { richSummary, isLoading: isRichLoading } = useRichSummary(youtubeId);
 
   const short = videoSummary?.summary_ko || videoSummary?.summary_en || null;
@@ -349,6 +359,8 @@ function RichSummaryV2NewBlock({
   const coreArg = analysis?.core_argument ?? null;
   const actionables = analysis?.actionables ?? [];
   const keyConcepts = analysis?.key_concepts ?? [];
+  // entities feed the KG bridge; absent on rows authored before they shipped.
+  const entities = analysis?.entities ?? [];
   const sections = segments?.sections ?? [];
   const atoms = segments?.atoms ?? [];
   const qaPairs = lora?.qa_pairs ?? [];
@@ -365,23 +377,65 @@ function RichSummaryV2NewBlock({
 
   return (
     <div className="space-y-4">
-      {oneLiner && (
+      {/* coreArgument in the headline slot. */}
+      {coreArg && (
         <section>
-          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
-            {t('learning.oneLiner')}
-          </h3>
-          <p className="rounded-r-[6px] border-l-2 border-[#818cf8] bg-[rgba(99,102,241,0.06)] px-[14px] py-[10px] text-[13px] leading-[1.65] text-[#ededf0]">
-            {oneLiner}
+          <p className="rounded-[6px] bg-[rgba(99,102,241,0.06)] px-[14px] py-[10px] text-[13px] leading-[1.65] text-[#ededf0]">
+            {coreArg}
           </p>
         </section>
       )}
 
-      {coreArg && (
+      {sections.length > 0 && (
         <section>
-          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
-            {t('learning.coreArgument')}
-          </h3>
-          <p className="text-[13px] leading-[1.6] text-[rgba(237,237,240,0.84)]">{coreArg}</p>
+          <div className="space-y-1">
+            {sections.map((sec, idx) => {
+              const jump = tsUrl(sec.from_sec);
+              const inner = (
+                <>
+                  <div className="flex items-baseline gap-3">
+                    <span className="font-mono text-[10px] text-[#818cf8] shrink-0">
+                      {formatSeconds(sec.from_sec)} — {formatSeconds(sec.to_sec)}
+                    </span>
+                    <p className="flex-1 text-[12px] font-semibold leading-[1.35] text-[rgba(237,237,240,0.92)]">
+                      {sec.title}
+                    </p>
+                    {typeof sec.relevance_pct === 'number' && (
+                      <span
+                        className={[
+                          'shrink-0 font-mono text-[11px] font-bold tabular-nums',
+                          sec.relevance_pct >= 75
+                            ? 'text-[#2dd4bf]'
+                            : sec.relevance_pct >= 50
+                              ? 'text-[#f59e0b]'
+                              : 'text-[#94a3b8]',
+                        ].join(' ')}
+                        title={t('learning.relevanceLabel')}
+                      >
+                        {sec.relevance_pct}%
+                      </span>
+                    )}
+                  </div>
+                  {sec.summary && (
+                    <p className="mt-[3px] pl-[88px] text-[11px] text-[rgba(237,237,240,0.66)]">
+                      {sec.summary}
+                    </p>
+                  )}
+                </>
+              );
+              const baseCls =
+                'block rounded-[6px] px-3 py-[10px] transition-colors hover:bg-[rgba(129,140,248,0.06)]';
+              return jump ? (
+                <Link key={idx} to={jump} className={`${baseCls} cursor-pointer`}>
+                  {inner}
+                </Link>
+              ) : (
+                <div key={idx} className={baseCls}>
+                  {inner}
+                </div>
+              );
+            })}
+          </div>
         </section>
       )}
 
@@ -439,36 +493,6 @@ function RichSummaryV2NewBlock({
         </section>
       )}
 
-      {sections.length > 0 && (
-        <section>
-          <h3 className="mb-[8px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
-            {t('learning.sectionAnalysis')}
-          </h3>
-          <div className="space-y-1">
-            {sections.map((sec, idx) => (
-              <div
-                key={idx}
-                className="rounded-[6px] px-3 py-[10px] transition-colors hover:bg-[rgba(255,255,255,0.02)]"
-              >
-                <div className="flex items-baseline gap-3">
-                  <span className="font-mono text-[10px] text-[#818cf8] shrink-0">
-                    {formatSeconds(sec.from_sec)} — {formatSeconds(sec.to_sec)}
-                  </span>
-                  <p className="text-[12px] font-semibold leading-[1.35] text-[rgba(237,237,240,0.92)]">
-                    {sec.title}
-                  </p>
-                </div>
-                {sec.summary && (
-                  <p className="mt-[3px] pl-[88px] text-[11px] text-[rgba(237,237,240,0.66)]">
-                    {sec.summary}
-                  </p>
-                )}
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
-
       {atoms.length > 0 && (
         <section>
           <h3 className="mb-[8px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
@@ -479,6 +503,25 @@ function RichSummaryV2NewBlock({
               <AtomRow key={idx} atom={atom} jumpUrl={tsUrl(atom.timestamp_sec)} />
             ))}
           </ul>
+        </section>
+      )}
+
+      {entities.length > 0 && (
+        <section>
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
+            {t('learning.tags')}
+          </h3>
+          <div className="flex flex-wrap gap-x-1 gap-y-[3px]">
+            {entities.map((ent) => (
+              <span
+                key={`${ent.type}:${ent.name}`}
+                className="inline-block rounded-[4px] bg-[rgba(129,140,248,0.08)] px-[7px] py-[2px] text-[10px] font-semibold text-[#818cf8]"
+                title={ent.type}
+              >
+                {ent.name}
+              </span>
+            ))}
+          </div>
         </section>
       )}
 

--- a/frontend/src/pages/learning/model/useHighlightReel.ts
+++ b/frontend/src/pages/learning/model/useHighlightReel.ts
@@ -45,14 +45,24 @@ export function useHighlightReel({ sections, playerRef, threshold }: UseHighligh
     (sections ?? []).every((s) => typeof s.relevance_pct === 'number');
   const enabled = allHaveRelevance && highlights.length > 0;
 
+  const totalSec = highlights.reduce((s, h) => s + Math.max(0, h.to - h.from), 0);
+
   const [active, setActive] = useState(false);
   const [currentIdx, setCurrentIdx] = useState(0);
+  const [remainingSec, setRemainingSec] = useState(totalSec);
   const expectedTimeRef = useRef<number | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Re-sync remainingSec to totalSec while idle (e.g., new video loaded,
+  // highlights array changed). Active mode controls remainingSec itself.
+  useEffect(() => {
+    if (!active) setRemainingSec(totalSec);
+  }, [totalSec, active]);
 
   const stop = useCallback(() => {
     setActive(false);
     setCurrentIdx(0);
+    setRemainingSec(totalSec);
     expectedTimeRef.current = null;
     if (intervalRef.current) {
       clearInterval(intervalRef.current);
@@ -63,7 +73,7 @@ export function useHighlightReel({ sections, playerRef, threshold }: UseHighligh
     } catch {
       /* swallow */
     }
-  }, [playerRef]);
+  }, [playerRef, totalSec]);
 
   const start = useCallback(() => {
     if (!enabled || !playerRef.current) return;
@@ -76,8 +86,9 @@ export function useHighlightReel({ sections, playerRef, threshold }: UseHighligh
     }
     expectedTimeRef.current = first.from;
     setCurrentIdx(0);
+    setRemainingSec(totalSec);
     setActive(true);
-  }, [enabled, highlights, playerRef]);
+  }, [enabled, highlights, playerRef, totalSec]);
 
   useEffect(() => {
     if (!active) return;
@@ -122,6 +133,16 @@ export function useHighlightReel({ sections, playerRef, threshold }: UseHighligh
         }
         expectedTimeRef.current = next.from;
         setCurrentIdx(nextIdx);
+        const futureSum = highlights
+          .slice(nextIdx + 1)
+          .reduce((s, h) => s + Math.max(0, h.to - h.from), 0);
+        setRemainingSec(Math.max(0, next.to - next.from) + futureSum);
+      } else {
+        const remInCur = Math.max(0, cur.to - now);
+        const futureSum = highlights
+          .slice(currentIdx + 1)
+          .reduce((s, h) => s + Math.max(0, h.to - h.from), 0);
+        setRemainingSec(remInCur + futureSum);
       }
     }, POLL_INTERVAL_MS);
     return () => {
@@ -137,6 +158,8 @@ export function useHighlightReel({ sections, playerRef, threshold }: UseHighligh
     active,
     highlights,
     currentIdx,
+    totalSec,
+    remainingSec,
     start,
     stop,
   };

--- a/frontend/src/pages/learning/model/useHighlightReel.ts
+++ b/frontend/src/pages/learning/model/useHighlightReel.ts
@@ -1,0 +1,143 @@
+/**
+ * "핵심만 보기" — sequentially plays only the highly-relevant segments
+ * (relevance_pct >= threshold) of the active video. User manual scrub
+ * exits the mode so the user is never trapped.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { YTPlayer } from '@/widgets/video-player/model/youtube-api';
+import type { VideoRichSummarySection } from '@/shared/lib/api-client';
+
+export const HIGHLIGHT_RELEVANCE_THRESHOLD = 80;
+const POLL_INTERVAL_MS = 500;
+// Manual scrub tolerance — currentTime can drift up to ~1s from polling cadence;
+// anything beyond this means the user moved the playhead.
+const SCRUB_TOLERANCE_SEC = 2;
+
+interface HighlightSection {
+  from: number;
+  to: number;
+}
+
+function pickHighlights(
+  sections: VideoRichSummarySection[] | undefined,
+  threshold = HIGHLIGHT_RELEVANCE_THRESHOLD
+): HighlightSection[] {
+  return (sections ?? [])
+    .filter(
+      (s) =>
+        typeof s.relevance_pct === 'number' && s.relevance_pct >= threshold && s.to_sec > s.from_sec
+    )
+    .map((s) => ({ from: s.from_sec, to: s.to_sec }))
+    .sort((a, b) => a.from - b.from);
+}
+
+export interface UseHighlightReelArgs {
+  sections: VideoRichSummarySection[] | undefined;
+  playerRef: React.MutableRefObject<YTPlayer | null>;
+  threshold?: number;
+}
+
+export function useHighlightReel({ sections, playerRef, threshold }: UseHighlightReelArgs) {
+  const highlights = pickHighlights(sections, threshold);
+  const allHaveRelevance =
+    (sections?.length ?? 0) > 0 &&
+    (sections ?? []).every((s) => typeof s.relevance_pct === 'number');
+  const enabled = allHaveRelevance && highlights.length > 0;
+
+  const [active, setActive] = useState(false);
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const expectedTimeRef = useRef<number | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stop = useCallback(() => {
+    setActive(false);
+    setCurrentIdx(0);
+    expectedTimeRef.current = null;
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    try {
+      playerRef.current?.pauseVideo();
+    } catch {
+      /* swallow */
+    }
+  }, [playerRef]);
+
+  const start = useCallback(() => {
+    if (!enabled || !playerRef.current) return;
+    const first = highlights[0]!;
+    try {
+      playerRef.current.seekTo(first.from, true);
+      playerRef.current.playVideo();
+    } catch {
+      return;
+    }
+    expectedTimeRef.current = first.from;
+    setCurrentIdx(0);
+    setActive(true);
+  }, [enabled, highlights, playerRef]);
+
+  useEffect(() => {
+    if (!active) return;
+    intervalRef.current = setInterval(() => {
+      const player = playerRef.current;
+      if (!player) return;
+      let now: number;
+      try {
+        now = player.getCurrentTime();
+      } catch {
+        return;
+      }
+      const expected = expectedTimeRef.current ?? now;
+      // Manual scrub guard — user moved the playhead, exit mode.
+      if (Math.abs(now - expected) > SCRUB_TOLERANCE_SEC && currentIdx > 0) {
+        stop();
+        return;
+      }
+      expectedTimeRef.current = now;
+      const cur = highlights[currentIdx];
+      if (!cur) {
+        stop();
+        return;
+      }
+      if (now >= cur.to) {
+        const nextIdx = currentIdx + 1;
+        const next = highlights[nextIdx];
+        if (!next) {
+          try {
+            player.pauseVideo();
+          } catch {
+            /* swallow */
+          }
+          stop();
+          return;
+        }
+        try {
+          player.seekTo(next.from, true);
+        } catch {
+          stop();
+          return;
+        }
+        expectedTimeRef.current = next.from;
+        setCurrentIdx(nextIdx);
+      }
+    }, POLL_INTERVAL_MS);
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [active, currentIdx, highlights, playerRef, stop]);
+
+  return {
+    enabled,
+    active,
+    highlights,
+    currentIdx,
+    start,
+    stop,
+  };
+}

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -248,9 +248,9 @@ export function CenterPanel({
               className={cn(
                 'inline-flex items-center justify-center w-8 h-8 rounded-full transition-colors',
                 highlightReel.active
-                  ? 'bg-[rgba(129,140,248,0.12)] text-[#818cf8] hover:bg-[rgba(129,140,248,0.22)]'
-                  : 'bg-[#818cf8] text-white shadow-sm hover:bg-[#6c78de]',
-                !highlightReel.enabled && 'opacity-40 cursor-not-allowed hover:bg-[#818cf8]'
+                  ? 'text-[#818cf8]/80 hover:bg-[rgba(129,140,248,0.10)]'
+                  : 'text-white hover:bg-white/10',
+                !highlightReel.enabled && 'opacity-40 cursor-not-allowed'
               )}
             >
               <Zap className="h-5 w-5" aria-hidden="true" />

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import {
   Sparkles,
+  Zap,
   BookText,
   Play,
   BookOpen,
@@ -17,6 +18,8 @@ import { toast } from 'sonner';
 import { PanelVideoPlayer } from '@/features/video-side-panel/ui/PanelVideoPlayer';
 import { PanelAISummary } from '@/features/video-side-panel/ui/PanelAISummary';
 import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
+import { useRichSummary } from '@/features/video-side-panel/model/useRichSummary';
+import { useHighlightReel, HIGHLIGHT_RELEVANCE_THRESHOLD } from '../model/useHighlightReel';
 import { useLearningStore } from '@/pages/learning/model/useLearningStore';
 import { useNoteDocument } from '@/pages/learning/model/useNoteDocument';
 import { useNoteAutoFollow } from '@/pages/learning/model/useNoteAutoFollow';
@@ -50,6 +53,15 @@ export function CenterPanel({
 }: CenterPanelProps) {
   const { t } = useTranslation();
   const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
+
+  // Highlight reel — auto-skip to sections whose relevance_pct >= threshold.
+  // Dormant until pre-CP474 rows are backfilled with segments + relevance.
+  const { richSummary: highlightRich } = useRichSummary(videoId);
+  const highlightSections = highlightRich?.segments?.sections ?? undefined;
+  const highlightReel = useHighlightReel({
+    sections: highlightSections,
+    playerRef,
+  });
   const centerTab = useLearningStore((s) => s.centerTab);
   const setCenterTab = useLearningStore((s) => s.setCenterTab);
   const centerViewMode = useLearningStore((s) => s.centerViewMode);
@@ -191,22 +203,50 @@ export function CenterPanel({
           style={{ maxWidth: 'calc(49.5vh * 16 / 9)' }}
           onMouseEnter={() => setActiveRegion('book-index')}
         >
-          <div className="flex">
-            {tabs.map(({ id, labelKey, fallback, icon: Icon }) => (
-              <button
-                key={id}
-                onClick={() => setCenterTab(id)}
-                className={cn(
-                  'flex items-center gap-1.5 py-2.5 px-3 text-[12px] transition-colors border-b-2',
-                  centerTab === id
-                    ? 'border-primary text-foreground font-semibold'
-                    : 'border-transparent text-muted-foreground font-normal hover:text-foreground'
-                )}
-              >
-                <Icon className="h-3.5 w-3.5" />
-                {t(labelKey, fallback)}
-              </button>
-            ))}
+          <div className="flex items-center justify-between">
+            <div className="flex">
+              {tabs.map(({ id, labelKey, fallback, icon: Icon }) => (
+                <button
+                  key={id}
+                  onClick={() => setCenterTab(id)}
+                  className={cn(
+                    'flex items-center gap-1.5 py-2.5 px-3 text-[12px] transition-colors border-b-2',
+                    centerTab === id
+                      ? 'border-primary text-foreground font-semibold'
+                      : 'border-transparent text-muted-foreground font-normal hover:text-foreground'
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                  {t(labelKey, fallback)}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={highlightReel.active ? highlightReel.stop : highlightReel.start}
+              disabled={!highlightReel.enabled}
+              title={
+                !highlightReel.enabled
+                  ? t('learning.highlightReelDisabledTooltip', {
+                      threshold: HIGHLIGHT_RELEVANCE_THRESHOLD,
+                    })
+                  : highlightReel.active
+                    ? t('learning.highlightReelActiveTooltip')
+                    : t('learning.highlightReelReadyTooltip', {
+                        count: highlightReel.highlights.length,
+                      })
+              }
+              className={cn(
+                'flex items-center gap-1 px-2.5 py-[3px] text-[11.5px] font-medium rounded-full transition-colors',
+                highlightReel.active
+                  ? 'bg-[rgba(129,140,248,0.12)] text-[#818cf8] hover:bg-[rgba(129,140,248,0.22)]'
+                  : 'bg-[#818cf8] text-white shadow-sm hover:bg-[#6c78de]',
+                !highlightReel.enabled && 'opacity-40 cursor-not-allowed hover:bg-[#818cf8]'
+              )}
+            >
+              <Zap className="h-3 w-3" aria-hidden="true" />
+              {t('learning.highlightReel')}
+            </button>
           </div>
         </div>
       )}

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -44,6 +44,13 @@ interface CenterPanelProps {
 
 type CenterTabId = 'summary' | 'section';
 
+function formatMMSS(seconds: number): string {
+  const total = Math.max(0, Math.round(seconds));
+  const mm = Math.floor(total / 60);
+  const ss = total % 60;
+  return `${mm.toString().padStart(2, '0')}:${ss.toString().padStart(2, '0')}`;
+}
+
 export function CenterPanel({
   mandalaId,
   videoId,
@@ -229,32 +236,47 @@ export function CenterPanel({
                 </button>
               ))}
             </div>
-            <button
-              type="button"
-              onClick={highlightReel.active ? highlightReel.stop : highlightReel.start}
-              disabled={!highlightReel.enabled}
-              title={
-                !highlightReel.enabled
-                  ? t('learning.highlightReelDisabledTooltip', {
-                      threshold: HIGHLIGHT_RELEVANCE_THRESHOLD,
-                    })
-                  : highlightReel.active
-                    ? t('learning.highlightReelActiveTooltip')
-                    : t('learning.highlightReelReadyTooltip', {
-                        count: highlightReel.highlights.length,
-                      })
-              }
-              aria-label={t('learning.highlightReel')}
-              className={cn(
-                'inline-flex items-center justify-center w-8 h-8 rounded-full transition-colors',
-                highlightReel.active
-                  ? 'text-[#818cf8]/80 hover:bg-[rgba(129,140,248,0.10)]'
-                  : 'text-white hover:bg-white/10',
-                !highlightReel.enabled && 'opacity-40 cursor-not-allowed'
+            <div className="flex items-center gap-2">
+              {highlightReel.enabled && (
+                <span
+                  className={cn(
+                    'text-[11px] tabular-nums font-medium transition-colors',
+                    highlightReel.active ? 'text-[#818cf8]/80' : 'text-white/60'
+                  )}
+                  aria-live="polite"
+                >
+                  {formatMMSS(
+                    highlightReel.active ? highlightReel.remainingSec : highlightReel.totalSec
+                  )}
+                </span>
               )}
-            >
-              <Zap className="h-5 w-5" aria-hidden="true" />
-            </button>
+              <button
+                type="button"
+                onClick={highlightReel.active ? highlightReel.stop : highlightReel.start}
+                disabled={!highlightReel.enabled}
+                title={
+                  !highlightReel.enabled
+                    ? t('learning.highlightReelDisabledTooltip', {
+                        threshold: HIGHLIGHT_RELEVANCE_THRESHOLD,
+                      })
+                    : highlightReel.active
+                      ? t('learning.highlightReelActiveTooltip')
+                      : t('learning.highlightReelReadyTooltip', {
+                          count: highlightReel.highlights.length,
+                        })
+                }
+                aria-label={t('learning.highlightReel')}
+                className={cn(
+                  'inline-flex items-center justify-center w-8 h-8 rounded-full transition-colors',
+                  highlightReel.active
+                    ? 'text-[#818cf8]/80 hover:bg-[rgba(129,140,248,0.10)]'
+                    : 'text-white hover:bg-white/10',
+                  !highlightReel.enabled && 'opacity-40 cursor-not-allowed'
+                )}
+              >
+                <Zap className="h-5 w-5" aria-hidden="true" />
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -244,16 +244,16 @@ export function CenterPanel({
                         count: highlightReel.highlights.length,
                       })
               }
+              aria-label={t('learning.highlightReel')}
               className={cn(
-                'flex items-center gap-1 px-2.5 py-[3px] text-[11.5px] font-medium rounded-full transition-colors',
+                'inline-flex items-center justify-center p-2.5 rounded-full transition-colors',
                 highlightReel.active
                   ? 'bg-[rgba(129,140,248,0.12)] text-[#818cf8] hover:bg-[rgba(129,140,248,0.22)]'
                   : 'bg-[#818cf8] text-white shadow-sm hover:bg-[#6c78de]',
                 !highlightReel.enabled && 'opacity-40 cursor-not-allowed hover:bg-[#818cf8]'
               )}
             >
-              <Zap className="h-3 w-3" aria-hidden="true" />
-              {t('learning.highlightReel')}
+              <Zap className="h-6 w-6" aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -38,6 +38,8 @@ interface CenterPanelProps {
   onUserPlayed?: () => void;
   onPlayStateChange?: (isPlaying: boolean) => void;
   startTime?: number;
+  onPlayerHoverIn?: () => void;
+  onPlayerHoverOut?: () => void;
 }
 
 type CenterTabId = 'summary' | 'section';
@@ -50,6 +52,8 @@ export function CenterPanel({
   onUserPlayed,
   onPlayStateChange,
   startTime,
+  onPlayerHoverIn,
+  onPlayerHoverOut,
 }: CenterPanelProps) {
   const { t } = useTranslation();
   const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
@@ -179,7 +183,11 @@ export function CenterPanel({
     <div className="flex flex-1 min-w-0 flex-col overflow-hidden pl-4 pr-3 pt-[5px]">
       <div
         className={cn('shrink-0', centerViewMode === 'note' && 'hidden')}
-        onMouseEnter={() => setActiveRegion('player')}
+        onMouseEnter={() => {
+          setActiveRegion('player');
+          onPlayerHoverIn?.();
+        }}
+        onMouseLeave={() => onPlayerHoverOut?.()}
       >
         <PanelVideoPlayer
           videoUrl={videoUrl}

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -246,14 +246,14 @@ export function CenterPanel({
               }
               aria-label={t('learning.highlightReel')}
               className={cn(
-                'inline-flex items-center justify-center p-2.5 rounded-full transition-colors',
+                'inline-flex items-center justify-center w-8 h-8 rounded-full transition-colors',
                 highlightReel.active
                   ? 'bg-[rgba(129,140,248,0.12)] text-[#818cf8] hover:bg-[rgba(129,140,248,0.22)]'
                   : 'bg-[#818cf8] text-white shadow-sm hover:bg-[#6c78de]',
                 !highlightReel.enabled && 'opacity-40 cursor-not-allowed hover:bg-[#818cf8]'
               )}
             >
-              <Zap className="h-6 w-6" aria-hidden="true" />
+              <Zap className="h-5 w-5" aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/frontend/src/pages/learning/ui/LearningPage.tsx
+++ b/frontend/src/pages/learning/ui/LearningPage.tsx
@@ -31,6 +31,7 @@ export default function LearningPage() {
   }, [videoId]);
 
   const centerViewMode = useLearningStore((s) => s.centerViewMode);
+  const [stripVisible, setStripVisible] = useState(false);
 
   // CP438+1: ?t=N query param drives in-page seek. When the user clicks
   // an atom timestamp link in the sidebar/panel, the same-video case
@@ -85,10 +86,23 @@ export default function LearningPage() {
     <div className="flex h-full overflow-hidden">
       {/* 좌측 column = VideoStrip + CenterPanel (둘 다 px-10 → player 와
           좌우 polo align). RightPanel 은 별도 column. */}
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        {/* CP445 (사용자 directive) — VideoStrip = player 폭 정렬. CenterPanel
-            의 px-4 padding 과 동일 적용 (베젤 축소). 노트 모드 시 hidden. */}
-        <div className={cn('shrink-0 pl-4 pr-3 pt-[5px]', centerViewMode === 'note' && 'hidden')}>
+      <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+        {/* VideoStrip slide-on-hover. Trigger = player wrapper only (via
+            onPlayerHoverIn/Out from CenterPanel). Strip itself also
+            stays visible while hovered so the user can click a thumb. */}
+        <div
+          onMouseEnter={() => setStripVisible(true)}
+          onMouseLeave={() => setStripVisible(false)}
+          className={cn(
+            'absolute left-0 right-0 top-0 z-20 pl-4 pr-3 pt-[5px]',
+            'bg-[hsl(var(--bg-base))]/95 backdrop-blur-sm',
+            'transition-transform duration-300 ease-out',
+            stripVisible
+              ? 'translate-y-0 pointer-events-auto'
+              : '-translate-y-full pointer-events-none',
+            centerViewMode === 'note' && 'hidden'
+          )}
+        >
           <VideoStrip mandalaId={mandalaId!} currentVideoId={videoId!} />
         </div>
         <CenterPanel
@@ -102,6 +116,8 @@ export default function LearningPage() {
           onUserPlayed={handleUserPlayed}
           onPlayStateChange={handlePlayStateChange}
           startTime={startTime}
+          onPlayerHoverIn={() => setStripVisible(true)}
+          onPlayerHoverOut={() => setStripVisible(false)}
         />
       </div>
       <RightPanel mandalaId={mandalaId!} videoId={videoId!} playerRef={playerRef} />

--- a/frontend/src/pages/learning/ui/LeftPanel.tsx
+++ b/frontend/src/pages/learning/ui/LeftPanel.tsx
@@ -7,12 +7,25 @@ import type { InsightCard } from '@/entities/card/model/types';
 
 interface LeftPanelProps {
   mandalaId: string;
+  /** Long-form mandala center goal — rendered as tooltip on the header. */
   centerGoal: string;
+  /** Short cell-name label; falls back to centerGoal when empty. */
+  centerLabel?: string;
+  /** Long-form sub-goals (8 cells). Used as tooltip on each row. */
   subGoals: string[];
+  /** Short sub-cell labels; each row prefers labels[idx] over subGoals[idx]. */
+  subjectLabels?: string[];
   currentVideoId?: string;
 }
 
-export function LeftPanel({ mandalaId, centerGoal, subGoals, currentVideoId }: LeftPanelProps) {
+export function LeftPanel({
+  mandalaId,
+  centerGoal,
+  centerLabel,
+  subGoals,
+  subjectLabels,
+  currentVideoId,
+}: LeftPanelProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const selectedCell = useLearningStore((s) => s.selectedCellIndex);
@@ -38,12 +51,19 @@ export function LeftPanel({ mandalaId, centerGoal, subGoals, currentVideoId }: L
     }
   };
 
+  // Header prefers the short label; long goal lives in the tooltip.
+  const headerLabel = centerLabel?.trim() || centerGoal || t('learning.goal');
+  const headerTooltip = centerGoal && centerGoal !== headerLabel ? centerGoal : undefined;
+
   return (
     <div className="flex flex-col border-r border-[hsl(var(--border))] bg-[hsl(var(--bg-base))]">
       {/* Header */}
       <div className="shrink-0 border-b border-[hsl(var(--border))] px-4 py-3">
-        <h2 className="text-[13px] font-bold text-[hsl(var(--foreground))] leading-snug">
-          {centerGoal || t('learning.goal')}
+        <h2
+          className="text-[13px] font-bold text-[hsl(var(--foreground))] leading-snug"
+          title={headerTooltip}
+        >
+          {headerLabel}
         </h2>
         <p className="mt-0.5 text-[11px] text-[hsl(var(--muted-foreground))]">
           {t('learning.videoCount', { count: mandalaCards.length })}
@@ -56,11 +76,15 @@ export function LeftPanel({ mandalaId, centerGoal, subGoals, currentVideoId }: L
           {subGoals.map((goal, idx) => {
             const cellCards = cardsByCell.get(idx + 1) ?? [];
             const isSelected = selectedCell === idx + 1;
+            // Row prefers the short label; long goal becomes the tooltip.
+            const rowLabel = subjectLabels?.[idx]?.trim() || goal;
+            const rowTooltip = goal && goal !== rowLabel ? goal : undefined;
 
             return (
               <div key={idx}>
                 <button
                   onClick={() => setSelectedCell(isSelected ? null : idx + 1)}
+                  title={rowTooltip}
                   className={[
                     'flex w-full items-center gap-2 px-4 py-2.5 text-left transition-colors',
                     isSelected ? 'bg-[rgba(129,140,248,0.08)]' : 'hover:bg-[hsl(var(--bg-mid))]',
@@ -73,7 +97,7 @@ export function LeftPanel({ mandalaId, centerGoal, subGoals, currentVideoId }: L
                     ].join(' ')}
                   />
                   <span className="flex-1 truncate text-[12px] font-medium text-[hsl(var(--foreground))]">
-                    {goal}
+                    {rowLabel}
                   </span>
                   {cellCards.length > 0 && (
                     <span className="shrink-0 rounded-full bg-[rgba(129,140,248,0.1)] px-1.5 py-0.5 text-[10px] font-semibold text-[#818cf8]">

--- a/frontend/src/pages/learning/ui/RightPanel.tsx
+++ b/frontend/src/pages/learning/ui/RightPanel.tsx
@@ -23,7 +23,7 @@ type RightTab = 'notes' | 'chatbot';
 
 export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
   const { t } = useTranslation();
-  const [activeTab, setActiveTab] = useState<RightTab>('notes');
+  const [activeTab, setActiveTab] = useState<RightTab>('chatbot');
   const setActiveRegion = useLearningStore((s) => s.setActiveRegion);
   const setNoteContext = useLearningStore((s) => s.setNoteContext);
   const centerViewMode = useLearningStore((s) => s.centerViewMode);

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -633,7 +633,10 @@
     "dropError": {
       "notVideoUrlTitle": "Video URL required",
       "notVideoUrlDescription": "Channel and playlist URLs cannot be added. Please drag the URL of the video page itself."
-    }
+    },
+    "statusQueued": "Queued",
+    "statusQueuedTooltip": "Pending background analysis",
+    "retryEnrichmentTooltip": "Retry caption fetch"
   },
   "contextHeader": {
     "home": "Home",
@@ -1767,6 +1770,11 @@
     "tabChatbot": "AI Chatbot",
     "tabSummary": "AI Summary",
     "tabSection": "Section",
+    "highlightReel": "Key Moments",
+    "tags": "Tags",
+    "highlightReelDisabledTooltip": "Activates once segment relevance is analysed (segments ≥ {{threshold}}%)",
+    "highlightReelActiveTooltip": "Playing key moments — click to stop",
+    "highlightReelReadyTooltip": "Play {{count}} key moment(s)",
     "noActiveSection": "Select a section from the book index on the left.",
     "chapterLabel": "Chapter {{n}}",
     "atomsLabel": "Atoms",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -641,7 +641,10 @@
     "dropError": {
       "notVideoUrlTitle": "영상 URL 이 필요합니다",
       "notVideoUrlDescription": "채널/플레이리스트 URL 은 추가할 수 없습니다. 영상 페이지의 URL 을 드래그해주세요."
-    }
+    },
+    "statusQueued": "분석 대기",
+    "statusQueuedTooltip": "자동 분석 대기 중",
+    "retryEnrichmentTooltip": "자막을 다시 가져옵니다"
   },
   "contextHeader": {
     "home": "홈",
@@ -1775,6 +1778,11 @@
     "tabChatbot": "AI 챗봇",
     "tabSummary": "AI 요약",
     "tabSection": "섹션 내용",
+    "highlightReel": "핵심만 보기",
+    "tags": "태그",
+    "highlightReelDisabledTooltip": "구간별 관련도 분석 후 활성화 ({{threshold}}% 이상 구간)",
+    "highlightReelActiveTooltip": "핵심 재생 중 — 클릭하여 종료",
+    "highlightReelReadyTooltip": "{{count}}개 핵심 구간 재생",
     "noActiveSection": "좌측 북인덱스에서 섹션을 선택하세요.",
     "chapterLabel": "챕터 {{n}}",
     "atomsLabel": "아톰",

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -150,13 +150,23 @@ export interface VideoRichSummaryKeyConcept {
   definition: string;
 }
 
+/** CP474 — typed entity emitted by the v2 prompt (5-type vocabulary). */
+export interface VideoRichSummaryEntity {
+  name: string;
+  type: 'concept' | 'person' | 'tool' | 'framework' | 'organization' | string;
+}
+
 export interface VideoRichSummaryAnalysis {
   core_argument?: string;
   key_concepts?: VideoRichSummaryKeyConcept[];
+  /** CP474 — KG bridge nodes (concept/person/tool/framework/organization). */
+  entities?: VideoRichSummaryEntity[];
   actionables?: string[];
   mandala_fit?: {
     suggested_goals?: string[];
     relevance_rationale?: string;
+    /** CP462+ — 0-100 whole-video score against the user's mandala center. */
+    mandala_relevance_pct?: number;
   };
   bias_signals?: {
     has_ad?: boolean;
@@ -173,6 +183,11 @@ export interface VideoRichSummarySection {
   from_sec: number;
   to_sec: number;
   summary?: string;
+  /** CP474 — intra-video relevance for this section vs the user's mandala
+   *  center goal (0-100 integer). Distinct from
+   *  `analysis.mandala_fit.mandala_relevance_pct` (whole-video score). */
+  relevance_pct?: number;
+  key_points?: Array<{ text: string; timestamp_sec?: number }>;
 }
 
 export interface VideoRichSummaryAtom {
@@ -180,6 +195,8 @@ export interface VideoRichSummaryAtom {
   type?: 'fact' | 'tip' | 'argument' | string;
   text: string;
   timestamp_sec?: number;
+  /** CP474 — links back to analysis.entities[].name (KG bridge). */
+  entity_refs?: string[];
 }
 
 export interface VideoRichSummarySegments {
@@ -1423,6 +1440,10 @@ class ApiClient {
         oneLiner: string | null;
         /** CP474 — `analysis.core_argument`, the v2 essence (2-3 sentences). */
         coreArgument: string | null;
+        /** Top `analysis.key_concepts[].term` values (≤ 3). */
+        keyConcepts: string[];
+        /** Fallback keywords from `video_summaries.tags` (≤ 3) when v2 absent. */
+        fallbackTags: string[];
         mandalaRelevancePct: number | null;
         qualityFlag: string | null;
         templateVersion: string;

--- a/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { BookOpen, ChevronRight, ChevronsDownUp, ChevronsUpDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -7,6 +7,9 @@ import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import { useMandalaCards } from '@/pages/learning/model/useMandalaCards';
 import { useLearningStore } from '@/pages/learning/model/useLearningStore';
 import type { MandalaBookChapter } from '@/shared/lib/api-client';
+import type { InsightCard } from '@/entities/card/model/types';
+import { extractYouTubeVideoId } from '@/shared/lib/url-normalize';
+import { useV2Summaries } from '@/features/card-management/model/useV2Summaries';
 import { cn } from '@/shared/lib/utils';
 
 interface SidebarLearningSectionProps {
@@ -21,6 +24,7 @@ export function SidebarLearningSection({
   collapsed,
 }: SidebarLearningSectionProps) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const setActiveSection = useLearningStore((s) => s.setActiveSection);
   const activeSectionRef = useLearningStore((s) => s.activeSectionRef);
   const setActiveRegion = useLearningStore((s) => s.setActiveRegion);
@@ -32,7 +36,10 @@ export function SidebarLearningSection({
   const { mandalaLevels } = useMandalaQuery(mandalaId);
   const rootLevel = mandalaLevels.root;
   const centerGoal = rootLevel?.centerGoal ?? '';
+  // Short cell labels in the tree; long goals move to the hover tooltip.
+  const centerLabel = rootLevel?.centerLabel ?? null;
   const subGoals = rootLevel?.subjects ?? [];
+  const subjectLabels = rootLevel?.subjectLabels ?? [];
 
   const { cards: mandalaCards } = useMandalaCards(mandalaId);
   // CP438+1 — book index PoC; non-null when a book has been generated.
@@ -43,6 +50,34 @@ export function SidebarLearningSection({
       bookChaptersByIdx.set(ch.ch, ch);
     }
   }
+
+  // Group liked cards by cellIndex so each sub-goal lists its own videos.
+  const cardsByCell = useMemo(() => {
+    const map = new Map<number, InsightCard[]>();
+    for (const card of mandalaCards) {
+      if (typeof card.cellIndex !== 'number' || card.cellIndex < 1) continue;
+      const list = map.get(card.cellIndex) ?? [];
+      list.push(card);
+      map.set(card.cellIndex, list);
+    }
+    return map;
+  }, [mandalaCards]);
+
+  // Pull v2 key-concept terms for every liked video so the sub-goal tree
+  // can render keyword-style book-index entries instead of raw titles.
+  const likedVideoIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const card of mandalaCards) {
+      try {
+        const vid = extractYouTubeVideoId(new URL(card.videoUrl));
+        if (vid) ids.push(vid);
+      } catch {
+        /* skip cards whose URL cannot be parsed */
+      }
+    }
+    return ids;
+  }, [mandalaCards]);
+  const { summariesByVideoId } = useV2Summaries(likedVideoIds);
 
   // CP438+1: find which chapter+section contains an atom whose vid matches
   // the currently-playing video. Used to highlight the active section in
@@ -115,7 +150,7 @@ export function SidebarLearningSection({
       <div className="px-2 py-1" onMouseEnter={() => setActiveRegion('sidebar')}>
         <button
           className="w-full flex items-center justify-center px-2 py-2.5 rounded-lg text-sm text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground transition-colors"
-          title={centerGoal || t('sidebar.learning', 'Learning')}
+          title={centerGoal || centerLabel || t('sidebar.learning', 'Learning')}
         >
           <BookOpen className="w-5 h-5" />
         </button>
@@ -123,13 +158,20 @@ export function SidebarLearningSection({
     );
   }
 
+  // Header text prefers the short label; long goal moves to the tooltip.
+  const headerText = centerLabel?.trim() || centerGoal || t('sidebar.learning', 'Learning');
+  const headerTooltip = centerGoal && centerGoal !== headerText ? centerGoal : undefined;
+
   return (
     <div className="pl-5 pr-2 flex flex-col" onMouseEnter={() => setActiveRegion('sidebar')}>
       <div className="px-3 py-2">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
-            <h3 className="text-[13px] font-bold text-sidebar-foreground leading-snug truncate">
-              {centerGoal || t('sidebar.learning', 'Learning')}
+            <h3
+              className="text-[13px] font-bold text-sidebar-foreground leading-snug truncate"
+              title={headerTooltip}
+            >
+              {headerText}
             </h3>
             {/* CP445 D18=B — 영상 모드 = 만다라 mapped 전체 영상 / 노트 모드 =
                 mandala_books 가 인용한 distinct vid 수 (필수 영상). */}
@@ -169,12 +211,16 @@ export function SidebarLearningSection({
         {subGoals.map((goal, idx) => {
           const bookChapter = bookChaptersByIdx.get(idx);
           const isExpanded = isChapterExpanded(idx);
+          // Row text shows the short label; long goal text is the tooltip.
+          const rowLabel = subjectLabels[idx]?.trim() || goal;
+          const rowTooltip = goal && goal !== rowLabel ? goal : undefined;
 
           return (
             <div key={idx} className="mb-0.5">
               <button
                 type="button"
                 onClick={() => toggleChapter(idx)}
+                title={rowTooltip}
                 className="group flex w-full items-center gap-2 px-2 py-1 text-left transition-colors"
               >
                 <ChevronRight
@@ -184,7 +230,7 @@ export function SidebarLearningSection({
                   )}
                 />
                 <span className="flex-1 truncate text-[13px] font-medium tracking-[-0.01em] text-sidebar-foreground/80 transition-colors group-hover:text-sidebar-foreground">
-                  {goal}
+                  {rowLabel}
                 </span>
               </button>
 
@@ -202,6 +248,56 @@ export function SidebarLearningSection({
                   />
                 </div>
               )}
+              {/* Book-index entries: keyword tokens distilled from v2
+                  analysis.key_concepts. Cards without a v2 row are
+                  omitted; they reappear once enrich-rich-summary lands. */}
+              {isExpanded &&
+                (() => {
+                  const cellCards = cardsByCell.get(idx + 1) ?? [];
+                  const indexedEntries = cellCards
+                    .map((card) => {
+                      let vid: string | null = null;
+                      try {
+                        vid = extractYouTubeVideoId(new URL(card.videoUrl));
+                      } catch {
+                        vid = null;
+                      }
+                      if (!vid) return null;
+                      const v2 = summariesByVideoId.get(vid);
+                      const primary = v2?.keyConcepts ?? [];
+                      const fallback = v2?.fallbackTags ?? [];
+                      const keywords = primary.length > 0 ? primary : fallback;
+                      if (keywords.length === 0) return null;
+                      const indexName = keywords.slice(0, 2).join(' · ');
+                      return { cardId: card.id, vid, indexName };
+                    })
+                    .filter(
+                      (e): e is { cardId: string; vid: string; indexName: string } => e !== null
+                    );
+                  if (indexedEntries.length === 0) return null;
+                  return (
+                    <ul className="ml-9 pt-0.5">
+                      {indexedEntries.map((entry) => {
+                        const isActive = entry.vid === currentVideoId;
+                        return (
+                          <li
+                            key={entry.cardId}
+                            onClick={() => navigate(`/learning/${mandalaId}/${entry.vid}`)}
+                            title={entry.indexName}
+                            className={cn(
+                              'cursor-pointer pl-3 py-1.5 leading-[1.5] border-l-2 transition-colors',
+                              isActive
+                                ? 'border-[#818cf8] text-[14px] font-medium text-[#818cf8]'
+                                : 'border-sidebar-foreground/10 text-[13px] text-sidebar-foreground/80 hover:border-sidebar-foreground/50 hover:text-sidebar-foreground'
+                            )}
+                          >
+                            {entry.indexName}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  );
+                })()}
             </div>
           );
         })}

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { InsightCard } from '@/entities/card/model/types';
 import { Card } from '@/shared/ui/card';
 import { cn } from '@/shared/lib/utils';
@@ -162,6 +163,7 @@ export function InsightCardItemV2({
   onArchived,
   sectorLabel,
 }: InsightCardItemV2Props) {
+  const { t } = useTranslation();
   const isSelected = selectedCardIds?.has(card.id) ?? false;
   const isMultiSelect = isSelected && selectedCardIds && selectedCardIds.size > 1;
   const dragData: DragData = isMultiSelect
@@ -231,6 +233,7 @@ export function InsightCardItemV2({
           videoId,
           mandalaId: card.mandalaId ?? undefined,
           title: card.title,
+          cellIndex: typeof card.cellIndex === 'number' ? card.cellIndex : undefined,
         },
         {
           onSuccess: () => {
@@ -317,6 +320,11 @@ export function InsightCardItemV2({
   const streamPhase = enrichStream.phase;
   const streamActive = enrichStream.isActive;
   const showFailedGlow = streamPhase === 'failed' || streamPhase === 'timeout';
+  // Persisted retry state — survives page refresh. mandala_relevance_pct
+  // is only populated when v2 enrichment landed with quality_flag='pass';
+  // a liked card whose pct is null means transcript fetch failed or the
+  // row never reached v2. Show the retry icon until enrichment succeeds.
+  const v2EnrichmentPending = liked && mandalaRelevancePct == null;
 
   return (
     <Card
@@ -599,22 +607,48 @@ export function InsightCardItemV2({
                             "재시도 아이콘이 현재 관련도 비율 위치에")
                   scored   → relevance % (color-tiered)
                   else     → empty */}
-            {!streamActive && !isEnriching && (isEnrichFailed || showFailedGlow) ? (
+            {!streamActive &&
+            !isEnriching &&
+            (isEnrichFailed || showFailedGlow || v2EnrichmentPending) ? (
               <button
                 type="button"
                 onClick={(e) => {
                   e.stopPropagation();
-                  if (showFailedGlow && videoId) {
-                    void enrichStream.open(videoId);
+                  e.preventDefault();
+                  if (showFailedGlow && videoId && card.mandalaId) {
+                    like.mutate(
+                      {
+                        videoId,
+                        mandalaId: card.mandalaId,
+                        title: card.title,
+                        cellIndex: typeof card.cellIndex === 'number' ? card.cellIndex : undefined,
+                      },
+                      {
+                        onSuccess: () => {
+                          void enrichStream.open(videoId);
+                        },
+                      }
+                    );
                   } else {
                     onRetryEnrich?.(card.id, card.videoUrl);
                   }
                 }}
-                className="shrink-0 text-destructive hover:text-destructive/80 transition-colors cursor-pointer"
-                aria-label="Retry enrichment"
+                className="shrink-0 text-white/50 hover:text-white transition-colors cursor-pointer"
+                aria-label="Retry enrichment (transcript missing)"
+                title={t('cards.retryEnrichmentTooltip')}
               >
                 <RotateCw className="w-3.5 h-3.5" aria-hidden="true" />
               </button>
+            ) : !streamActive && !isEnriching && mandalaRelevancePct == null && !liked ? (
+              // Not-liked + no v2 → background cron will analyse; show a
+              // passive "queued" label so the user knows the card is in
+              // the pipeline (no click action required).
+              <span
+                className="shrink-0 text-[10.5px] text-muted-foreground/60 tabular-nums"
+                title={t('cards.statusQueuedTooltip')}
+              >
+                {t('cards.statusQueued')}
+              </span>
             ) : relevanceBadge ? (
               <span
                 className={cn(

--- a/prisma/migrations/rich-summary-v2/007_demote_low_quality_v2.sql
+++ b/prisma/migrations/rich-summary-v2/007_demote_low_quality_v2.sql
@@ -1,0 +1,60 @@
+-- =========================================================================
+-- CP475 (2026-05-19) — demote pre-CP475 low-quality v2 rows
+-- =========================================================================
+--
+-- Why: prompt rule (rich-summary-v2-prompt.ts §field rules) requires
+--   - segments.sections: 3-8 entries with real timestamps
+--   - segments.atoms:    5-15 entries
+-- pre-CP475 scoreCompleteness() ignored segments, so quality_flag='pass'
+-- was stamped on rows that violated those minimums whenever transcript
+-- was missing (sections=1 catch-all with to_sec=0, atoms<5).
+--
+-- After CP475 the handler throws NO_TRANSCRIPT instead of generating
+-- description-only rows. This migration cleans up the historical inventory
+-- so the UI fallback path can render video_summaries.summary_ko instead.
+--
+-- Affected dimensions (any one match → demote):
+--   1. transcript_used = false                                   (CP474 column)
+--   2. jsonb_array_length(segments->'sections') < 3
+--   3. jsonb_array_length(segments->'atoms')    < 5
+--   4. every sections[].to_sec == 0  (description-only catch-all)
+--
+-- Apply (local):
+--   docker exec supabase-db-dev -e PGPASSWORD=... psql -U supabase_admin \
+--     -d postgres -f /path/to/007_demote_low_quality_v2.sql
+--
+-- Apply (prod): run via CI/CD deploy pipeline OR
+--   psql "$DIRECT_URL" -f 007_demote_low_quality_v2.sql
+--
+-- Verify:
+--   SELECT count(*) FILTER (WHERE quality_flag = 'low')  AS demoted,
+--          count(*) FILTER (WHERE quality_flag = 'pass') AS still_pass
+--     FROM public.video_rich_summaries
+--    WHERE template_version = 'v2';
+--
+-- Rollback (only if needed — replace TIMESTAMP with this migration's run):
+--   UPDATE public.video_rich_summaries
+--      SET quality_flag = 'pass'
+--    WHERE quality_flag = 'low'
+--      AND updated_at  = '<MIGRATION_TIMESTAMP>';
+-- =========================================================================
+
+BEGIN;
+
+UPDATE public.video_rich_summaries
+   SET quality_flag = 'low',
+       updated_at   = now()
+ WHERE template_version = 'v2'
+   AND quality_flag    = 'pass'
+   AND (
+        transcript_used = false
+        OR jsonb_array_length(COALESCE(segments->'sections', '[]'::jsonb)) < 3
+        OR jsonb_array_length(COALESCE(segments->'atoms',    '[]'::jsonb)) < 5
+        OR NOT EXISTS (
+             SELECT 1
+               FROM jsonb_array_elements(COALESCE(segments->'sections', '[]'::jsonb)) AS sec
+              WHERE (sec->>'to_sec')::int > 0
+        )
+   );
+
+COMMIT;

--- a/prisma/migrations/user-video-states-guards/001_protect_cell_index_regression.sql
+++ b/prisma/migrations/user-video-states-guards/001_protect_cell_index_regression.sql
@@ -1,0 +1,46 @@
+-- =========================================================================
+-- DB-level guard: prevent cell_index regression from a real cell (>= 0)
+-- back to scratchpad (-1). Any code path that tries to UPDATE a placed
+-- card's cell_index to -1 must fail at the DB boundary so no FE/BE bug
+-- can silently strand a user's bookmarked cards in scratchpad again.
+--
+-- Allowed transitions:
+--   * INSERT with any cell_index (including -1)             — fine.
+--   * UPDATE cell_index from -1 to >= 0                     — fine (place a card).
+--   * UPDATE cell_index from >= 0 to >= 0 (move between cells) — fine.
+--   * UPDATE cell_index from >= 0 to -1                     — BLOCKED.
+--
+-- If a future flow legitimately needs to demote a placed card to
+-- scratchpad, it must go through a dedicated /unpin-cell endpoint that
+-- bypasses this guard intentionally (e.g. `SET LOCAL session.replication_role`).
+--
+-- Apply (local):
+--   docker exec -i supabase-db-dev psql -U postgres -d postgres \
+--     -f prisma/migrations/user-video-states-guards/001_protect_cell_index_regression.sql
+-- =========================================================================
+
+CREATE OR REPLACE FUNCTION public.protect_cell_index_regression()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.cell_index IS NOT NULL
+     AND OLD.cell_index >= 0
+     AND NEW.cell_index = -1
+  THEN
+    RAISE EXCEPTION
+      'cell_index regression blocked: was=% new=% (route through a move endpoint, never via a generic UPSERT)',
+      OLD.cell_index, NEW.cell_index
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_cell_index ON public.user_video_states;
+
+CREATE TRIGGER trg_protect_cell_index
+  BEFORE UPDATE ON public.user_video_states
+  FOR EACH ROW
+  WHEN (OLD.cell_index IS DISTINCT FROM NEW.cell_index)
+  EXECUTE FUNCTION public.protect_cell_index_regression();

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -414,10 +414,15 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             ${pinnedAt}
           )
           ON CONFLICT (user_id, video_id) DO UPDATE
-            SET pinned_at = ${pinnedAt},
+            SET pinned_at  = ${pinnedAt},
                 surfaced_at = ${pinnedAt},
-                mandala_id = EXCLUDED.mandala_id,
-                cell_index = EXCLUDED.cell_index
+                auto_added = false,
+                -- A like is "pin this video". cell_index is intentionally
+                -- absent from the SET clause: moving cells is a different
+                -- intent that must go through /move-cell. mandala_id stays
+                -- so users can re-pin a video into a different mandala
+                -- (Q1 design — one video belongs to one mandala).
+                mandala_id = EXCLUDED.mandala_id
         `);
       } else {
         // No yt row → fall back to UPDATE-only path. Card stays in
@@ -427,7 +432,8 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         videoStatesUpdated = await prisma.$executeRaw`
           UPDATE public.user_video_states uvs
              SET pinned_at = ${pinnedAt},
-                 surfaced_at = ${pinnedAt}
+                 surfaced_at = ${pinnedAt},
+                 auto_added = false
             FROM public.youtube_videos yv
            WHERE uvs.user_id = ${userId}::uuid
              AND uvs.video_id = yv.id
@@ -519,7 +525,10 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         `;
         await prisma.$executeRaw`
           UPDATE public.user_video_states uvs
-             SET pinned_at = NULL
+             SET pinned_at = NULL,
+                 -- Preserve the user-owned mark so the auto-add eviction
+                 -- sweep never reclaims a previously-liked card.
+                 auto_added = false
             FROM public.youtube_videos yv
            WHERE uvs.user_id = ${userId}::uuid
              AND uvs.video_id = yv.id
@@ -721,38 +730,66 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
 
       const prisma = getPrismaClient();
       try {
-        const rows = await prisma.video_rich_summaries.findMany({
-          where: { video_id: { in: ids } },
-          select: {
-            video_id: true,
-            one_liner: true,
-            // CP474 — `analysis.core_argument` (2-3 sentences) is the v2
-            // essence/thesis. FE renders it as the grid-card blockquote
-            // (priority over the 20-char one_liner). Selecting the full
-            // `analysis` jsonb keeps the response shape stable if more
-            // fields surface to the card later.
-            analysis: true,
-            mandala_relevance_pct: true,
-            quality_flag: true,
-            template_version: true,
-          },
-        });
+        const [rows, summaryRows] = await Promise.all([
+          prisma.video_rich_summaries.findMany({
+            where: { video_id: { in: ids } },
+            select: {
+              video_id: true,
+              one_liner: true,
+              analysis: true,
+              mandala_relevance_pct: true,
+              quality_flag: true,
+              template_version: true,
+            },
+          }),
+          // Fallback keyword source for videos that have no v2 row yet —
+          // sidebar book-index can render video_summaries.tags so a card is
+          // not invisible while v2 is still being generated.
+          prisma.video_summaries.findMany({
+            where: { video_id: { in: ids } },
+            select: { video_id: true, tags: true },
+          }),
+        ]);
+        const tagsByVideo = new Map<string, string[]>();
+        for (const s of summaryRows) {
+          tagsByVideo.set(
+            s.video_id,
+            (s.tags ?? []).filter((t) => typeof t === 'string' && t.length > 0)
+          );
+        }
+        const v2RowByVid = new Map(rows.map((r) => [r.video_id, r] as const));
         return reply.code(200).send({
           status: 'ok',
           data: {
-            items: rows.map((r) => {
-              const analysis = (r.analysis ?? null) as { core_argument?: unknown } | null;
+            // Iterate over the full id list so videos without a v2 row still
+            // receive a fallbackTags payload — sidebar can render those.
+            items: ids.map((vid) => {
+              const r = v2RowByVid.get(vid);
+              const analysis = (r?.analysis ?? null) as {
+                core_argument?: unknown;
+                key_concepts?: unknown;
+              } | null;
               const coreArgument =
                 analysis && typeof analysis.core_argument === 'string'
                   ? analysis.core_argument
                   : null;
+              const keyConcepts: string[] =
+                analysis && Array.isArray(analysis.key_concepts)
+                  ? (analysis.key_concepts as Array<{ term?: unknown }>)
+                      .map((kc) => (kc && typeof kc.term === 'string' ? kc.term.trim() : ''))
+                      .filter((t): t is string => t.length > 0)
+                      .slice(0, 3)
+                  : [];
+              const fallbackTags = (tagsByVideo.get(vid) ?? []).slice(0, 3);
               return {
-                videoId: r.video_id,
-                oneLiner: r.one_liner,
+                videoId: vid,
+                oneLiner: r?.one_liner ?? null,
                 coreArgument,
-                mandalaRelevancePct: r.mandala_relevance_pct,
-                qualityFlag: r.quality_flag,
-                templateVersion: r.template_version,
+                keyConcepts,
+                fallbackTags,
+                mandalaRelevancePct: r?.mandala_relevance_pct ?? null,
+                qualityFlag: r?.quality_flag ?? null,
+                templateVersion: r?.template_version ?? '',
               };
             }),
           },

--- a/src/api/routes/internal/v2-summary-partial-patch.ts
+++ b/src/api/routes/internal/v2-summary-partial-patch.ts
@@ -1,0 +1,145 @@
+/**
+ * POST /api/v1/internal/v2-summary/partial-patch
+ *
+ * Partial backfill endpoint for pre-CP474 v2 rows that are missing the
+ * `analysis.entities[]` typed-vocabulary field or the per-section
+ * `segments.sections[].relevance_pct` field. Other fields are NEVER
+ * touched — caller specifies only what changes.
+ *
+ * Auth: x-internal-token header (shared INTERNAL_BATCH_TOKEN secret).
+ *
+ * Body:
+ *   {
+ *     videoId: string,
+ *     entities?: Array<{ name: string, type: 'concept'|'person'|'tool'|'framework'|'organization' }>,
+ *     sectionRelevances?: Record<string, number>   // key = section idx as string, value = 0..100
+ *   }
+ *
+ * Returns 200 { status: 'ok', data: { applied: { entities: bool, sections: bool } } }
+ */
+
+import type { FastifyPluginAsync } from 'fastify';
+import { getPrismaClient } from '@/modules/database/client';
+import { getInternalBatchToken } from '@/config/internal-auth';
+import { logger } from '@/utils/logger';
+
+const VALID_ENTITY_TYPES = new Set(['concept', 'person', 'tool', 'framework', 'organization']);
+
+interface PartialPatchBody {
+  videoId?: string;
+  entities?: Array<{ name?: unknown; type?: unknown }>;
+  sectionRelevances?: Record<string, unknown>;
+}
+
+export const v2SummaryPartialPatchRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post<{ Body: PartialPatchBody }>('/v2-summary/partial-patch', async (request, reply) => {
+    const expected = getInternalBatchToken();
+    if (!expected) {
+      return reply.code(503).send({ error: 'internal trigger not configured' });
+    }
+    const got = request.headers['x-internal-token'];
+    if (typeof got !== 'string' || got !== expected) {
+      return reply.code(401).send({ error: 'invalid internal token' });
+    }
+
+    const videoId = String(request.body?.videoId ?? '').trim();
+    if (!videoId || videoId.length > 20) {
+      return reply.code(400).send({ error: 'videoId required' });
+    }
+
+    const entitiesIn = Array.isArray(request.body?.entities) ? request.body.entities : null;
+    const sectionRelIn =
+      request.body?.sectionRelevances && typeof request.body.sectionRelevances === 'object'
+        ? request.body.sectionRelevances
+        : null;
+
+    if (!entitiesIn && !sectionRelIn) {
+      return reply.code(400).send({ error: 'entities or sectionRelevances required' });
+    }
+
+    // Validate + sanitise inputs.
+    const cleanEntities = entitiesIn
+      ? entitiesIn
+          .map((e) => {
+            const name = typeof e?.name === 'string' ? e.name.trim() : '';
+            const type = typeof e?.type === 'string' ? e.type.trim() : '';
+            if (!name || !VALID_ENTITY_TYPES.has(type)) return null;
+            return { name, type };
+          })
+          .filter((e): e is { name: string; type: string } => e !== null)
+      : null;
+
+    const cleanSectionRel: Record<number, number> | null = sectionRelIn
+      ? Object.entries(sectionRelIn).reduce<Record<number, number>>((acc, [k, v]) => {
+          const idx = Number(k);
+          const pct = typeof v === 'number' ? Math.round(v) : NaN;
+          if (Number.isInteger(idx) && idx >= 0 && Number.isFinite(pct) && pct >= 0 && pct <= 100) {
+            acc[idx] = pct;
+          }
+          return acc;
+        }, {})
+      : null;
+
+    const prisma = getPrismaClient();
+    const row = await prisma.video_rich_summaries.findUnique({
+      where: { video_id: videoId },
+      select: { video_id: true, analysis: true, segments: true },
+    });
+    if (!row) {
+      return reply.code(404).send({ error: 'v2 row not found' });
+    }
+
+    let appliedEntities = false;
+    let appliedSections = false;
+
+    // Patch analysis.entities (only if provided + non-empty).
+    if (cleanEntities && cleanEntities.length > 0) {
+      const analysis = (row.analysis ?? {}) as Record<string, unknown>;
+      analysis['entities'] = cleanEntities;
+      await prisma.video_rich_summaries.update({
+        where: { video_id: videoId },
+        data: {
+          analysis: analysis as object,
+          updated_at: new Date(),
+        },
+      });
+      appliedEntities = true;
+    }
+
+    // Patch segments.sections[idx].relevance_pct (only on indices present in map).
+    if (cleanSectionRel && Object.keys(cleanSectionRel).length > 0) {
+      const segments = (row.segments ?? null) as {
+        sections?: Array<Record<string, unknown>>;
+      } | null;
+      const sections = Array.isArray(segments?.sections) ? segments.sections : null;
+      if (sections && sections.length > 0) {
+        const next = sections.map((sec, idx) => {
+          const pct = cleanSectionRel[idx];
+          if (pct == null) return sec;
+          return { ...sec, relevance_pct: pct };
+        });
+        await prisma.video_rich_summaries.update({
+          where: { video_id: videoId },
+          data: {
+            segments: { ...(segments ?? {}), sections: next } as object,
+            updated_at: new Date(),
+          },
+        });
+        appliedSections = true;
+      }
+    }
+
+    logger.info('v2 partial-patch applied', {
+      videoId,
+      appliedEntities,
+      appliedSections,
+      entityCount: cleanEntities?.length ?? 0,
+      sectionCount: cleanSectionRel ? Object.keys(cleanSectionRel).length : 0,
+    });
+
+    return reply.code(200).send({
+      status: 'ok',
+      data: { applied: { entities: appliedEntities, sections: appliedSections } },
+    });
+  });
+};

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -34,6 +34,7 @@ import { internalBatchVideoCollectorRoutes } from './routes/internal/batch-video
 import { internalTrendCollectorRoutes } from './routes/internal/trend-collector';
 import { internalTranscriptRoutes } from './routes/internal/transcript';
 import { internalVideosBulkUpsertRoutes } from './routes/internal/videos-bulk-upsert';
+import { v2SummaryPartialPatchRoutes } from './routes/internal/v2-summary-partial-patch';
 import { internalVideoPoolPromoteRoutes } from './routes/internal/video-pool-promote';
 import { internalGoogleCseRoutes } from './routes/internal/google-cse';
 import { internalPlaylistImportRoutes } from './routes/internal/playlist-import';
@@ -326,6 +327,10 @@ export async function buildServer() {
       });
       // CP438 — Mac Mini new-collector bulk video metadata upsert.
       await instance.register(internalVideosBulkUpsertRoutes, {
+        prefix: '/internal',
+      });
+      // Partial backfill — entities[] + sections[].relevance_pct.
+      await instance.register(v2SummaryPartialPatchRoutes, {
         prefix: '/internal',
       });
       // CP438 — promote v2 layered summaries into video_pool (batched,

--- a/src/modules/caption/extractor.ts
+++ b/src/modules/caption/extractor.ts
@@ -40,8 +40,12 @@ export class CaptionExtractor {
     youtubeId: string,
     language?: string
   ): Promise<CaptionExtractionResult> {
-    // Language priority: explicit → en → ko → any available
-    const LANG_PRIORITY = language ? [language] : ['en', 'ko'];
+    // Korean-first default — auto captions follow the video's spoken
+    // language, and the prod pool skews Korean.
+    const BASE_LANGS = ['ko', 'en'];
+    const LANG_PRIORITY = language
+      ? [language, ...BASE_LANGS.filter((l) => l !== language)]
+      : BASE_LANGS;
 
     try {
       let segments: CaptionSegment[] = [];
@@ -50,20 +54,33 @@ export class CaptionExtractor {
       for (const lang of LANG_PRIORITY) {
         logger.info('Extracting captions', { videoId: youtubeId, language: lang });
 
-        try {
-          const transcript = await (await loadFetchTranscript())(youtubeId, { lang });
-          if (transcript && transcript.length > 0) {
-            segments = transcript.map((item) => ({
-              text: item.text,
-              start: item.offset / 1000,
-              duration: item.duration / 1000,
-            }));
-            resolvedLang = lang;
-            break;
+        // Single retry absorbs Innertube's transient drops without
+        // hammering on "captions not available" terminal errors.
+        let lastErr: unknown = null;
+        for (let attempt = 0; attempt < 2; attempt++) {
+          try {
+            const transcript = await (await loadFetchTranscript())(youtubeId, { lang });
+            if (transcript && transcript.length > 0) {
+              segments = transcript.map((item) => ({
+                text: item.text,
+                start: item.offset / 1000,
+                duration: item.duration / 1000,
+              }));
+              resolvedLang = lang;
+              lastErr = null;
+              break;
+            }
+          } catch (err) {
+            lastErr = err;
+            if (attempt === 0) {
+              await new Promise((r) => setTimeout(r, 300));
+            }
           }
-        } catch (err) {
-          const errMsg = err instanceof Error ? err.message : String(err);
-          logger.warn('youtube-transcript failed', { youtubeId, lang, error: errMsg });
+        }
+        if (segments.length > 0) break;
+        if (lastErr) {
+          const errMsg = lastErr instanceof Error ? lastErr.message : String(lastErr);
+          logger.warn('youtube-transcript failed after retry', { youtubeId, lang, error: errMsg });
         }
       }
 

--- a/src/modules/queue/handlers/enrich-rich-summary.ts
+++ b/src/modules/queue/handlers/enrich-rich-summary.ts
@@ -38,6 +38,7 @@ import { enrichRichSummary } from '../../skills/rich-summary';
 import { generateRichSummaryV2 } from '../../skills/rich-summary-v2-generator';
 import { getMandalaManager } from '../../mandala/manager';
 import { getCaptionExtractor } from '../../caption/extractor';
+import { getPrismaClient } from '../../database/client';
 import { logger } from '../../../utils/logger';
 import { getJobQueue } from '../manager';
 import {
@@ -46,6 +47,10 @@ import {
   RICH_SUMMARY_RETRY_OPTIONS,
   type EnrichRichSummaryPayload,
 } from '../types';
+
+/** Thrown when captions are unavailable so the worker fails fast and the
+ *  grid surfaces a retry affordance instead of a description-only row. */
+export const NO_TRANSCRIPT_ERROR = 'NO_TRANSCRIPT';
 
 /**
  * Register the enrich-rich-summary worker with pg-boss. Must be called
@@ -82,11 +87,35 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
     mandalaId,
   });
 
-  // Step 0 — fetch transcript (in-memory only, never persisted). Best
-  // effort: failure → undefined → generators fall back to description.
+  // Pick a language hint so caption-extractor probes the spoken language
+  // before falling through to its ko/en defaults.
+  let langHint: string | undefined;
+  try {
+    const prisma = getPrismaClient();
+    const [rsRow, ytRow] = await Promise.all([
+      prisma.video_rich_summaries.findUnique({
+        where: { video_id: videoId },
+        select: { source_language: true },
+      }),
+      prisma.youtube_videos.findUnique({
+        where: { youtube_video_id: videoId },
+        select: { default_language: true },
+      }),
+    ]);
+    langHint = rsRow?.source_language ?? ytRow?.default_language ?? undefined;
+  } catch (err) {
+    logger.warn('enrich-rich-summary: lang-hint lookup failed (continuing without)', {
+      jobId: job.id,
+      videoId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Hard rule: NO v2 row without a transcript. Captions absent ⇒ throw
+  // NO_TRANSCRIPT ⇒ SSE `failed` ⇒ grid renders the retry icon.
   let transcript: string | undefined;
   try {
-    const result = await getCaptionExtractor().extractCaptions(videoId);
+    const result = await getCaptionExtractor().extractCaptions(videoId, langHint);
     if (result.success && result.caption?.fullText) {
       transcript = result.caption.fullText;
       logger.info('enrich-rich-summary: transcript fetched', {
@@ -94,30 +123,45 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
         videoId,
         chars: transcript.length,
         language: result.language,
+        langHint: langHint ?? null,
       });
     } else {
-      logger.info('enrich-rich-summary: transcript unavailable (description fallback)', {
+      logger.info('enrich-rich-summary: transcript unavailable — surfacing retry', {
         jobId: job.id,
         videoId,
         reason: result.error ?? 'unknown',
+        langHint: langHint ?? null,
       });
     }
   } catch (err) {
-    logger.warn('enrich-rich-summary: transcript fetch threw (description fallback)', {
+    logger.warn('enrich-rich-summary: transcript fetch threw — surfacing retry', {
       jobId: job.id,
       videoId,
       error: err instanceof Error ? err.message : String(err),
     });
   }
 
-  // Step 1 — v1 generate. forceRegen when transcript just arrived so a
-  // description-only cache row is overwritten by transcript-derived content.
+  if (transcript === undefined) {
+    // Stamp the attempt timestamp so the scheduler 7-day cooldown holds.
+    try {
+      await getPrismaClient().youtube_videos.update({
+        where: { youtube_video_id: videoId },
+        data: { transcript_attempted_at: new Date() },
+      });
+    } catch {
+      /* non-fatal — stamping failure does not change retry semantics */
+    }
+    throw new Error(NO_TRANSCRIPT_ERROR);
+  }
+
+  // v1 generate — transcript guaranteed; forceRegen overrides any prior
+  // description-only cache row.
   const v1Result = await enrichRichSummary(videoId, {
     userId,
     title,
     description,
     transcript,
-    forceRegen: transcript !== undefined,
+    forceRegen: true,
   });
 
   // Step 2 — resolve the mandala center goal (root level, depth=0). When
@@ -137,20 +181,20 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
     });
   }
 
-  // Step 3 — v2 upgrade. forceRegen when a transcript arrived so a prior
-  // description-only v2 row is replaced with transcript-grounded content.
+  // v2 upgrade — transcript guaranteed; forceRegen replaces any prior
+  // description-only v2 row with transcript-grounded content.
   const v2Outcome = await generateRichSummaryV2({
     videoId,
     userId,
     mandalaCenterGoal: centerGoal,
     transcript,
-    forceRegen: transcript !== undefined,
+    forceRegen: true,
   });
 
   logger.info('enrich-rich-summary: completed', {
     jobId: job.id,
     videoId,
-    hadTranscript: transcript !== undefined,
+    hadTranscript: true,
     v1QualityFlag: v1Result.qualityFlag,
     v1QualityScore: v1Result.qualityScore,
     v2OutcomeKind: v2Outcome.kind,

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -99,8 +99,8 @@ export async function generateRichSummaryV2(
   if (!row) {
     return { kind: 'skip', videoId: input.videoId, reason: 'no_rich_summary_row' };
   }
-  // CP474 — description-only v2 rows fall through so a later Heart click
-  // with a successful captioner can regenerate them. forceRegen overrides.
+  // description-only rows fall through so the next Heart click with a
+  // working captioner can regenerate. forceRegen overrides.
   if (
     !input.forceRegen &&
     row.template_version === 'v2' &&

--- a/src/modules/skills/rich-summary-v2-prompt.ts
+++ b/src/modules/skills/rich-summary-v2-prompt.ts
@@ -145,6 +145,10 @@ export const PASS_THRESHOLD = 0.7;
 export const MIN_KEY_CONCEPTS = 3;
 export const MIN_ACTIONABLES = 3;
 export const MIN_QA_PAIRS_L1 = 5;
+// Segments hard gate — rejects description-only fallback (1 catch-all
+// section, to_sec=0, <5 atoms). Mirrors the prompt's own minimums.
+export const MIN_SECTIONS = 3;
+export const MIN_ATOMS = 5;
 
 const VALID_CONTENT_TYPES: ReadonlySet<ContentType> = new Set([
   'tutorial',
@@ -694,11 +698,28 @@ export function scoreCompleteness(s: RichSummaryV2Layered): CompletenessResult {
   if (l1Count >= MIN_QA_PAIRS_L1) score += 0.1;
   else reasons.push(`lora.qa_pairs L1 insufficient: ${l1Count} (expected ${MIN_QA_PAIRS_L1}+)`);
 
+  // Segments hard gate — description-only fallback fails outright even
+  // when the 10 core/analysis/lora weights satisfy the 0.7 threshold.
+  const sectionCount = s.segments?.sections?.length ?? 0;
+  const atomCount = s.segments?.atoms?.length ?? 0;
+  const sectionHasRealRange = (s.segments?.sections ?? []).some((sec) => sec.to_sec > 0);
+  const segmentsValid =
+    sectionCount >= MIN_SECTIONS && atomCount >= MIN_ATOMS && sectionHasRealRange;
+  if (sectionCount < MIN_SECTIONS) {
+    reasons.push(`segments.sections insufficient: ${sectionCount} (expected ${MIN_SECTIONS}+)`);
+  }
+  if (atomCount < MIN_ATOMS) {
+    reasons.push(`segments.atoms insufficient: ${atomCount} (expected ${MIN_ATOMS}+)`);
+  }
+  if (!sectionHasRealRange) {
+    reasons.push('segments.sections all have to_sec=0 (description-only fallback)');
+  }
+
   // round to 2 decimals
   score = Math.round(score * 100) / 100;
   return {
     score,
-    passed: score >= PASS_THRESHOLD,
+    passed: score >= PASS_THRESHOLD && segmentsValid,
     reasons,
   };
 }

--- a/tests/smoke/like-preserves-cell.test.ts
+++ b/tests/smoke/like-preserves-cell.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Invariant: a Heart click must NEVER destroy a card's cell_index.
+ * Source-level regression catch — the prod incident was a single SQL
+ * line (`SET cell_index = EXCLUDED.cell_index`) silently demoting placed
+ * cards to scratchpad (-1) when the FE omitted cellIndex. This test
+ * fails if that line reappears, and the DB-level trigger migration
+ * stays in place as the runtime safety net.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('user_video_states cell_index protection', () => {
+  const repoRoot = join(__dirname, '../..');
+  const cardsRouteSource = readFileSync(join(repoRoot, 'src/api/routes/cards.ts'), 'utf-8');
+
+  test('like ON CONFLICT must not unconditionally overwrite cell_index', () => {
+    const likeBlock = cardsRouteSource.match(
+      /INSERT INTO public\.user_video_states[\s\S]*?ON CONFLICT[\s\S]*?DO UPDATE[\s\S]*?\`/
+    );
+    expect(likeBlock).not.toBeNull();
+    const onConflictBody = likeBlock![0];
+    // The destructive pattern that caused the prod incident.
+    expect(onConflictBody).not.toMatch(/cell_index\s*=\s*EXCLUDED\.cell_index\s*[,\n)]/);
+  });
+
+  test('DB trigger migration exists and raises on regression', () => {
+    const triggerSql = readFileSync(
+      join(
+        repoRoot,
+        'prisma/migrations/user-video-states-guards/001_protect_cell_index_regression.sql'
+      ),
+      'utf-8'
+    );
+    expect(triggerSql).toMatch(/CREATE OR REPLACE FUNCTION[\s\S]*protect_cell_index_regression/);
+    expect(triggerSql).toMatch(/RAISE EXCEPTION/);
+    expect(triggerSql).toMatch(/BEFORE UPDATE ON public\.user_video_states/);
+  });
+
+  test('FE useLikeCard.like accepts cellIndex in its args contract', () => {
+    const hookSource = readFileSync(
+      join(repoRoot, 'frontend/src/features/card-management/model/useLikeCard.ts'),
+      'utf-8'
+    );
+    expect(hookSource).toMatch(/cellIndex\?:\s*number/);
+  });
+
+  test('FE InsightCardItemV2 forwards card.cellIndex on Heart click', () => {
+    const cardSource = readFileSync(
+      join(repoRoot, 'frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx'),
+      'utf-8'
+    );
+    // handleHeartClick should pass cellIndex (typed-number guard).
+    expect(cardSource).toMatch(/cellIndex:\s*typeof card\.cellIndex === 'number'/);
+  });
+});

--- a/tests/unit/skills/rich-summary-v2.test.ts
+++ b/tests/unit/skills/rich-summary-v2.test.ts
@@ -63,6 +63,42 @@ function validSummary(overrides: Partial<RichSummaryV2Layered> = {}): RichSummar
         { level: 1, q: 'Q5', a: 'A5', context: 'video' },
       ],
     },
+    // Segments are required for scoreCompleteness to pass.
+    segments: {
+      sections: [
+        {
+          idx: 0,
+          from_sec: 0,
+          to_sec: 60,
+          title: '도입',
+          summary: '시간관리 도입',
+          relevance_pct: 70,
+        },
+        {
+          idx: 1,
+          from_sec: 60,
+          to_sec: 180,
+          title: '계획',
+          summary: '계획 단계',
+          relevance_pct: 80,
+        },
+        {
+          idx: 2,
+          from_sec: 180,
+          to_sec: 300,
+          title: '실행',
+          summary: '실행 단계',
+          relevance_pct: 75,
+        },
+      ],
+      atoms: [
+        { idx: 0, type: 'fact', text: 'a0', timestamp_sec: 30 },
+        { idx: 1, type: 'tip', text: 'a1', timestamp_sec: 90 },
+        { idx: 2, type: 'fact', text: 'a2', timestamp_sec: 150 },
+        { idx: 3, type: 'argument', text: 'a3', timestamp_sec: 210 },
+        { idx: 4, type: 'tip', text: 'a4', timestamp_sec: 270 },
+      ],
+    },
     ...overrides,
   };
 }
@@ -167,6 +203,65 @@ describe('scoreCompleteness', () => {
     const r = scoreCompleteness(s);
     expect(r.score).toBeLessThan(1);
     expect(r.reasons.some((x) => x.includes('L1'))).toBe(true);
+  });
+
+  // Segments hard gate — description-only fallback must fail.
+  test('hard gate: rejects when sections.length < 3', () => {
+    const s = validSummary();
+    s.segments = {
+      sections: [{ idx: 0, from_sec: 0, to_sec: 60, title: 's', summary: 'x', relevance_pct: 50 }],
+      atoms: s.segments!.atoms,
+    };
+    const r = scoreCompleteness(s);
+    expect(r.passed).toBe(false);
+    expect(r.reasons.some((x) => x.includes('segments.sections insufficient'))).toBe(true);
+  });
+
+  test('hard gate: rejects when atoms.length < 5', () => {
+    const s = validSummary();
+    s.segments = {
+      sections: s.segments!.sections,
+      atoms: [{ idx: 0, type: 'fact', text: 'only one', timestamp_sec: 30 }],
+    };
+    const r = scoreCompleteness(s);
+    expect(r.passed).toBe(false);
+    expect(r.reasons.some((x) => x.includes('segments.atoms insufficient'))).toBe(true);
+  });
+
+  test('hard gate: rejects description-only catch-all (all to_sec=0)', () => {
+    const s = validSummary();
+    s.segments = {
+      sections: [
+        { idx: 0, from_sec: 0, to_sec: 0, title: 'catch-all', summary: 'whole', relevance_pct: 50 },
+        {
+          idx: 1,
+          from_sec: 0,
+          to_sec: 0,
+          title: 'catch-all-2',
+          summary: 'whole',
+          relevance_pct: 50,
+        },
+        {
+          idx: 2,
+          from_sec: 0,
+          to_sec: 0,
+          title: 'catch-all-3',
+          summary: 'whole',
+          relevance_pct: 50,
+        },
+      ],
+      atoms: s.segments!.atoms,
+    };
+    const r = scoreCompleteness(s);
+    expect(r.passed).toBe(false);
+    expect(r.reasons.some((x) => x.includes('to_sec=0'))).toBe(true);
+  });
+
+  test('hard gate: rejects entirely missing segments object', () => {
+    const s = validSummary();
+    delete (s as { segments?: unknown }).segments;
+    const r = scoreCompleteness(s);
+    expect(r.passed).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Multi-layer fix for the bookmark-data-loss incident plus a new **Key Moments** feature that auto-plays the high-relevance segments of a video.

## Data safety — `cards.ts /like` ON CONFLICT regression

The prod incident root cause: `INSERT ... ON CONFLICT (user_id, video_id) DO UPDATE SET cell_index = EXCLUDED.cell_index` unconditionally overwrote a placed card's cell_index when the FE omitted `cellIndex` (BE fell back to `-1`). `useMandalaCards`' `cellIndex >= 0` filter then dropped the row from the grid.

Five layers of defense ship in this PR:

1. **FE useLikeCard contract** accepts `cellIndex?: number`
2. **FE InsightCardItemV2** forwards `card.cellIndex` on Heart click
3. **BE `cards.ts` ON CONFLICT** no longer touches `cell_index` (intent narrowed to pin)
4. **DB trigger** (`user-video-states-guards/001`) raises on `cell_index 0+ → -1` UPDATE
5. **Smoke test** (`tests/smoke/like-preserves-cell.test.ts`) pins the SQL pattern + DB trigger contract

`auto_added=false` is also stamped on both `/like` and `/unlike` so the auto-add eviction sweep cannot reclaim a liked-then-unliked card.

## Transcript & v2 quality gates

- `enrich-rich-summary` throws `NO_TRANSCRIPT` instead of producing description-only v2 rows
- `caption-extractor` uses `source_language` hint + 1-retry per language
- `scoreCompleteness` hard gate: `segments.sections >= 3`, `segments.atoms >= 5`, at least one `to_sec > 0`
- Migration `007_demote_low_quality_v2.sql` demotes pre-CP475 low-quality v2 rows to `quality_flag='low'`

## UI

- **PanelAISummary** — relevance % per section, clickable section row → `seekTo(from_sec)`, entities tag chips, layout reordered so summary + sections lead the panel
- **Grid card** — `queued` / retry icon split on liked vs unliked + missing v2
- **Sidebar** — short label headers w/ goal tooltips, keyword-only book-index rows
- **Key Moments chip** in the learning-page summary tab: plays only `relevance_pct >= 80` segments end-to-end; user scrub exits the mode
- **RightPanel** — default tab = chatbot (was: notes)

## Endpoints

`POST /api/v1/internal/v2-summary/partial-patch` — entities + section relevance_pct partial update (production-runtime safe, `x-internal-token` auth).

## i18n

ko + en for `highlightReel`, `statusQueued`, retry tooltip, `tags`.

## Test plan

- [x] BE tsc PASS
- [x] FE tsc PASS
- [x] `tests/smoke/like-preserves-cell.test.ts` — 4/4 PASS
- [x] `tests/unit/skills/rich-summary-v2.test.ts` — 25/25 PASS
- [x] Manual browser verification on dev: 3 video URLs with full v2 data (FM0Ndi-brW0, TPRWbaCksJA, gs2Ff1Il2hU)
- [x] DB trigger smoke: \`UPDATE user_video_states SET cell_index=-1\` raises \`cell_index regression blocked\`

## Follow-up (separate PRs)

- Partial backfill cron over the existing v2 row inventory (entities + section relevance_pct)
- Tier 3 cron (Mac Mini v2-author batch) for video_pool pre-generation
- oneLiner prompt length relaxation (current ≤ 20 chars is too tight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)