### PR TITLE
feat(v2-quality-audit): Phase 3 — background regen worker + admin trigger routes (CP488+)

### DIFF
--- a/src/api/routes/admin/v2-quality-audit.ts
+++ b/src/api/routes/admin/v2-quality-audit.ts
@@ -23,6 +23,7 @@ import { z } from 'zod';
 import { db } from '@/modules/database/client';
 import { createSuccessResponse } from '../../schemas/common.schema';
 import { runV2AuditOnce } from '@/modules/scheduler/v2-quality-audit-cron';
+import { regenSingleVideo, runRegenBatchOnce } from '@/modules/scheduler/v2-quality-regen-cron';
 import { logger } from '@/utils/logger';
 
 const log = logger.child({ module: 'AdminV2QualityAudit' });
@@ -138,5 +139,98 @@ export async function adminV2QualityAuditRoutes(fastify: FastifyInstance) {
       });
     }
     return reply.send(createSuccessResponse({ summary }));
+  });
+
+  /**
+   * POST /api/v1/admin/v2-quality-audit/regen-now
+   * Phase 3 — triggers a single regen batch (claims up to batchSize
+   * highest-priority pending queue rows + processes them serially).
+   * Useful for kicking off the drain manually without waiting for the
+   * next cron tick.
+   */
+  fastify.post('/regen-now', adminAuth, async (_request: FastifyRequest, reply: FastifyReply) => {
+    log.info('admin manual regen batch triggered');
+    const summary = await runRegenBatchOnce();
+    if (!summary) {
+      return reply.status(409).send({
+        success: false,
+        error: 'regen_in_progress',
+        message: 'A previous regen batch is still in progress.',
+      });
+    }
+    return reply.send(createSuccessResponse({ summary }));
+  });
+
+  /**
+   * POST /api/v1/admin/v2-quality-audit/regen-trigger/:videoId
+   * Phase 3 — regenerate a specific video on-demand. Does not touch
+   * the queue (queueRowId=null); useful when the operator wants to
+   * recover one user-visible bad row without waiting for the batch.
+   */
+  fastify.post<{ Params: { videoId: string } }>(
+    '/regen-trigger/:videoId',
+    adminAuth,
+    async (request, reply) => {
+      const { videoId } = request.params;
+      if (!/^[\w-]{6,15}$/.test(videoId)) {
+        return reply.status(400).send({
+          success: false,
+          error: 'invalid_video_id',
+          message: 'videoId must match the YouTube id charset.',
+        });
+      }
+      log.info('admin manual single-video regen triggered', { videoId });
+      const result = await regenSingleVideo(videoId, null);
+      return reply.send(createSuccessResponse({ result }));
+    }
+  );
+
+  /**
+   * GET /api/v1/admin/v2-quality-audit/regen-queue
+   * Phase 3 — paginated view of the queue (pending + in-progress +
+   * recent resolved/failed) so the operator can see what the worker
+   * is actually doing.
+   */
+  fastify.get('/regen-queue', adminAuth, async (request, reply) => {
+    const limit = Math.min(
+      Math.max(
+        parseInt(String((request.query as Record<string, string>)?.['limit'] ?? '50'), 10) || 50,
+        1
+      ),
+      200
+    );
+    const items = await db.$queryRawUnsafe<
+      Array<{
+        id: string;
+        video_id: string;
+        title: string | null;
+        priority: number;
+        status: string;
+        reason: string | null;
+        enqueued_at: Date;
+        attempted_at: Date | null;
+        resolved_at: Date | null;
+      }>
+    >(
+      `SELECT q.id, q.video_id, yv.title, q.priority, q.status, q.reason,
+              q.enqueued_at, q.attempted_at, q.resolved_at
+         FROM v2_quality_regen_queue q
+         LEFT JOIN youtube_videos yv ON yv.youtube_video_id = q.video_id
+        ORDER BY (CASE q.status WHEN 'in_progress' THEN 0
+                                WHEN 'pending'     THEN 1
+                                WHEN 'failed'      THEN 2
+                                WHEN 'resolved'    THEN 3
+                                ELSE 9 END) ASC,
+                 q.priority ASC,
+                 q.enqueued_at DESC
+        LIMIT $1`,
+      limit
+    );
+    const summary = await db.$queryRawUnsafe<Array<{ status: string; cnt: bigint }>>(
+      `SELECT status, COUNT(*) AS cnt FROM v2_quality_regen_queue GROUP BY status`
+    );
+    const counts: Record<string, number> = {};
+    for (const r of summary) counts[r.status] = Number(r.cnt);
+    return reply.send(createSuccessResponse({ items, counts }));
   });
 }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -63,6 +63,10 @@ import {
   startV2QualityAuditCron,
   stopV2QualityAuditCron,
 } from '../modules/scheduler/v2-quality-audit-cron';
