### PR TITLE
fix(chatbot): selfManagedAgents ProxiedCopilotRuntimeAgent — eliminate warning storm (CP477+17, Issue #733)

### DIFF
--- a/frontend/src/pages/learning/ui/ChatAssistant.tsx
+++ b/frontend/src/pages/learning/ui/ChatAssistant.tsx
@@ -5,6 +5,7 @@
 import { useMemo, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CopilotKit, useCopilotReadable, useCopilotChat } from '@copilotkit/react-core';
+import { ProxiedCopilotRuntimeAgent } from '@copilotkit/core';
 import { CopilotChat } from '@copilotkit/react-ui';
 import '@copilotkit/react-ui/styles.css';
 import { toast } from 'sonner';
@@ -541,9 +542,71 @@ export function ChatAssistant({ mandalaId, videoId, onSeek }: ChatAssistantProps
   const token = apiClient.getAccessToken();
   const headers = useMemo(() => (token ? { Authorization: `Bearer ${token}` } : {}), [token]);
 
+  // Issue #733 Option (1) — explicit self-managed agent registry.
+  //
+  // Root cause we are addressing (verified via lib source, no guesses):
+  //   1. BE `copilotRuntimeNodeHttpEndpoint` is single-route only
+  //      (lib/integrations/node-http/index.ts:49 → createCopilotEndpointSingleRoute).
+  //   2. When `selfManagedAgents` is absent, FE's `_agents` map stays `{}`
+  //      until `fetchRuntimeInfo()` resolves; meanwhile every render of
+  //      `useCopilotChat` / `use-render-custom-messages` / `useAgent` hits
+  //      `core/dist/index.cjs:911 getAgent → if (id in _agents) {}` empty →
+  //      fires `console.warn(\`Agent default not found\`)` 600+ times per
+  //      page-load (the "warning storm" seen since CP477+8 / Issue #733).
+  //   3. After fetchRuntimeInfo resolves, lib auto-creates
+  //      `remoteAgents.default = new ProxiedCopilotRuntimeAgent({...,
+  //      transport: _runtimeTransport})` (core/index.cjs:966-981) and merges
+  //      it as `_agents = {...localAgents, ...remoteAgents}` (later spread
+  //      wins). At THAT point chat works normally. The storm is purely the
+  //      mount→fetch race window.
+  //
+  // Fix mechanism:
+  //   - Inject the SAME class lib creates at runtime
+  //     (`ProxiedCopilotRuntimeAgent`) into `localAgents` synchronously at
+  //     mount time. Provider's `useMemo({...agents, ...selfManagedAgents})`
+  //     (CopilotKitProvider.tsx:386-389) inlines it into the
+  //     `CopilotKitCoreReact` constructor's `agents__unsafe_dev_only` (line
+  //     548), which `AgentRegistry.initialize` sets as `localAgents` AND
+  //     `_agents` at construction (core/index.cjs:848-850). So `_agents.default`
+  //     is populated on the very first render → `getAgent("default")` always
+  //     hits → zero warns.
+  //
+  //   - Set `transport: 'single'` explicitly (matches our BE's single-route
+  //     endpoint). ProxiedCopilotRuntimeAgent's constructor (core/index.cjs:512)
+  //     reads transport: single → fetch URL = runtimeUrl (no /agent/:id/run
+  //     suffix) + body = `{method:"agent/run", params:{...}}` envelope. This
+  //     is exactly what `single-route-helpers.ts:validateMethod` accepts, so
+  //     even the first send before fetchRuntimeInfo resolves goes to BE 200.
+  //
+  //   - `useSingleEndpoint={true}` on the Provider tells the lib to skip
+  //     `fetchRuntimeInfoAutoDetect`'s GET /info probe (which returns 405 on
+  //     our BE) and go straight to single-route POST root — eliminates a
+  //     red console error per mount.
+  //
+  // Why this is the canonical fix and not a workaround: we inject the EXACT
+  // class lib would have created itself once fetchRuntimeInfo resolved,
+  // simply moved earlier in the lifecycle. After fetch resolves, the
+  // remoteAgents.default override (line 980) lands and merges cleanly with
+  // localAgents (identical class, identical transport). No protocol
+  // mismatch is possible because there's only one transport in play
+  // (single) at every point of the lifecycle.
+  const agents = useMemo(
+    () => ({
+      default: new ProxiedCopilotRuntimeAgent({
+        runtimeUrl: '/api/v1/chat',
+        agentId: 'default',
+        transport: 'single',
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      }),
+    }),
+    [token]
+  );
+
   return (
     <CopilotKit
       runtimeUrl="/api/v1/chat"
+      useSingleEndpoint={true}
+      selfManagedAgents={agents}
       showDevConsole={false}
       enableInspector={false}
       headers={headers}


### PR DESCRIPTION
## Why

`Agent default not found` console warning storm (~600/page-load), recurring 6+ sessions (CP477+8 onward), tracked as **Issue #733**.

## Root cause (verified via lib source, no guesses — code line refs inline)

@copilotkit/core 1.55.3 mount→fetch race window:

1. BE `copilotRuntimeNodeHttpEndpoint` is **single-route only** (`lib/integrations/node-http/index.ts:49 → createCopilotEndpointSingleRoute`).
2. FE `AgentRegistry._agents` initializes empty (`core/dist/index.cjs:793`). Stays empty until `fetchRuntimeInfo()` resolves (network roundtrip).
3. During that ms-window, every render of `useCopilotChat` / `use-render-custom-messages` / `useAgent` calls `getAgent("default")` (`core/dist/index.cjs:911`) → `_agents` empty → `console.warn(\`Agent ${id} not found\`)` × 5+ hooks × every render = the storm.
4. After fetchRuntimeInfo, lib **auto-creates** `remoteAgents.default = new ProxiedCopilotRuntimeAgent({runtimeUrl, agentId, transport: _runtimeTransport})` (`core/index.cjs:966-981`) and merges as `_agents = {...localAgents, ...remoteAgents}` (line 874). At that point chat works — storm was purely the race window.

A prior stub attempt with plain `HttpAgent` closed the storm but caused 400 "Missing method field" on first send: HttpAgent posts raw AG-UI body, no `{method}` envelope, which BE single-route rejects. **Only `ProxiedCopilotRuntimeAgent` constructs the correct single-route envelope.**

## Fix

Inject the **exact class lib creates at runtime**, just earlier in the lifecycle:

```ts
selfManagedAgents={{
  default: new ProxiedCopilotRuntimeAgent({
    runtimeUrl: '/api/v1/chat',
    agentId:    'default',
    transport:  'single',   // BE is single-route only
    headers,
  })
}}
useSingleEndpoint={true}
```

### Lifecycle (each step backed by lib code line)

| Phase | Mechanism |
|---|---|
| **Mount** | `Provider useMemo({...agents, ...selfManagedAgents})` (CopilotKitProvider.tsx:386-389) → `CopilotKitCoreReact` constructor `agents__unsafe_dev_only` (line 548) → `AgentRegistry.initialize` sets `localAgents` AND `_agents` SYNC (core/index.cjs:848-850). `_agents.default` exists on the very first render → `getAgent("default")` always hits → **zero warns**. |
| **Mount-window send** | `transport: 'single'` → agent posts `runtimeUrl` (no path suffix) with `{method:"agent/run", params:{...}}` envelope = exactly what `single-route-helpers.ts:99 validateMethod` accepts → **BE 200 SSE** on first send. |
| **After fetchRuntimeInfo** | `remoteAgents.default = new ProxiedCopilotRuntimeAgent(same shape)` overrides via later-spread merge. Same class, same transport → **seamless handoff**, no protocol mismatch at any point. |
| **/info probe** | `useSingleEndpoint={true}` skips `fetchRuntimeInfoAutoDetect`'s GET /info probe (BE returns 405) → removes secondary console red. |

## Why this is the canonical fix, not a workaround

We inject the exact class lib would have created itself once fetchRuntimeInfo resolved — just moved earlier in the lifecycle. Same constructor, same transport, same dispatch envelope. After fetch, the lib's `remoteAgents` override is **semantically a no-op** (identical class). The only thing that changes is *when* the agent exists relative to first render.

## Verification (dev — `/learning/<mandalaId>/<videoId>/...`)

- ✅ Console `Agent.*not found` count = **0** (was ~600/page-load)
- ✅ First chat send: POST /api/v1/chat returns **200** with AG-UI SSE stream (`RAW_TEXT_MESSAGE_START` / `TEXT_MESSAGE_CONTENT` / `TEXT_MESSAGE_END`)
- ✅ RAG block (mandala / cards / book / note context) preserved — chatbot answers from current context as before
- ✅ Hard reload + 5-min watch: storm 0 sustained

Browser screenshots: `Documents/bug report/0522002-버그-워닝 스톰/3rd/`

## Footprint

- BE: 0 lines changed
- FE: +63 lines in `frontend/src/pages/learning/ui/ChatAssistant.tsx` (1 import + `agents` useMemo + 3 Provider props)
- No lib bump required (works on 1.55.3 hardpin from CP479)
- PR #732 race-fix preserved (BE single-route path untouched)

## Refs

- Issue #733 Option (1) self-managed agents
- CP479 PR #716 (1.55.3 hardpin) — kept
- PR #732 (req.pause/resume race-fix) — unchanged

## Test plan

- [ ] CI green (lint / typecheck / FE test / BE test / build / a11y / hardcode-audit)
- [ ] dev verified (storm 0, first send 200 SSE, RAG context intact) ← already done, see screenshots
- [ ] prod deploy → live verification (storm 0 on insighta.one/learning/...)

🤖 Generated with [Claude Code](https://claude.com/claude-code)