### PR TITLE
fix(v2): un-stick quick-only rows when full path expires/fails (plan C)

### DIFF
--- a/prisma/migrations/rich-summary-v2/008_unstick_pending_pass_empty.sql
+++ b/prisma/migrations/rich-summary-v2/008_unstick_pending_pass_empty.sql
@@ -1,0 +1,49 @@
+-- =========================================================================
+-- CP475+ (2026-05-20) — un-stick v2 rows where quick path stamped 'pass'
+-- but full path never landed
+-- =========================================================================
+--
+-- Why: pre-CP475+ the quick generator (`rich-summary-v2-quick-generator.ts`)
+-- created new rows with `quality_flag='pass'` on the assumption that the
+-- full generator would always finish moments later and overwrite to the
+-- real verdict ('pass' / 'low'). With `RICH_SUMMARY_RETRY_OPTIONS.expireInMinutes=5`
+-- (CP462) about 15% of full-path jobs expired before finishing — leaving
+-- the row in a permanent `pass + sections=[] + atoms=[]` state that the
+-- cron Track A2 retry (`quality_flag='low'`) could never reach.
+--
+-- CP475+ fix:
+--   1. quick path now writes `quality_flag='pending'` (only full path stamps 'pass')
+--   2. `RICH_SUMMARY_RETRY_OPTIONS.expireInMinutes: 5 → 10`
+--   3. cron Track A2 also matches `pending + empty atoms`
+--
+-- This migration cleans up the historical inventory so the cron Track A2
+-- and the FE "still being generated" path can re-pick them.
+--
+-- Affected rows: template_version='v2' AND quality_flag='pass' AND
+-- (atoms is empty/missing) — these are quick-only rows.
+--
+-- Apply (local):
+--   docker exec -e PGPASSWORD=... supabase-db-dev psql -U supabase_admin \
+--     -d postgres -f /docker-entrypoint-initdb.d/008_unstick_pending_pass_empty.sql
+--   OR
+--   docker exec supabase-db-dev bash -c 'PGPASSWORD=$POSTGRES_PASSWORD psql -U supabase_admin -d postgres' < 008_unstick_pending_pass_empty.sql
+--
+-- Apply (prod):
+--   psql "$DIRECT_URL" -f 008_unstick_pending_pass_empty.sql
+--
+-- Verify:
+--   SELECT count(*) FILTER (WHERE quality_flag='pending') AS unstucked,
+--          count(*) FILTER (WHERE quality_flag='pass'
+--                            AND COALESCE(jsonb_array_length(NULLIF(segments->'atoms','null'::jsonb)),0)=0
+--                            AND template_version='v2') AS still_stuck
+--   FROM video_rich_summaries;
+--   -- expect still_stuck = 0
+--
+-- Rollback: one-way. Re-running won't change pending rows back to pass.
+
+UPDATE video_rich_summaries
+SET quality_flag = 'pending',
+    updated_at   = now() - interval '13 hours'   -- backdate so cron Track A2 picks them up on the next tick
+WHERE template_version = 'v2'
+  AND quality_flag = 'pass'
+  AND COALESCE(jsonb_array_length(NULLIF(segments->'atoms', 'null'::jsonb)), 0) = 0;

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -81,12 +81,18 @@ export const ENRICH_RETRY_OPTIONS = {
 
 /**
  * Heart-triggered rich summary — user is actively waiting (SSE-subscribed),
- * so fail fast: no retry, short expiry. The FE will show a Retry button on
- * failure rather than silent backoff. CP462+ Issue #649.
+ * so fail fast: no retry, but expiry must cover the full Sonnet generation,
+ * not just the quick path. CP462+ Issue #649.
+ *
+ * Timeout sized from prod-dev measurements (CP475+, 2026-05-20):
+ *   completed jobs p95 = 87s, max = 90s
+ *   pre-CP475 expireInMinutes=5 → 15% expired rate (3/20)
+ *   10min = ~6.9× p95 headroom; absorbs LLM stalls / proxy hiccups
+ *   without indefinitely tying up a worker slot.
  */
 export const RICH_SUMMARY_RETRY_OPTIONS = {
   retryLimit: 0,
-  expireInMinutes: 5,
+  expireInMinutes: 10,
 } as const;
 
 /** Batch scan: no retries (runs on schedule) */

--- a/src/modules/scheduler/rich-summary-v2-cron.ts
+++ b/src/modules/scheduler/rich-summary-v2-cron.ts
@@ -11,12 +11,14 @@
  *      - quality_flag = 'low'
  *      - actionables array < 3
  *      - completeness < 0.7 (v2 metric, when populated)
- *   2. Track A2 (CP475+): v2 rows where the first generation produced
- *      `quality_flag = 'low'` — cooldown V2_LOW_RETRY_COOLDOWN_HOURS (default 12h)
- *      since `updated_at` to avoid hammering transient failures. After one
- *      retry the row is marked `quality_flag = 'low_retried'` (permanent) so
- *      it is never re-picked by this track. Manual intervention required to
- *      reset.
+ *   2. Track A2 (CP475+): v2 rows whose full generation never landed —
+ *      either `quality_flag = 'low'` (full path ran and rejected) OR
+ *      `quality_flag = 'pending'` with empty segments (quick path stamped
+ *      the row then full path expired / failed mid-flight). Cooldown
+ *      V2_LOW_RETRY_COOLDOWN_HOURS (default 12h) since `updated_at` to avoid
+ *      hammering transient failures. After one retry the row is marked
+ *      `quality_flag = 'low_retried'` (permanent) so it is never re-picked
+ *      by this track. Manual intervention required to reset.
  *   3. Track B: youtube_videos with no rich_summary row at all
  *      - quality-pass (view_count ≥ 1000, duration 60-10800)
  *      - bookmark count desc, then view_count desc
@@ -86,17 +88,26 @@ export async function selectV2Candidates(limit: number): Promise<V2Candidate[]> 
   }));
   if (candidates.length >= limit) return candidates;
 
