### PR TITLE
fix(v2): SSE emits 'scored' on quick-pass + stream cap 5→10min

### DIFF
--- a/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
@@ -103,6 +103,19 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
       streamPhase === 'analyzing' ||
       (triggerKeyRef.current !== null && streamPhase === 'idle'));
 
+  // CP475+ — quick-pass closes the SSE stream long before the full path
+  // lands, so the FE needs a fallback poll until `segments` appear. 5s
+  // interval is gentle on the API and still feels live next to a Sonnet
+  // generation that averages ~90s.
+  useEffect(() => {
+    if (!youtubeId) return;
+    if (!isEnrichInProgress) return;
+    const interval = setInterval(() => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.video.richSummary(youtubeId) });
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [youtubeId, isEnrichInProgress, queryClient]);
+
   // Empty state: nothing to render. Distinguish "still being generated"
   // (background enrich in flight, or core present but segments missing)
   // from "no AI output at all" (truly empty row).

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -1004,6 +1004,32 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           closeStream();
           return;
         }
+        // CP475+ — quick path completes long before the full job moves
+        // to 'completed'. Without this check the dashboard spinner
+        // stayed in 'analyzing' for the full Sonnet duration even
+        // though `core.one_liner` + `mandala_relevance_pct` (the only
+        // fields the grid card needs) were already in the DB. We
+        // surface 'scored' as soon as the row carries the quick
+        // payload and close the stream — full path keeps running in
+        // the background; the Learning Page subscribes separately
+        // (`PanelAISummary` + `/enrich-bg`).
+        const quickRows = await prisma.$queryRaw<Array<{ has_quick: boolean }>>`
+          SELECT (
+            template_version = 'v2'
+            AND core IS NOT NULL
+            AND (core->>'one_liner') IS NOT NULL
+            AND mandala_relevance_pct IS NOT NULL
+          ) AS has_quick
+          FROM video_rich_summaries
+          WHERE video_id = ${videoId}
+          LIMIT 1
+        `;
+        if (quickRows[0]?.has_quick && lastPhase !== 'scored') {
+          sendPhase('scored', { trigger: 'quick' });
+          lastPhase = 'scored';
+          closeStream();
+          return;
+        }
         const rows = await prisma.$queryRaw<Array<{ state: string }>>`
           SELECT state
             FROM pgboss.job
@@ -1064,7 +1090,10 @@ function isUuid(s: string): boolean {
 // noticeably (LLM call takes 5-15s anyway, so 2s polling still emits
 // the transition within one cycle of the actual state change).
 const ENRICH_STREAM_POLL_MS = 2000;
-const ENRICH_STREAM_MAX_MS = 5 * 60 * 1000;
+// CP475+ — match RICH_SUMMARY_RETRY_OPTIONS.expireInMinutes (10min). The
+// previous 5min cap fired 'timeout' before the BE job could complete,
+// stranding the FE spinner without a final phase.
+const ENRICH_STREAM_MAX_MS = 10 * 60 * 1000;
 /**
  * v2-summaries batch cap — bounds response time + pg query cost. A typical
  * mandala renders 64 cards (V3_TARGET_TOTAL); doubling that absorbs heavy


### PR DESCRIPTION
## Summary
Fixes the dashboard "spinner stuck for ~90s while quick already landed" UX bug from the user's Image #75 report. The grid card only needs `core.one_liner` + `mandala_relevance_pct` (quick-path output, 3-4s); the full Sonnet generation is irrelevant to the grid view and belongs to the Learning Page (PR #696).

| Change | File |
|---|---|
| `pollOnce` reads `video_rich_summaries`; emits 'scored' as soon as the quick payload is present, then closes the stream | `src/api/routes/cards.ts` |
| `ENRICH_STREAM_MAX_MS`: 5min → 10min (matches PR #694 BE job timeout) | `src/api/routes/cards.ts` |
| `PanelAISummary` polls the rich-summary query every 5s while enrich-in-progress (because quick-pass closes SSE, not full done) | `frontend/.../PanelAISummary.tsx` |

## Measurement evidence
- Quick path p95 in current dev runs: 3-4s. Full path completed-job p95: 87s. The spinner was running ~22× longer than necessary for the grid card payload.
- BE job timeout: 10min (PR #694). SSE stream cap before this PR: 5min → mismatch → false 'timeout' for jobs finishing between 5-10min.

## Test plan
- [x] BE tsc PASS
- [x] FE tsc + vitest 320/320 + build PASS
- [ ] dev: like a card with no v2 row → spinner → 3-4s later 'scored' fires → one_liner+pct render
- [ ] dev: open Learning Page on a quick-only row → "상세 요약을 생성하고 있습니다 ..." → ~90s later segments render via 5s polling

## Rollback
Revert PR. SSE phase semantics revert to "scored = full done".

🤖 Generated with [Claude Code](https://claude.com/claude-code)