### PR TITLE
fix(chatbot): pin CopilotKit to 1.56.3 exact across FE+BE (CP477+1)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@copilotkit/react-core": "~1.56.3",
-    "@copilotkit/react-ui": "~1.56.3",
+    "@copilotkit/react-core": "1.56.3",
+    "@copilotkit/react-ui": "1.56.3",
     "@dicebear/collection": "^9.4.2",
     "@dicebear/core": "^9.4.2",
     "@dnd-kit/core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/runtime": "^1.56.3",
+        "@copilotkit/runtime": "1.56.3",
         "@fastify/cors": "^8.4.2",
         "@fastify/helmet": "^11.1.1",
         "@fastify/jwt": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@copilotkit/runtime": "^1.56.3",
+    "@copilotkit/runtime": "1.56.3",
     "@fastify/cors": "^8.4.2",
     "@fastify/helmet": "^11.1.1",
     "@fastify/jwt": "^7.2.3",


### PR DESCRIPTION
## Bug

Dev console errors:
```
POST localhost:8081/api/v1/chat 400 (Bad Request) ×2
[CopilotKit] Agent error: Runtime info request failed with status 400
  Code: runtime_info_fetch_failed
  Context: { runtimeUrl: '/api/v1/chat' }
  Stack: AgentRegistry.fetchRuntimeInfoSingle
       → AgentRegistry.updateRuntimeConnection
```

## Root cause — silent semver drift

| Package | package.json range | Installed |
|---|---|---|
| FE `@copilotkit/react-core` | `~1.56.3` (patch-only) | **1.56.5** |
| FE `@copilotkit/react-ui` | `~1.56.3` (patch-only) | (1.56.5 implied) |
| BE `@copilotkit/runtime` | `^1.56.3` (minor) | **1.56.3** (lock-pinned) |

FE 1.56.5 added `AgentRegistry.fetchRuntimeInfoSingle` which calls the BE with a Runtime-info payload shape the 1.56.3 yoga handler doesn't recognize → 400.

## Fix

- `package.json` `"@copilotkit/runtime": "^1.56.3"` → `"1.56.3"`
- `frontend/package.json`
  - `"@copilotkit/react-core": "~1.56.3"` → `"1.56.3"`
  - `"@copilotkit/react-ui":   "~1.56.3"` → `"1.56.3"`
- Lock files: BE refreshed; FE blocked by `npm install` audit warnings but CI uses `--no-package-lock` (CLAUDE.md note) so `package.json` exact pin is decisive.

## Rationale (exact pin vs BE upgrade to 1.56.5)

1.56.x is a patch range, and 1.56.5 shipped a **backwards-incompatible Runtime-info protocol change** disguised as a patch. Pinning both sides to 1.56.3 restores known-working parity without forcing an audit of every 1.56.{3,4,5} changelog before the next chatbot deploy.

Future upgrades become an **explicit decision** (both numbers move together intentionally), not silent semver drift.

## Out of scope (separate follow-ups)

- `GET localhost:3000/api/v1/mandalas/.../book 404` ×3 — dev-env DB data difference (the mandala in question isn't seeded in dev), not chatbot-related. Backlogged.
- **Timestamp consistency** (user-requested): chatbot output mixes `(M:SS-M:SS)` and raw `N초` formats. AI 요약 panel also doesn't apply `linkifyTimestamps`. Tracked as next PR: (a) tighten system prompt rule to force `M:SS` form, (b) extend `linkifyTimestamps` regex to `N초` + ranges, (c) apply linkify to the AI 요약 wrapper.

## Verification (post-merge)

1. Trigger `Deploy` workflow.
2. Open prod (or local dev after `npm install`).
3. Open Learning Page → chatbot tab.
4. Send a message.
5. DevTools Console: zero `runtime_info_fetch_failed`. Network: `POST /api/v1/chat` returns 200 (streaming).

## Regression

- BE tsc 0 errors (no code change)
- FE tsc 0 errors (no code change)
- No runtime-behaviour change beyond version

## Refs

CP477+1, dev console error stack 2026-05-20, work-efficiency.md Rule F (4-hotfix hard stop) — follow-up to CP475 chatbot saga (#699 ~ #711). Scoped to a single non-code dependency pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)