### PR TITLE
fix(v2-quick): strip markdown fence from Haiku — fast-path 60s fallthrough fix

### DIFF
--- a/src/modules/skills/rich-summary-v2-quick-generator.ts
+++ b/src/modules/skills/rich-summary-v2-quick-generator.ts
@@ -104,7 +104,17 @@ export async function generateRichSummaryV2Quick(input: V2QuickInput): Promise<V
     });
     let json: unknown;
     try {
-      json = JSON.parse(raw.trim());
+      // Haiku tends to wrap JSON output in a ```json … ``` markdown fence
+      // even when explicitly told not to. Strip the fence before parsing
+      // so the quick path doesn't fail and fall through to the slow
+      // (Sonnet) full generator. Same pattern as the Mac Mini batch
+      // scripts (`scripts/v2-partial-backfill.sh`, `scripts/v2-keyconcepts-lang-fix.sh`).
+      const stripped = raw
+        .trim()
+        .replace(/^\s*```(?:json)?\s*\n?/i, '')
+        .replace(/\n?\s*```\s*$/i, '')
+        .trim();
+      json = JSON.parse(stripped);
     } catch (parseErr) {
       log.warn('v2-quick JSON parse failed', {
         videoId: input.videoId,


### PR DESCRIPTION
**Critical** — fast path was failing on every call due to Haiku wrapping JSON in markdown fence. Resulted in 60s+ latency (Sonnet fallthrough) instead of 3-4s.

Dev logs (2026-05-20 13:54+) showed every quick attempt failing with:
`v2-quick JSON parse failed — "Unexpected token '`', \"```json\n{...\"`

Fix: regex strip the fence before JSON.parse (same pattern as `scripts/v2-*.sh`).

## Test plan
- [x] tsc PASS
- [ ] dev: 북마크 → ~3-4s 안에 spinner closed → filled → relevance %
