### PR TITLE
fix(chatbot): pause req stream during async getYoga() — race body loss fix (CP477+7)

### DIFF
--- a/src/api/routes/copilotkit.ts
+++ b/src/api/routes/copilotkit.ts
@@ -115,9 +115,34 @@ export const copilotKitRoutes: FastifyPluginCallback = (fastify, _opts, done) =>
   server.removeAllListeners('request');
   server.on('request', (req, res) => {
     if (req.url?.startsWith('/api/v1/chat') && !req.url?.startsWith('/api/v1/chat/config')) {
+      // CP477+7 — Pause the request stream BEFORE the async getYoga() wait
+      // so raw HTTP 'data'/'end' events don't fire and get lost while yoga
+      // is being lazily built or while chatbot_settings 5-min cache is being
+      // refreshed (DB query ~50-200ms). Without this pause the body is
+      // swallowed → yoga receives empty payload → "Invalid JSON payload" 400.
+      // Triggers: cold start (lazyYoga === null), settings cache miss every
+      // 5 min, admin model PUT (updatedAt advances).
+      req.pause();
       void (async () => {
-        const handler = await getYoga();
-        await handler(req, res);
+        try {
+          const handler = await getYoga();
+          req.resume();
+          await handler(req, res);
+        } catch (err) {
+          // Pre-handler async step failed (e.g., chatbot_settings DB
+          // unreachable, adapter env missing). Without this catch the
+          // rejection is silent and the client hangs until socket timeout.
+          if (!res.headersSent) {
+            res.statusCode = 500;
+            res.setHeader('content-type', 'application/json');
+            res.end(
+              JSON.stringify({
+                error: 'chat_runtime_unavailable',
+                message: err instanceof Error ? err.message : 'unknown error',
+              })
+            );
+          }
+        }
       })();
       return;
     }


### PR DESCRIPTION
## Summary

- Repro: `curl POST http://localhost:3000/api/v1/chat -d '{"query":"q"}'` → `{"error":"invalid_request","message":"Invalid JSON payload"}`
- Cause: `server.on('request')` listener calls `await getYoga()` before handing req to yoga. Raw HTTP 'data'/'end' events fire on req with NO listener — body dropped → yoga sees empty payload → 400.
- Trigger: cold start (`lazyYoga === null`), `chatbot_settings` 5-min cache miss (DB findUnique ~50-200ms), admin model PUT.
- Fix: `req.pause()` before async IIFE, `req.resume()` after `await getYoga()`. Adds try/catch → 500 `chat_runtime_unavailable` instead of silent hang.

User-reported pattern that matches the race exactly:
> "가끔 먹통, 한두번 새로고침하면 풀린다, 그러다가 또 어느순간엔가 발생"

Cold start race → reload → warm cache hit (race window microsec) → 5 min later cache miss → race again.

## Scope

Single file: `src/api/routes/copilotkit.ts` (+27 / -2)

**Out of scope** — `PR #720` (CP477+3) failover restoration is a separate P0 carryover per `docs/runbook/cp477+6-chatbot-rollback-handoff-2026-05-21.md §4.1`. Only spec item (3) "req stream 보호" is implemented here. Failover restoration ships separately.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Pre-fix reproduction confirmed via curl (Invalid JSON payload returned)
- [ ] Post-merge: dev BE restart → first chat request succeeds without race
- [ ] Post-deploy: prod chatbot 5+ consecutive requests over 5-10 minute span (covering one cache miss boundary) all succeed
- [ ] Post-deploy: admin model PUT → next chat request → no race fail
- [ ] CI 6/6 SUCCESS

## Risk

Low. `req.pause()` / `req.resume()` are stable Node `http.IncomingMessage` API. Body is internally buffered; yoga's stream listeners attach when its handler runs and receive the deferred 'data'/'end' events. Try/catch surface improves: previously silent rejections now return structured 500 instead of hanging the client until socket timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)