### PR TITLE
fix(chatbot): downgrade CopilotKit 1.56.3 → 1.55.3 (CP477+8) — bypass agent runtime warning + 404 cascade

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "insighta-frontend",
       "version": "0.4.0",
       "dependencies": {
-        "@copilotkit/react-core": "1.56.3",
-        "@copilotkit/react-ui": "1.56.3",
+        "@copilotkit/react-core": "1.55.3",
+        "@copilotkit/react-ui": "1.55.3",
         "@dicebear/collection": "^9.4.2",
         "@dicebear/core": "^9.4.2",
         "@dnd-kit/core": "^6.3.1",
@@ -122,9 +122,9 @@
       }
     },
     "node_modules/@a2ui/web_core/node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.2.1.tgz",
+      "integrity": "sha512-37RhSdxaG1suen6VDCza6rNrQfooyQh57HFVPwQGEq2QWliVLzPQZ8Oa017weOu+HZCnzI7N3Pf/wyoBKfEqrA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1556,9 +1556,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@copilotkit/a2ui-renderer": {
-      "version": "1.56.3",
-      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.56.3.tgz",
-      "integrity": "sha512-rZ1SWJvha0m0gwf/xl4AbIFweULf9bQY/bB2GzoL6bnqz+xTKa4+ztLH5NN2lfEoV2PUQiWDhSb6GfrwmJjSWg==",
+      "version": "1.55.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/a2ui-renderer/-/a2ui-renderer-1.55.3.tgz",
+      "integrity": "sha512-biChiWCTv4XQOGoXjYOOa+8auqnveAH6IdadZHi6vcBPiVlvN8Cr40Y6DPImBAZhshpvci5cNGjWakPHCx+lJw==",
       "license": "MIT",
       "dependencies": {
         "@a2ui/web_core": "0.9.0",
@@ -1572,13 +1572,12 @@
       }
     },
     "node_modules/@copilotkit/core": {
-      "version": "1.56.3",
-      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.56.3.tgz",
-      "integrity": "sha512-is7+XCadtjegH5X5OVQ8whLAzzbK5RYR6CXFRZwp7K/2WcpI0gVo//AegJPbctyqL90V/SMDtn2X+bouAft4jQ==",
+      "version": "1.55.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/core/-/core-1.55.3.tgz",
+      "integrity": "sha512-CMyLvisuBGdTKcDus1dM8oRuAE0OiRZ8NVArXWHkvZIYzweeJL/bXmdtkWM7V5v/a0ZW2ng+FzbAFEvknEMk7A==",
       "dependencies": {
         "@ag-ui/client": "0.0.52",
-        "@copilotkit/shared": "1.56.3",
-        "@tanstack/pacer": "^0.20.1",
+        "@copilotkit/shared": "1.55.3",
         "phoenix": "^1.8.4",
         "rxjs": "7.8.1",
         "zod-to-json-schema": "^3.24.6"
@@ -1588,23 +1587,23 @@
       }
     },
     "node_modules/@copilotkit/license-verifier": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/license-verifier/-/license-verifier-0.2.0.tgz",
