### PR TITLE
chore(prod): enable RICH_SUMMARY_V2_CRON_ENABLED for service backfill

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -101,9 +101,12 @@ services:
       # Tuning knob, not a secret (CP392 2-question test passes).
       # Revert: set to false or delete this line → cron stops at next process
       # restart (no in-flight call is interrupted).
-      # CP437 (2026-04-29) — DISABLED per user directive: 무조건적인 API 사용금지.
-      # OpenRouter 호출 차단. v2 요약은 CC 콘솔(claude-code-direct) 경유로만 진행.
-      - RICH_SUMMARY_V2_CRON_ENABLED=false
+      # CP475+ (2026-05-20) — ENABLED for service-path runtime backfill.
+      # CP437 freeze was a temporary cost-control measure; cron is service-only
+      # (prod user-facing enrichment) so the §"LLM API 호출 금지" rule
+      # (dataset/experiment/test) does not apply. Track A2 (PR #693/694) now
+      # retries pending/low rows on a 12h cooldown so this can stay on.
+      - RICH_SUMMARY_V2_CRON_ENABLED=true
       # CP437 (2026-04-29) — Operator flip: enable YouTube metadata backfill cron.
       # Default in code is `false` — cron stays dormant unless this env is
       # explicitly true. With this set, `startYouTubeMetadataCron()` schedules


### PR DESCRIPTION
## Summary
Flip `RICH_SUMMARY_V2_CRON_ENABLED` from `false` → `true` in `docker-compose.prod.yml`. User-authorized 2026-05-20: cron is service-path (prod runtime, user-facing enrichment), not dataset/experiment/test scope.

## Why now
- PR #694 shipped `quality_flag='pending'` quick path + Track A2 matching `pending + empty atoms` + backfill migration 008. Without the cron enabled, un-stuck rows sit in `pending` forever.
- Eligible inventory (local mirror): **15 low + 2 pending** rows, all `updated_at` ≥ 12h ago — ready for retry on the next tick.

## Cost guard
- Track A2 permanently stops after 1 retry (`low_retried`)
- Serial LLM calls (1 in-flight) — wizard path keeps OpenRouter rate headroom
- `RICH_SUMMARY_V2_BATCH_SIZE=50/day` unchanged

## Rollback
Set env back to `false` → cron stops at next API container restart. No code revert needed.

## Test plan
- [ ] After deploy, tail `insighta-api` logs for `v2 cron started` line
- [ ] After 17:00 UTC tick: log line `v2 cron batch done` with `picked >= 1`
- [ ] Spot-check 1-2 rows that were `low/pending` → flipped to `pass` or `low_retried`

🤖 Generated with [Claude Code](https://claude.com/claude-code)