### PR TITLE
feat(mandala): cache center_goal embedding (CP489)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ prisma/migrations/*
 !prisma/migrations/video-pool-depth-level/**
 !prisma/migrations/v2-quality-audit/
 !prisma/migrations/v2-quality-audit/**
+!prisma/migrations/center-goal-cache/
+!prisma/migrations/center-goal-cache/**
 
 # Logs
 logs/

--- a/prisma/migrations/center-goal-cache/001_partial_unique_level0.sql
+++ b/prisma/migrations/center-goal-cache/001_partial_unique_level0.sql
@@ -1,0 +1,18 @@
+-- ============================================================================
+-- CP489 — center_goal embedding cache (level=0) partial unique index
+-- ============================================================================
+-- Purpose: enable race-safe UPSERT (ON CONFLICT) in
+-- src/modules/mandala/center-goal-embedding.ts. Without a unique index,
+-- two concurrent add-cards calls for the same mandala would each insert
+-- a level=0 row → duplicates → next cache lookup ambiguous.
+--
+-- A partial unique index on (mandala_id) WHERE level=0 leaves the existing
+-- level=1 rows (8 per mandala, sub_goal_index 0..7) untouched while
+-- enforcing "at most 1 center_goal embedding per mandala".
+--
+-- Idempotent: CREATE UNIQUE INDEX IF NOT EXISTS.
+-- ============================================================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_mandala_emb_level0
+  ON public.mandala_embeddings (mandala_id)
+  WHERE level = 0;

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -111,6 +111,12 @@ APPLY_FILES=(
   # (V2_QUALITY_AUDIT_ENABLED=false), so empty tables on prod until
   # operator flips the flag.
   "prisma/migrations/v2-quality-audit/001_create_audit_tables.sql"
+  # CP489 (2026-05-28) — center_goal embedding cache (level=0) partial
+  # unique index. Enables ON CONFLICT in
+  # src/modules/mandala/center-goal-embedding.ts so concurrent add-cards
+  # calls race-safely upsert one level=0 row per mandala. CREATE UNIQUE
+  # INDEX IF NOT EXISTS — idempotent.
+  "prisma/migrations/center-goal-cache/001_partial_unique_level0.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "

--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -33,7 +33,7 @@ import { Prisma } from '@prisma/client';
 import { getPrismaClient } from '@/modules/database';
 import { logger } from '@/utils/logger';
 import { getMandalaManager } from '@/modules/mandala/manager';
-import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
+import { getCenterGoalEmbedding } from '@/modules/mandala/center-goal-embedding';
 import {
   matchFromVideoPoolByCenterGoal,
   type CachedMatch,
@@ -233,10 +233,13 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           });
           const language: 'ko' | 'en' = mandalaMeta?.language === 'en' ? 'en' : 'ko';
 
-          // 2. embed center_goal + extraKeywords (1 batch, chunk-fail-safe).
-          const embedTexts = [centerGoal, ...extraKeywords];
-          const embeddings = await embedBatch(embedTexts);
-          const centerEmbedding = embeddings[0];
+          // 2. center_goal embedding via cache (CP489 — was: re-embedded
+          //    every call together with extraKeywords; extraKeywords vectors
+          //    were never read (Layer 4 alphaEmbed deferred per spec §8 v2+).
+          //    Now: cache-backed (mandala_embeddings level=0). First miss
+          //    ~0.3s warm / ~10s cold; hits ~5ms.
+          //    See: src/modules/mandala/center-goal-embedding.ts.
+          const centerEmbedding = await getCenterGoalEmbedding(mandalaId, centerGoal);
           if (!centerEmbedding) {
             return reply.code(503).send({
               status: 'error',

--- a/src/modules/mandala/center-goal-embedding.ts
+++ b/src/modules/mandala/center-goal-embedding.ts
@@ -1,0 +1,122 @@
+/**
+ * CP489 — center_goal embedding cache helper.
+ *
+ * Background: every add-cards call + v3 executor Tier 1/Tier 2
+ * semantic-gate invocation previously re-embedded the same mandala
+ * centerGoal via Mac Mini Ollama (~0.3s warm, ~10s cold). That cold
+ * start dominated CP489 timeout incident (54s embed.batch hang →
+ * 60s panel timeout). Now: first call lazily writes mandala_embeddings
+ * level=0 row; subsequent calls hit the DB cache (~5ms).
+ *
+ * Cache schema: mandala_embeddings(mandala_id, level=0, sub_goal_index=NULL,
+ * text=centerGoal, embedding=4096d). Partial unique index on (mandala_id)
+ * WHERE level=0 enables race-safe ON CONFLICT (one row per mandala).
+ * Existing level=1 rows (8 sub_goals per mandala) untouched.
+ *
+ * Staleness: cached row.text compared against current centerGoal; mismatch
+ * triggers re-embed + UPSERT (mirror ensureMandalaEmbeddings level=1 pattern).
+ *
+ * Failure model: cache write is fire-and-forget — never blocks caller.
+ * Returns null only when both Ollama and OpenRouter fallback fail.
+ *
+ * Cross-ref:
+ *   - prisma/migrations/center-goal-cache/001_partial_unique_level0.sql
+ *   - src/modules/mandala/ensure-mandala-embeddings.ts (sibling, level=1)
+ *   - Call sites: src/api/routes/add-cards.ts, v3/executor.ts (Tier 1 + Tier 2)
+ */
+
+import { Prisma } from '@prisma/client';
+import { getPrismaClient } from '@/modules/database';
+import { logger } from '@/utils/logger';
+import {
+  embedBatch,
+  vectorToLiteral,
+  QWEN3_EMBED_DIMENSION,
+} from '@/skills/plugins/iks-scorer/embedding';
+
+const log = logger.child({ module: 'center-goal-embedding' });
+
+/**
+ * Get the 4096-d center_goal embedding for a mandala. Cache-backed.
+ *
+ * Hit (~5ms): SELECT mandala_embeddings WHERE level=0 AND text matches.
+ * Miss (~0.3s warm, ~10s cold): embedBatch → fire-and-forget UPSERT.
+ *
+ * Returns null when the embed provider chain (Ollama → OpenRouter) fails
+ * or when mandalaId / centerGoal is empty.
+ */
+export async function getCenterGoalEmbedding(
+  mandalaId: string,
+  centerGoal: string
+): Promise<number[] | null> {
+  const trimmed = centerGoal.trim();
+  if (!mandalaId || !trimmed) return null;
+  const db = getPrismaClient();
+
+  // 1. Cache lookup — level=0 row with matching text (staleness check)
+  try {
+    const rows = await db.$queryRaw<{ embedding: string; text: string | null }[]>(
+      Prisma.sql`SELECT embedding::text AS embedding, text
+                   FROM public.mandala_embeddings
+                  WHERE mandala_id = ${mandalaId}
+                    AND level = 0
+                    AND embedding IS NOT NULL
+                  LIMIT 1`
+    );
+    const hit = rows[0];
+    if (hit && hit.text === trimmed) {
+      const vec = parseVectorLiteral(hit.embedding);
+      if (vec.length === QWEN3_EMBED_DIMENSION) return vec;
+    }
+    // Text drift or wrong dim → fall through to re-embed + UPSERT.
+  } catch (err) {
+    log.warn(
+      `center-goal cache lookup failed (non-fatal, will re-embed): ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+
+  // 2. Cache miss → embed via provider chain (Ollama → OpenRouter fallback).
+  const [vec] = await embedBatch([trimmed]);
+  if (!vec || vec.length !== QWEN3_EMBED_DIMENSION) return null;
+
+  // 3. Fire-and-forget UPSERT — race-safe via partial unique index.
+  //    Failure logged but never thrown; embedding returned to caller.
+  const lit = vectorToLiteral(vec);
+  void (async () => {
+    try {
+      await db.$executeRaw(Prisma.sql`
+        INSERT INTO public.mandala_embeddings
+               (mandala_id, level, sub_goal_index, text, embedding, center_goal, created_at)
+        VALUES (${mandalaId}, 0, NULL, ${trimmed},
+                ${lit}::vector(4096), ${trimmed}, NOW())
+        ON CONFLICT (mandala_id) WHERE level = 0
+        DO UPDATE SET
+          text = EXCLUDED.text,
+          embedding = EXCLUDED.embedding,
+          center_goal = EXCLUDED.center_goal
+      `);
+    } catch (err) {
+      log.warn(
+        `center-goal cache write failed (non-fatal): ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  })();
+
+  return vec;
+}
+
+/** Parse pgvector text literal "[v1,v2,...]" → number[]. */
+function parseVectorLiteral(literal: string): number[] {
+  if (!literal || literal.length < 2) return [];
+  const inner = literal.startsWith('[') && literal.endsWith(']') ? literal.slice(1, -1) : literal;
+  const parts = inner.split(',');
+  const out = new Array<number>(parts.length);
+  for (let i = 0; i < parts.length; i++) {
+    out[i] = parseFloat(parts[i] ?? '0');
+  }
+  return out;
+}

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -48,6 +48,7 @@ import { resolveAlgorithm } from '@/modules/search/algorithm-resolver';
 import { filterByQualityGate } from './quality-gate';
 import { applyHybridRerank } from './hybrid-rerank';
 import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