-      "integrity": "sha512-hliCifqy5a65YTozgRckuQmvBEQlt4L2PhbpSDY6fb/TKqPHyNDJgItRSnOpxOVDqvEfHEbUUqw3NaD88ZtdJA=="
+      "version": "0.0.1-a1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/license-verifier/-/license-verifier-0.0.1-a1.tgz",
+      "integrity": "sha512-eTsupi14qPwDhpQBrFC6t4U5rxmHo9nPaHz60gOBPPCu7tTcA8GwEq5QfX/XGfmmKbCX2noL9yto1Pg0A8qQ9g=="
     },
     "node_modules/@copilotkit/react-core": {
-      "version": "1.56.3",
-      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.56.3.tgz",
-      "integrity": "sha512-qGgdGq7kSF8CfJDrimS28IirNeMkwatyeVKb74sCoV0wfXE2bvZChMz8PHglocMYLjf3p5EWh13VT6qhDHRHbQ==",
+      "version": "1.55.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/react-core/-/react-core-1.55.3.tgz",
+      "integrity": "sha512-K61WILVUjBgCjNYOTg6Xy/PIlYuWlT0QlhyOXwEF9SZmNSDkqlNRDqDTCGOx98RyfGTAJ9IliHo9YNr8Yqg2uQ==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.52",
         "@ag-ui/core": "0.0.52",
-        "@copilotkit/a2ui-renderer": "1.56.3",
-        "@copilotkit/core": "1.56.3",
-        "@copilotkit/runtime-client-gql": "1.56.3",
-        "@copilotkit/shared": "1.56.3",
-        "@copilotkit/web-inspector": "1.56.3",
+        "@copilotkit/a2ui-renderer": "1.55.3",
+        "@copilotkit/core": "1.55.3",
+        "@copilotkit/runtime-client-gql": "1.55.3",
+        "@copilotkit/shared": "1.55.3",
+        "@copilotkit/web-inspector": "1.55.3",
         "@jetbrains/websandbox": "^1.1.3",
         "@lit-labs/react": "^2.0.2",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -1651,14 +1650,14 @@
       }
     },
     "node_modules/@copilotkit/react-ui": {
-      "version": "1.56.3",
-      "resolved": "https://registry.npmjs.org/@copilotkit/react-ui/-/react-ui-1.56.3.tgz",
-      "integrity": "sha512-nJa3vYGt4ElRfX2RaAy44BlS08YI/VZgjfk5f/iGj8NVdSYOpCgUPuUp3yIIY34qFDxJXUKpfIuAkOB45/3gjg==",
+      "version": "1.55.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/react-ui/-/react-ui-1.55.3.tgz",
+      "integrity": "sha512-5gd2OhSDSVzZEIyqmeil1dGElmFRTVSXRGMNkKxBIrz7W9actpnkx5STEI5V/CYHLwnalGCbRIr1ih1SEyd5iA==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/react-core": "1.56.3",
-        "@copilotkit/runtime-client-gql": "1.56.3",
-        "@copilotkit/shared": "1.56.3",
+        "@copilotkit/react-core": "1.55.3",
+        "@copilotkit/runtime-client-gql": "1.55.3",
+        "@copilotkit/shared": "1.55.3",
         "@headlessui/react": "^2.2.9",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^15.6.1",
@@ -2461,12 +2460,12 @@
       }
     },
     "node_modules/@copilotkit/runtime-client-gql": {
-      "version": "1.56.3",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.56.3.tgz",
-      "integrity": "sha512-aQVyk9ddnYlrvjwcEYO7I+daTeQCCsBgJ4VQp/L2NVtnvYuRNRb8UlW8y6vDRV7Q+SvHA1OSOklPS1Exl8zAfw==",
+      "version": "1.55.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime-client-gql/-/runtime-client-gql-1.55.3.tgz",
+      "integrity": "sha512-xUm6F6kZzbiJQJp+mjQvjey2qZA71sFUGpQ/DkeNvG+0OAHvn5gLmIkwiSxu0HfSzc8q7EmisaXCvjp9oRAkYw==",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/shared": "1.56.3",
+        "@copilotkit/shared": "1.55.3",
         "@urql/core": "^5.0.3",
         "untruncate-json": "^0.0.1",
         "urql": "^4.1.0"
@@ -2476,13 +2475,13 @@
       }
     },
     "node_modules/@copilotkit/shared": {
-      "version": "1.56.3",
-      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.56.3.tgz",
-      "integrity": "sha512-XkXKAz3XaRkSXX9I7qPL9kCEwBnsB4ork7jbn8ERVAezqQt7aziiIOU+vtDCrArpv4kheJXsORRUE1ltc6IGRw==",
+      "version": "1.55.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.55.3.tgz",
+      "integrity": "sha512-hkKknX0lDmdQ3IsO5znXwLTkLbkxY97/yf0k9uIUq0c9BfmzWSssCCIBcVwdHEG5ZFd5C6mHDmjSC8b2pfCDhg==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.52",
-        "@copilotkit/license-verifier": "0.2.0",
+        "@copilotkit/license-verifier": "0.0.1-a1",
         "@segment/analytics-node": "^2.1.2",
         "@standard-schema/spec": "^1.0.0",
         "chalk": "4.1.2",
@@ -2497,12 +2496,12 @@
       }
     },
     "node_modules/@copilotkit/web-inspector": {
-      "version": "1.56.3",
-      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.56.3.tgz",
-      "integrity": "sha512-wwh/f0NszZ4kN67QRR8GadQlPsgerqNKR1HKswn9rmppXhLWSM/sLkLfCjYIBXAGq3WkGJM9wIo2s9MqYrceew==",
+      "version": "1.55.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/web-inspector/-/web-inspector-1.55.3.tgz",
+      "integrity": "sha512-qA6T6Si35lWFvcFyK4p69ROsOxfbl0y96Tsh0L6byWyreS8JfUeYK1l+kMzv8jnVBXmwVf/PxX9Gu1WOgK9XbQ==",
       "dependencies": {
         "@ag-ui/client": "0.0.52",
-        "@copilotkit/core": "1.56.3",
+        "@copilotkit/core": "1.55.3",
         "lit": "^3.2.0",
         "lucide": "^0.525.0",
         "marked": "^12.0.2"
@@ -3253,9 +3252,9 @@
       }
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
-      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@lit/react": {
@@ -3621,9 +3620,9 @@
       "license": "MIT"
     },
     "node_modules/@preact/signals-core": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
