### PR TITLE
feat(v2): Phase 1.5 — annotated transcript + duration prompt + range validator (CP488+)

### DIFF
--- a/src/modules/caption/format-transcript.ts
+++ b/src/modules/caption/format-transcript.ts
@@ -1,0 +1,47 @@
+/**
+ * Annotated transcript formatter (CP488+ Phase 1.5, 2026-05-27).
+ *
+ * Converts `CaptionSegment[]` (which carries `start` seconds per row) into
+ * a line-delimited string with `[mm:ss]` (or `[hh:mm:ss]` past one hour)
+ * timestamps preserved per segment. This is what `generateRichSummaryV2`
+ * sends to Sonnet 4.6 in place of the legacy `fullText` join — without
+ * timestamps in the input, the LLM has to guess timeline coverage and
+ * produces the hallucination pattern Phase 3 dogfooded:
+ *   sections.last.to_sec ≈ 50% of duration
+ *   atoms bunched in the first quarter
+ *
+ * Format: one segment per line, `[mm:ss] text` prefix (or `[hh:mm:ss]`
+ * if the start time exceeds 3600 s). Empty input ⇒ empty string (caller
+ * falls back to `(no transcript)`).
+ *
+ * Cost: ~10-20% longer than `fullText` due to the timestamp prefix per
+ * line — well within `RICH_SUMMARY_V2_TRANSCRIPT_MAX_CHARS` (default
+ * 100,000 covers a 90-min Korean lecture even with annotation overhead).
+ */
+
+import type { CaptionSegment } from './types';
+
+function formatStamp(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const hh = Math.floor(s / 3600);
+  const mm = Math.floor((s % 3600) / 60);
+  const ss = s % 60;
+  if (hh > 0) {
+    return `[${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}]`;
+  }
+  return `[${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}]`;
+}
+
+export function formatAnnotatedTranscript(
+  segments: ReadonlyArray<CaptionSegment> | undefined | null
+): string {
+  if (!segments || segments.length === 0) return '';
+  const lines: string[] = [];
+  for (const seg of segments) {
+    if (!seg || typeof seg.text !== 'string') continue;
+    const text = seg.text.replace(/\s*\n+\s*/g, ' ').trim();
+    if (text.length === 0) continue;
+    lines.push(`${formatStamp(seg.start ?? 0)} ${text}`);
+  }
+  return lines.join('\n');
+}

