### PR TITLE
feat(v2-cron): 12h cooldown auto-retry for quality_flag='low' rows (one shot)

### DIFF
--- a/src/config/rich-summary.ts
+++ b/src/config/rich-summary.ts
@@ -35,6 +35,11 @@ const positiveInt = z.preprocess(
   z.number().finite().int().positive().optional()
 );
 
+const positiveFloat = z.preprocess(
+  (v) => (v == null || v === '' ? undefined : Number(v)),
+  z.number().finite().positive().optional()
+);
+
 export const richSummaryEnvSchema = z.object({
   RICH_SUMMARY_ENABLED: boolFlag.default(false as unknown as string),
   RICH_SUMMARY_CAPTION_SOURCE: captionSourceSchema.default('disabled'),
@@ -43,6 +48,7 @@ export const richSummaryEnvSchema = z.object({
   RICH_SUMMARY_V2_CRON_SCHEDULE: z
     .preprocess((v) => (v == null || v === '' ? '0 17 * * *' : String(v).trim()), z.string())
     .default('0 17 * * *'),
+  V2_LOW_RETRY_COOLDOWN_HOURS: positiveFloat.transform((v) => v ?? 12),
 });
 
 export interface RichSummaryConfig {
@@ -51,6 +57,7 @@ export interface RichSummaryConfig {
   v2CronEnabled: boolean;
   v2BatchSize: number;
   v2CronSchedule: string;
+  v2LowRetryCooldownHours: number;
 }
 
 const FALLBACK_CONFIG: RichSummaryConfig = {
@@ -59,6 +66,7 @@ const FALLBACK_CONFIG: RichSummaryConfig = {
   v2CronEnabled: false,
   v2BatchSize: 50,
   v2CronSchedule: '0 17 * * *',
+  v2LowRetryCooldownHours: 12,
 };
 
 export function loadRichSummaryConfig(env: NodeJS.ProcessEnv = process.env): RichSummaryConfig {
@@ -68,6 +76,7 @@ export function loadRichSummaryConfig(env: NodeJS.ProcessEnv = process.env): Ric
     RICH_SUMMARY_V2_CRON_ENABLED: env['RICH_SUMMARY_V2_CRON_ENABLED'],
     RICH_SUMMARY_V2_BATCH_SIZE: env['RICH_SUMMARY_V2_BATCH_SIZE'],
     RICH_SUMMARY_V2_CRON_SCHEDULE: env['RICH_SUMMARY_V2_CRON_SCHEDULE'],
+    V2_LOW_RETRY_COOLDOWN_HOURS: env['V2_LOW_RETRY_COOLDOWN_HOURS'],
   });
   if (!parsed.success) {
     return FALLBACK_CONFIG;
@@ -78,5 +87,6 @@ export function loadRichSummaryConfig(env: NodeJS.ProcessEnv = process.env): Ric
     v2CronEnabled: parsed.data.RICH_SUMMARY_V2_CRON_ENABLED,
     v2BatchSize: parsed.data.RICH_SUMMARY_V2_BATCH_SIZE,
     v2CronSchedule: parsed.data.RICH_SUMMARY_V2_CRON_SCHEDULE,
+    v2LowRetryCooldownHours: parsed.data.V2_LOW_RETRY_COOLDOWN_HOURS,
   };
 }

--- a/src/modules/scheduler/rich-summary-v2-cron.ts
+++ b/src/modules/scheduler/rich-summary-v2-cron.ts
@@ -11,7 +11,13 @@
  *      - quality_flag = 'low'
  *      - actionables array < 3
  *      - completeness < 0.7 (v2 metric, when populated)
- *   2. Track B: youtube_videos with no rich_summary row at all
+ *   2. Track A2 (CP475+): v2 rows where the first generation produced
+ *      `quality_flag = 'low'` — cooldown V2_LOW_RETRY_COOLDOWN_HOURS (default 12h)
+ *      since `updated_at` to avoid hammering transient failures. After one
+ *      retry the row is marked `quality_flag = 'low_retried'` (permanent) so
+ *      it is never re-picked by this track. Manual intervention required to
+ *      reset.
+ *   3. Track B: youtube_videos with no rich_summary row at all
  *      - quality-pass (view_count ≥ 1000, duration 60-10800)
  *      - bookmark count desc, then view_count desc
  *
@@ -41,11 +47,20 @@ const log = logger.child({ module: 'RichSummaryV2Cron' });
 let cronTask: cron.ScheduledTask | null = null;
 let runInProgress = false;
 
+const V2_LOW_RETRIED_FLAG = 'low_retried';
+
+/** Distinct candidate kinds so retry rows can be tracked separately. */
+export type V2CandidateKind = 'trackA-v1' | 'trackA2-v2-low' | 'trackB-new';
+export interface V2Candidate {
+  videoId: string;
+  kind: V2CandidateKind;
+}
+
 /**
- * Pull up to `limit` videoIds for the next batch. Track A first; Track B fills
- * the remaining slots when Track A is exhausted.
+ * Pull up to `limit` candidates for the next batch. Track A → A2 → B in
+ * priority order; earlier tracks fill until exhausted.
  */
-export async function selectV2Candidates(limit: number): Promise<string[]> {
+export async function selectV2Candidates(limit: number): Promise<V2Candidate[]> {
   if (limit <= 0) return [];
   const prisma = getPrismaClient();
 
@@ -65,11 +80,34 @@ export async function selectV2Candidates(limit: number): Promise<string[]> {
     ORDER BY quality_score ASC NULLS FIRST
     LIMIT ${Prisma.raw(String(limit))}
   `);
-  const ids = trackA.map((r) => r.video_id);
-  if (ids.length >= limit) return ids;
+  const candidates: V2Candidate[] = trackA.map((r) => ({
+    videoId: r.video_id,
+    kind: 'trackA-v1' as const,
+  }));
+  if (candidates.length >= limit) return candidates;
+
+  // Track A2 — v2 rows with quality_flag='low', cooldown
+  // `v2LowRetryCooldownHours` (env-tunable, default 12) since `updated_at`.
+  // One retry only — after this pass the row is marked 'low_retried' so it
+  // can never re-enter this track.
+  const a2Remaining = limit - candidates.length;
+  const cooldownHours = loadRichSummaryConfig().v2LowRetryCooldownHours;
+  const trackA2 = await prisma.$queryRaw<{ video_id: string }[]>(Prisma.sql`
+    SELECT video_id
+    FROM video_rich_summaries
+    WHERE template_version = 'v2'
+      AND quality_flag = 'low'
+      AND updated_at < now() - make_interval(hours => ${Prisma.raw(String(cooldownHours))})
+    ORDER BY updated_at ASC
+    LIMIT ${Prisma.raw(String(a2Remaining))}
+  `);
+  for (const r of trackA2) {
+    candidates.push({ videoId: r.video_id, kind: 'trackA2-v2-low' });
+  }
+  if (candidates.length >= limit) return candidates;
 
   // Track B — youtube_videos with no rich_summary row, quality-pass, bookmark-priority
-  const remaining = limit - ids.length;
+  const remaining = limit - candidates.length;
   const trackB = await prisma.$queryRaw<{ youtube_video_id: string }[]>(Prisma.sql`
     SELECT yv.youtube_video_id
     FROM youtube_videos yv
@@ -89,8 +127,26 @@ export async function selectV2Candidates(limit: number): Promise<string[]> {
     ORDER BY COALESCE(book.bookmark_count, 0) DESC, yv.view_count DESC
     LIMIT ${Prisma.raw(String(remaining))}
   `);
-  for (const r of trackB) ids.push(r.youtube_video_id);
-  return ids;
+  for (const r of trackB) {
+    candidates.push({ videoId: r.youtube_video_id, kind: 'trackB-new' });
+  }
+  return candidates;
+}
+
+/**
+ * Mark a Track A2 row as `low_retried` so it can never re-enter the retry
+ * track regardless of further `updated_at` ageing. Called after a Track A2
+ * retry produces another `low` outcome.
+ */
+async function markLowRetried(videoId: string): Promise<void> {
+  const prisma = getPrismaClient();
+  await prisma.$executeRaw(Prisma.sql`
+    UPDATE video_rich_summaries
+    SET quality_flag = ${V2_LOW_RETRIED_FLAG}
+    WHERE video_id = ${videoId}
+      AND template_version = 'v2'
+      AND quality_flag = 'low'
+  `);
 }
 
 /**
@@ -103,46 +159,73 @@ export async function runV2BatchOnce(batchSize: number): Promise<{
   low: number;
   skip: number;
   errors: number;
+  lowRetried: number;
 }> {
   if (runInProgress) {
     log.warn('v2 cron tick skipped — previous run still in progress');
-    return { picked: 0, pass: 0, low: 0, skip: 0, errors: 0 };
+    return { picked: 0, pass: 0, low: 0, skip: 0, errors: 0, lowRetried: 0 };
   }
   runInProgress = true;
   const t0 = Date.now();
   try {
-    const ids = await selectV2Candidates(batchSize);
-    log.info('v2 cron batch start', { picked: ids.length, batchSize });
+    const candidates = await selectV2Candidates(batchSize);
+    log.info('v2 cron batch start', {
+      picked: candidates.length,
+      batchSize,
+      byKind: countByKind(candidates),
+    });
     let pass = 0;
     let low = 0;
     let skip = 0;
     let errors = 0;
-    for (const videoId of ids) {
+    let lowRetried = 0;
+    for (const cand of candidates) {
       try {
-        const outcome = await generateRichSummaryV2({ videoId });
+        const outcome = await generateRichSummaryV2({ videoId: cand.videoId });
         if (outcome.kind === 'pass') pass += 1;
-        else if (outcome.kind === 'low') low += 1;
-        else skip += 1;
+        else if (outcome.kind === 'low') {
+          low += 1;
+          // Track A2 retry that produced another 'low' → permanent stop marker.
+          if (cand.kind === 'trackA2-v2-low') {
+            await markLowRetried(cand.videoId);
+            lowRetried += 1;
+            log.info('v2 cron: row marked low_retried after retry', {
+              videoId: cand.videoId,
+            });
+          }
+        } else skip += 1;
       } catch (err) {
         errors += 1;
         log.error('v2 cron item failed', {
-          videoId,
+          videoId: cand.videoId,
+          kind: cand.kind,
           error: err instanceof Error ? err.message : String(err),
         });
       }
     }
     log.info('v2 cron batch done', {
-      picked: ids.length,
+      picked: candidates.length,
       pass,
       low,
       skip,
       errors,
+      lowRetried,
       elapsedMs: Date.now() - t0,
     });
-    return { picked: ids.length, pass, low, skip, errors };
+    return { picked: candidates.length, pass, low, skip, errors, lowRetried };
   } finally {
     runInProgress = false;
   }
+}
+
+function countByKind(candidates: V2Candidate[]): Record<V2CandidateKind, number> {
+  const out: Record<V2CandidateKind, number> = {
+    'trackA-v1': 0,
+    'trackA2-v2-low': 0,
+    'trackB-new': 0,
+  };
+  for (const c of candidates) out[c.kind] += 1;
+  return out;
 }
 
 /**

--- a/tests/unit/modules/rich-summary-config.test.ts
+++ b/tests/unit/modules/rich-summary-config.test.ts
@@ -66,6 +66,7 @@ describe('loadRichSummaryConfig', () => {
         v2CronEnabled: false,
         v2BatchSize: 50,
         v2CronSchedule: '0 17 * * *',
+        v2LowRetryCooldownHours: 12,
       });
     });
 
@@ -80,6 +81,7 @@ describe('loadRichSummaryConfig', () => {
         v2CronEnabled: false,
         v2BatchSize: 50,
         v2CronSchedule: '0 17 * * *',
+        v2LowRetryCooldownHours: 12,
       });
     });
   });
@@ -118,6 +120,33 @@ describe('loadRichSummaryConfig', () => {
       expect(loadRichSummaryConfig({ RICH_SUMMARY_V2_CRON_SCHEDULE: '' }).v2CronSchedule).toBe(
         '0 17 * * *'
       );
+    });
+  });
+
+  describe('v2 low-retry cooldown (CP475+)', () => {
+    it('default 12h when env unset', () => {
+      expect(loadRichSummaryConfig({}).v2LowRetryCooldownHours).toBe(12);
+    });
+
+    it('accepts positive float', () => {
+      expect(
+        loadRichSummaryConfig({ V2_LOW_RETRY_COOLDOWN_HOURS: '6' }).v2LowRetryCooldownHours
+      ).toBe(6);
+      expect(
+        loadRichSummaryConfig({ V2_LOW_RETRY_COOLDOWN_HOURS: '0.5' }).v2LowRetryCooldownHours
+      ).toBe(0.5);
+    });
+
+    it('invalid value falls back to 12', () => {
+      expect(
+        loadRichSummaryConfig({ V2_LOW_RETRY_COOLDOWN_HOURS: '0' }).v2LowRetryCooldownHours
+      ).toBe(12);
+      expect(
+        loadRichSummaryConfig({ V2_LOW_RETRY_COOLDOWN_HOURS: '-3' }).v2LowRetryCooldownHours
+      ).toBe(12);
+      expect(
+        loadRichSummaryConfig({ V2_LOW_RETRY_COOLDOWN_HOURS: 'garbage' }).v2LowRetryCooldownHours
+      ).toBe(12);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds **Track A2** to `rich-summary-v2-cron`: v2 rows with `quality_flag='low'` are auto-retried after `v2LowRetryCooldownHours` (default 12, env `V2_LOW_RETRY_COOLDOWN_HOURS`).
- One shot only — a retry that again produces `low` marks the row `quality_flag='low_retried'` (permanent). No infinite loops.
- Config knob lives in `src/config/rich-summary.ts` (zod), not raw `process.env` — per CLAUDE.md "하드코딩 금지" rule.
- Cron is still gated by `RICH_SUMMARY_V2_CRON_ENABLED=false` at default. No prod behavior change until operator flips the flag.

## Background
- This PR is the **safety net** behind PR #692 (root-cause fix for short-transcript → forced `low`).
- After #692, the only remaining cause for `quality_flag='low'` is a genuine transient failure (proxy slot exhaustion, Tailscale dropout, LLM 5xx). 12h is long enough to clear transients, short enough to feel hands-off.
- User directive (2026-05-20): "12시간."

## Measurement evidence
- J4B-s6KuVVs (1:48 video, transcript 415 chars) — pre-#692 produced `quality_flag='low'` with `diagnostics.reason="completeness_1_below_threshold"`. With #692 deployed + this PR, the next Track A2 tick (cooldown 12h after the low write) should land `pass`.
- This PR is **not** a symptom patch on top of #692. It is the recovery mechanism for transient failures that #692 cannot address.

## Test plan
- [x] tsc PASS
- [x] jest rich-summary-config 32/32 PASS (3 new cooldown tests)
- [x] jest rich-summary suite 87/88 PASS (1 pre-existing transcript test fails on main too, unrelated)
- [ ] dev: flip `V2_LOW_RETRY_COOLDOWN_HOURS=0.05`, plant a `low` row, observe Track A2 retry on the next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)