-      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.2.tgz",
+      "integrity": "sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -5315,39 +5314,6 @@
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
       }
     },
-    "node_modules/@tanstack/devtools-event-client": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/devtools-event-client/-/devtools-event-client-0.4.3.tgz",
-      "integrity": "sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==",
-      "license": "MIT",
-      "bin": {
-        "intent": "bin/intent.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/pacer": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/pacer/-/pacer-0.20.1.tgz",
-      "integrity": "sha512-ZNQ1bIL6eUXVKdic0tiImvBVkWrg/IoSK6VIacTrO3d3HAGnd70qFJNJagR/YOJIOw4EKGWnodwpYZkN1pWuVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/devtools-event-client": "^0.4.3",
-        "@tanstack/store": "^0.9.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
     "node_modules/@tanstack/query-core": {
       "version": "5.90.20",
       "license": "MIT",
@@ -5383,16 +5349,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@tanstack/store": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
-      "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/virtual-core": {
@@ -9276,9 +9232,9 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "16.13.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -11341,9 +11297,9 @@
       "license": "MIT"
     },
     "node_modules/lit": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
-      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -11363,9 +11319,9 @@
       }
     },
     "node_modules/lit-html": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
-      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -19036,9 +18992,9 @@
       }
     },
     "node_modules/phoenix": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.8.5.tgz",
-      "integrity": "sha512-Oj5nlRV/NKXkjBx8uMgCMmgMf1twd/B2qOcO30cHLH1PCGR8149o4T1lRIaqN4nq2KQJAeMqPiLdh1Asd0wQFg==",
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.8.7.tgz",
+      "integrity": "sha512-mQfiO4PNEjToj5iUfka6OjRWtCNe+0JsVrW6x+q94kPN8VX8taulJPTa4/u2ZPb2b8+hzmBAvMxQWnuTc0T4KQ==",
       "license": "MIT"
     },
     "node_modules/picocolors": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@copilotkit/react-core": "1.56.3",
-    "@copilotkit/react-ui": "1.56.3",
+    "@copilotkit/react-core": "1.55.3",
+    "@copilotkit/react-ui": "1.55.3",
     "@dicebear/collection": "^9.4.2",
     "@dicebear/core": "^9.4.2",
     "@dnd-kit/core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@copilotkit/runtime": "1.56.3",
+        "@copilotkit/runtime": "1.55.3",
         "@fastify/cors": "^8.4.2",
         "@fastify/helmet": "^11.1.1",
         "@fastify/jwt": "^7.2.3",
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@ag-ui/a2ui-middleware": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@ag-ui/a2ui-middleware/-/a2ui-middleware-0.0.5.tgz",
-      "integrity": "sha512-nhF8LBzq36BmLR1O3nStxqSpIu1+4//ttqOyQgiXUsKZK1znCyN4q4MBTARrkFa7CuFr3fcNTiZuS4V1HRUHTw==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@ag-ui/a2ui-middleware/-/a2ui-middleware-0.0.4.tgz",
+      "integrity": "sha512-N7goCObceqsCQgFRKBpo/X9D9Q0Jp6ALV+ier2W7WnK3sy0WfY2jAeFhqEaoZRqcNeLTKEt8sDqdtd4TGQE1+w==",
       "dependencies": {
         "clarinet": "^0.12.6"
       },
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@ag-ui/client/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -143,12 +143,12 @@
       }
     },
     "node_modules/@ag-ui/langgraph": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.29.tgz",
