### PR TITLE
fix(chatbot): resolve provider-native model when CHATBOT_MODEL unset (CP475+2)

### DIFF
--- a/src/api/routes/copilotkit-model-resolver.ts
+++ b/src/api/routes/copilotkit-model-resolver.ts
@@ -1,0 +1,47 @@
+/**
+ * Resolves which model name the CopilotKit chatbot route should hand to its
+ * service adapter, given:
+ *   - the configured provider (gemini / openrouter / local / qwen-runpod)
+ *   - the optional CHATBOT_MODEL explicit override
+ *   - the per-provider default models (passed in so this stays pure +
+ *     side-effect-free for unit testing — `config/index.ts` runs zod env
+ *     validation at module load and is awkward to import from jest).
+ *
+ * CP475+2 — pre-fix `CHATBOT_MODEL` had a hard-coded default of
+ * `google/gemini-2.5-flash`. The route then force-injected that model
+ * name into every provider's adapter, so the RunPod path sent
+ * `model=google/gemini-2.5-flash` to vLLM and the Pod returned 404
+ * (`The model 'google/gemini-2.5-flash' does not exist`).
+ *
+ * Fix: `CHATBOT_MODEL` is now optional. When unset, this resolver picks
+ * the provider's native default (vLLM `insighta-chatbot`, openrouter
+ * `google/gemini-2.5-flash`, etc).
+ */
+
+export type ChatbotProvider = 'gemini' | 'openrouter' | 'local' | 'qwen-runpod';
+
+export interface ProviderDefaults {
+  /** Gemini-via-OpenRouter / direct OpenRouter default — same model id. */
+  openrouter: string;
+  /** Local Ollama default (e.g. configured generateModel). */
+  local: string;
+  /** vLLM served-model-name on the RunPod Pod. */
+  qwenRunpod: string;
+}
+
+export function resolveChatbotModel(
+  provider: ChatbotProvider,
+  explicit: string | undefined,
+  defaults: ProviderDefaults
+): string {
+  if (explicit && explicit.length > 0) return explicit;
+  switch (provider) {
+    case 'gemini':
+    case 'openrouter':
+      return defaults.openrouter;
+    case 'local':
+      return defaults.local;
+    case 'qwen-runpod':
+      return defaults.qwenRunpod;
+  }
+}

--- a/src/api/routes/copilotkit.ts
+++ b/src/api/routes/copilotkit.ts
@@ -10,10 +10,23 @@ import OpenAI from 'openai';
 import { config } from '@/config/index';
 import { QwenRunpodAdapter } from '@/modules/chatbot-rag';
 import { toRunpodOpenAiBase } from './copilotkit-base-url';
+import {
+  resolveChatbotModel,
+  type ChatbotProvider,
+  type ProviderDefaults,
+} from './copilotkit-model-resolver';
 
-type ChatbotProvider = 'gemini' | 'openrouter' | 'local' | 'qwen-runpod';
+const OPENROUTER_DEFAULT_MODEL = 'google/gemini-2.5-flash';
 
-function createServiceAdapter(provider: ChatbotProvider, model?: string): CopilotServiceAdapter {
+function buildProviderDefaults(): ProviderDefaults {
+  return {
+    openrouter: OPENROUTER_DEFAULT_MODEL,
+    local: config.ollama.generateModel,
+    qwenRunpod: config.qwenLora.model,
+  };
+}
+
+function createServiceAdapter(provider: ChatbotProvider, model: string): CopilotServiceAdapter {
   switch (provider) {
     case 'gemini':
     case 'openrouter':
@@ -22,7 +35,7 @@ function createServiceAdapter(provider: ChatbotProvider, model?: string): Copilo
           apiKey: config.openrouter.apiKey,
           baseURL: 'https://openrouter.ai/api/v1',
         }),
-        model: model || 'google/gemini-2.5-flash',
+        model,
       });
 
     case 'local':
@@ -31,7 +44,7 @@ function createServiceAdapter(provider: ChatbotProvider, model?: string): Copilo
           apiKey: 'not-needed',
           baseURL: config.chatbot.localUrl,
         }),
-        model: model || config.ollama.generateModel,
+        model,
       });
 
     case 'qwen-runpod':
@@ -45,26 +58,17 @@ function createServiceAdapter(provider: ChatbotProvider, model?: string): Copilo
       return new QwenRunpodAdapter({
         baseURL: toRunpodOpenAiBase(config.qwenLora.apiUrl),
         apiKey: config.runpod.apiKey,
-        model: model || config.qwenLora.model,
+        model,
       });
-  }
-}
-
-function getDefaultModel(provider: ChatbotProvider): string {
-  switch (provider) {
-    case 'gemini':
-    case 'openrouter':
-      return 'google/gemini-2.5-flash';
-    case 'local':
-      return config.ollama.generateModel;
-    case 'qwen-runpod':
-      return config.qwenLora.model;
   }
 }
 
 export const copilotKitRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
   const provider = config.chatbot.provider;
