### PR TITLE
feat(cards): progress % spinner, drop bottom-left phase dot

### DIFF
--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -495,40 +495,10 @@ export function InsightCardItemV2({
           </button>
         )}
 
-        {/* CP463 — Heart SSE / legacy enrichment progress chip. Sits in
-            the BL corner (Archive is hidden while streamActive). Icon-
-            only (no "AI" label per user directive 2026-05-17). Phase
-            color encodes state:
-              fetching  → blue-500  (준비)
-              analyzing → amber-500 (진행중)
-              scored    → emerald-500 (완료, transient ~2.5s)
-            Legacy isEnriching prop falls into the blue fetching tier. */}
-        {(streamActive || isEnriching) && (
-          <div className="absolute bottom-2 left-2 z-[5] pointer-events-none">
-            <div
-              className={cn(
-                // CP463 — minimal dot per user directive 2026-05-17
-                // "보다 작게해서 점 형태로 하고 디밍으로 진행을 알리는
-                // 건 어떨까?". 8×8 colored dot, dim (animate-pulse =
-                // opacity 1 → 0.5 cycle) while in progress, stays
-                // solid on scored.
-                'w-2 h-2 rounded-full shadow-[0_1px_2px_rgba(0,0,0,0.5)]',
-                streamPhase === 'scored'
-                  ? 'bg-emerald-500'
-                  : streamPhase === 'analyzing'
-                    ? 'bg-blue-500 animate-pulse'
-                    : 'bg-amber-500 animate-pulse'
-              )}
-              aria-label={
-                streamPhase === 'scored'
-                  ? '평가 완료'
-                  : streamPhase === 'analyzing'
-                    ? '분석 중'
-                    : '준비 중'
-              }
-            />
-          </div>
-        )}
+        {/* CP475+ — bottom-left phase dot (yellow/blue/green) removed
+            per user directive 2026-05-20. Progress is now shown inline
+            with the relevance % slot as `⟳ NN%` (PR B2 spinner + phase
+            mapping). Less visual noise + single canonical location. */}
 
         {/* CP463 — failure Retry button moved to the footer meta row
             (right slot, where the % normally sits) per user directive
@@ -611,10 +581,29 @@ export function InsightCardItemV2({
                 {relevanceBadge.label}
               </span>
             ) : v2EnrichmentPending && !showFailedGlow ? (
-              <Loader2
-                className="w-3.5 h-3.5 animate-spin text-white/40 shrink-0"
+              <span
+                className="inline-flex items-center gap-1 shrink-0 text-[10.5px] text-white/50 tabular-nums"
                 aria-label={t('cards.enrichingAria')}
-              />
+              >
+                <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
+                {(() => {
+                  // SSE phase → progress %. Quick path (PR #686 fast-path)
+                  // typically transitions: idle → fetching → analyzing → scored.
+                  // 'scored' arrives within ~3-4s; this slot then swaps to the
+                  // mandala_relevance_pct text in the next render.
+                  switch (streamPhase) {
+                    case 'fetching':
+                      return 30;
+                    case 'analyzing':
+                      return 70;
+                    case 'scored':
+                      return 100;
+                    default:
+                      return 10;
+                  }
+                })()}
+                %
+              </span>
             ) : null}
           </div>
         )}


### PR DESCRIPTION
## Summary

User directive 2026-05-20:
1. 좌하단 노랑/파랑/초록 제거
2. 스피너가 비율 (%) 로 보여지게

## Changes

- `InsightCardItemV2.tsx` 의 BL phase dot 블록 제거 (legacy `streamPhase` → colored dot 패턴).
- Right slot pending spinner = `Loader2` + 옆에 phase-mapped % 텍스트:
  - fetching → 30%
  - analyzing → 70%
  - scored → 100% (transient → relevance % 로 swap)
  - default → 10%

## Test plan
- [x] tsc PASS
- [x] vitest 34 files / 320 tests PASS
- [ ] dev: 북마크 → 우측 슬롯에 ⟳ 30% → 70% → 100% → relevance % 로 swap. BL dot 안 보임.

🤖 Generated with [Claude Code](https://claude.com/claude-code)