-      "integrity": "sha512-7Q4YMtuI53N3uyZbEhYsIpfwYK1l5mWX88nm7BE242lIpPsiLIj3RL8xpT8lojqmR9MyZ72jlHIhXm1hbsrZjg==",
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/@ag-ui/langgraph/-/langgraph-0.0.27.tgz",
+      "integrity": "sha512-sfUG985ngG4HAGIZK04POvZVDrsI3QaeWuqJ388QgBPGg9n/oi4+vxueW7O5PIQv6uOPCLsbxf43pZZRN3zZtg==",
       "dependencies": {
-        "@langchain/core": "^1.1.40",
-        "@langchain/langgraph-sdk": "^1.8.8",
+        "@langchain/core": "^0.3.80",
+        "@langchain/langgraph-sdk": "^0.1.2",
         "langchain": ">=1.2.0",
         "partial-json": "^0.1.7",
         "rxjs": "7.8.1"
@@ -158,85 +158,6 @@
         "@ag-ui/core": ">=0.0.42"
       }
     },
-    "node_modules/@ag-ui/langgraph/node_modules/@langchain/core": {
-      "version": "1.1.41",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.41.tgz",
-      "integrity": "sha512-KdoNEf1YVJ9jnOP+smq4O6teu63tE7GDUryOnZ2lVfooHLrHK/ECUadjOcDSCK/yk/xBw/8nexJ3ZNBMtKnstw==",
-      "license": "MIT",
-      "dependencies": {
-        "@cfworker/json-schema": "^4.0.2",
-        "@standard-schema/spec": "^1.1.0",
-        "ansi-styles": "^5.0.0",
-        "camelcase": "6",
-        "decamelize": "1.2.0",
-        "js-tiktoken": "^1.0.12",
-        "langsmith": ">=0.5.0 <1.0.0",
-        "mustache": "^4.2.0",
-        "p-queue": "^6.6.2",
-        "uuid": "^11.1.0",
-        "zod": "^3.25.76 || ^4"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@ag-ui/langgraph/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@ag-ui/langgraph/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ag-ui/langgraph/node_modules/langsmith": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.25.tgz",
-      "integrity": "sha512-AG7NOymrDmwaWq+wus5hJHZjPFKXwsEdfqGBU3eZiF5242mme+5wuJocdBJKGyU1kgBO7TuLHiqtdyIwl4V4yQ==",
-      "license": "MIT",
-      "dependencies": {
-        "p-queue": "6.6.2"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "*",
-        "@opentelemetry/exporter-trace-otlp-proto": "*",
-        "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*",
-        "ws": ">=7"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/exporter-trace-otlp-proto": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@ag-ui/langgraph/node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -244,19 +165,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@ag-ui/langgraph/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@ag-ui/mcp-apps-middleware": {
@@ -1168,29 +1076,29 @@
       }
     },
     "node_modules/@copilotkit/license-verifier": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@copilotkit/license-verifier/-/license-verifier-0.2.0.tgz",
-      "integrity": "sha512-hliCifqy5a65YTozgRckuQmvBEQlt4L2PhbpSDY6fb/TKqPHyNDJgItRSnOpxOVDqvEfHEbUUqw3NaD88ZtdJA=="
+      "version": "0.0.1-a1",
+      "resolved": "https://registry.npmjs.org/@copilotkit/license-verifier/-/license-verifier-0.0.1-a1.tgz",
+      "integrity": "sha512-eTsupi14qPwDhpQBrFC6t4U5rxmHo9nPaHz60gOBPPCu7tTcA8GwEq5QfX/XGfmmKbCX2noL9yto1Pg0A8qQ9g=="
     },
     "node_modules/@copilotkit/runtime": {
-      "version": "1.56.3",
-      "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.56.3.tgz",
-      "integrity": "sha512-nvweNAC/qgYdQSWSqs5IVdfYxGM2cdhOtW/sAhkJiclH2GZmJwvNaTz5laWeA+56Fylv2cOwjuwwjuktplZsBQ==",
+      "version": "1.55.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/runtime/-/runtime-1.55.3.tgz",
+      "integrity": "sha512-Bj2mA/cvG6cXf+0G1Ve+4mz1MSYez9jM4VyBWXXfeCmdG8d0AEpZ0544zDd2OqxljVlT4ZX6KQWTZGFMc9X4Og==",
       "license": "MIT",
       "dependencies": {
-        "@ag-ui/a2ui-middleware": "0.0.5",
+        "@ag-ui/a2ui-middleware": "0.0.4",
         "@ag-ui/client": "0.0.52",
         "@ag-ui/core": "0.0.52",
         "@ag-ui/encoder": "0.0.52",
-        "@ag-ui/langgraph": "0.0.29",
+        "@ag-ui/langgraph": "0.0.27",
         "@ag-ui/mcp-apps-middleware": "0.0.3",
         "@ai-sdk/anthropic": "^3.0.49",
         "@ai-sdk/google": "^3.0.33",
         "@ai-sdk/google-vertex": "^3.0.97",
         "@ai-sdk/mcp": "^1.0.21",
         "@ai-sdk/openai": "^3.0.36",
-        "@copilotkit/license-verifier": "0.2.0",
-        "@copilotkit/shared": "1.56.3",
+        "@copilotkit/license-verifier": "0.0.1-a1",
+        "@copilotkit/shared": "1.55.3",
         "@graphql-yoga/plugin-defer-stream": "^3.3.1",
         "@hono/node-server": "^1.13.5",
         "@modelcontextprotocol/sdk": "^1.18.2",
@@ -1207,7 +1115,7 @@
         "graphql-scalars": "^1.23.0",
         "graphql-yoga": "^5.3.1",
         "hono": "^4.11.4",
-        "openai": "^4.85.1 || >=5.0.0",
+        "openai": "^4.85.1",
         "partial-json": "^0.1.7",
         "phoenix": "^1.8.4",
         "pino": "^9.2.0",
@@ -1228,8 +1136,7 @@
         "@langchain/langgraph-sdk": ">=0.1.2",
         "@langchain/openai": ">=0.4.2",
         "groq-sdk": ">=0.3.0 <1.0.0",
-        "langchain": ">=0.3.3",
-        "openai": "^4.85.1 || >=5.0.0"
+        "langchain": ">=0.3.3"
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {
@@ -1284,13 +1191,13 @@
       }
     },
     "node_modules/@copilotkit/shared": {
-      "version": "1.56.3",
-      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.56.3.tgz",
-      "integrity": "sha512-XkXKAz3XaRkSXX9I7qPL9kCEwBnsB4ork7jbn8ERVAezqQt7aziiIOU+vtDCrArpv4kheJXsORRUE1ltc6IGRw==",
+      "version": "1.55.3",
+      "resolved": "https://registry.npmjs.org/@copilotkit/shared/-/shared-1.55.3.tgz",
+      "integrity": "sha512-hkKknX0lDmdQ3IsO5znXwLTkLbkxY97/yf0k9uIUq0c9BfmzWSssCCIBcVwdHEG5ZFd5C6mHDmjSC8b2pfCDhg==",
       "license": "MIT",
       "dependencies": {
         "@ag-ui/client": "0.0.52",
-        "@copilotkit/license-verifier": "0.2.0",
+        "@copilotkit/license-verifier": "0.0.1-a1",
         "@segment/analytics-node": "^2.1.2",
         "@standard-schema/spec": "^1.0.0",
         "chalk": "4.1.2",
@@ -1305,9 +1212,9 @@
       }
     },
     "node_modules/@copilotkit/shared/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -3586,13 +3493,14 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.2.9.tgz",
-      "integrity": "sha512-3c7BtGycHC2v9p6w/Hv8L7kEl1YnZYOQTDJtmAp3knk6JOedO7d2bYP3y0SRyhv5orUEGf/KGvx8ZsB/ideP7g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.2.tgz",
+      "integrity": "sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph-checkpoint": "^1.0.1",
-        "@langchain/langgraph-sdk": "~1.8.9",
+        "@langchain/langgraph-checkpoint": "^1.0.2",
+        "@langchain/langgraph-sdk": "~1.9.4",
+        "@langchain/protocol": "^0.0.15",
         "@standard-schema/spec": "1.1.0",
         "uuid": "^10.0.0"
       },
@@ -3600,7 +3508,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.40",
+        "@langchain/core": "^1.1.44",
         "zod": "^3.25.32 || ^4.2.0",
         "zod-to-json-schema": "^3.x"
       },
