### PR TITLE
fix(settings): drop admin-tier special case from billing management

### DIFF
--- a/frontend/src/pages/settings/ui/SubscriptionSettingsTab.tsx
+++ b/frontend/src/pages/settings/ui/SubscriptionSettingsTab.tsx
@@ -87,10 +87,7 @@ export function SubscriptionSettingsTab() {
   const tierKey = subscription.tier?.toLowerCase() ?? 'free';
   const tierStyle = TIER_STYLES[tierKey] ?? TIER_STYLES.free;
 
-  const billingTier = billingData?.tier ?? 'free';
   const billingSub = billingData?.subscription ?? null;
-  const isAdmin = billingTier === 'admin';
-  const isLifetimeWithoutSub = billingTier === 'lifetime' && !billingSub;
   const showRenewalNote =
     billingSub?.planCode === 'lifetime' || billingSub?.planCode === 'pro_lifetime';
 
@@ -193,9 +190,7 @@ export function SubscriptionSettingsTab() {
           </div>
         </CardHeader>
         <CardContent className="space-y-4">
-          {isAdmin ? (
-            <p className="text-sm text-muted-foreground">{t('settings.billing.adminNote')}</p>
-          ) : billingSub ? (
+          {billingSub ? (
             <>
               <div className="flex items-center justify-between text-sm">
                 <span className="text-muted-foreground">
@@ -230,16 +225,6 @@ export function SubscriptionSettingsTab() {
               <p className="text-xs text-muted-foreground text-center">
                 {t('settings.billing.portalFooter')}
               </p>
-            </>
-          ) : isLifetimeWithoutSub ? (
-            <>
-              <p className="text-sm text-muted-foreground">
-                {t('settings.billing.lifetimeBadgeNote')}
-              </p>
-              <Button variant="outline" className="w-full gap-2" onClick={onViewPlans}>
-                {t('settings.billing.viewPlans')}
-                <ArrowRight className="w-4 h-4" />
-              </Button>
             </>
           ) : (
             <>

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -298,8 +298,6 @@
       "noSubscriptionDesc": "Start Pro or Lifetime to enable billing management",
       "viewPlans": "View Plans",
       "lifetimeNote": "No auto-renewal. Refund requests can be made via the billing portal",
-      "lifetimeBadgeNote": "Lifetime plan active — full access without further billing",
-      "adminNote": "Admin account — no billing management needed",
       "nextBilling": "Next billing date",
       "endingOn": "Ending on",
       "portalFooter": "Cancel / refund / payment method changes are handled in the Lemon Squeezy billing portal"

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -299,8 +299,6 @@
       "noSubscriptionDesc": "Pro 또는 평생 이용권을 시작하면 결제 관리가 활성화됩니다",
       "viewPlans": "플랜 보기",
       "lifetimeNote": "자동 갱신 없음. 환불은 결제 관리에서 신청 가능합니다",
-      "lifetimeBadgeNote": "평생 이용권 활성 — 결제 정보 없이도 모든 기능 사용 가능합니다",
-      "adminNote": "관리자 권한 — 결제 관리 불요",
       "nextBilling": "다음 결제일",
       "endingOn": "종료 예정일",
       "portalFooter": "취소 / 환불 / 결제 수단 변경은 Lemon Squeezy 결제 관리에서 처리됩니다"


### PR DESCRIPTION
## Summary

- PR #719 mistakenly treated admin tier as a billing-exempt class, showing 'Admin account — no billing management needed' on `/settings?tab=subscription`.
- That conflates permission scope (admin role) with billing identity. An admin user can still be a real LS subscriber, and that subscription is theirs to manage.
- User correction: '사용자가 본인 결제 내역을 관리하는거야. 권한이 왜 필요해?'

## What changes

- `SubscriptionSettingsTab.tsx`: collapses the 4-branch ternary to 2 branches keyed only on `billing_subscriptions` row presence — admin tier behaves like every other tier in user-facing settings.
- Removes 2 unused i18n keys: `settings.billing.adminNote`, `settings.billing.lifetimeBadgeNote` (ko + en).

| Condition | UI |
|---|---|
| `billingSub` present | Plan label + status badge + next billing date + LS portal button + cancel/refund footer |
| `billingSub` absent (free / admin-granted lifetime / pre-billing legacy) | 'View plans' empty state → `/subscription` |

## Out of scope

Admin-only billing tooling (force-cancel another user's subscription, issue an admin refund, view all billing events) belongs at `/admin/billing` if/when needed. This PR only fixes the user-facing settings page.

## Verify

- `cd frontend && npx tsc --noEmit` → 0 errors
- CI: Hardcode Audit, Lint, Type Check, Test Frontend, Build Frontend & Accessibility

## Test plan after merge

- [ ] Admin user opens `/settings?tab=subscription`:
  - With no `billing_subscriptions` row → 'View plans' empty state (same as free user)
  - With a real LS subscription row → portal card + plan/status/next-billing
- [ ] Free user → 'View plans' empty state
- [ ] Paying user (post-real-charge) → portal card

## Rollback

`gh pr revert` (1 PR, 3 files, FE only). PR #719 stays in place; this is a copy/branch-logic correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)