### PR TITLE
fix(cards): dedupe Updated chip against placed cells (CP475+8)

### DIFF
--- a/frontend/src/__tests__/smoke/newly-synced-cards.test.ts
+++ b/frontend/src/__tests__/smoke/newly-synced-cards.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from 'vitest';
 import {
   isNewlySyncedCard,
   countNewlySyncedByMandala,
+  dedupeNewlySyncedAgainstPlaced,
 } from '@/features/card-management/lib/cardUtils';
 import type { InsightCard } from '@/entities/card/model/types';
 
@@ -186,5 +187,50 @@ describe('countNewlySyncedByMandala', () => {
 
   it('returns empty object for empty input (no mandalas)', () => {
     expect(countNewlySyncedByMandala([])).toEqual({});
+  });
+});
+
+describe('dedupeNewlySyncedAgainstPlaced (CP475+8)', () => {
+  // Trivial test normaliser — production uses normalizeUrl from
+  // @/shared/lib/url-normalize, but the helper itself only needs to be
+  // pure and deterministic.
+  const normalise = (u: string) => u.trim().toLowerCase();
+
+  it('drops candidates whose URL is already placed', () => {
+    // Bug 2026-05-20: same video lives both as a placed card (sector pill)
+    // and as a sync-side card (Updated pill). After dedupe, only the
+    // placed-side card should survive — the Updated chip count drops to 0
+    // and the chip disappears for that video.
+    const candidates = [
+      makeCard({ id: 'sync-1', videoUrl: 'https://youtu.be/abc' }),
+      makeCard({ id: 'sync-2', videoUrl: 'https://youtu.be/def' }),
+    ];
+    const placed = ['https://youtu.be/abc'];
+    const out = dedupeNewlySyncedAgainstPlaced(candidates, placed, normalise);
+    expect(out.map((c) => c.id)).toEqual(['sync-2']);
+  });
+
+  it('returns the full candidate list when no placed URL overlaps', () => {
+    const candidates = [
+      makeCard({ id: 's1', videoUrl: 'https://youtu.be/aaa' }),
+      makeCard({ id: 's2', videoUrl: 'https://youtu.be/bbb' }),
+    ];
+    expect(dedupeNewlySyncedAgainstPlaced(candidates, [], normalise).map((c) => c.id)).toEqual([
+      's1',
+      's2',
+    ]);
+  });
+
+  it('uses the supplied normaliser when comparing URLs', () => {
+    // Case difference alone should NOT prevent a match when the normaliser
+    // lower-cases. This mirrors the real normalizeUrl helper, which is
+    // case-insensitive on host and strips trailing slashes.
+    const candidates = [makeCard({ id: 's', videoUrl: 'HTTPS://youtu.be/CAPS' })];
+    const placed = ['https://youtu.be/caps'];
+    expect(dedupeNewlySyncedAgainstPlaced(candidates, placed, normalise)).toEqual([]);
+  });
+
+  it('returns [] when given empty candidates regardless of placed URLs', () => {
+    expect(dedupeNewlySyncedAgainstPlaced([], ['https://youtu.be/a'], normalise)).toEqual([]);
   });
 });

--- a/frontend/src/features/card-management/lib/cardUtils.ts
+++ b/frontend/src/features/card-management/lib/cardUtils.ts
@@ -202,3 +202,33 @@ export function countNewCardsByMandala(cards: InsightCard[]): Record<string, num
  * @deprecated Use {@link countNewCardsByMandala}.
  */
 export const countNewlySyncedByMandala = countNewCardsByMandala;
+
+/**
+ * Filter the candidate newly-synced list to drop entries whose video URL
+ * already lives in a placed-cell card. This is the CP475+8 dedupe fix:
+ * when the same YouTube video has both a placed-side row (user dropped
+ * it into a cell at some earlier point — older metadata snapshot) AND a
+ * mapping-sync row (mapper just re-pulled the same URL — fresher
+ * metadata), the user saw the same video listed under both the sector
+ * pill AND the "Updated" pill with mismatched view counts and dates.
+ *
+ * After this dedupe, the placed-side row wins (the chip count drops to
+ * 0 and the "Updated" pill disappears for that video), so the user sees
+ * exactly one canonical card with one consistent metadata view.
+ *
+ * @param candidates  newly-synced predicate already applied
+ * @param placedUrls  normalised URLs of cards already placed in any cell
+ *                    (drawn from mandalaLocalCards + mandalaVideoCards)
+ * @param normalize   URL normaliser (caller supplies normalizeUrl from
+ *                    @/shared/lib/url-normalize so this helper stays
+ *                    pure and dependency-free for tests).
+ */
+export function dedupeNewlySyncedAgainstPlaced<T extends Pick<InsightCard, 'videoUrl'>>(
+  candidates: T[],
+  placedUrls: Iterable<string>,
+  normalize: (url: string) => string
+): T[] {
+  const placedSet = new Set<string>();
+  for (const u of placedUrls) placedSet.add(u);
+  return candidates.filter((c) => !placedSet.has(normalize(c.videoUrl)));
+}

