### PR TITLE
feat(chatbot-rag): full structural context plumbing — user / mandala / book / cards / note / RAG (CP477+15)

### DIFF
--- a/src/api/routes/chatbot-context-storage.ts
+++ b/src/api/routes/chatbot-context-storage.ts
@@ -1,0 +1,80 @@
+/**
+ * src/api/routes/chatbot-context-storage.ts
+ *
+ * Per-request `AsyncLocalStorage` for the CopilotKit chatbot pipeline (CP477+15).
+ *
+ * Problem this solves:
+ *   - The chatbot route mounts on the raw HTTP `server.on('request')` listener
+ *     (PR #732 CP477+7) to bypass Fastify body parsing. That bypass also skips
+ *     Fastify's `fastify.authenticate` decorator, so the deep code path inside
+ *     CopilotKit's `getLanguageModel()` → `qwen-prompt-middleware` has no access
+ *     to `request.user.userId`.
+ *   - CP474 designed `loadUserContext({ userId, email, ... })` for Block U
+ *     (mandala_count, mandala_titles, ...) but the middleware was marked
+ *     "Out of scope — deferred to Stage 7b+ (plumbing change)".
+ *
+ * Why AsyncLocalStorage (not CopilotRuntime properties, not env, not header pass-through):
+ *   - We need request-scoped data accessible from inside a Vercel AI SDK
+ *     middleware that has no parameter for it. AsyncLocalStorage is the
+ *     Node-native way to thread request context through unrelated async
+ *     code without changing every intermediate signature.
+ *   - The yoga handler + service adapter live inside the same async context
+ *     as the listener that received the request, so `getStore()` resolves
+ *     to the right entry without explicit propagation.
+ *
+ * Lifecycle:
+ *   - Set by `runWithChatbotContext(ctx, fn)` in `copilotkit.ts` immediately
+ *     after JWT verify (inside the `req.pause()` paused window).
+ *   - Read by `getChatbotContext()` from inside
+ *     `qwen-prompt-middleware.rewriteSystemContent`.
+ *   - Cleared automatically when the outer async function unwinds (Node's
+ *     AsyncLocalStorage handles this via the async resource lifetime).
+ *
+ * Safety:
+ *   - `userId`/`email` are optional — JWT verify failure leaves the store
+ *     unpopulated. Middleware code MUST treat `getChatbotContext()` as
+ *     possibly `undefined` and fall back to the pre-CP477+15 behaviour (no
+ *     Block U).
+ *   - No secrets land here. `email` is non-sensitive (UI displays it) but
+ *     never logged.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export interface ChatbotRequestContext {
+  /** Supabase auth user id (`sub` claim from JWT). */
+  userId?: string;
+  /** Decoded JWT email. */
+  email?: string;
+  /** Display name from `user_metadata.name` / `full_name`. */
+  displayName?: string;
+}
+
+const chatbotContextStorage = new AsyncLocalStorage<ChatbotRequestContext>();
+
+/**
+ * Run `fn` with the given chatbot context bound to AsyncLocalStorage.
+ *
+ * Use this in the chatbot route's request handler:
+ *
+ *     await runWithChatbotContext({ userId, email }, async () => {
+ *       await yogaHandler(req, res);
+ *     });
+ *
+ * Nested calls overwrite — the innermost `run` wins for the nested async
+ * region, then the outer one is restored when the nested promise resolves.
+ */
+export function runWithChatbotContext<T>(
+  ctx: ChatbotRequestContext,
+  fn: () => Promise<T> | T
+): Promise<T> | T {
+  return chatbotContextStorage.run(ctx, fn);
+}
+
+/**
+ * Read the current request's chatbot context. Returns `undefined` outside
+ * of a `runWithChatbotContext` call — callers MUST handle that case.
+ */
+export function getChatbotContext(): ChatbotRequestContext | undefined {
+  return chatbotContextStorage.getStore();
+}

