### PR TITLE
feat(v2): background enrich + "still being generated" UI on Learning Page

### DIFF
--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -565,6 +565,14 @@
     }
   }
 
+  /* Rolling ellipsis for "still being generated" labels (CP475+).
+     Three side-by-side dots each fade in turn — duration 1.4s with 0.2s
+     stagger between them. */
+  @keyframes enrich-dot {
+    0%, 80%, 100% { opacity: 0.2; }
+    40% { opacity: 1; }
+  }
+
   /* Card discovery progress animations */
   @keyframes fadeIn {
     from { opacity: 0; transform: translateY(4px); }

--- a/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
@@ -12,22 +12,24 @@
  *
  * Design tokens: insighta-side-editor-mockup-v3.html
  */
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import type { VideoSummary } from '@/entities/card/model/types';
 import { getYouTubeVideoId } from '@/widgets/video-player/model/youtube-api';
 import { queryKeys } from '@/shared/config/query-client';
-import type {
-  VideoRichSummaryAnalysis,
-  VideoRichSummaryAtom,
-  VideoRichSummaryCore,
-  VideoRichSummaryLora,
-  VideoRichSummarySegments,
+import {
+  apiClient,
+  type VideoRichSummaryAnalysis,
+  type VideoRichSummaryAtom,
+  type VideoRichSummaryCore,
+  type VideoRichSummaryLora,
+  type VideoRichSummarySegments,
 } from '@/shared/lib/api-client';
 import { Info, Quote, Lightbulb, Dot } from 'lucide-react';
 import { useRichSummary } from '../model/useRichSummary';
+import { useEnrichStream } from '@/features/card-management/model/useEnrichStream';
 
 export interface PanelAISummaryProps {
   videoSummary: VideoSummary | undefined;
@@ -56,7 +58,58 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
   const hasRich = hasNewV2 || hasLegacyRich;
   const hasShort = Boolean(short) || tags.length > 0;
 
+  // CP475+ — background enrich + SSE wiring. Fire `/enrich-bg` once per
+  // (videoId, mandalaId) when the segments block is missing; subscribe
+  // to /enrich-stream so the UI flips to the completed state without a
+  // manual refresh.
+  const hasSegments =
+    (richSummary?.segments?.atoms?.length ?? 0) > 0 ||
+    (richSummary?.segments?.sections?.length ?? 0) > 0;
+  const triggerKeyRef = useRef<string | null>(null);
+  const { phase: streamPhase, isActive: isStreamActive, open: openStream } = useEnrichStream();
+  useEffect(() => {
+    if (!youtubeId || !mandalaId) return;
+    if (isRichLoading) return;
+    if (hasSegments) return;
+    const key = `${youtubeId}:${mandalaId}`;
+    if (triggerKeyRef.current === key) return;
+    triggerKeyRef.current = key;
+    void (async () => {
+      try {
+        const res = await apiClient.enrichCardBackground(youtubeId, mandalaId);
+        if (res.data.reason !== 'already_complete') {
+          void openStream(youtubeId);
+        }
+      } catch {
+        /* Silent — UI falls back to the "still being generated" message
+           and the cron Track A2 retry will eventually land. */
+      }
+    })();
+  }, [youtubeId, mandalaId, isRichLoading, hasSegments, openStream]);
+
+  // When the SSE stream terminates with `scored`, refetch the v2 row so
+  // the segments block lands without a manual reload.
+  useEffect(() => {
+    if (!youtubeId) return;
+    if (streamPhase === 'scored') {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.video.richSummary(youtubeId) });
+    }
+  }, [streamPhase, youtubeId, queryClient]);
+
+  const isEnrichInProgress =
+    !hasSegments &&
+    (isStreamActive ||
+      streamPhase === 'fetching' ||
+      streamPhase === 'analyzing' ||
+      (triggerKeyRef.current !== null && streamPhase === 'idle'));
+
+  // Empty state: nothing to render. Distinguish "still being generated"
+  // (background enrich in flight, or core present but segments missing)
+  // from "no AI output at all" (truly empty row).
   if (!hasNewV2 && !hasLegacyRich && !hasShort && !isRichLoading) {
+    if (isEnrichInProgress) {
+      return <EnrichInProgressMessage label={t('learning.aiSummaryGenerating')} />;
+    }
     return (
       <p className="py-8 text-center text-[13px] text-[#4e4f5c]">
         {t('learning.aiSummaryNotReady')}
@@ -75,6 +128,9 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
           youtubeId={youtubeId}
           mandalaId={mandalaId ?? null}
         />
+      )}
+      {hasNewV2 && !hasSegments && isEnrichInProgress && (
+        <EnrichInProgressMessage label={t('learning.richSummaryGenerating')} />
       )}
       {hasLegacyRich && richSummary?.structured && (
         <RichSummaryBlock structured={richSummary.structured} />
@@ -591,5 +647,28 @@ function AtomRow({ atom, jumpUrl }: { atom: VideoRichSummaryAtom; jumpUrl: strin
         )}
       </span>
     </li>
+  );
+}
+
+/**
+ * CP475+ — "still being generated" message with rolling ellipsis. Used
+ * both for the all-empty case (quick path still in flight) and the
+ * quick-done-full-pending case (segments block awaiting the SSE-tracked
+ * background job).
+ */
+function EnrichInProgressMessage({ label }: { label: string }) {
+  return (
+    <p
+      role="status"
+      aria-live="polite"
+      className="flex items-center justify-center gap-[1px] py-8 text-center text-[13px] text-[#4e4f5c]"
+    >
+      <span>{label}</span>
+      <span aria-hidden className="ml-1 inline-flex">
+        <span className="animate-[enrich-dot_1.4s_ease-in-out_infinite]">.</span>
+        <span className="animate-[enrich-dot_1.4s_ease-in-out_0.2s_infinite]">.</span>
+        <span className="animate-[enrich-dot_1.4s_ease-in-out_0.4s_infinite]">.</span>
+      </span>
+    </p>
   );
 }

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1803,6 +1803,8 @@
     "reportPreparing": "Preparing report...",
     "contentCollecting": "Collecting content...",
     "aiSummaryNotReady": "No AI summary has been generated yet",
+    "aiSummaryGenerating": "Generating AI summary",
+    "richSummaryGenerating": "Generating detailed summary",
     "metaSummary": "Meta summary",
     "summaryLabel": "Summary",
     "keywordsLabel": "Keywords",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1811,6 +1811,8 @@
     "reportPreparing": "보고서 작성 준비중 ...",
     "contentCollecting": "콘텐츠 수집 중...",
     "aiSummaryNotReady": "아직 AI 요약이 생성되지 않았어요",
+    "aiSummaryGenerating": "AI 요약을 생성하고 있습니다",
+    "richSummaryGenerating": "상세 요약을 생성하고 있습니다",
     "metaSummary": "메타 요약",
     "summaryLabel": "요약",
     "keywordsLabel": "키워드",

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1348,6 +1348,28 @@ class ApiClient {
     });
   }
 