+import {
+  startV2QualityRegenCron,
+  stopV2QualityRegenCron,
+} from '../modules/scheduler/v2-quality-regen-cron';
 
 // Load environment variables
 dotenv.config();
@@ -608,6 +612,16 @@ export async function startServer() {
       fastify.log.warn({ err }, 'V2QualityAuditCron init failed (non-fatal)');
     }
 
+    // CP488+ Phase 3 — v2 Quality Regen worker (drains regen queue
+    // populated by the audit cron above). Default OFF; flip
+    // V2_QUALITY_REGEN_ENABLED=true once the audit has been running
+    // long enough for the operator to trust the score signal.
+    try {
+      startV2QualityRegenCron();
+    } catch (err) {
+      fastify.log.warn({ err }, 'V2QualityRegenCron init failed (non-fatal)');
+    }
+
     // Graceful shutdown
     const shutdown = async (signal: string) => {
       fastify.log.info(`${signal} received, shutting down gracefully...`);
@@ -638,6 +652,11 @@ export async function startServer() {
       }
       try {
         stopV2QualityAuditCron();
+      } catch {
+        /* ignore */
+      }
+      try {
+        stopV2QualityRegenCron();
       } catch {
         /* ignore */
       }

--- a/src/config/v2-quality-audit.ts
+++ b/src/config/v2-quality-audit.ts
@@ -33,8 +33,14 @@ export const v2QualityAuditEnvSchema = z.object({
   V2_QUALITY_AUDIT_WARNING_SCORE: positiveInt.transform((v) => v ?? 70),
   /** Max rows scanned per run. Default 5,000 covers current ~1,800 v2 row population with headroom. */
   V2_QUALITY_AUDIT_SCAN_LIMIT: positiveInt.transform((v) => v ?? 5000),
-  /** Phase 3 reads this; Phase 1 only writes regen_queue rows. Default 10 = conservative. */
-  V2_QUALITY_AUDIT_REGEN_BATCH_SIZE: positiveInt.transform((v) => v ?? 10),
+  /** Phase 3 batch size — videos processed per regen tick. Default 5 = ~2.5-5 min of LLM work per tick. */
+  V2_QUALITY_AUDIT_REGEN_BATCH_SIZE: positiveInt.transform((v) => v ?? 5),
+  /** Phase 3 — regen worker activation flag. Default OFF; safe to ship code without enabling. */
+  V2_QUALITY_REGEN_ENABLED: boolFlag.default(false as unknown as string),
+  /** Phase 3 — regen worker cron schedule. Default every 30 min (5 × 48 = 240 videos/day max throughput). */
+  V2_QUALITY_REGEN_CRON_SCHEDULE: z
+    .preprocess((v) => (v == null || v === '' ? '*/30 * * * *' : String(v).trim()), z.string())
+    .default('*/30 * * * *'),
   /** When true, the CI smoke test exercises a real OpenRouter call. Default OFF — env-gated for cost control. */
   V2_QUALITY_AUDIT_SMOKE_ENABLED: boolFlag.default(false as unknown as string),
 });
@@ -46,6 +52,10 @@ export interface V2QualityAuditConfig {
   warningScore: number;
   scanLimit: number;
   regenBatchSize: number;
+  /** Phase 3 — when true, the regen cron schedules itself; default false. */
+  regenEnabled: boolean;
+  /** Phase 3 — regen cron schedule (default every 30 min). */
+  regenCronSchedule: string;
   smokeEnabled: boolean;
 }
 
@@ -55,7 +65,9 @@ const FALLBACK_CONFIG: V2QualityAuditConfig = {
   passScore: 85,
   warningScore: 70,
   scanLimit: 5000,
-  regenBatchSize: 10,
+  regenBatchSize: 5,
+  regenEnabled: false,
+  regenCronSchedule: '*/30 * * * *',
   smokeEnabled: false,
 };
 
@@ -69,6 +81,8 @@ export function loadV2QualityAuditConfig(
     V2_QUALITY_AUDIT_WARNING_SCORE: env['V2_QUALITY_AUDIT_WARNING_SCORE'],
     V2_QUALITY_AUDIT_SCAN_LIMIT: env['V2_QUALITY_AUDIT_SCAN_LIMIT'],
     V2_QUALITY_AUDIT_REGEN_BATCH_SIZE: env['V2_QUALITY_AUDIT_REGEN_BATCH_SIZE'],
+    V2_QUALITY_REGEN_ENABLED: env['V2_QUALITY_REGEN_ENABLED'],
+    V2_QUALITY_REGEN_CRON_SCHEDULE: env['V2_QUALITY_REGEN_CRON_SCHEDULE'],
     V2_QUALITY_AUDIT_SMOKE_ENABLED: env['V2_QUALITY_AUDIT_SMOKE_ENABLED'],
   });
   if (!parsed.success) {
@@ -81,6 +95,8 @@ export function loadV2QualityAuditConfig(
     warningScore: parsed.data.V2_QUALITY_AUDIT_WARNING_SCORE,
     scanLimit: parsed.data.V2_QUALITY_AUDIT_SCAN_LIMIT,
     regenBatchSize: parsed.data.V2_QUALITY_AUDIT_REGEN_BATCH_SIZE,
+    regenEnabled: parsed.data.V2_QUALITY_REGEN_ENABLED,
+    regenCronSchedule: parsed.data.V2_QUALITY_REGEN_CRON_SCHEDULE,
     smokeEnabled: parsed.data.V2_QUALITY_AUDIT_SMOKE_ENABLED,
   };
 }