--- a/src/modules/queue/handlers/enrich-rich-summary.ts
+++ b/src/modules/queue/handlers/enrich-rich-summary.ts
@@ -124,7 +124,14 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
   try {
     const result = await getCaptionExtractor().extractCaptions(videoId, langHint);
     if (result.success && result.caption?.fullText) {
-      transcript = result.caption.fullText;
+      // CP488+ Phase 1.5 — annotated `[mm:ss] text\n` form gives the LLM
+      // real timestamp ground truth (legacy fullText join stripped them
+      // and forced Sonnet to guess timeline coverage → hallucination
+      // pattern Phase 3 dogfooding surfaced). Falls back to fullText if
+      // segments are absent.
+      const { formatAnnotatedTranscript } = await import('@/modules/caption/format-transcript');
+      const annotated = formatAnnotatedTranscript(result.caption.segments);
+      transcript = annotated || result.caption.fullText;
       logger.info('enrich-rich-summary: transcript fetched', {
         jobId: job.id,
         videoId,

--- a/src/modules/scheduler/rich-summary-v2-cron.ts
+++ b/src/modules/scheduler/rich-summary-v2-cron.ts
@@ -214,7 +214,14 @@ export async function runV2BatchOnce(batchSize: number): Promise<{
             });
             return null;
           });
-        const transcript = captionResult?.success ? captionResult.caption?.fullText : undefined;
+        // CP488+ Phase 1.5 — annotated [mm:ss] form (see
+        // enrich-rich-summary handler for full rationale). Falls back to
+        // fullText if segments are absent for any reason.
+        const { formatAnnotatedTranscript } = await import('@/modules/caption/format-transcript');
+        const transcript = captionResult?.success
+          ? formatAnnotatedTranscript(captionResult.caption?.segments) ||
+            captionResult.caption?.fullText
+          : undefined;
         if (!transcript) {
           // Stamp the attempt so this row enters the 7-day captioner
           // cooldown — avoids hammering the same unavailable captions

--- a/src/modules/scheduler/v2-quality-regen-cron.ts
+++ b/src/modules/scheduler/v2-quality-regen-cron.ts
@@ -47,6 +47,8 @@ import {
   type AuditInputSection,
 } from '../skills/rich-summary-quality-audit';
 import { generateRichSummaryV2 } from '../skills/rich-summary-v2-generator';
+import { getCaptionExtractor } from '../caption/extractor';
+import { formatAnnotatedTranscript } from '../caption/format-transcript';
 
 const log = logger.child({ module: 'V2QualityRegenCron' });
 
@@ -166,9 +168,29 @@ export async function regenSingleVideo(
   let newScore: number | null = null;
 
   try {
+    // CP488+ Phase 1.5 — fetch transcript BEFORE calling the generator.
+    // Phase 3 dogfood (2026-05-27) ran 5 regens without transcripts,
+    // generator silently fell back to description-only mode, Sonnet
+    // hallucinated timeline coverage → 0/5 resolved. Mirrors the
+    // canonical pattern in enrich-rich-summary handler.
+    let transcript: string | undefined;
+    try {
+      const captionResult = await getCaptionExtractor().extractCaptions(videoId);
+      if (captionResult.success && captionResult.caption?.fullText) {
+        const annotated = formatAnnotatedTranscript(captionResult.caption.segments);
+        transcript = annotated || captionResult.caption.fullText;
+      }
+    } catch (capErr) {
+      log.warn('regen: caption fetch threw (will continue without transcript)', {
+        videoId,
+        error: capErr instanceof Error ? capErr.message : String(capErr),
+      });
+    }
+
     const generationResult = await generateRichSummaryV2({
       videoId,
       forceRegen: true,
+      transcript,
     });
 
     if (generationResult.kind !== 'pass') {

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -20,6 +20,7 @@ import { getPrismaClient } from '@/modules/database/client';
 import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
 import { loadRichSummaryConfig } from '@/config/rich-summary';
 import { logger } from '@/utils/logger';
+import { validateV2TimelineRange, V2TimelineRangeError } from './rich-summary-v2-validator-range';
 
 // CP488+ — v2 full generator pinned to Sonnet 4.6. Previously this path
 // inherited the global provider (createGenerationProvider) which resolved
@@ -184,6 +185,10 @@ export async function generateRichSummaryV2(
     language,
     transcript: input.transcript,
     mandalaCenterGoal: input.mandalaCenterGoal,
+    // CP488+ Phase 1.5 — duration is now a first-class prompt input so the
+    // LLM can produce sections/atoms timestamps that fit the wall-clock
+    // length. The validator below rejects outputs that still over-shoot.
+    durationSeconds: ytRow.duration_seconds,
   });
 
   // CP488+ — pinned Sonnet 4.6 (see SONNET_MODEL doc-comment above).
@@ -235,6 +240,33 @@ export async function generateRichSummaryV2(
           reasons: score.reasons,
         });
         continue;
+      }
+
+      // CP488+ Phase 1.5 — timeline range guard. Rejects Sonnet 4.6
+      // hallucinated outputs (XrlKWAIFQUY pattern: sections.last.to_sec
+      // overshooting wall-clock duration by 30-50%). No-op when duration
+      // is unknown.
+      if (ytRow.duration_seconds != null) {
+        try {
+          validateV2TimelineRange({
+            durationSeconds: ytRow.duration_seconds,
+            sections: summary.segments?.sections,
+            atoms: summary.segments?.atoms,
+          });
+        } catch (rangeErr) {
+          const reason =
+            rangeErr instanceof V2TimelineRangeError
+              ? `timeline_range: ${rangeErr.path}: observed=${rangeErr.observed} max=${rangeErr.maxAllowed}`
+              : `timeline_range_threw: ${rangeErr instanceof Error ? rangeErr.message : String(rangeErr)}`;
+          lastReason = reason;
+          log.warn('v2 timeline range rejected', {
+            videoId: input.videoId,
+            attempt,
+            reason,
+            durationSec: ytRow.duration_seconds,
+          });
+          continue;
+        }
       }
 
       // UPSERT — the quick-path normally creates the row first, but

--- a/src/modules/skills/rich-summary-v2-prompt.ts
+++ b/src/modules/skills/rich-summary-v2-prompt.ts
@@ -196,6 +196,7 @@ export const RICH_SUMMARY_V2_LAYERED_PROMPT = `You are a learning content analys
 Video title: {title}
 Video description: {description}
 Channel: {channel}
+Video duration: {video_duration_sec} seconds ({video_duration_human}) — the wall-clock length of the video. Section and atom timestamps MUST stay within this range.
 Transcript (when available; empty otherwise): {transcript_block}
 User mandala center goal (the learning objective the viewer is pursuing; empty when not provided): {mandala_center_goal}
 
@@ -273,7 +274,8 @@ Output rules:
 - Return JSON only — no markdown fences, no commentary, no chain-of-thought.
 - Use {language} consistently across every string field (Korean if 'ko', English if 'en').
 - When the Transcript block is non-empty, prefer transcript content over description/title for evidence in qa_pairs.a and analysis.core_argument. When empty, fall back to title + description.
-- When the Transcript block is empty (= "(no transcript)"): segments.sections should be a single catch-all entry (from_sec: 0, to_sec: 0, relevance_pct: 50) and segments.atoms entries should omit timestamp_sec — the LLM cannot infer real timestamps without transcript evidence. Do NOT fabricate timestamps.`;
+- When the Transcript block is empty (= "(no transcript)"): segments.sections should be a single catch-all entry (from_sec: 0, to_sec: 0, relevance_pct: 50) and segments.atoms entries should omit timestamp_sec — the LLM cannot infer real timestamps without transcript evidence. Do NOT fabricate timestamps.
+- When the Transcript block is non-empty, it is formatted as ONE LINE PER CAPTION segment prefixed with [mm:ss] (or [hh:mm:ss] past one hour) — for example: "[00:12] 안녕하세요" / "[01:05] 오늘 주제는". These prefixes are ground truth. Derive every section's from_sec/to_sec and every atom's timestamp_sec by READING the bracket prefixes directly; DO NOT estimate. The first section must start at 0 and the last section's to_sec must equal (or be within 5% of) the Video duration listed above. atoms.timestamp_sec MUST be monotonically ascending and the maximum value MUST not exceed (Video duration × 1.05).`;
 
 // ============================================================================
 // Prompt fill helper
@@ -289,6 +291,12 @@ export interface PromptInput {
    * prefer transcript-derived evidence over description/title. The
    * transcript is truncated to TRANSCRIPT_MAX_CHARS to stay within
    * provider token limits.
+   *
+   * CP488+ Phase 1.5 — callers should pass the annotated form
+   * (`[mm:ss] text\n…` produced by `formatAnnotatedTranscript`). The
+   * legacy fullText form still works (the LLM falls back to estimating
+   * timeline coverage) but produces the hallucination pattern Phase 3
+   * dogfooding surfaced.
    */
   transcript?: string;
   /**
@@ -298,6 +306,24 @@ export interface PromptInput {
    * model is instructed to return 0 for that field.
    */
   mandalaCenterGoal?: string;
+  /**
+   * CP488+ Phase 1.5 — video wall-clock length in seconds (sourced from
+   * `youtube_videos.duration_seconds`). When known, the prompt declares
+   * it explicitly so the LLM can produce sections/atoms timestamps that
+   * fit the actual timeline. When unknown (null/undefined), the
+   * placeholder renders as "unknown" and the timeline-range validator
+   * downstream is a no-op.
+   */
+  durationSeconds?: number | null;
+}
+
+function formatHumanDuration(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const hh = Math.floor(s / 3600);
+  const mm = Math.floor((s % 3600) / 60);
+  const ss = s % 60;
+  if (hh > 0) return `${hh}h${mm}m${ss}s`;
+  return `${mm}m${ss}s`;
 }
 
 export function buildV2Prompt(input: PromptInput): string {
@@ -311,11 +337,19 @@ export function buildV2Prompt(input: PromptInput): string {
     input.mandalaCenterGoal && input.mandalaCenterGoal.trim().length > 0
       ? input.mandalaCenterGoal.trim().slice(0, MANDALA_CENTER_GOAL_MAX_CHARS)
       : '(empty)';
+  const durationSec =
+    input.durationSeconds != null && Number.isFinite(input.durationSeconds)
+      ? Math.max(0, Math.floor(input.durationSeconds))
+      : null;
+  const durationSecText = durationSec != null ? String(durationSec) : 'unknown';
+  const durationHumanText = durationSec != null ? formatHumanDuration(durationSec) : 'unknown';
   return RICH_SUMMARY_V2_LAYERED_PROMPT.replace(/\{title\}/g, input.title.slice(0, 200))
     .replace(/\{description\}/g, input.description.slice(0, 800))
     .replace(/\{channel\}/g, input.channel.slice(0, 80))
     .replace(/\{transcript_block\}/g, transcriptBlock)
     .replace(/\{mandala_center_goal\}/g, centerGoalBlock)
+    .replace(/\{video_duration_sec\}/g, durationSecText)
+    .replace(/\{video_duration_human\}/g, durationHumanText)
     .replace(/\{language\}/g, input.language)
     .replace(/\{language_label\}/g, languageLabel);
 }

--- a/src/modules/skills/rich-summary-v2-validator-range.ts
+++ b/src/modules/skills/rich-summary-v2-validator-range.ts
@@ -1,0 +1,83 @@
+/**
+ * Timeline range validator for v2 segments (CP488+ Phase 1.5, 2026-05-27).
+ *
+ * Rejects LLM outputs whose `sections.last.to_sec` or
+ * `atoms.max(timestamp_sec)` clearly hallucinate past the actual video
+ * duration. Sits behind the existing `validateV2Layered` (shape check)
+ * and `scoreCompleteness` (completeness) — runs ONLY when the row has
+ * a known `duration_seconds` from `youtube_videos`.
+ *
+ * Tolerance: 5% over duration. Real captions occasionally extend a
+ * second or two past the wall-clock duration; we don't want to fail
+ * on those. But Phase 3 dogfooding showed Sonnet 4.6 producing
+ * `to_sec = 1380` against `duration = 901` (53% over-shoot) — well
+ * outside any plausible rounding band.
+ *
+ * Design: docs/design/v2-quality-audit-system-2026-05-27.md §8
+ * (smoke-gate spec) + retroactive learning from Phase 3 dogfood.
+ */
+
+const OVER_SHOOT_TOLERANCE = 1.05;
+
+export class V2TimelineRangeError extends Error {
+  constructor(
+    message: string,
+    public readonly path: string,
+    public readonly observed: number,
+    public readonly maxAllowed: number
+  ) {
+    super(message);
+    this.name = 'V2TimelineRangeError';
+  }
+}
+
+export interface TimelineCheckInput {
+  durationSeconds: number;
+  sections?: Array<{ to_sec?: number }>;
+  atoms?: Array<{ timestamp_sec?: number | null }>;
+}
+
+/**
+ * Pure-function range check. Throws `V2TimelineRangeError` on the
+ * first violation it finds (caller's loop treats this as a retry
+ * reason). Returns silently if the row passes or if duration is
+ * unknown / non-positive (in which case the audit metrics handle
+ * detection downstream).
+ */
+export function validateV2TimelineRange(input: TimelineCheckInput): void {
+  const { durationSeconds } = input;
+  if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+    return;
+  }
+  const maxAllowed = Math.ceil(durationSeconds * OVER_SHOOT_TOLERANCE);
+
+  if (input.sections && input.sections.length > 0) {
+    const last = input.sections[input.sections.length - 1];
+    const toSec = typeof last?.to_sec === 'number' ? last.to_sec : null;
+    if (toSec != null && toSec > maxAllowed) {
+      throw new V2TimelineRangeError(
+        `sections.last.to_sec=${toSec} exceeds duration=${durationSeconds} (cap=${maxAllowed} with 5% tolerance)`,
+        'segments.sections.last.to_sec',
+        toSec,
+        maxAllowed
+      );
+    }
+  }
+
+  if (input.atoms && input.atoms.length > 0) {
+    const stamps = input.atoms
+      .map((a) => a?.timestamp_sec)
+      .filter((t): t is number => typeof t === 'number' && Number.isFinite(t));
+    if (stamps.length > 0) {
+      const maxTs = Math.max(...stamps);
+      if (maxTs > maxAllowed) {
+        throw new V2TimelineRangeError(
+          `atoms.max(timestamp_sec)=${maxTs} exceeds duration=${durationSeconds} (cap=${maxAllowed} with 5% tolerance)`,
+          'segments.atoms[].timestamp_sec',
+          maxTs,
+          maxAllowed
+        );
+      }
+    }
+  }
+}

--- a/tests/unit/caption/format-transcript.test.ts
+++ b/tests/unit/caption/format-transcript.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for the annotated transcript formatter (CP488+ Phase 1.5).
+ *
+ * The formatter is the load-bearing change of Phase 1.5 — switching from
+ * the legacy `fullText = segments.map(s => s.text).join(' ')` (which
+ * strips timestamps) to a `[mm:ss] text\n…` form that gives the LLM
+ * actual timeline ground-truth. Regressions here mean Sonnet 4.6 goes
+ * back to hallucinating coverage.
+ */
+
+import { formatAnnotatedTranscript } from '@/modules/caption/format-transcript';
+
+describe('formatAnnotatedTranscript', () => {
+  it('returns empty string for empty input', () => {
+    expect(formatAnnotatedTranscript([])).toBe('');
+    expect(formatAnnotatedTranscript(null)).toBe('');
+    expect(formatAnnotatedTranscript(undefined)).toBe('');
+  });
+
+  it('prefixes each segment with [mm:ss]', () => {
+    const out = formatAnnotatedTranscript([
+      { start: 0, duration: 5, text: '안녕하세요' },
+      { start: 12, duration: 3, text: '오늘 주제는' },
+      { start: 65, duration: 4, text: '시간 관리입니다' },
+    ]);
+    expect(out).toBe('[00:00] 안녕하세요\n[00:12] 오늘 주제는\n[01:05] 시간 관리입니다');
+  });
+
+  it('switches to [hh:mm:ss] past one hour', () => {
+    const out = formatAnnotatedTranscript([
+      { start: 3599, duration: 2, text: 'last minute' },
+      { start: 3600, duration: 2, text: 'first hour' },
+      { start: 5430, duration: 2, text: 'mid 90 min' },
+    ]);
+    const lines = out.split('\n');
+    expect(lines[0]).toBe('[59:59] last minute');
+    expect(lines[1]).toBe('[01:00:00] first hour');
+    expect(lines[2]).toBe('[01:30:30] mid 90 min');
+  });
+
+  it('collapses internal newlines and trims segment text', () => {
+    const out = formatAnnotatedTranscript([
+      { start: 5, duration: 3, text: '  line one\n  line two  ' },
+    ]);
+    expect(out).toBe('[00:05] line one line two');
+  });
+
+  it('skips empty / whitespace-only segments', () => {
+    const out = formatAnnotatedTranscript([
+      { start: 0, duration: 1, text: '' },
+      { start: 1, duration: 1, text: '   ' },
+      { start: 2, duration: 1, text: 'kept' },
+    ]);
+    expect(out).toBe('[00:02] kept');
+  });
+
+  it('handles missing start by defaulting to 0', () => {
+    const out = formatAnnotatedTranscript([
+      { start: undefined as unknown as number, duration: 0, text: 'fallback' },
+    ]);
+    expect(out).toBe('[00:00] fallback');
+  });
+});

--- a/tests/unit/skills/rich-summary-v2-validator-range.test.ts
+++ b/tests/unit/skills/rich-summary-v2-validator-range.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the timeline range validator (CP488+ Phase 1.5).
+ *
+ * The validator is what stops Sonnet 4.6's hallucinated over-shoot
+ * outputs from being persisted as `quality_flag='pass'`. Phase 3
+ * dogfooding (2026-05-27) confirmed the LLM produces `to_sec=1380`
+ * against `duration=901` (53% over) — exactly the shape these tests
+ * exercise.
+ */
+
+import {
+  validateV2TimelineRange,
+  V2TimelineRangeError,
+} from '@/modules/skills/rich-summary-v2-validator-range';
+
+describe('validateV2TimelineRange', () => {
+  it('passes when sections + atoms fit within duration', () => {
+    expect(() =>
+      validateV2TimelineRange({
+        durationSeconds: 600,
+        sections: [{ to_sec: 200 }, { to_sec: 400 }, { to_sec: 595 }],
+        atoms: [{ timestamp_sec: 100 }, { timestamp_sec: 400 }, { timestamp_sec: 580 }],
+      })
+    ).not.toThrow();
+  });
+
+  it('passes within the 5% tolerance band', () => {
+    expect(() =>
+      validateV2TimelineRange({
+        durationSeconds: 1000,
+        sections: [{ to_sec: 1040 }], // 1040 / 1000 = 1.04 ≤ 1.05
+        atoms: [{ timestamp_sec: 1045 }],
+      })
+    ).not.toThrow();
+  });
+
+  it('throws when sections.last.to_sec exceeds duration × 1.05', () => {
+    expect(() =>
+      validateV2TimelineRange({
+        durationSeconds: 901,
+        sections: [{ to_sec: 1380 }], // XrlKWAIFQUY incident
+      })
+    ).toThrow(V2TimelineRangeError);
+  });
+
+  it('throws when atoms max timestamp exceeds duration × 1.05', () => {
+    expect(() =>
+      validateV2TimelineRange({
+        durationSeconds: 600,
+        atoms: [{ timestamp_sec: 100 }, { timestamp_sec: 1200 }],
+      })
+    ).toThrow(V2TimelineRangeError);
+  });
+
+  it('attaches the observed value + cap on the error', () => {
+    let caught: V2TimelineRangeError | null = null;
+    try {
+      validateV2TimelineRange({
+        durationSeconds: 1000,
+        sections: [{ to_sec: 2000 }],
+      });
+    } catch (err) {
+      if (err instanceof V2TimelineRangeError) caught = err;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught?.observed).toBe(2000);
+    expect(caught?.maxAllowed).toBe(1050);
+    expect(caught?.path).toBe('segments.sections.last.to_sec');
+  });
+
+  it('is a no-op when duration is unknown', () => {
+    expect(() =>
+      validateV2TimelineRange({
+        durationSeconds: 0,
+        sections: [{ to_sec: 9999 }],
+      })
+    ).not.toThrow();
+    expect(() =>
+      validateV2TimelineRange({
+        durationSeconds: Number.NaN,
+        sections: [{ to_sec: 9999 }],
+      })
+    ).not.toThrow();
+  });
+
+  it('ignores atoms without timestamp_sec', () => {
+    expect(() =>
+      validateV2TimelineRange({
+        durationSeconds: 600,
+        atoms: [{ timestamp_sec: null }, {}, { timestamp_sec: 580 }],
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Root-cause fix for Phase 3 dogfooding failure (2026-05-27 0/5 resolved). The generator was sending the LLM a timestamp-stripped \`fullText\` join, so even Sonnet 4.6 had to guess timeline coverage → sections/atoms only cover first half. Phase 1.5 ships:

1. **Annotated transcript** \`[mm:ss] text\\n…\` — generator + cron + regen worker + queue handler all send the timestamped form
2. **Duration-aware prompt** — \`Video duration: N seconds (HmS)\` now declared explicitly + transcript-format rule explains \`[mm:ss]\` markers + 5% range cap
3. **Range validator** — \`validateV2TimelineRange\` throws if \`sections.last.to_sec\` or \`atoms.max(timestamp_sec)\` exceeds \`duration × 1.05\`. Runs inside the existing 1-retry loop
4. **Regen worker captioner fetch** — Phase 3 worker now fetches captions before calling the generator (the actual 0/5 root cause)

## Default behaviour
All callers switch to annotated form on merge. Range validator on by default (no-op when duration unknown). Existing 1,800 v2 rows untouched — only NEW generations see the new path.

## Test plan
- [x] BE \`tsc --noEmit\` clean
- [x] 163/163 rich-summary + caption + v2-quality tests pass (13 new + 150 existing)
- [x] \`eslint --fix\` applied
- [ ] CI 6/6 pass
- [ ] Post-merge: re-enable \`V2_QUALITY_REGEN_ENABLED=true\` + \`POST /admin/v2-quality-audit/regen-now\` → expect ≥4/5 resolved (vs 0/5 in Phase 3 dogfood). If still 0/5, the issue is elsewhere and the validator catches it (queue rows mark \`failed\` with reason \`timeline_range:…\`).

## Rollback
- Pure code revert (no env flag added, no schema change). Captioner consumers fall back to \`fullText\` if \`segments\` array is absent — defence in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)