### PR TITLE
feat(explore): per-domain icons on category chips with hover color

### DIFF
--- a/frontend/src/features/explore/ui/DomainChips.tsx
+++ b/frontend/src/features/explore/ui/DomainChips.tsx
@@ -1,6 +1,19 @@
 import { useTranslation } from 'react-i18next';
+import {
+  Grid3x3,
+  Code2,
+  GraduationCap,
+  HeartPulse,
+  Briefcase,
+  TrendingUp,
+  Users,
+  Palette,
+  Coffee,
+  Brain,
+  type LucideIcon,
+} from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
-import { MANDALA_DOMAINS, type MandalaDomain } from '@/shared/config/domain-colors';
+import { MANDALA_DOMAINS, DOMAIN_STYLES, type MandalaDomain } from '@/shared/config/domain-colors';
 
 interface DomainChipsProps {
   selected: MandalaDomain | 'all';
@@ -9,25 +22,52 @@ interface DomainChipsProps {
 
 const ALL_OPTIONS = ['all', ...MANDALA_DOMAINS] as const;
 
+// Icon per domain. 'all' uses a neutral grid glyph; other domains use a
+// semantically-aligned icon and pick up their hex color from DOMAIN_STYLES
+// on hover (group-hover via CSS variable).
+const DOMAIN_ICONS: Record<MandalaDomain | 'all', LucideIcon> = {
+  all: Grid3x3,
+  tech: Code2,
+  learning: GraduationCap,
+  health: HeartPulse,
+  business: Briefcase,
+  finance: TrendingUp,
+  social: Users,
+  creative: Palette,
+  lifestyle: Coffee,
+  mind: Brain,
+};
+
 export function DomainChips({ selected, onSelect }: DomainChipsProps) {
   const { t } = useTranslation();
 
   return (
     <div className="flex gap-1.5 justify-center flex-wrap mb-[84px]">
-      {ALL_OPTIONS.map((domain) => (
-        <button
-          key={domain}
-          onClick={() => onSelect(domain)}
-          className={cn(
-            'px-3.5 py-1.5 rounded-full text-xs font-medium transition-all duration-200',
-            selected === domain
-              ? 'bg-primary/10 border border-primary/25 text-primary'
-              : 'bg-transparent border border-border/30 text-muted-foreground/50 hover:border-border hover:text-muted-foreground'
-          )}
-        >
-          {t(`explore.domain.${domain}`)}
-        </button>
-      ))}
+      {ALL_OPTIONS.map((domain) => {
+        const Icon = DOMAIN_ICONS[domain];
+        const hoverColor =
+          domain === 'all' ? 'hsl(var(--foreground))' : DOMAIN_STYLES[domain].color;
+        return (
+          <button
+            key={domain}
+            onClick={() => onSelect(domain)}
+            style={{ ['--chip-hover-color' as string]: hoverColor }}
+            className={cn(
+              'group inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-medium transition-all duration-200',
+              selected === domain
+                ? 'bg-primary/10 border border-primary/25 text-primary'
+                : 'bg-transparent border border-border/30 text-muted-foreground/50 hover:border-border hover:text-muted-foreground'
+            )}
+          >
+            <Icon
+              className="h-3.5 w-3.5 transition-colors group-hover:[color:var(--chip-hover-color)]"
+              strokeWidth={1.8}
+              aria-hidden="true"
+            />
+            {t(`explore.domain.${domain}`)}
+          </button>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a lucide-react icon to each of the 10 domain category chips on `/explore` and shows the domain's brand color on the icon when the chip is hovered.

## Why

Text-only chips made the long category list (전체 / 기술·개발 / 학습·교육 / 건강·피트니스 / 비즈니스 / 재테크·투자 / 인간관계 / 창작·예술 / 라이프스타일 / 마인드) feel uniform and hard to scan. Adding a semantic icon per category + the existing brand-color on hover gives users a visual anchor without changing the resting visual weight.

## Implementation

| Change | Detail |
|---|---|
| Icon map | `DOMAIN_ICONS: Record<MandalaDomain \| 'all', LucideIcon>` — one icon per category |
| Hover color source | Reuses existing `DOMAIN_STYLES[domain].color` (canonical hex tokens) — no new color literals |
| Mechanism | `--chip-hover-color` CSS variable per chip + `group-hover:[color:var(--chip-hover-color)]` on Icon |
| Resting state | Icon inherits `text-muted-foreground/50` from button (unchanged) |
| Selected state | Icon inherits `text-primary` (unchanged) |

## Icon picks

| Domain | Icon | Hover color |
|---|---|---|
| all | `Grid3x3` | foreground (neutral) |
| tech | `Code2` | `#818cf8` indigo |
| learning | `GraduationCap` | `#2dd4bf` teal |
| health | `HeartPulse` | `#34d399` emerald |
| business | `Briefcase` | `#fb7185` rose |
| finance | `TrendingUp` | `#fbbf24` amber |
| social | `Users` | `#f472b6` pink |
| creative | `Palette` | `#a78bfa` violet |
| lifestyle | `Coffee` | `#38bdf8` sky |
| mind | `Brain` | `#a3e635` lime |

## Files

- `frontend/src/features/explore/ui/DomainChips.tsx` (+55 / -15)

## CLAUDE.md compliance

- ✅ No new color literals (reuses `DOMAIN_STYLES`)
- ✅ Hard Rules: no `.env` edit / no LLM API / no DB / no EC2 / no D&D protected file
- ✅ tsc EXIT=0
- ✅ i18n: all `explore.domain.*` keys pre-existing

## Test plan

- [x] tsc passes
- [ ] Browser manual: open `/explore` → confirm 10 chips render with icons
- [ ] Hover each chip → confirm icon transitions to its domain color
- [ ] Click chip → confirm filter still works (no functional regression)
- [ ] Locale switch ko ↔ en → confirm icon stays, label translates

🤖 Generated with [Claude Code](https://claude.com/claude-code)