@@ -3611,9 +3519,9 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
-      "integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.2.tgz",
+      "integrity": "sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==",
       "license": "MIT",
       "dependencies": {
         "uuid": "^10.0.0"
@@ -3622,13 +3530,14 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.0.1"
+        "@langchain/core": "^1.1.44"
       }
     },
     "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -3639,27 +3548,53 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.8.9.tgz",
-      "integrity": "sha512-vpz90auS4iFTNy2X/CFexOEoeFSvaK+MyI7iSmzYs9gGcfzwRjWUJ4MWsuc5ZNRecLStwho0PExVXRgGOXtcRw==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.1.10.tgz",
+      "integrity": "sha512-9srSCb2bSvcvehMgjA2sMMwX0o1VUgPN6ghwm5Fwc9JGAKsQa6n1S4eCwy1h4abuYxwajH5n3spBw+4I2WYbgw==",
       "license": "MIT",
       "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^9.0.0"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.31 <0.4.0 || ^1.0.0-alpha",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.4.tgz",
+      "integrity": "sha512-hhASJGKa2MDJDtDkuIFdWGysMTog/HkYe0r6B6Gn1XqsURWnF7FIFl9diITAPOv1tB8YpyjnbpsBj/NkT5d+jQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/protocol": "^0.0.15",
         "@types/json-schema": "^7.0.15",
         "p-queue": "^9.0.1",
         "p-retry": "^7.1.1",
         "uuid": "^13.0.0"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.16",
