### PR TITLE
feat(rich-summary): 90min duration cap + config-driven transcript/output budgets (CP488+)

### DIFF
--- a/src/config/rich-summary.ts
+++ b/src/config/rich-summary.ts
@@ -49,6 +49,34 @@ export const richSummaryEnvSchema = z.object({
     .preprocess((v) => (v == null || v === '' ? '0 17 * * *' : String(v).trim()), z.string())
     .default('0 17 * * *'),
   V2_LOW_RETRY_COOLDOWN_HOURS: positiveFloat.transform((v) => v ?? 12),
+  /**
+   * CP488+ — maximum video duration (seconds) eligible for v2 generation.
+   *
+   * Default 5400s (90min). Videos longer than this skip with reason
+   * 'duration_exceeds_cap' — the generator code path exists but is not
+   * activated for long content until we ship chunked / multi-pass
+   * summarisation. Operators can raise this cap via env when that path
+   * lands.
+   */
+  RICH_SUMMARY_V2_MAX_DURATION_SECONDS: positiveInt.transform((v) => v ?? 5400),
+  /**
+   * CP488+ — transcript char budget passed to the LLM. Default 100,000
+   * comfortably covers a 90-minute English lecture (~150-250 wpm × 4
+   * chars/word ≈ 54-90K chars) and a 90-minute Korean lecture (~25-50K
+   * chars). Well under Sonnet 4.6 / Haiku 4.5 200K context.
+   *
+   * Operators can lower this for cost/latency control without a code
+   * change. NOT a magic number — derived from the 90-minute duration cap
+   * above; if the duration cap rises, this should rise proportionally.
+   */
+  RICH_SUMMARY_V2_TRANSCRIPT_MAX_CHARS: positiveInt.transform((v) => v ?? 100000),
+  /**
+   * CP488+ — LLM output token budget. Default 8192. Raised from the
+   * historical 6144 because longer transcripts produce more sections +
+   * atoms; 8192 leaves headroom while staying under per-response output
+   * caps on Sonnet 4.6 / Haiku 4.5.
+   */
+  RICH_SUMMARY_V2_MAX_OUTPUT_TOKENS: positiveInt.transform((v) => v ?? 8192),
 });
 
 export interface RichSummaryConfig {
@@ -58,6 +86,12 @@ export interface RichSummaryConfig {
   v2BatchSize: number;
   v2CronSchedule: string;
   v2LowRetryCooldownHours: number;
+  /** Max video duration (seconds) eligible for v2 generation. Default 5400 (90min). */
+  maxDurationSeconds: number;
+  /** Transcript char budget for the LLM prompt. Default 100000. */
+  transcriptMaxChars: number;
+  /** Output token budget. Default 8192. */
+  maxOutputTokens: number;
 }
 
 const FALLBACK_CONFIG: RichSummaryConfig = {
@@ -67,6 +101,9 @@ const FALLBACK_CONFIG: RichSummaryConfig = {
   v2BatchSize: 50,
   v2CronSchedule: '0 17 * * *',
   v2LowRetryCooldownHours: 12,
+  maxDurationSeconds: 5400,
+  transcriptMaxChars: 100000,
+  maxOutputTokens: 8192,
 };
 
 export function loadRichSummaryConfig(env: NodeJS.ProcessEnv = process.env): RichSummaryConfig {
@@ -77,6 +114,9 @@ export function loadRichSummaryConfig(env: NodeJS.ProcessEnv = process.env): Ric
     RICH_SUMMARY_V2_BATCH_SIZE: env['RICH_SUMMARY_V2_BATCH_SIZE'],
     RICH_SUMMARY_V2_CRON_SCHEDULE: env['RICH_SUMMARY_V2_CRON_SCHEDULE'],
     V2_LOW_RETRY_COOLDOWN_HOURS: env['V2_LOW_RETRY_COOLDOWN_HOURS'],
+    RICH_SUMMARY_V2_MAX_DURATION_SECONDS: env['RICH_SUMMARY_V2_MAX_DURATION_SECONDS'],
+    RICH_SUMMARY_V2_TRANSCRIPT_MAX_CHARS: env['RICH_SUMMARY_V2_TRANSCRIPT_MAX_CHARS'],
+    RICH_SUMMARY_V2_MAX_OUTPUT_TOKENS: env['RICH_SUMMARY_V2_MAX_OUTPUT_TOKENS'],
   });
   if (!parsed.success) {
     return FALLBACK_CONFIG;
@@ -88,5 +128,8 @@ export function loadRichSummaryConfig(env: NodeJS.ProcessEnv = process.env): Ric
     v2BatchSize: parsed.data.RICH_SUMMARY_V2_BATCH_SIZE,
     v2CronSchedule: parsed.data.RICH_SUMMARY_V2_CRON_SCHEDULE,
     v2LowRetryCooldownHours: parsed.data.V2_LOW_RETRY_COOLDOWN_HOURS,
+    maxDurationSeconds: parsed.data.RICH_SUMMARY_V2_MAX_DURATION_SECONDS,
+    transcriptMaxChars: parsed.data.RICH_SUMMARY_V2_TRANSCRIPT_MAX_CHARS,
+    maxOutputTokens: parsed.data.RICH_SUMMARY_V2_MAX_OUTPUT_TOKENS,
   };
 }

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -18,6 +18,7 @@ import { Prisma } from '@prisma/client';
 
 import { getPrismaClient } from '@/modules/database/client';
 import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import { loadRichSummaryConfig } from '@/config/rich-summary';
 import { logger } from '@/utils/logger';
 
 // CP488+ — v2 full generator pinned to Sonnet 4.6. Previously this path
