### PR TITLE
fix(sidebar): jsonb-preferred + column-trimmed oneLiner (CP476 follow-up)

### DIFF
--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -53,6 +53,7 @@ import { Prisma } from '@prisma/client';
 import { getPrismaClient } from '@/modules/database';
 import { logger } from '@/utils/logger';
 import { enqueueEnrichRichSummary } from '@/modules/queue';
+import { trimOneLinerLabel } from '@/modules/skills/rich-summary-v2-quick-prompt';
 import { config } from '../../config';
 
 const YOUTUBE_VIDEO_ID_RE = /^[A-Za-z0-9_-]{11}$/;
@@ -838,6 +839,13 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             select: {
               video_id: true,
               one_liner: true,
+              // CP476+ — `core` for jsonb `one_liner` priority (v2 path).
+              // The legacy `one_liner` column was authored by the v1
+              // pipeline and frequently exceeds the sidebar's 20-char
+              // budget (one 44-char sentence observed in prod). The v2
+              // jsonb path is trimOneLinerLabel-validated, so we prefer
+              // it when present.
+              core: true,
               analysis: true,
               // CP475+ — `segments` for v2FullLanded detection (atoms count).
               // FE promotes v2 essence over v1 description only when atoms > 0.
@@ -891,9 +899,32 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
                 segments != null &&
                 Array.isArray(segments.atoms) &&
                 (segments.atoms as unknown[]).length > 0;
+              // CP476+ — oneLiner priority:
+              //   (1) jsonb `core.one_liner` (v2 path, trimOneLinerLabel-
+              //       validated) → use as-is
+              //   (2) column `one_liner` (legacy v1) → trim to 20 chars,
+              //       strip trailing punctuation
+              //   (3) both null → null
+              // Background: prod sidebar showed a 44-char sentence sourced
+              // from the legacy column, while the jsonb path held a
+              // compliant 12-char label ("2026년 네이버 변화"). Same row,
+              // two source of truth. This response-layer normalisation
+              // bypasses the dual-column ambiguity without touching the
+              // DB or the legacy write path.
+              const core = (r?.core ?? null) as { one_liner?: unknown } | null;
+              const jsonbOneLiner =
+                core && typeof core.one_liner === 'string' && core.one_liner.length > 0
+                  ? core.one_liner
+                  : null;
+              const oneLinerOut =
+                jsonbOneLiner !== null
+                  ? jsonbOneLiner
+                  : r?.one_liner
+                    ? trimOneLinerLabel(r.one_liner)
+                    : null;
               return {
                 videoId: vid,
-                oneLiner: r?.one_liner ?? null,
+                oneLiner: oneLinerOut,
                 coreArgument,
                 keyConcepts,
                 fallbackTags,


### PR DESCRIPTION
## Summary
Sidebar entries rendered full sentences (40+ chars) instead of mandala-sub-goal labels. PR #712 hardened the wrong source — measurement found `video_rich_summaries` has **two** `one_liner` columns and `/cards/v2-summaries` was selecting only the legacy column.

## Root cause (CP476 follow-up)
| Source | Path | Sidebar value example |
|--------|------|----------------------|
| column `one_liner` | Legacy v1, no cap | "2026년 네이버가 쿠팡처럼 변할 수 있다는 점을 분석하고 대응법을 제시합니다." (44 chars) |
| jsonb `core.one_liner` | v2 path, trimOneLinerLabel-validated | "2026년 네이버 변화" (12 chars) |

`useV2Summaries → SidebarLearningSection.indexName` only saw the column.

## Fix (response-layer normalisation)
1. SELECT now also fetches `core`.
2. Per-row composition: jsonb if present → else column trimmed via `trimOneLinerLabel` → else null.
3. Affects **all users immediately**. No DB write, raw column preserved.

## Self-critique (CP476 lesson reinforcement)
PR #712 hardened jsonb because I assumed that was the sidebar source. Measurement happened on jsonb, never on the column. New sub-rule to record next /save: **verify DB→BE-select→FE-render reference the same physical column before assuming the write-side fix reaches the UI.**

## Test plan
- [x] tsc PASS
- [x] jest 9/9 PASS (existing trimOneLinerLabel tests)
- [ ] prod: hard refresh sidebar → entries ≤20 chars, no trailing punctuation

## Rollback
Revert PR. No DB / schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)