+        "@langchain/core": "^1.1.44",
         "react": "^18 || ^19",
         "react-dom": "^18 || ^19",
         "svelte": "^4.0.0 || ^5.0.0",
         "vue": "^3.0.0"
       },
       "peerDependenciesMeta": {
-        "@langchain/core": {
-          "optional": true
-        },
         "react": {
           "optional": true
         },
@@ -3674,13 +3609,26 @@
         }
       }
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.2.tgz",
-      "integrity": "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==",
+    "node_modules/@langchain/langgraph/node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/langgraph/node_modules/p-queue": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
+        "eventemitter3": "^5.0.4",
         "p-timeout": "^7.0.0"
       },
       "engines": {
@@ -3690,7 +3638,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/p-retry": {
+    "node_modules/@langchain/langgraph/node_modules/p-retry": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
       "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
@@ -3705,7 +3653,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/p-timeout": {
+    "node_modules/@langchain/langgraph/node_modules/p-timeout": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
       "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
@@ -3717,23 +3665,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
     "node_modules/@langchain/langgraph/node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -3742,6 +3678,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/@langchain/protocol": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.15.tgz",
+      "integrity": "sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==",
+      "license": "MIT"
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
@@ -4908,6 +4850,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/nodemailer": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
@@ -5350,6 +5302,18 @@
         "node": ">= 14"
       }
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -5566,6 +5530,12 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/atomic-sleep": {
@@ -6418,6 +6388,18 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
@@ -6705,6 +6687,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6938,6 +6929,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7859,6 +7865,50 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "license": "MIT"
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -8372,6 +8422,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -8459,6 +8524,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/husky": {
@@ -8690,9 +8764,9 @@
       }
     },
     "node_modules/is-network-error": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
-      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -9624,28 +9698,27 @@
       "license": "MIT"
     },
     "node_modules/langchain": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.3.4.tgz",
-      "integrity": "sha512-umrD+ZC6vr0Q0U1lC5PoIMMQqgnP+7QhaIdAXCeZiSX2GPVBiVR7Ed2ZR+3MPvz1yWrRtIm17wPaovkND+wOXg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.4.1.tgz",
+      "integrity": "sha512-LHGdj0OQV5pgyZgC2WWiEvNg5g16dg+c3j7pw7Iuw7tJXEvltNLVl6DjC6egxSsWT03FJN0eUJxJ13Dxhz2bBA==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/langgraph": "^1.2.9",
+        "@langchain/langgraph": "^1.3.0",
         "@langchain/langgraph-checkpoint": "^1.0.1",
         "langsmith": ">=0.5.0 <1.0.0",
