### PR TITLE
fix(chatbot): accept Pod-direct ".../v1" URL in toRunpodOpenAiBase (CP475+1)

### DIFF
--- a/src/api/routes/copilotkit-base-url.ts
+++ b/src/api/routes/copilotkit-base-url.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalise a RunPod endpoint URL to its OpenAI-compatible base.
+ *
+ * Accepts:
+ *   https://<pod>.proxy.runpod.net/v1                → unchanged
+ *     (standard vLLM Pod started WITHOUT `--root-path /openai`, CP475+1)
+ *   https://api.runpod.ai/v2/<id>/openai/v1          → unchanged
+ *     (Serverless or Pod started WITH `--root-path /openai`)
+ *   https://api.runpod.ai/v2/<id>/runsync            → .../v2/<id>/openai/v1
+ *   https://api.runpod.ai/v2/<id>                    → .../v2/<id>/openai/v1
+ *
+ * Extracted from `copilotkit.ts` into its own module so unit tests can
+ * import the pure utility without triggering the route module's
+ * top-level `config/index.ts` env-validation side effect.
+ *
+ * CP475+1 (2026-05-20) — pre-fix the function only handled `/openai/v1`,
+ * so a Pod URL like `.../v1` was silently turned into `.../v1/openai/v1`
+ * (404). The `/v1`-passthrough branch fixes the post-migration Pod path.
+ */
+export function toRunpodOpenAiBase(raw: string): string {
+  const trimmed = raw.replace(/\/+$/, '');
+  if (trimmed.endsWith('/openai/v1')) return trimmed;
+  if (trimmed.endsWith('/v1')) return trimmed;
+  return trimmed.replace(/\/(?:runsync|run)$/, '') + '/openai/v1';
+}

