### PR TITLE
feat(deploy): wire V2_QUALITY_AUDIT_ENABLED env (activate Phase 1 cron) (CP488+)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,6 +272,17 @@ jobs:
           # rows that were created with snippet-only data and never
           # received the full videos.list metadata enrichment.
           YOUTUBE_METADATA_BACKFILL_ENABLED: ${{ vars.YOUTUBE_METADATA_BACKFILL_ENABLED }}
+          # CP488+ — v2 Quality Audit daily scan cron activation. Non-secret
+          # per CP392 (boolean toggle, not a credential). Default empty ⇒
+          # config/v2-quality-audit.ts coerces to `false` ⇒
+          # startV2QualityAuditCron() logs "v2 quality audit cron disabled"
+          # at startup and never schedules. Set GitHub Variable
+          # V2_QUALITY_AUDIT_ENABLED to "true" to activate the daily
+          # 04:00 UTC scan that scores every v2 rich-summary row against
+          # 8 hallucination metrics and enqueues critical rows into
+          # v2_quality_regen_queue for Phase 3 background regeneration.
+          # Design: docs/design/v2-quality-audit-system-2026-05-27.md
+          V2_QUALITY_AUDIT_ENABLED: ${{ vars.V2_QUALITY_AUDIT_ENABLED }}
           # CP489 — video-discover trace capture toggle. Non-secret per CP392
           # (boolean flag, not a credential). Default empty ⇒ config/index.ts
           # coerces to `false` ⇒ discover-tracing fireAndForgetWrite no-ops,
@@ -293,7 +304,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,V3_TRACE_ENABLED,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
+          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,V2_QUALITY_AUDIT_ENABLED,V3_TRACE_ENABLED,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
           script: |
             set -e
             cd /opt/tubearchive
@@ -332,6 +343,15 @@ jobs:
             # --body true` then redeploy.
             if [ -n "${YOUTUBE_METADATA_BACKFILL_ENABLED}" ]; then
               grep -q '^YOUTUBE_METADATA_BACKFILL_ENABLED=' .env 2>/dev/null && sed -i "s|^YOUTUBE_METADATA_BACKFILL_ENABLED=.*|YOUTUBE_METADATA_BACKFILL_ENABLED=${YOUTUBE_METADATA_BACKFILL_ENABLED}|" .env || echo "YOUTUBE_METADATA_BACKFILL_ENABLED=${YOUTUBE_METADATA_BACKFILL_ENABLED}" >> .env
+            fi
+            # CP488+ — v2 Quality Audit daily scan cron activation. Same
+            # idempotent grep/sed/echo pattern. When unset/empty, the
+            # conditional skips and config/v2-quality-audit.ts default
+            # `false` stays in effect ⇒ startV2QualityAuditCron() never
+            # schedules. Activate via `gh variable set
+            # V2_QUALITY_AUDIT_ENABLED --body true` then redeploy.
+            if [ -n "${V2_QUALITY_AUDIT_ENABLED}" ]; then
+              grep -q '^V2_QUALITY_AUDIT_ENABLED=' .env 2>/dev/null && sed -i "s|^V2_QUALITY_AUDIT_ENABLED=.*|V2_QUALITY_AUDIT_ENABLED=${V2_QUALITY_AUDIT_ENABLED}|" .env || echo "V2_QUALITY_AUDIT_ENABLED=${V2_QUALITY_AUDIT_ENABLED}" >> .env
             fi
             # CP489 — video-discover trace capture toggle. Same idempotent
             # pattern as RICH_SUMMARY_ENABLED / YOUTUBE_METADATA_BACKFILL_ENABLED.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -272,6 +272,16 @@ jobs:
           # rows that were created with snippet-only data and never
           # received the full videos.list metadata enrichment.
           YOUTUBE_METADATA_BACKFILL_ENABLED: ${{ vars.YOUTUBE_METADATA_BACKFILL_ENABLED }}
+          # CP489 — video-discover trace capture toggle. Non-secret per CP392
+          # (boolean flag, not a credential). Default empty ⇒ config/index.ts
+          # coerces to `false` ⇒ discover-tracing fireAndForgetWrite no-ops,
+          # so the algorithm versioning A/B oracle has no per-mandala data
+          # to attribute. Set GitHub Variable V3_TRACE_ENABLED=true to
+          # activate fire-and-forget INSERTs into public.video_discover_traces
+          # for every LLM/YouTube/Cohere/embed step. Volume: O(10-20 rows per
+          # discovery call). Rollback: unset (or set to false) + redeploy —
+          # no code revert needed.
+          V3_TRACE_ENABLED: ${{ vars.V3_TRACE_ENABLED }}
           # Mac Mini transcript proxy. EC2 outbound to YouTube is blocked
           # for caption fetch; the Mac Mini (KR ISP IP, Tailscale 4242)
           # successfully fetches and forwards via x-transcript-token auth.
