### PR TITLE
feat(add-cards): undo for 초기화 + fix collapsed-state stuck after reset

### DIFF
--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1867,6 +1867,7 @@
       "removeKeyword": "Remove keyword {{keyword}}",
       "searchButton": "Search",
       "resetButton": "Reset",
+      "restorePrevious": "Show previous results",
       "resultCount": "{{count}} matches",
       "expandOptions": "Expand options",
       "collapseOptions": "Collapse options",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1875,6 +1875,7 @@
       "removeKeyword": "키워드 {{keyword}} 제거",
       "searchButton": "검색",
       "resetButton": "초기화",
+      "restorePrevious": "이전 결과 보기",
       "resultCount": "{{count}}개 결과",
       "expandOptions": "검색 옵션 펼치기",
       "collapseOptions": "검색 옵션 접기",

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMandalaQuery } from '@/features/mandala';
-import { ChevronDown, ChevronUp, Loader2, Lock, RotateCcw, Search, X } from 'lucide-react';
+import { ChevronDown, ChevronUp, Loader2, Lock, RotateCcw, Search, Undo2, X } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/shared/lib/utils';
 import { useLikeCard } from '@/features/card-management/model/useLikeCard';
@@ -227,14 +227,52 @@ export function AddCardsPanel() {
     });
   }, [mandalaId, extraKeywords, filters, mutation, targetLevel, surfacedVideoIds]);
 
+  // In-memory snapshot of the last cleared search — enables a quick "Show
+  // previous results" undo when the user clicks 초기화 by mistake. Lost on
+  // panel close (use case is immediate undo, not long-term history; the
+  // existing localStorage layer already handles cross-session restore).
+  const [resetHistory, setResetHistory] = useState<{
+    cards: AddCardCandidate[];
+    picks: string[];
+    surfaced: string[];
+  } | null>(null);
+
   // Toggle: results visible → click clears them; empty → click searches.
   // Surfaced history is preserved across the toggle.
   const resetResults = useCallback(() => {
+    // Snapshot BEFORE clearing so the user can undo. Only useful when
+    // there's something to remember.
+    if (cards.length > 0) {
+      setResetHistory({
+        cards,
+        picks: Array.from(localPicks),
+        surfaced: surfacedVideoIds,
+      });
+    }
     mutation.reset();
     setRestoredCards(null);
     setLocalPicks(new Set());
+    // Re-expand the input zone so the user can pick filters / type a new
+    // keyword. Without this, if 초기화 was clicked while the auto-collapse
+    // (scroll-driven) was active, the header ChevronUp/Down toggle goes
+    // away with the results — leaving no way to expand the input again
+    // without closing the panel. (Bug report 2026-05-21.)
+    setInputCollapsed(false);
     if (mandalaId) clearSessionPicks(mandalaId);
-  }, [mutation, mandalaId]);
+  }, [mutation, mandalaId, cards, localPicks, surfacedVideoIds]);
+
+  // Restore the snapshot captured at the most recent 초기화 click. Pulls
+  // both the cards and the per-mandala picks back; re-persists picks to
+  // localStorage so subsequent panel close/reopen behaves as if 초기화
+  // had not happened.
+  const restorePrevious = useCallback(() => {
+    if (!resetHistory || !mandalaId) return;
+    setRestoredCards(resetHistory.cards);
+    setLocalPicks(new Set(resetHistory.picks));
+    setSurfacedVideoIds(resetHistory.surfaced);
+    saveSessionPicks(mandalaId, resetHistory.picks);
+    setResetHistory(null);
+  }, [resetHistory, mandalaId]);
   const triggerSearch = useCallback(() => {
     if (cards.length > 0) {
       resetResults();
@@ -439,6 +477,22 @@ export function AddCardsPanel() {
         {mutation.isSuccess && visibleCount > 0 && (
           <div className="px-5 py-1.5 text-[11px] text-muted-foreground sm:px-6">
             {t('addCards.panel.resultCount', '{{count}} matches', { count: visibleCount })}
+          </div>
+        )}
+
+        {cards.length === 0 && resetHistory && !mutation.isPending && (
+          <div className="px-5 py-2 sm:px-6">
+            <button
+              type="button"
+              onClick={restorePrevious}
+              className="inline-flex items-center gap-1.5 rounded-full border border-border/40 px-3 py-1 text-[11.5px] text-muted-foreground hover:text-foreground hover:border-border hover:bg-foreground/[0.04] transition-colors"
+            >
+              <Undo2 className="h-3 w-3" strokeWidth={2.2} aria-hidden="true" />
+              <span>
+                {t('addCards.panel.restorePrevious', 'Show previous results')}{' '}
+                <span className="opacity-60">({resetHistory.cards.length})</span>
+              </span>
+            </button>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Two issues on the Add Cards panel reported 2026-05-21:

1. **Feature** — accidental 초기화 click loses everything. Add a small undo button ("이전 결과 보기 (N)") that restores the cleared cards + picks instantly.
2. **Bug** — when the input zone is collapsed (scroll-driven), clicking 초기화 hides the header ChevronUp/Down toggle (gated on `hasSearched && cards.length > 0`), trapping the user with no way to expand the search options short of closing the panel.

## Implementation

### 1) Reset undo (feature)
- Session-local in-memory snapshot taken at the moment of 초기화 (cards + picks + surfaced-id set).
- New `restorePrevious` callback re-hydrates state and re-persists picks to localStorage.
- Snapshot lost on panel close (use case is *immediate undo*; long-term cross-session restore is already handled by the existing `addCards:state:` localStorage layer).
- UI: small chip-style button rendered just above the (empty) list, visible only when `cards.length === 0 && resetHistory && !mutation.isPending`.
- i18n key `addCards.panel.restorePrevious` ("이전 결과 보기" / "Show previous results").

### 2) Collapsed-state bug fix
- `resetResults` now also calls `setInputCollapsed(false)`. Reset semantically means "start over" → input zone naturally re-expanded with filters/keyword ready for new search.
- Root cause: post-reset, `cards.length === 0` → `hasSearched === false` → header ChevronUp/Down (line 324) hidden, but `inputCollapsed=true` persisted from earlier scroll trigger.

## Files

| File | Change |
|---|---|
| `frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx` | +Undo2 import, +`resetHistory` state, +`restorePrevious` callback, snapshot inside `resetResults`, `setInputCollapsed(false)` inside `resetResults`, undo chip UI |
| `frontend/src/shared/i18n/locales/ko.json` | +`addCards.panel.restorePrevious` = "이전 결과 보기" |
| `frontend/src/shared/i18n/locales/en.json` | +`addCards.panel.restorePrevious` = "Show previous results" |

Total: 3 files, +58 / -2.

## Verified

- [x] `tsc --noEmit` EXIT=0
- [x] `JSON.parse` ko + en OK

## Test plan

- [ ] Open Add Cards panel → search → see results
- [ ] Click 초기화 → results clear, undo chip "이전 결과 보기 (N)" appears
- [ ] Click chip → previous results return, picks intact
- [ ] Scroll list → input zone auto-collapses
- [ ] While collapsed, click 초기화 → input zone re-expands (was stuck before)
- [ ] Close panel → reopen → undo chip gone (session-local), but localStorage cards visible (existing behavior preserved)

## Regression risk

- D&D / orchestrator / dancing-dashboard: unaffected (panel-local change)
- localStorage persistence layer (`persistence.ts`): unchanged
- `clearSessionPicks` still called on reset (existing semantics) — `restorePrevious` re-`saveSessionPicks` to undo the clear
- Hover color / wizard chips / explore domain chips: unrelated PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)