### PR TITLE
feat(v2): Phase 4 — hide policy → subtle auto-improving indicator (CP488+)

### DIFF
--- a/frontend/src/features/video-side-panel/model/useRichSummary.ts
+++ b/frontend/src/features/video-side-panel/model/useRichSummary.ts
@@ -4,19 +4,22 @@
  * CP425 (C2) — wraps `GET /api/v1/videos/:id/rich-summary`. 404 → null
  * (empty state), other errors surface via TanStack Query `error`.
  *
- * CP488+ — when BE returns 404 with code='RICH_SUMMARY_QUALITY_LOW' the
- * hook surfaces `isQualityLow=true` so callers can show a
- * regeneration-pending message and SKIP the auto-enrich trigger that
- * would otherwise re-stamp the same qwen3 row in a loop (until B2
- * Sonnet 4.6 model swap ships).
+ * CP488+ Phase 4 (2026-05-27) — switched from "BE 404 hides non-pass
+ * rows + FE shows pending message" to "BE returns content with
+ * `qualityFlag` field + FE shows a subtle auto-improving badge".
+ * Honors the user's "detection, not blocking" spec
+ * (docs/design/v2-quality-audit-system-2026-05-27.md §2): broken row
+ * content is still shown so users can use whatever is available; the
+ * background regen worker (Phase 3) replaces it with better content
+ * on the next view.
  *
  * Contract: hook MUST NOT trigger generation. Generation is driven by
- * CP425 Trigger 1 (wizard completion) + the server's on-demand enrich
- * hook. This hook is read-only.
+ * the daily audit cron + Phase 3 regen worker + Heart-click on-demand
+ * path. This hook is read-only.
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { apiClient, type VideoRichSummaryResponse, ApiHttpError } from '@/shared/lib/api-client';
+import { apiClient, type VideoRichSummaryResponse } from '@/shared/lib/api-client';
 import { queryKeys } from '@/shared/config/query-client';
 
 const RICH_SUMMARY_STALE_MS = 5 * 60 * 1000;
@@ -25,13 +28,19 @@ export interface UseRichSummaryResult {
   richSummary: VideoRichSummaryResponse | null;
   isLoading: boolean;
   isError: boolean;
-  /** CP488+ — row exists but quality_flag != 'pass'. Callers should hide
-   *  segments / show regeneration-pending message / skip auto-enrich. */
-  isQualityLow: boolean;
+  /**
+   * CP488+ Phase 4 — true when the row exists but `quality_flag !== 'pass'`.
+   * Callers should:
+   *   1. Render the rich-summary content as-is (no hiding)
+   *   2. Display a subtle "auto-improving" indicator
+   *   3. SKIP the auto-enrich trigger (avoids re-stamping the same row
+   *      in a loop while Phase 3 worker is processing it)
+   */
+  isQualityWarning: boolean;
 }
 
 export function useRichSummary(videoId: string | null | undefined): UseRichSummaryResult {
-  const { data, isLoading, isError, error } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: videoId
       ? queryKeys.video.richSummary(videoId)
       : ['video', 'rich-summary', 'disabled'],
@@ -42,15 +51,12 @@ export function useRichSummary(videoId: string | null | undefined): UseRichSumma
     retry: false,
   });
 
-  const isQualityLow =
-    isError && error instanceof ApiHttpError && error.code === 'RICH_SUMMARY_QUALITY_LOW';
+  const isQualityWarning = Boolean(data && data.qualityFlag && data.qualityFlag !== 'pass');
 
   return {
     richSummary: data ?? null,
     isLoading,
-    // Quality-low is an expected state, not an error — keep the consumer's
-    // error UI from triggering when this is the only failure mode.
-    isError: isError && !isQualityLow,
-    isQualityLow,
+    isError,
+    isQualityWarning,
   };
 }

--- a/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
@@ -48,7 +48,7 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
     if (!youtubeId) return;
     void queryClient.invalidateQueries({ queryKey: queryKeys.video.richSummary(youtubeId) });
   }, [youtubeId, queryClient]);
-  const { richSummary, isLoading: isRichLoading, isQualityLow } = useRichSummary(youtubeId);
+  const { richSummary, isLoading: isRichLoading, isQualityWarning } = useRichSummary(youtubeId);
 
   const short = videoSummary?.summary_ko || videoSummary?.summary_en || null;
   const tags = videoSummary?.tags ?? [];
@@ -72,10 +72,11 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
     if (!youtubeId || !mandalaId) return;
     if (isRichLoading) return;
     if (hasSegments) return;
-    // CP488+ — skip auto-enrich when the row is already marked qwen3_low.
-    // Re-enriching with the same qwen3 model just re-stamps the same row;
-    // the upcoming Sonnet 4.6 (B2) ship will handle regeneration globally.
-    if (isQualityLow) return;
+    // CP488+ Phase 4 — skip auto-enrich for warning rows (Phase 3 worker
+    // is processing them in the background; firing Heart-click enrich on
+    // top of that would just queue a duplicate. The user still sees the
+    // current content + auto-improving indicator below).
+    if (isQualityWarning) return;
     const key = `${youtubeId}:${mandalaId}`;
     if (triggerKeyRef.current === key) return;
     triggerKeyRef.current = key;
