### PR TITLE
fix(add-cards-panel): backdrop blur

### DIFF
--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -284,7 +284,7 @@ export function AddCardsPanel() {
     <>
       <div
         className={cn(
-          'fixed inset-0 z-30 bg-black/20 transition-opacity duration-200 ease-in-out',
+          'fixed inset-0 z-30 bg-black/30 backdrop-blur-md transition-[opacity,backdrop-filter] duration-200 ease-in-out',
           isClosing ? 'opacity-0' : 'opacity-100'
         )}
         onClick={handleClose}


### PR DESCRIPTION
## Summary

User: "카드추가 슬라이드 매뉴 활성화 되면 나머지 사이드바/대시보드는 블러 처리해서 카드검색에 집중할수 있도록 개선 가능해?"

Existing scrim was `bg-black/20` only — dashboard stayed crisp under it. Added `backdrop-blur-md` (12px) so the sidebar + grid recede; bumped the dim to `bg-black/30` for stronger separation. Transition extended to animate opacity AND backdrop-filter together.

## Test plan

- [x] tsc PASS
- [ ] Open Add Cards panel — verify backdrop blur + dim