### PR TITLE
feat(add-cards): clickable picked card to unpick (idempotent toggle)

### DIFF
--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1935,7 +1935,8 @@
     },
     "actions": {
       "addOne": "Add to mandala",
-      "picked": "Picked"
+      "picked": "Picked",
+      "unpick": "Remove"
     }
   }
 }

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1943,7 +1943,8 @@
     },
     "actions": {
       "addOne": "만다라에 추가",
-      "picked": "추가됨"
+      "picked": "추가됨",
+      "unpick": "추가 취소"
     }
   }
 }

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
@@ -23,7 +23,7 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { AlertCircle, Bookmark, Check, Loader2, RotateCw } from 'lucide-react';
+import { AlertCircle, Bookmark, Check, Loader2, RotateCw, X } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { formatRelativeDate } from '@/shared/lib/format-date';
 import { formatDuration, formatViewCount } from '@/shared/lib/format-number';
@@ -107,14 +107,16 @@ export function AddCardsList({
     <ul className="grid grid-cols-3 gap-3 px-5 py-3 sm:px-6">
       {cards.map((card) => {
         const isPicked = pickedSet.has(card.videoId);
-        const disabled = isPicked || isPickPending;
-        const labelKey = isPicked ? 'addCards.actions.picked' : 'addCards.actions.addOne';
-        const labelDefault = isPicked ? 'Picked' : 'Add to mandala';
+        // CP480+ — picked cards are now clickable to unpick (idempotent
+        // toggle). Only mid-flight requests are disabled.
+        const disabled = isPickPending;
+        const labelKey = isPicked ? 'addCards.actions.unpick' : 'addCards.actions.addOne';
+        const labelDefault = isPicked ? 'Remove from mandala' : 'Add to mandala';
         return (
           <li
             key={card.videoId}
             role="button"
-            tabIndex={isPicked ? -1 : 0}
+            tabIndex={0}
             aria-pressed={isPicked}
             aria-disabled={disabled || undefined}
             aria-label={`${t(labelKey, labelDefault)}: ${card.title}`}
@@ -132,8 +134,8 @@ export function AddCardsList({
             className={cn(
               'group relative rounded-md overflow-hidden border bg-card transition-colors',
               'border-transparent',
-              !isPicked && 'cursor-pointer hover:border-border focus-visible:border-border',
-              isPicked && 'cursor-default',
+              !disabled && 'cursor-pointer hover:border-border focus-visible:border-border',
+              disabled && 'cursor-wait',
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
             )}
           >
@@ -172,17 +174,28 @@ export function AddCardsList({
                 </div>
               )}
 
-              {/* Picked overlay — strong layered cue (post-click). */}
+              {/* Picked overlay — strong layered cue (post-click).
+                  Hover state (CP480+) reveals the unpick affordance:
+                  green check → red X, label → "추가 취소". Click toggles
+                  via the same parent onPick handler. */}
               {isPicked && (
                 <div
-                  className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/55 backdrop-blur-[2px] gap-1"
+                  className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/55 backdrop-blur-[2px] gap-1 transition-colors group-hover:bg-rose-950/70"
                   aria-hidden="true"
                 >
-                  <span className="flex items-center justify-center w-9 h-9 rounded-full bg-emerald-500 shadow-lg">
+                  {/* Default badge — visible at rest, hidden on hover. */}
+                  <span className="flex items-center justify-center w-9 h-9 rounded-full bg-emerald-500 shadow-lg transition-opacity duration-150 group-hover:opacity-0">
                     <Check className="w-5 h-5 text-white" strokeWidth={3} />
                   </span>
-                  <span className="text-[10.5px] font-semibold text-white tracking-wide">
+                  {/* Hover badge — X cue for unpick. */}
+                  <span className="absolute flex items-center justify-center w-9 h-9 rounded-full bg-rose-500 shadow-lg opacity-0 transition-opacity duration-150 group-hover:opacity-100">
+                    <X className="w-5 h-5 text-white" strokeWidth={3} />
+                  </span>
+                  <span className="text-[10.5px] font-semibold text-white tracking-wide transition-opacity duration-150 group-hover:opacity-0">
                     {t('addCards.actions.picked', 'Picked')}
+                  </span>
+                  <span className="absolute text-[10.5px] font-semibold text-white tracking-wide opacity-0 transition-opacity duration-150 group-hover:opacity-100 mt-12">
+                    {t('addCards.actions.unpick', 'Remove from mandala')}
                   </span>
                 </div>
               )}

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -88,7 +88,6 @@ export function AddCardsPanel() {
     if (!mandalaId) return;
     saveSessionPicks(mandalaId, Array.from(localPicks));
   }, [mandalaId, localPicks]);
-  const { like } = useLikeCard();
   const queryClient = useQueryClient();
 
   // Server-truth set of mandala-pre-existing videoIds. Used as a list
@@ -119,10 +118,48 @@ export function AddCardsPanel() {
   );
   const hasSearched = mutation.isSuccess || mutation.isError || restoredCards !== null;
 
+  const { like, unlike } = useLikeCard();
+
+  const handleUnpick = useCallback(
+    (videoId: string) => {
+      if (!mandalaId) return;
+      // Optimistic flip — strip from local picks immediately so the
+      // overlay clears before the API round-trip.
+      setLocalPicks((prev) => {
+        if (!prev.has(videoId)) return prev;
+        const next = new Set(prev);
+        next.delete(videoId);
+        return next;
+      });
+      unlike.mutate(videoId, {
+        onSuccess: () => {
+          // unlike already invalidates local-cards + v2-summaries.
+          // Also nudge the grid sources (uvs + recommendations) so the
+          // card disappears from the mandala without a manual reload.
+          queryClient.invalidateQueries({ queryKey: youtubeSyncKeys.allVideoStates });
+          queryClient.invalidateQueries({ queryKey: ['mandala', 'recommendations', mandalaId] });
+        },
+        onError: () => {
+          // Restore overlay on failure so user sees the picked state again.
+          setLocalPicks((prev) => {
+            const next = new Set(prev);
+            next.add(videoId);
+            return next;
+          });
+        },
+      });
+    },
+    [mandalaId, unlike, queryClient]
+  );
+
   const handlePick = useCallback(
     (videoId: string, title: string) => {
       if (!mandalaId) return;
-      if (pickedSet.has(videoId)) return;
+      // Toggle: picked → unpick (CP480+). Idempotent like+unlike round-trip.
+      if (pickedSet.has(videoId)) {
+        handleUnpick(videoId);
+        return;
+      }
       const candidate = (mutation.data?.cards ?? restoredCards ?? []).find(
         (c) => c.videoId === videoId
       );
@@ -173,7 +210,7 @@ export function AddCardsPanel() {
         }
       );
     },
-    [mandalaId, pickedSet, like, mutation.data, restoredCards, queryClient]
+    [mandalaId, pickedSet, like, mutation.data, restoredCards, queryClient, handleUnpick]
   );
 
   // Seed wizard meta (focus_tags + target_level) as soon as the mandala
@@ -518,7 +555,7 @@ export function AddCardsPanel() {
               errorMessage={mutation.error?.message}
               onRetry={triggerSearch}
               pickedSet={pickedSet}
-              isPickPending={like.isPending}
+              isPickPending={like.isPending || unlike.isPending}
               onPick={handlePick}
             />
           </div>


### PR DESCRIPTION
## Summary
User-reported 2026-05-24: 'Find more cards' panel 의 '추가됨' 체크 표시가 클릭 안 되어 카드를 panel 안에서 unpick 할 수 없었다. BE 는 이미 unlike 지원 (POST /api/v1/cards/:videoId/unlike + useLikeCard.unlike) 인데 UI 가 read-only 였음.

## Changes
- **AddCardsPanel.tsx** — `handlePick` toggle 분기. picked → 새 `handleUnpick` (optimistic flip + unlike.mutate + invalidate uvs + recommendations + onError rollback). `{ like, unlike } = useLikeCard()`.
- **AddCardsList.tsx** — picked card 도 클릭 가능. `disabled = isPickPending` 만, `tabIndex={0}` on all rows, `cursor-pointer` on picked. Hover 시 emerald check → **rose X** + 라벨 "추가됨" → "추가 취소" transition.
- **ko.json / en.json** — `addCards.actions.unpick` 추가.

## Pre-flight
- tsc (frontend): ✅ 0 errors
- vitest: ✅ 35 files / 336 tests pass
- npm run build: ✅ pass (10.79s)
- /verify dev smoke (:8081): ✅ GET / 200

## Test plan
- [ ] CI pass
- [ ] Deploy health (insighta.one/health 200)
- [ ] '+카드 추가' 패널에서 이미 추가한 카드 hover → rose X 표시
- [ ] X 클릭 → optimistic flip (체크 즉시 사라짐) + 그리드에서 카드 사라짐
- [ ] 실패 시 자동 rollback (체크 복원)

🤖 Generated with [Claude Code](https://claude.com/claude-code)