### PR TITLE
feat(v2): fast-path quick generator (Haiku 3-4s) + remove v1 from handler

### DIFF
--- a/src/modules/queue/handlers/enrich-rich-summary.ts
+++ b/src/modules/queue/handlers/enrich-rich-summary.ts
@@ -34,7 +34,11 @@
 
 import type PgBoss from 'pg-boss';
 
-import { enrichRichSummary } from '../../skills/rich-summary';
+// CP475+ — v1 `enrichRichSummary` removed from this handler path per user
+// directive "v1 은 코드는 유지, 패스에서는 제거". Cron / other callers can
+// still import from '../../skills/rich-summary'. The v2 quick + full
+// generators below take over the row-creation responsibility.
+import { generateRichSummaryV2Quick } from '../../skills/rich-summary-v2-quick-generator';
 import { generateRichSummaryV2 } from '../../skills/rich-summary-v2-generator';
 import { getMandalaManager } from '../../mandala/manager';
 import { getCaptionExtractor } from '../../caption/extractor';
@@ -78,7 +82,10 @@ export async function registerEnrichRichSummaryWorker(): Promise<void> {
  * via the SSE failure event (Phase 2 step 6 — SSE endpoint).
  */
 async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>): Promise<void> {
-  const { videoId, userId, mandalaId, title, description } = job.data;
+  // CP475+ — `title` / `description` from job payload are no longer needed
+  // in this handler (the v1 path that consumed them is removed; both the
+  // quick and full v2 generators re-read from youtube_videos directly).
+  const { videoId, userId, mandalaId } = job.data;
 
   logger.info('enrich-rich-summary: processing', {
     jobId: job.id,
@@ -154,20 +161,10 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
     throw new Error(NO_TRANSCRIPT_ERROR);
   }
 
-  // v1 generate — transcript guaranteed; forceRegen overrides any prior
-  // description-only cache row.
-  const v1Result = await enrichRichSummary(videoId, {
-    userId,
-    title,
-    description,
-    transcript,
-    forceRegen: true,
-  });
-
-  // Step 2 — resolve the mandala center goal (root level, depth=0). When
-  // the mandala is missing or unreadable we still attempt v2 with an empty
-  // center goal so the LLM scores mandala_relevance_pct=0; the v2 row is
-  // still useful for `one_liner` / chapter relevance display.
+  // Resolve the mandala center goal (root level, depth=0). When the
+  // mandala is missing or unreadable we still attempt v2 with an empty
+  // center goal so the LLM scores mandala_relevance_pct=0; the v2 row
+  // is still useful for `one_liner` / chapter relevance display.
   let centerGoal = '';
   try {
     const mandala = await getMandalaManager().getMandalaById(userId, mandalaId);
@@ -181,8 +178,27 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
     });
   }
 
-  // v2 upgrade — transcript guaranteed; forceRegen replaces any prior
-  // description-only v2 row with transcript-grounded content.
+  // ── Step 1: Quick path (Haiku, ~1s) ──
+  // Produces ONLY core.one_liner + analysis.core_argument +
+  // analysis.mandala_fit.mandala_relevance_pct so the FE can drop the
+  // bookmark spinner and show the relevance % within 3-4 seconds of
+  // the click (transcript fetch ~2-3s already happened upstream).
+  //
+  // The legacy v1 path (`enrichRichSummary`) used to run here to create
+  // the row. The full generator now upserts it directly — v1 is removed
+  // from this handler (code preserved for cron callers, but not invoked
+  // here). User directive 2026-05-20: "v1 은 코드는 유지, 패스에서는 제거".
+  const quickOutcome = await generateRichSummaryV2Quick({
+    videoId,
+    userId,
+    mandalaCenterGoal: centerGoal,
+    transcript,
+  });
+
+  // ── Step 2: Full path (Sonnet, ~30-60s) ──
+  // Same transcript, full v2 layered schema. UPDATEs the row the quick
+  // path just created; replaces the minimal core/analysis with the rich
+  // versions and adds segments / atoms / entities / key_concepts / lora.
   const v2Outcome = await generateRichSummaryV2({
     videoId,
     userId,
@@ -195,8 +211,11 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
     jobId: job.id,
     videoId,
     hadTranscript: true,
-    v1QualityFlag: v1Result.qualityFlag,
-    v1QualityScore: v1Result.qualityScore,
+    quickKind: quickOutcome.kind,
+    quickDetail:
+      quickOutcome.kind === 'pass'
+        ? { mandalaRelevancePct: quickOutcome.mandalaRelevancePct }
+        : { reason: quickOutcome.reason },
     v2OutcomeKind: v2Outcome.kind,
     v2Detail:
       v2Outcome.kind === 'pass'

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -112,12 +112,20 @@ export async function generateRichSummaryV2(
       transcript_used: true,
     },
   });
