### PR TITLE
fix(v2): key_concepts language matches title (sidebar mixed ko/en)

### DIFF
--- a/src/api/routes/internal/v2-summary-partial-patch.ts
+++ b/src/api/routes/internal/v2-summary-partial-patch.ts
@@ -29,6 +29,7 @@ interface PartialPatchBody {
   videoId?: string;
   entities?: Array<{ name?: unknown; type?: unknown }>;
   sectionRelevances?: Record<string, unknown>;
+  keyConcepts?: Array<{ term?: unknown; definition?: unknown }>;
 }
 
 export const v2SummaryPartialPatchRoutes: FastifyPluginAsync = async (fastify) => {
@@ -52,9 +53,14 @@ export const v2SummaryPartialPatchRoutes: FastifyPluginAsync = async (fastify) =
       request.body?.sectionRelevances && typeof request.body.sectionRelevances === 'object'
         ? request.body.sectionRelevances
         : null;
+    const keyConceptsIn = Array.isArray(request.body?.keyConcepts)
+      ? request.body.keyConcepts
+      : null;
 
-    if (!entitiesIn && !sectionRelIn) {
-      return reply.code(400).send({ error: 'entities or sectionRelevances required' });
+    if (!entitiesIn && !sectionRelIn && !keyConceptsIn) {
+      return reply
+        .code(400)
+        .send({ error: 'entities, sectionRelevances, or keyConcepts required' });
     }
 
     // Validate + sanitise inputs.
@@ -80,6 +86,21 @@ export const v2SummaryPartialPatchRoutes: FastifyPluginAsync = async (fastify) =
         }, {})
       : null;
 
+    // 3-5 entries, each {term: string, definition: string}. Replaces the
+    // existing key_concepts array verbatim (no merge — caller passes the
+    // full set in the target language).
+    const cleanKeyConcepts = keyConceptsIn
+      ? keyConceptsIn
+          .map((kc) => {
+            const term = typeof kc?.term === 'string' ? kc.term.trim() : '';
+            const definition = typeof kc?.definition === 'string' ? kc.definition.trim() : '';
+            if (!term) return null;
+            return { term, definition };
+          })
+          .filter((kc): kc is { term: string; definition: string } => kc !== null)
+          .slice(0, 8)
+      : null;
+
     const prisma = getPrismaClient();
     const row = await prisma.video_rich_summaries.findUnique({
       where: { video_id: videoId },
@@ -91,11 +112,23 @@ export const v2SummaryPartialPatchRoutes: FastifyPluginAsync = async (fastify) =
 
     let appliedEntities = false;
     let appliedSections = false;
+    let appliedKeyConcepts = false;
 
-    // Patch analysis.entities (only if provided + non-empty).
-    if (cleanEntities && cleanEntities.length > 0) {
+    // Patch analysis.entities and/or analysis.key_concepts in a single
+    // analysis-column write (avoids two sequential updates that would race).
+    if (
+      (cleanEntities && cleanEntities.length > 0) ||
+      (cleanKeyConcepts && cleanKeyConcepts.length > 0)
+    ) {
       const analysis = (row.analysis ?? {}) as Record<string, unknown>;
-      analysis['entities'] = cleanEntities;
+      if (cleanEntities && cleanEntities.length > 0) {
+        analysis['entities'] = cleanEntities;
+        appliedEntities = true;
+      }
+      if (cleanKeyConcepts && cleanKeyConcepts.length > 0) {
+        analysis['key_concepts'] = cleanKeyConcepts;
+        appliedKeyConcepts = true;
+      }
       await prisma.video_rich_summaries.update({
         where: { video_id: videoId },
         data: {
@@ -103,7 +136,6 @@ export const v2SummaryPartialPatchRoutes: FastifyPluginAsync = async (fastify) =
           updated_at: new Date(),
         },
       });
-      appliedEntities = true;
     }
 
     // Patch segments.sections[idx].relevance_pct (only on indices present in map).
@@ -133,13 +165,21 @@ export const v2SummaryPartialPatchRoutes: FastifyPluginAsync = async (fastify) =
       videoId,
       appliedEntities,
       appliedSections,
+      appliedKeyConcepts,
       entityCount: cleanEntities?.length ?? 0,
       sectionCount: cleanSectionRel ? Object.keys(cleanSectionRel).length : 0,
+      keyConceptCount: cleanKeyConcepts?.length ?? 0,
     });
 
     return reply.code(200).send({
       status: 'ok',
-      data: { applied: { entities: appliedEntities, sections: appliedSections } },
+      data: {
+        applied: {
+          entities: appliedEntities,
+          sections: appliedSections,
+          keyConcepts: appliedKeyConcepts,
+        },
+      },
     });
   });
 };

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -28,6 +28,22 @@ import {
   type RichSummaryV2Layered,
 } from './rich-summary-v2-prompt';
 
