### PR TITLE
fix(dashboard): display server-truth cardCount in header, not FE 4-source aggregate

### DIFF
--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -155,9 +155,11 @@ function AuthenticatedApp() {
   const isViewingPending = !!pendingMandala && effectiveMandalaId === pendingMandala.tempId;
 
   // 3. Mandala data from DB (by selected mandala ID)
-  const { mandalaLevels: queryMandalaLevels, isLoading: mandalaQueryLoading } = useMandalaQuery(
-    isViewingPending ? null : effectiveMandalaId
-  );
+  const {
+    mandalaLevels: queryMandalaLevels,
+    mandalaMeta,
+    isLoading: mandalaQueryLoading,
+  } = useMandalaQuery(isViewingPending ? null : effectiveMandalaId);
 
   // Suppress "Sector 1..8" + empty-title placeholders while the detail query
   // is still inflight AND we have no useful subjects yet. Treated as
@@ -933,7 +935,7 @@ function AuthenticatedApp() {
                     allCards={cards.allMandalaCards}
                     scratchPadCards={cards.scratchPadCards}
                     cardsByCell={cards.cardsByCell}
-                    totalCards={cards.totalCards}
+                    totalCards={mandalaMeta?.cardCount ?? cards.totalCards}
                     sectorSubjects={
                       navigation.currentLevel.subjectLabels?.length
                         ? navigation.currentLevel.subjectLabels
@@ -1031,7 +1033,7 @@ function AuthenticatedApp() {
                       }
                       selectedCellIndex={navigation.selectedCellIndex}
                       onCellClick={navigation.handleCellClick}
-                      totalCardCount={cards.totalCards}
+                      totalCardCount={mandalaMeta?.cardCount ?? cards.totalCards}
                       cardsByCell={cards.cardsByCell}
                       isExternalCardDragActive={activeDragData?.type === 'card'}
                       isInternalCardDragActive={
@@ -1088,7 +1090,7 @@ function AuthenticatedApp() {
         {isMobile && (
           <MandalaPanel
             mode="floating"
-            totalCards={cards.totalCards}
+            totalCards={mandalaMeta?.cardCount ?? cards.totalCards}
             onToggleMode={() => {}}
             isOpen={isFloatingPanelOpen}
             onOpenChange={setIsFloatingPanelOpen}


### PR DESCRIPTION
## Summary

Top dashboard card count flickered during mandala switch because the FE summed 4 async sources (`useLocalCards` 5s / `useAllVideoStates` 30s / SSE buffer / `pendingLocalCards`) each with its own freshness window — the displayed total drifted as each source arrived at different times.

The BE already computes the authoritative count once per request in [`manager.ts:299 computeCardCount`](src/modules/mandala/manager.ts) — `UNION DISTINCT` over `user_local_cards` + `user_video_states JOIN youtube_videos`, scoped to `cell_index >= 0` + non-scratchpad — and the value flows to the FE as `mandalaMeta.cardCount` ([`useMandalaQuery.ts:69`](frontend/src/features/mandala/model/useMandalaQuery.ts)). A `grep -rn "meta\\.cardCount" frontend/src/` showed **0 consumers** — the field was being fetched and completely ignored.

## Change

Wire the existing server-truth value to the 3 display surfaces:

| Surface | Line | Before | After |
|---|---|---|---|
| `CardListView` header chip (primary symptom) | `IndexPage.tsx:1036` | `cards.totalCards` | `mandalaMeta?.cardCount ?? cards.totalCards` |
| `InsightsView` | `IndexPage.tsx:938` | same | same |
| `MandalaPanel` (mobile) | `IndexPage.tsx:1093` | same | same |

`cards.totalCards` (the FE 4-source aggregate) remains the fallback for the brief frame before `mandalaMeta` loads, and continues to drive the internal polling / skeleton gates that need FE-observed truth (line 291 `isNewMandalaActive` polling stop; lines 951/960/961 empty-state + skeleton gates).

## Scope (intentional minimal)

- The broader 4-source race that also causes **card re-ordering** still exists. That fix is tracked separately as the unified-endpoint refactor (Option C from the earlier investigation — `GET /api/v1/mandalas/:id/cards` returning `{ cardCount, cardsByCell, scratchPad }`, ~13-16h scope).
- This PR isolates the **count display** — the only visible symptom in the user's 2026-05-25 report.

## Trade-off

When the user adds/deletes a card, the displayed count won't update until `mandalaMeta` refetches (5min `staleTime` or focus refetch). If immediate freshness becomes a concern, follow-up: add `queryClient.invalidateQueries(queryKeys.mandala.detail(mandalaId))` to `useAddLocalCard` / `useDeleteLocalCard` / `useBatchMoveCards` `onSettled`.

## Files

| File | Change |
|---|---|
| `frontend/src/pages/index/ui/IndexPage.tsx` | + `mandalaMeta` destructured from `useMandalaQuery`, 3 display sites switched to `mandalaMeta?.cardCount ?? cards.totalCards` |

Total: 1 file, +8 / -6.

## Verified

- [x] `tsc --noEmit` EXIT=0
- [x] husky pre-commit (lint + prettier) PASS
- [ ] Browser manual smoke — blocked locally on parallel-session WIP (other-session) on `src/api/routes/copilotkit.ts`; deploy verification on CI / preview

## CLAUDE.md compliance

- ✅ No `.env` edit, no LLM API call, no prod DB write, no EC2 SSH bypass, no D&D protected file edit
- ✅ Plan→Approve→Execute: option (1) approved by user 2026-05-25
- ✅ Source-read first (CP391): all referenced files Read before editing
- ⚠️ The conflicted `src/api/routes/copilotkit.ts` was NOT touched (other-session work, multi-worktree LEVEL-2 rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)