### PR TITLE
fix(add-cards): wire Tier 1 threshold through resolveAlgorithm (CP489)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -44,6 +44,7 @@ import {
 } from '@/skills/plugins/video-discover/v3/executor';
 import { getAddCardsConfig } from '@/config/add-cards';
 import { MS_PER_DAY } from '@/utils/time-constants';
+import { resolveAlgorithm } from '@/modules/search/algorithm-resolver';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const YOUTUBE_VIDEO_ID_RE = /^[A-Za-z0-9_-]{11}$/;
@@ -211,6 +212,13 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         });
       }
 
+      // CP489 — Resolve the search-algorithm version that applies to this
+      // call (per-mandala override > global active row > seeded fallback >
+      // env defaults). Tier 1 cosine threshold + downstream consumers must
+      // honor the algorithm row so admin can A/B test without a code release.
+      // resolveAlgorithm never throws (DB outage falls back to env defaults).
+      const resolved = await resolveAlgorithm({ userId, mandalaId });
+
       // 3. Hybrid candidate fetch — reuse the SAME single-source-of-truth
       //    helpers that wizard-precompute / video-discover v3 already use,
       //    so any future tuning of either tier propagates here too:
@@ -227,7 +235,12 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           language,
           subGoals,
           limit: cfg.tier1KnnLimit,
-          threshold: cfg.semanticThreshold,
+          // CP489 — algorithm row wins; cfg.semanticThreshold (env) is now the
+          // 4th-tier fallback inside resolveAlgorithm (v3EnvSchema). Bypassing
+          // the algorithm system here would break A/B oracle parity with the
+          // v3 executor and wizard-precompute (both pull this value from the
+          // same resolveAlgorithm path).
+          threshold: resolved.parameters.semanticMinCosine,
         }),
         runDiscoverEphemeral({
           centerGoal,


### PR DESCRIPTION
## Summary
- `add-cards.ts` Tier 1 (`matchFromVideoPoolByCenterGoal`) was using `cfg.semanticThreshold` (env, default 0.45), bypassing the search-algorithm versioning system.
- Now resolves the active algorithm row via `resolveAlgorithm({userId, mandalaId})` (per-mandala override > global active > seeded fallback > env defaults) and uses `resolved.parameters.semanticMinCosine` (v1-current = 0.5).
- Restores A/B oracle parity with `v3/executor.ts` + `runDiscoverEphemeral` (both already go through `resolveAlgorithm`).

## Background
챗GPT / 인강 cards leaking into a 코인 mandala via the "카드 더 찾기" panel. Root cause: add-cards Tier 1 honored env (0.45) while the algorithm row (0.5) was active everywhere else, so:
- Per-mandala algorithm overrides had no effect on the add-cards panel.
- Admin algorithm flips (e.g. raising `semanticMinCosine` from 0.5 → 0.6) propagated to `v3/executor` and wizard-precompute but not here.
- `/admin/search-algorithms/comparison/:mandalaId` A/B oracle reported false parity.

## Diff
- `src/api/routes/add-cards.ts`: +14 / -1
  - +1 import: `resolveAlgorithm`
  - +1 call: `const resolved = await resolveAlgorithm({ userId, mandalaId })`
  - 1 line changed: `threshold: cfg.semanticThreshold` → `threshold: resolved.parameters.semanticMinCosine`
  - rest is doc-comments explaining the change

## Verification
- ✅ `tsc --noEmit`: clean
- ✅ `eslint src/api/routes/add-cards.ts`: 0 errors (1 pre-existing warning on line 462 unrelated to this change)
- ✅ `scripts/audit/hardcode-audit.ts`: 33 violations (baseline unchanged, 0 added)
- ⏭️ `tests/smoke/add-cards.test.ts`: skipped in this shell (env unset) — auth gate only, this change does not touch auth path

## Follow-up (separate PR)
Wrap handler body in `withTraceContext` so Tier 1 `recordTrace` calls inside `cache-matcher.ts` write rows with `algorithm_version` stamp. Without this, `/admin/search-algorithms/comparison/:mandalaId` A/B rollup for add-cards traffic shows NULL algorithm_version even after this PR lands. Separated for review scope (trace wrap adds try-block restructure).

## Test plan
- [ ] Local smoke test with env set (auth gate cases)
- [ ] Prod deploy: trigger "카드 더 찾기" on the affected coin mandala, verify off-topic ratio drops (compare against pre-deploy screenshots from /Users/jeonhokim/Documents/bug report/Screenshot 2026-05-27 at 9.53.24 AM.png)
- [ ] (Post-Phase-B-2) verify trace rows for add-cards have `algorithm_version = 'v1-current'` in `video_discover_traces`

🤖 Generated with [Claude Code](https://claude.com/claude-code)