### PR TITLE
fix(card): grid v2 fields land within seconds, not minutes

### DIFF
--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -9,6 +9,7 @@ import { GripVertical, NotepadText, Loader2, Play, Bookmark, Archive } from 'luc
 import { useLikeCard } from '@/features/card-management/model/useLikeCard';
 import { useArchiveCard } from '@/features/card-management/model/useArchiveCard';
 import { useEnrichStream } from '@/features/card-management/model/useEnrichStream';
+import { localCardsKeys } from '@/features/card-management/model/useLocalCards';
 import { extractYouTubeVideoId } from '@/shared/lib/url-normalize';
 import { type DragData, cardDragId } from '@/shared/lib/dnd';
 import {
@@ -216,12 +217,43 @@ export function InsightCardItemV2({
   // the empty payload until the next natural refetch. Force a refetch
   // here so the badge + footer one_liner appear the moment 'scored'
   // arrives.
+  //
+  // CP475+ — PR #704 moved the card grid v2 source from useV2Summaries
+  // (key ['cards','v2-summaries']) to the inlined fields on
+  // /local-cards/list (key localCardsKeys.list()). The old invalidate
+  // here became a no-op for the grid card. Both keys are now refreshed
+  // on 'scored', plus a single short follow-up after 1.5s to absorb the
+  // BE write-after-job-complete commit window (pgboss marks state=
+  // completed before the row's transactional commit is fully visible to
+  // a subsequent SELECT in rare cases).
   const queryClient = useQueryClient();
   useEffect(() => {
-    if (enrichStream.phase === 'scored') {
+    if (enrichStream.phase !== 'scored') return;
+    const invalidate = () => {
       void queryClient.invalidateQueries({ queryKey: ['cards', 'v2-summaries'] });
-    }
+      void queryClient.invalidateQueries({ queryKey: localCardsKeys.list() });
+    };
+    invalidate();
+    const t = window.setTimeout(invalidate, 1500);
+    return () => window.clearTimeout(t);
   }, [enrichStream.phase, queryClient]);
+
+  // CP475+ — safety-net polling for the case where the SSE stream
+  // closed (or never opened — page refresh after a like) but the
+  // server v2 row hasn't landed in our card payload yet. Only active
+  // while this card is liked AND its v2 essence is still empty. 5s
+  // interval matches PanelAISummary; the query auto-stops as soon as
+  // the row arrives (`coreArgument` becomes non-null on next refetch).
+  useEffect(() => {
+    if (!videoId) return;
+    if (!card.pinnedAt) return;
+    if ((card.v2CoreArgument ?? null) != null) return;
+    if ((card.v2OneLiner ?? null) != null) return;
+    const interval = window.setInterval(() => {
+      void queryClient.invalidateQueries({ queryKey: localCardsKeys.list() });
+    }, 5000);
+    return () => window.clearInterval(interval);
+  }, [videoId, card.pinnedAt, card.v2CoreArgument, card.v2OneLiner, queryClient]);
 
   const handleHeartClick = useCallback(
     (e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
Hot-path fix for "BE finishes in 41s but the dashboard card doesn't update for 3+ minutes" — discovered by measuring `pgboss.job` instead of guessing.

### Root cause (measurement-driven)
- `pgboss.job` for the user's `enrich-rich-summary`: **wait_s=1, dur_s=41, state=completed, retrycount=0** → BE was always healthy.
- PR #697 invalidates `['cards','v2-summaries']` on the SSE `scored` phase.
- PR #704 migrated the grid card's v2 source onto `/local-cards/list` (key `localCardsKeys.list()`). The PR #697 invalidate became a **no-op** for the grid card.
- Result: card stayed with `v2_* = null` until the next natural refetch (`60s` staleTime / nav / refresh).

### Not the earlier guess
My option D/E proposal (`POST /like` inline quick + per-channel worker pool, ~2.5h) would have shipped zero impact on this bug. Measurement caught it.

### Changes
1. **SSE `scored` invalidate** — `['cards','v2-summaries']` **+ `localCardsKeys.list()`** + a single 1.5s follow-up (absorbs the pgboss "completed-before-commit-visible" window).
2. **Safety-net poll** — while `card.pinnedAt && card.v2CoreArgument == null && card.v2OneLiner == null`, invalidate `localCardsKeys.list()` every 5s. Self-stops on success. Handles SSE drops / refresh-after-like.

### Regression scope
- Poll only runs while v2 is missing on a pinned card → no idle traffic.
- `localCardsKeys.list()` already invalidated by like / unlike / archive / pin — no contract change.
- No BE changes.

## Test plan
- [x] FE tsc + vitest 320/320 + build PASS
- [ ] prod after deploy: like a fresh card → footer one_liner + relevance % appear within ~3-5s of SSE `scored`
- [ ] prod: refresh page mid-enrichment → safety-net poll picks the row up within 5s of the BE write

🤖 Generated with [Claude Code](https://claude.com/claude-code)