--- a/frontend/src/pages/index/model/useCardOrchestrator.ts
+++ b/frontend/src/pages/index/model/useCardOrchestrator.ts
@@ -21,6 +21,7 @@ import {
   getCardById,
   isNewlySyncedCard,
   countNewlySyncedByMandala,
+  dedupeNewlySyncedAgainstPlaced,
 } from '@/features/card-management/lib/cardUtils';
 import {
   createMockCards,
@@ -301,10 +302,23 @@ export function useCardOrchestrator(
   // Issue #389: "Newly Synced" cards — mapped to a mandala via
   // source_mandala_mappings but not yet placed into a specific cell.
   // Predicate centralized in cardUtils.isNewlySyncedCard.
-  const newlySyncedCards = useMemo(
-    () => syncedCards.filter((c) => isNewlySyncedCard(c, mandalaId)),
-    [syncedCards, mandalaId]
-  );
+  //
+  // CP475+8 — dedupe against the current mandala's placed cards
+  // (`mandalaLocalCards` + `mandalaVideoCards`). When the same video URL
+  // already lives in a cell, the sync-side row should NOT also appear
+  // under the "Updated" chip — user-reported bug 2026-05-20: identical
+  // video showing in "전체 38" (placed) AND "Updated 1" (unplaced) with
+  // different metadata snapshots (5.5K vs 85.2K views). Each side is a
+  // different row with a different fetch timestamp; dedupe drops the
+  // sync-side row from "Updated" so the user sees the single canonical
+  // card under the sector pill with one consistent metadata view.
+  const newlySyncedCards = useMemo(() => {
+    const placedUrls: string[] = [];
+    for (const card of mandalaLocalCards) placedUrls.push(normalizeUrl(card.videoUrl));
+    for (const card of mandalaVideoCards) placedUrls.push(normalizeUrl(card.videoUrl));
+    const candidates = syncedCards.filter((c) => isNewlySyncedCard(c, mandalaId));
+    return dedupeNewlySyncedAgainstPlaced(candidates, placedUrls, normalizeUrl);
+  }, [syncedCards, mandalaId, mandalaLocalCards, mandalaVideoCards]);
 
   // Global per-mandala counts — drives sidebar dot+count indicator.
   // Not scoped to the current mandala so every mandala item can display


### PR DESCRIPTION
## Bug

User-reported 2026-05-20: the same YouTube video appeared in **both** the sector pill (전체 38) AND the "Updated 1" pill, with **mismatched metadata snapshots** — one row read `5.5K · 2 months ago`, the other `85.2K · 1 month ago`. Same thumbnail, same title, different counts. Screenshots attached to the chatbot saga thread.

## Root cause

`useCardOrchestrator` exposes two lists derived from disjoint sources:

- `allMandalaCards` (= `mandalaLocalCards` + `mandalaVideoCards` + ..., deduped internally) — drives the sector pills + sector cards grid.
- `newlySyncedCards` (= `syncedCards.filter(isNewlySyncedCard)`) — drives the "Updated" pill list.

The two lists **never deduped against each other**. If a video was already placed into a cell (older fetch → older metadata) AND the mapper re-pulled the same URL as a mapping-sync row (fresher fetch → fresher metadata), both rows survive and the user sees the same video twice with conflicting counts.

## Fix

### `cardUtils.ts` — NEW `dedupeNewlySyncedAgainstPlaced`
Pure helper. Drops candidates whose normalised URL is in the placed set. Caller supplies the normaliser (so the helper stays dependency-free for unit tests).

### `useCardOrchestrator.ts` — wire in dedupe
```ts
const placedUrls: string[] = [];
for (const card of mandalaLocalCards) placedUrls.push(normalizeUrl(card.videoUrl));
for (const card of mandalaVideoCards) placedUrls.push(normalizeUrl(card.videoUrl));
const candidates = syncedCards.filter((c) => isNewlySyncedCard(c, mandalaId));
return dedupeNewlySyncedAgainstPlaced(candidates, placedUrls, normalizeUrl);
```

### Effect
- "Updated N" chip count drops when a duplicate exists.
- Chip auto-hides at 0 (existing `useEffect` at line 217 handles this).
- User sees one canonical card with one metadata view.
- Placed-side row "wins" — it carries the user context (cell placement, watch position, notes), so it's the correct source-of-truth row.

## Tests (vitest, 17/17 PASS)

4 new cases for `dedupeNewlySyncedAgainstPlaced`:
- drops candidates whose URL is already placed (CP475+8 primary regression)
- returns full list when no overlap
- respects supplied normaliser (case-insensitive match)
- returns `[]` for empty input

All 13 existing cases still pass.

## Out of scope (separate follow-up)

This PR does **not** refresh the placed-side row's metadata when the mapper-side row has fresher view counts. Acceptable trade-off — user's primary complaint is "same card in two places with conflicting numbers"; after this fix only one card is visible, eliminating the comparison. A follow-up could JOIN `youtube_videos` for live counts (cards API change).

## Regression

- FE tsc 0 errors
- vitest 17/17 PASS on existing test file (4 new + 13 existing)

Refs: CP475+8, issue #389 (original Newly Synced feature), bug-report screenshots 2026-05-20 (sector vs Updated metadata mismatch surfaced during chatbot saga session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)