### PR TITLE
fix(cards): drop '분석 대기' placeholder label

### DIFF
--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -639,16 +639,6 @@ export function InsightCardItemV2({
               >
                 <RotateCw className="w-3.5 h-3.5" aria-hidden="true" />
               </button>
-            ) : !streamActive && !isEnriching && mandalaRelevancePct == null && !liked ? (
-              // Not-liked + no v2 → background cron will analyse; show a
-              // passive "queued" label so the user knows the card is in
-              // the pipeline (no click action required).
-              <span
-                className="shrink-0 text-[10.5px] text-muted-foreground/60 tabular-nums"
-                title={t('cards.statusQueuedTooltip')}
-              >
-                {t('cards.statusQueued')}
-              </span>
             ) : relevanceBadge ? (
               <span
                 className={cn(


### PR DESCRIPTION
## Summary

User: "카드에 '분석 대기' 는 제외하는게 좋겠음."

The not-liked + no-v2 branch used to render a passive `statusQueued` chip ("분석 대기" / "Analysis queued") on the right side of the card footer. Removed — empty slot is quieter for cards the user hasn't Heart'd yet. i18n keys retained for future revival.

## Root cause investigation (separate concern)

User also reported "북마크 시도해도 v2 요약이 안됨 → 재시도해도 처리 실패". Investigated and confirmed root cause: **YouTube creator has disabled captions** on those videos (e.g. `m8UhE33u40c`, `yfzbB9McZLE`, `c-a4GBOxhXQ`, `1oeWfAouwd4`). The retry icon promises a retry that can never succeed for these videos.

Out of scope for this PR. Follow-up: differentiate "permanently failed (captions disabled)" from "transient failure" in the FE — show a non-retryable indicator instead of the spinning retry icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)