### PR TITLE
feat(chatbot): Bug 1 fix + Insighta persona — qwen-runpod adapter + middleware (CP474)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -216,6 +216,13 @@ jobs:
           TAILSCALE_IP: ${{ vars.INSIGHTA_TAILSCALE_IP }}
           QWEN_LORA_API_URL: ${{ secrets.QWEN_LORA_API_URL }}
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+          # CP474 — selects which provider the CopilotKit chatbot route uses.
+          # Values: 'gemini' | 'openrouter' | 'local' | 'qwen-runpod'.
+          # Default 'openrouter' per src/config/index.ts when unset; set the
+          # GitHub Variable CHATBOT_PROVIDER=qwen-runpod to activate the
+          # RunPod/vLLM path (also activates the Bug 1 chat.completions fix
+          # via QwenRunpodAdapter + the persona/SFT prompt middleware).
+          CHATBOT_PROVIDER: ${{ vars.CHATBOT_PROVIDER }}
           LS_API_KEY: ${{ secrets.LEMONSQUEEZY_API_KEY }}
           LS_WEBHOOK_SECRET: ${{ secrets.LEMONSQUEEZY_WEBHOOK_SECRET }}
           LS_STORE_ID: ${{ vars.LEMONSQUEEZY_STORE_ID }}
@@ -250,7 +257,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
+          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
           script: |
             set -e
             cd /opt/tubearchive
@@ -367,6 +374,12 @@ jobs:
             fi
             if [ -n "${RUNPOD_API_KEY}" ]; then
               grep -q '^RUNPOD_API_KEY=' .env 2>/dev/null && sed -i "s|^RUNPOD_API_KEY=.*|RUNPOD_API_KEY=${RUNPOD_API_KEY}|" .env || echo "RUNPOD_API_KEY=${RUNPOD_API_KEY}" >> .env
+            fi
+            # CP474 — chatbot provider selector. Empty/unset ⇒ BE default
+            # 'openrouter' (src/config/index.ts:109). Set 'qwen-runpod' to
+            # activate the RunPod/vLLM path + Bug 1 chat.completions fix.
+            if [ -n "${CHATBOT_PROVIDER}" ]; then
+              grep -q '^CHATBOT_PROVIDER=' .env 2>/dev/null && sed -i "s|^CHATBOT_PROVIDER=.*|CHATBOT_PROVIDER=${CHATBOT_PROVIDER}|" .env || echo "CHATBOT_PROVIDER=${CHATBOT_PROVIDER}" >> .env
             fi
             # CP456 — Lemon Squeezy billing. billingConfig.enabled requires
             # API_KEY + WEBHOOK_SECRET + STORE_ID + VARIANT_MONTHLY +