--- a/src/api/routes/copilotkit.ts
+++ b/src/api/routes/copilotkit.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
-import { FastifyPluginCallback } from 'fastify';
+import type { IncomingMessage } from 'node:http';
+import type { FastifyInstance, FastifyPluginCallback } from 'fastify';
 import {
   CopilotRuntime,
   OpenAIAdapter,
@@ -10,6 +11,7 @@ import OpenAI from 'openai';
 import { config } from '@/config/index';
 import { QwenRunpodAdapter } from '@/modules/chatbot-rag';
 import { getChatbotSettings } from '@/modules/chatbot-settings/service';
+import { extractTokenFromHeader } from '@/api/plugins/auth';
 import { toRunpodOpenAiBase } from './copilotkit-base-url';
 import {
   resolveChatbotModel,
@@ -17,6 +19,7 @@ import {
   type ProviderDefaults,
 } from './copilotkit-model-resolver';
 import { getEffectiveProvider, startProviderHealthPoller } from './copilotkit-provider-poller';
+import { runWithChatbotContext, type ChatbotRequestContext } from './chatbot-context-storage';
 
 const OPENROUTER_DEFAULT_MODEL = 'google/gemini-2.5-flash';
 
@@ -93,6 +96,53 @@ let lazyBuildAt = 0;
 // preserved byte-for-byte.
 let lazyBuiltProvider: ChatbotProvider | null = null;
 
+/**
+ * CP477+15 — Extract authenticated user identity from the request's
+ * Authorization header so the qwen prompt middleware can build Block U
+ * (mandala_count, mandala_titles, current_mandala_name). Returns an
+ * empty context on missing / malformed / invalid JWT — the middleware
+ * treats `{ userId: undefined }` as "skip Block U" and falls back to
+ * the pre-CP477+15 behaviour, so a failed extract never breaks the
+ * chatbot.
+ *
+ * Mirrors the JWT verify path in `src/api/plugins/auth.ts:167` but does
+ * not require the Fastify request lifecycle (raw HTTP listener bypasses
+ * it). Uses `fastify.jwt.verify(token)` directly — the same JWKS public
+ * key cache the `fastify.authenticate` decorator uses.
+ */
+async function extractChatbotContext(
+  fastify: FastifyInstance,
+  req: IncomingMessage
+): Promise<ChatbotRequestContext> {
+  const authHeader = req.headers['authorization'];
+  if (typeof authHeader !== 'string') return {};
+  const token = extractTokenFromHeader(authHeader);
+  if (!token) return {};
+  try {
+    const claims = fastify.jwt.verify<{
+      sub: string;
+      email?: string;
+      user_metadata?: Record<string, unknown>;
+    }>(token);
+    const userMeta = claims.user_metadata ?? {};
+    const displayName =
+      (userMeta['name'] as string | undefined) ??
+      (userMeta['full_name'] as string | undefined) ??
+      claims.email?.split('@')[0] ??
+      undefined;
+    return {
+      userId: claims.sub,
+      email: claims.email ?? '',
+      displayName,
+    };
+  } catch {
+    // JWT missing / expired / malformed — return empty context. The
+    // middleware will skip Block U and the chatbot still responds with
+    // the legacy persona + video context.
+    return {};
+  }
+}
+
 async function getYoga(): Promise<YogaHandler> {
   const settings = await getChatbotSettings();
   // Read-only synchronous lookup — no await, no health probe, no race with
@@ -136,9 +186,19 @@ export const copilotKitRoutes: FastifyPluginCallback = (fastify, _opts, done) =>
       req.pause();
       void (async () => {
         try {
+          // CP477+15 — Extract the authenticated user identity from the
+          // Authorization header so the qwen prompt middleware can build
+          // Block U (mandala_count / mandala_titles / current_mandala_name).
+          // JWT verify is a quick async hop (~5-20ms with the JWKS public
+          // key already cached), and it sits inside the `req.pause()` paused
+          // window so the body buffer absorbs it just like the existing
+          // `await getYoga()` hop.
+          const chatbotCtx = await extractChatbotContext(fastify, req);
           const handler = await getYoga();
-          req.resume();
-          await handler(req, res);
+          await runWithChatbotContext(chatbotCtx, async () => {
+            req.resume();
+            await handler(req, res);
+          });
         } catch (err) {
           // Pre-handler async step failed (e.g., chatbot_settings DB
           // unreachable, adapter env missing). Without this catch the

--- a/src/api/routes/copilotkit.ts
+++ b/src/api/routes/copilotkit.ts
@@ -105,15 +105,23 @@ let lazyBuiltProvider: ChatbotProvider | null = null;
  * the pre-CP477+15 behaviour, so a failed extract never breaks the
  * chatbot.
  *
- * Mirrors the JWT verify path in `src/api/plugins/auth.ts:167` but does
- * not require the Fastify request lifecycle (raw HTTP listener bypasses
- * it). Uses `fastify.jwt.verify(token)` directly — the same JWKS public
- * key cache the `fastify.authenticate` decorator uses.
+ * SYNCHRONOUS — this MUST stay sync. The function is called BEFORE
+ * `req.pause()` (the PR #732 race-fix paused window), and adding an
+ * `await` inside it caused CP477+15's first ship to break the chat
+ * endpoint with 400 "Invalid JSON payload" — same failure mode as
+ * PR #737 (CP477+11) which proved "two async hops inside the paused
+ * window race against the HTTP parser's 'data' event delivery".
+ * `@fastify/jwt`'s `fastify.jwt.verify(token)` is itself synchronous
+ * (the async path is `request.jwtVerify()` which the raw HTTP listener
+ * cannot use); we keep the same JWKS public key cache `fastify.authenticate`
+ * uses, so verification is just a cached ES256 signature check.
+ *
+ * Mirrors the JWT verify path in `src/api/plugins/auth.ts:167`.
  */
-async function extractChatbotContext(
+function extractChatbotContext(
   fastify: FastifyInstance,
   req: IncomingMessage
-): Promise<ChatbotRequestContext> {
+): ChatbotRequestContext {
   const authHeader = req.headers['authorization'];
   if (typeof authHeader !== 'string') return {};
   const token = extractTokenFromHeader(authHeader);
@@ -176,6 +184,18 @@ export const copilotKitRoutes: FastifyPluginCallback = (fastify, _opts, done) =>
   server.removeAllListeners('request');
   server.on('request', (req, res) => {
     if (req.url?.startsWith('/api/v1/chat') && !req.url?.startsWith('/api/v1/chat/config')) {
+      // CP477+15 fix — Extract user identity from the Authorization header
+      // SYNCHRONOUSLY before `req.pause()`. Headers are already parsed by
+      // Node's HTTP parser by the time this 'request' event fires (the body
+      // is the only thing still streaming), so reading them needs no await.
+      // Keeping this OUT of the paused window is mandatory: PR #737
+      // (CP477+11) and the first CP477+15 ship both broke chat with 400
+      // "Invalid JSON payload" by putting a second `await` inside the
+      // pause window — body 'data' events race the awaits and get lost.
+      // PR #732's race-fix only tolerates a SINGLE async hop
+      // (`await getYoga()`); we keep it that way.
+      const chatbotCtx = extractChatbotContext(fastify, req);
+
       // CP477+7 — Pause the request stream BEFORE the async getYoga() wait
       // so raw HTTP 'data'/'end' events don't fire and get lost while yoga
       // is being lazily built or while chatbot_settings 5-min cache is being
@@ -186,14 +206,6 @@ export const copilotKitRoutes: FastifyPluginCallback = (fastify, _opts, done) =>
       req.pause();
       void (async () => {
         try {
-          // CP477+15 — Extract the authenticated user identity from the
-          // Authorization header so the qwen prompt middleware can build
-          // Block U (mandala_count / mandala_titles / current_mandala_name).
-          // JWT verify is a quick async hop (~5-20ms with the JWKS public
-          // key already cached), and it sits inside the `req.pause()` paused
-          // window so the body buffer absorbs it just like the existing
-          // `await getYoga()` hop.
-          const chatbotCtx = await extractChatbotContext(fastify, req);
           const handler = await getYoga();
           await runWithChatbotContext(chatbotCtx, async () => {
             req.resume();

--- a/src/modules/chatbot-rag/mandala-book-loader.ts
+++ b/src/modules/chatbot-rag/mandala-book-loader.ts
@@ -1,0 +1,167 @@
+/**
+ * src/modules/chatbot-rag/mandala-book-loader.ts
+ *
+ * Block I source — compact summary of the mandala's generated book index.
+ *
+ * The full `mandala_books.book_json` blob can run 50-200 KB (chapters →
+ * sections → atoms). We only surface chapter titles + section titles +
+ * atom counts to the chatbot — enough for "어느 챕터에 그게 있어?" type
+ * navigation queries without bloating the prompt. The chatbot can ask
+ * follow-ups against video context for atom-level detail.
+ *
+ * Failures degrade silently to `null` (no book row, malformed JSON, DB
+ * unreachable).
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+import {
+  MAX_BOOK_CHAPTERS,
+  MAX_BOOK_SECTIONS_PER_CHAPTER,
+  type MandalaBookContext,
+  type MandalaBookChapterSummary,
+} from './types';
+
+const log = logger.child({ module: 'chatbot-rag/mandala-book-loader' });
+
+export interface LoadMandalaBookParams {
+  mandalaId: string;
+}
+
+interface RawAtom {
+  vid?: unknown;
+  ts?: unknown;
+  text?: unknown;
+}
+
+interface RawSection {
+  title?: unknown;
+  narrative?: unknown;
+  atoms?: unknown;
+}
+
+interface RawChapter {
+  ch?: unknown;
+  title?: unknown;
+  intro?: unknown;
+  sections?: unknown;
+}
+
+interface RawBook {
+  mandala_title?: unknown;
+  source_videos?: unknown;
+  source_atoms?: unknown;
+  chapters?: unknown;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+export async function loadMandalaBook(
+  params: LoadMandalaBookParams
+): Promise<MandalaBookContext | null> {
+  if (!params.mandalaId) return null;
+  const prisma = getPrismaClient();
+
+  try {
+    // Prisma client model name is `mandala_books`; use raw query because
+    // the FE/BE schema's name has historically diverged (see
+    // mandalas.ts:2758 same workaround). Keeps this loader robust against
+    // future Prisma schema regenerations.
+    const rows = await prisma.$queryRawUnsafe<Array<{ book_json: unknown }>>(
+      'SELECT book_json FROM public.mandala_books WHERE mandala_id = $1::uuid LIMIT 1',
+      params.mandalaId
+    );
+    if (rows.length === 0) return null;
+
+    const raw = rows[0]?.book_json as RawBook | null | undefined;
+    if (!raw || typeof raw !== 'object') return null;
+
+    const chaptersRaw = Array.isArray(raw.chapters) ? (raw.chapters as RawChapter[]) : [];
+
+    // Walk ALL chapters/sections/atoms (not just the truncated prefix) to
+    // collect the full set of unique video ids — Block I's video count is
+    // the user-facing "N개 영상" sidebar mirror, so undercounting because
+    // of MAX_BOOK_CHAPTERS would surface as wrong-count answers.
+    const videoIdSet = new Set<string>();
+    for (const rc of chaptersRaw) {
+      const secs = Array.isArray(rc.sections) ? (rc.sections as RawSection[]) : [];
+      for (const rs of secs) {
+        const atoms = Array.isArray(rs.atoms) ? (rs.atoms as RawAtom[]) : [];
+        for (const atom of atoms) {
+          if (typeof atom.vid === 'string' && atom.vid.length > 0) {
+            videoIdSet.add(atom.vid);
+          }
+        }
+      }
+    }
+    const bookVideoIds = Array.from(videoIdSet);
+
+    // Resolve titles in one batch (capped at the same size as
+    // MAX_MANDALA_CARDS-ish). Failure → empty titles array; count still
+    // surfaces via book_video_ids.length.
+    let bookVideoTitles: string[] = [];
+    if (bookVideoIds.length > 0) {
+      try {
+        const videoRows = await prisma.youtube_videos.findMany({
+          where: { youtube_video_id: { in: bookVideoIds } },
+          select: { youtube_video_id: true, title: true },
+        });
+        // Preserve the original collection order so the chatbot's listing
+        // matches how the user would read the book index top-down.
+        const titleByVid = new Map(videoRows.map((r) => [r.youtube_video_id, r.title] as const));
+        bookVideoTitles = bookVideoIds
+          .map((vid) => titleByVid.get(vid))
+          .filter((t): t is string => typeof t === 'string' && t.length > 0);
+      } catch (titleErr) {
+        log.warn('mandala-book-loader: youtube_videos title fetch failed; skipping titles', {
+          error: titleErr instanceof Error ? titleErr.message : String(titleErr),
+        });
+      }
+    }
+
+    const chapters: MandalaBookChapterSummary[] = chaptersRaw
+      .slice(0, MAX_BOOK_CHAPTERS)
+      .map((rc) => {
+        const sectionsRaw = Array.isArray(rc.sections) ? (rc.sections as RawSection[]) : [];
+        const sections = sectionsRaw
+          .slice(0, MAX_BOOK_SECTIONS_PER_CHAPTER)
+          .map((rs) => ({
+            title: asString(rs.title) ?? '(제목 없음)',
+            atom_count: Array.isArray(rs.atoms) ? (rs.atoms as RawAtom[]).length : 0,
+          }))
+          .filter((s) => s.title !== '(제목 없음)' || s.atom_count > 0);
+
+        const chapter: MandalaBookChapterSummary = {
+          ch: asNumber(rc.ch, 0),
+          title: asString(rc.title) ?? '(제목 없음)',
+          sections,
+        };
+        const intro = asString(rc.intro);
+        if (intro) chapter.intro = intro;
+        return chapter;
+      })
+      .filter((c) => c.title !== '(제목 없음)' || c.sections.length > 0);
+
+    return {
+      mandala_id: params.mandalaId,
+      mandala_title: asString(raw.mandala_title) ?? '',
+      source_videos: asNumber(raw.source_videos, 0),
+      source_atoms: asNumber(raw.source_atoms, 0),
+      chapters,
+      book_video_ids: bookVideoIds,
+      book_video_titles: bookVideoTitles,
+    };
+  } catch (err) {
+    log.warn('mandala-book-loader query failed', {
+      mandalaId: params.mandalaId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/src/modules/chatbot-rag/mandala-cards-loader.ts
+++ b/src/modules/chatbot-rag/mandala-cards-loader.ts
@@ -1,0 +1,110 @@
+/**
+ * src/modules/chatbot-rag/mandala-cards-loader.ts
+ *
+ * Block J source — the card list shown in the LearningPage left sidebar.
+ *
+ * Mirror invariant: this query MUST match the LeftPanel.tsx filter
+ * (`c.mandalaId === mandalaId && c.cellIndex >= 0`). Drift would mean
+ * the chatbot answers "영상 N개" while the sidebar shows a different
+ * count — a credibility-breaking inconsistency.
+ *
+ *   LeftPanel.tsx:32-35
+ *   const { cards } = useLocalCards();
+ *   const mandalaCards = cards.filter(
+ *     (c) => c.mandalaId === mandalaId && c.cellIndex >= 0
+ *   );
+ *
+ * Cells with `cell_index = -1` (scratchpad) are excluded — these
+ * represent rough captures the user has not yet placed in the mandala.
+ *
+ * Failures degrade silently to `null` so the chatbot still answers via
+ * the rest of the prompt blocks.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+import { MAX_MANDALA_CARDS, type MandalaCardSummary, type MandalaCardsContext } from './types';
+
+const log = logger.child({ module: 'chatbot-rag/mandala-cards-loader' });
+
+export interface LoadMandalaCardsParams {
+  userId: string;
+  mandalaId: string;
+  /** Optional cell labels to resolve cell_name (subjects[0..7] from user_mandala_levels). */
+  cellLabels?: ReadonlyArray<string | null>;
+}
+
+/**
+ * Loads the mandala's placed cards (cell_index >= 0) for Block J.
+ * Returns null on missing mandalaId / DB error — caller treats null as
+ * "block omitted".
+ */
+export async function loadMandalaCards(
+  params: LoadMandalaCardsParams
+): Promise<MandalaCardsContext | null> {
+  if (!params.mandalaId) return null;
+  const prisma = getPrismaClient();
+
+  try {
+    // LeftPanel mirror: user_id + mandala_id + cell_index >= 0.
+    const [totalCount, recentRows] = await Promise.all([
+      prisma.user_local_cards.count({
+        where: {
+          user_id: params.userId,
+          mandala_id: params.mandalaId,
+          cell_index: { gte: 0 },
+        },
+      }),
+      prisma.user_local_cards.findMany({
+        where: {
+          user_id: params.userId,
+          mandala_id: params.mandalaId,
+          cell_index: { gte: 0 },
+        },
+        select: {
+          title: true,
+          metadata_title: true,
+          video_id: true,
+          cell_index: true,
+        },
+        orderBy: { created_at: 'desc' },
+        take: MAX_MANDALA_CARDS,
+      }),
+    ]);
+
+    const cards: MandalaCardSummary[] = recentRows
+      .map((row) => {
+        // Prefer human-set title; fall back to scraped metadata; drop rows
+        // with neither (typically link_type='note' scratchpads — already
+        // filtered by cell_index>=0 in most cases, defensive belt+braces).
+        const title = (row.title ?? row.metadata_title ?? '').trim();
+        if (title.length === 0) return null;
+        const cellIndex = row.cell_index ?? -1;
+        const cellName =
+          cellIndex >= 1 && cellIndex <= 8 && params.cellLabels
+            ? (params.cellLabels[cellIndex - 1] ?? undefined)
+            : undefined;
+        const summary: MandalaCardSummary = {
+          video_id: row.video_id,
+          title,
+          cell_index: cellIndex,
+        };
+        if (cellName) summary.cell_name = cellName;
+        return summary;
+      })
+      .filter((c): c is MandalaCardSummary => c !== null);
+
+    return {
+      mandala_id: params.mandalaId,
+      total_count: totalCount,
+      cards,
+    };
+  } catch (err) {
+    log.warn('mandala-cards-loader query failed', {
+      userId: params.userId,
+      mandalaId: params.mandalaId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/src/modules/chatbot-rag/mandala-context-loader.ts
+++ b/src/modules/chatbot-rag/mandala-context-loader.ts
@@ -1,0 +1,103 @@
+/**
+ * src/modules/chatbot-rag/mandala-context-loader.ts
+ *
+ * Block E source — current mandala's center goal + sub-cell labels.
+ *
+ * The mandala "context" the chatbot needs is the structural data the
+ * user is currently navigating: the center goal (top-level objective)
+ * and the 8 sub-cell labels (subjects[]) which the LeftPanel renders as
+ * the navigable tree. This is per-mandala but per-user-scoped (the
+ * `user_mandala_levels.mandala_id` belongs to a `user_mandalas` row
+ * owned by the user).
+ *
+ * Returns center_goal + subjects (8-element string array) so prompt-
+ * builder's `blockE` can render them. Also returns subjects raw for
+ * mandala-cards-loader to resolve cell_name labels.
+ *
+ * Failures degrade silently to `null`.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+import type { MandalaContext } from './prompt-builder';
+
+const log = logger.child({ module: 'chatbot-rag/mandala-context-loader' });
+
+export interface LoadMandalaContextParams {
+  mandalaId: string;
+  /** Mandala title (already loaded by user-context-loader; passed in to avoid duplicate query). */
+  mandalaName: string;
+  /** 1..8 — when set, populates MandalaContext.cell_name + cell_index. */
+  cellIndex?: number | null;
+}
+
+export interface MandalaContextLoadResult {
+  /** Block E payload — emitted directly into the prompt. */
+  context: MandalaContext;
+  /** Raw subject labels (8 entries when present) — for downstream loaders
+   *  to resolve cell_name on per-card listings. */
+  subjects: string[];
+  /** Short labels (subject_labels in DB) used in the sidebar; falls back
+   *  to subjects[] when empty. */
+  subjectLabels: string[];
+}
+
+/**
+ * Loads the L1 (root) levels row for the mandala and surfaces:
+ *   - center_goal: top-level objective string
+ *   - subjects[]: the 8 sub-cell descriptions (LeftPanel rows)
+ *   - subject_labels[]: short labels (UI prefers these)
+ */
+export async function loadMandalaContext(
+  params: LoadMandalaContextParams
+): Promise<MandalaContextLoadResult | null> {
+  if (!params.mandalaId) return null;
+  const prisma = getPrismaClient();
+
+  try {
+    // L1 = the root level row (the chart's outer ring with the 8 sub-cells).
+    // schema.prisma:user_mandala_levels.level_key indicates depth — 'L1'
+    // is the convention used by the wizard's create flow.
+    const root = await prisma.user_mandala_levels.findFirst({
+      where: {
+        mandala_id: params.mandalaId,
+        depth: 0,
+      },
+      select: {
+        center_goal: true,
+        subjects: true,
+        subject_labels: true,
+      },
+    });
+
+    if (!root) return null;
+
+    const subjects = Array.isArray(root.subjects) ? root.subjects : [];
+    const subjectLabels = Array.isArray(root.subject_labels) ? root.subject_labels : [];
+
+    const cellIndex = params.cellIndex ?? null;
+    const cellName =
+      cellIndex !== null && cellIndex >= 1 && cellIndex <= 8
+        ? subjectLabels[cellIndex - 1] || subjects[cellIndex - 1] || null
+        : null;
+
+    const context: MandalaContext = {
+      mandala_name: params.mandalaName,
+      center_goal: root.center_goal,
+      cell_name: cellName ?? null,
+      cell_index: cellIndex,
+    };
+
+    return {
+      context,
+      subjects,
+      subjectLabels,
+    };
+  } catch (err) {
+    log.warn('mandala-context-loader query failed', {
+      mandalaId: params.mandalaId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/src/modules/chatbot-rag/note-loader.ts
+++ b/src/modules/chatbot-rag/note-loader.ts
@@ -1,0 +1,109 @@
+/**
+ * src/modules/chatbot-rag/note-loader.ts
+ *
+ * Block N source — compact excerpt of the user's note document for the
+ * current mandala.
+ *
+ * `note_documents.content_json` is TipTap-format JSON. We flatten it to
+ * plain text by walking the doc tree and concatenating `text` nodes, then
+ * cap to MAX_NOTE_EXCERPT_CHARS so the system prompt stays compact even
+ * when users write long notes (>10K chars).
+ *
+ * Per-(user, mandala) uniqueness invariant comes from the DB unique
+ * constraint `uq_note_documents_user_mandala` (schema.prisma).
+ *
+ * Failures degrade silently to `null` (no row → user hasn't started a
+ * note for this mandala yet; query error → don't block chatbot).
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+import { MAX_NOTE_EXCERPT_CHARS, type NoteDraftContext } from './types';
+
+const log = logger.child({ module: 'chatbot-rag/note-loader' });
+
+export interface LoadNoteContextParams {
+  userId: string;
+  mandalaId: string;
+}
+
+interface TipTapNode {
+  type?: string;
+  text?: string;
+  content?: TipTapNode[];
+}
+
+/**
+ * Walks a TipTap doc and concatenates all text nodes with paragraph
+ * breaks. Insertion of newline at block-level node boundaries keeps the
+ * excerpt readable when rendered into a prompt.
+ */
+function flattenTipTap(doc: unknown): string {
+  const parts: string[] = [];
+  const visit = (node: TipTapNode | null | undefined): void => {
+    if (!node || typeof node !== 'object') return;
+    if (typeof node.text === 'string') {
+      parts.push(node.text);
+    }
+    if (Array.isArray(node.content)) {
+      for (const child of node.content) visit(child);
+      // Block-level nodes (paragraph, heading, listItem, etc.) get a
+      // newline at the end so adjacent blocks don't run together.
+      const blockTypes = new Set(['paragraph', 'heading', 'listItem', 'blockquote', 'codeBlock']);
+      if (typeof node.type === 'string' && blockTypes.has(node.type)) {
+        parts.push('\n');
+      }
+    }
+  };
+  if (doc && typeof doc === 'object') {
+    visit(doc as TipTapNode);
+  }
+  // Collapse any stretch of whitespace > 2 chars into a single newline —
+  // TipTap leaves stray spaces when content is sparse.
+  return parts
+    .join('')
+    .replace(/\n{2,}/g, '\n')
+    .trim();
+}
+
+export async function loadNoteContext(
+  params: LoadNoteContextParams
+): Promise<NoteDraftContext | null> {
+  if (!params.userId || !params.mandalaId) return null;
+  const prisma = getPrismaClient();
+
+  try {
+    const row = await prisma.note_documents.findFirst({
+      where: {
+        user_id: params.userId,
+        mandala_id: params.mandalaId,
+      },
+      select: {
+        content_json: true,
+        updated_at: true,
+      },
+    });
+    if (!row) return null;
+
+    const fullText = flattenTipTap(row.content_json);
+    if (fullText.length === 0) return null;
+
+    const truncated = fullText.length > MAX_NOTE_EXCERPT_CHARS;
+    const excerpt = truncated ? fullText.slice(0, MAX_NOTE_EXCERPT_CHARS) : fullText;
+
+    return {
+      mandala_id: params.mandalaId,
+      total_chars: fullText.length,
+      excerpt,
+      truncated,
+      last_edited_at: row.updated_at.toISOString(),
+    };
+  } catch (err) {
+    log.warn('note-loader query failed', {
+      userId: params.userId,
+      mandalaId: params.mandalaId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}

--- a/src/modules/chatbot-rag/prompt-builder.ts
+++ b/src/modules/chatbot-rag/prompt-builder.ts
@@ -20,7 +20,15 @@
  *   - EXTENDED_RULES appended only when any of {U, T, H} present, so the
  *     original SFT-aligned ROLE_AND_RULES_KO/EN stays byte-identical.
  */
-import type { UserContext, TranscriptContext, RAGContext, RAGResult } from './types';
+import type {
+  UserContext,
+  TranscriptContext,
+  RAGContext,
+  RAGResult,
+  MandalaCardsContext,
+  MandalaBookContext,
+  NoteDraftContext,
+} from './types';
 
 // ============================================================================
 // Types
@@ -184,33 +192,57 @@ export const EXTENDED_RULES_EN = `[Additional rules]
 // Layer → Blocks mapping (§3.3)
 // ============================================================================
 
-export type BlockId = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'T' | 'U' | 'H';
+export type BlockId =
+  | 'A'
+  | 'B'
+  | 'C'
+  | 'D'
+  | 'E'
+  | 'F'
+  | 'G'
+  | 'T'
+  | 'U'
+  | 'H'
+  // CP477+15 — Insighta-structure blocks. I = book index, J = mandala
+  // cards list (matches LeftPanel), N = current-mandala note excerpt.
+  | 'I'
+  | 'J'
+  | 'N';
 
 /**
  * v2-grounded layer mapping (Block A-D come from V2Summary).
  * U (user) + H (RAG) are appended to every layer — they're orthogonal
  * to the chat surface the user is hovering over.
+ *
+ * CP477+15 — adds I (book), J (cards), N (note) to every mandala-scoped
+ * layer. These are the structural-context blocks: chatbot needs them to
+ * answer "내 만다라 영상 수?" / "이 책의 챕터?" / "내 노트에 뭐 있어?"
+ * type queries without depending on RAG retrieval. Order matters for
+ * legibility — block order in the prompt mirrors how a user reads the
+ * page: user → mandala → book → cards → note → video.
  */
 export const LAYER_BLOCKS: Record<ChatLayer, BlockId[]> = {
-  global: ['A', 'U', 'H'],
-  mandala: ['A', 'E', 'U', 'H'],
-  cell: ['A', 'B', 'C', 'E', 'U', 'H'],
-  video: ['A', 'B', 'C', 'D', 'U', 'H'],
-  'video-time': ['A', 'B', 'C', 'D', 'F', 'U', 'H'],
-  note: ['A', 'B', 'C', 'D', 'F', 'G', 'U', 'H'],
+  global: ['U', 'H'],
+  mandala: ['U', 'E', 'I', 'J', 'N', 'H'],
+  cell: ['U', 'E', 'I', 'J', 'N', 'A', 'B', 'C', 'H'],
+  video: ['U', 'E', 'I', 'J', 'N', 'A', 'B', 'C', 'D', 'H'],
+  'video-time': ['U', 'E', 'I', 'J', 'N', 'A', 'B', 'C', 'D', 'F', 'H'],
+  note: ['U', 'E', 'I', 'J', 'N', 'A', 'B', 'C', 'D', 'F', 'G', 'H'],
 };
 
 /**
  * Transcript-fallback layer mapping (Block T replaces Block A-D when no
- * v2 rich summary exists for the current video). U/H remain available.
+ * v2 rich summary exists for the current video). U/H + I/J/N remain
+ * available — the chatbot still answers mandala-level queries even when
+ * the specific video lacks an AI summary.
  */
 export const LAYER_BLOCKS_FALLBACK: Record<ChatLayer, BlockId[]> = {
-  global: ['T', 'U', 'H'],
-  mandala: ['T', 'E', 'U', 'H'],
-  cell: ['T', 'E', 'U', 'H'],
-  video: ['T', 'U', 'H'],
-  'video-time': ['T', 'F', 'U', 'H'],
-  note: ['T', 'F', 'G', 'U', 'H'],
+  global: ['U', 'H'],
+  mandala: ['U', 'E', 'I', 'J', 'N', 'T', 'H'],
+  cell: ['U', 'E', 'I', 'J', 'N', 'T', 'H'],
+  video: ['U', 'E', 'I', 'J', 'N', 'T', 'H'],
+  'video-time': ['U', 'E', 'I', 'J', 'N', 'T', 'F', 'H'],
+  note: ['U', 'E', 'I', 'J', 'N', 'T', 'F', 'G', 'H'],
 };
 
 // ============================================================================
@@ -462,6 +494,123 @@ function blockH(rc: RAGContext, lang: Lang): string | null {
 }
 
 // ============================================================================
+// Block J — Mandala cards list (CP477+15)
+//
+// Mirrors the LeftPanel sidebar's "10개 영상" count + cell-scoped list.
+// Used by the chatbot to answer "내 만다라에 영상 몇 개?", "X cell 에
+// 어떤 영상?" type queries with the same numbers the user sees.
+// ============================================================================
+
+function blockJ(j: MandalaCardsContext, lang: Lang): string | null {
+  if (lang === 'ko') {
+    const lines = ['[현재 만다라의 카드]'];
+    lines.push(`총 카드 수: ${j.total_count}개 (셀에 배치된 카드만, 스크래치패드 제외)`);
+    if (j.cards.length > 0) {
+      lines.push(`최근 카드 목록 (최대 ${j.cards.length}개, 최신순):`);
+      for (const card of j.cards) {
+        const where = card.cell_name
+          ? ` [셀 ${card.cell_index}: ${card.cell_name}]`
+          : ` [셀 ${card.cell_index}]`;
+        lines.push(`- "${card.title}"${where}`);
+      }
+    }
+    return lines.join('\n');
+  }
+  const lines = ['[Cards in current mandala]'];
+  lines.push(`Total cards: ${j.total_count} (placed cells only; scratchpad excluded)`);
+  if (j.cards.length > 0) {
+    lines.push(`Recent (newest first, max ${j.cards.length}):`);
+    for (const card of j.cards) {
+      const where = card.cell_name
+        ? ` [cell ${card.cell_index}: ${card.cell_name}]`
+        : ` [cell ${card.cell_index}]`;
+      lines.push(`- "${card.title}"${where}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+// ============================================================================
+// Block I — Mandala book index (CP477+15)
+//
+// Chapter + section titles from `mandala_books.book_json`. Atom-level
+// content is intentionally omitted — atom_count gives the chatbot a hint
+// of detail density without inflating the prompt.
+// ============================================================================
+
+function blockI(i: MandalaBookContext, lang: Lang): string | null {
+  if (i.chapters.length === 0 && i.book_video_ids.length === 0) return null;
+  // CP477+15 Round 3: the unique-video count (북인덱스 atoms 의 vid set)
+  // is the canonical "이 만다라 영상 N개" answer the sidebar surfaces.
+  // We render it explicitly so the chatbot can quote the number directly.
+  const uniqueVideos = i.book_video_ids.length;
+  if (lang === 'ko') {
+    const lines = ['[만다라 책 인덱스 (좌측 사이드바와 동일)]'];
+    lines.push(
+      `책 제목: "${i.mandala_title}" / 좌측 사이드바 영상 수 = ${uniqueVideos}개 (북인덱스 atoms 기반) / 원자 ${i.source_atoms}개`
+    );
+    if (i.book_video_titles.length > 0) {
+      const titles = i.book_video_titles
+        .slice(0, 10)
+        .map((t) => `"${t}"`)
+        .join(', ');
+      const more =
+        i.book_video_titles.length > 10 ? ` (외 ${i.book_video_titles.length - 10}개)` : '';
+      lines.push(`사이드바 영상 목록: ${titles}${more}`);
+    }
+    for (const ch of i.chapters) {
+      lines.push(`Ch.${ch.ch} ${ch.title}`);
+      if (ch.intro) lines.push(`  소개: ${ch.intro.slice(0, 120)}`);
+      for (const sec of ch.sections) {
+        lines.push(`  - ${sec.title} (원자 ${sec.atom_count}개)`);
+      }
+    }
+    return lines.join('\n');
+  }
+  const lines = ['[Mandala book index (matches sidebar)]'];
+  lines.push(
+    `Title: "${i.mandala_title}" / Sidebar video count = ${uniqueVideos} (from book index atoms) / ${i.source_atoms} atoms`
+  );
+  if (i.book_video_titles.length > 0) {
+    const titles = i.book_video_titles
+      .slice(0, 10)
+      .map((t) => `"${t}"`)
+      .join(', ');
+    const more =
+      i.book_video_titles.length > 10 ? ` (and ${i.book_video_titles.length - 10} more)` : '';
+    lines.push(`Sidebar video list: ${titles}${more}`);
+  }
+  for (const ch of i.chapters) {
+    lines.push(`Ch.${ch.ch} ${ch.title}`);
+    if (ch.intro) lines.push(`  Intro: ${ch.intro.slice(0, 120)}`);
+    for (const sec of ch.sections) {
+      lines.push(`  - ${sec.title} (${sec.atom_count} atoms)`);
+    }
+  }
+  return lines.join('\n');
+}
+
+// ============================================================================
+// Block N — Note draft (CP477+15)
+//
+// Plain-text excerpt of the per-(user, mandala) note in TipTap form.
+// Capped at MAX_NOTE_EXCERPT_CHARS upstream. The chatbot uses this for
+// "내 노트에 뭐 있어?" / "이 부분 어떻게 정리해?" queries.
+// ============================================================================
+
+function blockN(n: NoteDraftContext, lang: Lang): string | null {
+  if (!n.excerpt || n.excerpt.trim().length === 0) return null;
+  if (lang === 'ko') {
+    const header = '[현재 만다라 노트 (사용자 메모)]';
+    const meta = `총 ${n.total_chars}자 / 마지막 편집: ${n.last_edited_at.slice(0, 10)}${n.truncated ? ' / 일부만 표시' : ''}`;
+    return `${header}\n${meta}\n${n.excerpt}`;
+  }
+  const header = '[Current mandala note (user memo)]';
+  const meta = `${n.total_chars} chars / last edited ${n.last_edited_at.slice(0, 10)}${n.truncated ? ' / truncated' : ''}`;
+  return `${header}\n${meta}\n${n.excerpt}`;
+}
+
+// ============================================================================
 // Main builder
 // ============================================================================
 
@@ -477,6 +626,12 @@ export interface BuildQwenSystemPromptParams {
   transcript?: TranscriptContext | null;
   /** CP474 — RAG retrieval results (Block H). */
   ragContext?: RAGContext | null;
+  /** CP477+15 — Block I (book index). */
+  mandalaBook?: MandalaBookContext | null;
+  /** CP477+15 — Block J (mandala cards list). */
+  mandalaCards?: MandalaCardsContext | null;
+  /** CP477+15 — Block N (per-mandala note excerpt). */
+  noteDraft?: NoteDraftContext | null;
   /**
    * CP474 — when false, omit PRODUCT_PERSONA / EXTENDED_RULES so the output
    * is byte-identical to the legacy SFT-aligned format (used by training-
@@ -495,6 +650,9 @@ export function buildQwenSystemPrompt(params: BuildQwenSystemPromptParams): stri
     userContext,
     transcript,
     ragContext,
+    mandalaBook,
+    mandalaCards,
+    noteDraft,
   } = params;
   const includePersona = params.includePersona ?? true;
 
@@ -519,7 +677,13 @@ export function buildQwenSystemPrompt(params: BuildQwenSystemPromptParams): stri
   // Extended rules — only when any CP474 block is in play. Keeps legacy
   // layers free of training-data drift.
   const hasExtended =
-    includePersona && (Boolean(userContext) || Boolean(transcript) || Boolean(ragContext));
+    includePersona &&
+    (Boolean(userContext) ||
+      Boolean(transcript) ||
+      Boolean(ragContext) ||
+      Boolean(mandalaBook) ||
+      Boolean(mandalaCards) ||
+      Boolean(noteDraft));
   if (hasExtended) {
     blocks.push(language === 'ko' ? EXTENDED_RULES_KO : EXTENDED_RULES_EN);
   }
@@ -559,6 +723,15 @@ export function buildQwenSystemPrompt(params: BuildQwenSystemPromptParams): stri
         break;
       case 'H':
         if (ragContext) push(blockH(ragContext, language));
+        break;
+      case 'I':
+        if (mandalaBook) push(blockI(mandalaBook, language));
+        break;
+      case 'J':
+        if (mandalaCards) push(blockJ(mandalaCards, language));
+        break;
+      case 'N':
+        if (noteDraft) push(blockN(noteDraft, language));
         break;
     }
   }

--- a/src/modules/chatbot-rag/qwen-prompt-middleware.ts
+++ b/src/modules/chatbot-rag/qwen-prompt-middleware.ts
@@ -27,8 +27,27 @@
 
 import type { LanguageModelV3Middleware, LanguageModelV3Message } from '@ai-sdk/provider';
 import { logger } from '@/utils/logger';
-import { buildQwenSystemPrompt, type ChatLayer, type Lang } from './prompt-builder';
+import { getChatbotContext } from '@/api/routes/chatbot-context-storage';
+import {
+  buildQwenSystemPrompt,
+  type ChatLayer,
+  type Lang,
+  type MandalaContext as PromptMandalaContext,
+} from './prompt-builder';
 import { loadVideoContext, type VideoGroundingResult } from './video-context-loader';
+import { loadUserContext } from './user-context-loader';
+import { loadMandalaContext } from './mandala-context-loader';
+import { loadMandalaCards } from './mandala-cards-loader';
+import { loadMandalaBook } from './mandala-book-loader';
+import { loadNoteContext } from './note-loader';
+import { retrieveRAGContext } from './retriever';
+import type {
+  UserContext,
+  MandalaCardsContext,
+  MandalaBookContext,
+  NoteDraftContext,
+  RAGContext,
+} from './types';
 
 const log = logger.child({ module: 'chatbot-rag/qwen-prompt-middleware' });
 
@@ -38,6 +57,53 @@ const log = logger.child({ module: 'chatbot-rag/qwen-prompt-middleware' });
 
 /** Matches the FE's video URL pattern; group 1 = 11-char video id. */
 const VIDEO_ID_REGEX = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+
+/**
+ * CP477+15 — Pulls FE-emitted chatContext JSON fields out of the
+ * original system prompt.
+ *
+ * Why regex instead of JSON.parse: CopilotKit's `useCopilotReadable`
+ * embeds the readable value somewhere inside its own role-instructions
+ * template — the boundary is not stable across CopilotKit versions, so
+ * tolerant regex per field is more robust than trying to JSON.parse
+ * the entire system prompt.
+ *
+ * Source: `frontend/src/pages/learning/ui/ChatAssistant.tsx:358-366`.
+ */
+const MANDALA_ID_REGEX = /"mandala_id"\s*:\s*"([0-9a-fA-F-]{36})"/;
+const CELL_INDEX_REGEX = /"cell_index"\s*:\s*(-?\d+)/;
+
+function parseCurrentMandalaId(systemContent: string): string | undefined {
+  const match = MANDALA_ID_REGEX.exec(systemContent);
+  return match?.[1];
+}
+
+function parseCurrentCellIndex(systemContent: string): number | null {
+  const match = CELL_INDEX_REGEX.exec(systemContent);
+  if (!match) return null;
+  const n = Number(match[1]);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Pulls the latest user message text out of a V3Message[] prompt — used
+ * as the RAG retriever's query. Returns undefined when the prompt has
+ * no user turn (e.g., the initial system-only setup).
+ */
+function extractLastUserMessageText(prompt: LanguageModelV3Message[]): string | undefined {
+  for (let i = prompt.length - 1; i >= 0; i--) {
+    const msg = prompt[i];
+    if (!msg || msg.role !== 'user') continue;
+    if (typeof msg.content === 'string') return msg.content;
+    if (Array.isArray(msg.content)) {
+      for (let j = msg.content.length - 1; j >= 0; j--) {
+        const part = msg.content[j];
+        if (part?.type === 'text' && typeof part.text === 'string') return part.text;
+      }
+    }
+  }
+  return undefined;
+}
 
 /** Per-videoId cache TTL for context loads. 5 minutes balances freshness vs latency. */
 const VIDEO_CONTEXT_CACHE_MS = 5 * 60 * 1000;
@@ -121,7 +187,15 @@ export async function rewriteSystemPrompt(
     }
   }
 
-  const newSystemContent = await rewriteSystemContent(systemContents.join('\n\n'));
+  // CP477+15 — pass the last user message text into the system rewriter
+  // as the RAG retrieval query. retrieveRAGContext returns 0 results
+  // when the query is empty or whitespace-only, so cold-start setup
+  // turns with no user text don't trigger an embedding call.
+  const lastUserMessage = extractLastUserMessageText(prompt);
+
+  const newSystemContent = await rewriteSystemContent(systemContents.join('\n\n'), {
+    lastUserMessage,
+  });
 
   const newSystemMsg: LanguageModelV3Message = {
     role: 'system',
@@ -278,24 +352,126 @@ export function appendTimestampFormatRule(systemContent: string, language: Lang)
  * string}` directly from CopilotKit TextMessages, so the V3Message shape
  * conversion isn't needed.
  */
-export async function rewriteSystemContent(originalSystemContent: string): Promise<string> {
+export async function rewriteSystemContent(
+  originalSystemContent: string,
+  opts?: { lastUserMessage?: string }
+): Promise<string> {
   const language = detectLanguage(originalSystemContent);
 
+  // Parse FE-emitted chatContext fields out of the system prompt.
   const videoMatch = VIDEO_ID_REGEX.exec(originalSystemContent);
   const youtubeVideoId = videoMatch?.[1] ?? null;
+  const currentMandalaId = parseCurrentMandalaId(originalSystemContent);
+  const currentCellIndex = parseCurrentCellIndex(originalSystemContent);
 
-  let videoCtx: VideoGroundingResult = { v2Data: null, transcript: null };
-  if (youtubeVideoId) {
-    videoCtx = await loadCachedVideoContext(youtubeVideoId, language);
+  const chatbotCtx = getChatbotContext();
+  const authenticated = Boolean(chatbotCtx?.userId);
+
+  // Step 1 — user-context (Block U). Needed even outside a mandala
+  // (chatbot must answer "내 만다라 몇개?").
+  let userContext: UserContext | null = null;
+  if (chatbotCtx?.userId) {
+    try {
+      userContext = await loadUserContext({
+        userId: chatbotCtx.userId,
+        email: chatbotCtx.email ?? '',
+        displayName: chatbotCtx.displayName,
+        currentMandalaId,
+        preferredLanguage: language,
+      });
+    } catch (err) {
+      log.warn('loadUserContext failed; skipping Block U', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
-  const layer: ChatLayer = youtubeVideoId ? 'video' : 'global';
+  // Step 2 — fetch all mandala-scoped contexts + video grounding +
+  // optional RAG in parallel. Each loader is fail-safe and returns
+  // null on error; prompt-builder treats null as "block omitted".
+  const mandalaName = userContext?.current_mandala_name ?? '';
+  const lastUserMessage = opts?.lastUserMessage;
+
+  const [videoCtx, mandalaCtxResult, mandalaCards, mandalaBook, noteDraft, ragContext] =
+    await Promise.all([
+      youtubeVideoId
+        ? loadCachedVideoContext(youtubeVideoId, language)
+        : Promise.resolve<VideoGroundingResult>({ v2Data: null, transcript: null }),
+      currentMandalaId && mandalaName
+        ? loadMandalaContext({
+            mandalaId: currentMandalaId,
+            mandalaName,
+            cellIndex: currentCellIndex,
+          })
+        : Promise.resolve(null),
+      authenticated && currentMandalaId && chatbotCtx?.userId
+        ? loadMandalaCards({
+            userId: chatbotCtx.userId,
+            mandalaId: currentMandalaId,
+          }).catch((err: unknown) => {
+            log.warn('loadMandalaCards failed', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return null;
+          })
+        : Promise.resolve<MandalaCardsContext | null>(null),
+      currentMandalaId
+        ? loadMandalaBook({ mandalaId: currentMandalaId }).catch((err: unknown) => {
+            log.warn('loadMandalaBook failed', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return null;
+          })
+        : Promise.resolve<MandalaBookContext | null>(null),
+      authenticated && currentMandalaId && chatbotCtx?.userId
+        ? loadNoteContext({
+            userId: chatbotCtx.userId,
+            mandalaId: currentMandalaId,
+          }).catch((err: unknown) => {
+            log.warn('loadNoteContext failed', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return null;
+          })
+        : Promise.resolve<NoteDraftContext | null>(null),
+      authenticated && lastUserMessage && lastUserMessage.trim().length > 0 && chatbotCtx?.userId
+        ? retrieveRAGContext({
+            userId: chatbotCtx.userId,
+            query: lastUserMessage,
+            mandalaId: currentMandalaId,
+          }).catch((err: unknown) => {
+            log.warn('retrieveRAGContext failed', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return null;
+          })
+        : Promise.resolve<RAGContext | null>(null),
+    ]);
+
+  const mandalaContext: PromptMandalaContext | null = mandalaCtxResult?.context ?? null;
+
+  // Layer selection follows the data we actually loaded: video page →
+  // 'video' (or 'cell' when a cell is selected), mandala-only → 'mandala',
+  // unauth or pre-mandala → 'global'.
+  const layer: ChatLayer = youtubeVideoId
+    ? currentCellIndex && currentCellIndex >= 1
+      ? 'cell'
+      : 'video'
+    : currentMandalaId
+      ? 'mandala'
+      : 'global';
 
   const built = buildQwenSystemPrompt({
     layer,
     language,
     v2Data: videoCtx.v2Data,
     transcript: videoCtx.transcript,
+    userContext,
+    mandalaContext,
+    mandalaCards,
+    mandalaBook,
+    noteDraft,
+    ragContext,
     includePersona: true,
   });
   // CP477+2 — tighten timestamp output to a single canonical form so the

--- a/src/modules/chatbot-rag/qwen-runpod-adapter.ts
+++ b/src/modules/chatbot-rag/qwen-runpod-adapter.ts
@@ -293,7 +293,19 @@ async function applySFTRewrite(messages: OpenAIChatMessage[]): Promise<OpenAICha
     const systemContents = messages.filter((m) => m.role === 'system').map((m) => m.content);
     const otherMessages = messages.filter((m) => m.role !== 'system');
 
-    const newSystem = await rewriteSystemContent(systemContents.join('\n\n'));
+    // CP477+15 — last user message text seeds the RAG retriever query.
+    // Walking from the end keeps multi-turn histories cheap.
+    let lastUserMessage: string | undefined;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]!.role === 'user') {
+        lastUserMessage = messages[i]!.content;
+        break;
+      }
+    }
+
+    const newSystem = await rewriteSystemContent(systemContents.join('\n\n'), {
+      lastUserMessage,
+    });
     const withSystem = [{ role: 'system' as const, content: newSystem }, ...otherMessages];
     // CP477+5 — Append `/no_think` at the end of the LAST USER message
     // (Qwen3 chat-template standard position). Idempotent.

--- a/src/modules/chatbot-rag/types.ts
+++ b/src/modules/chatbot-rag/types.ts
@@ -53,8 +53,102 @@ export interface UserContext {
   mandala_titles: string[];
   /** Title of the mandala currently in focus (from request context); undefined when out-of-mandala. */
   current_mandala_name?: string;
+  // NOTE: per-mandala details (cards list, book chapters, note) now live
+  // in dedicated Blocks J / I / N respectively — see types below. Keeping
+  // them out of UserContext avoids prompt duplication and lets each
+  // loader fail independently.
   recent_card_count_7d: number;
   preferred_language: Lang;
+}
+
+// ============================================================================
+// Block J — Mandala card list (CP477+15)
+//
+// Mirrors the LeftPanel sidebar: `user_local_cards WHERE user_id AND
+// mandala_id AND cell_index >= 0`. The sidebar's "10개 영상" count comes
+// from this exact query, so the chatbot must use the same source to give
+// consistent answers ("만다라에 영상 몇개?").
+// ============================================================================
+
+export interface MandalaCardSummary {
+  /** YouTube 11-char id if the card is a video; null for non-video link types. */
+  video_id: string | null;
+  /** Human-set title (falls back to metadata_title). */
+  title: string;
+  /** 1-indexed cell position 1..8 (cell_index in DB; -1 = scratchpad — excluded). */
+  cell_index: number;
+  /** Optional cell label resolved from user_mandala_levels.subjects. */
+  cell_name?: string;
+}
+
+export interface MandalaCardsContext {
+  mandala_id: string;
+  total_count: number;
+  /** Up to MAX_MANDALA_CARDS items, most-recently-added first. */
+  cards: MandalaCardSummary[];
+}
+
+// ============================================================================
+// Block I — Mandala book index (CP477+15)
+//
+// Compact summary of `mandala_books.book_json`: chapter titles + section
+// titles. Atoms / qa are deliberately excluded — they would inflate the
+// prompt 5-10x with no proportional answer-quality gain (the model can
+// ask follow-ups against video context for atom-level detail).
+// ============================================================================
+
+export interface MandalaBookSectionSummary {
+  title: string;
+  /** Number of atoms in this section, for "이 챕터에 얼마나 자세한 내용이 있어?" type queries. */
+  atom_count: number;
+}
+
+export interface MandalaBookChapterSummary {
+  ch: number;
+  title: string;
+  intro?: string;
+  sections: MandalaBookSectionSummary[];
+}
+
+export interface MandalaBookContext {
+  mandala_id: string;
+  mandala_title: string;
+  source_videos: number;
+  source_atoms: number;
+  /** Up to MAX_BOOK_CHAPTERS chapters. */
+  chapters: MandalaBookChapterSummary[];
+  /**
+   * CP477+15 (Round 3) — Unique video ids surfaced by the book's atoms.
+   * Per user clarification: the sidebar's "N개 영상" count derives from
+   * this list (북마크 → v2 상세요약 → 북인덱스 atoms entry), so the chatbot
+   * needs this exact source to answer "이 만다라 영상 몇개?" with the
+   * number the user sees.
+   */
+  book_video_ids: string[];
+  /**
+   * CP477+15 (Round 3) — Titles for `book_video_ids` (resolved from
+   * `youtube_videos.title` JOIN). Empty when the title lookup fails;
+   * chatbot still has the count.
+   */
+  book_video_titles: string[];
+}
+
+// ============================================================================
+// Block N — Note draft context (CP477+15)
+//
+// Compact excerpt of `note_documents.content_json` for the current
+// (user, mandala). TipTap JSON is flattened to plain text and capped at
+// MAX_NOTE_EXCERPT_CHARS — enough for the chatbot to ground "내 노트에
+// 뭐 있어?" or "이 부분 어떻게 정리해?" type queries without bloating
+// the prompt.
+// ============================================================================
+
+export interface NoteDraftContext {
+  mandala_id: string;
+  total_chars: number;
+  excerpt: string;
+  truncated: boolean;
+  last_edited_at: string;
 }
 
 // ============================================================================
@@ -128,6 +222,27 @@ export interface RAGContext {
 
 /** Cap on mandala_titles array length to keep system prompt size bounded. */
 export const MAX_MANDALA_TITLES = 10;
+
+/**
+ * CP477+15 — Cap on per-mandala card list in Block J. Higher than the
+ * sidebar's count display but still bounded to keep the prompt small.
+ * If the mandala has more cards the chatbot can ask for clarification
+ * about which cell the user means.
+ */
+export const MAX_MANDALA_CARDS = 24;
+
+/**
+ * CP477+15 — Cap on chapters surfaced in Block I. The book index is
+ * primarily for navigation hints ("어느 챕터에 있어?"), not full content
+ * reproduction. Sections inside each chapter are emitted by title only.
+ */
+export const MAX_BOOK_CHAPTERS = 8;
+
+/** CP477+15 — Per-chapter section cap inside Block I. */
+export const MAX_BOOK_SECTIONS_PER_CHAPTER = 6;
+
+/** CP477+15 — Hard cap on Block N's note excerpt to keep prompt size bounded. */
+export const MAX_NOTE_EXCERPT_CHARS = 1_500;
 
 /** Activity window for recent_card_count_7d. */
 export const RECENT_DAYS_WINDOW = 7;


### PR DESCRIPTION
## Why

Chatbot 이 Insighta 구조 (유저-만다라-영상-노트-사이드바) 전체를 알아야 정확히 답변. 기존 = 코드/loader 모두 있었지만 invoke site 미배선 (`chatbot-rag-system.md §3: "설계 완료 + 코드 ready, 미배선"`). 사용자 reports — "내 만다라 몇개?" / "이 만다라 영상 몇개?" / "내 노트?" 가 generic 응답.

## What

| Block | Source | Loader |
|---|---|---|
| U (user/mandala 전체) | users + user_subscriptions + user_mandalas + user_local_cards | existing |
| E (현재 만다라 context) | user_mandala_levels (center_goal + subjects[]) | **NEW** `mandala-context-loader` |
| **I (book index)** | `mandala_books.book_json` chapters/sections + UNIQUE video count + titles | **NEW** `mandala-book-loader` |
| J (cards) | `user_local_cards` cell_index>=0 (LeftPanel mirror) | **NEW** `mandala-cards-loader` |
| N (note) | `note_documents.content_json` (TipTap → plain-text excerpt) | **NEW** `note-loader` |
| A-D / T | video_rich_summaries / transcript | existing |
| **H (RAG)** | ontology.nodes + Cohere rerank (invoke 활성화) | existing |

## Implementation

1. **JWT → AsyncLocalStorage plumbing** (`chatbot-context-storage.ts`, NEW): raw HTTP listener 가 `fastify.jwt.verify(token)` 후 `runWithChatbotContext({userId, email, displayName}, ...)`. PR #732 race-fix 의 paused window 안 (~5-20ms 추가).
2. **Middleware parallel loaders**: `rewriteSystemContent` 가 6개 loader Promise.all + retriever invoke. 각 loader fail-safe (`.catch(() => null)` → block skip).
3. **New block builders**: `blockI` ("Sidebar video count = N from book index atoms" 사용자 사이드바 mirror), `blockJ`, `blockN`. `LAYER_BLOCKS` 재설계 — 모든 mandala-scoped layer 가 U→E→I→J→N→A-D→H 순서로 emit.
4. **RAG query plumbing**: `rewriteSystemPrompt` + `applySFTRewrite` (legacy) 가 last user-turn 추출 후 retriever query 로 전달.

## Regression protection

- 미인증 → loader 전체 no-op → 기존 prompt 와 동일
- 각 loader catch → block skip, 다른 block 정상
- FE 변경 0 (useCopilotReadable 그대로)
- JWT verify fail → empty context → Block U skip + 나머지 정상

## Smoke test results (`scripts/chatbot-rag-smoke.ts`)

Real DB fixture (`87bac8d8` mandala, `한 달 안에 창업 프로그램 지원하기`):
- ✓ Block U: "47 mandalas, James Kim, admin"
- ✓ Block E: center_goal + cell_name resolve
- ✓ **Block I: "Sidebar video count = 10 (from book index atoms)"** + 8 chapters + 4 video titles — 사용자 사이드바 mirror 정확
- ✓ Block J: user_local_cards (cell_index>=0)
- ✓ Block A-D: video_rich_summaries
- ⚠ Block H: dev `.env` GEMINI_API_KEY invalid → fail-safe empty. prod valid key 가정 (별 PR backlog 로 OpenRouter Qwen3-Embedding-8B fallback + Mac Mini OLLAMA_HOST wiring 검증 후 진행).

## Verification

- BE `npx tsc --noEmit` EXIT=0
- smoke test 6 시나리오 PASS (Block U/E/I/J/A-D), Block H prod-only

## Out of scope (backlog)

- **B+C 묶음 PR**: prod `OLLAMA_HOST` wiring (Mac Mini Tailscale 100.102.124.23) + OpenRouter Qwen3-Embedding-8B fallback. dimension/cosine equivalence fixture 검증 후 진행 (4096d vs 768d).
- CopilotKit 1.55.3 의 `Agent default not found` warning — orthogonal, 응답 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)