### PR TITLE
fix(v2-quick): hard-cap one_liner at 20 chars + reinforce prompt rule

### DIFF
--- a/src/modules/skills/rich-summary-v2-quick-prompt.ts
+++ b/src/modules/skills/rich-summary-v2-quick-prompt.ts
@@ -56,7 +56,12 @@ Schema:
 
 Rules:
 - Output language MUST be {language} ({language_label}).
-- core.one_liner: A short, direct label phrase. Think of how a Korean mandala sub-goal is labelled (e.g. "기초 체력", "장거리 지구력") — concise, scannable. NOT a sentence with verbs like "…을 설명합니다".
+- core.one_liner: A short, direct label phrase, **STRICT ≤ 18 characters** (count includes spaces). Think mandala sub-goal: "기초 체력", "월배당 ETF 전략", "절세 노하우".
+  - DO NOT write full sentences. DO NOT enumerate ("A, B, C 그리고 D"). DO NOT use verbs like "…을 설명합니다", "…에 대해 알아봅니다".
+  - GOOD: "월배당 ETF 전략" (10) / "노후 자산 관리" (8) / "온라인 창업 핵심" (8)
+  - BAD: "미국 10대 부자들이 SNS, 리셀, AI SaaS, 드롭쉬핑으로 돈 버는 4가지 방식" (a sentence)
+  - BAD: "이 영상은 ETF 전략을 설명합니다" (verb sentence)
+  - If you cannot summarize in 18 chars, output ONLY the most central concept noun phrase.
 - analysis.core_argument: 2-3 sentences that state the video's actual claim or insight directly. Forbidden filler: "이 영상은", "이 콘텐츠는", "…을 설명한다", "…을 주장한다", "…을 안내합니다", "…을 보여준다". Write as a declarative claim ("X 는 Y 다", "X 하려면 Y 가 핵심이다").
 - analysis.mandala_fit.mandala_relevance_pct: integer 0-100 measuring how well the video fits the user's mandala center goal below. Score 0 when the goal is empty or genuinely unrelated; reserve 90+ for videos that clearly address the exact goal. Be conservative.
 - Prefer transcript content over title/description for evidence. When transcript is empty, fall back to title + description.
@@ -122,6 +127,30 @@ function requireInteger(value: unknown, path: string, min = 0, max = 100): numbe
   return n;
 }
 