-  // Track A2 — v2 rows with quality_flag='low', cooldown
-  // `v2LowRetryCooldownHours` (env-tunable, default 12) since `updated_at`.
-  // One retry only — after this pass the row is marked 'low_retried' so it
-  // can never re-enter this track.
+  // Track A2 — v2 rows whose full generation never landed. Two shapes:
+  //   (i)  quality_flag='low'      — full path produced 'low'
+  //   (ii) quality_flag='pending' + empty atoms — quick path stamped row
+  //                                  but full path expired / failed mid-flight
+  // Cooldown `v2LowRetryCooldownHours` (env-tunable, default 12) since
+  // `updated_at`. One retry only — after this pass the row is marked
+  // 'low_retried' so it can never re-enter this track.
   const a2Remaining = limit - candidates.length;
   const cooldownHours = loadRichSummaryConfig().v2LowRetryCooldownHours;
   const trackA2 = await prisma.$queryRaw<{ video_id: string }[]>(Prisma.sql`
     SELECT video_id
     FROM video_rich_summaries
     WHERE template_version = 'v2'
-      AND quality_flag = 'low'
+      AND (
+        quality_flag = 'low'
+        OR (
+          quality_flag = 'pending'
+          AND COALESCE(jsonb_array_length(NULLIF(segments->'atoms', 'null'::jsonb)), 0) = 0
+        )
+      )
       AND updated_at < now() - make_interval(hours => ${Prisma.raw(String(cooldownHours))})
     ORDER BY updated_at ASC
     LIMIT ${Prisma.raw(String(a2Remaining))}
@@ -136,7 +147,8 @@ export async function selectV2Candidates(limit: number): Promise<V2Candidate[]> 
 /**
  * Mark a Track A2 row as `low_retried` so it can never re-enter the retry
  * track regardless of further `updated_at` ageing. Called after a Track A2
- * retry produces another `low` outcome.
+ * retry produces another `low` outcome. Accepts either of the two Track A2
+ * shapes (`low`, or `pending` with empty atoms).
  */
 async function markLowRetried(videoId: string): Promise<void> {
   const prisma = getPrismaClient();
@@ -145,7 +157,13 @@ async function markLowRetried(videoId: string): Promise<void> {
     SET quality_flag = ${V2_LOW_RETRIED_FLAG}
     WHERE video_id = ${videoId}
       AND template_version = 'v2'
-      AND quality_flag = 'low'
+      AND (
+        quality_flag = 'low'
+        OR (
+          quality_flag = 'pending'
+          AND COALESCE(jsonb_array_length(NULLIF(segments->'atoms', 'null'::jsonb)), 0) = 0
+        )
+      )
   `);
 }
 

--- a/src/modules/skills/rich-summary-v2-quick-generator.ts
+++ b/src/modules/skills/rich-summary-v2-quick-generator.ts
@@ -176,7 +176,11 @@ export async function generateRichSummaryV2Quick(input: V2QuickInput): Promise<V
         mandala_relevance_pct: parsed.analysis.mandala_fit.mandala_relevance_pct,
         source_language: language,
         transcript_used: true,
-        quality_flag: 'pass',
+        // Quick path is not the final verdict — only `one_liner` + `core_argument`
+        // + `mandala_relevance_pct` are populated. Full generator (segments,
+        // atoms, entities, lora) flips this to 'pass' or 'low' on completion.
+        // Premature 'pass' here caused stuck rows when full path expired/failed.
+        quality_flag: 'pending',
         ...(input.userId ? { user_id: input.userId } : {}),
       },
     });


### PR DESCRIPTION
## Summary
Bundles four atomic fixes for the **quick-only stuck row** failure mode (`quality_flag='pass' + sections=[] + atoms=[]` permanent state). See commit message for measurement evidence and per-file rationale.

| # | Change | File |
|---|---|---|
| 1 | quick path writes `quality_flag='pending'` | `rich-summary-v2-quick-generator.ts` |
| 2 | full-path job expiry 5min → 10min | `queue/types.ts` |
| 3 | cron Track A2 also matches `pending + empty atoms` | `scheduler/rich-summary-v2-cron.ts` |
| 4 | backfill stuck rows pass+empty → pending | `prisma/migrations/rich-summary-v2/008_*.sql` |

## Measurement evidence
- Pre-fix expired job duration: 313-326s (pg-boss 300s timeout direct hit) — 3/20 jobs (15%)
- Completed jobs p95: 87s, max: 90s → 10min new timeout = 6.9× headroom
- Local dev DB had 2 stuck rows (`eUGlonGv2EY`, `RA9yHJXCPw0`); after migration 008 both become `pending`; Track A2 query returns 17 candidates with cooldown=12h

## Not a symptom patch
- timeout bump 5→10 is anchored to measured p95=87s, not "feels too short"
- LLM provider stall / proxy hiccup root cause is still absorbed by Track A2 retry — bump only reduces *first-pass* false expiries

## Test plan
- [x] tsc PASS
- [x] jest 114/116 PASS (2 pre-existing fails on main, unrelated)
- [x] local DB migration applied; 2 rows demoted; new Track A2 returns 17 (15 low + 2 pending)
- [ ] dev: next cron tick (with `RICH_SUMMARY_V2_CRON_ENABLED=true`) → 라면 영상 retry → sections 1+ + atoms 1+
- [ ] prod: apply migration 008 via `DIRECT_URL` post-merge

## Rollback
- Code: revert PR. Backfill is one-way but harmless (pending rows just await the next Track A2 tick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)