### PR TITLE
feat(admin): dynamic chatbot model selector per provider (CP475+3)

### DIFF
--- a/frontend/src/app/router/index.tsx
+++ b/frontend/src/app/router/index.tsx
@@ -13,6 +13,7 @@ import { AdminPayments } from '@/pages/admin/ui/AdminPayments';
 import { AdminModeration } from '@/pages/admin/ui/AdminModeration';
 import { AdminHealth } from '@/pages/admin/ui/AdminHealth';
 import { AdminBilling } from '@/pages/admin/ui/AdminBilling';
+import { AdminChatbotModels } from '@/pages/admin/ui/AdminChatbotModels';
 
 const IndexPage = lazy(() => import('@/pages/index'));
 const LoginPage = lazy(() => import('@/pages/login'));
@@ -145,6 +146,7 @@ export function AppRouter() {
           <Route path="billing" element={<AdminBilling />} />
           <Route path="health" element={<AdminHealth />} />
           <Route path="audit-log" element={<AdminAuditLog />} />
+          <Route path="chatbot-models" element={<AdminChatbotModels />} />
         </Route>
 
         <Route path="*" element={<NotFoundPage />} />

--- a/frontend/src/pages/admin/ui/AdminChatbotModels.tsx
+++ b/frontend/src/pages/admin/ui/AdminChatbotModels.tsx
@@ -1,0 +1,170 @@
+/**
+ * Admin page for setting per-provider chatbot model overrides.
+ *
+ * Resolver order (top wins, displayed in the UI for transparency):
+ *   1. CHATBOT_MODEL env (operator-set, no UI control here)
+ *   2. this admin override (per-provider, editable here)
+ *   3. per-provider hardcoded default
+ *
+ * CP475+3 — admin UI dynamic chatbot model control.
+ */
+
+import { useEffect, useState } from 'react';
+import { apiClient, type AdminChatbotModelsResponse } from '@/shared/lib/api-client';
+import { toast } from 'sonner';
+
+interface FormState {
+  qwenRunpodModel: string;
+  openrouterModel: string;
+}
+
+const EMPTY_FORM: FormState = { qwenRunpodModel: '', openrouterModel: '' };
+
+export function AdminChatbotModels() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [data, setData] = useState<AdminChatbotModelsResponse | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await apiClient.getAdminChatbotModels();
+        if (cancelled) return;
+        setData(res);
+        setForm({
+          qwenRunpodModel: res.qwenRunpodModel ?? '',
+          openrouterModel: res.openrouterModel ?? '',
+        });
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'failed to load chatbot settings');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      // Empty string is sent through — BE normalises to null (clear override).
+      const res = await apiClient.setAdminChatbotModels({
+        qwenRunpodModel: form.qwenRunpodModel.length === 0 ? null : form.qwenRunpodModel,
+        openrouterModel: form.openrouterModel.length === 0 ? null : form.openrouterModel,
+      });
+      // Reflect server-normalised values back into the form + summary.
+      setData((prev) =>
+        prev
+          ? {
+              ...prev,
+              qwenRunpodModel: res.qwenRunpodModel,
+              openrouterModel: res.openrouterModel,
+              updatedAt: res.updatedAt,
+              updatedBy: res.updatedBy,
+            }
+          : prev
+      );
+      setForm({
+        qwenRunpodModel: res.qwenRunpodModel ?? '',
+        openrouterModel: res.openrouterModel ?? '',
+      });
+      toast.success('챗봇 모델 설정 저장됨');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'save failed';
+      setError(msg);
+      toast.error(`저장 실패: ${msg}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return <div className="p-6 text-muted-foreground">불러오는 중…</div>;
+  }
+
+  if (error && !data) {
+    return <div className="p-6 text-destructive">에러: {error}</div>;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <div className="p-6 space-y-6 max-w-3xl">
+      <header>
+        <h1 className="text-2xl font-semibold">챗봇 모델 설정</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          provider 별로 사용할 모델명을 지정합니다. 비워두면 환경변수 또는 코드 기본값으로 fallback.
+          변경은 즉시 prod 챗봇에 반영됩니다 (재배포 불필요).
+        </p>
+      </header>
+
+      {data.envExplicit && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+          <strong>주의:</strong> 환경변수 <code>CHATBOT_MODEL={data.envExplicit}</code>가 설정되어
+          있어 모든 provider 의 admin 설정을 덮어씁니다. 동적 제어를 사용하려면 이 환경변수를
+          제거하세요.
+        </div>
+      )}
+
+      <section className="space-y-2">
+        <label className="block">
+          <span className="text-sm font-medium">qwen-runpod 모델</span>
+          <input
+            type="text"
+            value={form.qwenRunpodModel}
+            onChange={(e) => setForm((f) => ({ ...f, qwenRunpodModel: e.target.value }))}
+            placeholder={data.defaults.qwenRunpod}
+            className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          />
+          <span className="text-xs text-muted-foreground">
+            기본값: <code>{data.defaults.qwenRunpod}</code> · vLLM <code>--served-model-name</code>.
+            비워두면 기본값 사용.
+          </span>
+        </label>
+
+        <label className="block">
+          <span className="text-sm font-medium">openrouter 모델</span>
+          <input
+            type="text"
+            value={form.openrouterModel}
+            onChange={(e) => setForm((f) => ({ ...f, openrouterModel: e.target.value }))}
+            placeholder={data.defaults.openrouter}
+            className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          />
+          <span className="text-xs text-muted-foreground">
+            기본값: <code>{data.defaults.openrouter}</code> · OpenRouter 모델 id (예{' '}
+            <code>anthropic/claude-3.5-sonnet</code>). 비워두면 기본값 사용.
+          </span>
+        </label>
+      </section>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={saving}
+          className="rounded-md bg-primary text-primary-foreground px-4 py-2 text-sm font-medium disabled:opacity-50"
+        >
+          {saving ? '저장 중…' : '저장'}
+        </button>
+        {data.updatedAt && (
+          <span className="text-xs text-muted-foreground">
+            마지막 변경: {new Date(data.updatedAt).toLocaleString('ko-KR')}
+            {data.updatedBy && ` · ${data.updatedBy.slice(0, 8)}…`}
+          </span>
+        )}
+      </div>
+
+      {error && <div className="text-sm text-destructive">에러: {error}</div>}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/ui/AdminLayout.tsx
+++ b/frontend/src/pages/admin/ui/AdminLayout.tsx
@@ -10,6 +10,7 @@ import {
   Shield,
   HeartPulse,
   ToggleRight,
+  Bot,
 } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 
@@ -23,6 +24,7 @@ const NAV_ITEMS = [
   { to: '/admin/billing', icon: ToggleRight, label: 'Billing Flag' },
   { to: '/admin/health', icon: HeartPulse, label: 'Health' },
   { to: '/admin/audit-log', icon: ScrollText, label: 'Audit Log' },
+  { to: '/admin/chatbot-models', icon: Bot, label: 'Chatbot Models' },
 ] as const;
 
 export function AdminLayout() {

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -390,6 +390,25 @@ export interface TemplateTypeaheadResult {
   domain: string | null;
 }
 
+/** CP475+3 — per-provider chatbot model overrides + context for admin UI. */
+export interface AdminChatbotModelsResponse {
+  qwenRunpodModel: string | null;
+  openrouterModel: string | null;
+  updatedAt: string;
+  updatedBy: string | null;
+  /** Hardcoded fallbacks (when no env / DB override). */
+  defaults: { openrouter: string; local: string; qwenRunpod: string };
+  /** Explicit `CHATBOT_MODEL` env value, if set — wins over DB. */
+  envExplicit: string | null;
+}
+
+export interface AdminChatbotModelsUpdateResponse {
+  qwenRunpodModel: string | null;
+  openrouterModel: string | null;
+  updatedAt: string;
+  updatedBy: string | null;
+}
+
 interface MandalaResponse {
   id: string;
   userId: string;
@@ -942,6 +961,40 @@ class ApiClient {
       success: boolean;
       data: { key: string; value: unknown };
     }>(`/admin/settings/${encodeURIComponent(key)}`);
+    return res.data;
+  }
+
+  // ─── CP475+3 Chatbot model overrides (admin only) ─────────────────────────
+
+  /**
+   * Read per-provider model overrides + their hardcoded defaults so the admin
+   * UI can show "currently using X, default Y".
+   */
+  async getAdminChatbotModels(): Promise<AdminChatbotModelsResponse> {
+    const res = await this.request<{ success: boolean; data: AdminChatbotModelsResponse }>(
+      '/admin/chatbot/models'
+    );
+    return res.data;
+  }
+
+  /**
+   * Update per-provider chatbot model overrides. `null` clears an override;
+   * `undefined` (omitted field) leaves it unchanged.
+   *
+   * The next /api/v1/chat request will pick up the new value (BE invalidates
+   * its in-memory cache + rebuilds the CopilotRuntime).
+   */
+  async setAdminChatbotModels(input: {
+    qwenRunpodModel?: string | null;
+    openrouterModel?: string | null;
+  }): Promise<AdminChatbotModelsUpdateResponse> {
+    const res = await this.request<{ success: boolean; data: AdminChatbotModelsUpdateResponse }>(
+      '/admin/chatbot/models',
+      {
+        method: 'PUT',
+        body: JSON.stringify(input),
+      }
+    );
     return res.data;
   }
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/jeonhokim/cursor/insighta/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/jeonhokim/cursor/insighta/node_modules

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2107,3 +2107,17 @@ model pipeline_events {
   @@index([created_at(sort: Desc)])
   @@schema("public")
 }
+
+/// Singleton (id=1) holding admin-overridable model names per chatbot provider.
+/// Resolver order: env CHATBOT_MODEL > this row > per-provider hardcoded default.
+/// Raw SQL DDL: prisma/migrations/chatbot-settings/001_create_table.sql
+/// CP475+3 — admin UI dynamic chatbot model control.
+model chatbot_settings {
+  id                Int      @id @default(1)
+  qwen_runpod_model String?
+  openrouter_model  String?
+  updated_at        DateTime @default(now()) @db.Timestamptz(6)
+  updated_by        String?  @db.Uuid
+
+  @@schema("public")
+}

--- a/src/api/routes/admin/chatbot.ts
+++ b/src/api/routes/admin/chatbot.ts
@@ -1,31 +1,145 @@
-import { FastifyInstance } from 'fastify';
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
 import { config } from '@/config/index';
 import { createSuccessResponse } from '../../schemas/common.schema';
+import { getChatbotSettings, updateChatbotSettings } from '@/modules/chatbot-settings/service';
+import { resolveChatbotModel, type ProviderDefaults } from '../copilotkit-model-resolver';
+
+const OPENROUTER_DEFAULT_MODEL = 'google/gemini-2.5-flash';
+
+function buildProviderDefaults(): ProviderDefaults {
+  return {
+    openrouter: OPENROUTER_DEFAULT_MODEL,
+    local: config.ollama.generateModel,
+    qwenRunpod: config.qwenLora.model,
+  };
+}
+
+// Empty string in PUT body is treated as "clear override" (null).
+const trimmedModel = z
+  .string()
+  .max(200)
+  .transform((s) => s.trim())
+  .nullable();
+
+const updateModelsBodySchema = z.object({
+  qwenRunpodModel: trimmedModel.optional(),
+  openrouterModel: trimmedModel.optional(),
+});
+
+interface AuthenticatedUser {
+  sub?: string;
+  user_id?: string;
+}
+
+function getUserId(request: FastifyRequest): string {
+  const user = (request as FastifyRequest & { user?: AuthenticatedUser }).user;
+  return user?.sub ?? user?.user_id ?? '';
+}
 
 export async function adminChatbotRoutes(fastify: FastifyInstance) {
-  fastify.get('/', async (_request, reply) => {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  // Read-only summary kept for backward compat (existing FE admin health page).
+  // CP475+3: also surface the per-provider override values so the admin UI
+  // can render them without an extra fetch.
+  fastify.get('/', adminAuth, async (_request, reply) => {
+    const provider = config.chatbot.provider;
+    const settings = await getChatbotSettings();
+    const defaults = buildProviderDefaults();
+    const liveModel = resolveChatbotModel(provider, config.chatbot.model, defaults, {
+      qwenRunpodModel: settings.qwenRunpodModel,
+      openrouterModel: settings.openrouterModel,
+    });
+
     return reply.send(
       createSuccessResponse({
-        provider: config.chatbot.provider,
-        model: config.chatbot.model || getDefaultModel(config.chatbot.provider),
+        provider,
+        model: liveModel,
         localUrl: config.chatbot.localUrl,
-        availableProviders: ['gemini', 'openrouter', 'local'],
+        availableProviders: ['gemini', 'openrouter', 'local', 'qwen-runpod'],
         hasGeminiKey: !!config.gemini.apiKey,
         hasOpenRouterKey: !!config.openrouter.apiKey,
+        // CP475+3 — admin-editable model overrides.
+        overrides: {
+          qwenRunpodModel: settings.qwenRunpodModel,
+          openrouterModel: settings.openrouterModel,
+        },
+        defaults: {
+          qwenRunpod: defaults.qwenRunpod,
+          openrouter: defaults.openrouter,
+          local: defaults.local,
+        },
+        envExplicit: config.chatbot.model ?? null,
+        updatedAt: settings.updatedAt.toISOString(),
+        updatedBy: settings.updatedBy,
       })
     );
   });
-}
 
-function getDefaultModel(provider: string): string {
-  switch (provider) {
-    case 'gemini':
-      return config.gemini.model || 'gemini-1.5-flash';
-    case 'openrouter':
-      return config.openrouter.model || 'google/gemini-flash-1.5';
-    case 'local':
-      return config.ollama.generateModel;
-    default:
-      return '';
-  }
+  // CP475+3 — dedicated admin endpoint for per-provider model overrides.
+  // Reuses the singleton settings row. Empty string is normalised to null.
+  fastify.get('/models', adminAuth, async (_request, reply) => {
+    const settings = await getChatbotSettings();
+    return reply.send(
+      createSuccessResponse({
+        qwenRunpodModel: settings.qwenRunpodModel,
+        openrouterModel: settings.openrouterModel,
+        updatedAt: settings.updatedAt.toISOString(),
+        updatedBy: settings.updatedBy,
+        defaults: buildProviderDefaults(),
+        envExplicit: config.chatbot.model ?? null,
+      })
+    );
+  });
+
+  fastify.put('/models', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
+    const parsed = updateModelsBodySchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({
+        status: 400,
+        code: 'INVALID_BODY',
+        message: parsed.error.message,
+      });
+    }
+
+    const userId = getUserId(request);
+    if (!userId) {
+      return reply.status(401).send({
+        status: 401,
+        code: 'NO_USER',
+        message: 'authenticated user id missing from token',
+      });
+    }
+
+    // Normalise: empty string → null (clear override). Leaves undefined
+    // fields unchanged (Prisma update no-op).
+    const qwenRunpodModel =
+      parsed.data.qwenRunpodModel === undefined
+        ? undefined
+        : parsed.data.qwenRunpodModel === null || parsed.data.qwenRunpodModel.length === 0
+          ? null
+          : parsed.data.qwenRunpodModel;
+    const openrouterModel =
+      parsed.data.openrouterModel === undefined
+        ? undefined
+        : parsed.data.openrouterModel === null || parsed.data.openrouterModel.length === 0
+          ? null
+          : parsed.data.openrouterModel;
+
+    const updated = await updateChatbotSettings({
+      qwenRunpodModel,
+      openrouterModel,
+      updatedBy: userId,
+    });
+
+    return reply.send(
+      createSuccessResponse({
+        qwenRunpodModel: updated.qwenRunpodModel,
+        openrouterModel: updated.openrouterModel,
+        updatedAt: updated.updatedAt.toISOString(),
+        updatedBy: updated.updatedBy,
+      })
+    );
+  });
 }

--- a/src/api/routes/copilotkit-model-resolver.ts
+++ b/src/api/routes/copilotkit-model-resolver.ts
@@ -16,6 +16,13 @@
  * Fix: `CHATBOT_MODEL` is now optional. When unset, this resolver picks
  * the provider's native default (vLLM `insighta-chatbot`, openrouter
  * `google/gemini-2.5-flash`, etc).
+ *
+ * CP475+3 — extends the resolver with an optional `overrides` source so
+ * the admin UI can persist per-provider model names in the DB without
+ * touching env / code. Resolver priority (top wins):
+ *   1. explicit env CHATBOT_MODEL
+ *   2. admin DB overrides (per-provider)
+ *   3. per-provider hardcoded default
  */
 
 export type ChatbotProvider = 'gemini' | 'openrouter' | 'local' | 'qwen-runpod';
@@ -29,19 +36,39 @@ export interface ProviderDefaults {
   qwenRunpod: string;
 }
 
+/**
+ * Admin-configured overrides (null = no override). CP475+3.
+ * Per-provider override slots; `local` has no admin slot (use env or default).
+ */
+export interface AdminOverrides {
+  qwenRunpodModel: string | null;
+  openrouterModel: string | null;
+}
+
+const EMPTY_OVERRIDES: AdminOverrides = {
+  qwenRunpodModel: null,
+  openrouterModel: null,
+};
+
 export function resolveChatbotModel(
   provider: ChatbotProvider,
   explicit: string | undefined,
-  defaults: ProviderDefaults
+  defaults: ProviderDefaults,
+  overrides: AdminOverrides = EMPTY_OVERRIDES
 ): string {
   if (explicit && explicit.length > 0) return explicit;
+
   switch (provider) {
     case 'gemini':
     case 'openrouter':
-      return defaults.openrouter;
+      return overrides.openrouterModel && overrides.openrouterModel.length > 0
+        ? overrides.openrouterModel
+        : defaults.openrouter;
     case 'local':
       return defaults.local;
     case 'qwen-runpod':
-      return defaults.qwenRunpod;
+      return overrides.qwenRunpodModel && overrides.qwenRunpodModel.length > 0
+        ? overrides.qwenRunpodModel
+        : defaults.qwenRunpod;
   }
 }

--- a/src/api/routes/copilotkit.ts
+++ b/src/api/routes/copilotkit.ts
@@ -9,6 +9,7 @@ import {
 import OpenAI from 'openai';
 import { config } from '@/config/index';
 import { QwenRunpodAdapter } from '@/modules/chatbot-rag';
+import { getChatbotSettings } from '@/modules/chatbot-settings/service';
 import { toRunpodOpenAiBase } from './copilotkit-base-url';
 import {
   resolveChatbotModel,
@@ -63,30 +64,54 @@ function createServiceAdapter(provider: ChatbotProvider, model: string): Copilot
   }
 }
 
+// ---------------------------------------------------------------------------
+// Lazy yoga handler — rebuilt only when admin settings change (CP475+3).
+//
+// `getChatbotSettings()` is cheap (5-min in-memory cache hit, O(1)). We rebuild
+// the yoga + serviceAdapter only when settings.updatedAt has advanced past
+// the last build timestamp. PUT /admin/chatbot/models invalidates the cache,
+// so the next request reads the new settings and rebuilds.
+// ---------------------------------------------------------------------------
+
+type YogaHandler = ReturnType<typeof copilotRuntimeNodeHttpEndpoint>;
+
+let lazyYoga: YogaHandler | null = null;
+let lazyBuildAt = 0;
+
+async function getYoga(): Promise<YogaHandler> {
+  const settings = await getChatbotSettings();
+  if (!lazyYoga || settings.updatedAt.getTime() > lazyBuildAt) {
+    const provider = config.chatbot.provider;
+    const model = resolveChatbotModel(provider, config.chatbot.model, buildProviderDefaults(), {
+      qwenRunpodModel: settings.qwenRunpodModel,
+      openrouterModel: settings.openrouterModel,
+    });
+    const serviceAdapter = createServiceAdapter(provider, model);
+    const runtime = new CopilotRuntime();
+    lazyYoga = copilotRuntimeNodeHttpEndpoint({
+      runtime,
+      serviceAdapter,
+      endpoint: '/api/v1/chat',
+    });
+    lazyBuildAt = Date.now();
+  }
+  return lazyYoga;
+}
+
 export const copilotKitRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
-  const provider = config.chatbot.provider;
-  // CP475+2 — resolve via provider-aware fallback so `qwen-runpod` no
-  // longer inherits the openrouter gemini-flash default and sends a
-  // model name vLLM doesn't recognise. CHATBOT_MODEL env still wins.
-  const model = resolveChatbotModel(provider, config.chatbot.model, buildProviderDefaults());
-  const serviceAdapter = createServiceAdapter(provider, model);
-  const runtime = new CopilotRuntime();
-
-  const yoga = copilotRuntimeNodeHttpEndpoint({
-    runtime,
-    serviceAdapter,
-    endpoint: '/api/v1/chat',
-  });
-
-  // yoga is a graphql-yoga instance — register on raw HTTP server
-  // to bypass Fastify body parsing entirely.
+  // yoga is a graphql-yoga instance — register on raw HTTP server to bypass
+  // Fastify body parsing entirely. CP475+3: build lazily on first request so
+  // we can read admin DB settings async.
   const server = fastify.server;
   const originalListeners = server.listeners('request');
 
   server.removeAllListeners('request');
   server.on('request', (req, res) => {
     if (req.url?.startsWith('/api/v1/chat') && !req.url?.startsWith('/api/v1/chat/config')) {
-      void yoga(req, res);
+      void (async () => {
+        const handler = await getYoga();
+        await handler(req, res);
+      })();
       return;
     }
     for (const listener of originalListeners) {
@@ -95,13 +120,17 @@ export const copilotKitRoutes: FastifyPluginCallback = (fastify, _opts, done) =>
   });
 
   fastify.get('/config', { onRequest: [fastify.authenticate] }, async (_request, reply) => {
+    // Resolve the live model the same way getYoga() does so /config always
+    // reflects the value the next chat request will actually use.
+    const provider = config.chatbot.provider;
+    const settings = await getChatbotSettings();
+    const model = resolveChatbotModel(provider, config.chatbot.model, buildProviderDefaults(), {
+      qwenRunpodModel: settings.qwenRunpodModel,
+      openrouterModel: settings.openrouterModel,
+    });
     return reply.send({
       status: 200,
-      data: {
-        provider,
-        // `model` is already provider-resolved above (CP475+2 fix); send as-is.
-        model,
-      },
+      data: { provider, model },
     });
   });
 

--- a/src/modules/chatbot-settings/service.ts
+++ b/src/modules/chatbot-settings/service.ts
@@ -1,0 +1,158 @@
+/**
+ * Chatbot model settings — admin-overridable per-provider model names.
+ *
+ * Resolver order (applied in src/api/routes/copilotkit.ts):
+ *   1. explicit env CHATBOT_MODEL              ← global override (legacy)
+ *   2. this DB row (chatbot_settings.id=1)     ← admin UI override
+ *   3. per-provider hardcoded default          ← bottom-of-stack safety
+ *
+ * The DB row is a singleton (id=1 CHECK). NULL fields mean "no override —
+ * fall through to the next layer". So clearing an admin override = PUT
+ * with the field set to null.
+ *
+ * Cache: module-level, 5-minute TTL. PUT calls invalidate immediately so
+ * the next request sees the new value without waiting for TTL.
+ *
+ * CP475+3 — admin UI dynamic chatbot model control.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'chatbot-settings/service' });
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export interface ChatbotSettings {
+  qwenRunpodModel: string | null;
+  openrouterModel: string | null;
+  updatedAt: Date;
+  updatedBy: string | null;
+}
+
+export interface UpdateChatbotSettingsInput {
+  /** Pass `null` to clear an override, `undefined` to leave unchanged. */
+  qwenRunpodModel?: string | null;
+  openrouterModel?: string | null;
+  /** Admin user id (for audit). */
+  updatedBy: string;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory cache
+// ---------------------------------------------------------------------------
+
+let cachedSettings: ChatbotSettings | null = null;
+let cachedAt = 0;
+
+/** Reset cache — call when settings are updated to ensure next read is fresh. */
+export function invalidateChatbotSettingsCache(): void {
+  cachedSettings = null;
+  cachedAt = 0;
+}
+
+/** Test-only hook to inject a known state. */
+export function _setCacheForTesting(settings: ChatbotSettings | null): void {
+  cachedSettings = settings;
+  cachedAt = settings ? Date.now() : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the singleton settings row (`id=1`), creating it lazily if missing.
+ * Cached for 5 minutes. Cache is invalidated on every successful write.
+ *
+ * On DB failure, returns a safe all-null settings object so the resolver can
+ * still fall through to env / hardcoded defaults — chatbot must keep working
+ * even if the admin-settings table is temporarily unreachable.
+ */
+export async function getChatbotSettings(): Promise<ChatbotSettings> {
+  const now = Date.now();
+  if (cachedSettings && now - cachedAt < CACHE_TTL_MS) {
+    return cachedSettings;
+  }
+
+  try {
+    const prisma = getPrismaClient();
+    const row = await prisma.chatbot_settings.findUnique({ where: { id: 1 } });
+
+    const settings: ChatbotSettings = row
+      ? {
+          qwenRunpodModel: row.qwen_runpod_model,
+          openrouterModel: row.openrouter_model,
+          updatedAt: row.updated_at,
+          updatedBy: row.updated_by,
+        }
+      : {
+          qwenRunpodModel: null,
+          openrouterModel: null,
+          updatedAt: new Date(0),
+          updatedBy: null,
+        };
+
+    cachedSettings = settings;
+    cachedAt = now;
+    return settings;
+  } catch (err) {
+    log.warn('chatbot_settings load failed; returning empty', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return {
+      qwenRunpodModel: null,
+      openrouterModel: null,
+      updatedAt: new Date(0),
+      updatedBy: null,
+    };
+  }
+}
+
+/**
+ * Upserts the singleton settings row. `undefined` fields are left unchanged;
+ * `null` fields explicitly clear an override. Returns the new settings.
+ */
+export async function updateChatbotSettings(
+  input: UpdateChatbotSettingsInput
+): Promise<ChatbotSettings> {
+  const prisma = getPrismaClient();
+
+  // Build update + create payloads. For Prisma, undefined fields are skipped
+  // (no-op), null fields are written as DB null.
+  const updateData: {
+    qwen_runpod_model?: string | null;
+    openrouter_model?: string | null;
+    updated_at: Date;
+    updated_by: string;
+  } = {
+    updated_at: new Date(),
+    updated_by: input.updatedBy,
+  };
+  if (input.qwenRunpodModel !== undefined) updateData.qwen_runpod_model = input.qwenRunpodModel;
+  if (input.openrouterModel !== undefined) updateData.openrouter_model = input.openrouterModel;
+
+  const row = await prisma.chatbot_settings.upsert({
+    where: { id: 1 },
+    update: updateData,
+    create: {
+      id: 1,
+      qwen_runpod_model: input.qwenRunpodModel ?? null,
+      openrouter_model: input.openrouterModel ?? null,
+      updated_at: updateData.updated_at,
+      updated_by: input.updatedBy,
+    },
+  });
+
+  invalidateChatbotSettingsCache();
+
+  const fresh: ChatbotSettings = {
+    qwenRunpodModel: row.qwen_runpod_model,
+    openrouterModel: row.openrouter_model,
+    updatedAt: row.updated_at,
+    updatedBy: row.updated_by,
+  };
+  cachedSettings = fresh;
+  cachedAt = Date.now();
+  return fresh;
+}

--- a/tests/unit/api/copilotkit-model-resolver.test.ts
+++ b/tests/unit/api/copilotkit-model-resolver.test.ts
@@ -1,19 +1,21 @@
 /**
- * Unit tests for `resolveChatbotModel` (CP475+2 regression).
+ * Unit tests for `resolveChatbotModel`.
  *
- * Pre-fix: the route used `config.chatbot.model` directly, which had a
- * hard-coded `google/gemini-2.5-flash` default. When `CHATBOT_PROVIDER`
+ * Pre-fix (CP475+2): the route used `config.chatbot.model` directly, which had
+ * a hard-coded `google/gemini-2.5-flash` default. When `CHATBOT_PROVIDER`
  * was `qwen-runpod` and `CHATBOT_MODEL` was unset (the prod default),
  * the route force-injected `google/gemini-2.5-flash` into the
  * QwenRunpodAdapter, which forwarded it to vLLM → 404.
  *
- * The resolver's contract:
- *   - explicit override always wins (matches existing /config behaviour)
- *   - explicit empty string falls back (defensive against `''` env value)
- *   - per-provider native default otherwise
+ * CP475+3: extended with admin DB overrides (per-provider). Priority:
+ *   explicit env CHATBOT_MODEL > admin DB override > hardcoded default.
  */
 
-import { resolveChatbotModel, type ProviderDefaults } from '@/api/routes/copilotkit-model-resolver';
+import {
+  resolveChatbotModel,
+  type ProviderDefaults,
+  type AdminOverrides,
+} from '@/api/routes/copilotkit-model-resolver';
 
 const DEFAULTS: ProviderDefaults = {
   openrouter: 'google/gemini-2.5-flash',
@@ -21,53 +23,126 @@ const DEFAULTS: ProviderDefaults = {
   qwenRunpod: 'insighta-chatbot',
 };
 
+const NO_OVERRIDES: AdminOverrides = {
+  qwenRunpodModel: null,
+  openrouterModel: null,
+};
+
 describe('resolveChatbotModel', () => {
-  describe('explicit override (CHATBOT_MODEL env set)', () => {
-    it('returns explicit model verbatim for qwen-runpod', () => {
-      expect(resolveChatbotModel('qwen-runpod', 'custom-model-v2', DEFAULTS)).toBe(
-        'custom-model-v2'
-      );
+  describe('explicit env (CHATBOT_MODEL) wins over everything', () => {
+    it('beats admin override + default for qwen-runpod', () => {
+      expect(
+        resolveChatbotModel('qwen-runpod', 'env-explicit', DEFAULTS, {
+          qwenRunpodModel: 'admin-override',
+          openrouterModel: null,
+        })
+      ).toBe('env-explicit');
     });
 
-    it('returns explicit model verbatim for openrouter', () => {
-      expect(resolveChatbotModel('openrouter', 'anthropic/claude-3.5-sonnet', DEFAULTS)).toBe(
-        'anthropic/claude-3.5-sonnet'
-      );
+    it('beats admin override + default for openrouter', () => {
+      expect(
+        resolveChatbotModel('openrouter', 'anthropic/claude-3.5-sonnet', DEFAULTS, {
+          qwenRunpodModel: null,
+          openrouterModel: 'admin-override',
+        })
+      ).toBe('anthropic/claude-3.5-sonnet');
     });
 
-    it('returns explicit model verbatim for local', () => {
+    it('returns explicit verbatim for local', () => {
       expect(resolveChatbotModel('local', 'llama3:8b', DEFAULTS)).toBe('llama3:8b');
     });
   });
 
-  describe('CHATBOT_MODEL unset — provider-native default (CP475+2 primary regression case)', () => {
+  describe('CP475+2 primary regression — env unset, no admin override', () => {
     it('qwen-runpod → insighta-chatbot (NOT gemini-flash)', () => {
-      // This is the exact case that 404'd in prod: explicit=undefined +
-      // provider='qwen-runpod' previously resolved to gemini-flash.
-      expect(resolveChatbotModel('qwen-runpod', undefined, DEFAULTS)).toBe('insighta-chatbot');
+      expect(resolveChatbotModel('qwen-runpod', undefined, DEFAULTS, NO_OVERRIDES)).toBe(
+        'insighta-chatbot'
+      );
     });
 
     it('openrouter → openrouter default', () => {
-      expect(resolveChatbotModel('openrouter', undefined, DEFAULTS)).toBe(
+      expect(resolveChatbotModel('openrouter', undefined, DEFAULTS, NO_OVERRIDES)).toBe(
         'google/gemini-2.5-flash'
       );
     });
 
     it('gemini → openrouter default (same OpenAIAdapter path)', () => {
-      expect(resolveChatbotModel('gemini', undefined, DEFAULTS)).toBe('google/gemini-2.5-flash');
+      expect(resolveChatbotModel('gemini', undefined, DEFAULTS, NO_OVERRIDES)).toBe(
+        'google/gemini-2.5-flash'
+      );
     });
 
     it('local → ollama default', () => {
-      expect(resolveChatbotModel('local', undefined, DEFAULTS)).toBe('qwen3:14b');
+      expect(resolveChatbotModel('local', undefined, DEFAULTS, NO_OVERRIDES)).toBe('qwen3:14b');
     });
   });
 
-  describe('defensive — explicit empty string falls back to default', () => {
-    // zod env config now uses `.optional()` so this should normally arrive
-    // as undefined, but if a process.env CHATBOT_MODEL='' somehow leaks
-    // through, the resolver must not return '' to the adapter (vLLM 400).
+  describe('CP475+3 — admin DB override applied when env unset', () => {
+    it('qwen-runpod admin override beats hardcoded default', () => {
+      expect(
+        resolveChatbotModel('qwen-runpod', undefined, DEFAULTS, {
+          qwenRunpodModel: 'insighta-chatbot-v2',
+          openrouterModel: null,
+        })
+      ).toBe('insighta-chatbot-v2');
+    });
+
+    it('openrouter admin override beats hardcoded default', () => {
+      expect(
+        resolveChatbotModel('openrouter', undefined, DEFAULTS, {
+          qwenRunpodModel: null,
+          openrouterModel: 'anthropic/claude-3.5-sonnet',
+        })
+      ).toBe('anthropic/claude-3.5-sonnet');
+    });
+
+    it('gemini provider reuses openrouter admin override slot', () => {
+      // Both gemini and openrouter go through OpenAIAdapter against the same
+      // base URL, so they share a single admin override.
+      expect(
+        resolveChatbotModel('gemini', undefined, DEFAULTS, {
+          qwenRunpodModel: null,
+          openrouterModel: 'openai/gpt-4o-mini',
+        })
+      ).toBe('openai/gpt-4o-mini');
+    });
+
+    it('null admin override falls through to default', () => {
+      expect(
+        resolveChatbotModel('qwen-runpod', undefined, DEFAULTS, {
+          qwenRunpodModel: null,
+          openrouterModel: 'admin-other',
+        })
+      ).toBe('insighta-chatbot');
+    });
+
+    it('empty-string admin override falls through to default', () => {
+      expect(
+        resolveChatbotModel('qwen-runpod', undefined, DEFAULTS, {
+          qwenRunpodModel: '',
+          openrouterModel: null,
+        })
+      ).toBe('insighta-chatbot');
+    });
+  });
+
+  describe('overrides arg omitted (CP475+2 callers, backward-compat)', () => {
+    it('qwen-runpod still resolves correctly', () => {
+      expect(resolveChatbotModel('qwen-runpod', undefined, DEFAULTS)).toBe('insighta-chatbot');
+    });
+
+    it('openrouter still resolves correctly', () => {
+      expect(resolveChatbotModel('openrouter', undefined, DEFAULTS)).toBe(
+        'google/gemini-2.5-flash'
+      );
+    });
+  });
+
+  describe('defensive — explicit empty string env falls back', () => {
     it('empty string for qwen-runpod → insighta-chatbot', () => {
-      expect(resolveChatbotModel('qwen-runpod', '', DEFAULTS)).toBe('insighta-chatbot');
+      expect(resolveChatbotModel('qwen-runpod', '', DEFAULTS, NO_OVERRIDES)).toBe(
+        'insighta-chatbot'
+      );
     });
   });
 });

--- a/tests/unit/modules/chatbot-settings.test.ts
+++ b/tests/unit/modules/chatbot-settings.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for the chatbot-settings service (CP475+3).
+ *
+ * Covers:
+ *   - First read populates the cache; second read within TTL hits cache.
+ *   - DB failure returns safe all-null settings (chatbot must keep working).
+ *   - Update invalidates the cache + writes new settings.
+ *   - `_setCacheForTesting(null)` resets cache for ordering between tests.
+ */
+
+const mockFindUnique = jest.fn();
+const mockUpsert = jest.fn();
+
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    chatbot_settings: {
+      findUnique: mockFindUnique,
+      upsert: mockUpsert,
+    },
+  }),
+}));
+
+jest.mock('@/utils/logger', () => {
+  type Logger = {
+    info: jest.Mock;
+    warn: jest.Mock;
+    error: jest.Mock;
+    debug: jest.Mock;
+    child: () => Logger;
+  };
+  const childLogger: Logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: () => childLogger,
+  };
+  return { logger: childLogger };
+});
+
+import {
+  getChatbotSettings,
+  updateChatbotSettings,
+  invalidateChatbotSettingsCache,
+  _setCacheForTesting,
+} from '@/modules/chatbot-settings/service';
+
+const SAMPLE_ROW = {
+  id: 1,
+  qwen_runpod_model: 'insighta-chatbot-v2',
+  openrouter_model: null,
+  updated_at: new Date('2026-05-20T10:00:00Z'),
+  updated_by: 'admin-uuid-1',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _setCacheForTesting(null);
+});
+
+describe('getChatbotSettings', () => {
+  it('returns row fields mapped to camelCase on cache miss', async () => {
+    mockFindUnique.mockResolvedValueOnce(SAMPLE_ROW);
+    const result = await getChatbotSettings();
+    expect(result.qwenRunpodModel).toBe('insighta-chatbot-v2');
+    expect(result.openrouterModel).toBeNull();
+    expect(result.updatedBy).toBe('admin-uuid-1');
+    expect(mockFindUnique).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+
+  it('returns safe empty settings when DB row is missing', async () => {
+    mockFindUnique.mockResolvedValueOnce(null);
+    const result = await getChatbotSettings();
+    expect(result.qwenRunpodModel).toBeNull();
+    expect(result.openrouterModel).toBeNull();
+  });
+
+  it('caches the result — second call within TTL does not re-query DB', async () => {
+    mockFindUnique.mockResolvedValueOnce(SAMPLE_ROW);
+    await getChatbotSettings();
+    await getChatbotSettings();
+    expect(mockFindUnique).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns safe empty settings on DB error (no throw)', async () => {
+    mockFindUnique.mockRejectedValueOnce(new Error('connection refused'));
+    const result = await getChatbotSettings();
+    expect(result.qwenRunpodModel).toBeNull();
+    expect(result.openrouterModel).toBeNull();
+  });
+
+  it('invalidateChatbotSettingsCache forces next call to hit DB', async () => {
+    mockFindUnique.mockResolvedValue(SAMPLE_ROW);
+    await getChatbotSettings();
+    invalidateChatbotSettingsCache();
+    await getChatbotSettings();
+    expect(mockFindUnique).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('updateChatbotSettings', () => {
+  it('upserts the singleton row and returns the new settings', async () => {
+    const updatedRow = {
+      ...SAMPLE_ROW,
+      qwen_runpod_model: 'new-model',
+      updated_by: 'admin-uuid-2',
+    };
+    mockUpsert.mockResolvedValueOnce(updatedRow);
+
+    const result = await updateChatbotSettings({
+      qwenRunpodModel: 'new-model',
+      updatedBy: 'admin-uuid-2',
+    });
+
+    expect(result.qwenRunpodModel).toBe('new-model');
+    expect(result.updatedBy).toBe('admin-uuid-2');
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const callArgs = mockUpsert.mock.calls[0]![0];
+    expect(callArgs.where).toEqual({ id: 1 });
+    expect(callArgs.update.qwen_runpod_model).toBe('new-model');
+    // openrouter_model was undefined in input — must NOT appear in update
+    expect(callArgs.update.openrouter_model).toBeUndefined();
+  });
+
+  it('undefined field is omitted from update (preserve existing value)', async () => {
+    mockUpsert.mockResolvedValueOnce(SAMPLE_ROW);
+    await updateChatbotSettings({ updatedBy: 'admin-x' });
+    const callArgs = mockUpsert.mock.calls[0]![0];
+    expect(callArgs.update.qwen_runpod_model).toBeUndefined();
+    expect(callArgs.update.openrouter_model).toBeUndefined();
+  });
+
+  it('null field explicitly clears the override', async () => {
+    mockUpsert.mockResolvedValueOnce({ ...SAMPLE_ROW, qwen_runpod_model: null });
+    await updateChatbotSettings({ qwenRunpodModel: null, updatedBy: 'admin-x' });
+    const callArgs = mockUpsert.mock.calls[0]![0];
+    expect(callArgs.update.qwen_runpod_model).toBeNull();
+  });
+
+  it('writes fresh cache so the next get reuses it (no extra DB query)', async () => {
+    mockUpsert.mockResolvedValueOnce({
+      ...SAMPLE_ROW,
+      qwen_runpod_model: 'after-write',
+    });
+    await updateChatbotSettings({
+      qwenRunpodModel: 'after-write',
+      updatedBy: 'admin-x',
+    });
+    // Second get should NOT hit findUnique — cache was repopulated by upsert.
+    const result = await getChatbotSettings();
+    expect(result.qwenRunpodModel).toBe('after-write');
+    expect(mockFindUnique).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

User-requested admin UI for setting `qwen-runpod` + `openrouter` model names at runtime without redeploy. Extends the CP475+2 resolver with a third source.

**Resolver priority (top wins):**
1. `CHATBOT_MODEL` env (global operator override, legacy)
2. `chatbot_settings.{qwen_runpod_model, openrouter_model}` — **admin UI (this PR)**
3. per-provider hardcoded default

## Architecture

```
PUT /api/v1/admin/chatbot/models  ──►  service.updateChatbotSettings()
                                           │
                                           ▼
                                    chatbot_settings (singleton id=1)
                                           │
                                           ▼
                                    invalidate in-mem cache
                                           │
                                           ▼ (next request)
GET  /api/v1/chat                  ──►  getChatbotSettings()  (5-min cache)
                                           │
                                           ▼
                                    resolveChatbotModel(env, db, defaults)
                                           │
                                           ▼
                                    rebuild yoga + serviceAdapter
                                    (only when settings.updatedAt advances)
```

The yoga rebuild is the cheapest possible — `getChatbotSettings()` is O(1) on cache hits, and we only reconstruct the runtime object when the admin's last-write timestamp has advanced.

## Files

**DB**:
- `prisma/migrations/chatbot-settings/001_create_table.sql` — singleton table (id INTEGER PK CHECK = 1, qwen_runpod_model TEXT NULL, openrouter_model TEXT NULL, updated_at, updated_by UUID). Seeds id=1 row.
- `prisma/schema.prisma` — adds `model chatbot_settings`.
- Applied to local supabase-db-dev + postgrest schema reloaded.

**BE**:
- `src/modules/chatbot-settings/service.ts` (NEW) — getChatbotSettings / updateChatbotSettings / invalidateChatbotSettingsCache + 5-min in-memory cache + safe DB-error fallback.
- `src/api/routes/copilotkit-model-resolver.ts` — adds optional `AdminOverrides` arg (backward-compat).
- `src/api/routes/admin/chatbot.ts` — GET `/admin/chatbot` extended + GET/PUT `/admin/chatbot/models` (admin authz).
- `src/api/routes/copilotkit.ts` — lazy yoga handler with timestamp-keyed rebuild.

**FE**:
- `frontend/src/shared/lib/api-client.ts` — `getAdminChatbotModels()` + `setAdminChatbotModels()` + types.
- `frontend/src/pages/admin/ui/AdminChatbotModels.tsx` (NEW) — page with 2 input fields + default placeholders + `CHATBOT_MODEL` env warning banner.
- `frontend/src/app/router/index.tsx` — `/admin/chatbot-models` route.
- `frontend/src/pages/admin/ui/AdminLayout.tsx` — sidebar nav entry (`Bot` icon).

**Tests** (24 cases total, all PASS):
- `tests/unit/api/copilotkit-model-resolver.test.ts` — 15 cases (env-wins × 3, env-unset × 4, admin-override × 6, backward-compat × 2).
- `tests/unit/modules/chatbot-settings.test.ts` — 9 cases (cache hit/miss, DB error safe fallback, invalidate, update side-effect, null/undefined semantics).

## Regression

- tsc 0 errors (BE + FE)
- jest 24/24 PASS on new tests (full suite green at PR #703 merge baseline)
- hardcode-audit 33/33 (no new violations)
- Local DB migration applied + postgrest schema reloaded

## Prod follow-up (post-merge, manual)

Per CLAUDE.md "prisma db push Silent Fail" rule, new tables need raw SQL DDL applied to prod separately:

```bash
# 1. Get prod DIRECT_URL from credentials.md
# 2. Apply migration
psql "$DIRECT_URL" -f prisma/migrations/chatbot-settings/001_create_table.sql

# 3. Verify
psql "$DIRECT_URL" -c '\d chatbot_settings'
psql "$DIRECT_URL" -c 'SELECT * FROM chatbot_settings;'  -- should show 1 row

# 4. Reload postgrest schema cache (Supabase dashboard → Settings → API → "Reload schema")

# 5. Wait for deploy.yml to redeploy (auto on this merge), then test admin UI at:
#    https://insighta.app/admin/chatbot-models
```

## Backwards compat

- No env var changes.
- Empty `chatbot_settings` row (all NULL) → identical resolver behaviour to pre-PR (provider-native default).
- Existing `CHATBOT_MODEL` env override still wins over admin DB.
- `/admin/chatbot` (legacy GET) returns the same shape + new `overrides`/`defaults`/`envExplicit` fields (additive).

## Why a 4th PR in this saga

CP474 → CP475 → CP475+1 → CP475+2 → **CP475+3**. Each PR fixed exactly the layer of breakage the previous PR's smoke surfaced. The admin UI is the only one that's a genuine new feature (per user request "두 provider model admin 에서 set"); #701-#703 were all hotfixes for the CP474 work that should have caught the issues in a single integration test.

Refs: CP475+3, PR #699 (CP474 origin), PR #701/702/703 (URL prefix + secret→vars + model resolver hotfixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)