### PR TITLE
fix(embedding): shorten EMBED_TIMEOUT_MS 60s → 20s for faster fallback (CP489)

### DIFF
--- a/src/skills/plugins/iks-scorer/embedding.ts
+++ b/src/skills/plugins/iks-scorer/embedding.ts
@@ -32,7 +32,17 @@ export const QWEN3_EMBED_MODEL = 'qwen3-embedding:8b';
 export const QWEN3_EMBED_DIMENSION = 4096;
 export const MAC_MINI_OLLAMA_DEFAULT_URL = 'http://100.91.173.17:11434';
 const HEALTH_CHECK_TIMEOUT_MS = 3000;
-const EMBED_TIMEOUT_MS = 60000;
+// CP489 — was 60000 (60s). Probe-verified actual call latencies:
+//   warm chunk (≤50 texts): ~0.3-3s
+//   cold start (Mac Mini Ollama reloads qwen3-embedding:8b 4.7GB): ~10s
+//   hang case (idle unload + concurrent load): observed 54.5s (CP489 incident)
+// 60s lets a hang block the entire user-facing pipeline (add-cards 60s
+// FE timeout fires before Ollama AbortController). 20s gives Mac Mini
+// enough headroom for cold start while triggering the OpenRouter
+// fallback (embedOneChunkViaOpenRouterRetrying) within the FE budget.
+// Cumulative worst case under fallback: 20s Ollama + 3× OpenRouter
+// chunks × ~1-3s typical = ~30s, still inside add-cards' 60s envelope.
+const EMBED_TIMEOUT_MS = 20000;
 
 /** OpenRouter cost-logger module label (Issue #543 fallback path). */
 const OPENROUTER_FALLBACK_MODULE = 'iks-embed-fallback';


### PR DESCRIPTION
## Summary
CP489 incident traced a 75-second add-cards request to a single `embed.batch` call hanging for 54.5 seconds on the Mac Mini Ollama path. The FE 60-second panel timeout fired before the AbortController gave up — OpenRouter fallback (`embedOneChunkViaOpenRouterRetrying`) never triggered.

## Change
`src/skills/plugins/iks-scorer/embedding.ts:35` — `EMBED_TIMEOUT_MS` 60000 → 20000. 1-file, ~11 line diff (10 of which are doc-comment justification).

## Probe-verified latency distribution (`video_discover_traces`)
- warm chunk (≤50 texts): **0.3-3 s**
- cold start (model reload qwen3-embedding:8b 4.7 GB): **~10 s**
- hang / concurrent load: observed **54.5 s** (CP489 incident)

20 s gives Mac Mini enough headroom for cold start while triggering OpenRouter fallback within the user-facing 60 s budget.

## Worst case under fallback
20 s Ollama timeout + 3 × OpenRouter chunks × ~1-3 s typical = **~30 s total**, still inside add-cards' 60 s envelope.

## Why not retry?
Add-cards path is interactive (FE 60s timeout). Retry on the same hung host would burn the budget without value. Existing OpenRouter retry (2 attempts, exponential backoff) inside the fallback is sufficient for transient 404/5xx.

## Why not health-check pre-flight?
`isOllamaReachable()` already exists. Adding it to every embedBatch costs a 3 s round-trip on the happy path (current warm latency 0.3 s) — net regression in 95% of calls.

## Verification
- ✅ `tsc --noEmit`: clean
- ✅ `eslint`: no new warnings or errors

## Test plan (post-merge)
- [ ] Verify `embed.batch` traces with `error_message='AbortError'` start appearing (currently 0 because 60s > 60s FE timeout) — proves fallback now triggers
- [ ] Verify add-cards `latency_ms` p99 drops from ~75s to ≤30s
- [ ] No regression on warm path (most calls still 0.3-3s, no change in latency_ms distribution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)