--- a/src/api/routes/copilotkit.ts
+++ b/src/api/routes/copilotkit.ts
@@ -9,19 +9,9 @@ import {
 import OpenAI from 'openai';
 import { config } from '@/config/index';
 import { QwenRunpodAdapter } from '@/modules/chatbot-rag';
+import { toRunpodOpenAiBase } from './copilotkit-base-url';
 
 type ChatbotProvider = 'gemini' | 'openrouter' | 'local' | 'qwen-runpod';
-
-// Normalise a RunPod endpoint URL to its OpenAI-compatible base.
-// Accepts:
-//   https://api.runpod.ai/v2/<id>/runsync     → .../v2/<id>/openai/v1
-//   https://api.runpod.ai/v2/<id>/openai/v1   → unchanged
-//   https://api.runpod.ai/v2/<id>             → .../v2/<id>/openai/v1
-function toRunpodOpenAiBase(raw: string): string {
-  const trimmed = raw.replace(/\/+$/, '');
-  if (trimmed.endsWith('/openai/v1')) return trimmed;
-  return trimmed.replace(/\/(?:runsync|run)$/, '') + '/openai/v1';
-}
 
 function createServiceAdapter(provider: ChatbotProvider, model?: string): CopilotServiceAdapter {
   switch (provider) {

--- a/tests/unit/api/copilotkit-base-url.test.ts
+++ b/tests/unit/api/copilotkit-base-url.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for `toRunpodOpenAiBase` (CP475+1 hotfix).
+ *
+ * The function must accept BOTH:
+ *   (a) RunPod Serverless / `--root-path /openai` style: `.../openai/v1`
+ *   (b) Standard vLLM Pod (no root-path):              `.../v1`
+ *
+ * Before CP475+1 it only handled (a) and silently appended `/openai/v1` to
+ * (b), producing `https://<pod>.proxy.runpod.net/v1/openai/v1` which 404s.
+ */
+
+import { toRunpodOpenAiBase } from '@/api/routes/copilotkit-base-url';
+
+describe('toRunpodOpenAiBase', () => {
+  describe('Pod-direct vLLM (CP475+1 — primary regression case)', () => {
+    it('passes through ".../v1" unchanged', () => {
+      expect(toRunpodOpenAiBase('https://bec5sptl1a5f8d-8000.proxy.runpod.net/v1')).toBe(
+        'https://bec5sptl1a5f8d-8000.proxy.runpod.net/v1'
+      );
+    });
+
+    it('strips trailing slash but otherwise leaves ".../v1/" unchanged', () => {
+      expect(toRunpodOpenAiBase('https://bec5sptl1a5f8d-8000.proxy.runpod.net/v1/')).toBe(
+        'https://bec5sptl1a5f8d-8000.proxy.runpod.net/v1'
+      );
+    });
+  });
+
+  describe('Serverless / root-path /openai', () => {
+    it('passes through ".../openai/v1" unchanged', () => {
+      expect(toRunpodOpenAiBase('https://api.runpod.ai/v2/abc/openai/v1')).toBe(
+        'https://api.runpod.ai/v2/abc/openai/v1'
+      );
+    });
+
+    it('appends "/openai/v1" when the URL ends with "/runsync"', () => {
+      expect(toRunpodOpenAiBase('https://api.runpod.ai/v2/abc/runsync')).toBe(
+        'https://api.runpod.ai/v2/abc/openai/v1'
+      );
+    });
+
+    it('appends "/openai/v1" when the URL ends with "/run"', () => {
+      expect(toRunpodOpenAiBase('https://api.runpod.ai/v2/abc/run')).toBe(
+        'https://api.runpod.ai/v2/abc/openai/v1'
+      );
+    });
+
+    it('appends "/openai/v1" when the URL is a bare Serverless ID', () => {
+      expect(toRunpodOpenAiBase('https://api.runpod.ai/v2/abc')).toBe(
+        'https://api.runpod.ai/v2/abc/openai/v1'
+      );
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('handles multiple trailing slashes', () => {
+      expect(toRunpodOpenAiBase('https://example.com/v1///')).toBe('https://example.com/v1');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Hotfix for the 2026-05-20 RunPod Pod migration. PR #699 just shipped the qwen-runpod adapter — Pod **must** be reachable for any of it to matter, and the new Pod uses a different URL prefix than the function knew about.

- **Old Pod** `5s4pyrvowjm0uh` (dead) — vLLM started with `--root-path /openai` → endpoints at `/openai/v1/...`
- **New Pod** `bec5sptl1a5f8d` (live) — vLLM started **without** `--root-path` → endpoints at standard `/v1/...`

`toRunpodOpenAiBase()` pre-fix only recognised `/openai/v1` and silently appended it to anything else. So setting `QWEN_LORA_API_URL=https://bec5sptl1a5f8d-8000.proxy.runpod.net/v1` produced a runtime call to `.../v1/openai/v1/chat/completions` → **404**.

## Evidence (curl against the live new Pod)

| Path | Result |
|------|-------:|
| `/health` | 200 ✅ |
| `/v1/models` (no auth) | 401 — vLLM up + `--api-key` set |
| `/openai/v1/models` | 404 ❌ |
| `/openai/health` | 404 |
| `/` | 404 |

Per CLAUDE.md §추측 전 소스 읽기 — gathered fact before code change.

## Changes

1) **NEW** `src/api/routes/copilotkit-base-url.ts` — extracts `toRunpodOpenAiBase` into a pure, side-effect-free module. Required because the unit test couldn't import the helper from `copilotkit.ts` without triggering `src/config/index.ts`'s top-level env-validation (which fails under jest).
2) **MODIFIED** `src/api/routes/copilotkit.ts` — replaces in-file function with a re-import. Behaviour identical for every previously-supported input.
3) **NEW** `tests/unit/api/copilotkit-base-url.test.ts` — 7 cases:
   - 2 × Pod-direct `/v1` (NEW path, primary regression case)
   - 4 × Serverless / root-path /openai (existing behaviour preserved)
   - 1 × multiple trailing slash edge case

## Required prod state after merge

deploy.yml auto-trigger writes to `/opt/tubearchive/.env`:

```
CHATBOT_PROVIDER=qwen-runpod                                      # (set in PR #699)
QWEN_LORA_API_URL=https://bec5sptl1a5f8d-8000.proxy.runpod.net/v1 # (set 08:51 UTC)
RUNPOD_API_KEY=<unchanged from old Pod — user confirmed same --api-key reused>
```

## Test plan

- [x] tsc EXIT 0
- [x] jest 7/7 PASS on new test
- [x] hardcode-audit 33/33 (no new violations)
- [ ] Merge → auto-deploy
- [ ] SSH verify `grep QWEN_LORA_API_URL /opt/tubearchive/.env` → `.../v1`
- [ ] Browser smoke: Learning Page chatbot
  - [ ] Single-turn responds + persona = "Insighta" (not "DAMO Academy")
  - [ ] Multi-turn (2nd message) **responds** (Bug 1 verification)

## Rollback

Pure config option: `gh variable set CHATBOT_PROVIDER --body "openrouter"` + redeploy. PR can stay merged (the `/v1`-passthrough branch is additive — it only changes behaviour for URLs ending exactly in `/v1`, none of which existed before this migration).

Refs: CP475+1 Pod migration, PR #699 (CP474 Stage 9+10), `memory/credentials.md` L165 (post-migration URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)