### PR TITLE
fix(caption): route via Mac Mini Tailscale proxy — EC2 IP blocked

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -239,11 +239,18 @@ jobs:
           # rows that were created with snippet-only data and never
           # received the full videos.list metadata enrichment.
           YOUTUBE_METADATA_BACKFILL_ENABLED: ${{ vars.YOUTUBE_METADATA_BACKFILL_ENABLED }}
+          # Mac Mini transcript proxy. EC2 outbound to YouTube is blocked
+          # for caption fetch; the Mac Mini (KR ISP IP, Tailscale 4242)
+          # successfully fetches and forwards via x-transcript-token auth.
+          # When unset, caption-extractor falls back to direct
+          # youtube-transcript on EC2 (known to fail) — set both to enable.
+          MAC_MINI_TRANSCRIPT_URL: ${{ secrets.MAC_MINI_TRANSCRIPT_URL }}
+          MAC_MINI_TRANSCRIPT_TOKEN: ${{ secrets.MAC_MINI_TRANSCRIPT_TOKEN }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED
+          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
           script: |
             set -e
             cd /opt/tubearchive
@@ -292,6 +299,16 @@ jobs:
             fi
             if [ -n "${DB_DIRECT}" ]; then
               grep -q '^DIRECT_URL=' .env 2>/dev/null && sed -i "s|^DIRECT_URL=.*|DIRECT_URL=${DB_DIRECT}|" .env || echo "DIRECT_URL=${DB_DIRECT}" >> .env
+            fi
+            # CP475+ — Mac Mini transcript proxy (Tailscale). When unset,
+            # caption-extractor falls back to direct youtube-transcript on
+            # EC2 (known to fail with false "disabled" errors due to
+            # YouTube IP blocking us-west-2 outbound). Idempotent set.
+            if [ -n "${MAC_MINI_TRANSCRIPT_URL}" ]; then
+              grep -q '^MAC_MINI_TRANSCRIPT_URL=' .env 2>/dev/null && sed -i "s|^MAC_MINI_TRANSCRIPT_URL=.*|MAC_MINI_TRANSCRIPT_URL=${MAC_MINI_TRANSCRIPT_URL}|" .env || echo "MAC_MINI_TRANSCRIPT_URL=${MAC_MINI_TRANSCRIPT_URL}" >> .env
+            fi
+            if [ -n "${MAC_MINI_TRANSCRIPT_TOKEN}" ]; then
+              grep -q '^MAC_MINI_TRANSCRIPT_TOKEN=' .env 2>/dev/null && sed -i "s|^MAC_MINI_TRANSCRIPT_TOKEN=.*|MAC_MINI_TRANSCRIPT_TOKEN=${MAC_MINI_TRANSCRIPT_TOKEN}|" .env || echo "MAC_MINI_TRANSCRIPT_TOKEN=${MAC_MINI_TRANSCRIPT_TOKEN}" >> .env
             fi
             # CP360 — primary YouTube API key for video-discover search.list.
             # Mirrors the OPENROUTER pattern: idempotent add-or-update.

--- a/src/modules/caption/extractor.ts
+++ b/src/modules/caption/extractor.ts
@@ -19,6 +19,78 @@ async function loadFetchTranscript() {
   return mod.fetchTranscript;
 }
 import { logger } from '../../utils/logger';
+
+// Mac Mini transcript proxy. EC2 us-west-2 outbound to YouTube is rate-
+// limited / returns false "Transcript is disabled" — verified by apples-
+// to-apples test (same library, same call, same video; KR ISP IP succeeds
+// from Mac Mini, AWS us-west-2 returns the disabled error). When
+// MAC_MINI_TRANSCRIPT_URL is set, we forward the fetch to Mac Mini over
+// Tailscale; the EC2 caption-extractor falls back to direct youtube-
+// transcript only if the proxy is unreachable (defence in depth).
+const MAC_MINI_URL = process.env['MAC_MINI_TRANSCRIPT_URL'] ?? '';
+const MAC_MINI_TOKEN = process.env['MAC_MINI_TRANSCRIPT_TOKEN'] ?? '';
+const MAC_MINI_TIMEOUT_MS = 30_000;
+
+interface MacMiniSegment {
+  text: string;
+  offset: number;
+  duration: number;
+}
+interface MacMiniResponse {
+  success: boolean;
+  videoId?: string;
+  language?: string;
+  segments?: MacMiniSegment[];
+  error?: string;
+}
+
+async function fetchViaMacMini(youtubeId: string, lang: string): Promise<MacMiniSegment[] | null> {
+  if (!MAC_MINI_URL || !MAC_MINI_TOKEN) return null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), MAC_MINI_TIMEOUT_MS);
+  try {
+    const resp = await fetch(
+      `${MAC_MINI_URL.replace(/\/$/, '')}/transcript/${encodeURIComponent(youtubeId)}?lang=${encodeURIComponent(lang)}`,
+      {
+        method: 'GET',
+        headers: { 'x-transcript-token': MAC_MINI_TOKEN },
+        signal: controller.signal,
+      }
+    );
+    if (resp.status === 404) {
+      // service reachable, captions absent in this language — bubble up
+      // as "no captions" so the outer loop can try the next language
+      return [];
+    }
+    if (!resp.ok) {
+      logger.warn('Mac Mini transcript proxy non-200', {
+        youtubeId,
+        lang,
+        status: resp.status,
+      });
+      return null;
+    }
+    const data = (await resp.json()) as MacMiniResponse;
+    if (!data.success || !Array.isArray(data.segments)) {
+      logger.warn('Mac Mini transcript proxy returned no segments', {
+        youtubeId,
+        lang,
+        error: data.error,
+      });
+      return null;
+    }
+    return data.segments;
+  } catch (err) {
+    logger.warn('Mac Mini transcript proxy fetch failed (falling back)', {
+      youtubeId,
+      lang,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
 import type {
   CaptionSegment,
   CaptionMetadata,
@@ -54,8 +126,25 @@ export class CaptionExtractor {
       for (const lang of LANG_PRIORITY) {
         logger.info('Extracting captions', { videoId: youtubeId, language: lang });
 
-        // Single retry absorbs Innertube's transient drops without
-        // hammering on "captions not available" terminal errors.
+        // Path 1 — Mac Mini Tailscale proxy (preferred). EC2 outbound IP
+        // is blocked by YouTube for caption fetch; Mac Mini uses a KR ISP
+        // residential IP that successfully fetches. When the env vars are
+        // configured and the proxy returns a usable result, skip path 2.
+        const macMini = await fetchViaMacMini(youtubeId, lang);
+        if (macMini && macMini.length > 0) {
+          segments = macMini.map((item) => ({
+            text: item.text,
+            start: item.offset / 1000,
+            duration: item.duration / 1000,
+          }));
+          resolvedLang = lang;
+          break;
+        }
+
+        // Path 2 — youtube-transcript direct (fallback). Used when Mac
+        // Mini proxy env is unset OR proxy is unreachable. Known to fail
+        // on EC2 outbound but retained as defence in depth (e.g. for
+        // local dev or if the IP block is later lifted).
         let lastErr: unknown = null;
         for (let attempt = 0; attempt < 2; attempt++) {
           try {


### PR DESCRIPTION
## Summary

User: "v2 안 만들어짐, 재시도해도 fail (거짓말 금지, 사실 기반 작업)"

## Root cause (verified)

Apples-to-apples test — same library, same call, same video, same options. Only diff = source IP.

| Env | Library | Result |
|---|---|---|
| Laptop (KR ISP IP) | youtube-transcript@1.3.0 (deep ESM) | ✅ 296 segments |
| Laptop (KR ISP IP) | youtube-transcript@1.3.1 (shallow) | ✅ 296 segments |
| **EC2 (AWS us-west-2)** | youtube-transcript@1.3.0 (deep) — **prod path** | ❌ "Transcript is disabled" (false) |

`yt-dlp --list-subs` for the same video confirms `ko + ko-orig + en + 190+` tracks are AVAILABLE. The library is unmaintained (issues #44 #49 #51 unfixed in 2025-2026) and coerces all fetch failures into the false "disabled" string. YouTube blocks/rate-limits AWS us-west-2 outbound for caption fetch.

## Fix

`caption/extractor.ts` now tries **Mac Mini Tailscale proxy** first (`http://100.91.173.17:4242/transcript/:videoId`), falls back to direct youtube-transcript only if proxy unset/unreachable. Mac Mini service `mac-mini-transcript-service.mjs` runs in tmux session `transcript-svc` on home-ISP IP that successfully fetches.

`deploy.yml` syncs `MAC_MINI_TRANSCRIPT_URL` + `MAC_MINI_TRANSCRIPT_TOKEN` from GitHub Secrets to `.env`. Both registered.

## Test plan

- [x] tsc PASS
- [x] Mac Mini service listening on 0.0.0.0:4242 (tmux `transcript-svc`)
- [x] Laptop → Mac Mini Tailscale → 296 segments
- [x] EC2 → Mac Mini Tailscale → 296 segments (Korean)
- [ ] Post-deploy: bookmark a previously failing video → v2 generates → relevance + book-index entries land

🤖 Generated with [Claude Code](https://claude.com/claude-code)