### PR TITLE
feat(cards): spinner in relevance slot while v2 pending

### DIFF
--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -636,7 +636,8 @@
     },
     "statusQueued": "Queued",
     "statusQueuedTooltip": "Pending background analysis",
-    "retryEnrichmentTooltip": "Retry caption fetch"
+    "retryEnrichmentTooltip": "Retry caption fetch",
+    "enrichingAria": "Analyzing"
   },
   "contextHeader": {
     "home": "Home",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -644,7 +644,8 @@
     },
     "statusQueued": "분석 대기",
     "statusQueuedTooltip": "자동 분석 대기 중",
-    "retryEnrichmentTooltip": "자막을 다시 가져옵니다"
+    "retryEnrichmentTooltip": "자막을 다시 가져옵니다",
+    "enrichingAria": "분석 중"
   },
   "contextHeader": {
     "home": "홈",

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -595,15 +595,12 @@ export function InsightCardItemV2({
               })()}
             </span>
             {/* Right slot priority:
-                  scored → relevance % (color-tiered)
-                  else   → empty
-                The legacy "retry" icon was removed (user directive
-                2026-05-20: "'재시도 아이콘' 을 우선 제거해 — 이후 재설계
-                해서 올릴 기로 결정"). The failure / pending branches
-                used to render a RotateCw button that re-enqueued
-                enrichment, but the click path was unreliable (depended
-                on autoSummaryEnabled + showFailedGlow state) and the
-                whole signal will be redesigned. Until then, no icon. */}
+                  scored        → relevance % (color-tiered)
+                  liked && pending && !failed → spinner (Phase 2 fast-path
+                                                 ~3-4s window between bookmark
+                                                 click and quick-result arrival)
+                  else          → empty (retry signal redesign pending,
+                                  user directive 2026-05-20) */}
             {relevanceBadge ? (
               <span
                 className={cn(
@@ -613,6 +610,11 @@ export function InsightCardItemV2({
               >
                 {relevanceBadge.label}
               </span>
+            ) : v2EnrichmentPending && !showFailedGlow ? (
+              <Loader2
+                className="w-3.5 h-3.5 animate-spin text-white/40 shrink-0"
+                aria-label={t('cards.enrichingAria')}
+              />
             ) : null}
           </div>
         )}


### PR DESCRIPTION
## Summary

User: "북마크 클릭하면, 관련도 위치에 '처리중인것을 사용자가 인지 가능하게' 원형프로그래스바(빙글빙글도는..) 를 배치" — Phase 2 fast-path 와 짝.

Right slot 조건 (우선순위):
1. `relevanceBadge` (mandala_relevance_pct present) → color-tiered %
2. `v2EnrichmentPending && !showFailedGlow` (liked, pct null, not failed) → spinner
3. otherwise → empty

Uses existing `Loader2` from lucide-react with `animate-spin`. i18n keys `cards.enrichingAria` added (ko: "분석 중" / en: "Analyzing").

실패 path 는 비워둠 — retry 신호 재설계 pending (user 별도 결정).

## Test plan
- [x] tsc PASS
- [x] vitest 34/34 (320 tests) PASS
- [ ] dev verify: 북마크 클릭 → 관련도 슬롯 spinner → 3-4초 후 % 로 swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)