--- a/src/modules/scheduler/v2-quality-regen-cron.ts
+++ b/src/modules/scheduler/v2-quality-regen-cron.ts
@@ -1,0 +1,367 @@
+/**
+ * v2 Quality Regen cron — Phase 3 (CP488+, 2026-05-27).
+ *
+ * Background worker that drains `v2_quality_regen_queue` by re-running the
+ * v2 generator on each critical video, re-auditing it, and resolving the
+ * queue row. Design: docs/design/v2-quality-audit-system-2026-05-27.md §6.
+ *
+ * Operator-facing contract:
+ * - Sit dormant until `V2_QUALITY_REGEN_ENABLED=true` flips the cron on.
+ * - Every `V2_QUALITY_REGEN_CRON_SCHEDULE` tick (default every 30 min),
+ *   claim the `V2_QUALITY_AUDIT_REGEN_BATCH_SIZE` highest-priority pending
+ *   rows (default 5) and process them serially.
+ * - For each row:
+ *   1. Mark `status='in_progress'` + `attempted_at=now()`.
+ *   2. Call `generateRichSummaryV2({videoId, forceRegen: true})`.
+ *   3. Re-compute the 8-metric audit on the new row.
+ *   4. If the new overall_score >= passScore → `status='resolved'`.
+ *      Else → `status='failed'` (no auto-retry; operator can manually
+ *      re-enqueue via the admin route).
+ *   5. Always update `v2_quality_audit_log` with the new score so the
+ *      audit history reflects regen attempts.
+ *
+ * Safety:
+ * - `runInProgress` guard prevents overlap if a tick fires while the
+ *   previous batch is still streaming (each video can take 30-60s due to
+ *   LLM + captioner latency).
+ * - Per-video try/catch — one failure doesn't kill the batch.
+ * - No infinite retry loops — every queue row terminates at resolved or
+ *   failed after one attempt.
+ *
+ * "Detection, not blocking" rule alignment: the worker reads the
+ * regen_queue (written by the daily audit cron in Phase 1) and updates
+ * `video_rich_summaries` in place. Users see the better v2 content on
+ * their next view — no service-side blocking, no FE-side hiding.
+ */
+
+import * as cron from 'node-cron';
+
+import { db } from '@/modules/database/client';
+import { loadV2QualityAuditConfig } from '@/config/v2-quality-audit';
+import { logger } from '@/utils/logger';
+
+import {
+  classifyScore,
+  computeAuditScore,
+  type AuditInputAtom,
+  type AuditInputSection,
+} from '../skills/rich-summary-quality-audit';
+import { generateRichSummaryV2 } from '../skills/rich-summary-v2-generator';
+
+const log = logger.child({ module: 'V2QualityRegenCron' });
+
+let cronTask: cron.ScheduledTask | null = null;
+let runInProgress = false;
+
+interface RegenQueueRow {
+  id: string;
+  video_id: string;
+  priority: number;
+  reason: string | null;
+  enqueued_at: Date;
+}
+
+interface RegeneratedRow {
+  video_id: string;
+  model: string | null;
+  core: unknown;
+  segments: unknown;
+  duration_seconds: number | null;
+}
+
+export interface RegenBatchSummary {
+  picked: number;
+  resolved: number;
+  failed: number;
+  errors: number;
+  elapsedMs: number;
+}
+
+function extractOneliner(core: unknown): string | null {
+  if (!core || typeof core !== 'object') return null;
+  const obj = core as Record<string, unknown>;
+  const candidate = obj['one_liner'];
+  return typeof candidate === 'string' ? candidate : null;
+}
+
+function extractSections(segments: unknown): AuditInputSection[] | null {
+  if (!segments || typeof segments !== 'object') return null;
+  const obj = segments as Record<string, unknown>;
+  const arr = obj['sections'];
+  if (!Array.isArray(arr)) return null;
+  const out: AuditInputSection[] = [];
+  for (const entry of arr) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    const fromSec = typeof e['from_sec'] === 'number' ? e['from_sec'] : null;
+    const toSec = typeof e['to_sec'] === 'number' ? e['to_sec'] : null;
+    if (fromSec == null || toSec == null) continue;
+    out.push({ from_sec: fromSec, to_sec: toSec });
+  }
+  return out;
+}
+
+function extractAtoms(segments: unknown): AuditInputAtom[] | null {
+  if (!segments || typeof segments !== 'object') return null;
+  const obj = segments as Record<string, unknown>;
+  const arr = obj['atoms'];
+  if (!Array.isArray(arr)) return null;
+  const out: AuditInputAtom[] = [];
+  for (const entry of arr) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    const ts = typeof e['timestamp_sec'] === 'number' ? e['timestamp_sec'] : null;
+    out.push({ timestamp_sec: ts });
+  }
+  return out;
+}
+
+/**
+ * Re-fetch the freshly regenerated row + duration so the new audit score
+ * reflects exactly what `generateRichSummaryV2` just wrote. Returns null
+ * if the row vanished (would be a logic bug elsewhere).
+ */
+async function loadRegeneratedRow(videoId: string): Promise<RegeneratedRow | null> {
+  const rows = await db.$queryRawUnsafe<RegeneratedRow[]>(
+    `SELECT vrs.video_id, vrs.model, vrs.core, vrs.segments, yv.duration_seconds
+       FROM video_rich_summaries vrs
+       LEFT JOIN youtube_videos yv ON yv.youtube_video_id = vrs.video_id
+      WHERE vrs.video_id = $1
+      LIMIT 1`,
+    videoId
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * Regenerate a single queued video. Public-on-export so the admin
+ * `/regen-trigger/:videoId` route can call it without re-implementing
+ * the audit + queue resolution flow.
+ *
+ * @param videoId — video to regenerate
+ * @param queueRowId — optional queue row to mark resolved/failed; pass null
+ *   for manual ad-hoc triggers that should not touch the queue.
+ * @returns the new audit overall_score, classification, and outcome string.
+ */
+export async function regenSingleVideo(
+  videoId: string,
+  queueRowId: string | null
+): Promise<{
+  videoId: string;
+  outcome: 'resolved' | 'failed';
+  reason: string;
+  newScore: number | null;
+}> {
+  const config = loadV2QualityAuditConfig();
+
+  if (queueRowId) {
+    await db.v2_quality_regen_queue.update({
+      where: { id: queueRowId },
+      data: { status: 'in_progress', attempted_at: new Date() },
+    });
+  }
+
+  let outcome: 'resolved' | 'failed' = 'failed';
+  let reason = '';
+  let newScore: number | null = null;
+
+  try {
+    const generationResult = await generateRichSummaryV2({
+      videoId,
+      forceRegen: true,
+    });
+
+    if (generationResult.kind !== 'pass') {
+      reason = `generator_${generationResult.kind}:${'reason' in generationResult ? generationResult.reason : ''}`;
+      log.info('regen: generator did not pass', { videoId, reason });
+    } else {
+      // Re-audit just this video using the freshly written row.
+      const row = await loadRegeneratedRow(videoId);
+      if (!row) {
+        reason = 'post_regen_row_missing';
+      } else {
+        const score = computeAuditScore(
+          {
+            videoId,
+            durationSeconds: row.duration_seconds,
+            oneliner: extractOneliner(row.core),
+            sections: extractSections(row.segments),
+            atoms: extractAtoms(row.segments),
+          },
+          config.warningScore
+        );
+        newScore = score.overall;
+        const classification = classifyScore(score.overall, config.passScore, config.warningScore);
+
+        // Update today's audit_log row so the dashboard reflects regen.
+        const today = new Date(new Date().toISOString().slice(0, 10));
+        // Reuse the latest run id (if any) so the row stays joined to a
+        // run; otherwise leave audit_run_id at the previous value.
+        const latestRun = await db.v2_quality_audit_runs.findFirst({
+          orderBy: { run_date: 'desc' },
+          select: { id: true },
+        });
+        if (latestRun) {
+          await db.v2_quality_audit_log.upsert({
+            where: { video_id_audit_date: { video_id: videoId, audit_date: today } },
+            create: {
+              video_id: videoId,
+              audit_date: today,
+              audit_run_id: latestRun.id,
+              overall_score: score.overall,
+              m1_range_fit: score.m1RangeFit,
+              m2_coverage_start: score.m2CoverageStart,
+              m3_coverage_end: score.m3CoverageEnd,
+              m4_atoms_range: score.m4AtomsRange,
+              m5_atoms_distribution: score.m5AtomsDistribution,
+              m6_atoms_sorted: score.m6AtomsSorted,
+              m7_sections_gap: score.m7SectionsGap,
+              m8_oneliner_len: score.m8OneLinerLen,
+              model: row.model,
+              duration_seconds: row.duration_seconds,
+              violations: score.violations as unknown as object,
+            },
+            update: {
+              overall_score: score.overall,
+              m1_range_fit: score.m1RangeFit,
+              m2_coverage_start: score.m2CoverageStart,
+              m3_coverage_end: score.m3CoverageEnd,
+              m4_atoms_range: score.m4AtomsRange,
+              m5_atoms_distribution: score.m5AtomsDistribution,
+              m6_atoms_sorted: score.m6AtomsSorted,
+              m7_sections_gap: score.m7SectionsGap,
+              m8_oneliner_len: score.m8OneLinerLen,
+              model: row.model,
+              duration_seconds: row.duration_seconds,
+              violations: score.violations as unknown as object,
+            },
+          });
+        }
+
+        if (classification === 'pass') {
+          outcome = 'resolved';
+          reason = `pass_score=${score.overall}`;
+        } else {
+          reason = `still_${classification}:score=${score.overall}`;
+        }
+      }
+    }
+  } catch (err) {
+    reason = `exception:${err instanceof Error ? err.message : String(err)}`;
+    log.error('regen: exception', { videoId, error: reason });
+  }
+
+  if (queueRowId) {
+    await db.v2_quality_regen_queue.update({
+      where: { id: queueRowId },
+      data: {
+        status: outcome,
+        reason,
+        resolved_at: outcome === 'resolved' ? new Date() : null,
+      },
+    });
+  }
+
+  return { videoId, outcome, reason, newScore };
+}
+
+/**
+ * Run a single regen batch — claim up to `batchSize` highest-priority
+ * pending rows and process them serially. Exposed so the admin route can
+ * call it on-demand.
+ */
+export async function runRegenBatchOnce(): Promise<RegenBatchSummary | null> {
+  if (runInProgress) {
+    log.info('regen batch skipped — previous batch still in progress');
+    return null;
+  }
+  runInProgress = true;
+  const t0 = Date.now();
+  const config = loadV2QualityAuditConfig();
+
+  try {
+    const candidates = await db.$queryRawUnsafe<RegenQueueRow[]>(
+      `SELECT id, video_id, priority, reason, enqueued_at
+         FROM v2_quality_regen_queue
+        WHERE status = 'pending'
+        ORDER BY priority ASC, enqueued_at ASC
+        LIMIT $1`,
+      config.regenBatchSize
+    );
+
+    if (candidates.length === 0) {
+      log.info('regen batch: no pending rows');
+      return {
+        picked: 0,
+        resolved: 0,
+        failed: 0,
+        errors: 0,
+        elapsedMs: Date.now() - t0,
+      };
+    }
+
+    let resolved = 0;
+    let failed = 0;
+    let errors = 0;
+
+    for (const c of candidates) {
+      try {
+        const result = await regenSingleVideo(c.video_id, c.id);
+        if (result.outcome === 'resolved') resolved += 1;
+        else failed += 1;
+      } catch (err) {
+        errors += 1;
+        log.error('regen batch: per-item exception (already updated to failed)', {
+          videoId: c.video_id,
+          queueId: c.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    const summary: RegenBatchSummary = {
+      picked: candidates.length,
+      resolved,
+      failed,
+      errors,
+      elapsedMs: Date.now() - t0,
+    };
+    log.info('regen batch done', summary);
+    return summary;
+  } finally {
+    runInProgress = false;
+  }
+}
+
+export function startV2QualityRegenCron(): void {
+  const config = loadV2QualityAuditConfig();
+  if (!config.regenEnabled) {
+    log.info('v2 quality regen cron disabled (V2_QUALITY_REGEN_ENABLED=false)');
+    return;
+  }
+  if (cronTask) {
+    cronTask.stop();
+    cronTask = null;
+  }
+  if (!cron.validate(config.regenCronSchedule)) {
+    log.error('v2 quality regen cron schedule invalid — not started', {
+      schedule: config.regenCronSchedule,
+    });
+    return;
+  }
+  cronTask = cron.schedule(config.regenCronSchedule, () => {
+    void runRegenBatchOnce();
+  });
+  log.info('v2 quality regen cron started', {
+    schedule: config.regenCronSchedule,
+    batchSize: config.regenBatchSize,
+  });
+}
+
+export function stopV2QualityRegenCron(): void {
+  if (cronTask) {
+    cronTask.stop();
+    cronTask = null;
+    log.info('v2 quality regen cron stopped');
+  }
+}

--- a/tests/unit/config/v2-quality-audit-config.test.ts
+++ b/tests/unit/config/v2-quality-audit-config.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for v2-quality-audit config loader (CP488+ Phase 1 + Phase 3).
+ *
+ * Verifies the zod schema defaults + env overrides for both the audit
+ * cron knobs and the Phase 3 regen worker knobs so a future env-name
+ * typo or default drift surfaces at the unit level.
+ */
+
+import { loadV2QualityAuditConfig } from '@/config/v2-quality-audit';
+
+describe('loadV2QualityAuditConfig', () => {
+  describe('defaults (empty env)', () => {
+    it('returns the Phase 1 + Phase 3 defaults', () => {
+      const cfg = loadV2QualityAuditConfig({});
+      expect(cfg.enabled).toBe(false);
+      expect(cfg.cronSchedule).toBe('0 4 * * *');
+      expect(cfg.passScore).toBe(85);
+      expect(cfg.warningScore).toBe(70);
+      expect(cfg.scanLimit).toBe(5000);
+      expect(cfg.regenBatchSize).toBe(5);
+      expect(cfg.regenEnabled).toBe(false);
+      expect(cfg.regenCronSchedule).toBe('*/30 * * * *');
+      expect(cfg.smokeEnabled).toBe(false);
+    });
+  });
+
+  describe('env overrides', () => {
+    it('parses truthy bool flags', () => {
+      const cfg = loadV2QualityAuditConfig({
+        V2_QUALITY_AUDIT_ENABLED: 'true',
+        V2_QUALITY_REGEN_ENABLED: '1',
+        V2_QUALITY_AUDIT_SMOKE_ENABLED: 'yes',
+      });
+      expect(cfg.enabled).toBe(true);
+      expect(cfg.regenEnabled).toBe(true);
+      expect(cfg.smokeEnabled).toBe(true);
+    });
+
+    it('accepts positive integer overrides', () => {
+      const cfg = loadV2QualityAuditConfig({
+        V2_QUALITY_AUDIT_PASS_SCORE: '90',
+        V2_QUALITY_AUDIT_WARNING_SCORE: '75',
+        V2_QUALITY_AUDIT_SCAN_LIMIT: '2000',
+        V2_QUALITY_AUDIT_REGEN_BATCH_SIZE: '20',
+      });
+      expect(cfg.passScore).toBe(90);
+      expect(cfg.warningScore).toBe(75);
+      expect(cfg.scanLimit).toBe(2000);
+      expect(cfg.regenBatchSize).toBe(20);
+    });
+
+    it('accepts custom cron schedules', () => {
+      const cfg = loadV2QualityAuditConfig({
+        V2_QUALITY_AUDIT_CRON_SCHEDULE: '0 0 * * *',
+        V2_QUALITY_REGEN_CRON_SCHEDULE: '*/15 * * * *',
+      });
+      expect(cfg.cronSchedule).toBe('0 0 * * *');
+      expect(cfg.regenCronSchedule).toBe('*/15 * * * *');
+    });
+
+    it('falls back to defaults on bad values', () => {
+      const cfg = loadV2QualityAuditConfig({
+        V2_QUALITY_AUDIT_PASS_SCORE: 'garbage',
+        V2_QUALITY_AUDIT_REGEN_BATCH_SIZE: '-1',
+      });
+      // Schema returns FALLBACK_CONFIG on parse failure (any field bad → whole reset).
+      expect(cfg.passScore).toBe(85);
+      expect(cfg.regenBatchSize).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Phase 3 of the v2 quality observability system (design doc §6). Drains the regen queue that Phase 1's audit cron populates. Default OFF on merge — code ships dormant until the operator flips \`V2_QUALITY_REGEN_ENABLED=true\` after reviewing Phase 1 score data.

## What lands
- **Worker** \`src/modules/scheduler/v2-quality-regen-cron.ts\`: \`runRegenBatchOnce()\` + \`regenSingleVideo()\` + start/stop, mirrors v2-quality-audit-cron pattern (node-cron, runInProgress guard, env-gated)
- **3 admin routes**:
  - \`POST /admin/v2-quality-audit/regen-now\` — trigger one batch
  - \`POST /admin/v2-quality-audit/regen-trigger/:videoId\` — ad-hoc single-video regen (queue untouched)
  - \`GET  /admin/v2-quality-audit/regen-queue?limit=N\` — paginated queue view + status counts
- **Config envs** (zod): \`V2_QUALITY_REGEN_ENABLED\` (bool, default false), \`V2_QUALITY_REGEN_CRON_SCHEDULE\` (default \`*/30 * * * *\`), \`V2_QUALITY_AUDIT_REGEN_BATCH_SIZE\` (default 5)
- **Tests**: 5 new config tests + existing 33 audit tests still pass (38 total)

## Semantics
For each queue row: \`status=in_progress\` + \`attempted_at=now\` → \`generateRichSummaryV2(forceRegen=true)\` → re-compute 8-metric audit → if pass: \`status=resolved\`, else \`status=failed\` (no auto-retry, no loop). Always updates today's \`v2_quality_audit_log\` row so dashboard reflects regen in real time.

## Throughput
5 × 48 = 240 videos/day max → current 518 critical rows drain in ~2.2 days. Adjustable via env.

## Detection-not-blocking preserved
Worker never hides anything. Users see whatever's in the row; regen happens in background. Better content appears on next view.

## Test plan
- [x] BE \`tsc --noEmit\` clean
- [x] 38 audit-related tests pass
- [x] \`eslint --fix\` applied
- [ ] CI 6/6 pass
- [ ] Post-merge: companion PR wires \`V2_QUALITY_REGEN_ENABLED\` into deploy.yml + \`gh variable set V2_QUALITY_REGEN_ENABLED true\` (atomic activation per CP392)
- [ ] Operator post-activation: \`POST /admin/v2-quality-audit/regen-now\` → batch of 5 processes → \`GET /regen-queue\` shows resolved/failed/pending counts

## Rollback
L1: \`gh variable set V2_QUALITY_REGEN_ENABLED false\` + redeploy. L2: revert PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)