### PR TITLE
fix(chatbot): unify timestamp format — prompt rule + regex extension (CP477+2)

### DIFF
--- a/frontend/src/__tests__/smoke/timestamp-regex.test.ts
+++ b/frontend/src/__tests__/smoke/timestamp-regex.test.ts
@@ -1,0 +1,85 @@
+/**
+ * CP477+2 — Timestamp regex + parser tests for the chatbot linkifier.
+ *
+ * The LoRA mixes two output styles:
+ *   - canonical M:SS or HH:MM:SS (e.g., `0:56`, `1:23:45`, `(0:56-1:12)`)
+ *   - raw-seconds variants the SFT didn't fully drill out (`380초`,
+ *     `380~682초`)
+ *
+ * Both must be detected so `linkifyTimestamps` can wrap them in a
+ * clickable button, and `parseTimestamp` must return the same seek
+ * second for the range-start of either form.
+ *
+ * The middleware now appends an explicit `[타임스탬프 형식]` directive
+ * (CP477+2 server side) but the model still drifts on long answers,
+ * so this regex is the FE backstop that catches everything the model
+ * still emits.
+ */
+import { describe, expect, it } from 'vitest';
+import { TIMESTAMP_RE, parseTimestamp } from '@/pages/learning/ui/ChatAssistant';
+
+function findAll(re: RegExp, text: string): string[] {
+  const out: string[] = [];
+  re.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) out.push(m[1]);
+  return out;
+}
+
+describe('TIMESTAMP_RE — matches both canonical and raw-seconds forms', () => {
+  it('catches M:SS in chatbot prose', () => {
+    expect(findAll(TIMESTAMP_RE, 'see 0:56 for context')).toEqual(['0:56']);
+  });
+
+  it('catches M:SS-M:SS range as two separate matches', () => {
+    expect(findAll(TIMESTAMP_RE, 'covered in (0:56-1:12)')).toEqual(['0:56', '1:12']);
+  });
+
+  it('catches HH:MM:SS', () => {
+    expect(findAll(TIMESTAMP_RE, 'goes 1:23:45 deep')).toEqual(['1:23:45']);
+  });
+
+  it('catches raw `N초` form', () => {
+    // CP477+2 primary regression case — bug-report 2026-05-20 showed
+    // `380초:` rendered as plain text, no seek button.
+    expect(findAll(TIMESTAMP_RE, '380초: 한 문제당 30분')).toEqual(['380초']);
+  });
+
+  it('catches `N~M초` range form', () => {
+    expect(findAll(TIMESTAMP_RE, '380~682초: 수2 고난도')).toEqual(['380~682초']);
+  });
+
+  it('catches `N ~ M 초` with spaces', () => {
+    expect(findAll(TIMESTAMP_RE, '380 ~ 682 초 까지')).toEqual(['380 ~ 682 초']);
+  });
+
+  it('mixed forms in one passage all match', () => {
+    // The bug report screenshot shows answers that mix forms within one
+    // response. Every form must surface as a clickable button.
+    const text = '핵심은 (0:56-1:12). 380~682초: 추가 분석. 마지막으로 6:20.';
+    expect(findAll(TIMESTAMP_RE, text)).toEqual(['0:56', '1:12', '380~682초', '6:20']);
+  });
+});
+
+describe('parseTimestamp — converts every form to a seek-second integer', () => {
+  it('M:SS → minutes×60 + seconds', () => {
+    expect(parseTimestamp('0:56')).toBe(56);
+    expect(parseTimestamp('1:12')).toBe(72);
+  });
+
+  it('HH:MM:SS → hours×3600 + minutes×60 + seconds', () => {
+    expect(parseTimestamp('1:23:45')).toBe(3600 + 23 * 60 + 45);
+  });
+
+  it('`N초` returns N directly', () => {
+    expect(parseTimestamp('380초')).toBe(380);
+  });
+
+  it('`N~M초` returns range START (matches M:SS-M:SS UX where button seeks first value)', () => {
+    expect(parseTimestamp('380~682초')).toBe(380);
+  });
+
+  it('`N ~ M 초` with whitespace also returns START', () => {
+    expect(parseTimestamp('380 ~ 682 초')).toBe(380);
+  });
+});

