### PR TITLE
chore(deploy): map LS prod secrets/vars to LEMONSQUEEZY_LIVE_* names

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -241,12 +241,12 @@ jobs:
           # RunPod/vLLM path (also activates the Bug 1 chat.completions fix
           # via QwenRunpodAdapter + the persona/SFT prompt middleware).
           CHATBOT_PROVIDER: ${{ vars.CHATBOT_PROVIDER }}
-          LS_API_KEY: ${{ secrets.LEMONSQUEEZY_API_KEY }}
-          LS_WEBHOOK_SECRET: ${{ secrets.LEMONSQUEEZY_WEBHOOK_SECRET }}
-          LS_STORE_ID: ${{ vars.LEMONSQUEEZY_STORE_ID }}
-          LS_VARIANT_MONTHLY: ${{ vars.LEMONSQUEEZY_VARIANT_ID_PRO_MONTHLY }}
-          LS_VARIANT_YEARLY: ${{ vars.LEMONSQUEEZY_VARIANT_ID_PRO_YEARLY }}
-          LS_VARIANT_LIFETIME: ${{ vars.LEMONSQUEEZY_VARIANT_ID_PRO_LIFETIME }}
+          LS_API_KEY: ${{ secrets.LEMONSQUEEZY_LIVE_API_KEY }}
+          LS_WEBHOOK_SECRET: ${{ secrets.LEMONSQUEEZY_LIVE_WEBHOOK_SECRET }}
+          LS_STORE_ID: ${{ vars.LEMONSQUEEZY_LIVE_STORE_ID }}
+          LS_VARIANT_MONTHLY: ${{ vars.LEMONSQUEEZY_LIVE_VARIANT_ID_PRO_MONTHLY }}
+          LS_VARIANT_YEARLY: ${{ vars.LEMONSQUEEZY_LIVE_VARIANT_ID_PRO_YEARLY }}
+          LS_VARIANT_LIFETIME: ${{ vars.LEMONSQUEEZY_LIVE_VARIANT_ID_PRO_LIFETIME }}
           # CP462+ Issue #649 — Heart-click on-demand v2 trigger.
           # Non-secret per CP392: toggle, not a credential. Default empty
           # ⇒ enrichRichSummary stays in its existing `enabled=false`


### PR DESCRIPTION
## Summary

- Renames the 6 source refs in `deploy.yml:244-249` (LS env-inject block) from `secrets/vars.LEMONSQUEEZY_*` to `secrets/vars.LEMONSQUEEZY_LIVE_*`.
- Matches the GitHub Secrets/Variables registered today (CP476 2026-05-20) for live mode billing activation.
- **No code change** — the `.env` write block (line 409-424) keeps single-name targets, so prod EC2 `.env`, `src/modules/billing/config.ts` read path, and dev local `.env` are all unchanged.

## What ships after merge

Next deploy reads the new GitHub references → injects live values into prod EC2 `.env` (still under single names like `LEMONSQUEEZY_API_KEY=`) → `billingConfig.enabled` flips `true` for the first time → billing routes (`/api/v1/billing/*`) leave 503 graceful-disable state.

## Why the lifetime line still says `_PRO_LIFETIME`

`refactor/lifetime-naming-cleanup` PR (rename `pro_lifetime` → `lifetime` across the codebase) is paused per user CP476 decision. This PR keeps the legacy `_PRO_LIFETIME` segment, just prefixes `_LIVE_`. When the naming PR resumes, the rename will happen in one pass (`vars.LEMONSQUEEZY_LIVE_VARIANT_ID_PRO_LIFETIME` → `_LIVE_VARIANT_ID_LIFETIME`) + a matching GitHub Variable rename.

## Test plan

- [ ] CI green (`Hardcode Audit`, `Lint`, `Test BE+Build`, `Test FE`, `Type Check`).
- [ ] After merge + deploy: `bash scripts/ssh-connect.sh "docker exec insighta-api printenv | grep LEMONSQUEEZY | awk -F= '{print \$1\"=\"substr(\$2,1,4)\"***\"}'"` → all 6 values start with live prefix (`1673***` for monthly/yearly/lifetime, `3698***` for store, hmac/jwt prefixes for secrets).
- [ ] User flips `system_settings.BILLING_ENABLED = true` via `/admin/billing` UI.
- [ ] User executes 1 live checkout end-to-end (LS Live mode) → `billing_events.payload.meta.test_mode = false` + `billing_subscriptions` row inserted + `user_subscriptions.tier = 'pro'` flipped.

## Rollback

`gh pr revert` (1 commit, 6 lines, no DB / no schema migration). Fallback: existing Repository-level test Secrets/Variables remain registered, so a revert restores the test mapping cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)