### PR TITLE
chore(deploy): wire QWEN_LORA_API_URL as Variable + named manual runs (CP475+1 cleanup)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,24 @@
 name: Deploy
 
+# Display name on the Actions tab + `gh run list`. push triggers show the
+# commit message (default GH behaviour); manual `workflow_dispatch` runs
+# would otherwise display only "Deploy" — the `reason` input + this
+# expression label them like "Deploy (manual: rotate QWEN_LORA secret)".
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+      && format('Deploy (manual: {0})', inputs.reason || 'no reason given')
+      || format('Deploy {0}', github.event.head_commit.message) }}
+
 on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Why are you running this manually? (shown in run-name)'
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: deploy-production
@@ -214,7 +229,10 @@ jobs:
           REDIS_INSIGHTA_PW: ${{ secrets.REDIS_INSIGHTA_PASSWORD }}
           REDIS_INSIGHTA_UPSERT_PW: ${{ secrets.REDIS_INSIGHTA_UPSERT_PASSWORD }}
           TAILSCALE_IP: ${{ vars.INSIGHTA_TAILSCALE_IP }}
-          QWEN_LORA_API_URL: ${{ secrets.QWEN_LORA_API_URL }}
+          # CP475+1 — migrated from secrets.QWEN_LORA_API_URL because the URL is
+          # not a credential (CP392 Hard Rule "non-secret config is not a Secret").
+          # Post-merge cleanup: `gh secret delete QWEN_LORA_API_URL`.
+          QWEN_LORA_API_URL: ${{ vars.QWEN_LORA_API_URL }}
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
           # CP474 — selects which provider the CopilotKit chatbot route uses.
           # Values: 'gemini' | 'openrouter' | 'local' | 'qwen-runpod'.


### PR DESCRIPTION
## Summary

Cleanup PR for two issues surfaced during today's CP474 → CP475+1 chatbot Pod migration:

### Issue 1 — `QWEN_LORA_API_URL` stored as GH Secret (CP392 violation)

The URL is not a credential (visible in `docker inspect`, error responses, vLLM logs). Stored as a Secret since 2026-05-11. When I updated the GH Variable to point at the new Pod URL today, `${{ secrets.QWEN_LORA_API_URL }}` on `deploy.yml:232` continued to win — silently routing prod chatbot traffic to the old (dead) Serverless URL.

→ Migrate to `vars.QWEN_LORA_API_URL`. Post-merge: `gh secret delete QWEN_LORA_API_URL`.

### Issue 2 — manual deploy runs unidentifiable

`gh workflow run deploy.yml --ref main` produced runs displayed as just "Deploy" with no context. Today's session left two such runs in the history (`26151673747`, `26154745506`) with identical display names — user surfaced this gap explicitly.

→ Add `run-name` expression + optional `workflow_dispatch.inputs.reason`:
  - push: `"Deploy <commit message>"` (matches GH default)
  - manual: `"Deploy (manual: <reason>)"` or `"Deploy (manual: no reason given)"`

New manual-trigger usage:
```bash
gh workflow run deploy.yml --ref main -f reason="rotate QWEN_LORA_API_URL after Pod migration"
```

## Changes

`.github/workflows/deploy.yml`
- L1-25 (top): `run-name` expression + `workflow_dispatch.inputs.reason`
- L232: `secrets.QWEN_LORA_API_URL` → `vars.QWEN_LORA_API_URL`

## Backwards compat

- GH Variable `QWEN_LORA_API_URL` is already set to the correct value (live new Pod URL) — first post-merge deploy reads it directly. No env interruption.
- `run-name` is GitHub-native, no runtime impact.
- `inputs.reason` is optional + defaults to empty string — existing `gh workflow run` invocations without `-f reason=...` still work.

## Post-merge

- [ ] `gh secret delete QWEN_LORA_API_URL` (remove leftover Secret — value identical content-wise now lives in Variable)
- [ ] (next manual deploy) Use `-f reason=...` to validate `run-name` formatting end-to-end

## Refs

- CP475+1 Pod migration `5s4pyrvowjm0uh` → `bec5sptl1a5f8d`
- CLAUDE.md §"Non-secret config 는 Secret 에 두지 않는다" (CP392 Hard Rule)
- `memory/credentials.md` L165 migration TODO (resolved by this PR)
- PR #699 (CP474 Stage 9 — original env-block wiring)
- PR #701 (CP475+1 — `toRunpodOpenAiBase` /v1 passthrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)