@@ -283,7 +293,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
+          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,V3_TRACE_ENABLED,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
           script: |
             set -e
             cd /opt/tubearchive
@@ -322,6 +332,19 @@ jobs:
             # --body true` then redeploy.
             if [ -n "${YOUTUBE_METADATA_BACKFILL_ENABLED}" ]; then
               grep -q '^YOUTUBE_METADATA_BACKFILL_ENABLED=' .env 2>/dev/null && sed -i "s|^YOUTUBE_METADATA_BACKFILL_ENABLED=.*|YOUTUBE_METADATA_BACKFILL_ENABLED=${YOUTUBE_METADATA_BACKFILL_ENABLED}|" .env || echo "YOUTUBE_METADATA_BACKFILL_ENABLED=${YOUTUBE_METADATA_BACKFILL_ENABLED}" >> .env
+            fi
+            # CP489 — video-discover trace capture toggle. Same idempotent
+            # pattern as RICH_SUMMARY_ENABLED / YOUTUBE_METADATA_BACKFILL_ENABLED.
+            # When the Variable is unset/empty the conditional skips and the
+            # src/config/index.ts default (`false` per :185) stays in effect
+            # — discover-tracing fireAndForgetWrite no-ops, video_discover_traces
+            # gets no rows, /admin/search-algorithms/comparison shows NULL
+            # algorithm_version for add-cards traffic. Activate via
+            # `gh variable set V3_TRACE_ENABLED --body true` then redeploy.
+            # Rollback: `gh variable set V3_TRACE_ENABLED --body false` or
+            # `gh variable delete V3_TRACE_ENABLED` + redeploy — no code revert.
+            if [ -n "${V3_TRACE_ENABLED}" ]; then
+              grep -q '^V3_TRACE_ENABLED=' .env 2>/dev/null && sed -i "s|^V3_TRACE_ENABLED=.*|V3_TRACE_ENABLED=${V3_TRACE_ENABLED}|" .env || echo "V3_TRACE_ENABLED=${V3_TRACE_ENABLED}" >> .env
             fi
             # 2026-04-18 — sync DB URLs from GitHub Secrets so password
             # rotations propagate to prod .env without manual SSH. Was


### PR DESCRIPTION
## Summary
Wires GitHub Variable \`V2_QUALITY_AUDIT_ENABLED\` through the deploy env-injection pipeline so the daily v2 quality audit cron actually activates on prod. Mirrors the exact pattern used by \`RICH_SUMMARY_ENABLED\` and \`YOUTUBE_METADATA_BACKFILL_ENABLED\`.

## Changes (3 surgical spots in deploy.yml)
1. Env block: \`V2_QUALITY_AUDIT_ENABLED: \${{ vars.V2_QUALITY_AUDIT_ENABLED }}\` with full comment block
2. \`envs:\` whitelist: added \`V2_QUALITY_AUDIT_ENABLED\`
3. Conditional sed/echo write into \`/opt/tubearchive/.env\`

## Companion repo variable (set concurrently)
\`gh variable set V2_QUALITY_AUDIT_ENABLED --body true\` ✅ already set (visible in \`gh variable list\`).

## Expected behaviour after merge
- Container restarts → reads \`V2_QUALITY_AUDIT_ENABLED=true\` → \`startV2QualityAuditCron()\` registers daily 04:00 UTC schedule
- First scheduled run produces 1 \`v2_quality_audit_runs\` row + ~1,800 \`v2_quality_audit_log\` rows + N \`v2_quality_regen_queue\` enqueues
- Admin dashboard \`/admin/v2-quality-audit\` displays real data (instead of empty state)

## Rollback
\`gh variable set V2_QUALITY_AUDIT_ENABLED --body false\` + redeploy. No code revert.

## Test plan
- [x] Diff is 3 surgical additions matching existing env wiring conventions
- [ ] CI 6/6 pass
- [ ] Deploy success
- [ ] Post-deploy: \`ssh insighta-ec2-ts docker exec insighta-api printenv V2_QUALITY_AUDIT_ENABLED\` → \`true\`
- [ ] Post-deploy: \`docker logs insighta-api | grep "v2 quality audit cron"\` → "started" (not "disabled")

🤖 Generated with [Claude Code](https://claude.com/claude-code)