### PR TITLE
feat(rich-summary): v2 full path pin to Sonnet 4.6 + cron transcript fetch (CP488+)

### DIFF
--- a/src/modules/scheduler/rich-summary-v2-cron.ts
+++ b/src/modules/scheduler/rich-summary-v2-cron.ts
@@ -43,6 +43,7 @@ import { loadRichSummaryConfig } from '@/config/rich-summary';
 import { logger } from '@/utils/logger';
 
 import { generateRichSummaryV2 } from '../skills/rich-summary-v2-generator';
+import { getCaptionExtractor } from '../caption/extractor';
 
 const log = logger.child({ module: 'RichSummaryV2Cron' });
 
@@ -199,7 +200,43 @@ export async function runV2BatchOnce(batchSize: number): Promise<{
     let lowRetried = 0;
     for (const cand of candidates) {
       try {
-        const outcome = await generateRichSummaryV2({ videoId: cand.videoId });
+        // CP488+ — fetch transcript before calling the generator. Without
+        // this, the generator ran in description-only fall-back and the
+        // LLM hallucinated segments (broken atoms / unsorted timestamps /
+        // back half of the video uncovered). Mirrors the enrich-rich-summary
+        // queue handler's hard rule: NO v2 row without a transcript.
+        const captionResult = await getCaptionExtractor()
+          .extractCaptions(cand.videoId)
+          .catch((err) => {
+            log.warn('v2 cron: caption fetch threw', {
+              videoId: cand.videoId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return null;
+          });
+        const transcript = captionResult?.success ? captionResult.caption?.fullText : undefined;
+        if (!transcript) {
+          // Stamp the attempt so this row enters the 7-day captioner
+          // cooldown — avoids hammering the same unavailable captions
+          // every cron tick.
+          await getPrismaClient()
+            .youtube_videos.update({
+              where: { youtube_video_id: cand.videoId },
+              data: { transcript_attempted_at: new Date() },
+            })
+            .catch(() => {
+              /* non-fatal */
+            });
+          skip += 1;
+          continue;
+        }
+        // forceRegen=true so legacy description-only / qwen3_low rows
+        // can be upgraded by this transcript-grounded run.
+        const outcome = await generateRichSummaryV2({
+          videoId: cand.videoId,
+          transcript,
+          forceRegen: true,
+        });
         if (outcome.kind === 'pass') pass += 1;
         else if (outcome.kind === 'low') {
           low += 1;

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -17,8 +17,17 @@
 import { Prisma } from '@prisma/client';
 
 import { getPrismaClient } from '@/modules/database/client';
-import { createGenerationProvider } from '@/modules/llm';
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
 import { logger } from '@/utils/logger';
+
+// CP488+ — v2 full generator pinned to Sonnet 4.6. Previously this path
+// inherited the global provider (createGenerationProvider) which resolved
+// to openrouter/qwen/qwen3-30b-a3b in prod and produced broken segments
+// (unsorted atom timestamps, narrator-perspective summaries, back half
+// uncovered). 491 rows marked `quality_flag='qwen3_low'`. Quick path
+// already uses claude-haiku-4.5 explicitly; this aligns the slow path on
+// the next tier up. Search-replace point for future model swaps.
+const SONNET_MODEL = 'anthropic/claude-sonnet-4-6';
 
 import {
   buildV2Prompt,
@@ -158,7 +167,8 @@ export async function generateRichSummaryV2(
     mandalaCenterGoal: input.mandalaCenterGoal,
   });
 
-  const provider = await createGenerationProvider();
+  // CP488+ — pinned Sonnet 4.6 (see SONNET_MODEL doc-comment above).
+  const provider = new OpenRouterGenerationProvider(SONNET_MODEL);
 
   let lastReason = 'unknown_error';
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {


### PR DESCRIPTION
## Summary

Two paired fixes for the broken-segments root cause traced in PR #752 (qwen3_low FE guard).

### 1. v2 full generator → Sonnet 4.6

`rich-summary-v2-generator.ts` previously called `createGenerationProvider()`, which resolved to the global `OPENROUTER_MODEL` (`qwen/qwen3-30b-a3b` in prod). qwen3-30b-a3b output had:

- atom timestamps unsorted (LLM-guessed)
- narrator-perspective summaries ("영상에서는 … 합니다")
- back-half of long videos uncovered

→ **491 prod rows ended up `quality_flag='qwen3_low'`**.

New: explicit `new OpenRouterGenerationProvider('anthropic/claude-sonnet-4-6')` in the full path. Quick path already uses `claude-haiku-4.5` the same way — this aligns the slow tier on the next size up.

### 2. Cron path captioner integration

`rich-summary-v2-cron.ts:202` was calling the generator with **no transcript**. Generator fell back to description-only mode → LLM hallucinated chapters.

New: fetch transcript via `getCaptionExtractor()` before each call. On caption-unavailable: stamp `transcript_attempted_at` (7-day cooldown) + skip. On success: pass transcript + `forceRegen: true` so legacy qwen3_low rows get upgraded by the next transcript-grounded tick.

## Combined effect after ship

- New cron-generated rows: Sonnet 4.6 + transcript = quality baseline ≈ claude-code-direct CC console batches (atoms avg 10.4, sections avg 5.1, measured in PR #752 root-cause probe).
- After this PR ships, **PR #753 (cron disable) can be reverted** so the cron resumes with both pre-conditions met.

## Out of scope

- **B3**: Mac Mini Claude Code (Opus 4.7) bulk regeneration of the 491 marked rows. Done separately so user can run on their schedule.
- Cron candidate selector update to include `qwen3_low` (Track A2 matches `low`/`pending` only) — B3 covers this directly.

## Verify

- ✅ BE tsc clean
- ✅ FE unchanged (no FE files)
- BE jest pre-existing failure on `main` (frontend mocks ESM transform) — unrelated.

## Rollback

Revert PR. Cron path returns to `createGenerationProvider()` + no transcript fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)