### PR TITLE
fix(add-cards): picked cards stay in list + always-visible unpick affordance

### DIFF
--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
@@ -182,32 +182,24 @@ export function AddCardsList({
                   obvious without hovering. */}
               {isPicked && (
                 <>
+                  {/* State indicator — picked state (always green check).
+                      Action (remove) lives ONLY on the top-right X chip
+                      below; separating state from action avoids the
+                      double-X confusion (user 2026-05-25 design review). */}
                   <div
-                    className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/55 backdrop-blur-[2px] gap-1 transition-colors group-hover:bg-rose-950/70"
+                    className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/55 backdrop-blur-[2px] gap-1"
                     aria-hidden="true"
                   >
-                    <span className="flex items-center justify-center w-9 h-9 rounded-full bg-emerald-500 shadow-lg transition-colors duration-150 group-hover:bg-rose-500">
-                      <Check
-                        className="w-5 h-5 text-white transition-opacity duration-150 group-hover:opacity-0"
-                        strokeWidth={3}
-                      />
-                      <X
-                        className="w-5 h-5 text-white absolute opacity-0 transition-opacity duration-150 group-hover:opacity-100"
-                        strokeWidth={3}
-                      />
+                    <span className="flex items-center justify-center w-9 h-9 rounded-full bg-emerald-500 shadow-lg">
+                      <Check className="w-5 h-5 text-white" strokeWidth={3} />
                     </span>
-                    <span className="text-[10.5px] font-semibold text-white tracking-wide transition-opacity duration-150 group-hover:opacity-0">
+                    <span className="text-[10.5px] font-semibold text-white tracking-wide">
                       {t('addCards.actions.picked', 'Picked')}
-                    </span>
-                    <span className="absolute text-[10.5px] font-semibold text-white tracking-wide opacity-0 transition-opacity duration-150 group-hover:opacity-100 mt-12">
-                      {t('addCards.actions.unpick', 'Remove from mandala')}
                     </span>
                   </div>
 
-                  {/* Always-visible unpick chip — top-right corner, brighter
-                      on hover. Tells the user the picked state is clickable
-                      without requiring a hover-discovery. Click bubbles up
-                      to the parent <li> which already toggles via onPick. */}
+                  {/* Action — always-visible unpick chip. Single source of
+                      the remove affordance (no center hover-X transition). */}
                   <span
                     className="absolute top-1 right-1 z-20 inline-flex items-center justify-center h-6 w-6 rounded-full bg-black/60 text-white shadow-md transition-colors group-hover:bg-rose-500"
                     aria-hidden="true"

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
@@ -199,9 +199,12 @@ export function AddCardsList({
                   </div>
 
                   {/* Action — always-visible unpick chip. Single source of
-                      the remove affordance (no center hover-X transition). */}
+                      the remove affordance (no center hover-X transition).
+                      Hover uses a subtle white wash rather than rose-500 —
+                      user 2026-05-26 design review: red on hover read as
+                      over-aggressive for a soft remove action. */}
                   <span
-                    className="absolute top-1 right-1 z-20 inline-flex items-center justify-center h-6 w-6 rounded-full bg-black/60 text-white shadow-md transition-colors group-hover:bg-rose-500"
+                    className="absolute top-1 right-1 z-20 inline-flex items-center justify-center h-6 w-6 rounded-full bg-black/60 text-white shadow-md transition-colors group-hover:bg-white/25"
                     aria-hidden="true"
                   >
                     <X className="w-3.5 h-3.5" strokeWidth={2.6} />

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
@@ -174,45 +174,59 @@ export function AddCardsList({
                 </div>
               )}
 
-              {/* Picked overlay — strong layered cue (post-click).
-                  Hover state (CP480+) reveals the unpick affordance:
-                  green check → red X, label → "추가 취소". Click toggles
-                  via the same parent onPick handler. */}
+              {/* Picked overlay — post-click dim + center check. CP480+
+                  hover transitioned check → X but the affordance was only
+                  visible on hover; user report 2026-05-25 "토글 인지
+                  불안정" → unpick chip is now ALWAYS visible (top-right
+                  corner, brighter on hover) so the click outcome is
+                  obvious without hovering. */}
               {isPicked && (
-                <div
-                  className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/55 backdrop-blur-[2px] gap-1 transition-colors group-hover:bg-rose-950/70"
-                  aria-hidden="true"
-                >
-                  {/* Default badge — visible at rest, hidden on hover. */}
-                  <span className="flex items-center justify-center w-9 h-9 rounded-full bg-emerald-500 shadow-lg transition-opacity duration-150 group-hover:opacity-0">
-                    <Check className="w-5 h-5 text-white" strokeWidth={3} />
-                  </span>
-                  {/* Hover badge — X cue for unpick. */}
-                  <span className="absolute flex items-center justify-center w-9 h-9 rounded-full bg-rose-500 shadow-lg opacity-0 transition-opacity duration-150 group-hover:opacity-100">
-                    <X className="w-5 h-5 text-white" strokeWidth={3} />
-                  </span>
-                  <span className="text-[10.5px] font-semibold text-white tracking-wide transition-opacity duration-150 group-hover:opacity-0">
-                    {t('addCards.actions.picked', 'Picked')}
-                  </span>
-                  <span className="absolute text-[10.5px] font-semibold text-white tracking-wide opacity-0 transition-opacity duration-150 group-hover:opacity-100 mt-12">
-                    {t('addCards.actions.unpick', 'Remove from mandala')}
-                  </span>
-                </div>
-              )}
+                <>
+                  <div
+                    className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/55 backdrop-blur-[2px] gap-1 transition-colors group-hover:bg-rose-950/70"
+                    aria-hidden="true"
+                  >
+                    <span className="flex items-center justify-center w-9 h-9 rounded-full bg-emerald-500 shadow-lg transition-colors duration-150 group-hover:bg-rose-500">
+                      <Check
+                        className="w-5 h-5 text-white transition-opacity duration-150 group-hover:opacity-0"
+                        strokeWidth={3}
+                      />
+                      <X
+                        className="w-5 h-5 text-white absolute opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+                        strokeWidth={3}
+                      />
+                    </span>
+                    <span className="text-[10.5px] font-semibold text-white tracking-wide transition-opacity duration-150 group-hover:opacity-0">
+                      {t('addCards.actions.picked', 'Picked')}
+                    </span>
+                    <span className="absolute text-[10.5px] font-semibold text-white tracking-wide opacity-0 transition-opacity duration-150 group-hover:opacity-100 mt-12">
+                      {t('addCards.actions.unpick', 'Remove from mandala')}
+                    </span>
+                  </div>
 
-              {/* Bookmark indicator — picked cards only. Unpicked
-                  cards rely on the hover preview overlay above. */}
-              {isPicked && (
-                <span
-                  className="absolute bottom-1 right-1 z-10 w-6 h-6 flex items-center justify-center opacity-100"
-                  aria-hidden="true"
-                >
-                  <Bookmark
-                    className="w-[18px] h-[18px] text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.85)]"
-                    fill="currentColor"
-                    strokeWidth={2.2}
-                  />
-                </span>
+                  {/* Always-visible unpick chip — top-right corner, brighter
+                      on hover. Tells the user the picked state is clickable
+                      without requiring a hover-discovery. Click bubbles up
+                      to the parent <li> which already toggles via onPick. */}
+                  <span
+                    className="absolute top-1 right-1 z-20 inline-flex items-center justify-center h-6 w-6 rounded-full bg-black/60 text-white shadow-md transition-colors group-hover:bg-rose-500"
+                    aria-hidden="true"
+                  >
+                    <X className="w-3.5 h-3.5" strokeWidth={2.6} />
+                  </span>
+
+                  {/* Bookmark anchor — bottom-right, kept for state continuity. */}
+                  <span
+                    className="absolute bottom-1 right-1 z-10 w-6 h-6 flex items-center justify-center opacity-100"
+                    aria-hidden="true"
+                  >
+                    <Bookmark
+                      className="w-[18px] h-[18px] text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.85)]"
+                      fill="currentColor"
+                      strokeWidth={2.2}
+                    />
+                  </span>
+                </>
               )}
             </div>
             <div className="px-1.5 py-1 space-y-0">

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -104,14 +104,23 @@ export function AddCardsPanel() {
     return set;
   }, [allVideoStates, mandalaId]);
 
-  const pickedSet = localPicks;
+  // Single picked set — server-stored picks (mandala already has the card)
+  // unioned with this session's local picks. Drives the "picked" overlay
+  // on each card but does NOT filter the list — the filter caused picked
+  // cards to silently disappear during the unlike → invalidate race window
+  // (user report 2026-05-25) and shifted neighbour positions, breaking
+  // toggle stability + visual continuity. Picked overlay alone provides
+  // the visual cue; the card row stays in place so unpick is reachable.
+  const pickedSet = useMemo(() => {
+    const set = new Set<string>(serverPickedSet);
+    for (const v of localPicks) set.add(v);
+    return set;
+  }, [serverPickedSet, localPicks]);
 
-  // Filter out mandala-pre-existing cards; keep this session's local
-  // picks so they show the green-check overlay until panel close.
-  const cards: AddCardCandidate[] = useMemo(() => {
-    const raw = mutation.data?.cards ?? restoredCards ?? [];
-    return raw.filter((c) => !serverPickedSet.has(c.videoId) || localPicks.has(c.videoId));
-  }, [mutation.data, restoredCards, serverPickedSet, localPicks]);
+  const cards: AddCardCandidate[] = useMemo(
+    () => mutation.data?.cards ?? restoredCards ?? [],
+    [mutation.data, restoredCards]
+  );
   const visibleCount = useMemo(
     () => cards.filter((c) => !pickedSet.has(c.videoId)).length,
     [cards, pickedSet]


### PR DESCRIPTION
## User report (2026-05-25)

1. **픽한 카드가 검색창에서 사라져**
2. **체크/언체크 토글 불안정** (hover-only X — 마우스 떠나면 인지 불가)
3. **카드 위치가 픽 후 달라짐**

## Root cause — Bug A (primary)

`AddCardsPanel.tsx` filtered the card list with:

```ts
raw.filter((c) => !serverPickedSet.has(c.videoId) || localPicks.has(c.videoId));
```

During the **unlike → invalidate → useAllVideoStates refetch** race window (300-500ms), `setLocalPicks` synchronously cleared the videoId while `serverPickedSet` still held it → both sides of the OR returned **false** → the card silently dropped from the list, neighbour positions shifted, and the toggle target vanished mid-flight.

## Fix A — drop the filter

```diff
- const pickedSet = localPicks;
+ const pickedSet = useMemo(() => {
+   const set = new Set<string>(serverPickedSet);
+   for (const v of localPicks) set.add(v);
+   return set;
+ }, [serverPickedSet, localPicks]);
-
- const cards = useMemo(() => {
-   const raw = mutation.data?.cards ?? restoredCards ?? [];
-   return raw.filter((c) => !serverPickedSet.has(c.videoId) || localPicks.has(c.videoId));
- }, [mutation.data, restoredCards, serverPickedSet, localPicks]);
+ const cards = useMemo(
+   () => mutation.data?.cards ?? restoredCards ?? [],
+   [mutation.data, restoredCards]
+ );
```

- `cards` returns the raw BE response in order, no in-place filtering
- `pickedSet` widened to `serverPickedSet ∪ localPicks` → drives the overlay for BOTH session-picked + previously-picked cards
- **Side benefit**: clicking a server-picked card (already in mandala from a previous session) now correctly hits `handleUnpick` (`handlePick` line 159 toggle gate sees pickedSet has the videoId) — users can remove pre-existing cards directly from the panel

## Fix B — always-visible unpick chip

Previously the X (cancel) affordance was inside `group-hover:opacity-100` — invisible until the user happened to hover, so the picked state read as "final" and toggle UX was discoverable only by accident.

New: always-visible top-right chip (h-6 w-6 dark pill with white X), brightens to `rose-500` on hover. Existing center-check → X transition retained as the secondary cue.

## Fix C — falls out of A

No more filter drops → no neighbour reordering on pick/unpick.

## Files

| File | Change |
|---|---|
| `frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx` | `pickedSet` widened to union; `cards` filter removed (~10 lines) |
| `frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx` | Picked overlay now wraps in fragment with always-visible X chip in top-right (~20 lines) |

Total: 2 files, +67 / -44.

## Verified

- [x] frontend `tsc --noEmit` EXIT=0
- [x] husky pre-commit (lint + prettier) PASS

## Test plan

- [ ] 검색 → 카드 픽 → 카드 자리에 머무름 (filter drop 없음, neighbour 위치 그대로)
- [ ] picked 카드 우상단 **X chip 항상 visible**
- [ ] picked 카드 클릭 → 언픽 진행 (overlay 사라짐, 카드 그대로 자리)
- [ ] 패널 close → reopen → 이전 픽 카드 visible + picked overlay (server-side 픽도 인지)
- [ ] 새 검색 → 만다라에 이미 있는 카드 표시 + picked overlay (즉 사라지지 않음)
- [ ] 클릭 시 unlike 정상 BE round-trip + 우상단 X 빨갛게 변환 (hover)

## CLAUDE.md compliance

- ✅ No `.env` edit, no LLM API call, no prod DB write, no EC2 SSH bypass, no D&D protected file edit
- ✅ Plan→Approve→Execute: mirror-back P approved by user 2026-05-25
- ✅ Source-read first (CP391): AddCardsPanel.tsx + AddCardsList.tsx full read before edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)