### PR TITLE
fix(nginx): sw.js + manifest no-cache + Clear-Site-Data one-shot purge (CP477+12)

### DIFF
--- a/frontend/nginx/nginx.conf.template
+++ b/frontend/nginx/nginx.conf.template
@@ -18,6 +18,36 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
+    # CP477+12 — PWA update entry points MUST NOT be aggressively cached.
+    # `sw.js`, `registerSW.js`, `workbox-*.js`, and `manifest.webmanifest`
+    # are fixed-name files (no content hash in the filename) that gate
+    # every future SW update. The 1-year immutable rule below catches
+    # every `.js` extension by regex and was freezing `sw.js` in user
+    # browsers for up to 30 days, so `autoUpdate` + `skipWaiting` +
+    # `clientsClaim` were powerless to roll out new builds — users stayed
+    # pinned to the old precache manifest indefinitely.
+    # These exact-match blocks (`location =`) take precedence over the
+    # regex below, so the immutable rule still applies to hashed assets
+    # like `assets/index-BGfM-roU.js`.
+    location = /sw.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        expires 0;
+        access_log off;
+    }
+    location = /registerSW.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        expires 0;
+        access_log off;
+    }
+    location = /manifest.webmanifest {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        expires 0;
+        access_log off;
+    }
+
     # Static file caching - Vite uses content hashes in filenames
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
@@ -49,6 +79,18 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
         add_header Pragma "no-cache";
         add_header Expires "0";
+
+        # CP477+12 — one-shot client-side cache clear so users whose
+        # browsers already have the previous (incorrectly cached) sw.js
+        # frozen for up to 30 days will fetch the new (no-cache) sw.js
+        # on their next navigation. `Clear-Site-Data: "cache"` empties
+        # the HTTP cache (including the stale sw.js) but preserves
+        # localStorage / IndexedDB / SW registration data, so users do
+        # not lose any app state. The new SW registers on the same load
+        # and uses the new chunk manifest.
+        # TODO (remove ~1-2 weeks after deploy): keeping this header
+        # long-term hurts cache hit rate. Tracked as a follow-up.
+        add_header Clear-Site-Data "\"cache\"" always;
     }
 
     # Error pages


### PR DESCRIPTION
## Root cause

User reported chatbot loading the OLD CopilotKit 1.56.x build (chunks like `mermaid-VLURNSYL-Bn_0jG_E.js`) even after 20× hard refresh. The freshly-deployed `/sw.js` precache references the NEW chunk `mermaid-VLURNSYL-BSKyIf3V.js`. Service Worker was frozen, holding the precache manifest from the pre-1.55.3-downgrade build.

```
$ curl -sI https://insighta.one/sw.js
cache-control: max-age=2592000
cache-control: public, immutable
```

The `nginx.conf.template` regex `location ~* \.(js|css|png|...)$` matched `sw.js` and gave it 30-day immutable cache. Browsers serve `sw.js` from disk cache for 30 days — hard refresh doesn't bypass it. With `sw.js` frozen, the precache manifest is frozen, and `autoUpdate` / `skipWaiting` / `clientsClaim` have no new manifest to apply.

This explains every stale-build report that survived hard refreshes.

## Fix

1. **Exact-match locations for PWA gates** (`/sw.js`, `/registerSW.js`, `/manifest.webmanifest`) → `no-cache, no-store, must-revalidate`. `location =` precedes the regex, so hashed assets keep their 1-year immutable cache.

2. **One-shot `Clear-Site-Data: "cache"`** on the SPA fallback so users whose browsers already have the 30-day stale `sw.js` will drop their HTTP cache (including the stale sw.js) on the next page load. Preserves localStorage / IndexedDB / SW registration — no app data lost.

## Post-deploy verification

- [ ] `curl -sI https://insighta.one/sw.js | grep -i cache` → `no-cache, no-store, must-revalidate`
- [ ] `curl -sI https://insighta.one/ | grep -i clear-site-data` → `"cache"`
- [ ] User browser next navigation → stale sw.js refetched → chatbot loads 1.55.3 build → 5-icon add-to-note + race fix + failover all active

## Backlog

- Remove `Clear-Site-Data` header 1-2 weeks after this deploy (cache hit rate hurts long-term).
- Investigate versioned-filename `sw.js` via vite-plugin-pwa so this class can't recur if the regex is widened again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)