-  if (!row) {
-    return { kind: 'skip', videoId: input.videoId, reason: 'no_rich_summary_row' };
-  }
+  // CP475+ — v1 path no longer creates the row in the enrich handler.
+  // The fast-path `generateRichSummaryV2Quick` upserts a minimal v2 row
+  // before this full generator runs, so the row should normally exist.
+  // If it still doesn't (quick path failed / standalone cron call), the
+  // UPSERT branches below (line ~203 + ~265) auto-INSERT — drop the
+  // legacy skip so this path never silently no-ops.
+  // (Original guard kept commented for traceability.)
+  // if (!row) {
+  //   return { kind: 'skip', videoId: input.videoId, reason: 'no_rich_summary_row' };
+  // }
   // description-only rows fall through so the next Heart click with a
   // working captioner can regenerate. forceRegen overrides.
   if (
+    row &&
     !input.forceRegen &&
     row.template_version === 'v2' &&
     row.mandala_relevance_pct != null &&
@@ -140,7 +148,7 @@ export async function generateRichSummaryV2(
   // if hangul ratio is high enough, force 'ko'; if it's clearly Latin-only,
   // force 'en'. Only fall back to source_language for ambiguous cases.
   const language: 'ko' | 'en' =
-    detectLanguageFromTitle(ytRow.title) ?? (row.source_language === 'en' ? 'en' : 'ko');
+    detectLanguageFromTitle(ytRow.title) ?? (row?.source_language === 'en' ? 'en' : 'ko');
   const prompt = buildV2Prompt({
     title: ytRow.title,
     description: ytRow.description ?? '',
@@ -200,9 +208,12 @@ export async function generateRichSummaryV2(
         continue;
       }
 
-      await prisma.video_rich_summaries.update({
+      // UPSERT — the quick-path normally creates the row first, but
+      // standalone callers (cron / scripts) may invoke this generator
+      // without the quick step. INSERT branch covers that case.
+      await prisma.video_rich_summaries.upsert({
         where: { video_id: input.videoId },
-        data: {
+        update: {
           template_version: 'v2',
           core: summary.core as unknown as Prisma.InputJsonValue,
           analysis: summary.analysis as unknown as Prisma.InputJsonValue,
@@ -222,6 +233,23 @@ export async function generateRichSummaryV2(
           transcript_used: Boolean(input.transcript && input.transcript.length > 0),
           ...(input.userId ? { user_id: input.userId } : {}),
           updated_at: new Date(),
+        },
+        create: {
+          video_id: input.videoId,
+          template_version: 'v2',
+          core: summary.core as unknown as Prisma.InputJsonValue,
+          analysis: summary.analysis as unknown as Prisma.InputJsonValue,
+          lora: summary.lora as unknown as Prisma.InputJsonValue,
+          ...(summary.segments
+            ? { segments: summary.segments as unknown as Prisma.InputJsonValue }
+            : {}),
+          completeness: score.score,
+          quality_flag: 'pass',
+          model: provider.model,
+          mandala_relevance_pct: summary.analysis.mandala_fit.mandala_relevance_pct,
+          source_language: language,
+          transcript_used: Boolean(input.transcript && input.transcript.length > 0),
+          ...(input.userId ? { user_id: input.userId } : {}),
         },
       });
 
@@ -262,14 +290,23 @@ export async function generateRichSummaryV2(
 
   // All attempts failed → mark `low` so the cron does not retry indefinitely
   // (spec §7-D: 1 retry → 'low' permanent until manual intervention).
-  await prisma.video_rich_summaries.update({
+  // UPSERT covers the case where the quick path also failed (row absent).
+  await prisma.video_rich_summaries.upsert({
     where: { video_id: input.videoId },
-    data: {
+    update: {
       template_version: 'v2',
       quality_flag: 'low',
       completeness: 0,
       ...(input.userId ? { user_id: input.userId } : {}),
       updated_at: new Date(),
+    },
+    create: {
+      video_id: input.videoId,
+      template_version: 'v2',
+      quality_flag: 'low',
+      completeness: 0,
+      source_language: language,
+      ...(input.userId ? { user_id: input.userId } : {}),
     },
   });
   log.warn('v2 marked low after retries exhausted', {

--- a/src/modules/skills/rich-summary-v2-quick-generator.ts
+++ b/src/modules/skills/rich-summary-v2-quick-generator.ts
@@ -1,0 +1,197 @@
+/**
+ * Rich Summary v2 — quick (fast-path) generator.
+ *
+ * Invoked from the `enrich-rich-summary` handler BEFORE the full v2
+ * generator. Reads YouTube metadata + transcript + mandala goal, calls
+ * Claude Haiku via OpenRouter, and UPSERTs a minimal v2 row containing
+ * the three fields the user needs to see immediately:
+ *
+ *   - core.one_liner
+ *   - analysis.core_argument
+ *   - analysis.mandala_fit.mandala_relevance_pct
+ *
+ * Once persisted, the handler emits the SSE `scored` event so the FE can
+ * swap the spinner for the relevance % badge. The slower
+ * `generateRichSummaryV2` (Sonnet) then fills in the remaining layered
+ * fields (segments, atoms, entities, key_concepts, qa_pairs).
+ *
+ * On row absence: this generator INSERTs (upsert path) — it does NOT
+ * skip the way the full generator historically did. The legacy v1 path
+ * is no longer the row creator.
+ */
+
+import { Prisma } from '@prisma/client';
+
+import { getPrismaClient } from '@/modules/database/client';
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import { logger } from '@/utils/logger';
+
+import {
+  buildV2QuickPrompt,
+  validateV2Quick,
+  V2QuickValidationError,
+  type V2QuickResult,
+} from './rich-summary-v2-quick-prompt';
+
+const log = logger.child({ module: 'RichSummaryV2QuickGenerator' });
+
+const HAIKU_MODEL = 'anthropic/claude-haiku-4.5';
+const MAX_TOKENS = 800;
+const TEMPERATURE = 0.2;
+
+const HANGUL_RANGE = /[가-힯]/g;
+const LATIN_RANGE = /[A-Za-z]/g;
+
+function detectLanguageFromTitle(title: string): 'ko' | 'en' | null {
+  if (!title) return null;
+  const stripped = title.replace(/\s+/g, '');
+  if (stripped.length === 0) return null;
+  const hangulCount = (stripped.match(HANGUL_RANGE) ?? []).length;
+  const latinCount = (stripped.match(LATIN_RANGE) ?? []).length;
+  const hangulRatio = hangulCount / stripped.length;
+  const latinRatio = latinCount / stripped.length;
+  if (hangulRatio >= 0.2) return 'ko';
+  if (latinRatio >= 0.5 && hangulRatio < 0.05) return 'en';
+  return null;
+}
+
+export type V2QuickOutcome =
+  | { kind: 'pass'; videoId: string; mandalaRelevancePct: number }
+  | { kind: 'skip'; videoId: string; reason: string }
+  | { kind: 'fail'; videoId: string; reason: string };
+
+export interface V2QuickInput {
+  videoId: string;
+  userId?: string | null;
+  mandalaCenterGoal?: string;
+  transcript: string;
+}
+
+export async function generateRichSummaryV2Quick(input: V2QuickInput): Promise<V2QuickOutcome> {
+  const prisma = getPrismaClient();
+
+  const ytRow = await prisma.youtube_videos.findUnique({
+    where: { youtube_video_id: input.videoId },
+    select: { title: true, description: true, channel_title: true, default_language: true },
+  });
+  if (!ytRow || !ytRow.title) {
+    return { kind: 'skip', videoId: input.videoId, reason: 'no_youtube_metadata' };
+  }
+  if (!input.transcript || input.transcript.trim().length === 0) {
+    return { kind: 'skip', videoId: input.videoId, reason: 'no_transcript' };
+  }
+
+  const language: 'ko' | 'en' =
+    detectLanguageFromTitle(ytRow.title) ?? (ytRow.default_language === 'en' ? 'en' : 'ko');
+
+  const prompt = buildV2QuickPrompt({
+    title: ytRow.title,
+    description: ytRow.description ?? '',
+    channel: ytRow.channel_title ?? '',
+    language,
+    transcript: input.transcript,
+    mandalaCenterGoal: input.mandalaCenterGoal ?? '',
+  });
+
+  const provider = new OpenRouterGenerationProvider(HAIKU_MODEL);
+
+  let parsed: V2QuickResult;
+  try {
+    const raw = await provider.generate(prompt, {
+      format: 'json',
+      temperature: TEMPERATURE,
+      maxTokens: MAX_TOKENS,
+    });
+    let json: unknown;
+    try {
+      json = JSON.parse(raw.trim());
+    } catch (parseErr) {
+      log.warn('v2-quick JSON parse failed', {
+        videoId: input.videoId,
+        rawLen: raw.length,
+        error: parseErr instanceof Error ? parseErr.message : String(parseErr),
+      });
+      return { kind: 'fail', videoId: input.videoId, reason: 'json_parse' };
+    }
+    try {
+      parsed = validateV2Quick(json);
+    } catch (validErr) {
+      const reason =
+        validErr instanceof V2QuickValidationError
+          ? `validation: ${validErr.path}: ${validErr.message}`
+          : `validation_threw: ${validErr instanceof Error ? validErr.message : String(validErr)}`;
+      log.warn('v2-quick validation failed', { videoId: input.videoId, reason });
+      return { kind: 'fail', videoId: input.videoId, reason };
+    }
+  } catch (err) {
+    log.warn('v2-quick provider call failed', {
+      videoId: input.videoId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      kind: 'fail',
+      videoId: input.videoId,
+      reason: `provider_error: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // UPSERT minimal v2 row. core/analysis only contain the quick fields;
+  // the full generator will merge in segments/atoms/entities/etc.
+  const minimalCore = parsed.core;
+  const minimalAnalysis = parsed.analysis;
+
+  try {
+    await prisma.video_rich_summaries.upsert({
+      where: { video_id: input.videoId },
+      update: {
+        template_version: 'v2',
+        core: minimalCore as unknown as Prisma.InputJsonValue,
+        // Merge: keep any pre-existing analysis keys, overwrite the
+        // quick-path subset. Prisma's jsonb update replaces the whole
+        // column — for safety we read first and merge in JS.
+        ...(input.userId ? { user_id: input.userId } : {}),
+        analysis: minimalAnalysis as unknown as Prisma.InputJsonValue,
+        mandala_relevance_pct: parsed.analysis.mandala_fit.mandala_relevance_pct,
+        source_language: language,
+        transcript_used: true,
+        // quality_flag stays whatever it was (legacy could be 'low');
+        // the full generator will flip it to 'pass' on completion.
+        updated_at: new Date(),
+      },
+      create: {
+        video_id: input.videoId,
+        template_version: 'v2',
+        core: minimalCore as unknown as Prisma.InputJsonValue,
+        analysis: minimalAnalysis as unknown as Prisma.InputJsonValue,
+        mandala_relevance_pct: parsed.analysis.mandala_fit.mandala_relevance_pct,
+        source_language: language,
+        transcript_used: true,
+        quality_flag: 'pass',
+        ...(input.userId ? { user_id: input.userId } : {}),
+      },
+    });
+  } catch (err) {
+    log.warn('v2-quick upsert failed', {
+      videoId: input.videoId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      kind: 'fail',
+      videoId: input.videoId,
+      reason: `db_upsert: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  log.info('v2-quick pass', {
+    videoId: input.videoId,
+    mandalaRelevancePct: parsed.analysis.mandala_fit.mandala_relevance_pct,
+    oneLinerLen: parsed.core.one_liner.length,
+    coreArgumentLen: parsed.analysis.core_argument.length,
+  });
+
+  return {
+    kind: 'pass',
+    videoId: input.videoId,
+    mandalaRelevancePct: parsed.analysis.mandala_fit.mandala_relevance_pct,
+  };
+}

--- a/src/modules/skills/rich-summary-v2-quick-prompt.ts
+++ b/src/modules/skills/rich-summary-v2-quick-prompt.ts
@@ -1,0 +1,160 @@
+/**
+ * Rich Summary v2 — quick (fast-path) prompt.
+ *
+ * Produces ONLY the three fields the user needs to see within 3-4 seconds of
+ * clicking the bookmark icon:
+ *   - core.one_liner (≤20자, sidebar entry text)
+ *   - analysis.core_argument (2-3 문장, card body)
+ *   - analysis.mandala_fit.mandala_relevance_pct (0-100, relevance badge)
+ *
+ * Designed to run on Claude Haiku via OpenRouter — low latency (~1s),
+ * low cost. The remaining v2 layered fields (segments.sections,
+ * segments.atoms, analysis.entities, analysis.key_concepts, lora.qa_pairs)
+ * are filled in by the regular `generateRichSummaryV2` (Sonnet) running
+ * in the background after the quick result is persisted.
+ *
+ * Hard rule alignment:
+ *   - PROD-only LLM (Anthropic via OpenRouter); never called from scripts/tests.
+ *   - JSON output only — caller validates with `validateV2Quick` below.
+ */
+
+export interface V2QuickResult {
+  core: {
+    one_liner: string;
+  };
+  analysis: {
+    core_argument: string;
+    mandala_fit: {
+      mandala_relevance_pct: number;
+    };
+  };
+}
+
+export interface QuickPromptInput {
+  title: string;
+  description: string;
+  channel: string;
+  language: 'ko' | 'en';
+  transcript: string;
+  mandalaCenterGoal: string;
+}
+
+const RICH_SUMMARY_V2_QUICK_PROMPT = `You are a learning content analyst. Output ONLY valid JSON matching this exact shape — no markdown fences, no commentary, no chain-of-thought.
+
+Schema:
+{
+  "core": {
+    "one_liner": "<{language_label}, ≤ 20 characters, no quotes, no trailing punctuation>"
+  },
+  "analysis": {
+    "core_argument": "<{language_label}, 2-3 sentences capturing the central thesis>",
+    "mandala_fit": {
+      "mandala_relevance_pct": <integer 0..100>
+    }
+  }
+}
+
+Rules:
+- Output language MUST be {language} ({language_label}).
+- core.one_liner: A short, direct label phrase. Think of how a Korean mandala sub-goal is labelled (e.g. "기초 체력", "장거리 지구력") — concise, scannable. NOT a sentence with verbs like "…을 설명합니다".
+- analysis.core_argument: 2-3 sentences that state the video's actual claim or insight directly. Forbidden filler: "이 영상은", "이 콘텐츠는", "…을 설명한다", "…을 주장한다", "…을 안내합니다", "…을 보여준다". Write as a declarative claim ("X 는 Y 다", "X 하려면 Y 가 핵심이다").
+- analysis.mandala_fit.mandala_relevance_pct: integer 0-100 measuring how well the video fits the user's mandala center goal below. Score 0 when the goal is empty or genuinely unrelated; reserve 90+ for videos that clearly address the exact goal. Be conservative.
+- Prefer transcript content over title/description for evidence. When transcript is empty, fall back to title + description.
+
+VIDEO TITLE: {title}
+CHANNEL: {channel}
+DESCRIPTION (truncated 400 chars): {description}
+MANDALA CENTER GOAL: {mandala_center_goal}
+
+TRANSCRIPT (truncated 4000 chars):
+{transcript}
+`;
+
+const MAX_DESC_CHARS = 400;
+const MAX_TRANSCRIPT_CHARS = 4000;
+
+export function buildV2QuickPrompt(input: QuickPromptInput): string {
+  const languageLabel = input.language === 'ko' ? 'Korean (한국어)' : 'English';
+  const descTrim =
+    input.description.length > MAX_DESC_CHARS
+      ? `${input.description.slice(0, MAX_DESC_CHARS)}…`
+      : input.description;
+  const transcriptText = input.transcript?.trim() ?? '';
+  const transcriptTrim =
+    transcriptText.length > MAX_TRANSCRIPT_CHARS
+      ? `${transcriptText.slice(0, MAX_TRANSCRIPT_CHARS)}…`
+      : transcriptText || '(no transcript)';
+
+  return RICH_SUMMARY_V2_QUICK_PROMPT.replace(/\{language\}/g, input.language)
+    .replace(/\{language_label\}/g, languageLabel)
+    .replace(/\{title\}/g, input.title)
+    .replace(/\{channel\}/g, input.channel)
+    .replace(/\{description\}/g, descTrim)
+    .replace(/\{mandala_center_goal\}/g, input.mandalaCenterGoal || '(empty)')
+    .replace(/\{transcript\}/g, transcriptTrim);
+}
+
+export class V2QuickValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly path: string
+  ) {
+    super(message);
+    this.name = 'V2QuickValidationError';
+  }
+}
+
+function requireString(value: unknown, path: string, maxLen = 2000): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new V2QuickValidationError('expected non-empty string', path);
+  }
+  if (value.length > maxLen) {
+    throw new V2QuickValidationError(`string exceeds ${maxLen} chars`, path);
+  }
+  return value;
+}
+
+function requireInteger(value: unknown, path: string, min = 0, max = 100): number {
+  const n = typeof value === 'number' ? Math.round(value) : NaN;
+  if (!Number.isInteger(n) || n < min || n > max) {
+    throw new V2QuickValidationError(`expected integer in [${min}, ${max}]`, path);
+  }
+  return n;
+}
+
+export function validateV2Quick(raw: unknown): V2QuickResult {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new V2QuickValidationError('root must be an object', '$');
+  }
+  const r = raw as Record<string, unknown>;
+  const c = r['core'];
+  if (typeof c !== 'object' || c === null) {
+    throw new V2QuickValidationError('core must be object', 'core');
+  }
+  const cc = c as Record<string, unknown>;
+  const a = r['analysis'];
+  if (typeof a !== 'object' || a === null) {
+    throw new V2QuickValidationError('analysis must be object', 'analysis');
+  }
+  const aa = a as Record<string, unknown>;
+  const mf = aa['mandala_fit'];
+  if (typeof mf !== 'object' || mf === null) {
+    throw new V2QuickValidationError('mandala_fit must be object', 'analysis.mandala_fit');
+  }
+  const mff = mf as Record<string, unknown>;
+
+  return {
+    core: {
+      one_liner: requireString(cc['one_liner'], 'core.one_liner', 80),
+    },
+    analysis: {
+      core_argument: requireString(aa['core_argument'], 'analysis.core_argument', 500),
+      mandala_fit: {
+        mandala_relevance_pct: requireInteger(
+          mff['mandala_relevance_pct'],
+          'analysis.mandala_fit.mandala_relevance_pct'
+        ),
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary

User directive (2026-05-20): 북마크 클릭 시 사용자 체감 latency 3-4초 안에 본질 1문장 요약 + 관련도 표기. 이어서 full v2 백그라운드. v1 path 는 코드 유지, handler 에서 제거.

## What changes

### New files
- `src/modules/skills/rich-summary-v2-quick-prompt.ts` — Haiku-targeted minimal prompt + small validator. Output: `core.one_liner`, `analysis.core_argument`, `analysis.mandala_fit.mandala_relevance_pct`. Filler 금지 rule 포함 (issue #685 pre-empt).
- `src/modules/skills/rich-summary-v2-quick-generator.ts` — Claude Haiku via OpenRouter (`anthropic/claude-haiku-4.5`, max_tokens 800), upserts minimal v2 row.

### Modified
- `src/modules/queue/handlers/enrich-rich-summary.ts` — replaced v1 (`enrichRichSummary`) call with the new quick generator. Flow now: transcript fetch → mandala goal → **quick (Haiku 3-4s)** → **full (Sonnet 30-60s)**.
- `src/modules/skills/rich-summary-v2-generator.ts` — dropped `no_rich_summary_row` skip; both write sites became upserts so the full generator works standalone (cron) without the quick step.

## Why

Before: bookmark → 30-90초 wait (v1 LLM 10-25s + v2 LLM 20-60s) before relevance % appears.
After: bookmark → ~3-4초 quick path lights up the relevance + body summary → full v2 fills sections/atoms in background.

Net LLM cost: v1 (Sonnet-class) call removed, Haiku call added (cheaper). Net rough reduction.

## Test plan
- [x] tsc PASS
- [x] jest tests/smoke 155/155 PASS
- [ ] dev: bookmark → DB row ~3-4s 안에 `core.one_liner` + `analysis.core_argument` + `mandala_relevance_pct` 채워짐
- [ ] dev: ~30-60s 후 same row 의 `segments` / `analysis.entities` / `analysis.key_concepts` / `lora.qa_pairs` 채워짐
- [ ] FE 시각 검증 (별 PR B2/B3 에서 다룸)

## Out of scope (deferred PRs)
- PR B2: FE 카드 spinner + SSE phase 처리
- PR B3: FE 사이드바 entries (북마크 + archive sync, text = oneLiner)
- Issue #685: 기존 row 의 core_argument filler backfill