### PR TITLE
fix(v2): no transient blank footer when a sibling card is bookmarked (option 1)

### DIFF
--- a/frontend/src/features/card-management/model/useV2Summaries.ts
+++ b/frontend/src/features/card-management/model/useV2Summaries.ts
@@ -17,7 +17,7 @@
  *     same set hit the same cache regardless of input order.
  */
 
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/shared/lib/api-client';
 
 export interface V2SummaryItem {
@@ -75,6 +75,15 @@ export function useV2Summaries(videoIds: string[] | null | undefined) {
     staleTime: V2_SUMMARIES_STALE_MS,
     refetchOnWindowFocus: false,
     refetchOnMount: false,
+    // CP475+ — bookmarking a new card invalidates this query, and the
+    // grid mutation simultaneously changes `dedupedIds.length` → a new
+    // cache entry with `data=undefined` would render every existing
+    // card's v2 summary as empty while the refetch runs (visible as a
+    // height-shrink jump across the grid). `keepPreviousData` makes
+    // the previous batch's data act as a placeholder until the next
+    // batch resolves, so no v2-derived field ever transiently goes to
+    // null on an unrelated card.
+    placeholderData: keepPreviousData,
   });
 
   const map = new Map<string, V2SummaryItem>();

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -309,12 +309,18 @@ export function InsightCardItemV2({
   //   3. v2 quick essence — fallback when v1 is missing (e.g. fresh-
   //      from-YouTube cards with no v1 row yet).
   //   4. v2 `core.one_liner` — last-resort 20-char headline.
+  //
+  // The previous `if (isV2Loading) return undefined` guard was a legacy
+  // from the v2-quick-wins era (preventing a long-v1 → short-quick text
+  // shrink during refetch). With v1 now winning over quick, v1 is stable
+  // across refetch cycles — the guard caused the new bug (siblings'
+  // bookmarks made every card's footer go transiently blank → height
+  // shrink → grid jump). Removed.
   const cardSummary = (() => {
     if (v2FullLanded) {
       const essence = coreArgument?.trim();
       if (essence) return essence;
     }
-    if (isV2Loading) return undefined;
     const v1 = card.videoSummary?.summary_ko?.trim();
     if (v1) return v1;
     const quickEssence = coreArgument?.trim();


### PR DESCRIPTION
## Summary
Hot-path fix for the 2026-05-20 prod bug where bookmarking one card briefly emptied every other card's footer summary, causing height-shrink + grid jump.

### Root cause (two CP475+ decisions colliding)
1. `useV2Summaries` queryKey contains `dedupedIds.length` — a new bookmark grows the list by one, queryKey changes, `data` momentarily undefined → every card sees null v2 fields.
2. `InsightCardItemV2.cardSummary` had a legacy `if (isV2Loading) return undefined;` guard from the v2-quick-wins era — combined with (1), every `v2FullLanded=false` card blanked out during refetch.

### Fix (minimum blast radius)
- `useV2Summaries`: add `placeholderData: keepPreviousData` (react-query standard) — previous batch keeps populating the map until the next batch resolves.
- `InsightCardItemV2`: remove the `isV2Loading` early-return — v1 `summary_ko` is the new default and is stable across refetches.

### Why not the bigger fix
The user's preferred end state is **batch → per-card cache fan-out** (true card independence). That's queued as a follow-up PR. This change stops the bleeding without rewriting the data layer.

### Regression scope
- `SidebarLearningSection` also uses `useV2Summaries` → benefits from `keepPreviousData` (entries stay rendered through bookmark churn).
- Learning Page (`PanelAISummary`) uses independent `useRichSummary` → unaffected.
- Card D&D — drop-zone math depends on stable heights → this PR **stabilises** height, improves D&D.

## Test plan
- [x] tsc + vitest 320/320 + build PASS
- [ ] prod: bookmark a fresh card; observe no other card's footer / height transiently changes
- [ ] prod: sidebar 학습 entry list stays visible through bookmark churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)