### PR TITLE
fix(chatbot): race-safe qwen-runpod → openrouter failover restore (CP477+11)

### DIFF
--- a/src/api/routes/copilotkit-health.ts
+++ b/src/api/routes/copilotkit-health.ts
@@ -16,7 +16,13 @@ import { toRunpodOpenAiBase } from './copilotkit-base-url';
 import type { ChatbotProvider } from './copilotkit-model-resolver';
 
 const VLLM_HEALTH_CACHE_MS = 5_000;
-const VLLM_HEALTH_PROBE_TIMEOUT_MS = 2_000;
+// CP477+11 — shortened from 2000 to 500ms per CP477+6 handoff §4.1 spec.
+// 2s probe timeout was an obvious user-facing tax on every cache-miss
+// path (cold start + every 5min cache boundary). 500ms is still generous
+// for a RunPod /health response (typical p95 < 100ms warm) while
+// keeping the worst-case race window narrow enough that the
+// req.pause()/req.resume() body buffer in copilotkit.ts can absorb it.
+const VLLM_HEALTH_PROBE_TIMEOUT_MS = 500;
 
 interface VllmHealthCache {
   healthy: boolean;

--- a/src/api/routes/copilotkit.ts
+++ b/src/api/routes/copilotkit.ts
@@ -11,11 +11,13 @@ import { config } from '@/config/index';
 import { QwenRunpodAdapter } from '@/modules/chatbot-rag';
 import { getChatbotSettings } from '@/modules/chatbot-settings/service';
 import { toRunpodOpenAiBase } from './copilotkit-base-url';
+import { isQwenRunpodHealthy, resolveEffectiveProvider } from './copilotkit-health';
 import {
   resolveChatbotModel,
   type ChatbotProvider,
   type ProviderDefaults,
 } from './copilotkit-model-resolver';
+import { logger } from '@/utils/logger';
 
 const OPENROUTER_DEFAULT_MODEL = 'google/gemini-2.5-flash';
 
@@ -84,16 +86,31 @@ type YogaHandler = ReturnType<typeof copilotRuntimeNodeHttpEndpoint>;
 
 let lazyYoga: YogaHandler | null = null;
 let lazyBuildAt = 0;
+// CP477+11 — Restored from PR #720 (CP477+3, reverted at CP477+6 PR #729
+// due to race condition). Race is now neutralised by CP477+7 PR #732
+// `req.pause()`/`req.resume()` body buffering, so health-check failover
+// can return safely. Tracks the provider the current yoga handler was
+// built for so we can rebuild when failover flips qwen-runpod ↔ openrouter.
+let lazyEffectiveProvider: ChatbotProvider | null = null;
 
 async function getYoga(): Promise<YogaHandler> {
   const settings = await getChatbotSettings();
-  if (!lazyYoga || settings.updatedAt.getTime() > lazyBuildAt) {
-    const provider = config.chatbot.provider;
-    const model = resolveChatbotModel(provider, config.chatbot.model, buildProviderDefaults(), {
+  // Resolve which provider will actually serve this request. When
+  // `config.chatbot.provider === 'qwen-runpod'` and the RunPod Pod
+  // /health probe fails, this returns 'openrouter' so users keep getting
+  // responses even while the Pod is down (cost-pause or migration).
+  const configured = config.chatbot.provider;
+  const effective = await resolveEffectiveProvider(configured, config.qwenLora.apiUrl);
+  if (
+    !lazyYoga ||
+    settings.updatedAt.getTime() > lazyBuildAt ||
+    effective !== lazyEffectiveProvider
+  ) {
+    const model = resolveChatbotModel(effective, config.chatbot.model, buildProviderDefaults(), {
       qwenRunpodModel: settings.qwenRunpodModel,
       openrouterModel: settings.openrouterModel,
     });
-    const serviceAdapter = createServiceAdapter(provider, model);
+    const serviceAdapter = createServiceAdapter(effective, model);
     const runtime = new CopilotRuntime();
     lazyYoga = copilotRuntimeNodeHttpEndpoint({
       runtime,
@@ -101,6 +118,7 @@ async function getYoga(): Promise<YogaHandler> {
       endpoint: '/api/v1/chat',
     });
     lazyBuildAt = Date.now();
+    lazyEffectiveProvider = effective;
   }
   return lazyYoga;
 }
@@ -153,18 +171,41 @@ export const copilotKitRoutes: FastifyPluginCallback = (fastify, _opts, done) =>
 
   fastify.get('/config', { onRequest: [fastify.authenticate] }, async (_request, reply) => {
     // Resolve the live model the same way getYoga() does so /config always
-    // reflects the value the next chat request will actually use.
-    const provider = config.chatbot.provider;
+    // reflects the value the next chat request will actually use —
+    // including the CP477+11 health-check failover (qwen-runpod →
+    // openrouter when Pod /health probe fails).
+    const configured = config.chatbot.provider;
+    const effective = await resolveEffectiveProvider(configured, config.qwenLora.apiUrl);
     const settings = await getChatbotSettings();
-    const model = resolveChatbotModel(provider, config.chatbot.model, buildProviderDefaults(), {
+    const model = resolveChatbotModel(effective, config.chatbot.model, buildProviderDefaults(), {
       qwenRunpodModel: settings.qwenRunpodModel,
       openrouterModel: settings.openrouterModel,
     });
     return reply.send({
       status: 200,
-      data: { provider, model },
+      data: { provider: effective, configured, model },
     });
   });
+
+  // CP477+11 — Server-start warm-up: prime the vLLM health cache once at
+  // boot so the first user chat request can hit a warm cache and skip
+  // the 500ms /health probe entirely. Fire-and-forget — failure here is
+  // recoverable (per-request probe will retry).
+  if (config.chatbot.provider === 'qwen-runpod' && config.qwenLora.apiUrl) {
+    void isQwenRunpodHealthy(config.qwenLora.apiUrl)
+      .then((healthy) => {
+        logger.info('CP477+11 chatbot health warm-up complete', {
+          healthy,
+          apiUrl: config.qwenLora.apiUrl,
+        });
+      })
+      .catch((err) => {
+        logger.warn(
+          'CP477+11 chatbot health warm-up failed (continuing — per-request probe will retry)',
+          { err: err instanceof Error ? err.message : String(err) }
+        );
+      });
+  }
 
   done();
 };


### PR DESCRIPTION
## Summary

Restores the health-check failover (PR #720 CP477+3 reverted at PR #729 CP477+6 due to race condition). Race is now plugged by PR #732 CP477+7 `req.pause()`/`req.resume()` body buffering, so failover can return.

**Operational benefit**: Pod stopped or in migration → chatbot keeps responding via OpenRouter Gemini 2.5 Flash. No manual `gh variable set` + redeploy needed every Pod outage. User directive: "데모시에는 runpod 올려서 보여주고, 이후 즉시 stop 예정이라서 fallback 이 있어야 openrouter로 서비스가 정상 동작할수 있음."

## Changes

1. **`copilotkit-health.ts`**: `VLLM_HEALTH_PROBE_TIMEOUT_MS` 2000 → 500ms. RunPod /health p95 < 100ms warm; 500ms cushion + body-buffer absorbs slow probes.

2. **`copilotkit.ts`**:
   - Restore `lazyEffectiveProvider` cache tag.
   - `getYoga()` calls `resolveEffectiveProvider(configured, apiUrl)` per request. Healthy Pod → 5s cache hit (microseconds). Pod down → resolver returns 'openrouter', next request rebuilds yoga.
   - `/config` returns `{ provider: effective, configured, model }` so ops can see when failover is active.
   - Server-start warm-up: fire-and-forget `isQwenRunpodHealthy(apiUrl)` once at route registration. First user chat hits warm cache.

## Race safety

PR #720's failover was reverted because `await getYoga()` widened the body-stream race window. PR #732's `req.pause()` / `req.resume()` now buffers the body during the same async window. Same buffer absorbs the failover's added async hop (5s cache hit or 500ms fetch).

## Verification

- [x] `npx tsc --noEmit` clean
- [ ] CI 6/6 SUCCESS
- [ ] Post-merge prod: Pod up → chat works (qwen-runpod, LoRA response)
- [ ] Post-merge prod: Pod stopped → chat keeps working (openrouter, Gemini Flash response)
- [ ] Post-merge prod: `/api/v1/chat/config` returns `provider:openrouter, configured:qwen-runpod` when Pod down
- [ ] Race regression check: cold-start chat request + settings cache miss → no 400 "Invalid JSON payload"

## Demo plan

- Demo: RunPod Pod up → LoRA responses (Insighta-specific fine-tune).
- Post-demo: stop RunPod Pod (cost) → failover kicks in automatically → users keep getting Gemini Flash responses. No service downtime, no manual flip.

## Related

- PR #720 CP477+3 — original failover (reverted)
- PR #729 CP477+6 — race-driven revert
- PR #732 CP477+7 — body buffer (race fix this PR depends on)
- Issue #733 — full 1.56.x agent migration (separate, deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)