--- a/reports/hardcode-audit/baseline.json
+++ b/reports/hardcode-audit/baseline.json
@@ -1,6 +1,6 @@
 {
   "ms-per-day-redeclared": 0,
-  "process-env-direct-read": 35,
+  "process-env-direct-read": 33,
   "inline-env-parser": 0,
   "raw-ms-per-day-literal": 0,
   "raw-ms-per-hour-literal": 0

--- a/src/api/routes/copilotkit.ts
+++ b/src/api/routes/copilotkit.ts
@@ -1,8 +1,14 @@
 import 'reflect-metadata';
 import { FastifyPluginCallback } from 'fastify';
-import { CopilotRuntime, OpenAIAdapter, copilotRuntimeNodeHttpEndpoint } from '@copilotkit/runtime';
+import {
+  CopilotRuntime,
+  OpenAIAdapter,
+  copilotRuntimeNodeHttpEndpoint,
+  type CopilotServiceAdapter,
+} from '@copilotkit/runtime';
 import OpenAI from 'openai';
 import { config } from '@/config/index';
+import { QwenRunpodAdapter } from '@/modules/chatbot-rag';
 
 type ChatbotProvider = 'gemini' | 'openrouter' | 'local' | 'qwen-runpod';
 
@@ -17,7 +23,7 @@ function toRunpodOpenAiBase(raw: string): string {
   return trimmed.replace(/\/(?:runsync|run)$/, '') + '/openai/v1';
 }
 
-function createServiceAdapter(provider: ChatbotProvider, model?: string): OpenAIAdapter {
+function createServiceAdapter(provider: ChatbotProvider, model?: string): CopilotServiceAdapter {
   switch (provider) {
     case 'gemini':
     case 'openrouter':
@@ -39,13 +45,16 @@ function createServiceAdapter(provider: ChatbotProvider, model?: string): OpenAI
       });
 
     case 'qwen-runpod':
+      // CP474 — QwenRunpodAdapter uses createOpenAI({...}).chat(model) so the
+      // request hits /v1/chat/completions (vLLM-compatible) instead of the
+      // /v1/responses path that OpenAIAdapter's getLanguageModel() routes to.
+      // This is the Bug 1 fix: multi-turn chats no longer fail with
+      // "Invalid Responses API request" on the second turn.
       if (!config.qwenLora.apiUrl) throw new Error('QWEN_LORA_API_URL not set');
       if (!config.runpod.apiKey) throw new Error('RUNPOD_API_KEY not set');
-      return new OpenAIAdapter({
-        openai: new OpenAI({
-          apiKey: config.runpod.apiKey,
-          baseURL: toRunpodOpenAiBase(config.qwenLora.apiUrl),
-        }),
+      return new QwenRunpodAdapter({
+        baseURL: toRunpodOpenAiBase(config.qwenLora.apiUrl),
+        apiKey: config.runpod.apiKey,
         model: model || config.qwenLora.model,
       });
   }

--- a/src/config/transcript.ts
+++ b/src/config/transcript.ts
@@ -1,0 +1,56 @@
+/**
+ * Transcript proxy configuration (Mac Mini Tailscale path).
+ *
+ * EC2 us-west-2 outbound to YouTube is rate-limited / returns false
+ * "Transcript is disabled". The Mac Mini proxy (KR residential ISP IP)
+ * is the primary transcript fetcher; EC2 falls back to direct
+ * youtube-transcript only when the proxy is unreachable.
+ *
+ * Both values are optional — if unset the consumer treats the Mac Mini
+ * path as disabled and uses the direct fallback unconditionally.
+ *
+ * Consumers (replace previous in-file `process.env` reads):
+ *   - src/modules/caption/extractor.ts          (primary fetch path)
+ *   - src/modules/chatbot-rag/video-context-loader.ts  (source label heuristic)
+ *
+ * Hardcode-audit baseline impact: removes 3 `process-env-direct-read`
+ * violations (2 in extractor.ts + 1 in video-context-loader.ts).
+ */
+
+import { z } from 'zod';
+
+const optionalStr = z.preprocess((v) => {
+  if (v == null) return '';
+  const s = String(v).trim();
+  return s;
+}, z.string());
+
+export const transcriptEnvSchema = z.object({
+  MAC_MINI_TRANSCRIPT_URL: optionalStr.default(''),
+  MAC_MINI_TRANSCRIPT_TOKEN: optionalStr.default(''),
+});
+
+export interface TranscriptConfig {
+  /** Mac Mini proxy base URL. Empty string ⇒ proxy disabled. */
+  macMiniUrl: string;
+  /** Bearer token (`x-transcript-token` header) for the Mac Mini proxy. */
+  macMiniToken: string;
+  /** True iff both URL and token are non-empty. */
+  macMiniEnabled: boolean;
+}
+
+export function loadTranscriptConfig(env: NodeJS.ProcessEnv = process.env): TranscriptConfig {
+  const parsed = transcriptEnvSchema.safeParse({
+    MAC_MINI_TRANSCRIPT_URL: env['MAC_MINI_TRANSCRIPT_URL'],
+    MAC_MINI_TRANSCRIPT_TOKEN: env['MAC_MINI_TRANSCRIPT_TOKEN'],
+  });
+  if (!parsed.success) {
+    return { macMiniUrl: '', macMiniToken: '', macMiniEnabled: false };
+  }
+  const { MAC_MINI_TRANSCRIPT_URL: url, MAC_MINI_TRANSCRIPT_TOKEN: token } = parsed.data;
+  return {
+    macMiniUrl: url,
+    macMiniToken: token,
+    macMiniEnabled: url.length > 0 && token.length > 0,
+  };
+}

--- a/src/modules/caption/extractor.ts
+++ b/src/modules/caption/extractor.ts
@@ -19,6 +19,7 @@ async function loadFetchTranscript() {
   return mod.fetchTranscript;
 }
 import { logger } from '../../utils/logger';
+import { loadTranscriptConfig } from '@/config/transcript';
 
 // Mac Mini transcript proxy. EC2 us-west-2 outbound to YouTube is rate-
 // limited / returns false "Transcript is disabled" — verified by apples-
@@ -27,8 +28,9 @@ import { logger } from '../../utils/logger';
 // MAC_MINI_TRANSCRIPT_URL is set, we forward the fetch to Mac Mini over
 // Tailscale; the EC2 caption-extractor falls back to direct youtube-
 // transcript only if the proxy is unreachable (defence in depth).
-const MAC_MINI_URL = process.env['MAC_MINI_TRANSCRIPT_URL'] ?? '';
-const MAC_MINI_TOKEN = process.env['MAC_MINI_TRANSCRIPT_TOKEN'] ?? '';
+const TRANSCRIPT_CONFIG = loadTranscriptConfig();
+const MAC_MINI_URL = TRANSCRIPT_CONFIG.macMiniUrl;
+const MAC_MINI_TOKEN = TRANSCRIPT_CONFIG.macMiniToken;
 const MAC_MINI_TIMEOUT_MS = 30_000;
 
 interface MacMiniSegment {

--- a/src/modules/chatbot-rag/index.ts
+++ b/src/modules/chatbot-rag/index.ts
@@ -1,0 +1,59 @@
+/**
+ * src/modules/chatbot-rag/index.ts
+ *
+ * Public surface of the chatbot RAG module.
+ *
+ * Consumers (BE only — FE never imports this module):
+ *   - src/api/routes/copilotkit.ts  (qwen-runpod adapter wire-up; Stage 4)
+ *   - tests/integration/**          (E2E chatbot path verification)
+ *   - scripts/lora-chatbot/*        (SSOT mirror to Python — Stage 5)
+ */
+
+// Existing SSOT (untouched by CP474 Phase B initial commit)
+export {
+  buildQwenSystemPrompt,
+  deriveTrainingLayer,
+  ROLE_AND_RULES_KO,
+  ROLE_AND_RULES_EN,
+  LAYER_BLOCKS,
+  type ChatLayer,
+  type Lang,
+  type V2Summary,
+  type V2Core,
+  type V2Analysis,
+  type V2Segments,
+  type V2Section,
+  type V2Atom,
+  type KeyConcept,
+  type MandalaContext,
+  type RegionContext,
+  type MandalaFit,
+  type BlockId,
+  type BuildQwenSystemPromptParams,
+} from './prompt-builder';
+
+// NEW in CP474 Phase B — shared types
+export {
+  type UserContext,
+  type TranscriptContext,
+  type RAGSourceType,
+  type RAGResult,
+  type RAGContext,
+  MAX_MANDALA_TITLES,
+  RECENT_DAYS_WINDOW,
+  TRANSCRIPT_PROMPT_MAX_CHARS,
+} from './types';
+
+// NEW in CP474 Phase B — loaders + retriever + adapter
+export { loadUserContext, type LoadUserContextParams } from './user-context-loader';
+
+export {
+  loadVideoContext,
+  summaryHasUsableContent,
+  type VideoGroundingResult,
+  type LoadVideoContextParams,
+} from './video-context-loader';
+
+export { retrieveRAGContext, type RetrieveRAGContextParams } from './retriever';
+
+export { QwenRunpodAdapter, type QwenRunpodAdapterParams } from './qwen-runpod-adapter';

--- a/src/modules/chatbot-rag/index.ts
+++ b/src/modules/chatbot-rag/index.ts
@@ -57,3 +57,11 @@ export {
 export { retrieveRAGContext, type RetrieveRAGContextParams } from './retriever';
 
 export { QwenRunpodAdapter, type QwenRunpodAdapterParams } from './qwen-runpod-adapter';
+
+// CP474 Stage 7a — Vercel AI SDK middleware that rewrites system prompts
+// at the LanguageModel layer (persona + v2/transcript fallback injection).
+export {
+  createQwenPromptMiddleware,
+  rewriteSystemPrompt,
+  rewriteSystemContent,
+} from './qwen-prompt-middleware';

--- a/src/modules/chatbot-rag/prompt-builder.ts
+++ b/src/modules/chatbot-rag/prompt-builder.ts
@@ -10,7 +10,17 @@
  * Used by:
  *   - BE serving (qwen-lora mode):  /api/v1/chat/qwen route (TBD)
  *   - LoRA training data generator:  convert-to-sft-v2.py (Python mirror)
+ *
+ * CP474 extensions (inference-only, NOT in training data):
+ *   - PRODUCT_PERSONA prepended (Insighta intro + glossary) — eliminates
+ *     "Insighta = DAMO Academy" hallucination class.
+ *   - Block U: per-user session context (tier / mandala list / activity).
+ *   - Block T: raw transcript fallback when v2 rich summary is absent.
+ *   - Block H: RAG retrieval results (cards / notes / KG concepts).
+ *   - EXTENDED_RULES appended only when any of {U, T, H} present, so the
+ *     original SFT-aligned ROLE_AND_RULES_KO/EN stays byte-identical.
  */
+import type { UserContext, TranscriptContext, RAGContext, RAGResult } from './types';
 
 // ============================================================================
 // Types
@@ -116,18 +126,91 @@ You are Insighta's learning assistant. Help the user based on their mandala char
 - Quote the video; prefer concrete facts over abstract summary.`;
 
 // ============================================================================
+// Product persona + glossary (CP474 — NEW, prepended before role/rules)
+//
+// These two blocks eliminate the "Insighta = DAMO Academy" hallucination
+// class observed during raw-curl LoRA testing. The model has no product
+// docs in its SFT data — feeding the brief here grounds product Q&A.
+// ============================================================================
+
+export const PRODUCT_PERSONA_KO = `[Insighta 소개]
+Insighta 는 YouTube 영상 기반 개인 지식 관리 플랫폼입니다. 핵심 구조:
+- 9x9 만다라 차트로 학습 목표 체계화 (1 중심 목표 + 8 서브 목표 + 64 액션 cell = 총 81 cell)
+- 사용자가 YouTube 영상을 만다라 cell 에 매핑하여 학습 진행
+- AI 챗봇이 영상 내용 + 만다라 컨텍스트를 활용해 사용자 학습 지원
+- 결제 tier: Free (3 만다라/150 카드) / Pro (20 만다라/1K 카드) / Lifetime (무제한)
+
+[Insighta 용어 사전]
+- 만다라 (Mandala): 사용자의 9x9 학습 목표 차트. 81개 cell 로 구성
+- Center goal (중심 목표): 만다라 가운데 cell, 사용자의 최종 학습 목표
+- Sub-goal (서브 목표): 중심 목표 주변 8개 cell, 1차 분해된 학습 영역
+- Action cell (실행 cell): 각 sub-goal 의 8개 세부 액션, 영상이 매핑되는 단위
+- Card (카드): 만다라 cell 에 매핑된 YouTube 영상 1개
+- Wizard mode (위자드 모드): 만다라 자동 생성 도우미
+- Learning page (학습 페이지): 영상 + 노트 + 챗봇 3-panel UI`;
+
+export const PRODUCT_PERSONA_EN = `[About Insighta]
+Insighta is a YouTube-based personal knowledge management platform. Core structure:
+- 9x9 mandala chart to organize learning goals (1 center + 8 sub-goals + 64 action cells = 81 cells total)
+- Users map YouTube videos to mandala cells to track learning progress
+- AI chatbot leverages video content + mandala context to support learning
+- Tiers: Free (3 mandalas / 150 cards) / Pro (20 / 1K) / Lifetime (unlimited)
+
+[Insighta glossary]
+- Mandala: a user's 9x9 learning goal chart (81 cells)
+- Center goal: the chart's middle cell — the user's top-level learning objective
+- Sub-goal: each of the 8 cells around the center — a 1st-level decomposition
+- Action cell: 8 cells per sub-goal — granular learning actions; videos attach here
+- Card: a YouTube video mapped to a mandala cell
+- Wizard mode: assistant that auto-generates the initial mandala
+- Learning page: 3-panel UI combining video, notes, and chatbot`;
+
+// EXTENDED_RULES — appended only when any of Block {U, T, H} is present.
+// Keeps the SFT-aligned ROLE_AND_RULES_KO/EN byte-identical for layers that
+// don't use the CP474 extensions.
+export const EXTENDED_RULES_KO = `[추가 규칙]
+- Insighta 제품/기능 질문은 [Insighta 소개] 및 [용어 사전] 에 근거하여 답변
+- [관련 자료 (RAG)] 가 있으면 적극 활용 — 출처 명시 (예: "당신이 학습한 X 영상에서도…", "당신의 노트(YYYY-MM-DD)에 따르면…")
+- [영상 정보] 가 없고 [원본 자막] 만 있으면 자막에서 직접 발췌하여 답변 (추상 요약 X, 발화 인용)
+- [영상 정보] 와 [원본 자막] 둘 다 없으면 "이 영상은 아직 분석되지 않았어요" 명시 후 일반 답변`;
+
+export const EXTENDED_RULES_EN = `[Additional rules]
+- Product/feature questions about Insighta MUST be grounded in [About Insighta] and [Insighta glossary] above.
+- If [Related Materials (RAG)] is present, cite explicitly (e.g., "From the X video you watched…", "Your note (YYYY-MM-DD) states…").
+- If only [Raw Transcript] is present (no [Video info]), quote the transcript directly instead of summarising.
+- If neither [Video info] nor [Raw Transcript] is present, reply "This video hasn't been analysed yet" before answering generally.`;
+
+// ============================================================================
 // Layer → Blocks mapping (§3.3)
 // ============================================================================
 
-export type BlockId = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G';
+export type BlockId = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'T' | 'U' | 'H';
 
+/**
+ * v2-grounded layer mapping (Block A-D come from V2Summary).
+ * U (user) + H (RAG) are appended to every layer — they're orthogonal
+ * to the chat surface the user is hovering over.
+ */
 export const LAYER_BLOCKS: Record<ChatLayer, BlockId[]> = {
-  global: ['A'],
-  mandala: ['A', 'E'],
-  cell: ['A', 'B', 'C', 'E'],
-  video: ['A', 'B', 'C', 'D'],
-  'video-time': ['A', 'B', 'C', 'D', 'F'],
-  note: ['A', 'B', 'C', 'D', 'F', 'G'],
+  global: ['A', 'U', 'H'],
+  mandala: ['A', 'E', 'U', 'H'],
+  cell: ['A', 'B', 'C', 'E', 'U', 'H'],
+  video: ['A', 'B', 'C', 'D', 'U', 'H'],
+  'video-time': ['A', 'B', 'C', 'D', 'F', 'U', 'H'],
+  note: ['A', 'B', 'C', 'D', 'F', 'G', 'U', 'H'],
+};
+
+/**
+ * Transcript-fallback layer mapping (Block T replaces Block A-D when no
+ * v2 rich summary exists for the current video). U/H remain available.
+ */
+export const LAYER_BLOCKS_FALLBACK: Record<ChatLayer, BlockId[]> = {
+  global: ['T', 'U', 'H'],
+  mandala: ['T', 'E', 'U', 'H'],
+  cell: ['T', 'E', 'U', 'H'],
+  video: ['T', 'U', 'H'],
+  'video-time': ['T', 'F', 'U', 'H'],
+  note: ['T', 'F', 'G', 'U', 'H'],
 };
 
 // ============================================================================
@@ -251,6 +334,134 @@ function blockG(r: RegionContext, lang: Lang): string | null {
 }
 
 // ============================================================================
+// Block T — Transcript fallback (CP474 NEW)
+//
+// Emitted when no v2 rich summary exists. The transcript is already
+// truncated to TRANSCRIPT_PROMPT_MAX_CHARS upstream (video-context-loader.ts).
+// ============================================================================
+
+function blockT(t: TranscriptContext, lang: Lang): string {
+  if (lang === 'ko') {
+    const header = '[원본 자막] (AI 요약 미생성, 자막 원본 활용)';
+    const meta = `출처: ${t.source} / 언어: ${t.language}`;
+    const note = t.truncated ? '\n\n[자막 일부 잘림 — 위 내용만 활용]' : '';
+    return `${header}\n${meta}\n${t.full_text}${note}`;
+  }
+  const header = '[Raw Transcript] (no AI summary yet — quote captions directly)';
+  const meta = `Source: ${t.source} / Language: ${t.language}`;
+  const note = t.truncated ? '\n\n[Transcript truncated — use the above only]' : '';
+  return `${header}\n${meta}\n${t.full_text}${note}`;
+}
+
+// ============================================================================
+// Block U — User session context (CP474 NEW)
+// ============================================================================
+
+function blockU(u: UserContext, lang: Lang): string | null {
+  // Defensive: blank user context (no tier signal, empty mandalas, no email)
+  // → emit nothing rather than a near-empty block.
+  if (!u.email && u.tier === 'free' && u.mandala_count === 0) {
+    return null;
+  }
+
+  if (lang === 'ko') {
+    const lines = ['[사용자 컨텍스트]'];
+    lines.push(`사용자: ${u.display_name}${u.email ? ` (${u.email})` : ''}`);
+    lines.push(`Tier: ${u.tier}`);
+    if (u.join_date && u.days_active > 0) {
+      lines.push(`가입일: ${u.join_date} (${u.days_active}일째 학습 중)`);
+    }
+    if (u.mandala_count > 0 && u.mandala_titles.length > 0) {
+      const titles = u.mandala_titles.map((t) => `"${t}"`).join(', ');
+      lines.push(`운영 중인 만다라: ${u.mandala_count}개 (${titles})`);
+    }
+    if (u.current_mandala_name) {
+      lines.push(`현재 만다라: ${u.current_mandala_name}`);
+    }
+    if (u.recent_card_count_7d > 0) {
+      lines.push(`이번 주 학습 카드: ${u.recent_card_count_7d}개`);
+    }
+    return lines.join('\n');
+  }
+
+  const lines = ['[User context]'];
+  lines.push(`User: ${u.display_name}${u.email ? ` (${u.email})` : ''}`);
+  lines.push(`Tier: ${u.tier}`);
+  if (u.join_date && u.days_active > 0) {
+    lines.push(`Joined: ${u.join_date} (${u.days_active} days learning)`);
+  }
+  if (u.mandala_count > 0 && u.mandala_titles.length > 0) {
+    const titles = u.mandala_titles.map((t) => `"${t}"`).join(', ');
+    lines.push(`Active mandalas: ${u.mandala_count} (${titles})`);
+  }
+  if (u.current_mandala_name) {
+    lines.push(`Current mandala: ${u.current_mandala_name}`);
+  }
+  if (u.recent_card_count_7d > 0) {
+    lines.push(`Cards added this week: ${u.recent_card_count_7d}`);
+  }
+  return lines.join('\n');
+}
+
+// ============================================================================
+// Block H — RAG context (CP474 NEW)
+// ============================================================================
+
+function formatRAGResult(r: RAGResult, lang: Lang, index: number): string {
+  if (lang === 'ko') {
+    const lines: string[] = [];
+    const label =
+      r.source_type === 'card'
+        ? '저장 카드'
+        : r.source_type === 'note'
+          ? '내 노트'
+          : 'Knowledge Graph';
+    const where =
+      r.mandala_name && r.cell_name
+        ? ` — ${r.mandala_name} / ${r.cell_name}`
+        : r.mandala_name
+          ? ` — ${r.mandala_name}`
+          : '';
+    lines.push(`${index + 1}. ${label}${where}: "${r.title}"`);
+    if (r.excerpt) lines.push(`   ${r.excerpt}`);
+    if (r.date) lines.push(`   (${r.date})`);
+    if (r.kg_links && r.kg_links.length > 0) {
+      const kg = r.kg_links.map((k) => `${k.concept} (${k.card_count} 카드)`).join(', ');
+      lines.push(`   연결: ${kg}`);
+    }
+    return lines.join('\n');
+  }
+  const lines: string[] = [];
+  const label =
+    r.source_type === 'card'
+      ? 'Saved card'
+      : r.source_type === 'note'
+        ? 'My note'
+        : 'Knowledge Graph';
+  const where =
+    r.mandala_name && r.cell_name
+      ? ` — ${r.mandala_name} / ${r.cell_name}`
+      : r.mandala_name
+        ? ` — ${r.mandala_name}`
+        : '';
+  lines.push(`${index + 1}. ${label}${where}: "${r.title}"`);
+  if (r.excerpt) lines.push(`   ${r.excerpt}`);
+  if (r.date) lines.push(`   (${r.date})`);
+  if (r.kg_links && r.kg_links.length > 0) {
+    const kg = r.kg_links.map((k) => `${k.concept} (${k.card_count} cards)`).join(', ');
+    lines.push(`   Links: ${kg}`);
+  }
+  return lines.join('\n');
+}
+
+function blockH(rc: RAGContext, lang: Lang): string | null {
+  if (!rc.results || rc.results.length === 0) return null;
+  const header = lang === 'ko' ? '[관련 자료 (RAG)]' : '[Related Materials (RAG)]';
+  const items = rc.results.map((r, i) => formatRAGResult(r, lang, i));
+  return [header, ...items].join('\n\n');
+}
+
+// ============================================================================
 // Main builder
 // ============================================================================
 
@@ -260,25 +471,97 @@ export interface BuildQwenSystemPromptParams {
   v2Data?: V2Summary | null;
   mandalaContext?: MandalaContext | null;
   regionContext?: RegionContext | null;
+  /** CP474 — per-user session context (Block U). */
+  userContext?: UserContext | null;
+  /** CP474 — transcript fallback (Block T). Used only when v2Data absent. */
+  transcript?: TranscriptContext | null;
+  /** CP474 — RAG retrieval results (Block H). */
+  ragContext?: RAGContext | null;
+  /**
+   * CP474 — when false, omit PRODUCT_PERSONA / EXTENDED_RULES so the output
+   * is byte-identical to the legacy SFT-aligned format (used by training-
+   * data generation paths or A/B comparison). Default true (production).
+   */
+  includePersona?: boolean;
 }
 
 export function buildQwenSystemPrompt(params: BuildQwenSystemPromptParams): string {
-  const { layer, language, v2Data, mandalaContext, regionContext } = params;
+  const {
+    layer,
+    language,
+    v2Data,
+    mandalaContext,
+    regionContext,
+    userContext,
+    transcript,
+    ragContext,
+  } = params;
+  const includePersona = params.includePersona ?? true;
 
-  const wanted = LAYER_BLOCKS[layer] ?? LAYER_BLOCKS.global;
-  const blocks: string[] = [language === 'ko' ? ROLE_AND_RULES_KO : ROLE_AND_RULES_EN];
+  // Decide block set: v2 present → standard (A-D); else transcript exists
+  // → fallback (T); else still walk the standard set and let each block
+  // builder no-op when its source data is null.
+  const useFallback = !v2Data && Boolean(transcript);
+  const wanted = useFallback
+    ? (LAYER_BLOCKS_FALLBACK[layer] ?? LAYER_BLOCKS_FALLBACK.global)
+    : (LAYER_BLOCKS[layer] ?? LAYER_BLOCKS.global);
 
-  const push = (b: string | null) => {
+  const blocks: string[] = [];
+
+  // Persona + glossary (CP474 — always first when enabled).
+  if (includePersona) {
+    blocks.push(language === 'ko' ? PRODUCT_PERSONA_KO : PRODUCT_PERSONA_EN);
+  }
+
+  // SFT-aligned role + rules (byte-identical to training data).
+  blocks.push(language === 'ko' ? ROLE_AND_RULES_KO : ROLE_AND_RULES_EN);
+
+  // Extended rules — only when any CP474 block is in play. Keeps legacy
+  // layers free of training-data drift.
+  const hasExtended =
+    includePersona && (Boolean(userContext) || Boolean(transcript) || Boolean(ragContext));
+  if (hasExtended) {
+    blocks.push(language === 'ko' ? EXTENDED_RULES_KO : EXTENDED_RULES_EN);
+  }
+
+  const push = (b: string | null): void => {
     if (b) blocks.push(b);
   };
 
-  if (wanted.includes('A') && v2Data) push(blockA(v2Data, language));
-  if (wanted.includes('B') && v2Data) push(blockB(v2Data, language));
-  if (wanted.includes('C') && v2Data) push(blockC(v2Data, language));
-  if (wanted.includes('D') && v2Data) push(blockD(v2Data, language));
-  if (wanted.includes('E') && mandalaContext) push(blockE(mandalaContext, language));
-  if (wanted.includes('F') && regionContext) push(blockF(regionContext, language));
-  if (wanted.includes('G') && regionContext) push(blockG(regionContext, language));
+  for (const id of wanted) {
+    switch (id) {
+      case 'A':
+        if (v2Data) push(blockA(v2Data, language));
+        break;
+      case 'B':
+        if (v2Data) push(blockB(v2Data, language));
+        break;
+      case 'C':
+        if (v2Data) push(blockC(v2Data, language));
+        break;
+      case 'D':
+        if (v2Data) push(blockD(v2Data, language));
+        break;
+      case 'E':
+        if (mandalaContext) push(blockE(mandalaContext, language));
+        break;
+      case 'F':
+        if (regionContext) push(blockF(regionContext, language));
+        break;
+      case 'G':
+        if (regionContext) push(blockG(regionContext, language));
+        break;
+      case 'T':
+        if (transcript) push(blockT(transcript, language));
+        break;
+      case 'U':
+        if (userContext) push(blockU(userContext, language));
+        break;
+      case 'H':
+        if (ragContext) push(blockH(ragContext, language));
+        break;
+    }
+  }
 
   return blocks.join('\n\n');
 }

--- a/src/modules/chatbot-rag/qwen-prompt-middleware.ts
+++ b/src/modules/chatbot-rag/qwen-prompt-middleware.ts
@@ -1,0 +1,183 @@
+/**
+ * src/modules/chatbot-rag/qwen-prompt-middleware.ts
+ *
+ * Vercel AI SDK middleware (LanguageModelV3) that rewrites the system
+ * prompt for qwen-runpod requests so the LoRA model receives its
+ * SFT-aligned format (Persona + Block A-D or Block T) instead of the
+ * legacy FE-built English prompt.
+ *
+ * Path (per call):
+ *   1. Extract concatenated system-message content from `params.prompt`.
+ *   2. Parse YouTube video_id from the URL embedded by the FE builder.
+ *   3. Detect language (`ko` default, `en` when FE prompt opens "You are").
+ *   4. Load video context (v2 row OR transcript fallback) — cached 5min.
+ *   5. Call `buildQwenSystemPrompt({ ..., includePersona: true })`.
+ *   6. Replace all system messages with a single new one carrying the
+ *      SFT-aligned prompt.
+ *
+ * Out of scope (deferred to Stage 7b+):
+ *   - userId-aware Block U / Block H. The middleware runs at the
+ *     LanguageModel layer and doesn't have direct access to the HTTP
+ *     request's JWT. Threading user identity through CopilotRuntime
+ *     context is a separate plumbing change.
+ *
+ * Fail-safe: any error in the middleware returns the original params
+ * unchanged so requests still succeed (just without persona injection).
+ */
+
+import type { LanguageModelV3Middleware, LanguageModelV3Message } from '@ai-sdk/provider';
+import { logger } from '@/utils/logger';
+import { buildQwenSystemPrompt, type ChatLayer, type Lang } from './prompt-builder';
+import { loadVideoContext, type VideoGroundingResult } from './video-context-loader';
+
+const log = logger.child({ module: 'chatbot-rag/qwen-prompt-middleware' });
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Matches the FE's video URL pattern; group 1 = 11-char video id. */
+const VIDEO_ID_REGEX = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+
+/** Per-videoId cache TTL for context loads. 5 minutes balances freshness vs latency. */
+const VIDEO_CONTEXT_CACHE_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  context: VideoGroundingResult;
+  expiresAt: number;
+}
+
+const videoContextCache = new Map<string, CacheEntry>();
+
+// Test hook — clears the singleton cache between unit tests.
+export function _resetMiddlewareCacheForTesting(): void {
+  videoContextCache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a fresh middleware instance. Each call returns a new object so
+ * the underlying cache (module-level) can be shared across instances but
+ * the middleware object itself stays disposable.
+ */
+export function createQwenPromptMiddleware(): LanguageModelV3Middleware {
+  return {
+    specificationVersion: 'v3' as const,
+    transformParams: async ({ params }) => {
+      try {
+        const rewritten = await rewriteSystemPrompt(params.prompt);
+        if (!rewritten) return params;
+        return { ...params, prompt: rewritten };
+      } catch (err) {
+        log.warn('middleware failed; forwarding original params', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return params;
+      }
+    },
+  };
+}
+
+/**
+ * Exposed for the AI SDK middleware path (getLanguageModel route).
+ * Returns the rewritten LanguageModelV3 prompt or null when nothing
+ * needed rewriting.
+ */
+export async function rewriteSystemPrompt(
+  prompt: LanguageModelV3Message[]
+): Promise<LanguageModelV3Message[] | null> {
+  if (prompt.length === 0) return null;
+
+  // Split system vs non-system messages, preserving order of the latter.
+  const systemContents: string[] = [];
+  const otherMessages: LanguageModelV3Message[] = [];
+
+  for (const msg of prompt) {
+    if (msg.role === 'system' && typeof msg.content === 'string') {
+      systemContents.push(msg.content);
+    } else {
+      otherMessages.push(msg);
+    }
+  }
+
+  const newSystemContent = await rewriteSystemContent(systemContents.join('\n\n'));
+
+  const newSystemMsg: LanguageModelV3Message = {
+    role: 'system',
+    content: newSystemContent,
+  };
+
+  return [newSystemMsg, ...otherMessages];
+}
+
+/**
+ * Plain-string variant for the legacy SSE streaming path (QwenRunpodAdapter.process).
+ *
+ * Same pipeline as rewriteSystemPrompt but consumes/returns a single
+ * concatenated system-content string — process() builds `{role, content:
+ * string}` directly from CopilotKit TextMessages, so the V3Message shape
+ * conversion isn't needed.
+ */
+export async function rewriteSystemContent(originalSystemContent: string): Promise<string> {
+  const language = detectLanguage(originalSystemContent);
+
+  const videoMatch = VIDEO_ID_REGEX.exec(originalSystemContent);
+  const youtubeVideoId = videoMatch?.[1] ?? null;
+
+  let videoCtx: VideoGroundingResult = { v2Data: null, transcript: null };
+  if (youtubeVideoId) {
+    videoCtx = await loadCachedVideoContext(youtubeVideoId, language);
+  }
+
+  const layer: ChatLayer = youtubeVideoId ? 'video' : 'global';
+
+  return buildQwenSystemPrompt({
+    layer,
+    language,
+    v2Data: videoCtx.v2Data,
+    transcript: videoCtx.transcript,
+    includePersona: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+async function loadCachedVideoContext(
+  videoId: string,
+  language: Lang
+): Promise<VideoGroundingResult> {
+  const cached = videoContextCache.get(videoId);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.context;
+  }
+
+  const fresh = await loadVideoContext({
+    youtubeVideoId: videoId,
+    preferredLanguage: language,
+  });
+  videoContextCache.set(videoId, {
+    context: fresh,
+    expiresAt: Date.now() + VIDEO_CONTEXT_CACHE_MS,
+  });
+  return fresh;
+}
+
+/**
+ * Lightweight language sniff. FE buildInstructions begins with English
+ * "You are Insighta's learning assistant." when language=en, otherwise
+ * with Korean role intro. We don't ship i18n parsing into the middleware
+ * — a single first-line probe is enough for the persona language toggle.
+ */
+function detectLanguage(systemContent: string): Lang {
+  const firstLine = systemContent.slice(0, 200);
+  if (/^You are Insighta/i.test(firstLine)) return 'en';
+  if (/You are/i.test(firstLine) && !/한국어|만다라|챗봇|학습/.test(firstLine)) {
+    return 'en';
+  }
+  return 'ko';
+}

--- a/src/modules/chatbot-rag/qwen-runpod-adapter.ts
+++ b/src/modules/chatbot-rag/qwen-runpod-adapter.ts
@@ -32,13 +32,17 @@
 
 import OpenAI from 'openai';
 import { createOpenAI } from '@ai-sdk/openai';
-import type { LanguageModel } from 'ai';
+import { wrapLanguageModel, type LanguageModel } from 'ai';
 import { randomUUID } from '@copilotkit/shared';
 import type {
   CopilotServiceAdapter,
   CopilotRuntimeChatCompletionRequest,
   CopilotRuntimeChatCompletionResponse,
 } from '@copilotkit/runtime';
+import { createQwenPromptMiddleware, rewriteSystemContent } from './qwen-prompt-middleware';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'chatbot-rag/qwen-runpod-adapter' });
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -105,13 +109,21 @@ export class QwenRunpodAdapter implements CopilotServiceAdapter {
    * 비교:
    *   - `createOpenAI({...})(modelId)` → Responses API (❌ Bug 1 source)
    *   - `createOpenAI({...}).chat(modelId)` → chat.completions (✅ vLLM compat)
+   *
+   * The base chat.completions model is wrapped with the qwen prompt middleware
+   * which rewrites the system message to the SFT-aligned format (persona +
+   * Block A-D or Block T) on every request.
    */
   getLanguageModel(): LanguageModel {
     const aiProvider = createOpenAI({
       baseURL: this.baseURL,
       apiKey: this.apiKey,
     });
-    return aiProvider.chat(this.model);
+    const baseModel = aiProvider.chat(this.model);
+    return wrapLanguageModel({
+      model: baseModel,
+      middleware: createQwenPromptMiddleware(),
+    });
   }
 
   /**
@@ -130,10 +142,15 @@ export class QwenRunpodAdapter implements CopilotServiceAdapter {
   ): Promise<CopilotRuntimeChatCompletionResponse> {
     const { messages, eventSource, threadId, forwardedParameters } = request;
 
-    const openaiMessages = messages.filter(textMessageGuard).map((m) => {
+    const rawMessages = messages.filter(textMessageGuard).map((m) => {
       const t = m as unknown as TextMessageLike;
       return { role: normalizeRole(t.role), content: t.content };
     });
+
+    // CP474 Stage 7a — rewrite the system prompt to the SFT-aligned format
+    // (Persona + Block A-D or Block T). Non-system messages pass through
+    // unchanged. Fail-safe: any error reverts to original messages.
+    const openaiMessages = await applySFTRewrite(rawMessages);
 
     // vLLM-specific: chat_template_kwargs (enable_thinking=false) is forwarded
     // as an extra body key. OpenAI SDK's chat.completions request type doesn't
@@ -217,6 +234,11 @@ export class QwenRunpodAdapter implements CopilotServiceAdapter {
 
 type TextMessageLike = { isTextMessage: () => boolean; role: string; content: string };
 
+interface OpenAIChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
 function textMessageGuard(m: unknown): m is TextMessageLike {
   if (!m || typeof m !== 'object') return false;
   const guard = m as { isTextMessage?: () => boolean };
@@ -227,4 +249,26 @@ function normalizeRole(role: string): 'system' | 'user' | 'assistant' {
   if (role === 'system' || role === 'developer') return 'system';
   if (role === 'assistant') return 'assistant';
   return 'user';
+}
+
+/**
+ * Concatenates all system messages, runs them through `rewriteSystemContent`,
+ * and returns a fresh messages array with a single rewritten system message
+ * followed by the original non-system messages.
+ *
+ * Fail-safe: any thrown error logs and returns the input unchanged.
+ */
+async function applySFTRewrite(messages: OpenAIChatMessage[]): Promise<OpenAIChatMessage[]> {
+  try {
+    const systemContents = messages.filter((m) => m.role === 'system').map((m) => m.content);
+    const otherMessages = messages.filter((m) => m.role !== 'system');
+
+    const newSystem = await rewriteSystemContent(systemContents.join('\n\n'));
+    return [{ role: 'system', content: newSystem }, ...otherMessages];
+  } catch (err) {
+    log.warn('SFT rewrite failed; falling back to raw messages', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return messages;
+  }
 }

--- a/src/modules/chatbot-rag/qwen-runpod-adapter.ts
+++ b/src/modules/chatbot-rag/qwen-runpod-adapter.ts
@@ -1,0 +1,230 @@
+/**
+ * src/modules/chatbot-rag/qwen-runpod-adapter.ts
+ *
+ * Custom CopilotServiceAdapter for the RunPod-hosted Qwen chatbot.
+ *
+ * 🎯 Bug 1 (multi-turn fail on prod) — root cause + fix
+ *
+ * Root cause (verified 2026-05-20, CP474 review):
+ *   - `OpenAIAdapter.getLanguageModel()` calls `createOpenAI({...})(model)`,
+ *     which `@ai-sdk/openai/openai-provider.ts:239-241` resolves to
+ *     `createResponsesModel` → OpenAI **Responses API** endpoint `/v1/responses`.
+ *   - vLLM (and OpenRouter for older Gemini models) does NOT implement
+ *     `/v1/responses`. On the second turn, when the assistant history
+ *     gets serialized to Responses-API format (`apply_patch_call_output`
+ *     etc.), schema validation fails → `Invalid Responses API request`.
+ *
+ * Fix:
+ *   - This adapter calls `createOpenAI({...}).chat(model)` instead, which
+ *     `openai-provider.ts:245` routes to `createChatModel` → **Chat
+ *     Completions endpoint** `/v1/chat/completions`. vLLM v0.9.0 supports
+ *     this 1-1, and multi-turn smoke (manual curl) confirmed end-to-end.
+ *
+ * Secondary roles (not yet wired in this MVP):
+ *   - Inject Insighta persona / user context / RAG block / Block T
+ *     transcript fallback into the system message. Currently the FE's
+ *     `buildInstructions` produces the system message; rewriting happens
+ *     in Stage 4 (separate commit) via a middleware that wraps the
+ *     returned LanguageModel.
+ *
+ * Design ref: docs/design/insighta-chatbot-prompt-serving-design.md §6(d).
+ */
+
+import OpenAI from 'openai';
+import { createOpenAI } from '@ai-sdk/openai';
+import type { LanguageModel } from 'ai';
+import { randomUUID } from '@copilotkit/shared';
+import type {
+  CopilotServiceAdapter,
+  CopilotRuntimeChatCompletionRequest,
+  CopilotRuntimeChatCompletionResponse,
+} from '@copilotkit/runtime';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MODEL = 'insighta-chatbot';
+
+/**
+ * vLLM Qwen3 chat template knob — disables `<think>` reasoning blocks so
+ * answers come back as direct content rather than wrapped reasoning. The
+ * matching FE behaviour exists in `ChatAssistant.tsx` (`/no_think`).
+ */
+const CHAT_TEMPLATE_KWARGS = { enable_thinking: false } as const;
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export interface QwenRunpodAdapterParams {
+  /** Full base URL of the vLLM endpoint, e.g. `https://<pod>.proxy.runpod.net/openai/v1`. */
+  baseURL: string;
+  /** Bearer token configured on vLLM via `--api-key`. */
+  apiKey: string;
+  /** Served model name (vLLM's `--served-model-name`). Default 'insighta-chatbot'. */
+  model?: string;
+}
+
+/**
+ * Adapter that routes Insighta chatbot traffic to the RunPod-hosted vLLM
+ * Qwen LoRA model via OpenAI **chat.completions** (not Responses API).
+ *
+ * Implements both:
+ *   - `getLanguageModel()` — preferred path; used by CopilotRuntime
+ *     BuiltInAgent integration. Returns a Vercel AI SDK LanguageModel
+ *     pinned to chat.completions.
+ *   - `process()` — legacy/streaming fallback for runtime configurations
+ *     that don't take the BuiltInAgent path.
+ */
+export class QwenRunpodAdapter implements CopilotServiceAdapter {
+  public readonly provider = 'qwen-runpod';
+  public readonly model: string;
+  public readonly name = 'QwenRunpodAdapter';
+  private readonly baseURL: string;
+  private readonly apiKey: string;
+  private readonly openaiSDK: OpenAI;
+
+  constructor(params: QwenRunpodAdapterParams) {
+    if (!params.baseURL) {
+      throw new Error('QwenRunpodAdapter: baseURL is required');
+    }
+    if (!params.apiKey) {
+      throw new Error('QwenRunpodAdapter: apiKey is required');
+    }
+    this.baseURL = params.baseURL;
+    this.apiKey = params.apiKey;
+    this.model = params.model ?? DEFAULT_MODEL;
+    this.openaiSDK = new OpenAI({ baseURL: this.baseURL, apiKey: this.apiKey });
+  }
+
+  /**
+   * Returns a Vercel AI SDK LanguageModel that targets the **chat.completions**
+   * endpoint (not Responses API). This is the Bug 1 fix — see file header.
+   *
+   * 비교:
+   *   - `createOpenAI({...})(modelId)` → Responses API (❌ Bug 1 source)
+   *   - `createOpenAI({...}).chat(modelId)` → chat.completions (✅ vLLM compat)
+   */
+  getLanguageModel(): LanguageModel {
+    const aiProvider = createOpenAI({
+      baseURL: this.baseURL,
+      apiKey: this.apiKey,
+    });
+    return aiProvider.chat(this.model);
+  }
+
+  /**
+   * Legacy streaming path used by older CopilotRuntime call sites.
+   *
+   * Scope (MVP):
+   *   - Text messages only (Insighta chatbot has no tool/action use case)
+   *   - Streams plain text deltas through eventSource (start → content → end)
+   *
+   * Future (Stage 4):
+   *   - System message rewrite (persona + user_ctx + RAG + Block T)
+   *   - Tool call passthrough if Insighta later introduces useCopilotAction
+   */
+  async process(
+    request: CopilotRuntimeChatCompletionRequest
+  ): Promise<CopilotRuntimeChatCompletionResponse> {
+    const { messages, eventSource, threadId, forwardedParameters } = request;
+
+    const openaiMessages = messages.filter(textMessageGuard).map((m) => {
+      const t = m as unknown as TextMessageLike;
+      return { role: normalizeRole(t.role), content: t.content };
+    });
+
+    // vLLM-specific: chat_template_kwargs (enable_thinking=false) is forwarded
+    // as an extra body key. OpenAI SDK's chat.completions request type doesn't
+    // include it, so we type the body as a structural shape.
+    interface QwenChatRequestBody {
+      model: string;
+      stream: true;
+      messages: ReadonlyArray<{ role: 'system' | 'user' | 'assistant'; content: string }>;
+      chat_template_kwargs: { enable_thinking: boolean };
+      max_completion_tokens?: number;
+      temperature?: number;
+      stop?: string | string[];
+    }
+    const body: QwenChatRequestBody = {
+      model: this.model,
+      stream: true,
+      messages: openaiMessages,
+      chat_template_kwargs: CHAT_TEMPLATE_KWARGS,
+    };
+    if (forwardedParameters?.maxTokens) body.max_completion_tokens = forwardedParameters.maxTokens;
+    if (forwardedParameters?.temperature !== undefined)
+      body.temperature = forwardedParameters.temperature;
+    if (forwardedParameters?.stop) body.stop = forwardedParameters.stop;
+
+    // `stream: true` returns Stream<ChatCompletionChunk> which is AsyncIterable.
+    // The cast is needed because TS picks the non-stream overload when the
+    // body type doesn't statically expose `stream: true` to the SDK's overload.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stream = (await this.openaiSDK.chat.completions.create(
+      body as any
+    )) as unknown as AsyncIterable<{
+      id?: string;
+      choices: Array<{ delta?: { content?: string } }>;
+    }>;
+
+    // Fire-and-forget — eventSource.stream() drives the SSE write loop; the
+    // adapter returns the threadId immediately while streaming continues in
+    // the background. `void` marks the intentional unawaited promise.
+    void eventSource.stream(async (eventStream$) => {
+      let mode: 'message' | null = null;
+      let currentMessageId = '';
+
+      try {
+        for await (const chunk of stream) {
+          const delta = chunk.choices[0]?.delta?.content;
+          if (delta) {
+            if (mode === null) {
+              mode = 'message';
+              currentMessageId = chunk.id ?? randomUUID();
+              eventStream$.sendTextMessageStart({ messageId: currentMessageId });
+            }
+            eventStream$.sendTextMessageContent({
+              messageId: currentMessageId,
+              content: delta,
+            });
+          }
+        }
+
+        if (mode === 'message') {
+          eventStream$.sendTextMessageEnd({ messageId: currentMessageId });
+        }
+      } catch (err) {
+        // Stream-time errors surface to the client via eventStream$.complete()
+        // closure — CopilotKit FE will render a fallback.
+        if (mode === 'message' && currentMessageId) {
+          eventStream$.sendTextMessageEnd({ messageId: currentMessageId });
+        }
+        throw err;
+      }
+
+      eventStream$.complete();
+    });
+
+    return { threadId: threadId ?? randomUUID() };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (module-private)
+// ---------------------------------------------------------------------------
+
+type TextMessageLike = { isTextMessage: () => boolean; role: string; content: string };
+
+function textMessageGuard(m: unknown): m is TextMessageLike {
+  if (!m || typeof m !== 'object') return false;
+  const guard = m as { isTextMessage?: () => boolean };
+  return typeof guard.isTextMessage === 'function' && guard.isTextMessage();
+}
+
+function normalizeRole(role: string): 'system' | 'user' | 'assistant' {
+  if (role === 'system' || role === 'developer') return 'system';
+  if (role === 'assistant') return 'assistant';
+  return 'user';
+}

--- a/src/modules/chatbot-rag/retriever.ts
+++ b/src/modules/chatbot-rag/retriever.ts
@@ -1,0 +1,213 @@
+/**
+ * src/modules/chatbot-rag/retriever.ts
+ *
+ * RAG retrieval for the chatbot — produces Block H content.
+ *
+ * Pipeline (MVP):
+ *   1. Embed the user's query (ontology embedding provider — Gemini/Ollama)
+ *   2. Cosine search against `ontology.nodes` filtered to this user
+ *      (searchByVector applies `n.user_id = ${userId}` automatically)
+ *   3. Cohere rerank the top-N hits to refine ranking
+ *   4. Hydrate node properties (title, mandala_name, cell_name, date)
+ *      into RAGResult shape
+ *
+ * Future extensions (out of scope MVP):
+ *   - Direct text search on user_local_cards (joined with video_rich_summaries)
+ *   - Direct query on note_documents
+ *   - Knowledge graph neighbor expansion via getNeighbors()
+ *   - Per-user retrieval cache (1-min TTL)
+ *
+ * Failures degrade gracefully:
+ *   - Embedding throws → return empty results (chatbot answers without RAG)
+ *   - Vector search throws → empty results
+ *   - Cohere reranker missing/throws → fall back to raw vector ranking
+ *
+ * Design: docs/design/insighta-chatbot-prompt-serving-design.md §4 + CP474.
+ */
+
+import { generateEmbedding } from '@/modules/ontology/embedding';
+import { searchByVector, type VectorSearchResult } from '@/modules/ontology/search';
+import { rerank } from '@/modules/rerank/cohere-client';
+import { logger } from '@/utils/logger';
+import { type RAGResult, type RAGContext } from './types';
+
+const log = logger.child({ module: 'chatbot-rag/retriever' });
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/** Initial top-N from vector search before rerank trims further. */
+const VECTOR_TOP_N = 12;
+
+/** Final top-K returned to the prompt builder (Block H size). */
+const DEFAULT_FINAL_K = 5;
+
+/** Lower bound on Cohere relevance_score. Below this → drop the candidate. */
+const RERANK_MIN_SCORE = 0.15;
+
+/** Lower bound on cosine similarity (handed straight to searchByVector). */
+const SEARCH_SIMILARITY_THRESHOLD = 0.3;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface RetrieveRAGContextParams {
+  userId: string;
+  query: string;
+  /** Optional: focus retrieval to a specific mandala. Currently unused (KG nodes are user-scoped). */
+  mandalaId?: string;
+  /** Override the default final K (Block H size). */
+  topK?: number;
+  /** Optional ISO timestamp to attach to the returned RAGContext (test injection). */
+  now?: () => Date;
+}
+
+/**
+ * Run the chatbot RAG pipeline and return the prompt-ready context.
+ * Never throws — caller can always pass the result into prompt-builder.
+ *
+ * @returns A RAGContext with 0–topK results.
+ */
+export async function retrieveRAGContext(params: RetrieveRAGContextParams): Promise<RAGContext> {
+  const finalK = params.topK ?? DEFAULT_FINAL_K;
+  const now = (params.now ?? ((): Date => new Date()))();
+
+  // Defensive: empty / whitespace-only query short-circuits without
+  // triggering the embedding pipeline.
+  const trimmedQuery = params.query.trim();
+  if (trimmedQuery.length === 0) {
+    return { results: [], query: '', retrieved_at: now.toISOString() };
+  }
+
+  // Stage 1+2: embed + vector search (user-scoped via searchByVector).
+  let candidates: VectorSearchResult[] = [];
+  try {
+    const embedding = await generateEmbedding(trimmedQuery);
+    candidates = await searchByVector(params.userId, embedding, {
+      limit: VECTOR_TOP_N,
+      threshold: SEARCH_SIMILARITY_THRESHOLD,
+    });
+  } catch (err) {
+    log.warn('vector retrieval failed — returning empty RAG context', {
+      userId: params.userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { results: [], query: trimmedQuery, retrieved_at: now.toISOString() };
+  }
+
+  if (candidates.length === 0) {
+    return { results: [], query: trimmedQuery, retrieved_at: now.toISOString() };
+  }
+
+  // Stage 3: Cohere rerank (best-effort). Failure → keep vector ranking.
+  const reranked = await rerankCandidates(trimmedQuery, candidates, finalK);
+
+  // Stage 4: hydrate RAGResult shape.
+  const results: RAGResult[] = reranked.map((c) => toRAGResult(c));
+
+  return {
+    results,
+    query: trimmedQuery,
+    retrieved_at: now.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/**
+ * Cohere rerank with graceful fallback. When the reranker isn't configured
+ * or returns an error, we keep the original vector ranking and trim to finalK.
+ */
+async function rerankCandidates(
+  query: string,
+  candidates: VectorSearchResult[],
+  finalK: number
+): Promise<VectorSearchResult[]> {
+  if (candidates.length <= 1) return candidates.slice(0, finalK);
+
+  const documents = candidates.map((c) =>
+    // Concatenate the most signal-bearing fields so the cross-encoder has
+    // text to score against. Keep ordering identical to `candidates`.
+    [
+      c.title,
+      (c.properties['summary'] as string | undefined) ?? '',
+      (c.properties['one_liner'] as string | undefined) ?? '',
+    ]
+      .filter(Boolean)
+      .join('\n')
+  );
+
+  try {
+    const response = await rerank({
+      query,
+      documents,
+      topN: finalK,
+    });
+
+    return response.results
+      .filter((r) => r.relevanceScore >= RERANK_MIN_SCORE)
+      .map((r) => candidates[r.index])
+      .filter((c): c is VectorSearchResult => c !== undefined);
+  } catch (err) {
+    log.warn('Cohere rerank failed — falling back to raw vector ranking', {
+      error: err instanceof Error ? err.message : String(err),
+      candidateCount: candidates.length,
+    });
+    return candidates.slice(0, finalK);
+  }
+}
+
+/**
+ * Map an ontology VectorSearchResult into the prompt-ready RAGResult shape.
+ *
+ * Ontology node `type` values seen in prod (non-exhaustive):
+ *   - 'video', 'card'       → source_type 'card'
+ *   - 'note', 'document'    → source_type 'note'
+ *   - others (concept/etc.) → source_type 'kg_node'
+ */
+function toRAGResult(c: VectorSearchResult): RAGResult {
+  const sourceType = classifySourceType(c.type);
+  const props = c.properties ?? {};
+
+  return {
+    source_type: sourceType,
+    title: c.title,
+    excerpt: extractExcerpt(props),
+    mandala_name: optionalString(props['mandala_name']),
+    cell_name: optionalString(props['cell_name']),
+    date: optionalString(props['saved_at'] ?? props['created_at']),
+    similarity: c.similarity,
+  };
+}
+
+function classifySourceType(nodeType: string): RAGResult['source_type'] {
+  const t = nodeType.toLowerCase();
+  if (t === 'video' || t === 'card' || t === 'youtube_video') return 'card';
+  if (t === 'note' || t === 'document') return 'note';
+  return 'kg_node';
+}
+
+function extractExcerpt(props: Record<string, unknown>): string {
+  const candidates = [
+    props['summary'],
+    props['one_liner'],
+    props['core_argument'],
+    props['description'],
+    props['excerpt'],
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.trim().length > 0) {
+      return c.length > 280 ? `${c.slice(0, 277)}...` : c;
+    }
+  }
+  return '';
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.length > 0) return value;
+  return undefined;
+}

--- a/src/modules/chatbot-rag/types.ts
+++ b/src/modules/chatbot-rag/types.ts
@@ -1,0 +1,136 @@
+/**
+ * src/modules/chatbot-rag/types.ts
+ *
+ * Shared types for Insighta chatbot RAG pipeline.
+ *
+ * Consumed by:
+ *   - user-context-loader.ts  → emits UserContext
+ *   - video-context-loader.ts → emits V2Summary | TranscriptContext
+ *   - retriever.ts            → emits RAGContext
+ *   - qwen-runpod-adapter.ts  → orchestrates loaders + prompt-builder
+ *   - prompt-builder.ts       → consumes all of the above to render the
+ *                               SFT-aligned Qwen system prompt
+ *
+ * Design: docs/design/insighta-chatbot-prompt-serving-design.md §3 + CP474 review.
+ *
+ * NOTE: V2Summary, MandalaContext, RegionContext, ChatLayer, Lang are
+ * already exported by prompt-builder.ts (SSOT). Re-importing here would
+ * create a cycle, so we re-export only the structurally-new types in this
+ * file. Callers that need ChatLayer/Lang should import from prompt-builder
+ * directly.
+ */
+
+import type { Lang } from './prompt-builder';
+
+// ============================================================================
+// User session context (NEW — Block U in the SFT-aligned prompt)
+// ============================================================================
+
+/**
+ * Per-user session context inlined into the chatbot system prompt.
+ *
+ * Source of truth:
+ *   - tier              ← user_subscriptions.tier
+ *   - mandala_titles    ← user_mandalas.title (most-recent first, capped at MAX_MANDALA_TITLES)
+ *   - mandala_count     ← user_mandalas count
+ *   - recent_card_count ← user_local_cards count in the last RECENT_DAYS_WINDOW days
+ *   - join_date         ← users.created_at (or user_subscriptions.created_at as fallback)
+ *   - email / display_name ← decoded JWT claims (request.user)
+ *
+ * NEVER includes secrets or PII beyond display_name + email.
+ */
+export interface UserContext {
+  user_id: string;
+  display_name: string;
+  email: string;
+  tier: 'free' | 'pro' | 'lifetime' | 'admin';
+  /** ISO date (YYYY-MM-DD). Empty string when unknown. */
+  join_date: string;
+  /** Days since join_date; 0 when join_date is unknown. */
+  days_active: number;
+  mandala_count: number;
+  /** Up to MAX_MANDALA_TITLES titles, most-recent first. */
+  mandala_titles: string[];
+  /** Title of the mandala currently in focus (from request context); undefined when out-of-mandala. */
+  current_mandala_name?: string;
+  recent_card_count_7d: number;
+  preferred_language: Lang;
+}
+
+// ============================================================================
+// Transcript fallback (NEW — Block T in the SFT-aligned prompt)
+// ============================================================================
+
+/**
+ * Raw YouTube caption text used when no v2 rich summary is available
+ * for the current video. The chatbot is instructed (via Block T's role
+ * rule) to answer strictly from this transcript, not to fabricate.
+ *
+ * Source: src/modules/caption/extractor.ts
+ *   - Primary: MAC_MINI_TRANSCRIPT_URL (Tailscale fetch, residential IP)
+ *   - Fallback: youtube-transcript npm package directly from EC2
+ *   - Both fail → caller passes null TranscriptContext + sets has_no_content
+ */
+export interface TranscriptContext {
+  full_text: string;
+  /** Origin of the transcript, used for source attribution in prompt. */
+  source: 'mac-mini' | 'youtube-transcript' | 'cached';
+  /** ISO 639-1 code or 'auto' when the extractor's language probe is ambiguous. */
+  language: Lang | 'auto';
+  /** True when full_text was clipped to fit TRANSCRIPT_PROMPT_MAX_CHARS. */
+  truncated: boolean;
+  total_chars: number;
+}
+
+// ============================================================================
+// RAG retrieval (NEW — Block H in the SFT-aligned prompt)
+// ============================================================================
+
+/** Kind of artefact the RAG retriever surfaced for the user. */
+export type RAGSourceType = 'card' | 'note' | 'kg_node';
+
+/**
+ * A single retrieval hit. Rendered in Block H with source attribution
+ * (the SFT rule mandates explicit citation, e.g. "당신이 학습한 X 영상에서도…").
+ */
+export interface RAGResult {
+  source_type: RAGSourceType;
+  /** Human-readable label for the source (video title / note title / KG concept). */
+  title: string;
+  /** 1-3 sentence excerpt or canonical statement from the source. */
+  excerpt: string;
+  /** Mandala the source was attached to, when applicable. */
+  mandala_name?: string;
+  /** Cell within the mandala, when applicable. */
+  cell_name?: string;
+  /** ISO date when the source was saved / created. */
+  date?: string;
+  /** Cosine similarity score from the embedding retrieval, when applicable. */
+  similarity?: number;
+  /** For kg_node results: surfaced concept edges with their card counts. */
+  kg_links?: { concept: string; card_count: number }[];
+}
+
+/**
+ * Wrapper around the retriever's output. Carries the originating query
+ * so that downstream log/cache layers can correlate.
+ */
+export interface RAGContext {
+  results: RAGResult[];
+  query: string;
+  /** ISO timestamp when the retrieval ran. */
+  retrieved_at: string;
+}
+
+// ============================================================================
+// Constants (module-level — shared across loaders)
+// ============================================================================
+
+/** Cap on mandala_titles array length to keep system prompt size bounded. */
+export const MAX_MANDALA_TITLES = 10;
+
+/** Activity window for recent_card_count_7d. */
+export const RECENT_DAYS_WINDOW = 7;
+
+/** Hard cap on transcript text length — mirrors the FE constant in ChatAssistant.tsx. */
+export const TRANSCRIPT_PROMPT_MAX_CHARS = 20_000;

--- a/src/modules/chatbot-rag/user-context-loader.ts
+++ b/src/modules/chatbot-rag/user-context-loader.ts
@@ -1,0 +1,150 @@
+/**
+ * src/modules/chatbot-rag/user-context-loader.ts
+ *
+ * Loads the per-user session context block (Block U) for the chatbot
+ * SFT-aligned system prompt.
+ *
+ * Source tables:
+ *   - users                (join_date via created_at)
+ *   - user_subscriptions   (tier; default 'free' on missing row)
+ *   - user_mandalas        (title list + total count)
+ *   - user_local_cards     (count within RECENT_DAYS_WINDOW)
+ *
+ * Failures degrade gracefully — the loader never throws. Each missing
+ * source is silently substituted (tier→'free', titles→[], counts→0).
+ * Justification: chatbot must still respond when a user just signed up
+ * and has no subscription/mandala/card rows yet.
+ *
+ * Performance: all queries dispatch in a single Promise.all batch.
+ * p50 expected < 50ms on a warm Supabase connection.
+ *
+ * Design: docs/design/insighta-chatbot-prompt-serving-design.md §3 (CP474 review).
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import type { Tier } from '@/config/quota';
+import { type UserContext, MAX_MANDALA_TITLES, RECENT_DAYS_WINDOW } from './types';
+import type { Lang } from './prompt-builder';
+
+// ---------------------------------------------------------------------------
+// Constants / helpers
+// ---------------------------------------------------------------------------
+
+const VALID_TIERS: ReadonlySet<Tier> = new Set<Tier>(['free', 'pro', 'lifetime', 'admin']);
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+function normalizeTier(value: string | null | undefined): Tier {
+  if (value && VALID_TIERS.has(value as Tier)) return value as Tier;
+  return 'free';
+}
+
+function daysBetween(from: Date | null | undefined, to: Date): number {
+  if (!from) return 0;
+  const diffMs = to.getTime() - from.getTime();
+  return Math.max(0, Math.floor(diffMs / MS_PER_DAY));
+}
+
+function isoDate(d: Date | null | undefined): string {
+  if (!d) return '';
+  return d.toISOString().slice(0, 10);
+}
+
+function deriveDisplayName(explicit: string | undefined, email: string): string {
+  if (explicit && explicit.trim().length > 0) return explicit.trim();
+  const local = email.split('@')[0];
+  return local && local.length > 0 ? local : 'user';
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface LoadUserContextParams {
+  /** Supabase auth user id (from request.user.userId after JWT verify). */
+  userId: string;
+  /** Decoded JWT email; falls back to '' when absent. */
+  email: string;
+  /** Display name from JWT user_metadata. Optional — falls back to email local-part. */
+  displayName?: string;
+  /** Mandala the user is currently viewing; used to populate current_mandala_name. */
+  currentMandalaId?: string;
+  /** UI language (request from i18n.language); drives the prompt's KO/EN selection. */
+  preferredLanguage: Lang;
+  /** Reference timestamp for the recent-cards window. Injected for tests; defaults to now. */
+  now?: Date;
+}
+
+/**
+ * Returns the user's session context as a structured object. Never throws.
+ *
+ * @see UserContext for field-level documentation
+ */
+export async function loadUserContext(params: LoadUserContextParams): Promise<UserContext> {
+  const prisma = getPrismaClient();
+  const now = params.now ?? new Date();
+  const recencyCutoff = new Date(now.getTime() - RECENT_DAYS_WINDOW * MS_PER_DAY);
+
+  // All queries run in parallel — single round-trip in Prisma's connection pool.
+  const [userRow, subscription, mandalaRows, mandalaCount, recentCardCount, currentMandala] =
+    await Promise.all([
+      prisma.users
+        .findUnique({
+          where: { id: params.userId },
+          select: { created_at: true },
+        })
+        .catch(() => null),
+      prisma.user_subscriptions
+        .findUnique({
+          where: { user_id: params.userId },
+          select: { tier: true },
+        })
+        .catch(() => null),
+      prisma.user_mandalas
+        .findMany({
+          where: { user_id: params.userId },
+          select: { title: true },
+          orderBy: { created_at: 'desc' },
+          take: MAX_MANDALA_TITLES,
+        })
+        .catch(() => [] as Array<{ title: string }>),
+      prisma.user_mandalas
+        .count({
+          where: { user_id: params.userId },
+        })
+        .catch(() => 0),
+      prisma.user_local_cards
+        .count({
+          where: {
+            user_id: params.userId,
+            created_at: { gte: recencyCutoff },
+          },
+        })
+        .catch(() => 0),
+      params.currentMandalaId
+        ? prisma.user_mandalas
+            .findUnique({
+              where: { id: params.currentMandalaId },
+              select: { title: true },
+            })
+            .catch(() => null)
+        : Promise.resolve(null),
+    ]);
+
+  const tier = normalizeTier(subscription?.tier);
+  const joinDate = userRow?.created_at ?? null;
+
+  return {
+    user_id: params.userId,
+    display_name: deriveDisplayName(params.displayName, params.email),
+    email: params.email,
+    tier,
+    join_date: isoDate(joinDate),
+    days_active: daysBetween(joinDate, now),
+    mandala_count: mandalaCount,
+    mandala_titles: mandalaRows.map((m) => m.title),
+    current_mandala_name: currentMandala?.title,
+    recent_card_count_7d: recentCardCount,
+    preferred_language: params.preferredLanguage,
+  };
+}

--- a/src/modules/chatbot-rag/user-context-loader.ts
+++ b/src/modules/chatbot-rag/user-context-loader.ts
@@ -23,6 +23,7 @@
 
 import { getPrismaClient } from '@/modules/database/client';
 import type { Tier } from '@/config/quota';
+import { MS_PER_DAY } from '@/utils/time-constants';
 import { type UserContext, MAX_MANDALA_TITLES, RECENT_DAYS_WINDOW } from './types';
 import type { Lang } from './prompt-builder';
 
@@ -31,8 +32,6 @@ import type { Lang } from './prompt-builder';
 // ---------------------------------------------------------------------------
 
 const VALID_TIERS: ReadonlySet<Tier> = new Set<Tier>(['free', 'pro', 'lifetime', 'admin']);
-
-const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 function normalizeTier(value: string | null | undefined): Tier {
   if (value && VALID_TIERS.has(value as Tier)) return value as Tier;

--- a/src/modules/chatbot-rag/video-context-loader.ts
+++ b/src/modules/chatbot-rag/video-context-loader.ts
@@ -20,6 +20,7 @@
 
 import { getPrismaClient } from '@/modules/database/client';
 import { getCaptionExtractor } from '@/modules/caption/extractor';
+import { loadTranscriptConfig } from '@/config/transcript';
 import { logger } from '@/utils/logger';
 import { TRANSCRIPT_PROMPT_MAX_CHARS, type TranscriptContext } from './types';
 import type { V2Summary, Lang } from './prompt-builder';
@@ -194,9 +195,7 @@ async function tryFetchTranscript(
     // falling back; the Mac Mini path doesn't set a distinct flag on the
     // return value, but its env-gated success is the dominant prod path.
     // Heuristic: env present → assume Mac Mini took the first hit.
-    const macMiniEnabled = Boolean(
-      process.env['MAC_MINI_TRANSCRIPT_URL'] && process.env['MAC_MINI_TRANSCRIPT_TOKEN']
-    );
+    const { macMiniEnabled } = loadTranscriptConfig();
 
     return {
       full_text: fullText,

--- a/src/modules/chatbot-rag/video-context-loader.ts
+++ b/src/modules/chatbot-rag/video-context-loader.ts
@@ -1,0 +1,215 @@
+/**
+ * src/modules/chatbot-rag/video-context-loader.ts
+ *
+ * Decides which video-grounding block(s) the chatbot prompt should carry:
+ *
+ *   - v2 rich summary present + usable → return V2Summary (Block A-D)
+ *   - v2 absent OR not usable → fall back to transcript fetch (Block T)
+ *   - both unavailable → null/null → caller adds the "분석 미생성" rule
+ *
+ * "Usable" mirrors FE summaryHasUsableContent (ChatAssistant.tsx) so BE
+ * and FE agree on the same decision boundary. Source of truth = this BE
+ * port; FE port is reviewed periodically for drift.
+ *
+ * Failures (DB unreachable, Mac Mini proxy down, no public captions) all
+ * degrade to a null result on the affected branch. This loader never
+ * throws — the chatbot must respond even when both data sources are gone.
+ *
+ * Design: docs/design/insighta-chatbot-prompt-serving-design.md §3 + CP474.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { getCaptionExtractor } from '@/modules/caption/extractor';
+import { logger } from '@/utils/logger';
+import { TRANSCRIPT_PROMPT_MAX_CHARS, type TranscriptContext } from './types';
+import type { V2Summary, Lang } from './prompt-builder';
+
+const log = logger.child({ module: 'chatbot-rag/video-context-loader' });
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface VideoGroundingResult {
+  /** Populated when v2 row exists and passes summaryHasUsableContent. */
+  v2Data: V2Summary | null;
+  /** Populated when v2 absent/unusable AND the caption extractor returned text. */
+  transcript: TranscriptContext | null;
+}
+
+export interface LoadVideoContextParams {
+  /** YouTube 11-char video id (NOT the internal youtube_videos.id UUID). */
+  youtubeVideoId: string;
+  /**
+   * Hint for which language to request from the caption extractor.
+   * Affects only the transcript branch.
+   */
+  preferredLanguage?: Lang;
+}
+
+/**
+ * Returns whichever grounding source is available for `youtubeVideoId`.
+ * Order of attempts: v2 row → transcript fetch. Each branch is fail-safe;
+ * the function always returns a `VideoGroundingResult` (with both slots
+ * potentially null in the worst case).
+ */
+export async function loadVideoContext(
+  params: LoadVideoContextParams
+): Promise<VideoGroundingResult> {
+  const v2Data = await tryLoadV2(params.youtubeVideoId);
+  if (v2Data) {
+    return { v2Data, transcript: null };
+  }
+
+  const transcript = await tryFetchTranscript(params.youtubeVideoId, params.preferredLanguage);
+  return { v2Data: null, transcript };
+}
+
+// ---------------------------------------------------------------------------
+// Public utility — exported for testing + reuse by adapter for logging
+// ---------------------------------------------------------------------------
+
+/**
+ * BE port of the FE `summaryHasUsableContent` helper
+ * (frontend/.../ChatAssistant.tsx). Returns true when the row carries any
+ * content the chatbot prompt can ground answers in.
+ *
+ * Mirror invariant: if either side returns true, the other should too.
+ */
+export function summaryHasUsableContent(input: {
+  oneLiner?: string | null;
+  core?: { one_liner?: string | null } | null;
+  analysis?: {
+    core_argument?: string | null;
+    key_concepts?: ReadonlyArray<unknown> | null;
+    actionables?: ReadonlyArray<unknown> | null;
+  } | null;
+  structured?: {
+    core_argument?: string | null;
+    key_points?: ReadonlyArray<unknown> | null;
+    actionables?: ReadonlyArray<unknown> | null;
+  } | null;
+}): boolean {
+  if (input.core?.one_liner) return true;
+  if (input.analysis?.core_argument) return true;
+  if ((input.analysis?.key_concepts?.length ?? 0) > 0) return true;
+  if ((input.analysis?.actionables?.length ?? 0) > 0) return true;
+  if (input.oneLiner) return true;
+  if (input.structured?.core_argument) return true;
+  if ((input.structured?.key_points?.length ?? 0) > 0) return true;
+  if ((input.structured?.actionables?.length ?? 0) > 0) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Branch 1 — v2 rich summary
+// ---------------------------------------------------------------------------
+
+async function tryLoadV2(youtubeVideoId: string): Promise<V2Summary | null> {
+  const prisma = getPrismaClient();
+
+  try {
+    const row = await prisma.video_rich_summaries.findUnique({
+      where: { video_id: youtubeVideoId },
+      select: {
+        one_liner: true,
+        structured: true,
+        core: true,
+        analysis: true,
+        segments: true,
+        quality_flag: true,
+        template_version: true,
+      },
+    });
+
+    if (!row) return null;
+
+    // quality_flag must be 'pass' (or 'pending' but with usable content);
+    // 'low' / 'fail' rows are silently treated as if absent.
+    if (row.quality_flag && row.quality_flag !== 'pass' && row.quality_flag !== 'pending') {
+      return null;
+    }
+
+    const usable = summaryHasUsableContent({
+      oneLiner: row.one_liner,
+      core: row.core as { one_liner?: string | null } | null,
+      analysis: row.analysis as never,
+      structured: row.structured as never,
+    });
+    if (!usable) return null;
+
+    // Title comes from a separate JOIN — we keep it as an optional Block A
+    // field. Fetched in parallel with the row when present.
+    const titleRow = await prisma.youtube_videos
+      .findUnique({
+        where: { youtube_video_id: youtubeVideoId },
+        select: { title: true },
+      })
+      .catch(() => null);
+
+    return {
+      title: titleRow?.title ?? null,
+      core: (row.core ?? null) as V2Summary['core'],
+      analysis: (row.analysis ?? null) as V2Summary['analysis'],
+      segments: (row.segments ?? null) as V2Summary['segments'],
+    };
+  } catch (err) {
+    log.warn('v2 row lookup failed', {
+      youtubeVideoId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Branch 2 — transcript fallback
+// ---------------------------------------------------------------------------
+
+async function tryFetchTranscript(
+  youtubeVideoId: string,
+  preferredLanguage?: Lang
+): Promise<TranscriptContext | null> {
+  try {
+    const result = await getCaptionExtractor().extractCaptions(youtubeVideoId, preferredLanguage);
+
+    if (!result.success || !result.caption || !result.caption.fullText) {
+      return null;
+    }
+
+    const total = result.caption.fullText.length;
+    const truncated = total > TRANSCRIPT_PROMPT_MAX_CHARS;
+    const fullText = truncated
+      ? result.caption.fullText.slice(0, TRANSCRIPT_PROMPT_MAX_CHARS)
+      : result.caption.fullText;
+
+    // Extractor's `language` is the resolved language (ko / en / ...);
+    // we narrow to our Lang union or 'auto'.
+    const resolved =
+      result.caption.language === 'ko' || result.caption.language === 'en'
+        ? (result.caption.language as Lang)
+        : 'auto';
+
+    // Source detection: extractor logs `source: 'youtube-transcript'` when
+    // falling back; the Mac Mini path doesn't set a distinct flag on the
+    // return value, but its env-gated success is the dominant prod path.
+    // Heuristic: env present → assume Mac Mini took the first hit.
+    const macMiniEnabled = Boolean(
+      process.env['MAC_MINI_TRANSCRIPT_URL'] && process.env['MAC_MINI_TRANSCRIPT_TOKEN']
+    );
+
+    return {
+      full_text: fullText,
+      source: macMiniEnabled ? 'mac-mini' : 'youtube-transcript',
+      language: resolved,
+      truncated,
+      total_chars: total,
+    };
+  } catch (err) {
+    log.warn('transcript fetch failed', {
+      youtubeVideoId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/tests/unit/modules/chatbot-rag/prompt-builder.test.ts
+++ b/tests/unit/modules/chatbot-rag/prompt-builder.test.ts
@@ -1,0 +1,439 @@
+/**
+ * tests/unit/modules/chatbot-rag/prompt-builder.test.ts
+ *
+ * Unit tests for prompt-builder.ts CP474 extensions:
+ *   - Backward compatibility: legacy params (no U/T/H) still produce the
+ *     SFT-aligned format byte-for-byte (ROLE_AND_RULES_KO at the head).
+ *   - includePersona toggle gates PRODUCT_PERSONA + EXTENDED_RULES.
+ *   - Transcript fallback path engages LAYER_BLOCKS_FALLBACK when v2Data
+ *     is absent but transcript present.
+ *   - Block U / Block H format and skip rules.
+ *   - EXTENDED_RULES appended only when any of {U, T, H} is in play.
+ *
+ * Pure functions — no mocks needed.
+ */
+
+import {
+  buildQwenSystemPrompt,
+  PRODUCT_PERSONA_KO,
+  PRODUCT_PERSONA_EN,
+  ROLE_AND_RULES_KO,
+  ROLE_AND_RULES_EN,
+  EXTENDED_RULES_KO,
+  LAYER_BLOCKS,
+  LAYER_BLOCKS_FALLBACK,
+  type V2Summary,
+  type MandalaContext,
+  type RegionContext,
+} from '@/modules/chatbot-rag/prompt-builder';
+import type { UserContext, TranscriptContext, RAGContext } from '@/modules/chatbot-rag/types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const V2: V2Summary = {
+  title: '하프 1:30의 벽, 이것만 바꾸면 깨집니다',
+  core: { one_liner: '속도/지구력/회복 균형이 1:30 벽을 깬다', domain: 'running' },
+  analysis: {
+    core_argument: '균형 잡힌 훈련',
+    key_concepts: [
+      { term: '인터벌', definition: '짧고 빠른 반복' },
+      { term: 'LSD', definition: 'Long Slow Distance' },
+    ],
+    actionables: ['1km 인터벌 8-10세트 주 1회'],
+  },
+  segments: {
+    sections: [{ idx: 0, title: '속도 훈련', from_sec: 103, to_sec: 201, summary: '인터벌 도입' }],
+  },
+};
+
+const MANDALA: MandalaContext = {
+  mandala_name: '마라톤 완주',
+  center_goal: '하프 1:30',
+};
+
+const REGION: RegionContext = {
+  active_region: 'player',
+  layer: 'video-time',
+  player_time_sec: 103,
+  player_state: 'playing',
+  current_section: '속도 훈련',
+};
+
+const USER: UserContext = {
+  user_id: 'u-1',
+  display_name: 'Jeonho',
+  email: 'jeonho@example.com',
+  tier: 'lifetime',
+  join_date: '2026-01-15',
+  days_active: 125,
+  mandala_count: 3,
+  mandala_titles: ['마라톤 완주', 'Python 풀스택', '프랑스어 B1'],
+  current_mandala_name: '마라톤 완주',
+  recent_card_count_7d: 12,
+  preferred_language: 'ko',
+};
+
+const TRANSCRIPT: TranscriptContext = {
+  full_text: '안녕하세요 하프 마라톤 훈련법을 소개합니다',
+  source: 'mac-mini',
+  language: 'ko',
+  truncated: false,
+  total_chars: 22,
+};
+
+const RAG: RAGContext = {
+  query: '인터벌',
+  retrieved_at: '2026-05-20T00:00:00.000Z',
+  results: [
+    {
+      source_type: 'card',
+      title: 'VO2 Max 5x5',
+      excerpt: '1km 인터벌 VO2 Max 향상',
+      mandala_name: '마라톤 완주',
+      cell_name: '속도',
+      date: '2026-04-22',
+      similarity: 0.92,
+    },
+    {
+      source_type: 'note',
+      title: '5km TT 페이스 메모',
+      excerpt: '5:10 → 4:55 목표',
+      mandala_name: '마라톤 완주',
+      date: '2026-05-02',
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Backward compatibility
+// ---------------------------------------------------------------------------
+
+describe('buildQwenSystemPrompt — backward compatibility', () => {
+  it('produces SFT-aligned format (no persona) when includePersona=false', () => {
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: V2,
+      includePersona: false,
+    });
+
+    expect(out).not.toContain(PRODUCT_PERSONA_KO);
+    expect(out).not.toContain(EXTENDED_RULES_KO);
+    // ROLE_AND_RULES_KO must be the very first block — SFT distribution match.
+    expect(out.startsWith(ROLE_AND_RULES_KO)).toBe(true);
+  });
+
+  it('legacy params produce no Block U / H / T headers', () => {
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: V2,
+      includePersona: false,
+    });
+
+    expect(out).not.toContain('[사용자 컨텍스트]');
+    expect(out).not.toContain('[관련 자료');
+    expect(out).not.toContain('[원본 자막]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persona + extended rules (CP474)
+// ---------------------------------------------------------------------------
+
+describe('buildQwenSystemPrompt — persona + extended rules', () => {
+  it('prepends PRODUCT_PERSONA_KO when includePersona=true (default)', () => {
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: V2,
+    });
+
+    expect(out.startsWith(PRODUCT_PERSONA_KO)).toBe(true);
+    expect(out).toContain(ROLE_AND_RULES_KO);
+  });
+
+  it('uses EN persona for language="en"', () => {
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'en',
+      v2Data: V2,
+    });
+
+    expect(out.startsWith(PRODUCT_PERSONA_EN)).toBe(true);
+    expect(out).toContain(ROLE_AND_RULES_EN);
+  });
+
+  it('appends EXTENDED_RULES_KO only when a CP474 block (U/T/H) is present', () => {
+    const withoutExt = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: V2,
+    });
+    expect(withoutExt).not.toContain(EXTENDED_RULES_KO);
+
+    const withUser = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: V2,
+      userContext: USER,
+    });
+    expect(withUser).toContain(EXTENDED_RULES_KO);
+  });
+
+  it('appends EXTENDED_RULES when transcript fallback engaged', () => {
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: null,
+      transcript: TRANSCRIPT,
+    });
+    expect(out).toContain(EXTENDED_RULES_KO);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Block U — user context
+// ---------------------------------------------------------------------------
+
+describe('buildQwenSystemPrompt — Block U (user context)', () => {
+  it('renders user context with tier, mandalas, current mandala, recent activity', () => {
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: V2,
+      userContext: USER,
+    });
+
+    expect(out).toContain('[사용자 컨텍스트]');
+    expect(out).toContain('사용자: Jeonho (jeonho@example.com)');
+    expect(out).toContain('Tier: lifetime');
+    expect(out).toContain('운영 중인 만다라: 3개');
+    expect(out).toContain('현재 만다라: 마라톤 완주');
+    expect(out).toContain('이번 주 학습 카드: 12개');
+  });
+
+  it('omits Block U entirely for a blank user (free tier, no mandalas, no email)', () => {
+    const blankUser: UserContext = {
+      user_id: 'u-empty',
+      display_name: 'user',
+      email: '',
+      tier: 'free',
+      join_date: '',
+      days_active: 0,
+      mandala_count: 0,
+      mandala_titles: [],
+      recent_card_count_7d: 0,
+      preferred_language: 'ko',
+    };
+
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: V2,
+      userContext: blankUser,
+    });
+
+    expect(out).not.toContain('[사용자 컨텍스트]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Block H — RAG context
+// ---------------------------------------------------------------------------
+
+describe('buildQwenSystemPrompt — Block H (RAG)', () => {
+  it('renders RAG results with source attribution (card / note)', () => {
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: V2,
+      ragContext: RAG,
+    });
+
+    expect(out).toContain('[관련 자료 (RAG)]');
+    expect(out).toContain('저장 카드');
+    expect(out).toContain('내 노트');
+    expect(out).toContain('VO2 Max 5x5');
+    expect(out).toContain('5km TT 페이스 메모');
+    expect(out).toContain('(2026-04-22)');
+    expect(out).toContain('(2026-05-02)');
+  });
+
+  it('omits Block H when ragContext has empty results', () => {
+    const emptyRAG: RAGContext = {
+      query: 'unrelated',
+      retrieved_at: '2026-05-20T00:00:00.000Z',
+      results: [],
+    };
+
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: V2,
+      ragContext: emptyRAG,
+    });
+
+    // Block-specific content (RAG result titles) MUST NOT appear. The
+    // header '[관련 자료 (RAG)]' is also referenced inside EXTENDED_RULES_KO,
+    // so we check unique result-row content instead of the header alone.
+    expect(out).not.toContain('VO2 Max 5x5');
+    expect(out).not.toContain('5km TT 페이스 메모');
+    expect(out).not.toContain('저장 카드');
+  });
+
+  it('renders kg_node results with KG link annotations', () => {
+    const kgRAG: RAGContext = {
+      query: '인터벌',
+      retrieved_at: '2026-05-20T00:00:00.000Z',
+      results: [
+        {
+          source_type: 'kg_node',
+          title: '인터벌 훈련',
+          excerpt: 'VO2 Max 강화',
+          kg_links: [
+            { concept: 'VO2 Max', card_count: 8 },
+            { concept: '젖산 임계점', card_count: 5 },
+          ],
+        },
+      ],
+    };
+
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: V2,
+      ragContext: kgRAG,
+    });
+
+    expect(out).toContain('Knowledge Graph');
+    expect(out).toContain('연결: VO2 Max (8 카드), 젖산 임계점 (5 카드)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Block T — transcript fallback
+// ---------------------------------------------------------------------------
+
+describe('buildQwenSystemPrompt — Block T (transcript fallback)', () => {
+  it('engages LAYER_BLOCKS_FALLBACK when v2Data absent and transcript present', () => {
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: null,
+      transcript: TRANSCRIPT,
+    });
+
+    expect(out).toContain('출처: mac-mini');
+    expect(out).toContain('안녕하세요 하프 마라톤');
+    // v2-only block markers (NOT referenced in EXTENDED_RULES) must be absent.
+    expect(out).not.toContain('[핵심 개념]');
+    expect(out).not.toContain('[실행 아이템]');
+    expect(out).not.toContain('[구간별 내용]');
+    // V2-specific values must also be absent.
+    expect(out).not.toContain('속도/지구력/회복 균형');
+  });
+
+  it('appends truncation note when transcript.truncated=true', () => {
+    const truncated: TranscriptContext = { ...TRANSCRIPT, truncated: true };
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      transcript: truncated,
+    });
+
+    expect(out).toContain('[자막 일부 잘림');
+  });
+
+  it('v2 wins over transcript when both supplied', () => {
+    const out = buildQwenSystemPrompt({
+      layer: 'video',
+      language: 'ko',
+      v2Data: V2,
+      transcript: TRANSCRIPT,
+    });
+
+    // v2 specific value present
+    expect(out).toContain('속도/지구력/회복 균형');
+    // Transcript-unique content (the actual fulltext) must be absent — the
+    // `[원본 자막]` header is also referenced inside EXTENDED_RULES_KO so we
+    // assert against the transcript body itself.
+    expect(out).not.toContain('안녕하세요 하프 마라톤');
+    expect(out).not.toContain('출처: mac-mini');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Layer mapping sanity
+// ---------------------------------------------------------------------------
+
+describe('LAYER_BLOCKS shape', () => {
+  it('includes U and H in every standard layer', () => {
+    for (const blocks of Object.values(LAYER_BLOCKS)) {
+      expect(blocks).toContain('U');
+      expect(blocks).toContain('H');
+    }
+  });
+
+  it('LAYER_BLOCKS_FALLBACK substitutes T for A-D blocks', () => {
+    expect(LAYER_BLOCKS_FALLBACK.video).toEqual(['T', 'U', 'H']);
+    expect(LAYER_BLOCKS_FALLBACK['video-time']).toEqual(['T', 'F', 'U', 'H']);
+    for (const blocks of Object.values(LAYER_BLOCKS_FALLBACK)) {
+      // Fallback layers must never carry the v2-grounded A-D blocks.
+      expect(blocks).not.toContain('A');
+      expect(blocks).not.toContain('B');
+      expect(blocks).not.toContain('C');
+      expect(blocks).not.toContain('D');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end smoke: persona + user + v2 + mandala + region + RAG
+// ---------------------------------------------------------------------------
+
+describe('buildQwenSystemPrompt — full stack assembly', () => {
+  it('assembles all blocks in the expected order for note layer', () => {
+    const out = buildQwenSystemPrompt({
+      layer: 'note',
+      language: 'ko',
+      v2Data: V2,
+      mandalaContext: MANDALA,
+      regionContext: { ...REGION, note_selection_text: '하이라이트' },
+      userContext: USER,
+      ragContext: RAG,
+    });
+
+    // Persona FIRST
+    const idxPersona = out.indexOf(PRODUCT_PERSONA_KO);
+    const idxRole = out.indexOf(ROLE_AND_RULES_KO);
+    const idxExtended = out.indexOf(EXTENDED_RULES_KO);
+    // The block-A header `[영상 정보]` is also mentioned inside EXTENDED_RULES_KO
+    // for negative-case wording — use lastIndexOf to find the actual Block A
+    // occurrence, which sits AFTER the rules block.
+    const idxA = out.lastIndexOf('[영상 정보]');
+    const idxE = out.indexOf('[만다라 컨텍스트]');
+    const idxF = out.indexOf('[현재 상태]');
+    const idxG = out.indexOf('[노트 컨텍스트]');
+    const idxU = out.indexOf('[사용자 컨텍스트]');
+    // Block H header `[관련 자료 (RAG)]` is also referenced inside EXTENDED_RULES_KO;
+    // use lastIndexOf so we pick the actual Block H occurrence rather than the
+    // rules-text mention.
+    const idxH = out.lastIndexOf('[관련 자료 (RAG)]');
+
+    expect(idxPersona).toBe(0);
+    expect(idxRole).toBeGreaterThan(idxPersona);
+    expect(idxExtended).toBeGreaterThan(idxRole);
+    // Per LAYER_BLOCKS.note = ['A','B','C','D','F','G','U','H'], A precedes
+    // F, G, U, H — and E is NOT in the note layer (mandala block only attaches
+    // to mandala/cell layers).
+    expect(idxA).toBeGreaterThan(idxExtended);
+    expect(idxE).toBe(-1);
+    expect(idxF).toBeGreaterThan(idxA);
+    expect(idxG).toBeGreaterThan(idxF);
+    expect(idxU).toBeGreaterThan(idxG);
+    expect(idxH).toBeGreaterThan(idxU);
+  });
+});

--- a/tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
+++ b/tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
@@ -1,0 +1,227 @@
+/**
+ * tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
+ *
+ * Unit tests for the qwen prompt middleware (CP474 Stage 7a).
+ *
+ * Coverage:
+ *   - rewriteSystemContent extracts video_id from YouTube URL
+ *   - rewriteSystemContent passes v2 / transcript through to prompt-builder
+ *   - Korean vs English detection
+ *   - Cache: second call for same videoId reuses loaded context
+ *   - Cache invalidates after TTL (5min)
+ *   - rewriteSystemPrompt (V3 form) keeps non-system messages in order
+ *   - rewriteSystemPrompt with empty prompt returns null
+ *   - createQwenPromptMiddleware transformParams handles errors fail-safe
+ */
+
+const mockLoadVideoContext = jest.fn();
+
+jest.mock('@/utils/logger', () => {
+  type Logger = {
+    info: jest.Mock;
+    warn: jest.Mock;
+    error: jest.Mock;
+    debug: jest.Mock;
+    child: () => Logger;
+  };
+  const childLogger: Logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: () => childLogger,
+  };
+  return { logger: childLogger };
+});
+
+jest.mock('@/modules/chatbot-rag/video-context-loader', () => ({
+  loadVideoContext: mockLoadVideoContext,
+}));
+
+import {
+  rewriteSystemContent,
+  rewriteSystemPrompt,
+  createQwenPromptMiddleware,
+  _resetMiddlewareCacheForTesting,
+} from '@/modules/chatbot-rag/qwen-prompt-middleware';
+import { PRODUCT_PERSONA_KO, PRODUCT_PERSONA_EN } from '@/modules/chatbot-rag/prompt-builder';
+
+const SAMPLE_V2 = {
+  title: '하프 1:30의 벽',
+  core: { one_liner: '속도/지구력/회복', domain: 'running' },
+  analysis: { core_argument: '균형 잡힌 훈련' },
+};
+
+const SAMPLE_TRANSCRIPT = {
+  full_text: '안녕하세요',
+  source: 'mac-mini' as const,
+  language: 'ko' as const,
+  truncated: false,
+  total_chars: 5,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _resetMiddlewareCacheForTesting();
+  // Default: no v2, no transcript — keeps tests deterministic
+  mockLoadVideoContext.mockResolvedValue({ v2Data: null, transcript: null });
+});
+
+describe('rewriteSystemContent', () => {
+  it('parses video_id from a YouTube URL and forwards it to loadVideoContext', async () => {
+    await rewriteSystemContent('URL: https://www.youtube.com/watch?v=abc12345678 something');
+
+    expect(mockLoadVideoContext).toHaveBeenCalledWith({
+      youtubeVideoId: 'abc12345678',
+      preferredLanguage: 'ko',
+    });
+  });
+
+  it('omits loadVideoContext entirely when no YouTube URL is present', async () => {
+    await rewriteSystemContent('한국어 일반 응답 요청 — 영상 없음');
+
+    expect(mockLoadVideoContext).not.toHaveBeenCalled();
+  });
+
+  it('passes loaded v2 data into the system prompt', async () => {
+    mockLoadVideoContext.mockResolvedValueOnce({ v2Data: SAMPLE_V2, transcript: null });
+
+    const out = await rewriteSystemContent('URL: https://www.youtube.com/watch?v=abc12345678');
+
+    expect(out).toContain('[영상 정보]');
+    expect(out).toContain('제목: 하프 1:30의 벽');
+    expect(out).toContain('핵심 주장: 속도/지구력/회복');
+  });
+
+  it('engages the transcript fallback when no v2', async () => {
+    mockLoadVideoContext.mockResolvedValueOnce({ v2Data: null, transcript: SAMPLE_TRANSCRIPT });
+
+    const out = await rewriteSystemContent('URL: https://www.youtube.com/watch?v=abc12345678');
+
+    expect(out).toContain('출처: mac-mini');
+    expect(out).toContain('안녕하세요');
+    // v2-only block markers (NOT referenced in EXTENDED_RULES_KO) must be absent.
+    expect(out).not.toContain('제목:');
+    expect(out).not.toContain('[핵심 개념]');
+  });
+
+  it('always prepends the Korean persona block by default', async () => {
+    const out = await rewriteSystemContent('아무거나');
+    expect(out.startsWith(PRODUCT_PERSONA_KO)).toBe(true);
+  });
+
+  it('detects English when the FE prompt opens "You are Insighta..."', async () => {
+    const out = await rewriteSystemContent(
+      "You are Insighta's learning assistant. URL: https://www.youtube.com/watch?v=eng12345678"
+    );
+
+    expect(out.startsWith(PRODUCT_PERSONA_EN)).toBe(true);
+    expect(mockLoadVideoContext).toHaveBeenCalledWith({
+      youtubeVideoId: 'eng12345678',
+      preferredLanguage: 'en',
+    });
+  });
+});
+
+describe('rewriteSystemContent — caching', () => {
+  it('caches video context per videoId (second call within TTL hits cache)', async () => {
+    mockLoadVideoContext.mockResolvedValue({ v2Data: SAMPLE_V2, transcript: null });
+
+    await rewriteSystemContent('URL: https://www.youtube.com/watch?v=cache000001');
+    await rewriteSystemContent('URL: https://www.youtube.com/watch?v=cache000001');
+
+    expect(mockLoadVideoContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats different videoIds as separate cache keys', async () => {
+    mockLoadVideoContext.mockResolvedValue({ v2Data: null, transcript: null });
+
+    await rewriteSystemContent('URL: https://www.youtube.com/watch?v=videoa00001');
+    await rewriteSystemContent('URL: https://www.youtube.com/watch?v=videob00002');
+
+    expect(mockLoadVideoContext).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('rewriteSystemPrompt — LanguageModelV3 form', () => {
+  it('returns null when prompt is empty', async () => {
+    const result = await rewriteSystemPrompt([]);
+    expect(result).toBeNull();
+  });
+
+  it('rewrites system messages and preserves non-system message order', async () => {
+    const original = [
+      { role: 'system' as const, content: 'sys A' },
+      { role: 'user' as const, content: [{ type: 'text' as const, text: 'hi' }] },
+      { role: 'assistant' as const, content: [{ type: 'text' as const, text: 'hello' }] },
+      { role: 'system' as const, content: 'sys B' },
+    ];
+
+    const result = await rewriteSystemPrompt(original);
+
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(3); // 1 rewritten system + 1 user + 1 assistant
+    expect(result![0]!.role).toBe('system');
+    expect(result![1]!.role).toBe('user');
+    expect(result![2]!.role).toBe('assistant');
+  });
+
+  it('still emits a system message even when input has no system messages', async () => {
+    const original = [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'hi' }] }];
+
+    const result = await rewriteSystemPrompt(original);
+
+    expect(result).not.toBeNull();
+    expect(result![0]!.role).toBe('system');
+    expect((result![0]! as { content: string }).content.startsWith(PRODUCT_PERSONA_KO)).toBe(true);
+  });
+});
+
+describe('createQwenPromptMiddleware', () => {
+  it('returns LanguageModelV3Middleware shape (specificationVersion=v3 + transformParams)', () => {
+    const mw = createQwenPromptMiddleware();
+    expect(mw.specificationVersion).toBe('v3');
+    expect(typeof mw.transformParams).toBe('function');
+  });
+
+  it('transformParams rewrites the prompt on success', async () => {
+    mockLoadVideoContext.mockResolvedValueOnce({ v2Data: SAMPLE_V2, transcript: null });
+    const mw = createQwenPromptMiddleware();
+    const inputParams = {
+      prompt: [
+        { role: 'system' as const, content: 'URL: https://www.youtube.com/watch?v=abc12345678' },
+      ],
+      maxOutputTokens: 100,
+    };
+
+    const out = await mw.transformParams!({
+      type: 'stream',
+      params: inputParams as never,
+      model: {} as never,
+    });
+
+    expect(out.maxOutputTokens).toBe(100);
+    expect(out.prompt[0]!.role).toBe('system');
+    expect((out.prompt[0]! as { content: string }).content).toContain('[영상 정보]');
+  });
+
+  it('transformParams falls back to original params on inner error (fail-safe)', async () => {
+    mockLoadVideoContext.mockRejectedValueOnce(new Error('db down'));
+    const mw = createQwenPromptMiddleware();
+    const inputParams = {
+      prompt: [
+        { role: 'system' as const, content: 'URL: https://www.youtube.com/watch?v=fail00000aa' },
+      ],
+      maxOutputTokens: 100,
+    };
+
+    const out = await mw.transformParams!({
+      type: 'stream',
+      params: inputParams as never,
+      model: {} as never,
+    });
+
+    // On error, original params returned unchanged (no rewrite).
+    expect(out).toBe(inputParams);
+  });
+});

--- a/tests/unit/modules/chatbot-rag/qwen-runpod-adapter.test.ts
+++ b/tests/unit/modules/chatbot-rag/qwen-runpod-adapter.test.ts
@@ -1,0 +1,333 @@
+/**
+ * tests/unit/modules/chatbot-rag/qwen-runpod-adapter.test.ts
+ *
+ * Unit tests for QwenRunpodAdapter (CP474 Phase B — Bug 1 fix).
+ *
+ * Coverage:
+ *   - Constructor validation (baseURL, apiKey required)
+ *   - Public properties: provider, model, name
+ *   - getLanguageModel() returns chat.completions LanguageModel — NOT
+ *     Responses API. This is the Bug 1 fix verification (mock createOpenAI
+ *     and assert `.chat()` was called, not `provider(model)`).
+ *   - process() filters non-text messages
+ *   - process() streams text deltas (start → content → end events)
+ *   - process() handles empty stream gracefully (no events)
+ *   - process() propagates threadId or generates new UUID
+ *
+ * Mocks: OpenAI SDK + @ai-sdk/openai + @copilotkit/shared.
+ */
+
+const mockChatCompletionsCreate = jest.fn();
+
+jest.mock('openai', () =>
+  jest.fn().mockImplementation(() => ({
+    chat: { completions: { create: mockChatCompletionsCreate } },
+  }))
+);
+
+const mockChatModel = { __chatModel: true };
+const mockResponsesModel = { __responsesModel: true };
+const mockCreateOpenAI = jest.fn().mockImplementation(() => {
+  const provider = jest.fn(() => mockResponsesModel);
+  // Mimic @ai-sdk/openai's provider surface: provider(model) → Responses,
+  // provider.chat(model) → Chat Completions, provider.responses(...) → Responses
+  Object.assign(provider, {
+    chat: jest.fn(() => mockChatModel),
+    responses: jest.fn(() => mockResponsesModel),
+  });
+  return provider;
+});
+
+jest.mock('@ai-sdk/openai', () => ({
+  createOpenAI: mockCreateOpenAI,
+}));
+
+jest.mock('@copilotkit/shared', () => ({
+  randomUUID: () => 'mock-uuid-1234',
+}));
+
+import { QwenRunpodAdapter } from '@/modules/chatbot-rag/qwen-runpod-adapter';
+
+const BASE = 'https://abc-8000.proxy.runpod.net/openai/v1';
+const KEY = '0123456789abcdef';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Re-prime createOpenAI default behaviour
+  mockCreateOpenAI.mockImplementation(() => {
+    const provider = jest.fn(() => mockResponsesModel);
+    Object.assign(provider, {
+      chat: jest.fn(() => mockChatModel),
+      responses: jest.fn(() => mockResponsesModel),
+    });
+    return provider;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Constructor + properties
+// ---------------------------------------------------------------------------
+
+describe('QwenRunpodAdapter — constructor', () => {
+  it('throws when baseURL is empty', () => {
+    expect(() => new QwenRunpodAdapter({ baseURL: '', apiKey: KEY })).toThrow(/baseURL/);
+  });
+
+  it('throws when apiKey is empty', () => {
+    expect(() => new QwenRunpodAdapter({ baseURL: BASE, apiKey: '' })).toThrow(/apiKey/);
+  });
+
+  it('sets provider="qwen-runpod" and default model="insighta-chatbot"', () => {
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });
+    expect(a.provider).toBe('qwen-runpod');
+    expect(a.model).toBe('insighta-chatbot');
+    expect(a.name).toBe('QwenRunpodAdapter');
+  });
+
+  it('accepts custom model override', () => {
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY, model: 'custom-name' });
+    expect(a.model).toBe('custom-name');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 1 fix verification — getLanguageModel()
+// ---------------------------------------------------------------------------
+
+describe('QwenRunpodAdapter — getLanguageModel() (Bug 1 fix)', () => {
+  it('uses createOpenAI({baseURL, apiKey}) for provider construction', () => {
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });
+    a.getLanguageModel();
+
+    expect(mockCreateOpenAI).toHaveBeenCalledWith({
+      baseURL: BASE,
+      apiKey: KEY,
+    });
+  });
+
+  it('invokes provider.chat(model) — chat.completions endpoint (NOT Responses API)', () => {
+    // This is the Bug 1 fix: provider.chat() forces /v1/chat/completions,
+    // not provider(model) which would route to /v1/responses.
+    let capturedProvider:
+      | (jest.Mock & {
+          chat: jest.Mock;
+          responses: jest.Mock;
+        })
+      | null = null;
+    mockCreateOpenAI.mockImplementationOnce(() => {
+      const provider = jest.fn(() => mockResponsesModel);
+      Object.assign(provider, {
+        chat: jest.fn(() => mockChatModel),
+        responses: jest.fn(() => mockResponsesModel),
+      });
+      capturedProvider = provider as unknown as typeof capturedProvider;
+      return provider;
+    });
+
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY, model: 'm-1' });
+    const lm = a.getLanguageModel();
+
+    expect(lm).toBe(mockChatModel);
+    expect(capturedProvider!.chat).toHaveBeenCalledWith('m-1');
+    // Critical: the default callable (Responses API) MUST NOT be invoked.
+    expect(capturedProvider!).not.toHaveBeenCalled();
+    expect(capturedProvider!.responses).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// process() streaming
+// ---------------------------------------------------------------------------
+
+function makeTextMessage(role: 'user' | 'assistant' | 'system', content: string) {
+  return {
+    isTextMessage: () => true,
+    isActionExecutionMessage: () => false,
+    isResultMessage: () => false,
+    role,
+    content,
+  };
+}
+
+function makeNonTextMessage() {
+  return {
+    isTextMessage: () => false,
+    isActionExecutionMessage: () => true,
+    isResultMessage: () => false,
+    role: 'assistant',
+    content: '',
+  };
+}
+
+function makeEventSource() {
+  const calls: Array<{ method: string; args: unknown }> = [];
+  const eventStream$ = {
+    sendTextMessageStart: jest.fn((args) => calls.push({ method: 'start', args })),
+    sendTextMessageContent: jest.fn((args) => calls.push({ method: 'content', args })),
+    sendTextMessageEnd: jest.fn((args) => calls.push({ method: 'end', args })),
+    sendActionExecutionStart: jest.fn(),
+    sendActionExecutionEnd: jest.fn(),
+    sendActionExecutionArgs: jest.fn(),
+    complete: jest.fn(() => calls.push({ method: 'complete', args: undefined })),
+  };
+  // `done` resolves once the streaming handler completes. The adapter's
+  // call to `eventSource.stream(...)` is fired-and-forget — process()
+  // returns the threadId immediately while the handler runs in the
+  // background. Tests must await `done` before asserting event order.
+  let resolveDone!: () => void;
+  const done = new Promise<void>((res) => {
+    resolveDone = res;
+  });
+  return {
+    eventStream$,
+    calls,
+    done,
+    stream: jest.fn(async (handler: (es: typeof eventStream$) => Promise<void>) => {
+      try {
+        await handler(eventStream$);
+      } finally {
+        resolveDone();
+      }
+    }),
+  };
+}
+
+async function* iterChunks(chunks: Array<{ id?: string; delta?: string }>) {
+  for (const c of chunks) {
+    yield { id: c.id ?? 'chunk-1', choices: [{ delta: { content: c.delta } }] };
+  }
+}
+
+describe('QwenRunpodAdapter — process()', () => {
+  it('forwards only text messages to chat.completions', async () => {
+    mockChatCompletionsCreate.mockResolvedValueOnce(iterChunks([]));
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });
+    const es = makeEventSource();
+
+    await a.process({
+      messages: [
+        makeTextMessage('system', 'sys') as never,
+        makeTextMessage('user', 'hi') as never,
+        makeNonTextMessage() as never,
+      ],
+      actions: [],
+      eventSource: es as never,
+    });
+
+    expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(1);
+    const callArg = mockChatCompletionsCreate.mock.calls[0]![0];
+    expect(callArg.messages).toEqual([
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+    ]);
+  });
+
+  it('streams deltas as start → content → end → complete', async () => {
+    mockChatCompletionsCreate.mockResolvedValueOnce(
+      iterChunks([
+        { id: 'c-1', delta: 'Hello' },
+        { id: 'c-1', delta: ', world' },
+      ])
+    );
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });
+    const es = makeEventSource();
+
+    await a.process({
+      messages: [makeTextMessage('user', 'hi') as never],
+      actions: [],
+      eventSource: es as never,
+    });
+    await es.done;
+
+    const methods = es.calls.map((c) => c.method);
+    expect(methods).toEqual(['start', 'content', 'content', 'end', 'complete']);
+
+    expect(es.eventStream$.sendTextMessageContent).toHaveBeenNthCalledWith(1, {
+      messageId: 'c-1',
+      content: 'Hello',
+    });
+    expect(es.eventStream$.sendTextMessageContent).toHaveBeenNthCalledWith(2, {
+      messageId: 'c-1',
+      content: ', world',
+    });
+  });
+
+  it('skips all message events when the stream is empty', async () => {
+    mockChatCompletionsCreate.mockResolvedValueOnce(iterChunks([]));
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });
+    const es = makeEventSource();
+
+    await a.process({
+      messages: [makeTextMessage('user', 'hi') as never],
+      actions: [],
+      eventSource: es as never,
+    });
+    await es.done;
+
+    expect(es.eventStream$.sendTextMessageStart).not.toHaveBeenCalled();
+    expect(es.eventStream$.sendTextMessageContent).not.toHaveBeenCalled();
+    expect(es.eventStream$.sendTextMessageEnd).not.toHaveBeenCalled();
+    expect(es.eventStream$.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes vLLM-specific chat_template_kwargs.enable_thinking=false', async () => {
+    mockChatCompletionsCreate.mockResolvedValueOnce(iterChunks([]));
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });
+    const es = makeEventSource();
+
+    await a.process({
+      messages: [makeTextMessage('user', 'hi') as never],
+      actions: [],
+      eventSource: es as never,
+    });
+
+    const callArg = mockChatCompletionsCreate.mock.calls[0]![0];
+    expect(callArg.chat_template_kwargs).toEqual({ enable_thinking: false });
+  });
+
+  it('returns provided threadId when present', async () => {
+    mockChatCompletionsCreate.mockResolvedValueOnce(iterChunks([]));
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });
+    const es = makeEventSource();
+
+    const result = await a.process({
+      messages: [makeTextMessage('user', 'hi') as never],
+      actions: [],
+      eventSource: es as never,
+      threadId: 'thread-abc',
+    });
+
+    expect(result.threadId).toBe('thread-abc');
+  });
+
+  it('generates a UUID threadId when not provided', async () => {
+    mockChatCompletionsCreate.mockResolvedValueOnce(iterChunks([]));
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });
+    const es = makeEventSource();
+
+    const result = await a.process({
+      messages: [makeTextMessage('user', 'hi') as never],
+      actions: [],
+      eventSource: es as never,
+    });
+
+    expect(result.threadId).toBe('mock-uuid-1234');
+  });
+
+  it('honours forwardedParameters.maxTokens + temperature when provided', async () => {
+    mockChatCompletionsCreate.mockResolvedValueOnce(iterChunks([]));
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });
+    const es = makeEventSource();
+
+    await a.process({
+      messages: [makeTextMessage('user', 'hi') as never],
+      actions: [],
+      eventSource: es as never,
+      forwardedParameters: { maxTokens: 800, temperature: 0.5 },
+    });
+
+    const callArg = mockChatCompletionsCreate.mock.calls[0]![0];
+    expect(callArg.max_completion_tokens).toBe(800);
+    expect(callArg.temperature).toBe(0.5);
+  });
+});

--- a/tests/unit/modules/chatbot-rag/qwen-runpod-adapter.test.ts
+++ b/tests/unit/modules/chatbot-rag/qwen-runpod-adapter.test.ts
@@ -46,6 +46,32 @@ jest.mock('@copilotkit/shared', () => ({
   randomUUID: () => 'mock-uuid-1234',
 }));
 
+// Mock the qwen prompt middleware so the adapter tests stay pure: no DB
+// calls, no caption extractor, just identity rewriting.
+jest.mock('@/modules/chatbot-rag/qwen-prompt-middleware', () => ({
+  createQwenPromptMiddleware: jest.fn(() => ({ specificationVersion: 'v3' })),
+  rewriteSystemContent: jest.fn(async (content: string) => content || 'REWRITTEN'),
+}));
+
+// Mock logger because the adapter imports it at module level.
+jest.mock('@/utils/logger', () => {
+  type Logger = {
+    info: jest.Mock;
+    warn: jest.Mock;
+    error: jest.Mock;
+    debug: jest.Mock;
+    child: () => Logger;
+  };
+  const childLogger: Logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: () => childLogger,
+  };
+  return { logger: childLogger };
+});
+
 import { QwenRunpodAdapter } from '@/modules/chatbot-rag/qwen-runpod-adapter';
 
 const BASE = 'https://abc-8000.proxy.runpod.net/openai/v1';
@@ -125,9 +151,11 @@ describe('QwenRunpodAdapter — getLanguageModel() (Bug 1 fix)', () => {
     });
 
     const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY, model: 'm-1' });
-    const lm = a.getLanguageModel();
+    // Returns wrapLanguageModel-wrapped LanguageModel (not the raw chat model).
+    // Identity isn't asserted; the critical assertion is that the chat
+    // factory was called, NOT the default (Responses) factory.
+    a.getLanguageModel();
 
-    expect(lm).toBe(mockChatModel);
     expect(capturedProvider!.chat).toHaveBeenCalledWith('m-1');
     // Critical: the default callable (Responses API) MUST NOT be invoked.
     expect(capturedProvider!).not.toHaveBeenCalled();
@@ -199,7 +227,7 @@ async function* iterChunks(chunks: Array<{ id?: string; delta?: string }>) {
 }
 
 describe('QwenRunpodAdapter — process()', () => {
-  it('forwards only text messages to chat.completions', async () => {
+  it('forwards only text messages to chat.completions, with system message rewritten', async () => {
     mockChatCompletionsCreate.mockResolvedValueOnce(iterChunks([]));
     const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });
     const es = makeEventSource();
@@ -216,6 +244,8 @@ describe('QwenRunpodAdapter — process()', () => {
 
     expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(1);
     const callArg = mockChatCompletionsCreate.mock.calls[0]![0];
+    // System message goes through rewriteSystemContent (mocked as identity);
+    // non-system messages pass through untouched.
     expect(callArg.messages).toEqual([
       { role: 'system', content: 'sys' },
       { role: 'user', content: 'hi' },

--- a/tests/unit/modules/chatbot-rag/retriever.test.ts
+++ b/tests/unit/modules/chatbot-rag/retriever.test.ts
@@ -1,0 +1,253 @@
+/**
+ * tests/unit/modules/chatbot-rag/retriever.test.ts
+ *
+ * Unit tests for the chatbot RAG retriever (CP474 Phase E).
+ *
+ * Coverage:
+ *   - Empty/whitespace query → short-circuit, no embedding call
+ *   - Embedding throws → empty results (graceful)
+ *   - searchByVector returns 0 → empty results
+ *   - Happy path: candidates returned with hydrated RAGResult shape
+ *   - Cohere rerank trims to topK
+ *   - Cohere rerank throws → fallback to raw vector ranking (no result loss)
+ *   - Below RERANK_MIN_SCORE filtered out
+ *   - source_type classification: video/card/note/concept variants
+ *   - extractExcerpt prefers summary > one_liner > description
+ *   - extractExcerpt truncates excerpts > 280 chars
+ *
+ * Mocks: ontology.embedding + ontology.search + rerank/cohere-client + logger.
+ */
+
+const mockGenerateEmbedding = jest.fn();
+const mockSearchByVector = jest.fn();
+const mockRerank = jest.fn();
+
+jest.mock('@/utils/logger', () => {
+  type Logger = {
+    info: jest.Mock;
+    warn: jest.Mock;
+    error: jest.Mock;
+    debug: jest.Mock;
+    child: () => Logger;
+  };
+  const childLogger: Logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: () => childLogger,
+  };
+  return { logger: childLogger };
+});
+
+jest.mock('@/modules/ontology/embedding', () => ({
+  generateEmbedding: mockGenerateEmbedding,
+}));
+
+jest.mock('@/modules/ontology/search', () => ({
+  searchByVector: mockSearchByVector,
+}));
+
+jest.mock('@/modules/rerank/cohere-client', () => ({
+  rerank: mockRerank,
+}));
+
+import { retrieveRAGContext } from '@/modules/chatbot-rag/retriever';
+
+const FIXED_NOW = new Date('2026-05-20T00:00:00.000Z');
+const FIXED_NOW_FN = () => FIXED_NOW;
+
+function makeCandidate(overrides: {
+  id?: string;
+  type?: string;
+  title?: string;
+  similarity?: number;
+  properties?: Record<string, unknown>;
+}) {
+  return {
+    id: overrides.id ?? 'n-1',
+    type: overrides.type ?? 'video',
+    title: overrides.title ?? '하프 마라톤 1:30',
+    properties: overrides.properties ?? { summary: '인터벌 + LSD 균형' },
+    similarity: overrides.similarity ?? 0.85,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: embedding succeeds, search returns 3 candidates, rerank returns same order.
+  mockGenerateEmbedding.mockResolvedValue([0.1, 0.2, 0.3]);
+  mockSearchByVector.mockResolvedValue([
+    makeCandidate({ id: 'n-1', similarity: 0.9, title: '인터벌' }),
+    makeCandidate({ id: 'n-2', similarity: 0.8, title: 'LSD' }),
+    makeCandidate({ id: 'n-3', similarity: 0.7, title: '테이퍼링' }),
+  ]);
+  mockRerank.mockResolvedValue({
+    results: [
+      { index: 0, relevanceScore: 0.95 },
+      { index: 1, relevanceScore: 0.85 },
+      { index: 2, relevanceScore: 0.65 },
+    ],
+  });
+});
+
+describe('retrieveRAGContext — short-circuit', () => {
+  it('returns empty results immediately for empty query', async () => {
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: '', now: FIXED_NOW_FN });
+    expect(ctx.results).toEqual([]);
+    expect(mockGenerateEmbedding).not.toHaveBeenCalled();
+  });
+
+  it('returns empty results for whitespace-only query', async () => {
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: '   \t\n', now: FIXED_NOW_FN });
+    expect(ctx.results).toEqual([]);
+    expect(mockGenerateEmbedding).not.toHaveBeenCalled();
+  });
+});
+
+describe('retrieveRAGContext — graceful degradation', () => {
+  it('returns empty results when embedding throws', async () => {
+    mockGenerateEmbedding.mockRejectedValueOnce(new Error('provider down'));
+
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: '마라톤', now: FIXED_NOW_FN });
+
+    expect(ctx.results).toEqual([]);
+    expect(mockSearchByVector).not.toHaveBeenCalled();
+  });
+
+  it('returns empty results when searchByVector throws', async () => {
+    mockSearchByVector.mockRejectedValueOnce(new Error('db unreachable'));
+
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: '마라톤', now: FIXED_NOW_FN });
+
+    expect(ctx.results).toEqual([]);
+  });
+
+  it('returns empty when vector search yields zero candidates', async () => {
+    mockSearchByVector.mockResolvedValueOnce([]);
+
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: '마라톤', now: FIXED_NOW_FN });
+
+    expect(ctx.results).toEqual([]);
+    expect(mockRerank).not.toHaveBeenCalled();
+  });
+
+  it('falls back to raw vector ranking when Cohere rerank throws', async () => {
+    mockRerank.mockRejectedValueOnce(new Error('cohere 503'));
+
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: '마라톤', now: FIXED_NOW_FN });
+
+    expect(ctx.results.length).toBe(3);
+    expect(ctx.results[0]!.title).toBe('인터벌');
+  });
+});
+
+describe('retrieveRAGContext — happy path', () => {
+  it('returns reranked candidates with hydrated RAGResult shape', async () => {
+    const ctx = await retrieveRAGContext({
+      userId: 'u-1',
+      query: '인터벌 훈련법?',
+      now: FIXED_NOW_FN,
+    });
+
+    expect(ctx).toMatchObject({
+      query: '인터벌 훈련법?',
+      retrieved_at: '2026-05-20T00:00:00.000Z',
+    });
+    expect(ctx.results.length).toBe(3);
+    expect(ctx.results[0]).toMatchObject({
+      source_type: 'card',
+      title: '인터벌',
+      excerpt: '인터벌 + LSD 균형',
+    });
+  });
+
+  it('filters out candidates below RERANK_MIN_SCORE', async () => {
+    mockRerank.mockResolvedValueOnce({
+      results: [
+        { index: 0, relevanceScore: 0.95 },
+        { index: 1, relevanceScore: 0.1 }, // below 0.15 threshold
+        { index: 2, relevanceScore: 0.2 },
+      ],
+    });
+
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: '마라톤', now: FIXED_NOW_FN });
+
+    expect(ctx.results.length).toBe(2);
+    expect(ctx.results.map((r) => r.title)).toEqual(['인터벌', '테이퍼링']);
+  });
+
+  it('passes topK as topN to Cohere rerank', async () => {
+    await retrieveRAGContext({
+      userId: 'u-1',
+      query: '마라톤',
+      topK: 2,
+      now: FIXED_NOW_FN,
+    });
+
+    expect(mockRerank).toHaveBeenCalledWith(expect.objectContaining({ topN: 2, query: '마라톤' }));
+  });
+});
+
+describe('retrieveRAGContext — source_type classification', () => {
+  it('classifies type=video as "card"', async () => {
+    mockSearchByVector.mockResolvedValueOnce([makeCandidate({ type: 'video', title: 'X' })]);
+    mockRerank.mockResolvedValueOnce({ results: [{ index: 0, relevanceScore: 0.9 }] });
+
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: 'q', now: FIXED_NOW_FN });
+    expect(ctx.results[0]!.source_type).toBe('card');
+  });
+
+  it('classifies type=note as "note"', async () => {
+    mockSearchByVector.mockResolvedValueOnce([makeCandidate({ type: 'note', title: 'Y' })]);
+    mockRerank.mockResolvedValueOnce({ results: [{ index: 0, relevanceScore: 0.9 }] });
+
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: 'q', now: FIXED_NOW_FN });
+    expect(ctx.results[0]!.source_type).toBe('note');
+  });
+
+  it('classifies arbitrary type as "kg_node"', async () => {
+    mockSearchByVector.mockResolvedValueOnce([makeCandidate({ type: 'concept', title: 'Z' })]);
+    mockRerank.mockResolvedValueOnce({ results: [{ index: 0, relevanceScore: 0.9 }] });
+
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: 'q', now: FIXED_NOW_FN });
+    expect(ctx.results[0]!.source_type).toBe('kg_node');
+  });
+});
+
+describe('retrieveRAGContext — excerpt extraction', () => {
+  it('prefers summary over one_liner', async () => {
+    mockSearchByVector.mockResolvedValueOnce([
+      makeCandidate({
+        title: 'X',
+        properties: { summary: 'SUMMARY', one_liner: 'ONELINER' },
+      }),
+    ]);
+    mockRerank.mockResolvedValueOnce({ results: [{ index: 0, relevanceScore: 0.9 }] });
+
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: 'q', now: FIXED_NOW_FN });
+    expect(ctx.results[0]!.excerpt).toBe('SUMMARY');
+  });
+
+  it('truncates excerpts beyond 280 chars', async () => {
+    const longText = 'A'.repeat(300);
+    mockSearchByVector.mockResolvedValueOnce([
+      makeCandidate({ title: 'X', properties: { summary: longText } }),
+    ]);
+    mockRerank.mockResolvedValueOnce({ results: [{ index: 0, relevanceScore: 0.9 }] });
+
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: 'q', now: FIXED_NOW_FN });
+    expect(ctx.results[0]!.excerpt.length).toBe(280);
+    expect(ctx.results[0]!.excerpt.endsWith('...')).toBe(true);
+  });
+
+  it('returns empty excerpt when no textual properties present', async () => {
+    mockSearchByVector.mockResolvedValueOnce([
+      makeCandidate({ title: 'X', properties: { unrelated: 123 } }),
+    ]);
+    mockRerank.mockResolvedValueOnce({ results: [{ index: 0, relevanceScore: 0.9 }] });
+
+    const ctx = await retrieveRAGContext({ userId: 'u-1', query: 'q', now: FIXED_NOW_FN });
+    expect(ctx.results[0]!.excerpt).toBe('');
+  });
+});

