### PR TITLE
fix(deps): align frontend lock file with package.json exact pin (CP479+1)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "insighta-frontend",
       "version": "0.4.0",
       "dependencies": {
-        "@copilotkit/react-core": "^1.56.3",
-        "@copilotkit/react-ui": "^1.56.3",
+        "@copilotkit/react-core": "1.56.3",
+        "@copilotkit/react-ui": "1.56.3",
         "@dicebear/collection": "^9.4.2",
         "@dicebear/core": "^9.4.2",
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Bug

User reported chatbot buttons disabled / dead chat input on **localhost:8081 dev** with 22+ console errors:

```
[CopilotKit] Agent error: Runtime info request failed with status 400
  Code: runtime_info_fetch_failed
  Stack: AgentRegistry.fetchRuntimeInfoSingle
       → AgentRegistry.updateRuntimeConnection
```

Identical signature to the CP477+1 (PR #716) regression — but only in dev, not prod.

## Root cause

PR #716 updated `frontend/package.json` to `"1.56.3"` exact, but the follow-up `npm install --package-lock-only` exited 1 (npm audit failed on unrelated vulnerabilities), so the lock file's **top-level dependencies block** stayed at `"^1.56.3"`:

```
"dependencies": {
  "@copilotkit/react-core": "^1.56.3",  ← stale, semver range allows drift to 1.56.5
  "@copilotkit/react-ui": "^1.56.3",    ← stale
  ...
}
```

CI uses `npm install --no-package-lock` (per CLAUDE.md `npm/cli#4828` note), so prod resolved to 1.56.3 exact and worked. But user dev did `npm install` against the lock file's `^1.56.3` range and got 1.56.5 → 400 regression.

## Fix

Pure 2-line lock-file reconciliation (no source, no behaviour change):

```diff
"dependencies": {
- "@copilotkit/react-core": "^1.56.3",
- "@copilotkit/react-ui": "^1.56.3",
+ "@copilotkit/react-core": "1.56.3",
+ "@copilotkit/react-ui": "1.56.3",
```

Nested package entries were already `"1.56.3"` exact at PR #716 time, so this is the only delta.

## Verification (locally reproduced + fixed)

User dev was on 1.56.5 → ran `npm install --no-audit --no-fund` against the updated lock file:

```
$ cat frontend/node_modules/@copilotkit/react-core/package.json | grep version
"version": "1.56.3"
$ cat frontend/node_modules/@copilotkit/react-ui/package.json | grep version
"version": "1.56.3"
```

User reports chatbot working after the dev `node_modules` refresh.

## Why this slipped past PR #716

CP479+1 NEW troubleshooting pattern: **"silent semver drift on `~X.Y.Z` / `^X.Y.Z` patch range for protocol-shared libs"** is now LEVEL-1 in `troubleshooting.md`. The CP480 IT (enumerated audit list of cross-process API libs) was specifically generated for this class of bug; this PR is the live application.

The audit blocker (npm audit exit 1) needs a future workflow guard — `npm install --no-audit` in CI/dev bootstrap docs — separate follow-up.

## Out of scope

- Other `^` / `~` semver ranges on other deps remain (CP480 IT will audit them; expected zero protocol-shared offenders besides CopilotKit).
- npm audit vulnerabilities themselves (31 reported at PR #716 time) — separate dependency-hygiene PR.

## Refs

CP479+1, PR #716 (CP477+1) lock-file completion, user dev regression report 2026-05-21 02:12 KST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)