### PR TITLE
fix(security): redact JWT in request URL logs (CP475+7)

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -2,6 +2,7 @@ import Fastify, { FastifyError, FastifyReply, FastifyRequest } from 'fastify';
 import cors from '@fastify/cors';
 import helmet from '@fastify/helmet';
 import { registerRateLimit } from './plugins/rate-limit';
+import { sanitizeLogUrl } from './utils/log-url-sanitizer';
 import dotenv from 'dotenv';
 import { Prisma } from '@prisma/client';
 import { registerAuth } from './plugins/auth';
@@ -68,6 +69,27 @@ export async function buildServer() {
   const fastify = Fastify({
     logger: {
       level: process.env['LOG_LEVEL'] || 'info',
+      // CP475+7 — strip JWTs and other auth-bearing query values from
+      // logged URLs. EventSource (used by /videos/stream and friends)
+      // can't send Authorization headers, so the JWT is passed via
+      // `?access_token=...`; the default pino serializer would land
+      // that token in production logs in plaintext.
+      serializers: {
+        req(req) {
+          // Mirror fastify's default `req` serializer shape, replacing
+          // only the `url` field with a sanitised variant. Custom
+          // serializers fully replace the default — we keep every
+          // existing field so log shape stays compatible with
+          // downstream consumers (CloudWatch queries, dashboards).
+          return {
+            method: req.method,
+            url: sanitizeLogUrl(req.url),
+            hostname: req.hostname,
+            remoteAddress: req.ip,
+            remotePort: req.socket?.remotePort,
+          };
+        },
+      },
     },
     ajv: {
       customOptions: {

--- a/src/api/utils/log-url-sanitizer.ts
+++ b/src/api/utils/log-url-sanitizer.ts
@@ -1,0 +1,49 @@
+/**
+ * URL sanitiser for fastify pino request logs.
+ *
+ * `EventSource` (browser SSE primitive) cannot send custom Authorization
+ * headers, so any auth-protected SSE endpoint accepts the JWT via the
+ * `?access_token=` query parameter. fastify's default `req` serializer
+ * stores `req.url` verbatim → the JWT lands in production logs in
+ * plaintext.
+ *
+ * This helper masks any auth-bearing query value so the URL stays useful
+ * for debugging (path + other params visible) without leaking secrets.
+ *
+ * Covered params (case-insensitive):
+ *   - access_token
+ *   - id_token
+ *   - refresh_token
+ *   - token
+ *   - api_key
+ *
+ * Refs: CP475+7 — JWT leak via `/api/v1/mandalas/:id/videos/stream?access_token=...`
+ * surfaced in prod logs during the CP475 chatbot saga.
+ */
+
+const SENSITIVE_QUERY_PARAMS = [
+  'access_token',
+  'id_token',
+  'refresh_token',
+  'token',
+  'api_key',
+] as const;
+
+const REDACTED = '<redacted>';
+
+const REDACT_REGEX = new RegExp(`(?<=[?&])(${SENSITIVE_QUERY_PARAMS.join('|')})=[^&#]+`, 'gi');
+
+/**
+ * Returns the URL with sensitive query parameter VALUES replaced by
+ * `<redacted>`. Param names + everything else is left untouched.
+ *
+ * Examples:
+ *   /a/b?access_token=eyJh.abc&lastEventId=42
+ *     → /a/b?access_token=<redacted>&lastEventId=42
+ *   /a/b?lastEventId=42
+ *     → /a/b?lastEventId=42   (unchanged)
+ */
+export function sanitizeLogUrl(url: string | undefined | null): string {
+  if (!url) return url ?? '';
+  return url.replace(REDACT_REGEX, (_match, paramName: string) => `${paramName}=${REDACTED}`);
+}

--- a/tests/unit/api/log-url-sanitizer.test.ts
+++ b/tests/unit/api/log-url-sanitizer.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for `sanitizeLogUrl` (CP475+7 — JWT log leak fix).
+ *
+ * The function must mask any value belonging to an auth-bearing query
+ * parameter while leaving the rest of the URL intact.
+ */
+
+import { sanitizeLogUrl } from '@/api/utils/log-url-sanitizer';
+
+describe('sanitizeLogUrl', () => {
+  describe('redacts sensitive query params', () => {
+    it('masks access_token value (the CP475+7 primary case)', () => {
+      const url =
+        '/api/v1/mandalas/abc/videos/stream?access_token=eyJhbGciOiJFUzI1NiIsImtpZCI6IjRhOWUxM2ZjIn0.long_jwt_body.signature';
+      expect(sanitizeLogUrl(url)).toBe(
+        '/api/v1/mandalas/abc/videos/stream?access_token=<redacted>'
+      );
+    });
+
+    it('masks token value', () => {
+      expect(sanitizeLogUrl('/x?token=abcdef123')).toBe('/x?token=<redacted>');
+    });
+
+    it('masks api_key value', () => {
+      expect(sanitizeLogUrl('/y?api_key=AIzaSyD-abc')).toBe('/y?api_key=<redacted>');
+    });
+
+    it('masks id_token and refresh_token values', () => {
+      expect(sanitizeLogUrl('/z?id_token=foo&refresh_token=bar')).toBe(
+        '/z?id_token=<redacted>&refresh_token=<redacted>'
+      );
+    });
+
+    it('is case-insensitive on param name', () => {
+      expect(sanitizeLogUrl('/x?Access_Token=eyJ.h')).toBe('/x?Access_Token=<redacted>');
+    });
+  });
+
+  describe('preserves non-sensitive params', () => {
+    it('leaves lastEventId untouched while masking access_token', () => {
+      const url = '/api/v1/mandalas/m1/videos/stream?access_token=eyJ.x.y&lastEventId=42';
+      expect(sanitizeLogUrl(url)).toBe(
+        '/api/v1/mandalas/m1/videos/stream?access_token=<redacted>&lastEventId=42'
+      );
+    });
+
+    it('leaves a URL with no sensitive params unchanged', () => {
+      const url = '/api/v1/cards?cursor=abc&limit=20';
+      expect(sanitizeLogUrl(url)).toBe(url);
+    });
+
+    it('leaves a URL with no query string unchanged', () => {
+      expect(sanitizeLogUrl('/api/v1/health')).toBe('/api/v1/health');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles undefined gracefully', () => {
+      expect(sanitizeLogUrl(undefined)).toBe('');
+    });
+
+    it('handles null gracefully', () => {
+      expect(sanitizeLogUrl(null)).toBe('');
+    });
+
+    it('handles empty string gracefully', () => {
+      expect(sanitizeLogUrl('')).toBe('');
+    });
+
+    it('does NOT mask param values that merely START with a sensitive name (e.g. access_token_hint)', () => {
+      // The regex matches the param name as a discrete token (boundary before `=`).
+      // `access_token_hint=foo` is a different key → must NOT be masked.
+      expect(sanitizeLogUrl('/x?access_token_hint=public_value')).toBe(
+        '/x?access_token_hint=public_value'
+      );
+    });
+
+    it('masks across hash fragments correctly (stops at #)', () => {
+      // `#` ends the query string; the hash fragment is not part of params.
+      expect(sanitizeLogUrl('/x?access_token=secret#section')).toBe(
+        '/x?access_token=<redacted>#section'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 🚨 Security fix

Production `insighta-api` logs were storing **JWT access tokens in plaintext**, leaked via the EventSource `?access_token=` query string used by SSE endpoints.

### Observed in prod (CP475+7 discovery)

```
GET /api/v1/mandalas/9d1ee45a-.../videos/stream?
    access_token=eyJhbGciOiJFUzI1NiIsImtpZCI6IjRhOWUxM2Z...
```

The JWT decodes to user identity + session id. Anyone with log-read access (CloudWatch, log aggregator, SSH to EC2) within the JWT's TTL could impersonate the user.

## Cause

- `EventSource` (browser SSE primitive) **cannot set custom Authorization headers**. PR #620 (CP455) accepted the JWT as a query string param; the auth plugin synthesises the Authorization header server-side. Standard SSE auth workaround, not a code bug.
- fastify's default `req` serializer logs `req.url` verbatim. The auth workaround puts the JWT in `req.url`. → leak.

## Fix

### `src/api/utils/log-url-sanitizer.ts` (NEW)

`sanitizeLogUrl(url)` masks values for: `access_token`, `id_token`, `refresh_token`, `token`, `api_key`. Case-insensitive. Preserves param names + non-sensitive params + hash fragment boundary.

```
/api/v1/mandalas/abc/videos/stream?access_token=eyJh.x.y&lastEventId=42
→ /api/v1/mandalas/abc/videos/stream?access_token=<redacted>&lastEventId=42
```

### `src/api/server.ts`

Custom `req` serializer routes the `url` field through `sanitizeLogUrl()`. Other fields (method, hostname, remoteAddress, remotePort) keep the default shape so log consumers (CloudWatch queries, dashboards) stay compatible.

## Test coverage (13 cases, all PASS)

- Every sensitive param × redaction (`access_token`, `token`, `api_key`, `id_token`, `refresh_token`)
- Multiple co-mingled params (`?id_token=x&refresh_token=y`)
- Case-insensitive (`?Access_Token=...`)
- Non-sensitive params preserved (`?cursor=abc&limit=20`)
- No-query baseline
- Undefined / null / empty inputs
- **Prefix-confusion safety** — `?access_token_hint=foo` is NOT masked (different key)
- Hash fragment boundary — `?access_token=x#section` → `?access_token=<redacted>#section`

## Backwards compat

- **Behavioural**: identical for clients. Only log content changes.
- **Historical logs**: still contain the old plaintext JWTs. Out of scope for this PR. Mitigation options:
  - CloudWatch log group retention shortening
  - Manual log-aggregator search + purge by param name
  - Accept residual risk — JWT TTL is ~1h, blast radius decays naturally
- **JWT rotation**: not required as a result of this PR (no new exposure introduced).

## Regression

- tsc 0 errors
- jest 13/13 PASS on new test
- hardcode-audit 33/33 (no new violations)

## Out of scope (separate follow-ups)

- Historical log purge (CloudWatch retention policy)
- Audit of other potential leaks: `req.body` for sensitive POST payloads (unlikely — Authorization is header-borne for POST, and pino default doesn't serialize body); `Authorization` header itself in case some logger ever logs `req.headers` (currently not the case in this codebase)
- Long-term: replace SSE with fetch + ReadableStream so JWT travels via Authorization header (much larger change)

## Refs

CP475+7, PR #620 (CP455 SSE auth via ?access_token=), prod logs leak surfaced 2026-05-20 during chatbot saga debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)