--- a/tests/unit/modules/chatbot-rag/user-context-loader.test.ts
+++ b/tests/unit/modules/chatbot-rag/user-context-loader.test.ts
@@ -1,0 +1,202 @@
+/**
+ * tests/unit/modules/chatbot-rag/user-context-loader.test.ts
+ *
+ * Unit tests for the chatbot user-context loader (CP474 Phase B).
+ *
+ * Coverage:
+ *   - Happy path: all 6 source queries return data → UserContext fully populated
+ *   - New user without subscription row → tier defaults to 'free'
+ *   - currentMandalaId absent → current_mandala_name undefined
+ *   - mandala_titles ordering + cap (MAX_MANDALA_TITLES)
+ *   - Recent cards filter uses RECENT_DAYS_WINDOW from `now` injection
+ *   - displayName fallback to email local-part when JWT user_metadata missing
+ *   - Graceful degradation: individual Prisma query rejection → field falls back
+ *
+ * Mocks: Prisma client only. No real DB, no env vars, no network calls.
+ */
+
+const mockUsersFindUnique = jest.fn();
+const mockSubscriptionFindUnique = jest.fn();
+const mockMandalasFindMany = jest.fn();
+const mockMandalasCount = jest.fn();
+const mockMandalaFindUnique = jest.fn();
+const mockCardsCount = jest.fn();
+
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    users: { findUnique: mockUsersFindUnique },
+    user_subscriptions: { findUnique: mockSubscriptionFindUnique },
+    user_mandalas: {
+      findMany: mockMandalasFindMany,
+      count: mockMandalasCount,
+      findUnique: mockMandalaFindUnique,
+    },
+    user_local_cards: { count: mockCardsCount },
+  }),
+}));
+
+import { loadUserContext } from '@/modules/chatbot-rag/user-context-loader';
+import { MAX_MANDALA_TITLES, RECENT_DAYS_WINDOW } from '@/modules/chatbot-rag/types';
+
+const FIXED_NOW = new Date('2026-05-20T00:00:00.000Z');
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Defaults reused across happy-path tests.
+  mockUsersFindUnique.mockResolvedValue({
+    created_at: new Date('2026-01-15T00:00:00.000Z'),
+  });
+  mockSubscriptionFindUnique.mockResolvedValue({ tier: 'lifetime' });
+  mockMandalasFindMany.mockResolvedValue([
+    { title: '마라톤 완주' },
+    { title: 'Python 풀스택' },
+    { title: '프랑스어 B1' },
+  ]);
+  mockMandalasCount.mockResolvedValue(3);
+  mockCardsCount.mockResolvedValue(12);
+  mockMandalaFindUnique.mockResolvedValue({ title: '마라톤 완주' });
+});
+
+describe('loadUserContext — happy path', () => {
+  it('returns fully populated UserContext when all sources resolve', async () => {
+    const ctx = await loadUserContext({
+      userId: 'u-1',
+      email: 'jeonho@example.com',
+      displayName: 'Jeonho',
+      currentMandalaId: 'm-1',
+      preferredLanguage: 'ko',
+      now: FIXED_NOW,
+    });
+
+    expect(ctx).toMatchObject({
+      user_id: 'u-1',
+      display_name: 'Jeonho',
+      email: 'jeonho@example.com',
+      tier: 'lifetime',
+      join_date: '2026-01-15',
+      mandala_count: 3,
+      mandala_titles: ['마라톤 완주', 'Python 풀스택', '프랑스어 B1'],
+      current_mandala_name: '마라톤 완주',
+      recent_card_count_7d: 12,
+      preferred_language: 'ko',
+    });
+    // 2026-01-15 → 2026-05-20 = 125 days (Jan 16-31:16, Feb:28, Mar:31, Apr:30, May 1-20:20 = 16+28+31+30+20 = 125)
+    expect(ctx.days_active).toBe(125);
+  });
+
+  it('passes the correct recency cutoff to user_local_cards.count', async () => {
+    await loadUserContext({
+      userId: 'u-1',
+      email: 'jeonho@example.com',
+      preferredLanguage: 'ko',
+      now: FIXED_NOW,
+    });
+
+    const expectedCutoff = new Date(FIXED_NOW.getTime() - RECENT_DAYS_WINDOW * ONE_DAY_MS);
+    expect(mockCardsCount).toHaveBeenCalledWith({
+      where: {
+        user_id: 'u-1',
+        created_at: { gte: expectedCutoff },
+      },
+    });
+  });
+
+  it('caps mandala_titles to MAX_MANDALA_TITLES via Prisma take', async () => {
+    await loadUserContext({
+      userId: 'u-1',
+      email: 'jeonho@example.com',
+      preferredLanguage: 'ko',
+      now: FIXED_NOW,
+    });
+
+    expect(mockMandalasFindMany).toHaveBeenCalledWith({
+      where: { user_id: 'u-1' },
+      select: { title: true },
+      orderBy: { created_at: 'desc' },
+      take: MAX_MANDALA_TITLES,
+    });
+  });
+});
+
+describe('loadUserContext — defaults + degradation', () => {
+  it('defaults tier to "free" when user_subscriptions row is missing', async () => {
+    mockSubscriptionFindUnique.mockResolvedValueOnce(null);
+
+    const ctx = await loadUserContext({
+      userId: 'new-user',
+      email: 'newbie@example.com',
+      preferredLanguage: 'ko',
+      now: FIXED_NOW,
+    });
+
+    expect(ctx.tier).toBe('free');
+  });
+
+  it('returns current_mandala_name undefined when currentMandalaId not passed', async () => {
+    const ctx = await loadUserContext({
+      userId: 'u-1',
+      email: 'jeonho@example.com',
+      preferredLanguage: 'ko',
+      now: FIXED_NOW,
+    });
+
+    expect(ctx.current_mandala_name).toBeUndefined();
+    expect(mockMandalaFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('falls back display_name to email local-part when displayName is empty', async () => {
+    const ctx = await loadUserContext({
+      userId: 'u-1',
+      email: 'taro@example.com',
+      displayName: '   ', // whitespace
+      preferredLanguage: 'en',
+      now: FIXED_NOW,
+    });
+
+    expect(ctx.display_name).toBe('taro');
+  });
+
+  it('returns join_date="" and days_active=0 when users row lacks created_at', async () => {
+    mockUsersFindUnique.mockResolvedValueOnce({ created_at: null });
+
+    const ctx = await loadUserContext({
+      userId: 'u-1',
+      email: 'jeonho@example.com',
+      preferredLanguage: 'ko',
+      now: FIXED_NOW,
+    });
+
+    expect(ctx.join_date).toBe('');
+    expect(ctx.days_active).toBe(0);
+  });
+
+  it('survives individual Prisma rejection — empty mandalas list when findMany throws', async () => {
+    mockMandalasFindMany.mockRejectedValueOnce(new Error('connection lost'));
+
+    const ctx = await loadUserContext({
+      userId: 'u-1',
+      email: 'jeonho@example.com',
+      preferredLanguage: 'ko',
+      now: FIXED_NOW,
+    });
+
+    expect(ctx.mandala_titles).toEqual([]);
+    // Other fields still populated from their successful queries
+    expect(ctx.tier).toBe('lifetime');
+    expect(ctx.mandala_count).toBe(3);
+  });
+
+  it('normalizes unknown tier strings to "free"', async () => {
+    mockSubscriptionFindUnique.mockResolvedValueOnce({ tier: 'enterprise-trial' });
+
+    const ctx = await loadUserContext({
+      userId: 'u-1',
+      email: 'jeonho@example.com',
+      preferredLanguage: 'ko',
+      now: FIXED_NOW,
+    });
+
+    expect(ctx.tier).toBe('free');
+  });
+});

--- a/tests/unit/modules/chatbot-rag/video-context-loader.test.ts
+++ b/tests/unit/modules/chatbot-rag/video-context-loader.test.ts
@@ -1,0 +1,282 @@
+/**
+ * tests/unit/modules/chatbot-rag/video-context-loader.test.ts
+ *
+ * Unit tests for the chatbot video grounding decision (CP474 Phase B).
+ *
+ * Coverage:
+ *   - summaryHasUsableContent: 8 scenarios (FE↔BE mirror invariant)
+ *   - loadVideoContext: v2 happy path → V2Summary returned
+ *   - loadVideoContext: v2 absent → transcript fallback engaged
+ *   - loadVideoContext: v2 not usable (empty core/analysis) → transcript fallback
+ *   - loadVideoContext: v2 quality_flag='low' → treated as absent
+ *   - loadVideoContext: both branches fail → { v2Data: null, transcript: null }
+ *   - loadVideoContext: transcript truncation at TRANSCRIPT_PROMPT_MAX_CHARS
+ *   - loadVideoContext: youtube_videos title JOIN failure → V2Summary with title=null
+ *
+ * Mocks: Prisma client + caption extractor singleton.
+ */
+
+const mockV2FindUnique = jest.fn();
+const mockYoutubeVideosFindUnique = jest.fn();
+const mockExtractCaptions = jest.fn();
+
+// Mock logger first — its module imports `@/config/index` which validates env
+// vars (ENCRYPTION_SECRET etc.). Mocking the logger keeps the test purely unit.
+jest.mock('@/utils/logger', () => {
+  type Logger = {
+    info: jest.Mock;
+    warn: jest.Mock;
+    error: jest.Mock;
+    debug: jest.Mock;
+    child: () => Logger;
+  };
+  const childLogger: Logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: () => childLogger,
+  };
+  return { logger: childLogger };
+});
+
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    video_rich_summaries: { findUnique: mockV2FindUnique },
+    youtube_videos: { findUnique: mockYoutubeVideosFindUnique },
+  }),
+}));
+
+jest.mock('@/modules/caption/extractor', () => ({
+  getCaptionExtractor: () => ({
+    extractCaptions: mockExtractCaptions,
+  }),
+}));
+
+import {
+  loadVideoContext,
+  summaryHasUsableContent,
+} from '@/modules/chatbot-rag/video-context-loader';
+import { TRANSCRIPT_PROMPT_MAX_CHARS } from '@/modules/chatbot-rag/types';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default success-shaped responses; individual tests override as needed.
+  mockYoutubeVideosFindUnique.mockResolvedValue({ title: '하프 1:30의 벽' });
+  mockExtractCaptions.mockResolvedValue({
+    success: false,
+    videoId: 'abc123',
+    language: 'ko',
+    error: 'No publicly available captions found',
+  });
+});
+
+describe('summaryHasUsableContent — FE/BE mirror invariant', () => {
+  it('returns true when core.one_liner present', () => {
+    expect(
+      summaryHasUsableContent({
+        core: { one_liner: '핵심 한 줄' },
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when analysis.core_argument present', () => {
+    expect(
+      summaryHasUsableContent({
+        analysis: { core_argument: '주장' },
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when analysis.key_concepts has items', () => {
+    expect(
+      summaryHasUsableContent({
+        analysis: { key_concepts: [{ term: 't', definition: 'd' }] },
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when analysis.actionables has items', () => {
+    expect(
+      summaryHasUsableContent({
+        analysis: { actionables: ['a'] },
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when v1 oneLiner present', () => {
+    expect(summaryHasUsableContent({ oneLiner: '한 줄' })).toBe(true);
+  });
+
+  it('returns true when v1 structured.core_argument present', () => {
+    expect(
+      summaryHasUsableContent({
+        structured: { core_argument: 'v1 주장' },
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when v1 structured.key_points has items', () => {
+    expect(
+      summaryHasUsableContent({
+        structured: { key_points: ['a'] },
+      })
+    ).toBe(true);
+  });
+
+  it('returns false when all fields empty / absent', () => {
+    expect(summaryHasUsableContent({})).toBe(false);
+    expect(
+      summaryHasUsableContent({
+        core: { one_liner: '' },
+        analysis: { core_argument: '', key_concepts: [], actionables: [] },
+        structured: { core_argument: '', key_points: [], actionables: [] },
+      })
+    ).toBe(false);
+  });
+});
+
+describe('loadVideoContext — v2 path', () => {
+  it('returns V2Summary when v2 row is usable', async () => {
+    mockV2FindUnique.mockResolvedValueOnce({
+      one_liner: null,
+      structured: null,
+      core: { one_liner: '핵심 한 줄', domain: 'running' },
+      analysis: { core_argument: '주장', key_concepts: [], actionables: [] },
+      segments: { sections: [] },
+      quality_flag: 'pass',
+      template_version: 'v2',
+    });
+
+    const result = await loadVideoContext({ youtubeVideoId: 'abc12345678' });
+
+    expect(result.v2Data).not.toBeNull();
+    expect(result.v2Data?.title).toBe('하프 1:30의 벽');
+    expect(result.v2Data?.core).toMatchObject({ one_liner: '핵심 한 줄' });
+    expect(result.transcript).toBeNull();
+    // Transcript extractor must not run when v2 wins.
+    expect(mockExtractCaptions).not.toHaveBeenCalled();
+  });
+
+  it('returns V2Summary with title=null when youtube_videos JOIN fails', async () => {
+    mockV2FindUnique.mockResolvedValueOnce({
+      one_liner: null,
+      core: { one_liner: '핵심' },
+      analysis: null,
+      segments: null,
+      quality_flag: 'pass',
+      template_version: 'v2',
+    });
+    mockYoutubeVideosFindUnique.mockRejectedValueOnce(new Error('db down'));
+
+    const result = await loadVideoContext({ youtubeVideoId: 'abc12345678' });
+
+    expect(result.v2Data?.title).toBeNull();
+    expect(result.v2Data?.core).toMatchObject({ one_liner: '핵심' });
+  });
+
+  it('treats quality_flag="low" as absent and falls back to transcript', async () => {
+    mockV2FindUnique.mockResolvedValueOnce({
+      one_liner: '한 줄',
+      core: { one_liner: '한 줄' },
+      analysis: null,
+      segments: null,
+      quality_flag: 'low',
+      template_version: 'v2',
+    });
+    mockExtractCaptions.mockResolvedValueOnce({
+      success: true,
+      videoId: 'abc12345678',
+      language: 'ko',
+      caption: { videoId: 'abc12345678', language: 'ko', fullText: '자막 내용', segments: [] },
+    });
+
+    const result = await loadVideoContext({ youtubeVideoId: 'abc12345678' });
+
+    expect(result.v2Data).toBeNull();
+    expect(result.transcript?.full_text).toBe('자막 내용');
+  });
+
+  it('falls back to transcript when v2 row has all-empty content', async () => {
+    mockV2FindUnique.mockResolvedValueOnce({
+      one_liner: null,
+      core: { one_liner: '' },
+      analysis: { core_argument: '', key_concepts: [], actionables: [] },
+      segments: null,
+      quality_flag: 'pass',
+      template_version: 'v2',
+      structured: null,
+    });
+    mockExtractCaptions.mockResolvedValueOnce({
+      success: true,
+      videoId: 'abc12345678',
+      language: 'en',
+      caption: { videoId: 'abc12345678', language: 'en', fullText: 'transcript', segments: [] },
+    });
+
+    const result = await loadVideoContext({ youtubeVideoId: 'abc12345678' });
+
+    expect(result.v2Data).toBeNull();
+    expect(result.transcript?.full_text).toBe('transcript');
+    expect(result.transcript?.language).toBe('en');
+  });
+});
+
+describe('loadVideoContext — transcript fallback', () => {
+  it('returns transcript when v2 row is absent and caption extractor succeeds', async () => {
+    mockV2FindUnique.mockResolvedValueOnce(null);
+    mockExtractCaptions.mockResolvedValueOnce({
+      success: true,
+      videoId: 'abc12345678',
+      language: 'ko',
+      caption: { videoId: 'abc12345678', language: 'ko', fullText: '안녕하세요', segments: [] },
+    });
+
+    const result = await loadVideoContext({ youtubeVideoId: 'abc12345678' });
+
+    expect(result.v2Data).toBeNull();
+    expect(result.transcript).toMatchObject({
+      full_text: '안녕하세요',
+      language: 'ko',
+      truncated: false,
+      total_chars: 5,
+    });
+  });
+
+  it('truncates transcript to TRANSCRIPT_PROMPT_MAX_CHARS when oversized', async () => {
+    mockV2FindUnique.mockResolvedValueOnce(null);
+    const huge = '가'.repeat(TRANSCRIPT_PROMPT_MAX_CHARS + 500);
+    mockExtractCaptions.mockResolvedValueOnce({
+      success: true,
+      videoId: 'abc12345678',
+      language: 'ko',
+      caption: { videoId: 'abc12345678', language: 'ko', fullText: huge, segments: [] },
+    });
+
+    const result = await loadVideoContext({ youtubeVideoId: 'abc12345678' });
+
+    expect(result.transcript?.truncated).toBe(true);
+    expect(result.transcript?.full_text.length).toBe(TRANSCRIPT_PROMPT_MAX_CHARS);
+    expect(result.transcript?.total_chars).toBe(TRANSCRIPT_PROMPT_MAX_CHARS + 500);
+  });
+
+  it('returns both null when v2 absent AND transcript fetch fails', async () => {
+    mockV2FindUnique.mockResolvedValueOnce(null);
+    // default mockExtractCaptions returns success:false (set in beforeEach)
+
+    const result = await loadVideoContext({ youtubeVideoId: 'abc12345678' });
+
+    expect(result.v2Data).toBeNull();
+    expect(result.transcript).toBeNull();
+  });
+
+  it('returns both null when v2 lookup throws AND transcript fetch throws', async () => {
+    mockV2FindUnique.mockRejectedValueOnce(new Error('db down'));
+    mockExtractCaptions.mockRejectedValueOnce(new Error('mac mini timeout'));
+
+    const result = await loadVideoContext({ youtubeVideoId: 'abc12345678' });
+
+    expect(result.v2Data).toBeNull();
+    expect(result.transcript).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Activates the RunPod-hosted Qwen LoRA chatbot end-to-end and ships the **Bug 1 multi-turn fix** + **Insighta persona injection** as immediate prod value.

- **Bug 1 fix** — `OpenAIAdapter` defaults `createOpenAI({...})(model)` to OpenAI **Responses API** (`/v1/responses`), which vLLM (and older OpenRouter Gemini deployments) don't implement. On the 2nd turn the assistant history fails Responses-API schema validation. New `QwenRunpodAdapter` calls `createOpenAI({...}).chat(model)` instead → **chat.completions** endpoint, which vLLM v0.9.0 supports 1-1. Verified via raw curl multi-turn on Pod `5s4pyrvowjm0uh`.
- **Persona injection** — LoRA (cp4000, 22744 SFT samples) doesn't know "Insighta" by name and hallucinated "DAMO Academy". `qwen-prompt-middleware.ts` wraps the chat model via Vercel AI SDK `wrapLanguageModel` and rewrites the system message at runtime with `PRODUCT_PERSONA_KO/EN` + (v2 ? Block A-D : Block T transcript fallback). FE prompt format unchanged.
- **Foundation for full RAG** — `user-context-loader.ts`, `video-context-loader.ts`, `retriever.ts` (ontology vector search + Cohere rerank), prompt-builder Block U/T/H landed but not yet activated in the middleware (requires JWT-derived userId plumbing). Code is in module + tested; activation is a follow-up.

## Architecture

```
FE prompt (buildInstructions)
       │
       ▼
CopilotKit Runtime  ──► QwenRunpodAdapter.getLanguageModel()
                              │
                              ▼
                       createOpenAI({...}).chat(model)   ← Bug 1 fix
                              │
                              ▼
                       wrapLanguageModel(middleware)
                              │
                              ▼
                       qwen-prompt-middleware
                       (Persona + Block A-D | Block T)
                              │
                              ▼
                       vLLM /v1/chat/completions
                       (chat_template_kwargs.enable_thinking=false)
```

## Activation

Three GH config items must be set before redeploy:

```bash
gh secret set RUNPOD_API_KEY --body "<vLLM --api-key value>"
gh variable set QWEN_LORA_API_URL --body "https://<pod-id>-8000.proxy.runpod.net/openai/v1"
gh variable set CHATBOT_PROVIDER --body "qwen-runpod"
```

Rollback is config-only (no code revert):

```bash
gh variable set CHATBOT_PROVIDER --body "openrouter"
```

The openrouter/gemini branch in \`copilotkit.ts\` is byte-identical to pre-CP474 behaviour.

## Files

**New (\`src/modules/chatbot-rag/\`)** — isolated module, BE-only:
- \`types.ts\` — UserContext, RAGResult, TranscriptContext shared types
- \`user-context-loader.ts\` — Prisma-backed tier/mandala/card snapshot
- \`video-context-loader.ts\` — v2 from \`video_rich_summaries\` + Mac Mini transcript fallback
- \`retriever.ts\` — \`searchByVector\` (ontology) + Cohere rerank
- \`qwen-runpod-adapter.ts\` — CopilotServiceAdapter implementation
- \`qwen-prompt-middleware.ts\` — Vercel AI SDK V3 middleware
- \`prompt-builder.ts\` — extended with Persona + Block U/T/H (original \`ROLE_AND_RULES_KO/EN\` byte-identical for SFT alignment)
- \`index.ts\` — public surface

**Modified**:
- \`src/api/routes/copilotkit.ts\` — \`qwen-runpod\` case now uses \`QwenRunpodAdapter\`; return type widened to \`CopilotServiceAdapter\`.
- \`.github/workflows/deploy.yml\` — 3 wirings for \`CHATBOT_PROVIDER\` (env / envs comma list / sed write block), mirroring the existing \`QWEN_LORA_API_URL\` pattern.

**Tests** (\`tests/unit/modules/chatbot-rag/\`): 6 files, **84/84 PASS**.

## Hard Rule compliance

- ✅ 0 LLM API direct calls (Anthropic/OpenRouter) from this PR's code
- ✅ 0 \`.env\` edits
- ✅ 0 prod DB writes
- ✅ 0 EC2 SSH bypass
- ✅ Pre-push verification: \`tsc --noEmit\` EXIT 0, jest 84/84 PASS
- ✅ Non-secret config (\`CHATBOT_PROVIDER\`) wired as GH Variable, not Secret (CP392)
- ✅ Plan→Approve→Execute observed at every stage (1→9)

## Test plan

- [ ] Set GH Secret \`RUNPOD_API_KEY\` + Variables \`QWEN_LORA_API_URL\` + \`CHATBOT_PROVIDER=qwen-runpod\`
- [ ] User resumes Pod \`5s4pyrvowjm0uh\` (currently stopped to save credits)
- [ ] Trigger deploy.yml (merge or manual run-workflow)
- [ ] Verify prod \`/opt/tubearchive/.env\` contains \`CHATBOT_PROVIDER=qwen-runpod\` after deploy
- [ ] Dev smoke: open Learning Page → ask question with YouTube video context → verify response is in-character (no "DAMO Academy"), references the v2/transcript
- [ ] Multi-turn smoke: ask 1st question → ask 2nd follow-up → verify 2nd response returns (Bug 1 fix verification)
- [ ] Tab-switch smoke: ask question → switch to Note tab → switch back → verify chat history preserved (Bug 2 — orthogonal but co-shipped FE state)
- [ ] Monitor \`docker logs insighta-api -f --since 10m\` for adapter errors during smoke

## Deferred (separate PRs)

- **SSOT mirror to Python** — \`scripts/lora-chatbot/convert-to-sft-v2.py\` must mirror Block U/T/H builders at next LoRA training. Per CP474 user directive, "다음 LoRA 학습 시점에 별도 PR."
- **UserContext (Block U) + RAG (Block H) full activation** — requires JWT plumbing from CopilotKit request → middleware. Stage 7b.
- **Bug 3 (chip rotation)** — orthogonal FE work, separate PR.

## References

- Design: \`docs/design/insighta-chatbot-prompt-serving-design.md\`
- Pod: \`5s4pyrvowjm0uh\` (H100 SXM 80GB Community, vLLM v0.9.0, max_model_len 8192)
- LoRA: \`jamesjk4242/insighta-chatbot-v1-cp4000-merged-v2\` (Qwen3-30B-A3B + 22744 SFT samples)
- Memory: \`memory/credentials.md\` rows for \`RUNPOD_API_KEY\` / \`QWEN_LORA_API_URL\` / \`CHATBOT_PROVIDER\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)