### PR TITLE
chore(prod): disable RICH_SUMMARY_V2_CRON_ENABLED (CP488+ qwen3 quality)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -106,7 +106,15 @@ services:
       # (prod user-facing enrichment) so the §"LLM API 호출 금지" rule
       # (dataset/experiment/test) does not apply. Track A2 (PR #693/694) now
       # retries pending/low rows on a 12h cooldown so this can stay on.
-      - RICH_SUMMARY_V2_CRON_ENABLED=true
+      #
+      # CP488+ (2026-05-26) — DISABLED. The cron path calls generateRichSummaryV2
+      # WITHOUT transcript (rich-summary-v2-cron.ts:202) and the provider
+      # (openrouter/qwen/qwen3-30b-a3b) produced broken segments — unsorted
+      # atom timestamps, narrator-perspective summaries, back-half of the
+      # video uncovered. 491 prod rows marked `quality_flag='qwen3_low'`.
+      # Re-enable AFTER (a) cron path captioner integration ships AND
+      # (b) the LLM provider is swapped to Sonnet 4.6 in the v2 path.
+      - RICH_SUMMARY_V2_CRON_ENABLED=false
       # CP437 (2026-04-29) — Operator flip: enable YouTube metadata backfill cron.
       # Default in code is `false` — cron stays dormant unless this env is
       # explicitly true. With this set, `startYouTubeMetadataCron()` schedules


### PR DESCRIPTION
## Summary

Flip `RICH_SUMMARY_V2_CRON_ENABLED=true → false` in `docker-compose.prod.yml`.

PR #695 (2026-05-20) enabled this cron. Subsequent fact-trace established that the cron path calls `generateRichSummaryV2` **without** captioner-fetched transcript (`rich-summary-v2-cron.ts:202`), and provider `openrouter/qwen/qwen3-30b-a3b` produced broken segments:

- atom timestamps unsorted (LLM guessed without transcript anchors)
- narrator-perspective summaries ("영상에서는 … 합니다")
- back half of long videos uncovered

**491 prod rows** now marked `quality_flag='qwen3_low'`; FE hide gate shipped in PR #752.

## Why now

This flip stops the bleeding immediately. Without it, every cron tick (50 rows / day) generates more broken rows that PR #752 has to hide.

## Re-enable after

1. **B1**: cron path captioner integration (transcript always passed).
2. **B2**: v2 LLM provider swap to `anthropic/claude-sonnet-4-6`.
3. **B3**: Mac Mini Claude Code bulk regeneration of the 491 marked rows.

## Rollback

Revert PR. Cron resumes on next API container restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)