@@ -56,11 +57,10 @@ function detectLanguageFromTitle(title: string): 'ko' | 'en' | null {
 const log = logger.child({ module: 'RichSummaryV2Generator' });
 
 const MAX_RETRIES = 1; // 1 retry → spec §7-D
-// CP474 — raised from 4096 to accommodate segments.sections (3-8 entries
-// with summary + key_points) and segments.atoms (5-15 entries). Empirical
-// upper bound for the full layered output is ~3000 tokens; 6144 leaves
-// safe buffer for verbose outputs without truncation.
-const MAX_TOKENS = 6144;
+// CP488+ — output token budget now sourced from config
+// (RICH_SUMMARY_V2_MAX_OUTPUT_TOKENS, default 8192). Previously a
+// file-local const that drifted away from the actual transcript budget
+// when long videos started landing.
 const TEMPERATURE = 0.3;
 
 export type V2GenerationOutcome =
@@ -145,10 +145,29 @@ export async function generateRichSummaryV2(
 
   const ytRow = await prisma.youtube_videos.findUnique({
     where: { youtube_video_id: input.videoId },
-    select: { title: true, description: true, channel_title: true },
+    select: { title: true, description: true, channel_title: true, duration_seconds: true },
   });
   if (!ytRow || !ytRow.title) {
     return { kind: 'skip', videoId: input.videoId, reason: 'no_youtube_metadata' };
+  }
+
+  // CP488+ — duration cap. Videos longer than the configured cap (default
+  // 90min) skip v2 generation. The generator code path stays in place
+  // (no behavioural change beyond this guard) so flipping the env opens
+  // it back up without a code change. Long-form chunked summarisation
+  // is the follow-up that would justify raising the cap.
+  const richConfig = loadRichSummaryConfig();
+  if (ytRow.duration_seconds != null && ytRow.duration_seconds > richConfig.maxDurationSeconds) {
+    log.info('v2 skip: duration exceeds cap', {
+      videoId: input.videoId,
+      durationSec: ytRow.duration_seconds,
+      capSec: richConfig.maxDurationSeconds,
+    });
+    return {
+      kind: 'skip',
+      videoId: input.videoId,
+      reason: `duration_exceeds_cap_${richConfig.maxDurationSeconds}s`,
+    };
   }
 
   // Title-based language override — `source_language` is stamped from the
@@ -176,7 +195,7 @@ export async function generateRichSummaryV2(
       const raw = await provider.generate(prompt, {
         format: 'json',
         temperature: TEMPERATURE,
-        maxTokens: MAX_TOKENS,
+        maxTokens: richConfig.maxOutputTokens,
       });
       let parsed: unknown;
       try {

--- a/src/modules/skills/rich-summary-v2-prompt.ts
+++ b/src/modules/skills/rich-summary-v2-prompt.ts
@@ -14,6 +14,7 @@
  */
 
 import { DOMAIN_SLUGS, type DomainSlug } from '@/config/domains';
+import { loadRichSummaryConfig } from '@/config/rich-summary';
 
 // ============================================================================
 // Layered v2 schema types — match prisma columns
@@ -265,8 +266,8 @@ Field rules:
 - analysis.bias_signals.has_ad / is_sponsored: boolean. Only true when explicitly visible in the title/description.
 - lora.qa_pairs: 5-7 entries, all level=1, all context="video". Each Q is something a learner would ask AFTER watching this video; A is grounded in the video content.
 - prerequisites: empty string when none.
-- segments.sections: 1-8 entries dividing the video timeline (adapt to video length — a 2-minute video may legitimately have 1-2 sections; a 20-minute video may have 6-8). from_sec/to_sec integers in seconds, monotonically increasing, derived from transcript timestamps. relevance_pct (integer 0-100) is the intra-video metric for THIS section vs the user's mandala center goal — distinct from analysis.mandala_fit.mandala_relevance_pct (which is the whole-video score). Each section has 1-3 key_points; timestamp_sec is optional and falls within the section's [from_sec, to_sec] window.
-- segments.atoms: 1-15 standalone insights (adapt to content density — short videos may yield 2-3 atoms; longer / denser videos 8-15). type MUST be one of: fact | argument | tip | other. timestamp_sec is optional (use when derivable from the transcript). entity_refs is optional and links to analysis.entities[].name values (fallback: analysis.key_concepts[].term).
+- segments.sections: dividing the video timeline. Section count adapts to video length — a 2-minute video may legitimately have 1-2 sections; a 20-minute video 6-8; a 40-60 minute lecture 10-15; longer talks more as needed. from_sec/to_sec integers in seconds, monotonically increasing, derived from transcript timestamps. **CRITICAL: sections MUST cover the ENTIRE video timeline — the last section's to_sec must be at or near the final transcript timestamp. Do NOT stop after the first 20-30 minutes of a longer video.** If the transcript provided spans the full video, produce sections that tile it end-to-end (no gaps after the last section). relevance_pct (integer 0-100) is the intra-video metric for THIS section vs the user's mandala center goal — distinct from analysis.mandala_fit.mandala_relevance_pct (which is the whole-video score). Each section has 1-3 key_points; timestamp_sec is optional and falls within the section's [from_sec, to_sec] window.
+- segments.atoms: standalone insights spanning the FULL video timeline (not just the first quarter). Atom count adapts to content density — short videos may yield 2-3 atoms; 20-minute videos 8-15; longer/denser videos 15-30. type MUST be one of: fact | argument | tip | other. timestamp_sec is optional but, when provided, MUST be sorted ascending across the array AND the highest timestamp_sec should be at or near the final transcript timestamp (mirrors the "cover the full timeline" rule above). entity_refs is optional and links to analysis.entities[].name values (fallback: analysis.key_concepts[].term).
 
 Output rules:
 - Return JSON only — no markdown fences, no commentary, no chain-of-thought.
@@ -299,18 +300,12 @@ export interface PromptInput {
   mandalaCenterGoal?: string;
 }
 
-/**
- * Hard limit on transcript chars passed to the LLM. ~6,000 Korean chars ≈
- * ~3,000 tokens — leaves room for system prompt + JSON output budget under
- * 4,096 max tokens.
- */
-export const TRANSCRIPT_MAX_CHARS = 6000;
-
 export function buildV2Prompt(input: PromptInput): string {
   const languageLabel = input.language === 'ko' ? 'Korean' : 'English';
+  const { transcriptMaxChars } = loadRichSummaryConfig();
   const transcriptBlock =
     input.transcript && input.transcript.length > 0
-      ? input.transcript.slice(0, TRANSCRIPT_MAX_CHARS)
+      ? input.transcript.slice(0, transcriptMaxChars)
       : '(no transcript)';
   const centerGoalBlock =
     input.mandalaCenterGoal && input.mandalaCenterGoal.trim().length > 0

--- a/src/modules/skills/rich-summary-v2-quick-generator.ts
+++ b/src/modules/skills/rich-summary-v2-quick-generator.ts
@@ -24,6 +24,7 @@ import { Prisma } from '@prisma/client';
 
 import { getPrismaClient } from '@/modules/database/client';
 import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import { loadRichSummaryConfig } from '@/config/rich-summary';
 import { logger } from '@/utils/logger';
 
 import {
@@ -72,13 +73,35 @@ export async function generateRichSummaryV2Quick(input: V2QuickInput): Promise<V
 
   const ytRow = await prisma.youtube_videos.findUnique({
     where: { youtube_video_id: input.videoId },
-    select: { title: true, description: true, channel_title: true, default_language: true },
+    select: {
+      title: true,
+      description: true,
+      channel_title: true,
+      default_language: true,
+      duration_seconds: true,
+    },
   });
   if (!ytRow || !ytRow.title) {
     return { kind: 'skip', videoId: input.videoId, reason: 'no_youtube_metadata' };
   }
   if (!input.transcript || input.transcript.trim().length === 0) {
     return { kind: 'skip', videoId: input.videoId, reason: 'no_transcript' };
+  }
+
+  // CP488+ — same duration cap as the full generator. Skips Heart-click
+  // path for long videos until chunked summarisation lands.
+  const richConfig = loadRichSummaryConfig();
+  if (ytRow.duration_seconds != null && ytRow.duration_seconds > richConfig.maxDurationSeconds) {
+    log.info('v2-quick skip: duration exceeds cap', {
+      videoId: input.videoId,
+      durationSec: ytRow.duration_seconds,
+      capSec: richConfig.maxDurationSeconds,
+    });
+    return {
+      kind: 'skip',
+      videoId: input.videoId,
+      reason: `duration_exceeds_cap_${richConfig.maxDurationSeconds}s`,
+    };
   }
 
   const language: 'ko' | 'en' =

--- a/tests/unit/modules/rich-summary-config.test.ts
+++ b/tests/unit/modules/rich-summary-config.test.ts
@@ -67,6 +67,9 @@ describe('loadRichSummaryConfig', () => {
         v2BatchSize: 50,
         v2CronSchedule: '0 17 * * *',
         v2LowRetryCooldownHours: 12,
+        maxDurationSeconds: 5400,
+        transcriptMaxChars: 100000,
+        maxOutputTokens: 8192,
       });
     });
 
@@ -82,6 +85,9 @@ describe('loadRichSummaryConfig', () => {
         v2BatchSize: 50,
         v2CronSchedule: '0 17 * * *',
         v2LowRetryCooldownHours: 12,
+        maxDurationSeconds: 5400,
+        transcriptMaxChars: 100000,
+        maxOutputTokens: 8192,
       });
     });
   });
