### PR TITLE
fix(chatbot): openrouter chat.completions + remove /no_think echo (CP477+4)

### DIFF
--- a/src/api/routes/copilotkit.ts
+++ b/src/api/routes/copilotkit.ts
@@ -32,12 +32,20 @@ function createServiceAdapter(provider: ChatbotProvider, model: string): Copilot
   switch (provider) {
     case 'gemini':
     case 'openrouter':
-      return new OpenAIAdapter({
-        openai: new OpenAI({
-          apiKey: config.openrouter.apiKey,
-          baseURL: 'https://openrouter.ai/api/v1',
-        }),
+      // CP477+4 — Use QwenRunpodAdapter (chat.completions forced) instead
+      // of CopilotKit's default OpenAIAdapter (which routes via Responses
+      // API → not supported by OpenRouter for many models → Bug 1
+      // "Invalid Responses API request" on turn 2). Same Bug 1 fix as
+      // qwen-runpod path. chat_template_kwargs disabled because OpenRouter
+      // is not vLLM and the field is undocumented there.
+      if (!config.openrouter.apiKey) {
+        throw new Error('OPENROUTER_API_KEY not set');
+      }
+      return new QwenRunpodAdapter({
+        baseURL: 'https://openrouter.ai/api/v1',
+        apiKey: config.openrouter.apiKey,
         model,
+        includeChatTemplateKwargs: false,
       });
 
     case 'local':

--- a/src/modules/chatbot-rag/qwen-prompt-middleware.ts
+++ b/src/modules/chatbot-rag/qwen-prompt-middleware.ts
@@ -213,12 +213,23 @@ export async function rewriteSystemContent(originalSystemContent: string): Promi
   // FE linkifier can convert every timestamp to a clickable seek button
   // (chatbot output was mixing `(M:SS-M:SS)` with `N초` / `N~M초`).
   const withTimestampRule = appendTimestampFormatRule(built, language);
-  // CP475+5 — suppress Qwen3 reasoning chain. The `chat_template_kwargs`
-  // path (`enable_thinking: false`) only works on the legacy process() body;
-  // Vercel AI SDK V3 strips provider-specific kwargs, so the textual
-  // `/no_think` directive is the reliable way to gate reasoning on every
-  // request that hits vLLM.
-  return appendNoThinkDirective(withTimestampRule);
+  // CP477+4 — system-prompt `/no_think` REMOVED.
+  //   - User-reported 2026-05-21: openrouter Qwen3.5-9B emitted `/no_think`
+  //     as a raw token (echo) at the start of every response, and the echo
+  //     in history corrupted the next turn (multi-turn break).
+  //   - Root cause: Qwen3 chat template only recognises `/no_think` at the
+  //     END OF THE USER MESSAGE, not in the system prompt. The vLLM path
+  //     gates reasoning via `chat_template_kwargs.enable_thinking=false`
+  //     (process()-only), so the system-prompt directive was always the
+  //     wrong tool — it just happened to be silently ignored by the LoRA
+  //     in CP475+5 testing and only surfaced as echo on the OpenRouter
+  //     base model.
+  //   - Trade-off: Vercel AI SDK V3 (`getLanguageModel()` path) still
+  //     strips `chat_template_kwargs`, so reasoning chain MAY leak on the
+  //     qwen-runpod path. Acceptable until a proper user-message-end
+  //     directive lands. The legacy process() path is unaffected (body
+  //     still carries `chat_template_kwargs.enable_thinking=false`).
+  return withTimestampRule;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/modules/chatbot-rag/qwen-runpod-adapter.ts
+++ b/src/modules/chatbot-rag/qwen-runpod-adapter.ts
@@ -68,6 +68,20 @@ export interface QwenRunpodAdapterParams {
   apiKey: string;
   /** Served model name (vLLM's `--served-model-name`). Default 'insighta-chatbot'. */
   model?: string;
+  /**
+   * CP477+4 — Vendor-specific extras toggle.
+   *
+   * `chat_template_kwargs.enable_thinking=false` is a vLLM extension that
+   * suppresses Qwen3 reasoning blocks. OpenRouter (used as a Pod-down
+   * failover) does not document this field — it may be silently ignored or
+   * 400-rejected depending on the OpenRouter router strictness. Disable
+   * this flag when the adapter is pointed at OpenRouter (or any non-vLLM
+   * OpenAI-compatible backend).
+   *
+   * Default `true` (preserves existing QwenRunpodAdapter behaviour for
+   * the qwen-runpod provider).
+   */
+  includeChatTemplateKwargs?: boolean;
 }
 
 /**
@@ -88,6 +102,7 @@ export class QwenRunpodAdapter implements CopilotServiceAdapter {
   private readonly baseURL: string;
   private readonly apiKey: string;
   private readonly openaiSDK: OpenAI;
+  private readonly includeChatTemplateKwargs: boolean;
 
   constructor(params: QwenRunpodAdapterParams) {
     if (!params.baseURL) {
@@ -99,6 +114,7 @@ export class QwenRunpodAdapter implements CopilotServiceAdapter {
     this.baseURL = params.baseURL;
     this.apiKey = params.apiKey;
     this.model = params.model ?? DEFAULT_MODEL;
+    this.includeChatTemplateKwargs = params.includeChatTemplateKwargs ?? true;
     this.openaiSDK = new OpenAI({ baseURL: this.baseURL, apiKey: this.apiKey });
   }
 
@@ -159,7 +175,9 @@ export class QwenRunpodAdapter implements CopilotServiceAdapter {
       model: string;
       stream: true;
       messages: ReadonlyArray<{ role: 'system' | 'user' | 'assistant'; content: string }>;
-      chat_template_kwargs: { enable_thinking: boolean };
+      // vLLM-only extension (CP474). Omitted on non-vLLM backends
+      // (e.g. OpenRouter failover, CP477+4) where the field is undocumented.
+      chat_template_kwargs?: { enable_thinking: boolean };
       // CP475+4 — explicitly disable tool calling. vLLM Pod is started
       // without --enable-auto-tool-choice; any inbound tool_choice='auto'
       // (Vercel SDK default) produces 400 "auto" tool choice requires ...".
@@ -173,9 +191,11 @@ export class QwenRunpodAdapter implements CopilotServiceAdapter {
       model: this.model,
       stream: true,
       messages: openaiMessages,
-      chat_template_kwargs: CHAT_TEMPLATE_KWARGS,
       tool_choice: 'none',
     };
+    if (this.includeChatTemplateKwargs) {
+      body.chat_template_kwargs = CHAT_TEMPLATE_KWARGS;
+    }
     if (forwardedParameters?.maxTokens) body.max_completion_tokens = forwardedParameters.maxTokens;
     if (forwardedParameters?.temperature !== undefined)
       body.temperature = forwardedParameters.temperature;

--- a/tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
+++ b/tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
@@ -273,15 +273,19 @@ describe('appendNoThinkDirective (CP475+5)', () => {
   });
 });
 
-describe('rewriteSystemContent — CP475+5 /no_think suppression', () => {
-  it('appends /no_think to the generated system prompt (Korean)', async () => {
+describe('rewriteSystemContent — CP477+4 /no_think REMOVED from system prompt', () => {
+  // CP475+5 had appended `/no_think` to the system prompt; CP477+4 reverted
+  // that because the directive only works at user-message end (Qwen3 chat
+  // template requirement). The system-prompt placement caused token echo on
+  // the OpenRouter base model AND multi-turn history corruption.
+  it('does NOT contain /no_think anywhere (Korean)', async () => {
     const out = await rewriteSystemContent('한국어 인사이트 챗봇 사용');
-    expect(out.endsWith('/no_think')).toBe(true);
+    expect(out).not.toContain('/no_think');
   });
 
-  it('appends /no_think to the generated system prompt (English)', async () => {
+  it('does NOT contain /no_think anywhere (English)', async () => {
     const out = await rewriteSystemContent("You are Insighta's learning assistant.");
-    expect(out.endsWith('/no_think')).toBe(true);
+    expect(out).not.toContain('/no_think');
   });
 });
 
@@ -320,18 +324,15 @@ describe('appendTimestampFormatRule (CP477+2)', () => {
 });
 
 describe('rewriteSystemContent — CP477+2 timestamp rule injection', () => {
-  it('Korean system prompt ends with /no_think after timestamp rule and persona', async () => {
+  it('Korean system prompt contains the timestamp rule (CP477+4: no /no_think appended)', async () => {
     const out = await rewriteSystemContent('한국어 인사이트 챗봇 사용');
     expect(out).toContain('[타임스탬프 형식]');
-    expect(out.endsWith('/no_think')).toBe(true);
-    // Timestamp rule sits BEFORE /no_think (the /no_think directive must be
-    // the very last token so Qwen3's chat template picks it up cleanly).
-    expect(out.indexOf('[타임스탬프 형식]')).toBeLessThan(out.indexOf('/no_think'));
+    expect(out).not.toContain('/no_think');
   });
 
   it('English system prompt also gets the rule', async () => {
     const out = await rewriteSystemContent("You are Insighta's learning assistant.");
     expect(out).toContain('[Timestamp format]');
-    expect(out.endsWith('/no_think')).toBe(true);
+    expect(out).not.toContain('/no_think');
   });
 });

--- a/tests/unit/modules/chatbot-rag/qwen-runpod-adapter.test.ts
+++ b/tests/unit/modules/chatbot-rag/qwen-runpod-adapter.test.ts
@@ -334,6 +334,32 @@ describe('QwenRunpodAdapter — process()', () => {
     expect(callArg.chat_template_kwargs).toEqual({ enable_thinking: false });
   });
 
+  it('CP477+4 — OMITS chat_template_kwargs when includeChatTemplateKwargs=false (OpenRouter failover)', async () => {
+    // OpenRouter is not vLLM and does not document `chat_template_kwargs`.
+    // Sending the field may be silently ignored OR 400-rejected depending
+    // on router strictness. The opt-out flag keeps the OpenRouter path
+    // strictly OpenAI-API-compatible.
+    mockChatCompletionsCreate.mockResolvedValueOnce(iterChunks([]));
+    const a = new QwenRunpodAdapter({
+      baseURL: BASE,
+      apiKey: KEY,
+      includeChatTemplateKwargs: false,
+    });
+    const es = makeEventSource();
+
+    await a.process({
+      messages: [makeTextMessage('user', 'hi') as never],
+      actions: [],
+      eventSource: es as never,
+    });
+
+    const callArg = mockChatCompletionsCreate.mock.calls[0]![0];
+    expect(callArg.chat_template_kwargs).toBeUndefined();
+    // tool_choice must still be 'none' — that one is OpenAI-API-standard
+    // and OpenRouter respects it.
+    expect(callArg.tool_choice).toBe('none');
+  });
+
   it('returns provided threadId when present', async () => {
     mockChatCompletionsCreate.mockResolvedValueOnce(iterChunks([]));
     const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });


### PR DESCRIPTION
## 🚨 Demo-blocking regression (User report 2026-05-21 02:37)

OpenRouter failover path (PR #720) had two bugs:
1. Every response begins with literal `/no_think` token (echo) — see image 16
2. Multi-turn break — first response arrives, second turn silent — see images 17/18

User explicitly confirmed: **"오픈라우터에서 발생한 것"** (Pod is stopped, failover active).

## Fact-verified root cause (full re-read of 3 files)

**(1) `/no_think` echo**

Qwen3 chat template recognises `/no_think` only at the **end of the user message**, not in system. CP475+5 placed it at system end — the LoRA on qwen-runpod silently ignored it in earlier testing, but OpenRouter's Qwen3.5-9B base emitted it as a raw token. The echo then landed in the assistant turn of `useCopilotChat.visibleMessages` → next turn's prompt included a `/no_think`-prefixed assistant message → model confused → empty response → **multi-turn break**.

Two bugs, **one root** — the misplaced directive.

**(2) OpenRouter multi-turn break (Bug 1 redux)**

`createServiceAdapter('openrouter')` returned CopilotKit's default `OpenAIAdapter`, which uses `createOpenAI({...})(model)` → **Responses API**. OpenRouter does not implement `/v1/responses` → second turn's assistant history fails schema validation → exact same pattern PR #699 fixed for vLLM.

## Fix

### `qwen-runpod-adapter.ts`
- New opt-in `includeChatTemplateKwargs?: boolean` on constructor.
- Default `true` (preserves qwen-runpod behaviour byte-identically).
- Setting `false` omits `chat_template_kwargs` from the body (used for OpenRouter — field is undocumented, may be silently ignored OR 400-rejected depending on router strictness).

### `copilotkit.ts`
- `case 'gemini' | 'openrouter'`: replace `new OpenAIAdapter(...)` with `new QwenRunpodAdapter({ baseURL: 'https://openrouter.ai/api/v1', apiKey: config.openrouter.apiKey, model, includeChatTemplateKwargs: false })`.
- Same Bug 1 fix (chat.completions forced) now applies to OpenRouter failover.

### `qwen-prompt-middleware.ts`
- `rewriteSystemContent` no longer calls `appendNoThinkDirective`. The directive was always at the wrong location.
- Trade-off: legacy `process()` path still has `chat_template_kwargs.enable_thinking=false` so vLLM reasoning gated there. On the Vercel-SDK `getLanguageModel()` path the reasoning chain MAY leak — accepted regression until a proper user-message-end directive lands (post-demo PR).
- `appendNoThinkDirective` export kept for that future helper.

## Tests (42/42 PASS)

- `qwen-prompt-middleware.test.ts`
  - `rewriteSystemContent` blocks negated: now asserts `not.toContain('/no_think')` for KR + EN
  - Existing `appendNoThinkDirective` × 3 + `appendTimestampFormatRule` × 5 untouched
- `qwen-runpod-adapter.test.ts`
  - NEW: `OMITS chat_template_kwargs when includeChatTemplateKwargs=false`
  - Existing `chat_template_kwargs` default-true case stays

## Regression safety

- tsc 0 errors
- No dependency / lock-file change
- PR #720 health-check failover unchanged — only the openrouter ADAPTER swapped, not the failover decision
- PR #717 timestamp regex + format rule preserved
- **qwen-runpod path**: byte-identical request body minus the system-prompt `/no_think` line. Reasoning gating moves entirely to `chat_template_kwargs` (process() path) or leaks on Vercel-SDK path.
- **openrouter failover path**: now multi-turn works (Bug 1 fixed). `chat_template_kwargs` omitted (safe — field is undocumented for OpenRouter).

## Why this PR vs. user-message-end directive

- Demo tomorrow → demo-blocking regression (multi-turn break) requires the smallest, safest change.
- Single-line behaviour removal fixes BOTH reported symptoms at once.
- User-message-end placement requires multi-message traversal + cross-path traversal + extra test fixtures — more surface to verify under pressure.
- Reasoning leak on Vercel-SDK path is annoying but non-blocking (response is correct, just preceded by chain).
- Proper user-message-end fix tracked as **carryover PR after demo**.

## Refs

CP477+4 (demo emergency fix), CP475+5 (original misplacement to revert), PR #699 (CP474 Bug 1 fix for qwen-runpod), PR #720 (CP477+3 failover), user demo regression report 2026-05-21 02:37 KST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)