### PR TITLE
fix(deploy): register v2-quality-audit/001 in apply-custom-sql.sh (CP488+)

### DIFF
--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -105,6 +105,12 @@ APPLY_FILES=(
   # search-time difficulty filtering. ADD COLUMN IF NOT EXISTS +
   # CREATE INDEX IF NOT EXISTS — fully idempotent.
   "prisma/migrations/video-pool-depth-level/001_add_columns.sql"
+  # CP488+ (2026-05-27) — v2 Quality Audit Phase 1 MVP. 3 tables wrapped
+  # in BEGIN/COMMIT, every CREATE TABLE / CREATE INDEX uses IF NOT EXISTS
+  # — re-application safely no-ops. Default OFF behaviourally
+  # (V2_QUALITY_AUDIT_ENABLED=false), so empty tables on prod until
+  # operator flips the flag.
+  "prisma/migrations/v2-quality-audit/001_create_audit_tables.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "


### PR DESCRIPTION
## Summary

PR #760 (Phase 1 MVP) added `prisma/migrations/v2-quality-audit/001_create_audit_tables.sql` and the matching Prisma models but did **not** register the migration in `scripts/apply-custom-sql.sh` APPLY_FILES allowlist. Result: the 3 audit tables would silently never land on prod even when the deploy step ran (exactly the CP486 silent-fail class the script was created to prevent).

This PR adds the one missing entry.

## Why this matters

- The deploy of PR #760 (run `26495468106`, commit `b928b441`) failed at the Database Schema Sync step, but on a different file: `prisma/migrations/ontology/011_drop_edge_triggers.sql` hit the 180s statement timeout on `DROP TRIGGER` (transient lock contention — the same migration succeeded in the prior deploy run `26487957819` / PR #758).
- I set `vars.SKIP_SQL_FILES="prisma/migrations/ontology/011_drop_edge_triggers.sql"` per the script's documented escape hatch (lines 19-26) so this re-deploy will bypass the transient ontology/011 lock issue and apply the v2-quality-audit tables. Will unset the variable after the deploy succeeds so the skip is not permanent.

## Idempotency

The migration uses `BEGIN/COMMIT` with `IF NOT EXISTS` on every `CREATE TABLE` / `CREATE INDEX`, satisfying the script's stated re-apply contract.

## Test plan

- [x] Diff is a single 6-line addition to the allowlist array
- [ ] CI 6/6 pass
- [ ] Deploy run succeeds (with `SKIP_SQL_FILES` set)
- [ ] Operator post-deploy: `bash scripts/ssh-connect.sh 'docker exec -i insighta-api node -' < /tmp/verify-v2-audit-schema.cjs` shows the 3 new tables present
- [ ] `gh variable delete SKIP_SQL_FILES` after deploy verifies

🤖 Generated with [Claude Code](https://claude.com/claude-code)