### PR TITLE
feat(video-pool): depth_level + content_type columns + cascading sync (CP488+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ prisma/migrations/*
 !prisma/migrations/youtube-metadata-completeness/**
 !prisma/migrations/search-quality-overhaul/
 !prisma/migrations/search-quality-overhaul/**
+!prisma/migrations/video-pool-depth-level/
+!prisma/migrations/video-pool-depth-level/**
 
 # Logs
 logs/

--- a/prisma/migrations/video-pool-depth-level/001_add_columns.sql
+++ b/prisma/migrations/video-pool-depth-level/001_add_columns.sql
@@ -1,0 +1,41 @@
+-- ============================================================================
+-- CP488+ — video_pool.depth_level + companion columns
+-- ============================================================================
+-- Purpose:
+--   Persist the LLM-evaluated depth level (`beginner` | `intermediate` |
+--   `advanced` | `mixed`) and content type on `video_pool` so search-time
+--   difficulty filtering becomes a single SELECT against an indexed column,
+--   instead of a runtime LLM evaluation per search.
+--
+-- Sync source priority (handled in a separate Step 1 SQL):
+--   1. `video_rich_summaries.core->>'depth_level'` (transcript+LLM evaluated,
+--      `claude-code-direct` or `anthropic/*` model rows ONLY — excludes the
+--      491 `quality_flag='qwen3_low'` rows hidden by PR #752).
+--   2. Title regex + duration heuristics for rows without a rich_summary
+--      (later step — handled by Mac Mini CC console batch, NOT this DDL).
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS. Safe
+-- to re-run.
+-- ============================================================================
+
+ALTER TABLE public.video_pool
+  ADD COLUMN IF NOT EXISTS depth_level             VARCHAR(15),
+  ADD COLUMN IF NOT EXISTS depth_level_confidence  REAL,
+  ADD COLUMN IF NOT EXISTS depth_level_source      VARCHAR(30),
+  ADD COLUMN IF NOT EXISTS depth_level_at          TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS content_type            VARCHAR(20);
+
+-- Indexes for search-time filtering. Partial-index on the filtered values
+-- only — keeps the index small (NULL rows are the majority until backfill
+-- catches up).
+CREATE INDEX IF NOT EXISTS idx_vpool_depth_level
+  ON public.video_pool(depth_level)
+  WHERE depth_level IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_vpool_content_type
+  ON public.video_pool(content_type)
+  WHERE content_type IS NOT NULL;
+
+-- PostgREST schema reload — without this, the Supabase client silently
+-- drops the new columns from query responses (CLAUDE.md LEVEL-2 rule).
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -464,7 +464,7 @@ model user_mandalas {
   /// CP488 — per-mandala search algorithm override. NULL = use global active
   /// row from search_algorithm_versions. FK ON DELETE SET NULL so removing
   /// an algorithm row falls back to default rather than breaking the mandala.
-  search_algorithm_version String?                     @db.VarChar(50)
+  search_algorithm_version String?                    @db.VarChar(50)
   search_algorithm         search_algorithm_versions? @relation(fields: [search_algorithm_version], references: [id], onDelete: SetNull, onUpdate: NoAction)
 
   @@index([user_id], map: "idx_user_mandalas_user_id")
@@ -2020,6 +2020,18 @@ model video_pool {
   expires_at       DateTime  @default(dbgenerated("(now() + interval '30 days')")) @db.Timestamptz(6)
   is_active        Boolean   @default(true)
 
+  /// CP488+ — LLM-evaluated learning depth level. Sync source priority:
+  ///   1. video_rich_summaries.core->>'depth_level' (transcript-grounded, claude-code-direct or anthropic/*)
+  ///   2. Title regex + duration heuristics (CC console batch for rows without a rich_summary)
+  /// Values: 'beginner' | 'intermediate' | 'advanced' | 'mixed' | NULL.
+  /// Raw SQL DDL: prisma/migrations/video-pool-depth-level/001_add_columns.sql
+  depth_level            String?   @db.VarChar(15)
+  depth_level_confidence Float?
+  depth_level_source     String?   @db.VarChar(30)
+  depth_level_at         DateTime? @db.Timestamptz(6)
+  /// CP488+ — content type tag. Values: 'tutorial' | 'lecture' | 'vlog' | 'interview' | 'documentary' | 'review' | NULL.
+  content_type           String?   @db.VarChar(20)
+
   embeddings  video_pool_embeddings[]
   domain_tags video_pool_domain_tags[]
 
@@ -2027,6 +2039,8 @@ model video_pool {
   @@index([expires_at], map: "idx_vpool_expires")
   @@index([source], map: "idx_vpool_source")
   @@index([refreshed_at], map: "idx_vpool_refreshed")
+  @@index([depth_level], map: "idx_vpool_depth_level")
+  @@index([content_type], map: "idx_vpool_content_type")
   @@schema("public")
 }
 
@@ -2099,13 +2113,13 @@ model video_pool_collection_runs {
 /// per-mandala override. Raw SQL DDL:
 ///   prisma/migrations/search-quality-overhaul/001_algo_versions_catalog.sql
 model search_algorithm_versions {
-  id            String   @id @db.VarChar(50)
-  display_name  String
-  description   String?
-  parameters    Json
-  is_active     Boolean  @default(false)
-  created_at    DateTime @default(now()) @db.Timestamptz(6)
-  created_by    String?  @db.Uuid
+  id           String   @id @db.VarChar(50)
+  display_name String
+  description  String?
+  parameters   Json
+  is_active    Boolean  @default(false)
+  created_at   DateTime @default(now()) @db.Timestamptz(6)
+  created_by   String?  @db.Uuid
 
   mandalas user_mandalas[]
 

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -101,6 +101,10 @@ APPLY_FILES=(
   # CP488 FLAG sub-PR — seed v0-pre-cp488 + update v1-current with explicit
   # boolean flags so admin can toggle the 3 CP488 hardenings on/off.
   "prisma/migrations/search-quality-overhaul/004_v0_pre_cp488_seed.sql"
+  # CP488+ (2026-05-26) — video_pool.depth_level + companion columns for
+  # search-time difficulty filtering. ADD COLUMN IF NOT EXISTS +
+  # CREATE INDEX IF NOT EXISTS — fully idempotent.
+  "prisma/migrations/video-pool-depth-level/001_add_columns.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "


### PR DESCRIPTION
## Summary

Persist LLM-evaluated `depth_level` + `content_type` on `video_pool` so the Add Cards "기초/중급/심화" filter (and any future difficulty-aware ranking) can run as a single indexed SELECT instead of a runtime LLM eval per query.

## Schema

5 columns + 2 partial indexes added (idempotent — ADD COLUMN IF NOT EXISTS / CREATE INDEX IF NOT EXISTS):

| Column | Type | Purpose |
|---|---|---|
| `depth_level` | VARCHAR(15) | 'beginner' \| 'intermediate' \| 'advanced' \| 'mixed' \| NULL |
| `depth_level_confidence` | REAL | 0.0-1.0 |
| `depth_level_source` | VARCHAR(30) | `'rich-summary-v2'` (0.95) \| `'title-regex'` (0.65) \| (future) `'cc-console'` (0.95) |
| `depth_level_at` | TIMESTAMPTZ | stamp |
| `content_type` | VARCHAR(20) | tutorial / lecture / vlog / interview / documentary / review |

Prisma schema synced. `apply-custom-sql.sh` allowlist updated for idempotent CI re-apply. `.gitignore` negate lines added (LEVEL-1 pattern — `prisma/migrations/*` is blanket-excluded).

## Already applied in prod (separate ssh-connect steps)

### Schema apply
Local + Prod DB both received the 5 columns + 2 indexes via Prisma node `$executeRawUnsafe` (statement-by-statement — `prisma db push` silent-fails on Supabase auth-owned tables, CLAUDE.md LEVEL-3).

### Step 1 sync (rich_summary → video_pool)

```sql
UPDATE video_pool vp SET depth_level = (vrs.core->>'depth_level'), ...
FROM video_rich_summaries vrs
WHERE vp.video_id = vrs.video_id
  AND vrs.template_version = 'v2'
  AND vrs.quality_flag = 'pass'
  AND vrs.core->>'depth_level' IN ('beginner','intermediate','advanced')
  AND vrs.model NOT LIKE 'openrouter/qwen%'  -- excludes qwen3 cohort
  AND vp.depth_level IS NULL;
```

**1,271 rows synced**. Excludes the 491 `qwen3_low` rows hidden by PR #752. Confidence: 0.95 (transcript_used=true) or 0.70 (transcript_used=false). Distribution: beginner 673 / intermediate 595 / advanced 3.

### Step 2 title-regex bulk (Korean + English)

3-pass UPDATE for the long tail of pool entries without a rich_summary:

- beginner: `입문|기초|초보|시작|첫걸음|초심자|beginner|intro|basics?|getting started|for dummies`
- advanced: `심화|전문가|고급|마스터|상급|본격|advanced|expert|deep dive|masterclass|in.depth|hardcore`
- mixed (range marker, overrides beginner): `기초부터 심화|초보부터 고급|0 to hero|complete (course|guide)`

**921 rows classified**. Confidence: 0.65 (R1 finding — title regex accuracy 0.60-0.75). Future `rich_summary v2` generations (PR #754's Sonnet 4.6 + cron captioner) will overwrite this with conf 0.95 automatically via Step 1 logic.

### Final coverage

**2,192 / 17,128 = 12.8%** classified, broken down:

| source | depth_level | rows | avg_conf |
|---|---|---|---|
| rich-summary-v2 | beginner | 673 | 0.95 |
| rich-summary-v2 | intermediate | 595 | 0.95 |
| rich-summary-v2 | advanced | 3 | 0.95 |
| title-regex | beginner | 763 | 0.65 |
| title-regex | advanced | 158 | 0.65 |

## Out of scope (deferred)

- **Add Cards UI / `/cards/add-cards` BE wiring** to actually filter by `depth_level`. The data is there; the query layer hook follows in a separate PR once Add Cards UI ships the "기초/중급/심화" control.
- **CC console Opus 4.7 batch** for the remaining ~15k rows (`'cc-console'` source, conf 0.95). The title-regex confidence differential gives the runtime layer the option to soft-demote regex-classified rows when better data isn't available yet — regex pass is a reasonable bridge until then.
- The 119 `qwen3_low` rows in `video_pool` stay at `depth_level=NULL` until PR #755's Mac Mini backfill regenerates their `rich_summary` (Step 1 will then auto-sync them on next run).

## Verify

- ✅ BE tsc clean
- ✅ Local + Prod schema verified (5 columns + 2 indexes)
- ✅ Step 1 prod UPDATE: 1,271 rows
- ✅ Step 2 prod UPDATE: 921 rows  
- ✅ Final coverage 12.8% (2,192/17,128)

## Rollback

Schema is additive (IF NOT EXISTS). Data is recoverable: drop columns or `UPDATE SET depth_level=NULL` — no source data lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)