@@ -90,7 +91,7 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
            and the cron Track A2 retry will eventually land. */
       }
     })();
-  }, [youtubeId, mandalaId, isRichLoading, hasSegments, isQualityLow, openStream]);
+  }, [youtubeId, mandalaId, isRichLoading, hasSegments, isQualityWarning, openStream]);
 
   // When the SSE stream terminates with `scored`, refetch the v2 row so
   // the segments block lands without a manual reload.
@@ -124,14 +125,11 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
   // Empty state: nothing to render. Distinguish "still being generated"
   // (background enrich in flight, or core present but segments missing)
   // from "no AI output at all" (truly empty row).
+  //
+  // CP488+ Phase 4 — quality-warning rows now fall through to the normal
+  // render path (they have content, just at lower quality) + display a
+  // subtle "auto-improving" indicator below. No more hide.
   if (!hasNewV2 && !hasLegacyRich && !hasShort && !isRichLoading) {
-    // CP488+ — qwen3_low row: surface as an in-progress (dot-animated)
-    // message via the existing EnrichInProgressMessage component so the
-    // visual matches the rest of the loading states and the user
-    // understands this is awaiting regeneration, not a missing row.
-    if (isQualityLow) {
-      return <EnrichInProgressMessage label={t('learning.richSummaryQualityLowPendingRegen')} />;
-    }
     if (isEnrichInProgress) {
       return <EnrichInProgressMessage label={t('learning.aiSummaryGenerating')} />;
     }
@@ -144,6 +142,7 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
 
   return (
     <div className="space-y-5">
+      {isQualityWarning && <AIQualityImprovingBadge />}
       {hasNewV2 && richSummary && (
         <RichSummaryV2NewBlock
           core={richSummary.core ?? null}
@@ -709,5 +708,31 @@ function EnrichInProgressMessage({ label }: { label: string }) {
         <span className="animate-[enrich-dot_1.4s_ease-in-out_0.4s_infinite]">.</span>
       </span>
     </p>
+  );
+}
+
+/**
+ * CP488+ Phase 4 — subtle indicator surfaced when the v2 row's
+ * `quality_flag !== 'pass'`. Per the user's "detection, not blocking"
+ * spec (docs/design/v2-quality-audit-system-2026-05-27.md §2 + §7), the
+ * content still renders normally and a small amber badge tells the user
+ * a background regeneration is in flight. No hide, no early return —
+ * users keep using whatever the current row contains; better content
+ * lands on the next view once Phase 3 worker resolves the queue row.
+ */
+function AIQualityImprovingBadge() {
+  const { t } = useTranslation();
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-300"
+      title={t('learning.aiQualityImprovingTooltip')}
+    >
+      <span aria-hidden className="text-amber-400">
+        ●
+      </span>
+      <span>{t('learning.aiQualityImproving')}</span>
+    </div>
   );
 }

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1853,6 +1853,8 @@
     "aiSummaryGenerating": "Generating AI summary",
     "richSummaryGenerating": "Generating detailed summary",
     "richSummaryQualityLowPendingRegen": "Improving the AI analysis for this video",
+    "aiQualityImproving": "AI analysis auto-improving in background",
+    "aiQualityImprovingTooltip": "This video's chapter breakdown is being re-generated with the latest model. The current content is shown as-is; better content will appear on your next view.",
     "metaSummary": "Meta summary",
     "summaryLabel": "Summary",
     "keywordsLabel": "Keywords",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1861,6 +1861,8 @@
     "aiSummaryGenerating": "AI 요약을 생성하고 있습니다",
     "richSummaryGenerating": "상세 요약을 생성하고 있습니다",
     "richSummaryQualityLowPendingRegen": "이 영상의 AI 분석을 개선하고 있습니다",
+    "aiQualityImproving": "AI 분석을 백그라운드에서 개선 중",
+    "aiQualityImprovingTooltip": "이 영상의 챕터/원자 분석을 최신 모델로 재생성 중입니다. 현재 내용은 그대로 표시되며, 다음 시청 시 자동으로 개선된 내용이 나타납니다.",
     "metaSummary": "메타 요약",
     "summaryLabel": "요약",
     "keywordsLabel": "키워드",

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -238,6 +238,13 @@ export interface VideoRichSummaryResponse {
   segments?: VideoRichSummarySegments | null;
   lora?: VideoRichSummaryLora | null;
   qualityScore: number | null;
+  /**
+   * CP488+ Phase 4 — server-side quality_flag of the row ('pass' | 'low'
+   * | 'qwen3_low' | 'pending' | null). Anything other than 'pass'
+   * surfaces a subtle "auto-improving" indicator in the UI; the content
+   * still renders (Phase 4 "detection, not blocking" policy).
+   */
+  qualityFlag: string | null;
   model: string | null;
   updatedAt: string;
 }
@@ -819,13 +826,10 @@ class ApiClient {
       );
       return res.data;
     } catch (err) {
+      // CP488+ Phase 4 — BE now returns 200 with `qualityFlag` for non-pass
+      // rows (detection, not blocking). 404 means the row genuinely does
+      // not exist; null lets callers show an empty state.
       if (err instanceof ApiHttpError && err.statusCode === 404) {
-        // CP488+ — RICH_SUMMARY_QUALITY_LOW (row exists but quality_flag != pass)
-        // propagates so callers can show a pending-regeneration message and
-        // skip the auto-enrich trigger that would re-stamp the same row.
-        if (err.code === 'RICH_SUMMARY_QUALITY_LOW') {
-          throw err;
-        }
         return null;
       }
       throw err;

--- a/src/api/routes/videos.ts
+++ b/src/api/routes/videos.ts
@@ -528,21 +528,22 @@ export const videoRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       const row = await getPrismaClient().video_rich_summaries.findUnique({
         where: { video_id: id },
       });
-      if (!row || row.quality_flag !== 'pass') {
-        // CP488+ — distinguish "no row" from "row exists but quality_flag != pass"
-        // so FE can render a different message (regeneration pending) for the
-        // latter and crucially NOT re-trigger enrich (which would re-stamp the
-        // same qwen3 row in a loop until B2 Sonnet model swap ships).
-        const isLowQuality = Boolean(row && row.quality_flag !== 'pass');
+      if (!row) {
         return reply.code(404).send({
           status: 'error',
-          code: isLowQuality ? 'RICH_SUMMARY_QUALITY_LOW' : 'RICH_SUMMARY_NOT_FOUND',
-          message: isLowQuality
-            ? `Rich summary quality_flag=${row!.quality_flag} — awaiting model upgrade regeneration`
-            : 'No rich summary available for this video',
-          details: isLowQuality ? { qualityFlag: row!.quality_flag } : undefined,
+          code: 'RICH_SUMMARY_NOT_FOUND',
+          message: 'No rich summary available for this video',
         });
       }
+      // CP488+ Phase 4 — "detection, not blocking" per user spec
+      // (docs/design/v2-quality-audit-system-2026-05-27.md §2). Previously
+      // any quality_flag != 'pass' row 404'd, hiding chapters from users
+      // entirely until regeneration finished. With Phase 1.5 producing
+      // good Sonnet 4.6 output + Phase 3 worker draining the regen
+      // queue + Phase 1 daily audit measuring drift, the right policy is
+      // to always serve whatever content exists and let the FE render a
+      // subtle "auto-improving" indicator. Users see the current best
+      // content; better content appears on the next view.
       return reply.code(200).send({
         status: 'ok',
         data: {
@@ -558,6 +559,10 @@ export const videoRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           segments: row.segments ?? null,
           lora: row.lora ?? null,
           qualityScore: row.quality_score,
+          // CP488+ Phase 4 — surface quality_flag so FE can decide
+          // whether to render the auto-improving badge. Values: 'pass'
+          // | 'low' | 'qwen3_low' | 'pending' | null.
+          qualityFlag: row.quality_flag,
           model: row.model,
           updatedAt: row.updated_at.toISOString(),
         },


### PR DESCRIPTION
## Summary
Replaces PR #752's "hide chapter, show pending message" with "render content as-is + display subtle amber badge when \`quality_flag != 'pass'\`". Honors user's explicit *"detection, not blocking"* spec — broken row content is visible, while Phase 3 worker replaces it with better content in the background.

## BE
\`src/api/routes/videos.ts\` GET /:id/rich-summary:
- Drops the \`quality_flag != 'pass' → 404 RICH_SUMMARY_QUALITY_LOW\` branch
- Always returns 200 with content when the row exists
- Adds \`qualityFlag\` field so FE can decide whether to render the badge

## FE
- \`useRichSummary\`: \`isQualityLow\` → \`isQualityWarning\` (from \`data.qualityFlag !== 'pass'\`)
- \`PanelAISummary\`: removes early-return hide; adds \`AIQualityImprovingBadge\` component (amber badge + tooltip); keeps auto-enrich skip for warning rows
- \`api-client.getVideoRichSummary\`: simplified (no more 404+code re-throw)
- i18n: \`learning.aiQualityImproving\` + tooltip (ko + en)

## After deploy
- Phase 1 (audit cron): unchanged
- Phase 3 (regen worker): unchanged — keeps draining the regen queue (508 pending → ~2.6 days)
- 508 currently-pending critical rows: users now see whatever content exists + the badge (instead of full hide). Badge disappears as soon as Phase 3 re-audits the row at score ≥ 85.

## Test plan
- [x] BE \`tsc --noEmit\` clean
- [x] FE \`tsc --noEmit\` clean
- [x] FE vitest 343/343 pass
- [x] FE build clean
- [x] 0 remaining \`RICH_SUMMARY_QUALITY_LOW\` / \`isQualityLow\` refs in codebase
- [ ] CI 6/6 pass
- [ ] Post-merge: open a learning page for a known qwen3_low video — chapter renders + amber badge visible at top

## Rollback
Pure code revert. No schema change, no env flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)