### PR TITLE
fix(chatbot): force tool_choice=none on vLLM Pod requests (CP475+4)

### DIFF
--- a/src/modules/chatbot-rag/qwen-prompt-middleware.ts
+++ b/src/modules/chatbot-rag/qwen-prompt-middleware.ts
@@ -69,8 +69,19 @@ export function createQwenPromptMiddleware(): LanguageModelV3Middleware {
     transformParams: async ({ params }) => {
       try {
         const rewritten = await rewriteSystemPrompt(params.prompt);
-        if (!rewritten) return params;
-        return { ...params, prompt: rewritten };
+        // CP475+4 — vLLM Pod started without --enable-auto-tool-choice +
+        // --tool-call-parser, so any inbound `tool_choice: 'auto'` (the
+        // Vercel AI SDK default when the route configures tools) produces:
+        //   400 "auto" tool choice requires --enable-auto-tool-choice ...
+        // The Insighta chatbot doesn't use tool calling, so we force tools
+        // off in the request that hits vLLM.
+        const next = {
+          ...params,
+          prompt: rewritten ?? params.prompt,
+          toolChoice: { type: 'none' as const },
+          tools: [],
+        };
+        return next;
       } catch (err) {
         log.warn('middleware failed; forwarding original params', {
           error: err instanceof Error ? err.message : String(err),

--- a/src/modules/chatbot-rag/qwen-runpod-adapter.ts
+++ b/src/modules/chatbot-rag/qwen-runpod-adapter.ts
@@ -160,6 +160,11 @@ export class QwenRunpodAdapter implements CopilotServiceAdapter {
       stream: true;
       messages: ReadonlyArray<{ role: 'system' | 'user' | 'assistant'; content: string }>;
       chat_template_kwargs: { enable_thinking: boolean };
+      // CP475+4 — explicitly disable tool calling. vLLM Pod is started
+      // without --enable-auto-tool-choice; any inbound tool_choice='auto'
+      // (Vercel SDK default) produces 400 "auto" tool choice requires ...".
+      // The chatbot doesn't use function calling, so 'none' is correct.
+      tool_choice: 'none';
       max_completion_tokens?: number;
       temperature?: number;
       stop?: string | string[];
@@ -169,6 +174,7 @@ export class QwenRunpodAdapter implements CopilotServiceAdapter {
       stream: true,
       messages: openaiMessages,
       chat_template_kwargs: CHAT_TEMPLATE_KWARGS,
+      tool_choice: 'none',
     };
     if (forwardedParameters?.maxTokens) body.max_completion_tokens = forwardedParameters.maxTokens;
     if (forwardedParameters?.temperature !== undefined)

--- a/tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
+++ b/tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
@@ -224,4 +224,32 @@ describe('createQwenPromptMiddleware', () => {
     // On error, original params returned unchanged (no rewrite).
     expect(out).toBe(inputParams);
   });
+
+  it('CP475+4 — transformParams forces toolChoice=none + empty tools', async () => {
+    // The vLLM Pod was launched without --enable-auto-tool-choice, so any
+    // inbound `tool_choice: 'auto'` returns 400. Middleware must always
+    // override regardless of caller intent.
+    const mw = createQwenPromptMiddleware();
+    const inputParams = {
+      prompt: [{ role: 'system' as const, content: 'arbitrary' }],
+      toolChoice: { type: 'auto' as const },
+      tools: [
+        {
+          type: 'function' as const,
+          name: 'someTool',
+          description: '',
+          inputSchema: {},
+        },
+      ],
+    };
+
+    const out = await mw.transformParams!({
+      type: 'stream',
+      params: inputParams as never,
+      model: {} as never,
+    });
+
+    expect(out.toolChoice).toEqual({ type: 'none' });
+    expect(out.tools).toEqual([]);
+  });
 });

--- a/tests/unit/modules/chatbot-rag/qwen-runpod-adapter.test.ts
+++ b/tests/unit/modules/chatbot-rag/qwen-runpod-adapter.test.ts
@@ -252,6 +252,25 @@ describe('QwenRunpodAdapter — process()', () => {
     ]);
   });
 
+  it('CP475+4 — request body sets tool_choice=none + chat_template_kwargs', async () => {
+    // vLLM Pod was started without --enable-auto-tool-choice. The chatbot
+    // doesn't use function calling, so the adapter must explicitly tell
+    // vLLM not to expect tool-call output.
+    mockChatCompletionsCreate.mockResolvedValueOnce(iterChunks([]));
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });
+    const es = makeEventSource();
+
+    await a.process({
+      messages: [makeTextMessage('user', 'hi') as never],
+      actions: [],
+      eventSource: es as never,
+    });
+
+    const callArg = mockChatCompletionsCreate.mock.calls[0]![0];
+    expect(callArg.tool_choice).toBe('none');
+    expect(callArg.chat_template_kwargs).toEqual({ enable_thinking: false });
+  });
+
   it('streams deltas as start → content → end → complete', async () => {
     mockChatCompletionsCreate.mockResolvedValueOnce(
       iterChunks([


### PR DESCRIPTION
## Summary — final hotfix in the CP474 saga

User smoke surfaced this. Pod logs response body:

```
"auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set
statusCode: 400
```

CopilotKit / Vercel AI SDK defaults `tool_choice: 'auto'` whenever the route hands it a LanguageModel — even with zero registered tools. vLLM v0.9.0 only accepts that value when the Pod was started with `--enable-auto-tool-choice --tool-call-parser <parser>`. The current Pod (`bec5sptl1a5f8d`) wasn't, and the Insighta chatbot doesn't use function calling, so the fix is to force `tool_choice: 'none'` on every request hitting vLLM.

## Why this PR vs. restarting the Pod

| Option | Pros | Cons |
|---|---|---|
| Restart Pod with `--enable-auto-tool-choice --tool-call-parser hermes` | "Native" vLLM solution | Requires user action; chatbot doesn't actually use tools, so this enables dead capability; model can still emit spurious tool-call attempts |
| **This PR — force tool_choice=none** | Zero Pod changes; correct semantics for a chatbot that never uses tools; defence in depth (both code paths) | Single code change |

We picked option 2.

## Changes

Both code paths into vLLM are patched (defence in depth):

### 1. `qwen-prompt-middleware.ts`
`transformParams` now appends:
```ts
toolChoice: { type: 'none' as const },
tools: [],
```
Catches the BuiltInAgent / `getLanguageModel()` path that Vercel SDK uses to call chat.completions on behalf of CopilotRuntime.

### 2. `qwen-runpod-adapter.ts`
`process()` body now sets:
```ts
tool_choice: 'none'
```
alongside existing `chat_template_kwargs`. Catches the legacy streaming path in case CopilotRuntime falls back to `process()`.

## Symptom in the user's smoke logs

```
[OpenRouter] model=qwen/qwen3-30b-a3b ... 200      # Rich Summary, unrelated
APICallError [AI_APICallError]: Bad Request        # ← chatbot turn 1
  url: 'https://bec5sptl1a5f8d-8000.proxy.runpod.net/v1/chat/completions',
  statusCode: 400,
  responseBody: '...auto tool choice requires --enable-auto-tool-choice...'
Agent execution failed: APICallError ...           # ← user sees no response
```

Some turns went through `process()` (no `tool_choice` in body → vLLM accepted, user saw answers). Others went through the BuiltInAgent path (Vercel SDK auto-injected `tool_choice='auto'` → 400). Hence the inconsistent "응답 받음 → 응답 없음" pattern in the screenshot.

## Tests (29/29 PASS)

- middleware: NEW case verifies `transformParams` returns `toolChoice={type:'none'}` + `tools=[]` even when caller sets `tool_choice='auto'` + non-empty tools.
- adapter: NEW case verifies the body sent to vLLM contains `tool_choice:'none'` and `chat_template_kwargs:{enable_thinking:false}`.

All existing tests still pass.

Regression: tsc 0 errors. hardcode-audit unchanged.

## Saga recap

| PR | Layer | Symptom that surfaced it |
|---|---|---|
| #699 (CP474) | Bug 1 multi-turn + Persona | Origin work |
| #701 (CP475+1) | URL prefix `/v1` passthrough | Pod migration `5s4pyrvowjm0uh` → `bec5sptl1a5f8d` |
| #702 (CP475+1) | secret→vars + run-name | `QWEN_LORA_API_URL` was a Secret (CP392 violation) |
| #703 (CP475+2) | Model resolver provider-native fallback | Pod returned 404 — model=gemini-flash sent to vLLM |
| #705 (CP475+3) | Admin UI per-provider model selector | User requested dynamic control |
| **#706 (CP475+4)** | **tool_choice=none** | **vLLM 400 on BuiltInAgent path** |

After this PR, **every** chatbot turn (Bug 1 multi-turn / Persona / Admin-overridden model) should land successfully.

Refs: CP475+4

🤖 Generated with [Claude Code](https://claude.com/claude-code)