### PR TITLE
fix(chatbot): preserve history across tab switch (CP475+6, Bug 2)

### DIFF
--- a/frontend/src/pages/learning/ui/ChatAssistant.tsx
+++ b/frontend/src/pages/learning/ui/ChatAssistant.tsx
@@ -498,8 +498,21 @@ function ChatPanel({
 }
 
 export function ChatAssistant({ mandalaId, videoId, onSeek }: ChatAssistantProps) {
+  // CP475+6 — Bug 2 fix: chat history preserved across tab switches (chatbot ↔
+  // notes) within the same videoId.
+  //
+  // Pre-fix `headers` was a fresh `{ Authorization: ... }` object on every
+  // render. RightPanel re-renders on every `activeTab` change → ChatAssistant
+  // re-renders → new `headers` reference → CopilotKit Provider treats it as a
+  // config change and re-creates its internal runtime → `useCopilotChat()`'s
+  // visibleMessages reset to an empty array. User-reported symptom: "노트
+  // 탭 갔다 챗봇 탭 돌아오면 대화 사라짐."
+  //
+  // `useMemo` keyed on the token string stabilises the reference for the
+  // lifetime of a token. When the JWT rotates, headers _do_ change (correctly)
+  // and the runtime rebuilds — but for ordinary tab navigation it stays put.
   const token = apiClient.getAccessToken();
-  const headers: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+  const headers = useMemo(() => (token ? { Authorization: `Bearer ${token}` } : {}), [token]);
 
   return (
     <CopilotKit


### PR DESCRIPTION
## Summary

User-reported regression (task #4): chatbot conversation disappears when switching from the chatbot tab to the notes tab and back, even with the videoId unchanged.

## Root cause

`<CopilotKit>` received a fresh `headers` object on every render:

```tsx
const token = apiClient.getAccessToken();
const headers: Record<string, string> = token
  ? { Authorization: `Bearer ${token}` }
  : {};
return <CopilotKit ... headers={headers}>...</CopilotKit>;
```

Tab click → `RightPanel.activeTab` state change → re-render cascade → fresh `headers` `{}` object → CopilotKit Provider treats the new reference as a config change → re-creates the internal runtime → `useCopilotChat().visibleMessages` resets to `[]`.

The wrapper around `<ChatAssistant>` already uses `activeTab !== 'chatbot' && 'hidden'` (component stays mounted) and `<ChatAssistant key={videoId} />` (different video → intentional reset). The remaining gap was the unstable prop reference.

## Fix

```diff
- const token = apiClient.getAccessToken();
- const headers: Record<string, string> = token
-   ? { Authorization: `Bearer ${token}` }
-   : {};
+ const token = apiClient.getAccessToken();
+ const headers = useMemo(
+   () => (token ? { Authorization: `Bearer ${token}` } : {}),
+   [token]
+ );
```

Stable for the lifetime of a token. JWT rotation correctly triggers a rebuild; tab navigation does not.

## Verification

- tsc 0 errors (FE)
- Manual UI smoke after deploy:
  - [ ] Open Learning Page, ask question in chatbot tab → response arrives
  - [ ] Switch to notes tab → write something
  - [ ] Switch back to chatbot tab → **previous conversation still visible** (this is the regression case)
  - [ ] Send follow-up question → multi-turn history intact
  - [ ] Navigate to different video → chatbot resets (intentional, `key={videoId}` behaviour)

## Out of scope (separate backlog)

- DB persistence of chat history (page reload still wipes — needs `chatbot_conversations` table + CopilotKit message hooks)
- Cross-video conversation linking
- Conversation summarisation when context window fills

Refs: CP475+6, task #4 "Chatbot tab-switch state reset bug — same-videoId 시 preserve", PR #707 (prior chatbot fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)