@@ -120,6 +126,37 @@ describe('loadRichSummaryConfig', () => {
       expect(loadRichSummaryConfig({ RICH_SUMMARY_V2_CRON_SCHEDULE: '' }).v2CronSchedule).toBe(
         '0 17 * * *'
       );
+    });
+  });
+
+  describe('CP488+ duration cap + transcript / output budgets', () => {
+    it('defaults to 5400s / 100000 chars / 8192 tokens', () => {
+      const cfg = loadRichSummaryConfig({});
+      expect(cfg.maxDurationSeconds).toBe(5400);
+      expect(cfg.transcriptMaxChars).toBe(100000);
+      expect(cfg.maxOutputTokens).toBe(8192);
+    });
+
+    it('accepts positive integer overrides', () => {
+      const cfg = loadRichSummaryConfig({
+        RICH_SUMMARY_V2_MAX_DURATION_SECONDS: '7200',
+        RICH_SUMMARY_V2_TRANSCRIPT_MAX_CHARS: '150000',
+        RICH_SUMMARY_V2_MAX_OUTPUT_TOKENS: '12000',
+      });
+      expect(cfg.maxDurationSeconds).toBe(7200);
+      expect(cfg.transcriptMaxChars).toBe(150000);
+      expect(cfg.maxOutputTokens).toBe(12000);
+    });
+
+    it('rejects non-positive + garbage, falls back to defaults', () => {
+      const cfg = loadRichSummaryConfig({
+        RICH_SUMMARY_V2_MAX_DURATION_SECONDS: '0',
+        RICH_SUMMARY_V2_TRANSCRIPT_MAX_CHARS: '-1',
+        RICH_SUMMARY_V2_MAX_OUTPUT_TOKENS: 'garbage',
+      });
+      expect(cfg.maxDurationSeconds).toBe(5400);
+      expect(cfg.transcriptMaxChars).toBe(100000);
+      expect(cfg.maxOutputTokens).toBe(8192);
     });
   });
 

