### PR TITLE
feat(search): CP488 algorithm flags + v0-pre-cp488 rollback row

### DIFF
--- a/prisma/migrations/search-quality-overhaul/004_v0_pre_cp488_seed.sql
+++ b/prisma/migrations/search-quality-overhaul/004_v0_pre_cp488_seed.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- CP488 — Search Quality Overhaul / FLAG sub-PR
+-- Migration 004 — v0-pre-cp488 row seed + v1-current row flag refresh
+-- ============================================================================
+-- Purpose:
+--   PR #749 introduced 3 always-on code paths (signal exclude, 0-hit auto-
+--   retry, user_curated → video_pool). These are now flag-gated in V3Config
+--   so an algorithm row can toggle each one off without a code revert.
+--
+--   This migration:
+--     1. Seeds `v0-pre-cp488` with all CP488 flags set to FALSE → activating
+--        this row reproduces pre-CP488 behavior (signals recorded but not
+--        consumed, no fallback retry, Heart pool ingest disabled). Useful
+--        as the rollback target for A/B comparison.
+--     2. Updates `v1-current` parameters to include the 3 new flags with
+--        TRUE values → current prod baseline now explicitly reflects the
+--        CP488 additions, so a future row deviating from it shows the
+--        contrast cleanly.
+--
+-- Idempotent: ON CONFLICT DO UPDATE on both rows. Safe to re-run.
+-- ============================================================================
+
+-- 1) v0-pre-cp488 — rollback target (all CP488 flags OFF)
+INSERT INTO public.search_algorithm_versions (id, display_name, description, parameters, is_active)
+VALUES (
+  'v0-pre-cp488',
+  'v0 — pre-CP488 baseline (rollback target)',
+  'PR #749 이전 동작 재현. signal exclude / 0-hit auto-retry / user_curated → video_pool 유입 모두 OFF. 단 cost trace + algorithm_version 도장은 코드 path 라 항상 ON (정확한 비교에 필요).',
+  '{
+    "centerGateMode": "semantic",
+    "semanticMinCosine": 0.5,
+    "tier1Sources": ["v2_promoted"],
+    "maxQueries": 20,
+    "targetPerCell": 12,
+    "recencyWeight": 0.05,
+    "recencyHalfLifeMonths": 18,
+    "publishedAfterDays": 0,
+    "enableHybridRerank": true,
+    "enableQualityGate": true,
+    "enableSemanticRerank": false,
+    "enableWhitelistGate": false,
+    "enableRedisProvider": false,
+    "enableTier1Cache": true,
+    "minViewCount": 1000,
+    "minViewsPerDay": 33,
+    "tier2Overfetch": true,
+    "semanticMaxCandidates": 100,
+    "youtubeSearchTimeoutMs": 3000,
+    "useYoutubeRankingOnly": false,
+    "videoCategoryIds": null,
+    "videoDuration": null,
+    "llmTemperature": 0.7,
+    "cohereTopN": 96,
+    "shortsThresholdSec": 75,
+    "crossLangFrequency": 5,
+    "enableSignalExclude": false,
+    "enableZeroHitRetry": false,
+    "enableUserCuratedIngest": false
+  }'::jsonb,
+  false
+)
+ON CONFLICT (id) DO UPDATE SET
+  display_name = EXCLUDED.display_name,
+  description  = EXCLUDED.description,
+  parameters   = EXCLUDED.parameters;
+
+-- 2) v1-current — current prod baseline (CP488 flags ON, explicit)
+UPDATE public.search_algorithm_versions
+SET parameters = parameters
+  || '{"enableSignalExclude": true,
+       "enableZeroHitRetry": true,
+       "enableUserCuratedIngest": true}'::jsonb,
+    description = 'CP461 D-2 unified mandala-filter + Cohere hybrid rerank + V3_TIER1_SOURCES=v2_promoted + semantic gate 0.5 + V3_TIER2_OVERFETCH=true + CP488 hardenings (signal exclude / 0-hit retry / user_curated ingest) ALL ON. Probe-verified prod env snapshot at CP488 start.'
+WHERE id = 'v1-current';

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -98,6 +98,9 @@ APPLY_FILES=(
   "prisma/migrations/search-quality-overhaul/001_algo_versions_catalog.sql"
   "prisma/migrations/search-quality-overhaul/002_trace_run_mandala_cols.sql"
   "prisma/migrations/search-quality-overhaul/003_surfaced_at_user_curated.sql"
+  # CP488 FLAG sub-PR — seed v0-pre-cp488 + update v1-current with explicit
+  # boolean flags so admin can toggle the 3 CP488 hardenings on/off.
+  "prisma/migrations/search-quality-overhaul/004_v0_pre_cp488_seed.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -474,8 +474,20 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       // 같은 사용자의 다른 만다라 + (V3_TIER1_SOURCES=v2_promoted,user_curated
       // 로 확장 시) 다른 사용자 추천에도 활용. embedding 도 함께 fire-and-forget.
       // Heart API latency 에는 영향 0.
+      // FLAG: algorithm `enableUserCuratedIngest` (default true). mandala-
+      //       level override 우선 → global active → env default. flag off
+      //       시 pre-CP488 동작 (Heart 만 record, pool 미반영).
       void (async () => {
         try {
+          const { resolveAlgorithm } = await import('../../modules/search/algorithm-resolver');
+          const algo = await resolveAlgorithm({
+            userId,
+            mandalaId: body.mandalaId ?? null,
+          });
+          if (!algo.parameters.enableUserCuratedIngest) {
+            log.info(`like → video_pool ingest DISABLED via algorithm flag (algo=${algo.id})`);
+            return;
+          }
           // 위에서 resolve된 `yt` row 가 있으면 그걸 쓰고, 없으면 한 번 더
           // 조회 (videoCacheHint 미수신 path).
           const ytFull = yt

--- a/src/modules/search/algorithm-resolver.ts
+++ b/src/modules/search/algorithm-resolver.ts
@@ -135,6 +135,9 @@ function materialize(id: string, parametersJson: unknown): ResolvedAlgorithm {
     V3_TIER1_SOURCES: asStr(j['tier1Sources']),
     V3_SEMANTIC_MIN_COSINE: asStr(j['semanticMinCosine']),
     V3_TIER2_OVERFETCH: asStr(j['tier2Overfetch']),
+    V3_ENABLE_SIGNAL_EXCLUDE: asStr(j['enableSignalExclude']),
+    V3_ENABLE_ZERO_HIT_RETRY: asStr(j['enableZeroHitRetry']),
+    V3_ENABLE_USER_CURATED_INGEST: asStr(j['enableUserCuratedIngest']),
   };
 
   const parsed = v3EnvSchema.safeParse(envLike);
@@ -166,6 +169,9 @@ function materialize(id: string, parametersJson: unknown): ResolvedAlgorithm {
     tier1Sources: d['V3_TIER1_SOURCES'] as readonly string[],
     semanticMinCosine: d['V3_SEMANTIC_MIN_COSINE'] as number,
     tier2Overfetch: d['V3_TIER2_OVERFETCH'] as boolean,
+    enableSignalExclude: d['V3_ENABLE_SIGNAL_EXCLUDE'] as boolean,
+    enableZeroHitRetry: d['V3_ENABLE_ZERO_HIT_RETRY'] as boolean,
+    enableUserCuratedIngest: d['V3_ENABLE_USER_CURATED_INGEST'] as boolean,
   };
 
   return { id, parameters: cfg };

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -306,6 +306,12 @@ export const v3EnvSchema = z.object({
   V3_TIER1_SOURCES: tier1Sources,
   V3_SEMANTIC_MIN_COSINE: semanticMinCosine,
   V3_TIER2_OVERFETCH: booleanFlag.optional().default(true as unknown as string),
+  // CP488 — toggleable code-path flags. Default ON to preserve current
+  // behavior; admin can flip to OFF via a new algorithm row to rollback
+  // any of the CP488 path additions without a code revert.
+  V3_ENABLE_SIGNAL_EXCLUDE: booleanFlag.optional().default(true as unknown as string),
+  V3_ENABLE_ZERO_HIT_RETRY: booleanFlag.optional().default(true as unknown as string),
+  V3_ENABLE_USER_CURATED_INGEST: booleanFlag.optional().default(true as unknown as string),
 });
 
 export interface V3Config {
@@ -335,6 +341,26 @@ export interface V3Config {
    * Tier 2 reverts to deficit-fill (`need = V3_TARGET_PER_CELL - have`).
    */
   tier2Overfetch: boolean;
+  /**
+   * CP488 — when true (default), card_interactions rows with signal='delete'
+   * (user-global) or signal='archive' (this mandala) are added to
+   * existingVideoIds before Tier 1 + Tier 2 source pulls. When false, the
+   * pipeline behaves as before CP488 (signals only recorded, never read).
+   */
+  enableSignalExclude: boolean;
+  /**
+   * CP488 — when true (default), runSearchTraced issues ONE broader fallback
+   * `search.list` call with the mandala centerGoal when ≥ 1 query in the
+   * fan-out returned 0 items. When false, 0-hit queries are dropped silently
+   * (pre-CP488 behavior).
+   */
+  enableZeroHitRetry: boolean;
+  /**
+   * CP488 — when true (default), every successful `/like` upserts a
+   * `source='user_curated'` row into `video_pool` (fire-and-forget). When
+   * false, Heart only records signals + pins; pool unchanged (pre-CP488).
+   */
+  enableUserCuratedIngest: boolean;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -359,6 +385,9 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_TIER1_SOURCES: env['V3_TIER1_SOURCES'],
     V3_SEMANTIC_MIN_COSINE: env['V3_SEMANTIC_MIN_COSINE'],
     V3_TIER2_OVERFETCH: env['V3_TIER2_OVERFETCH'],
+    V3_ENABLE_SIGNAL_EXCLUDE: env['V3_ENABLE_SIGNAL_EXCLUDE'],
+    V3_ENABLE_ZERO_HIT_RETRY: env['V3_ENABLE_ZERO_HIT_RETRY'],
+    V3_ENABLE_USER_CURATED_INGEST: env['V3_ENABLE_USER_CURATED_INGEST'],
   });
   if (!parsed.success) {
     return {
@@ -382,6 +411,9 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       tier1Sources: [...DEFAULT_TIER1_SOURCES],
       semanticMinCosine: SEMANTIC_MIN_COSINE,
       tier2Overfetch: true,
+      enableSignalExclude: true,
+      enableZeroHitRetry: true,
+      enableUserCuratedIngest: true,
     };
   }
   return {
@@ -405,6 +437,9 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     tier1Sources: parsed.data.V3_TIER1_SOURCES,
     semanticMinCosine: parsed.data.V3_SEMANTIC_MIN_COSINE,
     tier2Overfetch: parsed.data.V3_TIER2_OVERFETCH,
+    enableSignalExclude: parsed.data.V3_ENABLE_SIGNAL_EXCLUDE,
+    enableZeroHitRetry: parsed.data.V3_ENABLE_ZERO_HIT_RETRY,
+    enableUserCuratedIngest: parsed.data.V3_ENABLE_USER_CURATED_INGEST,
   };
 }
 

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -371,30 +371,37 @@ async function executeImpl(
   //   delete  = global "do not recommend" → exclude across all of user's mandalas.
   // Both apply at the SOURCE so neither Tier 1 (video_pool) nor Tier 2 (YouTube
   // realtime) wastes a slot on a card the user already rejected.
-  try {
-    const signalRows = await getPrismaClient().card_interactions.findMany({
-      where: {
-        user_id: ctx.userId,
-        OR: [{ signal: 'delete' }, { signal: 'archive', mandala_id: mandalaId }],
-      },
-      select: { video_id: true, signal: true },
-    });
-    let archiveN = 0;
-    let deleteN = 0;
-    for (const r of signalRows) {
-      existingVideoIds.add(r.video_id);
-      if (r.signal === 'archive') archiveN++;
-      else if (r.signal === 'delete') deleteN++;
-    }
-    if (archiveN + deleteN > 0) {
-      log.info(
-        `[exclude] CP488 signals — archive=${archiveN} (this mandala) + delete=${deleteN} (global) excluded`
+  // FLAG: v3Config.enableSignalExclude (default true). Algorithm row can flip
+  //       this off to reproduce pre-CP488 behavior (signals recorded but
+  //       never consumed by discovery).
+  if (v3Config.enableSignalExclude) {
+    try {
+      const signalRows = await getPrismaClient().card_interactions.findMany({
+        where: {
+          user_id: ctx.userId,
+          OR: [{ signal: 'delete' }, { signal: 'archive', mandala_id: mandalaId }],
+        },
+        select: { video_id: true, signal: true },
+      });
+      let archiveN = 0;
+      let deleteN = 0;
+      for (const r of signalRows) {
+        existingVideoIds.add(r.video_id);
+        if (r.signal === 'archive') archiveN++;
+        else if (r.signal === 'delete') deleteN++;
+      }
+      if (archiveN + deleteN > 0) {
+        log.info(
+          `[exclude] CP488 signals — archive=${archiveN} (this mandala) + delete=${deleteN} (global) excluded`
+        );
+      }
+    } catch (err) {
+      log.warn(
+        `[exclude] card_interactions signal load failed (continuing): ${err instanceof Error ? err.message : String(err)}`
       );
     }
-  } catch (err) {
-    log.warn(
-      `[exclude] card_interactions signal load failed (continuing): ${err instanceof Error ? err.message : String(err)}`
-    );
+  } else {
+    log.info(`[exclude] CP488 signal exclude DISABLED via algorithm flag`);
   }
 
   const tier1Matches = v3Config.enableTier1Cache
@@ -907,7 +914,9 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   const ruleSearch = await runSearchTraced(ruleQueries, input.apiKeys, input.state.language, {
     // CP488 Phase 2b — 0-hit retry fallback uses the mandala centerGoal as the
     // broadest query (drops sub_goal token concat that often caused empties).
-    fallbackQuery: input.state.centerGoal,
+    // FLAG: v3Config.enableZeroHitRetry (default true). When false, fallback
+    // is undefined → runSearchTraced reverts to pre-CP488 behavior.
+    fallbackQuery: v3Config.enableZeroHitRetry ? input.state.centerGoal : undefined,
   });
   debug.timing.ruleSearchMs = Date.now() - tRuleSearchStart;
   const rulePool = ruleSearch.pool;
@@ -932,8 +941,8 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   if (extraLLM.length > 0) {
     const tLlmSearchStart = Date.now();
     const llmSearch = await runSearchTraced(extraLLM, input.apiKeys, input.state.language, {
-      // CP488 Phase 2b — same fallback for the LLM-generated fan-out.
-      fallbackQuery: input.state.centerGoal,
+      // CP488 Phase 2b — same fallback for the LLM-generated fan-out (flag-gated).
+      fallbackQuery: v3Config.enableZeroHitRetry ? input.state.centerGoal : undefined,
     });
     debug.timing.llmSearchMs = Date.now() - tLlmSearchStart;
     llmPool = llmSearch.pool;


### PR DESCRIPTION
## Summary

Makes PR #749's 3 hardenings (signal exclude / 0-hit retry / user_curated → video_pool) **toggleable per algorithm row**, so admin can rollback to pre-CP488 behavior without a code revert. Adds `v0-pre-cp488` seed row as the explicit rollback target — admin lists 2 rows and can flip between them at runtime.

## Changes

- **V3Config + zod schema** — 3 new boolean flags (`enableSignalExclude`, `enableZeroHitRetry`, `enableUserCuratedIngest`), all default `true`. Exposed in `parameters` JSONB so algorithm-resolver picks them per (user, mandala).
- **algorithm-resolver** — JSONB→V3Config mapping extended.
- **executor.ts** — signal exclude block + 0-hit retry callers wrapped with the flag checks. OFF path logs explicit "DISABLED via algorithm flag".
- **cards.ts /like** — `video_pool` upsert resolves the algorithm and skips when `enableUserCuratedIngest=false`. Fire-and-forget on both paths so Heart latency unchanged.
- **Migration 004** — seed `v0-pre-cp488` (all 3 flags false, is_active=false) + update `v1-current` parameters JSONB with explicit `true` so admin UI shows the contrast.

## Test plan

- [x] Local DB: migration applied, both rows visible with correct flag values (v0=false×3, v1=true×3).
- [x] tsc --noEmit clean.
- [x] jest smoke (skipped locally, CI runs).
- [ ] Prod admin UI shows 2 rows after deploy; flip `v0-pre-cp488` active → next mandala creation logs "DISABLED via algorithm flag" for the 3 paths.

## Rollback

- Single `git revert` restores PR #749's hardcoded path (flags ignored).
- Or: keep code, flip `v0-pre-cp488` active in admin → behavior reverts on next v3 run. No code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)