+const HANGUL_RANGE = /[가-힯]/g;
+const LATIN_RANGE = /[A-Za-z]/g;
+
+function detectLanguageFromTitle(title: string): 'ko' | 'en' | null {
+  if (!title) return null;
+  const stripped = title.replace(/\s+/g, '');
+  if (stripped.length === 0) return null;
+  const hangulCount = (stripped.match(HANGUL_RANGE) ?? []).length;
+  const latinCount = (stripped.match(LATIN_RANGE) ?? []).length;
+  const hangulRatio = hangulCount / stripped.length;
+  const latinRatio = latinCount / stripped.length;
+  if (hangulRatio >= 0.2) return 'ko';
+  if (latinRatio >= 0.5 && hangulRatio < 0.05) return 'en';
+  return null;
+}
+
 const log = logger.child({ module: 'RichSummaryV2Generator' });
 
 const MAX_RETRIES = 1; // 1 retry → spec §7-D
@@ -118,7 +134,13 @@ export async function generateRichSummaryV2(
     return { kind: 'skip', videoId: input.videoId, reason: 'no_youtube_metadata' };
   }
 
-  const language: 'ko' | 'en' = row.source_language === 'en' ? 'en' : 'ko';
+  // Title-based language override — `source_language` is stamped from the
+  // transcript track YouTube returned, which is sometimes the wrong track
+  // (e.g. auto-translated EN captions for a Korean video). Trust the title:
+  // if hangul ratio is high enough, force 'ko'; if it's clearly Latin-only,
+  // force 'en'. Only fall back to source_language for ambiguous cases.
+  const language: 'ko' | 'en' =
+    detectLanguageFromTitle(ytRow.title) ?? (row.source_language === 'en' ? 'en' : 'ko');
   const prompt = buildV2Prompt({
     title: ytRow.title,
     description: ytRow.description ?? '',


### PR DESCRIPTION
## Summary

- Sidebar book-index entries appeared in English for Korean videos (and vice versa) because the v2 LLM honored `source_language`, which gets stamped from the YouTube caption track and is sometimes the wrong language.
- Prompt now starts from a **title-language detector** (hangul ratio ≥ 0.20 → ko; latin ratio ≥ 0.50 with hangul < 0.05 → en); only ambiguous titles fall back to `source_language`.
- `/internal/v2-summary/partial-patch` now also accepts a `keyConcepts` field — batched re-translation of the existing 165 mismatched rows runs via `scripts/v2-keyconcepts-lang-fix.sh` (gitignored, Mac Mini tmux).

## Scope

| Affected rows (prod) | Count |
|---|---|
| Korean title + EN key_concepts | 157 |
| English title + KO key_concepts | 8 |
| **Total mismatch** | **165 / 1322** |

## Test plan

- [x] `tsc --noEmit` PASS (backend)
- [x] `jest tests/smoke` PASS (155/155)
- [ ] Deploy → endpoint live → Mac Mini batch on 5 dry-run rows
- [ ] Mac Mini batch full run (165 rows, ~10 min)
- [ ] Sidebar visual verification (Korean videos → Korean concept entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)