+/**
+ * CP476+ — hard cap on core.one_liner for sidebar entry legibility.
+ *
+ * The quick prompt instructs ≤ 20 chars + no trailing punctuation +
+ * mandala-sub-goal style (e.g. "기초 체력"). LLM compliance is good
+ * (15/16 mandalas pass) but the long tail produces full sentences.
+ * Rather than fail the whole quick path on a length violation, we
+ * truncate at 20 chars (slice + trim) and strip trailing
+ * `.!?,;:、。…` so the sidebar always renders a clean label.
+ */
+const ONE_LINER_HARD_CAP = 20;
+const TRAILING_PUNCT_RE = /[.!?,;:、。…\s]+$/;
+
+export function trimOneLinerLabel(raw: string): string {
+  let s = raw.trim();
+  if (s.length > ONE_LINER_HARD_CAP) {
+    s = s.slice(0, ONE_LINER_HARD_CAP);
+  }
+  // Strip trailing punctuation/whitespace AFTER truncation so a slice
+  // that lands on ", " or "." doesn't render mid-clause.
+  s = s.replace(TRAILING_PUNCT_RE, '');
+  return s;
+}
+
 export function validateV2Quick(raw: unknown): V2QuickResult {
   if (typeof raw !== 'object' || raw === null) {
     throw new V2QuickValidationError('root must be an object', '$');
@@ -145,7 +174,16 @@ export function validateV2Quick(raw: unknown): V2QuickResult {
 
   return {
     core: {
-      one_liner: requireString(cc['one_liner'], 'core.one_liner', 80),
+      // CP476+ — soft truncate at 20 chars. LLM occasionally ignores the
+      // "≤ 20 characters" prompt rule (~1 outlier per 80 rows observed in
+      // prod sampling 2026-05-20: one entry was a full 51-char sentence
+      // "미국 10대 부자들이 SNS, 리셀, AI SaaS..."). Sidebar legibility
+      // depends on a hard cap, but raising the validator error rate would
+      // also fail valid 21-25 char outputs, so we accept up to 200 chars
+      // raw and trim instead of rejecting. Also strip trailing punctuation
+      // (rule says "no trailing punctuation"; some outputs still include
+      // periods).
+      one_liner: trimOneLinerLabel(requireString(cc['one_liner'], 'core.one_liner', 200)),
     },
     analysis: {
       core_argument: requireString(aa['core_argument'], 'analysis.core_argument', 500),

--- a/tests/unit/skills/rich-summary-v2-quick-prompt.test.ts
+++ b/tests/unit/skills/rich-summary-v2-quick-prompt.test.ts
@@ -1,0 +1,82 @@
+/**
+ * CP476+ — validateV2Quick + trimOneLinerLabel: sidebar label sanity.
+ *
+ * Background: prod sampling found 1 row out of ~80 where the LLM ignored
+ * the "≤ 20 characters" prompt rule and emitted a full 51-char sentence.
+ * Rather than fail the quick path entirely on these outliers, the
+ * validator now soft-truncates the label so the sidebar renders cleanly.
+ */
+import {
+  trimOneLinerLabel,
+  validateV2Quick,
+  V2QuickValidationError,
+} from '@/modules/skills/rich-summary-v2-quick-prompt';
+
+describe('trimOneLinerLabel — CP476+ sidebar hard cap', () => {
+  it('passes through a compliant short label unchanged', () => {
+    expect(trimOneLinerLabel('월배당 ETF 전략')).toBe('월배당 ETF 전략');
+  });
+
+  it('truncates a 51-char sentence to 20 chars (no mid-word ellipsis)', () => {
+    const long = '미국 10대 부자들이 SNS, 리셀, AI SaaS, 드롭쉬핑+코인으로 돈 버는 4가지 방식';
+    const out = trimOneLinerLabel(long);
+    expect(out.length).toBeLessThanOrEqual(20);
+    expect(out.startsWith('미국 10대 부자들이')).toBe(true);
+  });
+
+  it('strips trailing punctuation after truncation', () => {
+    expect(trimOneLinerLabel('ETF 전략을 알아보자.')).not.toMatch(/[.!?,;:、。…]$/);
+    expect(trimOneLinerLabel('ETF 전략을 알아보자,')).not.toMatch(/[.!?,;:、。…]$/);
+  });
+
+  it('handles full sentence with trailing comma after truncation', () => {
+    // After truncation a comma can end up at position 20 — must strip.
+    const out = trimOneLinerLabel(
+      '하나, 둘, 셋, 넷, 다섯, 여섯, 일곱, 여덟, 아홉, 열' // commas everywhere
+    );
+    expect(out).not.toMatch(/[,\s]$/);
+    expect(out.length).toBeLessThanOrEqual(20);
+  });
+
+  it('trims leading/trailing whitespace', () => {
+    expect(trimOneLinerLabel('   ETF 전략   ')).toBe('ETF 전략');
+  });
+});
+
+describe('validateV2Quick — quick path schema', () => {
+  const validRaw = {
+    core: { one_liner: '월배당 ETF 전략' },
+    analysis: {
+      core_argument: '월배당 ETF 는 안정적 현금흐름을 제공한다.',
+      mandala_fit: { mandala_relevance_pct: 85 },
+    },
+  };
+
+  it('returns parsed result on compliant input', () => {
+    const out = validateV2Quick(validRaw);
+    expect(out.core.one_liner).toBe('월배당 ETF 전략');
+    expect(out.analysis.mandala_fit.mandala_relevance_pct).toBe(85);
+  });
+
+  it('truncates over-long one_liner instead of rejecting', () => {
+    const raw = {
+      ...validRaw,
+      core: { one_liner: '미국 10대 부자들이 SNS, 리셀, AI SaaS 로 돈 버는 4가지 방식' },
+    };
+    const out = validateV2Quick(raw);
+    expect(out.core.one_liner.length).toBeLessThanOrEqual(20);
+  });
+
+  it('rejects when one_liner exceeds the hard raw cap (200 chars)', () => {
+    const raw = {
+      ...validRaw,
+      core: { one_liner: '가'.repeat(250) },
+    };
+    expect(() => validateV2Quick(raw)).toThrow(V2QuickValidationError);
+  });
+
+  it('rejects empty one_liner', () => {
+    const raw = { ...validRaw, core: { one_liner: '' } };
+    expect(() => validateV2Quick(raw)).toThrow(V2QuickValidationError);
+  });
+});


### PR DESCRIPTION
## Summary
Sidebar entry text occasionally rendered as a full sentence (51 chars) instead of a mandala sub-goal label. Root cause: prompt said "≤ 20 chars" but validator accepted up to 80, so non-compliant LLM output landed in the DB unchanged.

## Measurement (CP476 lesson — measurement-first)
- Sampled all v2 quick rows for one user: 80 rows / 16 mandalas
- 15/16 mandalas within spec (max_len 9-17 chars)
- 1 outlier: "미국 10대 부자들이 SNS, 리셀, AI SaaS, 드롭쉬핑+코인으로 돈 버는 4가지 방식" (51 chars)

## Changes
1. **`trimOneLinerLabel(raw)`** — soft truncate at 20 chars + strip trailing `.!?,;:、。…\s`
2. **Validator** raw-accepts up to 200 chars (safety) then passes through `trimOneLinerLabel`
3. **Prompt rule restated** — STRICT ≤ 18 char target + explicit DO NOT / GOOD / BAD examples

## Carryover (user self-execute SQL — not in this PR)
```sql
UPDATE video_rich_summaries
SET core = jsonb_set(core, '{one_liner}', '"미국 10대 부자 사례"'::jsonb)
WHERE video_id = (
  SELECT youtube_video_id FROM youtube_videos
  WHERE title LIKE '방구석에서 노트북 하나로 6억%'
  LIMIT 1
) AND template_version = 'v2';
```

## Test plan
- [x] new `tests/unit/skills/rich-summary-v2-quick-prompt.test.ts`: 9 cases all green
- [x] tsc PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)