### PR TITLE
fix(chatbot): suppress Qwen3 reasoning leak + clickable timestamps (CP475+5)

### DIFF
--- a/frontend/src/pages/learning/ui/ChatAssistant.tsx
+++ b/frontend/src/pages/learning/ui/ChatAssistant.tsx
@@ -444,15 +444,41 @@ function ChatPanel({
   useEffect(() => {
     const wrapper = wrapperRef.current;
     if (!wrapper || !onSeek) return;
-    const observer = new MutationObserver((mutations) => {
-      for (const m of mutations)
-        for (const node of m.addedNodes) if (node instanceof HTMLElement) linkifyTimestamps(node);
+
+    // CP475+5 — streaming chat messages mutate via characterData on the
+    // existing textNode (Vercel SDK / CopilotKit incremental render),
+    // NOT childList additions. Pre-fix the observer only watched
+    // childList, so timestamps that arrived chunk-by-chunk (e.g. "0:",
+    // then "56") were never re-walked and stayed as plain text. The
+    // bug-report screenshot (2026-05-20) shows `(0:56-1:12)` rendered
+    // as plain text with no click affordance.
+    //
+    // We now (a) also observe characterData, (b) debounce 200ms past the
+    // last mutation so we only walk once React has finished settling a
+    // streamed message — without this, each streaming chunk would trigger
+    // a linkify pass that React's next reconciliation would immediately
+    // overwrite (textNode replace cycle), so the user never sees a button
+    // until streaming ends.
+    let debounce: ReturnType<typeof setTimeout> | null = null;
+    const reLinkify = () => {
+      if (debounce !== null) clearTimeout(debounce);
+      debounce = setTimeout(() => {
+        debounce = null;
+        linkifyTimestamps(wrapper);
+      }, 200);
+    };
+
+    const observer = new MutationObserver(() => reLinkify());
+    observer.observe(wrapper, {
+      childList: true,
+      subtree: true,
+      characterData: true,
     });
-    observer.observe(wrapper, { childList: true, subtree: true });
     linkifyTimestamps(wrapper);
     wrapper.addEventListener('click', handleTsClick);
     return () => {
       observer.disconnect();
+      if (debounce !== null) clearTimeout(debounce);
       wrapper.removeEventListener('click', handleTsClick);
     };
   }, [onSeek, handleTsClick]);

--- a/src/modules/chatbot-rag/qwen-prompt-middleware.ts
+++ b/src/modules/chatbot-rag/qwen-prompt-middleware.ts
@@ -125,6 +125,23 @@ export async function rewriteSystemPrompt(
 }
 
 /**
+ * Append the Qwen3 `/no_think` directive to a system prompt to suppress the
+ * model's reasoning block. Required because the chat_template_kwargs path
+ * (`enable_thinking: false`) is only honoured on the legacy `process()`
+ * code path — the Vercel AI SDK V3 chat model in `getLanguageModel()` does
+ * not forward provider-specific kwargs, so without this textual directive
+ * the model leaks its full English reasoning chain into the response.
+ *
+ * CP475+5 — bug-report 2026-05-20: chatbot responses started with
+ * "Okay, let me try to figure out how to handle this..." (entire reasoning
+ * chain in English) before the actual Korean answer.
+ */
+export function appendNoThinkDirective(systemContent: string): string {
+  if (systemContent.includes('/no_think')) return systemContent;
+  return `${systemContent}\n\n/no_think`;
+}
+
+/**
  * Plain-string variant for the legacy SSE streaming path (QwenRunpodAdapter.process).
  *
  * Same pipeline as rewriteSystemPrompt but consumes/returns a single
@@ -145,13 +162,19 @@ export async function rewriteSystemContent(originalSystemContent: string): Promi
 
   const layer: ChatLayer = youtubeVideoId ? 'video' : 'global';
 
-  return buildQwenSystemPrompt({
+  const built = buildQwenSystemPrompt({
     layer,
     language,
     v2Data: videoCtx.v2Data,
     transcript: videoCtx.transcript,
     includePersona: true,
   });
+  // CP475+5 — suppress Qwen3 reasoning chain. The `chat_template_kwargs`
+  // path (`enable_thinking: false`) only works on the legacy process() body;
+  // Vercel AI SDK V3 strips provider-specific kwargs, so the textual
+  // `/no_think` directive is the reliable way to gate reasoning on every
+  // request that hits vLLM.
+  return appendNoThinkDirective(built);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
+++ b/tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
@@ -42,6 +42,7 @@ import {
   rewriteSystemContent,
   rewriteSystemPrompt,
   createQwenPromptMiddleware,
+  appendNoThinkDirective,
   _resetMiddlewareCacheForTesting,
 } from '@/modules/chatbot-rag/qwen-prompt-middleware';
 import { PRODUCT_PERSONA_KO, PRODUCT_PERSONA_EN } from '@/modules/chatbot-rag/prompt-builder';
@@ -251,5 +252,34 @@ describe('createQwenPromptMiddleware', () => {
 
     expect(out.toolChoice).toEqual({ type: 'none' });
     expect(out.tools).toEqual([]);
+  });
+});
+
+describe('appendNoThinkDirective (CP475+5)', () => {
+  it('appends /no_think to a system prompt lacking it', () => {
+    expect(appendNoThinkDirective('You are Insighta...')).toBe('You are Insighta...\n\n/no_think');
+  });
+
+  it('is idempotent — does not add /no_think twice', () => {
+    const once = appendNoThinkDirective('hello');
+    const twice = appendNoThinkDirective(once);
+    expect(twice).toBe(once);
+  });
+
+  it('passes through if /no_think already appears anywhere in the content', () => {
+    const prompt = 'instructions\n/no_think\nmore instructions';
+    expect(appendNoThinkDirective(prompt)).toBe(prompt);
+  });
+});
+
+describe('rewriteSystemContent — CP475+5 /no_think suppression', () => {
+  it('appends /no_think to the generated system prompt (Korean)', async () => {
+    const out = await rewriteSystemContent('한국어 인사이트 챗봇 사용');
+    expect(out.endsWith('/no_think')).toBe(true);
+  });
+
+  it('appends /no_think to the generated system prompt (English)', async () => {
+    const out = await rewriteSystemContent("You are Insighta's learning assistant.");
+    expect(out.endsWith('/no_think')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Two bugs surfaced during the post-#706 smoke. One PR, both fixed.

### Bug 1 — English reasoning chain leaked into the response

User question (KR): "관련 영상 찾아줄수 있어 ?"

Response prefix: `Okay, let me try to figure out how to handle this. The user asked for related videos, but the current guidelines say I can't provide external links or search results. I need to stick to the rules. The user might be looking for more content on smart store setup or e-commerce strategies. Since I can't browse, I should suggest they search YouTube for keywords like ...`

(then the actual Korean answer follows)

**Root cause** — the existing `chat_template_kwargs: { enable_thinking: false }` gate only ships on the legacy `process()` body. The Vercel AI SDK V3 chat model (used by `getLanguageModel()` / BuiltInAgent) strips provider-specific kwargs before posting to vLLM, so Qwen3 emits its full `<think>` chain.

**Fix** — append the `/no_think` textual directive to the system prompt in `rewriteSystemContent`. Honoured by Qwen3's chat template regardless of how the request was assembled.

### Bug 2 — Timestamps not clickable

User: "타임스탬프는 Insighta 링크 형태로 제공되어야, 즉시 재생이 가능함."

`linkifyTimestamps()` + `.chat-ts` CSS have been in the codebase, but streamed timestamps stay plain text.

**Root cause** — streaming chat messages mutate via `characterData` on the existing textNode, NOT via `childList` additions. The pre-fix MutationObserver only watched `childList`, so a timestamp arriving chunk-by-chunk (e.g. "0:" then "56") was never re-walked.

**Fix** in `ChatAssistant.tsx`:
- observe `characterData: true` in addition to `childList` + `subtree`
- debounce 200ms past the last mutation (avoid the React reconciliation overwrite cycle — each chunk would otherwise trigger a linkify that React immediately reverts on the next render)
- clean up the debounce timer on unmount

## Files

- `src/modules/chatbot-rag/qwen-prompt-middleware.ts`
  - new `appendNoThinkDirective(s)` — idempotent, no-op when directive present
  - `rewriteSystemContent` now ends with `/no_think`
- `frontend/src/pages/learning/ui/ChatAssistant.tsx`
  - MutationObserver options + 200ms debounce + cleanup
- `tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts`
  - 5 new cases (3 × `appendNoThinkDirective`, 2 × `rewriteSystemContent` KR/EN)
  - all 15 existing middleware tests still pass; total 20/20

## Regression

- tsc 0 errors (BE + FE)
- jest 20/20 PASS on middleware test
- hardcode-audit unchanged

## Why `/no_think` text directive vs. properly wiring `providerOptions.openai.extraBody`

A future cleanup PR can wire `providerOptions.openai.extraBody.chat_template_kwargs` to remove the textual directive once we've audited Vercel SDK 6.x's exact provider-options shape. Until then, the textual directive is:
- model-agnostic (works on any Qwen3 chat template version)
- SDK-agnostic (survives Vercel SDK bumps)
- visible in logs (easy to verify)

## Saga

| PR | Fix |
|---|---|
| #699 (CP474) | Bug 1 multi-turn + Persona |
| #701 (CP475+1) | URL prefix `/v1` |
| #702 (CP475+1) | secret→vars + run-name |
| #703 (CP475+2) | model resolver provider-native |
| #705 (CP475+3) | admin UI dynamic model selector |
| #706 (CP475+4) | tool_choice='none' |
| **#707 (CP475+5)** | **/no_think + clickable timestamps** |

After this PR — Korean answer comes out clean (no English reasoning prefix), and timestamps in chat responses are clickable buttons that seek the video player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)