### PR TITLE
fix(qwen3-low): reuse EnrichInProgressMessage dot-loader for the placeholder (CP488+)

### DIFF
--- a/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
@@ -125,15 +125,12 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
   // (background enrich in flight, or core present but segments missing)
   // from "no AI output at all" (truly empty row).
   if (!hasNewV2 && !hasLegacyRich && !hasShort && !isRichLoading) {
-    // CP488+ — qwen3_low row: surface a regeneration-pending message
-    // instead of the generic "not ready" copy so the user understands
-    // this is awaiting a model upgrade, not a missing generation.
+    // CP488+ — qwen3_low row: surface as an in-progress (dot-animated)
+    // message via the existing EnrichInProgressMessage component so the
+    // visual matches the rest of the loading states and the user
+    // understands this is awaiting regeneration, not a missing row.
     if (isQualityLow) {
-      return (
-        <p className="py-8 text-center text-[13px] text-[#4e4f5c]">
-          {t('learning.richSummaryQualityLowPendingRegen')}
-        </p>
-      );
+      return <EnrichInProgressMessage label={t('learning.richSummaryQualityLowPendingRegen')} />;
     }
     if (isEnrichInProgress) {
       return <EnrichInProgressMessage label={t('learning.aiSummaryGenerating')} />;


### PR DESCRIPTION
## Summary

PR #752 introduced a static-text placeholder for `qwen3_low` rows. Adjust to use the existing `EnrichInProgressMessage` component (defined in the same file, `PanelAISummary.tsx:701`) so the visual matches every other "still being generated" state in the panel — the 3 staggered dots animation makes it clear this is in-progress regeneration, not a permanent dead-end.

## Changes

- `PanelAISummary.tsx`: swap `<p>{t('learning.richSummaryQualityLowPendingRegen')}</p>` for `<EnrichInProgressMessage label={t('learning.richSummaryQualityLowPendingRegen')} />`. The component appends the animated dots automatically.
- **i18n unchanged** ("이 영상의 AI 분석을 개선하고 있습니다" / "Improving the AI analysis for this video") — the copy reads naturally with or without the trailing dots.

No new copy, no new component, no logic change.

## Verify

- ✅ FE tsc clean
- Same checks as PR #752 (FE-only)

## Rollback

Revert PR. Reverts to the static-text variant from PR #752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)