--- a/tests/unit/skills/rich-summary-v2-transcript.test.ts
+++ b/tests/unit/skills/rich-summary-v2-transcript.test.ts
@@ -6,7 +6,13 @@
  * we just ensure the prompt template path is wired correctly.
  */
 
-import { buildV2Prompt, TRANSCRIPT_MAX_CHARS } from '@/modules/skills/rich-summary-v2-prompt';
+import { buildV2Prompt } from '@/modules/skills/rich-summary-v2-prompt';
+import { loadRichSummaryConfig } from '@/config/rich-summary';
+
+// CP488+ — transcript char budget is no longer a magic constant; it comes
+// from RICH_SUMMARY_V2_TRANSCRIPT_MAX_CHARS (default 100,000). Resolve
+// the default once for the truncation assertion below.
+const TRANSCRIPT_MAX_CHARS = loadRichSummaryConfig({}).transcriptMaxChars;
 
 describe('buildV2Prompt — transcript injection', () => {
   const base = {
@@ -26,7 +32,12 @@ describe('buildV2Prompt — transcript injection', () => {
     const transcript = '이 영상은 시간관리의 3단계를 다룬다. 계획 / 실행 / 회고.';
     const out = buildV2Prompt({ ...base, transcript });
     expect(out).toContain(transcript);
-    expect(out).not.toContain('(no transcript)');
+    // The instruction block legitimately mentions the literal string
+    // "(no transcript)" (it describes the empty-transcript fallback rule),
+    // so we cannot assert the whole prompt is free of it. Instead, assert
+    // the Transcript line itself carries the actual transcript, not the
+    // placeholder.
+    expect(out).toMatch(/Transcript[^\n]*:[^\n]*이 영상은 시간관리/);
   });
 
   test('long transcript is truncated to TRANSCRIPT_MAX_CHARS', () => {


### PR DESCRIPTION
## Summary

Two user-directives addressed:

1. **하드코딩 금지** (CLAUDE.md LEVEL-3). The previous attempt to bump `TRANSCRIPT_MAX_CHARS` to a magic-number `40000` violated the `src/config/**` zod-driven config pattern. This PR removes the constant entirely and sources every tuning knob from `src/config/rich-summary.ts`.

2. **\"최대 1시간 30분까지만 요약 지원, 나머지는 코드 명시하되 활성화 X. 이후 추가 여부 다시 결정.\"** — adds a duration cap that skips v2 generation for videos longer than the configured maximum. **Code path stays in place**; operators raise the env to open it back up when chunked summarisation lands.

## Config additions (zod schema)

| env | default | meaning |
|---|---|---|
| `RICH_SUMMARY_V2_MAX_DURATION_SECONDS` | **5400** (90min) | skip threshold |
| `RICH_SUMMARY_V2_TRANSCRIPT_MAX_CHARS` | 100000 | LLM prompt char budget |
| `RICH_SUMMARY_V2_MAX_OUTPUT_TOKENS`    | 8192 | LLM output token budget |

Defaults derived from the 90-minute cap:
- **100K chars** covers a 90-minute English lecture (~150-250 wpm × 4 chars/word ≈ 54-90K) AND a 90-minute Korean lecture (~25-50K) with safety margin.
- **8192 tokens** leaves headroom for the verbose sections + atoms output of a 90-minute lecture (previously 6144 truncated mid-array on long content).

## Generator changes

- `rich-summary-v2-generator.ts`: selects `duration_seconds` from `youtube_videos`, skips with reason `duration_exceeds_cap_5400s` when over the configured cap. `MAX_TOKENS` const removed — `provider.generate` now receives `richConfig.maxOutputTokens`.
- `rich-summary-v2-quick-generator.ts`: same duration guard so the Heart-click path also honours the cap. Quick-path `MAX_TOKENS=800` unchanged (config-isation deferred — out of scope).
- `rich-summary-v2-prompt.ts`: `TRANSCRIPT_MAX_CHARS` const removed. `buildV2Prompt` loads config and uses `richConfig.transcriptMaxChars` for the slice. Sections-rule prompt copy unchanged from the prior PR (still mandates full-timeline coverage for in-cap videos).

## Tests

- `rich-summary-config.test.ts`: expectations updated for the 3 new fields; new describe block covers parsing + override + fallback.
- `rich-summary-v2-transcript.test.ts`: drops the `TRANSCRIPT_MAX_CHARS` named import; resolves the default via `loadRichSummaryConfig({}).transcriptMaxChars` and asserts truncation against that. Also fixes a pre-existing false-positive `(no transcript)` assertion that was matching the instruction string, not the placeholder.

## Verify

- ✅ BE tsc clean
- ✅ All rich-summary jest tests pass (35 + 4 + others, no fails)
- ✅ Pre-existing FE jest mocks failure (unrelated, main-branch issue)

## Rollback

Revert PR. Config returns to the previous 6 fields and the magic constants `TRANSCRIPT_MAX_CHARS=6000` + `MAX_TOKENS=6144` come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)