-  const model = config.chatbot.model;
+  // CP475+2 — resolve via provider-aware fallback so `qwen-runpod` no
+  // longer inherits the openrouter gemini-flash default and sends a
+  // model name vLLM doesn't recognise. CHATBOT_MODEL env still wins.
+  const model = resolveChatbotModel(provider, config.chatbot.model, buildProviderDefaults());
   const serviceAdapter = createServiceAdapter(provider, model);
   const runtime = new CopilotRuntime();
 
@@ -95,7 +99,8 @@ export const copilotKitRoutes: FastifyPluginCallback = (fastify, _opts, done) =>
       status: 200,
       data: {
         provider,
-        model: model || getDefaultModel(provider),
+        // `model` is already provider-resolved above (CP475+2 fix); send as-is.
+        model,
       },
     });
   });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -107,7 +107,13 @@ const envSchema = z.object({
   // (`<base>/openai/v1/chat/completions`). The model id sent in requests
   // is `insighta-chatbot` (vLLM `--served-model-name`).
   CHATBOT_PROVIDER: z.enum(['gemini', 'openrouter', 'local', 'qwen-runpod']).default('openrouter'),
-  CHATBOT_MODEL: z.string().default('google/gemini-2.5-flash'),
+  // CHATBOT_MODEL — explicit override only. When unset, the route falls
+  // back to `getDefaultModel(provider)` so each provider picks its native
+  // model (qwen-runpod → `insighta-chatbot`, openrouter → gemini-flash).
+  // CP475+2: pre-fix the default was `google/gemini-2.5-flash`, which the
+  // route then force-injected into every provider's adapter — so the
+  // RunPod path sent `model=google/gemini-2.5-flash` to vLLM and 404'd.
+  CHATBOT_MODEL: z.string().optional(),
   CHATBOT_LOCAL_URL: z.string().default('http://localhost:11434/v1'),
 
   // Qwen-LoRA serving — RunPod Serverless endpoint base URL.

--- a/tests/unit/api/copilotkit-model-resolver.test.ts
+++ b/tests/unit/api/copilotkit-model-resolver.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for `resolveChatbotModel` (CP475+2 regression).
+ *
+ * Pre-fix: the route used `config.chatbot.model` directly, which had a
+ * hard-coded `google/gemini-2.5-flash` default. When `CHATBOT_PROVIDER`
+ * was `qwen-runpod` and `CHATBOT_MODEL` was unset (the prod default),
+ * the route force-injected `google/gemini-2.5-flash` into the
+ * QwenRunpodAdapter, which forwarded it to vLLM → 404.
+ *
+ * The resolver's contract:
+ *   - explicit override always wins (matches existing /config behaviour)
+ *   - explicit empty string falls back (defensive against `''` env value)
+ *   - per-provider native default otherwise
+ */
+
+import { resolveChatbotModel, type ProviderDefaults } from '@/api/routes/copilotkit-model-resolver';
+
+const DEFAULTS: ProviderDefaults = {
+  openrouter: 'google/gemini-2.5-flash',
+  local: 'qwen3:14b',
+  qwenRunpod: 'insighta-chatbot',
+};
+
+describe('resolveChatbotModel', () => {
+  describe('explicit override (CHATBOT_MODEL env set)', () => {
+    it('returns explicit model verbatim for qwen-runpod', () => {
+      expect(resolveChatbotModel('qwen-runpod', 'custom-model-v2', DEFAULTS)).toBe(
+        'custom-model-v2'
+      );
+    });
+
+    it('returns explicit model verbatim for openrouter', () => {
+      expect(resolveChatbotModel('openrouter', 'anthropic/claude-3.5-sonnet', DEFAULTS)).toBe(
+        'anthropic/claude-3.5-sonnet'
+      );
+    });
+
+    it('returns explicit model verbatim for local', () => {
+      expect(resolveChatbotModel('local', 'llama3:8b', DEFAULTS)).toBe('llama3:8b');
+    });
+  });
+
+  describe('CHATBOT_MODEL unset — provider-native default (CP475+2 primary regression case)', () => {
+    it('qwen-runpod → insighta-chatbot (NOT gemini-flash)', () => {
+      // This is the exact case that 404'd in prod: explicit=undefined +
+      // provider='qwen-runpod' previously resolved to gemini-flash.
+      expect(resolveChatbotModel('qwen-runpod', undefined, DEFAULTS)).toBe('insighta-chatbot');
+    });
+
+    it('openrouter → openrouter default', () => {
+      expect(resolveChatbotModel('openrouter', undefined, DEFAULTS)).toBe(
+        'google/gemini-2.5-flash'
+      );
+    });
+
+    it('gemini → openrouter default (same OpenAIAdapter path)', () => {
+      expect(resolveChatbotModel('gemini', undefined, DEFAULTS)).toBe('google/gemini-2.5-flash');
+    });
+
+    it('local → ollama default', () => {
+      expect(resolveChatbotModel('local', undefined, DEFAULTS)).toBe('qwen3:14b');
+    });
+  });
+
+  describe('defensive — explicit empty string falls back to default', () => {
+    // zod env config now uses `.optional()` so this should normally arrive
+    // as undefined, but if a process.env CHATBOT_MODEL='' somehow leaks
+    // through, the resolver must not return '' to the adapter (vLLM 400).
+    it('empty string for qwen-runpod → insighta-chatbot', () => {
+      expect(resolveChatbotModel('qwen-runpod', '', DEFAULTS)).toBe('insighta-chatbot');
+    });
+  });
+});


### PR DESCRIPTION
## Summary — prod 404 hotfix

PR #701 unblocked the URL prefix; smoke immediately surfaced the **next** layer of breakage. Pod logs:

```
ERROR [serving_chat.py:135] Error with model object='error'
  message='The model `google/gemini-2.5-flash` does not exist.' code=404
POST /v1/chat/completions HTTP/1.1" 404 Not Found
```

Traffic reached vLLM but with the wrong `model` field. Trace:

| Layer | Pre-fix value | Why |
|---|---|---|
| `config/index.ts:110` `CHATBOT_MODEL` default | `'google/gemini-2.5-flash'` | global default, provider-agnostic |
| `copilotkit.ts:67` `const model = config.chatbot.model` | `'google/gemini-2.5-flash'` | default applied (env unset) |
| `createServiceAdapter('qwen-runpod', model)` → `model || config.qwenLora.model` | `'google/gemini-2.5-flash'` | model truthy → fallback never runs |
| vLLM `/v1/chat/completions` | 404 — served-model-name is `insighta-chatbot` | model mismatch |

## Changes

### 1. `src/config/index.ts:110` — drop the gemini default

```diff
- CHATBOT_MODEL: z.string().default('google/gemini-2.5-flash'),
+ CHATBOT_MODEL: z.string().optional(),
```

Explicit `CHATBOT_MODEL=...` env still wins. Empty/unset now falls through.

### 2. `src/api/routes/copilotkit-model-resolver.ts` (NEW pure helper)

`resolveChatbotModel(provider, explicit, defaults): string` with explicit-wins + per-provider fallback semantics. **Zero config import** so unit tests can run without zod env validation side-effects (same pattern as PR #701's `copilotkit-base-url.ts`).

### 3. `src/api/routes/copilotkit.ts` — wire resolver

- Routes through `resolveChatbotModel` once at request time.
- `createServiceAdapter(provider, model: string)` now takes a required resolved string (no more `model || fallback` magic inside cases).
- Old per-case `'google/gemini-2.5-flash'` magic value lifted to a named constant `OPENROUTER_DEFAULT_MODEL` (CLAUDE.md §하드코딩 — magic value → named constant).
- Old `getDefaultModel()` function deleted (responsibility subsumed by resolver + named constant).
- `/config` GET response uses the already-resolved value.

### 4. Tests (NEW) `tests/unit/api/copilotkit-model-resolver.test.ts` — 8 cases

- 3 × explicit override per provider
- 4 × undefined fallback per provider (incl. **CP475+2 primary regression**: `qwen-runpod + undefined → 'insighta-chatbot'`)
- 1 × empty-string defensive fallback

## Backwards compat

- Existing prod has no `CHATBOT_MODEL` set → now resolves to provider-native default. **Desired behaviour** — prod chatbot now talks to vLLM with `model='insighta-chatbot'` instead of `'google/gemini-2.5-flash'`.
- Anyone with explicit `CHATBOT_MODEL=anthropic/...` env still wins via the explicit branch.
- `/config` GET response shape unchanged (`{ provider, model }`).
- No new env vars. `deploy.yml` not touched.

## Regression hardening

- tsc EXIT 0
- jest 8/8 PASS on new test
- hardcode-audit 33/33 (no new violations)

## Follow-up (separate PR)

User requested admin UI to set per-provider model name in DB `runtime_config`:
- Scope = `qwen-runpod` model + `openrouter` model both editable from admin
- Reads DB-first, env fallback, hardcoded provider-native default last
- Will land as PR #704 after this hotfix ships

## Why a third PR for what should have been one job

CP474 / PR #699 missed this because the unit tests covered the adapter in isolation (`model` injected explicitly) but never exercised the prod route's `config.chatbot.model` → adapter injection path. CLAUDE.md §추측 전 소스 읽기 self-violation — I assumed `model || qwenLora.model` would fallback without tracing `config.chatbot.model`'s default. This PR adds the missing route-layer regression coverage.

Refs: CP475+2 hotfix, PR #699 (CP474 — origin), PR #701 (CP475+1 — URL prefix), PR #702 (CP475+1 — secret→vars + run-name), Pod `bec5sptl1a5f8d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)