### PR TITLE
revert(chatbot): drop CP477+11 failover restore (race-fix paused window insufficient)

### DIFF
--- a/src/api/routes/copilotkit-health.ts
+++ b/src/api/routes/copilotkit-health.ts
@@ -16,13 +16,7 @@ import { toRunpodOpenAiBase } from './copilotkit-base-url';
 import type { ChatbotProvider } from './copilotkit-model-resolver';
 
 const VLLM_HEALTH_CACHE_MS = 5_000;
-// CP477+11 — shortened from 2000 to 500ms per CP477+6 handoff §4.1 spec.
-// 2s probe timeout was an obvious user-facing tax on every cache-miss
-// path (cold start + every 5min cache boundary). 500ms is still generous
-// for a RunPod /health response (typical p95 < 100ms warm) while
-// keeping the worst-case race window narrow enough that the
-// req.pause()/req.resume() body buffer in copilotkit.ts can absorb it.
-const VLLM_HEALTH_PROBE_TIMEOUT_MS = 500;
+const VLLM_HEALTH_PROBE_TIMEOUT_MS = 2_000;
 
 interface VllmHealthCache {
   healthy: boolean;

--- a/src/api/routes/copilotkit.ts
+++ b/src/api/routes/copilotkit.ts
@@ -11,13 +11,11 @@ import { config } from '@/config/index';
 import { QwenRunpodAdapter } from '@/modules/chatbot-rag';
 import { getChatbotSettings } from '@/modules/chatbot-settings/service';
 import { toRunpodOpenAiBase } from './copilotkit-base-url';
-import { isQwenRunpodHealthy, resolveEffectiveProvider } from './copilotkit-health';
 import {
   resolveChatbotModel,
   type ChatbotProvider,
   type ProviderDefaults,
 } from './copilotkit-model-resolver';
-import { logger } from '@/utils/logger';
 
 const OPENROUTER_DEFAULT_MODEL = 'google/gemini-2.5-flash';
 
@@ -86,31 +84,16 @@ type YogaHandler = ReturnType<typeof copilotRuntimeNodeHttpEndpoint>;
 
 let lazyYoga: YogaHandler | null = null;
 let lazyBuildAt = 0;
-// CP477+11 — Restored from PR #720 (CP477+3, reverted at CP477+6 PR #729
-// due to race condition). Race is now neutralised by CP477+7 PR #732
-// `req.pause()`/`req.resume()` body buffering, so health-check failover
-// can return safely. Tracks the provider the current yoga handler was
-// built for so we can rebuild when failover flips qwen-runpod ↔ openrouter.
-let lazyEffectiveProvider: ChatbotProvider | null = null;
 
 async function getYoga(): Promise<YogaHandler> {
   const settings = await getChatbotSettings();
-  // Resolve which provider will actually serve this request. When
-  // `config.chatbot.provider === 'qwen-runpod'` and the RunPod Pod
-  // /health probe fails, this returns 'openrouter' so users keep getting
-  // responses even while the Pod is down (cost-pause or migration).
-  const configured = config.chatbot.provider;
-  const effective = await resolveEffectiveProvider(configured, config.qwenLora.apiUrl);
-  if (
-    !lazyYoga ||
-    settings.updatedAt.getTime() > lazyBuildAt ||
-    effective !== lazyEffectiveProvider
-  ) {
-    const model = resolveChatbotModel(effective, config.chatbot.model, buildProviderDefaults(), {
+  if (!lazyYoga || settings.updatedAt.getTime() > lazyBuildAt) {
+    const provider = config.chatbot.provider;
+    const model = resolveChatbotModel(provider, config.chatbot.model, buildProviderDefaults(), {
       qwenRunpodModel: settings.qwenRunpodModel,
       openrouterModel: settings.openrouterModel,
     });
-    const serviceAdapter = createServiceAdapter(effective, model);
+    const serviceAdapter = createServiceAdapter(provider, model);
     const runtime = new CopilotRuntime();
     lazyYoga = copilotRuntimeNodeHttpEndpoint({
       runtime,
@@ -118,7 +101,6 @@ async function getYoga(): Promise<YogaHandler> {
       endpoint: '/api/v1/chat',
     });
     lazyBuildAt = Date.now();
-    lazyEffectiveProvider = effective;
   }
   return lazyYoga;
 }
@@ -171,41 +153,18 @@ export const copilotKitRoutes: FastifyPluginCallback = (fastify, _opts, done) =>
 
   fastify.get('/config', { onRequest: [fastify.authenticate] }, async (_request, reply) => {
     // Resolve the live model the same way getYoga() does so /config always
-    // reflects the value the next chat request will actually use —
-    // including the CP477+11 health-check failover (qwen-runpod →
-    // openrouter when Pod /health probe fails).
-    const configured = config.chatbot.provider;
-    const effective = await resolveEffectiveProvider(configured, config.qwenLora.apiUrl);
+    // reflects the value the next chat request will actually use.
+    const provider = config.chatbot.provider;
     const settings = await getChatbotSettings();
-    const model = resolveChatbotModel(effective, config.chatbot.model, buildProviderDefaults(), {
+    const model = resolveChatbotModel(provider, config.chatbot.model, buildProviderDefaults(), {
       qwenRunpodModel: settings.qwenRunpodModel,
       openrouterModel: settings.openrouterModel,
     });
     return reply.send({
       status: 200,
-      data: { provider: effective, configured, model },
+      data: { provider, model },
     });
   });
-
-  // CP477+11 — Server-start warm-up: prime the vLLM health cache once at
-  // boot so the first user chat request can hit a warm cache and skip
-  // the 500ms /health probe entirely. Fire-and-forget — failure here is
-  // recoverable (per-request probe will retry).
-  if (config.chatbot.provider === 'qwen-runpod' && config.qwenLora.apiUrl) {
-    void isQwenRunpodHealthy(config.qwenLora.apiUrl)
-      .then((healthy) => {
-        logger.info('CP477+11 chatbot health warm-up complete', {
-          healthy,
-          apiUrl: config.qwenLora.apiUrl,
-        });
-      })
-      .catch((err) => {
-        logger.warn(
-          'CP477+11 chatbot health warm-up failed (continuing — per-request probe will retry)',
-          { err: err instanceof Error ? err.message : String(err) }
-        );
-      });
-  }
 
   done();
 };


### PR DESCRIPTION
## Reason

Restoring CP477+11 failover (PR #737) reintroduced the body-stream race that PR #737 itself claimed to neutralise. Dev/prod both showed `[CopilotKit] sendMessage error: HTTP 400 Invalid JSON payload` storm after `843e7213` was on main. After this revert commit dropped the failover (`c9a1a63a`, since dropped, recreated here), user-confirmed dev test = chatbot + 메모추가 정상 동작. After failover was put back, dev broke again — direct user observation.

PR #737's hypothesis was that `req.pause()/req.resume()` would buffer the body across the failover's additional `await resolveEffectiveProvider()` hop. Prod BE log evidence (16:18-16:21 UTC) refutes that:

```
Request stream consumed with no available body; sending empty payload.
× 5+
```

i.e. the paused window does not, in practice, hold the body across a second async hop on this BE+Fastify+CopilotKit-1.55.3 stack.

## Trade-off

Without failover, a stopped/migrated RunPod Pod = chatbot down until manual `gh variable set CHATBOT_PROVIDER=openrouter` + redeploy.

**Demo mitigation**: keep RunPod Pod alive throughout the demo. Stop the Pod only after the demo session. Cost vs reliability is acceptable for the launch window.

## What this revert restores

`src/api/routes/copilotkit.ts`:
- Drop `isQwenRunpodHealthy` + `resolveEffectiveProvider` imports
- Drop `lazyEffectiveProvider` tracking
- `getYoga()` reverts to: settings cache only, no per-request health probe
- `/config` returns the configured provider only (no effective vs configured split)
- Drop server-start health warm-up

`src/api/routes/copilotkit-health.ts`:
- File preserved as dead code (no imports). Available for a future, properly-race-isolated failover (e.g. proxy-layer failover, separate process, or runtime-managed adapter switch — out of scope here).

## Follow-up backlog

- Real failover requires moving the provider-selection async hop **out** of the raw HTTP request path. Candidates:
  1. Background poller updates `lazyEffectiveProvider` every 5s; request handler only reads (no await).
  2. Failover at the nginx/proxy layer (upstream group with passive health checks).
  3. CopilotKit `CopilotRuntime` accepts an adapter factory function — switch adapter on health change event, not per-request.
- Track as issue once chatbot is stable on prod.

## Verification

- BE `npx tsc --noEmit` clean (verified pre-push)
- FE `npx tsc --noEmit` clean (no FE changes in this revert)
- Dev (tsx watch will auto-reload on file change) — user already validated this state once before the revert was dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)