### PR TITLE
fix(internal/upsert-direct): default mandala_relevance_pct=0 when missing (CP488+)

### DIFF
--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -352,9 +352,35 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
     const videoId = typeof body.videoId === 'string' ? body.videoId.trim() : '';
     if (!videoId) return reply.code(400).send({ error: 'videoId required' });
 
+    // CP488+ (2026-05-28) — defensive default for cron-driven backfill
+    // clients (Mac Mini process-one.sh) whose embedded prompt predates
+    // CP462+ (Issue #649) and does not emit `mandala_relevance_pct`.
+    // The validator requires it (integer 0-100); inject 0 when missing
+    // so the bulk Mac Mini path doesn't bottleneck on a single field
+    // the cron context legitimately doesn't know.
+    let analysisForValidation: unknown = body.analysis;
+    if (
+      analysisForValidation &&
+      typeof analysisForValidation === 'object' &&
+      'mandala_fit' in analysisForValidation
+    ) {
+      const a = analysisForValidation as Record<string, unknown>;
+      const mf = a['mandala_fit'];
+      if (mf && typeof mf === 'object' && !('mandala_relevance_pct' in mf)) {
+        analysisForValidation = {
+          ...a,
+          mandala_fit: { ...(mf as Record<string, unknown>), mandala_relevance_pct: 0 },
+        };
+      }
+    }
+
     let summary;
     try {
-      summary = validateV2Layered({ core: body.core, analysis: body.analysis, lora: body.lora });
+      summary = validateV2Layered({
+        core: body.core,
+        analysis: analysisForValidation,
+        lora: body.lora,
+      });
       // Strict key whitelist on segments — catches start_sec/end_sec/ts_sec
       // class typos at the API boundary so the bridge never silently stores
       // 0/null (CP437 incident).


### PR DESCRIPTION
## Summary
Mac Mini batch backfill via process-one.sh has an embedded prompt that predates CP462+ Issue #649 — claude doesn't emit \`analysis.mandala_fit.mandala_relevance_pct\`. Validator requires integer 0-100 → 422. **1차 wet backfill 결과 107/116 videos hit this validation_failed path.**

Fix: defensive default at the route boundary — inject \`mandala_relevance_pct: 0\` into \`analysis.mandala_fit\` when missing, BEFORE \`validateV2Layered\`.

## Why default = 0
\`V2GenerationInput.mandalaCenterGoal\` doc-comment: "cron-driven backfill does not know which user mandala triggered the video" → 0 is documented correct for non-user-context generations.

## Companion fix on Mac Mini side
process-one.sh PROMPT_HEADER patched (local on Mac Mini, not in this repo per public-repo Hard Rule) to emit the field explicitly. This API-side default is the defensive backstop.

## Test plan
- [x] BE \`tsc --noEmit\` clean
- [ ] CI 6/6 pass
- [ ] After deploy: kill Mac Mini PID 30587 (already exited at OAuth cap) + wait for OAuth recovery (~15:00 KST) + re-launch batch with /tmp/insighta-wet2/remaining-vids.txt — expect rc=0 pass count to climb (was 0/116)

🤖 Generated with [Claude Code](https://claude.com/claude-code)