+  /**
+   * Idempotent background enrich trigger (CP475+). Fired by Learning Page
+   * when the v2 row exists but its `segments` are empty. BE either starts
+   * a fresh enrich job, returns the in-flight one, or noops if already
+   * complete. Subscribe to GET /cards/:videoId/enrich-stream for progress.
+   */
+  async enrichCardBackground(
+    videoId: string,
+    mandalaId: string
+  ): Promise<{
+    status: string;
+    data: {
+      jobId: string | null;
+      reason: 'enqueued' | 'in_progress' | 'already_complete';
+    };
+  }> {
+    return this.request(`/cards/${videoId}/enrich-bg`, {
+      method: 'POST',
+      body: JSON.stringify({ mandalaId }),
+    });
+  }
+
   async archiveCard(videoId: string, mandalaId: string): Promise<void> {
     return this.request(`/cards/${videoId}/archive`, {
       method: 'POST',

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -548,6 +548,108 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
   );
 
   /**
+   * POST /api/v1/cards/:videoId/enrich-bg — idempotent background enrich
+   * trigger (CP475+, 2026-05-20).
+   *
+   * The Learning Page mounts this when the side panel opens and the v2
+   * row is missing its `segments` block (full path expired / not yet
+   * generated). Heart-click also enqueues via `/like`; this endpoint
+   * exists separately so we can fire it without changing pinned state.
+   *
+   * Body: { mandalaId: string }
+   *
+   * Returns 202 with one of:
+   *   { jobId: string, reason: 'enqueued' }       → fresh job started
+   *   { jobId: null,   reason: 'in_progress' }    → existing job still running
+   *   { jobId: null,   reason: 'already_complete' } → row already has atoms
+   *
+   * Subscribe to GET /:videoId/enrich-stream for SSE phase updates.
+   */
+  fastify.post<{
+    Params: { videoId: string };
+    Body: { mandalaId: string };
+  }>('/:videoId/enrich-bg', { onRequest: [fastify.authenticate] }, async (request, reply) => {
+    if (!request.user || !('userId' in request.user)) {
+      return reply
+        .code(401)
+        .send({ status: 'error', code: 'UNAUTHORIZED', message: 'Unauthorized' });
+    }
+    const userId = request.user.userId;
+    const { videoId } = request.params;
+    const { mandalaId } = request.body ?? { mandalaId: '' };
+
+    if (!YOUTUBE_VIDEO_ID_RE.test(videoId)) {
+      return reply.code(400).send({
+        status: 'error',
+        code: 'INVALID_VIDEO_ID',
+        message: `videoId must be a YouTube 11-char id; got ${videoId.slice(0, VIDEO_ID_LOG_TRIM)}`,
+      });
+    }
+    if (!mandalaId || typeof mandalaId !== 'string') {
+      return reply.code(400).send({
+        status: 'error',
+        code: 'INVALID_MANDALA_ID',
+        message: 'mandalaId is required',
+      });
+    }
+
+    const prisma = getPrismaClient();
+    try {
+      // 1. Skip if the row already has segments — full path landed.
+      const rs = await prisma.$queryRaw<Array<{ atom_count: number; quality_flag: string | null }>>`
+        SELECT
+          COALESCE(jsonb_array_length(NULLIF(segments->'atoms', 'null'::jsonb)), 0)::int AS atom_count,
+          quality_flag
+        FROM video_rich_summaries
+        WHERE video_id = ${videoId}
+          AND template_version = 'v2'
+        LIMIT 1
+      `;
+      const row = rs[0];
+      if (row && row.atom_count > 0) {
+        return reply
+          .code(202)
+          .send({ status: 'ok', data: { jobId: null, reason: 'already_complete' } });
+      }
+      // 2. Skip if a recent job is still in-flight (created/active/retry).
+      const inflight = await prisma.$queryRaw<Array<{ id: string }>>`
+        SELECT id::text AS id
+        FROM pgboss.job
+        WHERE name = 'enrich-rich-summary'
+          AND data->>'videoId' = ${videoId}
+          AND data->>'userId' = ${userId}
+          AND state IN ('created', 'active', 'retry')
+        ORDER BY createdon DESC
+        LIMIT 1
+      `;
+      if (inflight.length > 0) {
+        return reply
+          .code(202)
+          .send({ status: 'ok', data: { jobId: inflight[0]!.id, reason: 'in_progress' } });
+      }
+      // 3. Enqueue a fresh job.
+      const jobId = await enqueueEnrichRichSummary({
+        videoId,
+        userId,
+        mandalaId,
+        title: '',
+      });
+      return reply.code(202).send({
+        status: 'ok',
+        data: { jobId, reason: 'enqueued' },
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(`enrich-bg failed: videoId=${videoId} userId=${userId} err=${msg}`);
+      return reply.code(500).send({
+        status: 'error',
+        code: 'ENRICH_BG_FAILED',
+        message: msg.slice(0, 200),
+      });
+    }
+  });
+
+  /**
    * POST /api/v1/cards/:videoId/archive — soft-hide the video within a
    * mandala (Phase 3 FE provides the visible undo affordance).
    *


### PR DESCRIPTION
## Summary
Closes the user-visible gap between **quick path completion** (3-4s, one-liner only) and **full path completion** (segments + atoms).

### Service scenario (user-confirmed 2026-05-20)
1. Add card → quick lands in 3-4s → dashboard card with one_liner + pct (already worked)
2. Click into Learning Page → if segments missing, fire `/enrich-bg` (idempotent) + subscribe to `/enrich-stream`
3. Render **"상세 요약을 생성하고 있습니다 ..."** with rolling ellipsis until SSE 'scored'
4. On 'scored' invalidate the rich-summary query → segments render without a manual refresh
5. Timeout/fail → cron Track A2 (PR #693/694) retries 12h later

### Pre-fix gap
- PanelAISummary only showed "아직 AI 요약이 생성되지 않았어요" on a fully-empty row
- Quick-done / full-missing window (the 라면 / 갤럭시 cases) → rendered nothing → looked stuck

## Changes
| Layer | Change |
|---|---|
| BE | New `POST /api/v1/cards/:videoId/enrich-bg` — idempotent (`already_complete` / `in_progress` / `enqueued`) |
| FE api-client | `apiClient.enrichCardBackground(videoId, mandalaId)` |
| FE component | PanelAISummary mount-fires `/enrich-bg`, subscribes via existing `useEnrichStream`, renders progress message |
| i18n | `learning.aiSummaryGenerating` + `learning.richSummaryGenerating` (ko/en) |
| CSS | `@keyframes enrich-dot` — 3-dot fade ellipsis (1.4s, 0.2s stagger) |

## Test plan
- [x] BE tsc PASS
- [x] FE tsc + vitest 320/320 + build PASS
- [ ] dev: open learning page for `eUGlonGv2EY` (quick='pending') → "상세 요약을 생성하고 있습니다 ..." → segments render on completion
- [ ] dev: open learning page for `WRSb3RBH2MU` (quality_flag='low') → same in-progress state → resolves on fresh enrich-bg
- [ ] dev: open learning page for a fully-complete row → no progress message, no double-fire

## Rollback
Revert PR. New endpoint is additive — nothing else calls it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)