-        "uuid": "^11.1.0",
         "zod": "^3.25.76 || ^4"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.41"
+        "@langchain/core": "^1.1.47"
       }
     },
     "node_modules/langchain/node_modules/langsmith": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.25.tgz",
-      "integrity": "sha512-AG7NOymrDmwaWq+wus5hJHZjPFKXwsEdfqGBU3eZiF5242mme+5wuJocdBJKGyU1kgBO7TuLHiqtdyIwl4V4yQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.1.tgz",
+      "integrity": "sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==",
       "license": "MIT",
       "dependencies": {
         "p-queue": "6.6.2"
@@ -9673,19 +9746,6 @@
         "ws": {
           "optional": true
         }
-      }
-    },
-    "node_modules/langchain/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/langsmith": {
@@ -10737,16 +10797,25 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
-      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
+      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
       "bin": {
         "openai": "bin/cli"
       },
       "peerDependencies": {
         "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
+        "zod": "^3.23.8"
       },
       "peerDependenciesMeta": {
         "ws": {
@@ -10756,6 +10825,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/openapi-types": {
       "version": "12.1.3",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@copilotkit/runtime": "1.56.3",
+    "@copilotkit/runtime": "1.55.3",
     "@fastify/cors": "^8.4.2",
     "@fastify/helmet": "^11.1.1",
     "@fastify/jwt": "^7.2.3",


### PR DESCRIPTION
## Summary

CopilotKit 1.56.x introduced an agent-mandatory runtime model that the Insighta codebase has not migrated to. Two production-impact symptoms result:

1. **C1: `Agent default not found` warning ~1000/sec** — FE useCopilotChat / useAgent look up agentId `'default'` every render. Neither BE (`new CopilotRuntime()`) nor FE (`<CopilotKit>`) registers it. 16k warnings in <1h prod session, PostHog session replay bloat.
2. **C2: `POST .../learning/<id>/<id>/<random> 404` — chip click no response** — FE fetches sub-paths that resolve against current page URL instead of `runtimeUrl`. Every sendMessage 404s. User reports: chip click silent fail.

This PR pins all three @copilotkit packages to `1.55.3` (last pre-agent-runtime release):

| Package | Before | After |
|---|---|---|
| `frontend/@copilotkit/react-core` | `1.56.3` | `1.55.3` |
| `frontend/@copilotkit/react-ui` | `1.56.3` | `1.55.3` |
| `@copilotkit/runtime` (BE) | `1.56.3` | `1.55.3` |

Exact pin (no `~`/`^`) per CP479 silent-drift lesson.

## Scope

4 files: 2 package.json + 2 package-lock.json (+336 / -296)

**Out of scope** — `PR #732` race body-buffering fix preserved (copilotkit.ts not touched).

**Backlog** — Full 1.56.x agent runtime migration tracked in **#733** (deferred until after demo). Issue body carries:
- Full CP479 → CP477+8 history chain
- C1 + C2 error catalog
- 3 migration option specs (self-managed agents / CopilotCloud / FE-only proxy shim)
- Fact-check requirements + acceptance criteria

## Verification

- [x] BE `npx tsc --noEmit` clean
- [x] FE `npx tsc --noEmit` clean
- [x] FE `npx vitest run` — 35 files / 336 tests PASS
- [x] FE `npx vite build` clean (built 10.87s)
- [ ] CI 6/6 SUCCESS
- [ ] Post-merge: prod chip click → 200 stream response (no 404)
- [ ] Post-merge: console `Agent default not found` warning count = 0 over 5 min session
- [ ] Post-merge: race fix (PR #732) regression-free — body buffering still works on first request after settings cache miss

## Risk

Low. 1.55.3 is a published stable release of the line Insighta originally adopted. Pre-1.56 agent-runtime addition. CP479 already exercised an exact-pin downgrade pattern (1.56.5 auto-bump → 1.56.3 exact).

## Demo readiness

- This downgrade restores: chip click functional behaviour, console clean for session replay, no fetch URL resolution bug.
- Backlog item #733 retains the full migration spec so post-demo work can resume from a complete history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)