### PR TITLE
fix(chatbot): /no_think at user-message-end (Qwen3 standard) — both providers (CP477+5)

### DIFF
--- a/src/modules/chatbot-rag/qwen-prompt-middleware.ts
+++ b/src/modules/chatbot-rag/qwen-prompt-middleware.ts
@@ -69,6 +69,13 @@ export function createQwenPromptMiddleware(): LanguageModelV3Middleware {
     transformParams: async ({ params }) => {
       try {
         const rewritten = await rewriteSystemPrompt(params.prompt);
+        // CP477+5 — Append `/no_think` at the END OF THE LAST USER MESSAGE
+        // (Qwen3 chat template standard location for reasoning gating).
+        // System-prompt placement caused echo + multi-turn break (CP475+5
+        // → CP477+4 regression). `@ai-sdk/openai@3.0.53` has no extraBody
+        // escape hatch so we cannot forward `chat_template_kwargs` here —
+        // user-message-end is the only Vercel-SDK-compatible path.
+        const withDirective = appendNoThinkToLastUserMessage(rewritten ?? params.prompt);
         // CP475+4 — vLLM Pod started without --enable-auto-tool-choice +
         // --tool-call-parser, so any inbound `tool_choice: 'auto'` (the
         // Vercel AI SDK default when the route configures tools) produces:
@@ -77,7 +84,7 @@ export function createQwenPromptMiddleware(): LanguageModelV3Middleware {
         // off in the request that hits vLLM.
         const next = {
           ...params,
-          prompt: rewritten ?? params.prompt,
+          prompt: withDirective,
           toolChoice: { type: 'none' as const },
           tools: [],
         };
@@ -139,6 +146,88 @@ export async function rewriteSystemPrompt(
 export function appendNoThinkDirective(systemContent: string): string {
   if (systemContent.includes('/no_think')) return systemContent;
   return `${systemContent}\n\n/no_think`;
+}
+
+/**
+ * Append `/no_think` to the END of the LAST USER MESSAGE in the prompt.
+ *
+ * CP477+5 — Qwen3 chat template recognises `/no_think` only when it
+ * appears at the end of the user turn's content (verified empirically:
+ * image 16 showed the directive emitted as a raw token when placed in
+ * system; images 17/18 showed multi-turn break caused by the echo). The
+ * vLLM-specific `chat_template_kwargs.enable_thinking=false` is forwarded
+ * on the legacy `process()` body but NOT by `@ai-sdk/openai@3.0.53` (no
+ * `extraBody` escape hatch in V3 — verified by reading
+ * `node_modules/@ai-sdk/openai/dist/index.js`), so the user-message-end
+ * placement is the only path that gates reasoning on both Vercel SDK and
+ * vLLM backends — and it works for OpenRouter Qwen3.5-9B too (same
+ * Qwen-family chat template).
+ *
+ * Idempotent — leaves the message unchanged if it already ends with
+ * `/no_think`.
+ */
+export function appendNoThinkToLastUserMessage(
+  prompt: LanguageModelV3Message[]
+): LanguageModelV3Message[] {
+  if (prompt.length === 0) return prompt;
+  let lastUserIdx = -1;
+  for (let i = prompt.length - 1; i >= 0; i--) {
+    if (prompt[i]!.role === 'user') {
+      lastUserIdx = i;
+      break;
+    }
+  }
+  if (lastUserIdx === -1) return prompt;
+
+  const userMsg = prompt[lastUserIdx]!;
+  if (userMsg.role !== 'user') return prompt;
+  const parts = userMsg.content;
+  if (!Array.isArray(parts) || parts.length === 0) return prompt;
+
+  let lastTextIdx = -1;
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (parts[i]!.type === 'text') {
+      lastTextIdx = i;
+      break;
+    }
+  }
+  if (lastTextIdx === -1) return prompt;
+
+  const textPart = parts[lastTextIdx]!;
+  if (textPart.type !== 'text') return prompt;
+  const trimmed = textPart.text.trimEnd();
+  if (trimmed.endsWith('/no_think')) return prompt;
+
+  const newParts = [...parts];
+  newParts[lastTextIdx] = { ...textPart, text: `${trimmed} /no_think` };
+  const newPrompt = [...prompt];
+  newPrompt[lastUserIdx] = { ...userMsg, content: newParts };
+  return newPrompt;
+}
+
+/**
+ * Plain-string variant for the legacy `process()` path — message content
+ * there is already a flat `{role, content: string}` shape. Same
+ * idempotency + last-user semantics as the V3 variant.
+ */
+export function appendNoThinkToLastUserMessageString(
+  messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>
+): Array<{ role: 'system' | 'user' | 'assistant'; content: string }> {
+  if (messages.length === 0) return messages;
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.role === 'user') {
+      lastUserIdx = i;
+      break;
+    }
+  }
+  if (lastUserIdx === -1) return messages;
+  const msg = messages[lastUserIdx]!;
+  const trimmed = msg.content.trimEnd();
+  if (trimmed.endsWith('/no_think')) return messages;
+  const newMessages = messages.slice();
+  newMessages[lastUserIdx] = { ...msg, content: `${trimmed} /no_think` };
+  return newMessages;
 }
 
 /**

--- a/src/modules/chatbot-rag/qwen-runpod-adapter.ts
+++ b/src/modules/chatbot-rag/qwen-runpod-adapter.ts
@@ -39,7 +39,11 @@ import type {
   CopilotRuntimeChatCompletionRequest,
   CopilotRuntimeChatCompletionResponse,
 } from '@copilotkit/runtime';
-import { createQwenPromptMiddleware, rewriteSystemContent } from './qwen-prompt-middleware';
+import {
+  createQwenPromptMiddleware,
+  rewriteSystemContent,
+  appendNoThinkToLastUserMessageString,
+} from './qwen-prompt-middleware';
 import { logger } from '@/utils/logger';
 
 const log = logger.child({ module: 'chatbot-rag/qwen-runpod-adapter' });
@@ -290,7 +294,10 @@ async function applySFTRewrite(messages: OpenAIChatMessage[]): Promise<OpenAICha
     const otherMessages = messages.filter((m) => m.role !== 'system');
 
     const newSystem = await rewriteSystemContent(systemContents.join('\n\n'));
-    return [{ role: 'system', content: newSystem }, ...otherMessages];
+    const withSystem = [{ role: 'system' as const, content: newSystem }, ...otherMessages];
+    // CP477+5 — Append `/no_think` at the end of the LAST USER message
+    // (Qwen3 chat-template standard position). Idempotent.
+    return appendNoThinkToLastUserMessageString(withSystem);
   } catch (err) {
     log.warn('SFT rewrite failed; falling back to raw messages', {
       error: err instanceof Error ? err.message : String(err),

--- a/tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
+++ b/tests/unit/modules/chatbot-rag/qwen-prompt-middleware.test.ts
@@ -43,6 +43,8 @@ import {
   rewriteSystemPrompt,
   createQwenPromptMiddleware,
   appendNoThinkDirective,
+  appendNoThinkToLastUserMessage,
+  appendNoThinkToLastUserMessageString,
   appendTimestampFormatRule,
   _resetMiddlewareCacheForTesting,
 } from '@/modules/chatbot-rag/qwen-prompt-middleware';
@@ -334,5 +336,156 @@ describe('rewriteSystemContent — CP477+2 timestamp rule injection', () => {
     const out = await rewriteSystemContent("You are Insighta's learning assistant.");
     expect(out).toContain('[Timestamp format]');
     expect(out).not.toContain('/no_think');
+  });
+});
+
+describe('appendNoThinkToLastUserMessage (CP477+5) — V3 prompt shape', () => {
+  // Tests cover the Vercel-SDK getLanguageModel() path. V3 user content is
+  // `Array<TextPart | FilePart>` (string for `system`, array for others).
+  type Msg = Parameters<typeof appendNoThinkToLastUserMessage>[0][number];
+
+  function userText(text: string): Msg {
+    return { role: 'user', content: [{ type: 'text', text }] } as Msg;
+  }
+  function assistantText(text: string): Msg {
+    return { role: 'assistant', content: [{ type: 'text', text }] } as Msg;
+  }
+  function systemText(text: string): Msg {
+    return { role: 'system', content: text } as Msg;
+  }
+
+  it('appends `/no_think` to the last user message text', () => {
+    const out = appendNoThinkToLastUserMessage([systemText('persona'), userText('영상 요약')]);
+    expect(out[1]!.role).toBe('user');
+    expect((out[1]! as { content: Array<{ type: string; text: string }> }).content[0]!.text).toBe(
+      '영상 요약 /no_think'
+    );
+  });
+
+  it('multi-turn — only the LAST user message gets the directive', () => {
+    const out = appendNoThinkToLastUserMessage([
+      systemText('persona'),
+      userText('first turn'),
+      assistantText('first answer'),
+      userText('second turn'),
+    ]);
+    expect((out[1]! as { content: Array<{ type: string; text: string }> }).content[0]!.text).toBe(
+      'first turn'
+    ); // untouched
+    expect((out[3]! as { content: Array<{ type: string; text: string }> }).content[0]!.text).toBe(
+      'second turn /no_think'
+    );
+  });
+
+  it('idempotent — second call leaves the message unchanged', () => {
+    const once = appendNoThinkToLastUserMessage([userText('hi')]);
+    const twice = appendNoThinkToLastUserMessage(once);
+    expect(twice).toBe(once);
+  });
+
+  it('preserves trailing whitespace normalization (uses trimEnd before appending)', () => {
+    const out = appendNoThinkToLastUserMessage([userText('hi   \n\n')]);
+    expect((out[0]! as { content: Array<{ type: string; text: string }> }).content[0]!.text).toBe(
+      'hi /no_think'
+    );
+  });
+
+  it('handles empty prompt without throwing', () => {
+    expect(appendNoThinkToLastUserMessage([])).toEqual([]);
+  });
+
+  it('no user message in prompt → passthrough', () => {
+    const input = [systemText('persona only')];
+    expect(appendNoThinkToLastUserMessage(input)).toBe(input);
+  });
+
+  it('user message with empty parts array → passthrough', () => {
+    const input = [{ role: 'user' as const, content: [] }] as unknown as Msg[];
+    expect(appendNoThinkToLastUserMessage(input)).toBe(input);
+  });
+
+  it('user message ending with a FilePart still gets directive on the last TextPart', () => {
+    const input = [
+      {
+        role: 'user' as const,
+        content: [
+          { type: 'text', text: '이 영상' },
+          { type: 'file', mediaType: 'image/png', data: 'base64...' },
+        ],
+      },
+    ] as unknown as Msg[];
+    const out = appendNoThinkToLastUserMessage(input);
+    expect((out[0]! as { content: Array<{ type: string; text?: string }> }).content[0]!.text).toBe(
+      '이 영상 /no_think'
+    );
+    // file part untouched
+    expect((out[0]! as { content: Array<{ type: string }> }).content[1]!.type).toBe('file');
+  });
+});
+
+describe('appendNoThinkToLastUserMessageString (CP477+5) — legacy process() path', () => {
+  it('appends `/no_think` to the last user message content string', () => {
+    const out = appendNoThinkToLastUserMessageString([
+      { role: 'system', content: 'persona' },
+      { role: 'user', content: '영상 요약' },
+    ]);
+    expect(out[1]!.content).toBe('영상 요약 /no_think');
+  });
+
+  it('multi-turn — only the LAST user message', () => {
+    const out = appendNoThinkToLastUserMessageString([
+      { role: 'system', content: 'persona' },
+      { role: 'user', content: 'first turn' },
+      { role: 'assistant', content: 'first answer' },
+      { role: 'user', content: 'second turn' },
+    ]);
+    expect(out[1]!.content).toBe('first turn');
+    expect(out[3]!.content).toBe('second turn /no_think');
+  });
+
+  it('idempotent', () => {
+    const once = appendNoThinkToLastUserMessageString([{ role: 'user', content: 'hi' }]);
+    const twice = appendNoThinkToLastUserMessageString(once);
+    expect(twice).toBe(once);
+  });
+
+  it('empty input → passthrough', () => {
+    const input: Parameters<typeof appendNoThinkToLastUserMessageString>[0] = [];
+    expect(appendNoThinkToLastUserMessageString(input)).toBe(input);
+  });
+
+  it('no user message in input → passthrough', () => {
+    const input: Parameters<typeof appendNoThinkToLastUserMessageString>[0] = [
+      { role: 'system', content: 'persona' },
+    ];
+    expect(appendNoThinkToLastUserMessageString(input)).toBe(input);
+  });
+});
+
+describe('createQwenPromptMiddleware — CP477+5 end-to-end shape', () => {
+  it('transformParams output has /no_think on the LAST user message (not in system)', async () => {
+    const mw = createQwenPromptMiddleware();
+    const out = await mw.transformParams!({
+      type: 'stream',
+      params: {
+        prompt: [
+          { role: 'system' as const, content: 'persona' },
+          {
+            role: 'user' as const,
+            content: [{ type: 'text', text: '영상 요약 부탁' }],
+          },
+        ],
+      } as never,
+      model: {} as never,
+    });
+    // system message rewritten by middleware — must NOT carry /no_think
+    expect((out.prompt[0]! as { content: string }).content).not.toContain('/no_think');
+    // user message tail — MUST carry /no_think
+    const userPart = (
+      out.prompt[1]! as {
+        content: Array<{ type: string; text: string }>;
+      }
+    ).content[0]!;
+    expect(userPart.text.endsWith('/no_think')).toBe(true);
   });
 });

--- a/tests/unit/modules/chatbot-rag/qwen-runpod-adapter.test.ts
+++ b/tests/unit/modules/chatbot-rag/qwen-runpod-adapter.test.ts
@@ -51,6 +51,28 @@ jest.mock('@copilotkit/shared', () => ({
 jest.mock('@/modules/chatbot-rag/qwen-prompt-middleware', () => ({
   createQwenPromptMiddleware: jest.fn(() => ({ specificationVersion: 'v3' })),
   rewriteSystemContent: jest.fn(async (content: string) => content || 'REWRITTEN'),
+  // CP477+5 — adapter's applySFTRewrite now calls this on the final
+  // user-message-end. Mock it to use the real implementation so the
+  // adapter test stays end-to-end on the user-msg-append behaviour.
+  appendNoThinkToLastUserMessageString: jest.fn(
+    (messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>) => {
+      if (messages.length === 0) return messages;
+      let lastUserIdx = -1;
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i]!.role === 'user') {
+          lastUserIdx = i;
+          break;
+        }
+      }
+      if (lastUserIdx === -1) return messages;
+      const msg = messages[lastUserIdx]!;
+      const trimmed = msg.content.trimEnd();
+      if (trimmed.endsWith('/no_think')) return messages;
+      const next = messages.slice();
+      next[lastUserIdx] = { ...msg, content: `${trimmed} /no_think` };
+      return next;
+    }
+  ),
 }));
 
 // Mock logger because the adapter imports it at module level.
@@ -245,10 +267,11 @@ describe('QwenRunpodAdapter — process()', () => {
     expect(mockChatCompletionsCreate).toHaveBeenCalledTimes(1);
     const callArg = mockChatCompletionsCreate.mock.calls[0]![0];
     // System message goes through rewriteSystemContent (mocked as identity);
-    // non-system messages pass through untouched.
+    // user messages pass through untouched EXCEPT the last user gets the
+    // CP477+5 `/no_think` suffix (Qwen3 chat-template-standard placement).
     expect(callArg.messages).toEqual([
       { role: 'system', content: 'sys' },
-      { role: 'user', content: 'hi' },
+      { role: 'user', content: 'hi /no_think' },
     ]);
   });
 
@@ -404,5 +427,32 @@ describe('QwenRunpodAdapter — process()', () => {
     const callArg = mockChatCompletionsCreate.mock.calls[0]![0];
     expect(callArg.max_completion_tokens).toBe(800);
     expect(callArg.temperature).toBe(0.5);
+  });
+
+  it('CP477+5 — appends `/no_think` to the LAST user message in body.messages', async () => {
+    // Process path equivalent of the V3 middleware behaviour. Both code
+    // paths must agree on the Qwen3 chat-template-standard placement.
+    mockChatCompletionsCreate.mockResolvedValueOnce(iterChunks([]));
+    const a = new QwenRunpodAdapter({ baseURL: BASE, apiKey: KEY });
+    const es = makeEventSource();
+
+    await a.process({
+      messages: [
+        makeTextMessage('user', '첫 질문') as never,
+        makeTextMessage('assistant', '첫 응답') as never,
+        makeTextMessage('user', '두번째 질문') as never,
+      ],
+      actions: [],
+      eventSource: es as never,
+    });
+
+    const callArg = mockChatCompletionsCreate.mock.calls[0]![0];
+    const messages: Array<{ role: string; content: string }> = callArg.messages;
+    // First user message untouched.
+    expect(messages[1]!.content).toBe('첫 질문');
+    // Assistant turn untouched.
+    expect(messages[2]!.content).toBe('첫 응답');
+    // LAST user message ends with /no_think (CP477+5 contract).
+    expect(messages[3]!.content).toBe('두번째 질문 /no_think');
   });
 });


### PR DESCRIPTION
## 🚨 Demo-blocking (User report 2026-05-21 10:03)

LoRA multi-turn break: 첫 응답 도착 → 두번째 turn POST 자체가 Pod 에 안 옴 (Pod logs 에 health check polling 만). User explicit demand: **"양쪽 모두 동작 가능" (qwen-runpod LoRA + openrouter haiku 둘 다)**.

## Fact-verified root cause

1. **CP477+4 removed `/no_think` from system prompt** — fix for OpenRouter echo + multi-turn corruption (image 16/17/18 from previous bug round).
2. **Side effect**: Vercel-SDK `getLanguageModel()` path lost its reasoning-gating signal. `chat_template_kwargs.enable_thinking=false` is forwarded on legacy `process()` body but **`@ai-sdk/openai@3.0.53` has NO `extraBody` escape hatch** — verified by reading `node_modules/@ai-sdk/openai/dist/index.js` (only `providerOptions.openai.imageDetail` exists, not body-level).
3. **Without gating**, LoRA emits `<think>…</think>` block → lands in `useCopilotChat.visibleMessages` as the assistant turn → next turn's prompt serialises the malformed assistant message → vLLM/Vercel-SDK can't parse the history → no POST issued by the serializer (Pod logs confirm: only `/health` polling after turn 1).

## Fix — `/no_think` at Qwen3 chat-template-standard position (END OF LAST USER MESSAGE)

### Two new helpers (`qwen-prompt-middleware.ts`)

- **`appendNoThinkToLastUserMessage(prompt: LanguageModelV3Message[])`** — Vercel-SDK V3 path. V3 user content is `Array<TextPart | FilePart>`. Finds last user message → last `TextPart` → appends ` /no_think`. Idempotent.
- **`appendNoThinkToLastUserMessageString(messages)`** — legacy `process()` path. Same semantics on `{role, content: string}` shape.

### Wire-up

- `middleware.transformParams`: after `rewriteSystemPrompt`, call `appendNoThinkToLastUserMessage`.
- `adapter.applySFTRewrite`: after rebuilding with new system, call `appendNoThinkToLastUserMessageString`.

Both paths now satisfy Qwen3 chat template contract on every turn.

## Provider coverage (per user demand "양쪽 모두 동작")

| Provider | Behaviour |
|---|---|
| **qwen-runpod** (LoRA Qwen3-30B-A3B) | `/no_think` at user-msg-end is the documented Qwen3 trigger. LoRA inherits base chat template. ✅ |
| **openrouter — Anthropic Claude Haiku** | Claude has no reasoning chain to gate. `/no_think` is harmless trailing filler. OpenAIAdapter forwards messages 1-1. ✅ |
| **openrouter — Qwen3.5-9B** | Same Qwen-family chat template. User-message-end is the published trigger. ✅ |

## Tests (15 NEW + 42 existing → 57/57 PASS)

- middleware: `appendNoThinkToLastUserMessage` × 8 (V3 shape, multi-turn, idempotent, whitespace, empty, no-user, file-part, e2e via transformParams)
- middleware: `appendNoThinkToLastUserMessageString` × 5 (legacy shape)
- middleware: `createQwenPromptMiddleware` × 1 (e2e: system has no `/no_think`, last user does)
- adapter: 1 new "appends /no_think to last user message" + 1 updated existing case (body.messages now includes the suffix)

## Regression safety

- tsc 0 errors
- jest 57/57 PASS (15 new + 42 existing all pass)
- No dependency / lock-file change
- PR #720 health-check failover unchanged
- PR #726 chat.completions adapter swap for openrouter unchanged

## Side-effect handling

- User typing `/no_think` themselves: `appendNoThinkToLastUserMessage` is idempotent (checks trailing position). Mid-string `/no_think` left as-is (acceptable false-positive rate).
- Whitespace normalization: uses `trimEnd()` before appending so we don't get `"hi   \n\n /no_think"` artefacts.

## Verification plan (post-deploy — user-facing comparison report)

After this PR ships, the user-requested comparison should test BOTH paths:

```
[1st — qwen-runpod LoRA, Pod healthy]
  Test 1A: Single-turn "영상 요약" → /no_think absent from response
  Test 1B: Multi-turn 3 follow-ups → all 3 receive responses
  Test 1C: Timestamp citation → M:SS format

[2nd — openrouter (haiku via admin UI override), Pod stopped]
  Test 2A: Single-turn "영상 요약" → response from Claude Haiku
  Test 2B: Multi-turn 3 follow-ups → all 3 receive (chat.completions Bug 1 fix)
  Test 2C: /no_think absent from rendered response (suffix consumed by template)
```

To switch openrouter to haiku: `/admin/chatbot-models` → set `openrouter_model = anthropic/claude-3.5-haiku` (or exact OpenRouter id) → Save.

## Refs

CP477+5 (this fix), CP477+4 (system-prompt removal that exposed the Vercel-SDK gap), CP475+5 (original misplacement), PR #720 (failover), PR #726 (openrouter chat.completions swap), user demo regression 2026-05-21 10:03 KST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)