--- a/frontend/src/pages/learning/ui/ChatAssistant.tsx
+++ b/frontend/src/pages/learning/ui/ChatAssistant.tsx
@@ -59,9 +59,23 @@ interface ChatAssistantProps {
   onSeek?: (seconds: number) => void;
 }
 
-const TIMESTAMP_RE = /(\d{1,2}:\d{2}(?::\d{2})?)/g;
+// CP477+2 — match both the canonical M:SS / HH:MM:SS form AND the raw-seconds
+// variants the LoRA occasionally emits (`380초`, `380~682초`). The middleware
+// tightens the output contract via `appendTimestampFormatRule`, but the model
+// still drifts on long answers; we want every form to be clickable.
+//
+// Exported (with parseTimestamp) so the regex + parser can be unit-tested
+// without rendering the React tree.
+export const TIMESTAMP_RE = /(\d{1,2}:\d{2}(?::\d{2})?|\d+\s*~\s*\d+\s*초|\d+\s*초)/g;
 
-function parseTimestamp(ts: string): number {
+export function parseTimestamp(ts: string): number {
+  // Raw-seconds variants — read the leading integer as a second count.
+  // `380초` → 380, `380~682초` → 380 (range start, matching the UX of
+  // M:SS-M:SS ranges where the button seeks to the FIRST value).
+  if (/초/.test(ts)) {
+    const m = /^(\d+)/.exec(ts);
+    return m ? Number(m[1]) : 0;
+  }
   const parts = ts.split(':').map(Number);
   if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
   return parts[0] * 60 + parts[1];

--- a/src/modules/chatbot-rag/qwen-prompt-middleware.ts
+++ b/src/modules/chatbot-rag/qwen-prompt-middleware.ts
@@ -142,6 +142,46 @@ export function appendNoThinkDirective(systemContent: string): string {
 }
 
 /**
+ * Force the chatbot's timestamp output into a single canonical format so the
+ * FE `linkifyTimestamps` can convert ALL timestamps into clickable buttons.
+ *
+ * CP477+2 — bug-report 2026-05-20: the model sometimes emits `(0:56-1:12)`
+ * (M:SS form, FE regex matches → clickable) and sometimes `380~682초:`
+ * (raw seconds, FE regex does NOT match → plain text). Users see
+ * inconsistent timestamp affordance across responses on the same video.
+ *
+ * The Insighta SFT-aligned `ROLE_AND_RULES_KO/EN` already gives one example
+ * (`(1:00-1:12)`) but doesn't forbid raw-seconds variants. Adding a
+ * stand-alone directive at runtime keeps the SFT byte-identical while
+ * tightening the output contract on every request.
+ *
+ * Idempotent — directive marker is detected by a unique substring.
+ */
+const TIMESTAMP_RULE_KO = `[타임스탬프 형식]
+- 타임스탬프는 반드시 "M:SS" 또는 "(M:SS-M:SS)" 형식.
+- "N초" (예: 380초) 또는 "N~M초" (예: 380~682초) 형식 금지.
+- 초 단위 값 언급 필요 시: 380초 → "(6:20)" 으로 변환해 출력.`;
+
+const TIMESTAMP_RULE_EN = `[Timestamp format]
+- All timestamps MUST be in "M:SS" or "(M:SS-M:SS)" form.
+- Forbidden: raw-seconds form ("380s") or seconds range ("380~682s").
+- Convert seconds to M:SS before emitting (e.g., 380s → "(6:20)").`;
+
+const TIMESTAMP_RULE_MARKER = '[타임스탬프 형식]';
+const TIMESTAMP_RULE_MARKER_EN = '[Timestamp format]';
+
+export function appendTimestampFormatRule(systemContent: string, language: Lang): string {
+  if (
+    systemContent.includes(TIMESTAMP_RULE_MARKER) ||
+    systemContent.includes(TIMESTAMP_RULE_MARKER_EN)
+  ) {
+    return systemContent;
+  }
+  const rule = language === 'en' ? TIMESTAMP_RULE_EN : TIMESTAMP_RULE_KO;
+  return `${systemContent}\n\n${rule}`;
+}
+
+/**
  * Plain-string variant for the legacy SSE streaming path (QwenRunpodAdapter.process).
  *
  * Same pipeline as rewriteSystemPrompt but consumes/returns a single
@@ -169,12 +209,16 @@ export async function rewriteSystemContent(originalSystemContent: string): Promi
     transcript: videoCtx.transcript,
     includePersona: true,
   });
+  // CP477+2 — tighten timestamp output to a single canonical form so the
+  // FE linkifier can convert every timestamp to a clickable seek button
+  // (chatbot output was mixing `(M:SS-M:SS)` with `N초` / `N~M초`).
+  const withTimestampRule = appendTimestampFormatRule(built, language);
   // CP475+5 — suppress Qwen3 reasoning chain. The `chat_template_kwargs`
   // path (`enable_thinking: false`) only works on the legacy process() body;
   // Vercel AI SDK V3 strips provider-specific kwargs, so the textual
   // `/no_think` directive is the reliable way to gate reasoning on every
   // request that hits vLLM.
-  return appendNoThinkDirective(built);
+  return appendNoThinkDirective(withTimestampRule);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
+++ b/tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
@@ -43,6 +43,7 @@ import {
   rewriteSystemPrompt,
   createQwenPromptMiddleware,
   appendNoThinkDirective,
+  appendTimestampFormatRule,
   _resetMiddlewareCacheForTesting,
 } from '@/modules/chatbot-rag/qwen-prompt-middleware';
 import { PRODUCT_PERSONA_KO, PRODUCT_PERSONA_EN } from '@/modules/chatbot-rag/prompt-builder';
@@ -280,6 +281,57 @@ describe('rewriteSystemContent — CP475+5 /no_think suppression', () => {
 
   it('appends /no_think to the generated system prompt (English)', async () => {
     const out = await rewriteSystemContent("You are Insighta's learning assistant.");
+    expect(out.endsWith('/no_think')).toBe(true);
+  });
+});
+
+describe('appendTimestampFormatRule (CP477+2)', () => {
+  it('adds the Korean rule when language=ko + marker absent', () => {
+    const out = appendTimestampFormatRule('hello', 'ko');
+    expect(out).toContain('[타임스탬프 형식]');
+    expect(out).toContain('"M:SS"');
+    expect(out).toContain('"N초"');
+  });
+
+  it('adds the English rule when language=en + marker absent', () => {
+    const out = appendTimestampFormatRule('hello', 'en');
+    expect(out).toContain('[Timestamp format]');
+    expect(out).toContain('"M:SS"');
+    expect(out).toContain('380s');
+  });
+
+  it('is idempotent on Korean — second call returns input unchanged', () => {
+    const once = appendTimestampFormatRule('hello', 'ko');
+    const twice = appendTimestampFormatRule(once, 'ko');
+    expect(twice).toBe(once);
+  });
+
+  it('is idempotent on English', () => {
+    const once = appendTimestampFormatRule('hello', 'en');
+    const twice = appendTimestampFormatRule(once, 'en');
+    expect(twice).toBe(once);
+  });
+
+  it('does not double-add when KO marker exists and EN call follows', () => {
+    // Either marker variant should short-circuit, regardless of language arg.
+    const out = appendTimestampFormatRule('foo\n[타임스탬프 형식]\nbar', 'en');
+    expect(out).toBe('foo\n[타임스탬프 형식]\nbar');
+  });
+});
+
+describe('rewriteSystemContent — CP477+2 timestamp rule injection', () => {
+  it('Korean system prompt ends with /no_think after timestamp rule and persona', async () => {
+    const out = await rewriteSystemContent('한국어 인사이트 챗봇 사용');
+    expect(out).toContain('[타임스탬프 형식]');
+    expect(out.endsWith('/no_think')).toBe(true);
+    // Timestamp rule sits BEFORE /no_think (the /no_think directive must be
+    // the very last token so Qwen3's chat template picks it up cleanly).
+    expect(out.indexOf('[타임스탬프 형식]')).toBeLessThan(out.indexOf('/no_think'));
+  });
+
+  it('English system prompt also gets the rule', async () => {
+    const out = await rewriteSystemContent("You are Insighta's learning assistant.");
+    expect(out).toContain('[Timestamp format]');
     expect(out.endsWith('/no_think')).toBe(true);
   });
 });


### PR DESCRIPTION
## Bug

User-reported 2026-05-20: chatbot output mixed two timestamp styles **within the same conversation**:
- canonical `(0:56-1:12)` form (FE regex matches → clickable seek button) ✅
- raw seconds `380~682초:` (FE regex doesn't match → plain text) ❌

Inconsistent UX on the same video. Some answers had clickable timestamps, others didn't.

## Fix — two layers, defence in depth

### (A) System-prompt directive (BE middleware)

NEW `appendTimestampFormatRule()` helper in `qwen-prompt-middleware.ts`. Appends a stand-alone `[타임스탬프 형식]` (KO) / `[Timestamp format]` (EN) directive on every request:

```
[타임스탬프 형식]
- 타임스탬프는 반드시 "M:SS" 또는 "(M:SS-M:SS)" 형식.
- "N초" (예: 380초) 또는 "N~M초" (예: 380~682초) 형식 금지.
- 초 단위 값 언급 필요 시: 380초 → "(6:20)" 으로 변환해 출력.
```

Wired into `rewriteSystemContent`:
```
buildQwenSystemPrompt(...)        # SFT-aligned ROLE_AND_RULES_KO/EN
  → appendTimestampFormatRule()   # ← NEW (CP477+2)
  → appendNoThinkDirective()       # /no_think MUST be last token
```

The SFT-aligned `ROLE_AND_RULES_KO/EN` stays byte-identical (LoRA alignment preserved) — we just append a stricter contract at runtime.

### (B) FE regex extension

The directive in (A) tightens the contract but the LoRA still drifts on long answers, so the FE linkifier needs to cover both forms:

```ts
export const TIMESTAMP_RE =
  /(\d{1,2}:\d{2}(?::\d{2})?|\d+\s*~\s*\d+\s*초|\d+\s*초)/g;

export function parseTimestamp(ts: string): number {
  if (/초/.test(ts)) {
    const m = /^(\d+)/.exec(ts);
    return m ? Number(m[1]) : 0;
  }
  // ... existing M:SS / HH:MM:SS parser
}
```

`380~682초` → seek to 380 (range start, matching the M:SS-M:SS UX where the button jumps to the FIRST value).

`TIMESTAMP_RE` and `parseTimestamp` are now exported so vitest can unit-test them without rendering React.

### (C) AI 요약 panel — already covered ✅

`PanelAISummary` already wraps each section in `<Link to=".../?t=N">` → LearningPage's `?t=` useEffect calls `playerRef.seekTo(N)` (in-page seek). The "looks like plain text" impression in the bug report came from the small font-mono indigo styling, not from broken behaviour. **No code change needed.**

## Tests

**BE (jest, 7 NEW cases, 27/27 total PASS):**
- `appendTimestampFormatRule` × 5 (KO/EN add, KO/EN idempotent, cross-language marker detection)
- `rewriteSystemContent` × 2 (KO/EN — directive present + ordering BEFORE `/no_think`)

**FE (vitest, 12 NEW cases, 12/12 PASS):**
- `TIMESTAMP_RE` × 7 (M:SS, M:SS-M:SS range, HH:MM:SS, N초, N~M초, whitespace-tolerant range, mixed-form passage)
- `parseTimestamp` × 5 (every form → correct seek second)

## Regression

- BE tsc 0 errors
- FE tsc 0 errors
- 20 existing middleware tests all pass (KR/EN, video-id parse, cache, V3 prompt shape, fail-safe, tool_choice=none, /no_think)

## Verification (manual smoke, post-deploy)

1. Open Learning Page → ask the chatbot a question covering multiple timestamp ranges.
2. Response should use **only** `(M:SS)` / `(M:SS-M:SS)` form — no `N초` text.
3. Click a timestamp → video seeks to that second (in-page, no new tab).
4. If the LoRA still drifts to `N초` form (edge case), the FE regex now catches it → still clickable.

## Refs

CP477+2, bug-report 2026-05-20 (mixed timestamp form), PR #707 (prior linkify work — CP475+5), prompt-builder `ROLE_AND_RULES_KO/EN` byte-identical preservation (CP474). Follow-up to PR #716 (CopilotKit 1.56.3 pin — chatbot 400 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)