+import { getCenterGoalEmbedding } from '@/modules/mandala/center-goal-embedding';
 import { withTraceContext, recordTrace } from '@/modules/discover-tracing';
 import { resolveLanguage } from '@/utils/detect-language';
 
@@ -424,13 +425,19 @@ async function executeImpl(
       try {
         const cap = v3Config.semanticMaxCandidates;
         const capped = fresh.slice(0, cap);
-        const texts = [state.centerGoal, ...capped.map((m) => m.title)];
-        const vectors = await embedBatch(texts);
-        if (vectors.length === texts.length) {
-          const centerEmbedding = vectors[0] ?? undefined;
+        // CP489 — center_goal embed via cache; candidate title embeddings
+        // remain fresh (per-call YouTube candidates change every run).
+        const titles = capped.map((m) => m.title);
+        const [centerVec, titleVecs] = await Promise.all([
+          getCenterGoalEmbedding(mandalaId, state.centerGoal),
+          embedBatch(titles),
+        ]);
+        const vectorsOk = centerVec != null && titleVecs.length === titles.length;
+        if (vectorsOk) {
+          const centerEmbedding = centerVec;
           const candidateEmbeddings = new Map<string, number[]>();
           for (let i = 0; i < capped.length; i++) {
-            const vec = vectors[i + 1];
+            const vec = titleVecs[i];
             const id = capped[i]?.videoId;
             if (vec && id) candidateEmbeddings.set(id, vec);
           }
@@ -484,7 +491,7 @@ async function executeImpl(
           });
         } else {
           log.warn(
-            `[tier1] mandala-filter embed mismatch: got ${vectors.length}/${texts.length} — admitting unfiltered`
+            `[tier1] mandala-filter embed mismatch: center=${centerVec != null} titles=${titleVecs.length}/${titles.length} — admitting unfiltered`
           );
         }
       } catch (err) {
@@ -551,6 +558,8 @@ async function executeImpl(
       openRouterApiKey: openRouterApiKey || undefined,
       openRouterModel,
       existingVideoIds,
+      // CP489 — enable center_goal cache for mandala-bound runs.
+      mandalaId,
     });
     slots.push(...tier2Fill.slots);
     tier2Count = tier2Fill.slots.length;
@@ -772,6 +781,13 @@ interface Tier2Input {
   openRouterApiKey?: string;
   openRouterModel: string;
   existingVideoIds: ReadonlySet<string>;
+  /**
+   * CP489 — mandalaId for center_goal embedding cache lookup. Pass from
+   * mandala-bound caller (executeImpl). Undefined for ephemeral path
+   * (runDiscoverEphemeralImpl — no mandalaId yet), which then falls back
+   * to fresh embed.
+   */
+  mandalaId?: string;
 }
 
 interface Tier2Debug {
@@ -1095,20 +1111,31 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     const cap = v3Config.semanticMaxCandidates;
     const cappedFilterInputs = filterInputs.slice(0, cap);
     const overflow = Math.max(0, filterInputs.length - cap);
-    const texts: string[] = [input.state.centerGoal, ...cappedFilterInputs.map((f) => f.title)];
+    // CP489 — center_goal via cache when mandalaId known; titles always fresh.
+    // Ephemeral path (input.mandalaId undefined) falls back to embedBatch
+    // for the center as well via plain embedBatch call.
+    const titles = cappedFilterInputs.map((f) => f.title);
     try {
-      const vectors = await embedBatch(texts);
-      if (vectors.length === texts.length) {
-        centerEmbedding = vectors[0] ?? undefined;
+      const [centerVec, titleVecs] = await Promise.all([
+        input.mandalaId
+          ? getCenterGoalEmbedding(input.mandalaId, input.state.centerGoal)
+          : (async () => {
+              const [v] = await embedBatch([input.state.centerGoal]);
+              return v ?? null;
+            })(),
+        embedBatch(titles),
+      ]);
+      if (centerVec != null && titleVecs.length === titles.length) {
+        centerEmbedding = centerVec;
         candidateEmbeddings = new Map<string, number[]>();
         for (let i = 0; i < cappedFilterInputs.length; i++) {
-          const vec = vectors[i + 1];
+          const vec = titleVecs[i];
           const id = cappedFilterInputs[i]?.videoId;
           if (vec && id) candidateEmbeddings.set(id, vec);
         }
       } else {
         log.warn(
-          `semantic gate embed vector mismatch: got ${vectors.length}/${texts.length} — falling back to substring`
+          `semantic gate embed vector mismatch: center=${centerVec != null} titles=${titleVecs.length}/${titles.length} — falling back to substring`
         );
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
Eliminates ~0.3s warm / ~10s cold per-call cost of re-embedding the same mandala `center_goal` across add-cards + v3 Tier 1/Tier 2 semantic-gate paths. The cold start dominated the CP489 timeout incident (embed.batch 54s hang → 60s panel timeout).

## Mechanism
- New cache row: `mandala_embeddings` level=0 (one per mandala, 4096d).
- Partial unique index `(mandala_id) WHERE level=0` → race-safe ON CONFLICT.
- Helper `getCenterGoalEmbedding(mandalaId, centerGoal)`:
  - Cache hit (~5ms): SELECT mandala_embeddings, text-match staleness check
  - Miss: embed via existing Ollama→OpenRouter chain → fire-and-forget UPSERT
- Existing 3,665 level=1 rows untouched. level=0 was globally empty (0 rows) before this PR — lazy backfill.

## Diff
+193/-17, 5 files + 1 migration:
| File | Δ | Note |
|---|---|---|
| `prisma/migrations/center-goal-cache/001_partial_unique_level0.sql` | NEW | CREATE UNIQUE INDEX IF NOT EXISTS (idempotent) |
| `src/modules/mandala/center-goal-embedding.ts` | NEW (~120L) | Helper + parseVectorLiteral |
| `src/api/routes/add-cards.ts` | -1 import, ~5 line swap | Drop unused extraKeywords embed |
| `src/skills/plugins/video-discover/v3/executor.ts` | 3 spots | Tier 1 + Tier 2 + Tier2Input.mandalaId optional |
| `scripts/apply-custom-sql.sh` | +6 | Register migration in APPLY_FILES |
| `.gitignore` | +2 | Allowlist new migration dir |

## Backfill
Lazy. level=0 rows accumulate as users naturally use add-cards / v3 discovery. No backfill script needed; safe-zero-state.

## Expected impact
- add-cards latency (warm cache): ~3-9s saved per call (no more cold embed of centerGoal)
- v3 executor Tier 1 + Tier 2: same savings × every recommendation cycle
- Net cold-start incidents (like CP489 timeout): reduced when centerGoal embed is on the cache path
- Ephemeral path (wizard precompute) unchanged — no mandalaId yet, can't cache

## Verification
- ✅ `tsc --noEmit`: clean
- ✅ `eslint` on changed files: 0 errors (4 pre-existing warnings unrelated)
- ✅ `scripts/audit/hardcode-audit.ts`: baseline unchanged (33 violations, 0 added)

## Test plan (post-merge)
- [ ] First add-cards call on a mandala writes `mandala_embeddings` level=0 row
- [ ] Second call hits cache (trace: `embed.batch` latency for centerGoal disappears, only candidate titles embedded)
- [ ] `mandala_embeddings` level=0 row count grows monotonically with unique mandala users
- [ ] Stale centerGoal (user renames mandala) triggers re-embed + UPSERT, level=0 row updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)