### PR TITLE
fix(billing): graceful fallback when LS customer is orphaned (404 vs 502)

### DIFF
--- a/frontend/src/features/billing/ui/SubscriptionStatusCard.tsx
+++ b/frontend/src/features/billing/ui/SubscriptionStatusCard.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/shared/ui/badge';
 import { ExternalLink, Crown } from 'lucide-react';
 import { usePortalUrl } from '../model/usePortalUrl';
 import { toast } from '@/shared/lib/use-toast';
+import { ApiHttpError } from '@/shared/lib/api-client';
 import type {
   BillingSubscriptionMeResponse,
   BillingSubscriptionStatus,
@@ -63,6 +64,18 @@ export function SubscriptionStatusCard({ data }: SubscriptionStatusCardProps) {
       const res = await portal.mutateAsync();
       window.open(res.portalUrl, '_blank', 'noopener,noreferrer');
     } catch (err) {
+      if (
+        err instanceof ApiHttpError &&
+        err.statusCode === 404 &&
+        err.code === 'BILLING_CUSTOMER_NOT_FOUND'
+      ) {
+        toast({
+          title: t('billing.card.portalOrphanedTitle'),
+          description: t('billing.card.portalOrphanedDesc'),
+          variant: 'destructive',
+        });
+        return;
+      }
       const message = err instanceof Error ? err.message : t('billing.card.portalErrorDesc');
       toast({
         title: t('billing.card.portalErrorTitle'),

--- a/frontend/src/pages/settings/ui/SubscriptionSettingsTab.tsx
+++ b/frontend/src/pages/settings/ui/SubscriptionSettingsTab.tsx
@@ -10,6 +10,7 @@ import { useBillingSubscription } from '@/features/billing/model/useBillingSubsc
 import { usePortalUrl } from '@/features/billing/model/usePortalUrl';
 import { toast } from '@/shared/lib/use-toast';
 import { cn } from '@/shared/lib/utils';
+import { ApiHttpError } from '@/shared/lib/api-client';
 import type { BillingSubscriptionStatus } from '@/shared/lib/api-client';
 
 const TIER_STYLES: Record<string, string> = {
@@ -96,6 +97,18 @@ export function SubscriptionSettingsTab() {
       const res = await portal.mutateAsync();
       window.open(res.portalUrl, '_blank', 'noopener,noreferrer');
     } catch (err) {
+      if (
+        err instanceof ApiHttpError &&
+        err.statusCode === 404 &&
+        err.code === 'BILLING_CUSTOMER_NOT_FOUND'
+      ) {
+        toast({
+          title: t('settings.billing.portalOrphanedTitle'),
+          description: t('settings.billing.portalOrphanedDesc'),
+          variant: 'destructive',
+        });
+        return;
+      }
       const message = err instanceof Error ? err.message : t('settings.billing.portalErrorDesc');
       toast({
         title: t('settings.billing.portalErrorTitle'),

--- a/frontend/src/pages/subscription/ui/SubscriptionPage.tsx
+++ b/frontend/src/pages/subscription/ui/SubscriptionPage.tsx
@@ -280,6 +280,21 @@ export default function SubscriptionPage() {
       const res = await portal.mutateAsync();
       window.open(res.portalUrl, '_blank', 'noopener,noreferrer');
     } catch (err) {
+      // BE returns BILLING_CUSTOMER_NOT_FOUND (404) when the user's row is
+      // orphaned in LS (mode mismatch / admin-granted lifetime). Show a
+      // distinct, actionable copy instead of a generic retry message.
+      if (
+        err instanceof ApiHttpError &&
+        err.statusCode === 404 &&
+        err.code === 'BILLING_CUSTOMER_NOT_FOUND'
+      ) {
+        toast({
+          title: t('billing.card.portalOrphanedTitle'),
+          description: t('billing.card.portalOrphanedDesc'),
+          variant: 'destructive',
+        });
+        return;
+      }
       const message = err instanceof Error ? err.message : t('billing.card.portalErrorDesc');
       toast({
         title: t('billing.card.portalErrorTitle'),

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -295,6 +295,8 @@
       "openingPortal": "Opening...",
       "portalErrorTitle": "Failed to open billing portal",
       "portalErrorDesc": "Please try again in a moment",
+      "portalOrphanedTitle": "Billing record not found",
+      "portalOrphanedDesc": "Your subscription is not registered with Lemon Squeezy. Please start a new checkout or contact support.",
       "noSubscriptionDesc": "Start Pro or Lifetime to enable billing management",
       "viewPlans": "View Plans",
       "lifetimeNote": "No auto-renewal. Refund requests can be made via the billing portal",
@@ -475,7 +477,9 @@
       "portalOpening": "Opening billing portal…",
       "portalFooter": "Update payment method or cancel from the Lemon Squeezy billing portal.",
       "portalErrorTitle": "Failed to open billing portal",
-      "portalErrorDesc": "An error occurred while opening the billing portal."
+      "portalErrorDesc": "An error occurred while opening the billing portal.",
+      "portalOrphanedTitle": "Billing record not found",
+      "portalOrphanedDesc": "Your subscription is not registered with Lemon Squeezy. Please start a new checkout or contact support."
     },
     "success": {
       "heading": "Preparing your plan",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -296,6 +296,8 @@
       "openingPortal": "열리는 중...",
       "portalErrorTitle": "결제 관리 열기 실패",
       "portalErrorDesc": "잠시 후 다시 시도해주세요",
+      "portalOrphanedTitle": "결제 정보 미확인",
+      "portalOrphanedDesc": "현재 결제 정보가 Lemon Squeezy 에 없습니다. 새 결제를 진행하거나 관리자에 문의해주세요.",
       "noSubscriptionDesc": "Pro 또는 평생 이용권을 시작하면 결제 관리가 활성화됩니다",
       "viewPlans": "플랜 보기",
       "lifetimeNote": "자동 갱신 없음. 환불은 결제 관리에서 신청 가능합니다",
@@ -483,7 +485,9 @@
       "portalOpening": "결제 관리 열기…",
       "portalFooter": "결제 수단 변경 · 해지는 Lemon Squeezy 결제 관리에서 진행됩니다.",
       "portalErrorTitle": "결제 관리 열기 실패",
-      "portalErrorDesc": "결제 관리 페이지를 여는 중 오류가 발생했습니다."
+      "portalErrorDesc": "결제 관리 페이지를 여는 중 오류가 발생했습니다.",
+      "portalOrphanedTitle": "결제 정보 미확인",
+      "portalOrphanedDesc": "현재 결제 정보가 Lemon Squeezy 에 없습니다. 새 결제를 진행하거나 관리자에 문의해주세요."
     },
     "success": {
       "heading": "플랜 준비하는 중",

--- a/src/api/routes/billing/portal.ts
+++ b/src/api/routes/billing/portal.ts
@@ -64,6 +64,27 @@ export async function billingPortalRoutes(fastify: FastifyInstance): Promise<voi
       return reply.send(createSuccessResponse({ portalUrl }));
     } catch (err) {
       if (err instanceof LemonSqueezyApiError) {
+        // LS 404 = customer no longer resolves in the current API key's mode
+        // (test row vs live key, deleted customer, admin-granted lifetime
+        // without a real LS purchase). Surface as a distinct error code so
+        // the client can prompt re-checkout / admin contact instead of a
+        // generic "try again" message that won't help.
+        if (err.status === 404) {
+          logger.warn('billing.portal LS customer not found (orphaned row)', {
+            user_id: userId,
+            provider_subscription_id: sub.provider_subscription_id,
+            ls_status: err.status,
+          });
+          return reply
+            .code(404)
+            .send(
+              createErrorResponse(
+                ErrorCode.BILLING_CUSTOMER_NOT_FOUND,
+                'subscription row exists but LS customer is not resolvable',
+                request.url
+              )
+            );
+        }
         logger.warn('billing.portal LS error', { status: err.status });
         return reply
           .code(502)

--- a/src/api/schemas/common.schema.ts
+++ b/src/api/schemas/common.schema.ts
@@ -82,6 +82,14 @@ export enum ErrorCode {
   RESOURCE_NOT_FOUND = 'RESOURCE_NOT_FOUND',
   PLAYLIST_NOT_FOUND = 'PLAYLIST_NOT_FOUND',
   VIDEO_NOT_FOUND = 'VIDEO_NOT_FOUND',
+  /**
+   * Billing-specific 404: the user has a `billing_subscriptions` row but the
+   * associated LS customer no longer resolves (mode mismatch, deleted in LS
+   * dashboard, or admin-granted lifetime without a real LS customer). Lets
+   * the client distinguish "no subscription" from "subscription row exists
+   * but is orphaned" so the UI can prompt re-checkout / admin contact.
+   */
+  BILLING_CUSTOMER_NOT_FOUND = 'BILLING_CUSTOMER_NOT_FOUND',
 
   // Validation errors (400)
   VALIDATION_ERROR = 'VALIDATION_ERROR',


### PR DESCRIPTION
## Summary

When a \`billing_subscriptions\` row exists but the linked LS customer no longer resolves — test row + live API key, customer deleted in LS dashboard, or admin-granted lifetime without a real LS purchase — \`getCustomer()\` returns 404. The portal route previously surfaced this as a generic 502 \"LS portal lookup failed\" toast with no actionable advice.

This PR distinguishes **orphaned-customer (404)** from **generic LS API failure (5xx)** so the UI can prompt re-checkout / admin contact instead of a useless \"try again\" message.

## What changes

| Layer | File | Change |
|---|---|---|
| BE | \`src/api/schemas/common.schema.ts\` | New \`ErrorCode.BILLING_CUSTOMER_NOT_FOUND\` in Resource errors (404) with JSDoc |
| BE | \`src/api/routes/billing/portal.ts\` | \`LemonSqueezyApiError.status === 404\` → 404 + new ErrorCode + structured log (user_id + provider_subscription_id + ls_status). Other LS errors → keep 502 unchanged |
| FE | \`SubscriptionPage.tsx\` onPortal | \`err.code === 'BILLING_CUSTOMER_NOT_FOUND'\` → orphaned toast (distinct from generic) |
| FE | \`SubscriptionSettingsTab.tsx\` onPortal | Same pattern (settings page) |
| FE | \`SubscriptionStatusCard.tsx\` onPortal | Same pattern (legacy component, still used) |
| FE | \`shared/i18n/locales/{ko,en}.json\` | 4 new keys: \`billing.card.portalOrphanedTitle/Desc\` + \`settings.billing.portalOrphanedTitle/Desc\` |

## Why not just delete the orphaned row

The orphaned row might be intentional (admin-granted lifetime, founder access, etc.). Auto-deleting would silently remove admin override. This PR keeps the row and just makes the UX accurate.

## Test plan after merge

- [ ] Admin-granted lifetime user (current James Kim test case) clicks \"결제 관리\" → toast = \"결제 정보 미확인 / 현재 결제 정보가 Lemon Squeezy 에 없습니다. 새 결제를 진행하거나 관리자에 문의해주세요.\"
- [ ] Real LS subscriber (after new-account real-charge test, Phase 2 of CP476+1 plan) clicks \"결제 관리\" → LS portal opens in new tab (no regression).
- [ ] Other LS API failures (forced 5xx, network) → existing generic toast (no regression).

## Rollback

\`gh pr revert\` (7 files, no DB / no schema). Existing \`RESOURCE_NOT_FOUND\` 404 path for missing subscription stays untouched.

## CP460 worktree note

This PR built in an isolated \`git worktree\` (\`~/cursor/insighta-portal-fallback\`) so the main working directory (\`feat/learning-share-2026-05-21\` session) was unaffected. Standard practice now per CP460 LEVEL-2+ rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)