### PR TITLE
fix(nginx): forward client Connection header instead of forcing 'upgrade' (CP477+13)

### DIFF
--- a/frontend/nginx/nginx.conf.template
+++ b/frontend/nginx/nginx.conf.template
@@ -60,7 +60,18 @@ server {
         proxy_pass ${API_URL}/api/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
+        # CP477+13 — was hardcoded `Connection 'upgrade'`, which forced
+        # every BE request (including normal HTTP POST /api/v1/chat) to
+        # carry an `upgrade` connection header. CopilotKit 1.55.3 V2
+        # runtime sends JSON POSTs with no websocket; the forced upgrade
+        # combined with the BE raw HTTP `req.pause()`/`req.resume()` body
+        # buffering (PR #732 CP477+7) caused intermittent body stream
+        # loss -> `{"error":"invalid_request","message":"Invalid JSON
+        # payload"}` 400. Forward the client's own Connection header
+        # instead; real websocket clients still send `upgrade` and pass
+        # through, plain HTTP clients send `keep-alive` and avoid the
+        # upgrade negotiation entirely.
+        proxy_set_header Connection $http_connection;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Root cause (codebase-confirmed)

Prod chatbot returns `{"error":"invalid_request","message":"Invalid JSON payload"}` 400 on every CopilotKit message; dev (same code, no nginx) is fine. Curl `https://insighta.one/api/v1/chat` confirms the 400 is added by the prod edge, not the BE source.

`frontend/nginx/nginx.conf.template` `/api/` had hardcoded literal:

```nginx
proxy_set_header Connection 'upgrade';
```

This forced **every** upstream request — even plain HTTP POSTs — to carry `Connection: upgrade`. The classic nginx websocket-template mistake.

Stable for 3 months because the BE accepted bodies via Fastify body parser. PR #732 (CP477+7) moved `/api/v1/chat` onto a raw HTTP listener with `req.pause()`/`req.resume()` body buffering. Combination (forced upgrade + manual stream pause/resume) → BE log evidence in prod:

```
Request stream consumed with no available body; sending empty payload.
```

× 5+ at 16:18-16:21 UTC. CopilotKit 1.55.3 V2 runtime `parseMethodCall` then rejected the empty body with 400.

## Why dev was unaffected

`frontend/vite.config.ts` proxy forwards client's own Connection header (`keep-alive`) — no forced upgrade. Same BE code, different proxy = different result.

## Fix

```diff
- proxy_set_header Connection 'upgrade';
+ proxy_set_header Connection $http_connection;
```

Forward the client's Connection header verbatim — match dev behavior.

| Client | Sends | Upstream gets |
|---|---|---|
| Browser / curl (HTTP) | `keep-alive` | `keep-alive` ← drained cleanly |
| Websocket client | `upgrade` | `upgrade` ← still works |
| No Connection header | (empty) | (empty) ← HTTP/1.1 default close |

`Upgrade $http_upgrade` kept for future WS endpoints.

## Post-deploy verification

```
curl -sS -X POST https://insighta.one/api/v1/chat \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer ...' \
  -d '{"method":"info","params":{}}' --max-time 8
```

Expect: NOT 400 "Invalid JSON payload" (401 unauth or 200 depending on token).

Browser: chatbot responses return instead of `[CopilotKit] sendMessage error: HTTP 400` storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)