### PR TITLE
fix(upsert-direct): forward segments to validateV2Layered + dryRun gate (CP488+)

### DIFF
--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -25,7 +25,6 @@ import { getPrismaClient } from '@/modules/database/client';
 import { generateRichSummaryV2 } from '@/modules/skills/rich-summary-v2-generator';
 import {
   validateV2Layered,
-  validateV2Segments,
   scoreCompleteness,
   V2ValidationError,
 } from '@/modules/skills/rich-summary-v2-prompt';
@@ -333,6 +332,14 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
       sourceLanguage?: string;
       stampTranscriptFetchedAt?: boolean;
       /**
+       * CP488+ (2026-05-28) — when true, run validation + scoreCompleteness
+       * and return the result WITHOUT touching the DB. Used by Mac Mini
+       * verify-one.sh as a pre-bulk gate (proxy/fetch/chunker/claude/route
+       * all green before kicking off batch-backfill.sh). Side-effect-free:
+       * no pipeline_events, no video_pool promote, no transcript_fetched_at.
+       */
+      dryRun?: boolean;
+      /**
        * CP446+ — atom validation telemetry from process-one.sh's
        * validate-atoms.py. Optional; when present the route stamps a
        * `pipeline_events.stage='atom_validation'` row for downstream
@@ -376,15 +383,19 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
 
     let summary;
     try {
+      // CP488+ root fix — forward `segments` so summary.segments populates
+      // and scoreCompleteness can see sections/atoms. Before this fix the
+      // route omitted segments from the validateV2Layered input, so every
+      // Mac Mini payload 422'd with `segments.sections empty: 0` even when
+      // 2+ sections were present in body. Strict key whitelist (start_sec/
+      // end_sec/ts_sec typos) runs inside validateV2Layered → no separate
+      // validateV2Segments call needed here.
       summary = validateV2Layered({
         core: body.core,
         analysis: analysisForValidation,
         lora: body.lora,
+        segments: body.segments,
       });
-      // Strict key whitelist on segments — catches start_sec/end_sec/ts_sec
-      // class typos at the API boundary so the bridge never silently stores
-      // 0/null (CP437 incident).
-      validateV2Segments(body.segments);
     } catch (err) {
       const path = err instanceof V2ValidationError ? err.path : '';
       const msg = err instanceof Error ? err.message : String(err);
@@ -396,6 +407,20 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
         error: 'completeness_below_threshold',
         score: score.score,
         reasons: score.reasons,
+      });
+    }
+
+    // CP488+ — dryRun pre-bulk gate. After validation + scoreCompleteness pass,
+    // short-circuit before any DB write so verify-one.sh can confirm the full
+    // route contract works without altering production state.
+    if (body.dryRun === true) {
+      return reply.code(200).send({
+        kind: 'dry-run-pass',
+        videoId,
+        completeness: score.score,
+        domain: summary.core.domain,
+        sectionsCount: summary.segments?.sections?.length ?? 0,
+        atomsCount: summary.segments?.atoms?.length ?? 0,
       });
     }
 

--- a/tests/unit/api/transcript-direct-upsert-segments-forward.test.ts
+++ b/tests/unit/api/transcript-direct-upsert-segments-forward.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Regression guard: upsert-direct route MUST forward `segments` to
+ * validateV2Layered (CP488+ 3차 backfill fail root cause).
+ *
+ * Bug history (2026-05-28): the route's validateV2Layered call passed only
+ * {core, analysis, lora} — segments was omitted. validateV2Layered then
+ * populated summary.segments = undefined. scoreCompleteness saw sectionCount
+ * = 0 + atomCount = 0 → segmentsValid = false → 422 completeness_below_
+ * threshold for every Mac Mini payload (50+ videos in the failing batch).
+ *
+ * This test exercises the validator/scorer contract directly. The route's
+ * forwarding of `segments` is also guarded statically by
+ * scripts/health-check-v2-pipeline.sh stage L1 (grep on the source file).
+ */
+
+import {
+  validateV2Layered,
+  scoreCompleteness,
+  V2ValidationError,
+  type RichSummaryV2Layered,
+} from '@/modules/skills/rich-summary-v2-prompt';
+
+function validCoreAnalysisLora(): Omit<RichSummaryV2Layered, 'segments'> {
+  return {
+    core: {
+      one_liner: '시간관리 핵심 3단계',
+      domain: 'learning',
+      depth_level: 'beginner',
+      content_type: 'tutorial',
+      target_audience: '시간관리가 어려운 직장인',
+    },
+    analysis: {
+      core_argument: '효과적인 시간관리는 계획 / 실행 / 회고의 3단계로 구성된다.',
+      key_concepts: [
+        { term: '포모도로', definition: '25분 집중 + 5분 휴식' },
+        { term: '타임블로킹', definition: '시간대별 업무 고정 배치' },
+        { term: '회고', definition: '하루 끝 5분 정리' },
+      ],
+      entities: [
+        { name: '포모도로', type: 'concept' },
+        { name: '타임블로킹', type: 'concept' },
+      ],
+      actionables: ['오늘 저녁 내일 할 일 3가지 적기', '포모도로 앱 설치', '회고 노트 시작하기'],
+      mandala_fit: {
+        suggested_goals: ['생산성 향상', '루틴 만들기'],
+        relevance_rationale: '직접 적용 가능한 시간관리 기법.',
+        mandala_relevance_pct: 75,
+      },
+      bias_signals: { has_ad: false, is_sponsored: false, subjectivity_level: 'low', notes: '' },
+      prerequisites: '',
+    },
+    lora: {
+      qa_pairs: [
+        { level: 1, q: 'Q1', a: 'A1', context: 'video' },
+        { level: 1, q: 'Q2', a: 'A2', context: 'video' },
+        { level: 1, q: 'Q3', a: 'A3', context: 'video' },
+        { level: 1, q: 'Q4', a: 'A4', context: 'video' },
+        { level: 1, q: 'Q5', a: 'A5', context: 'video' },
+      ],
+    },
+  };
+}
+
+const TWO_SECTION_SEGMENTS = {
+  sections: [
+    { idx: 0, from_sec: 0, to_sec: 120, title: 'Intro', summary: 'overview' },
+    { idx: 1, from_sec: 120, to_sec: 240, title: 'Detail', summary: 'core mechanism' },
+  ],
+  atoms: [
+    { idx: 0, type: 'fact', text: 'Atom 1', timestamp_sec: 30 },
+    { idx: 1, type: 'tip', text: 'Atom 2', timestamp_sec: 150 },
+  ],
+};
+
+const ONE_CHUNK_SHORT_VIDEO_SEGMENTS = {
+  sections: [{ idx: 0, from_sec: 0, to_sec: 162, title: 'Whole', summary: 'short video' }],
+  atoms: [{ idx: 0, type: 'fact', text: 'Atom', timestamp_sec: 80 }],
+};
+
+describe('upsert-direct: segments forward to validateV2Layered (CP488+ regression)', () => {
+  test('segments forwarded → summary.segments populated → completeness passes', () => {
+    const base = validCoreAnalysisLora();
+    const summary = validateV2Layered({ ...base, segments: TWO_SECTION_SEGMENTS });
+    expect(summary.segments).toBeDefined();
+    expect(summary.segments?.sections?.length).toBe(2);
+    expect(summary.segments?.atoms?.length).toBe(2);
+
+    const score = scoreCompleteness(summary);
+    expect(score.passed).toBe(true);
+    expect(score.reasons).not.toContain('segments.sections empty: 0 (expected 1+)');
+  });
+
+  test('segments OMITTED (the bug) → completeness fails with "segments.sections empty"', () => {
+    const base = validCoreAnalysisLora();
+    // Bug repro: omit segments from the validateV2Layered call.
+    const summary = validateV2Layered(base);
+    expect(summary.segments).toBeUndefined();
+
+    const score = scoreCompleteness(summary);
+    expect(score.passed).toBe(false);
+    expect(score.reasons).toContain('segments.sections empty: 0 (expected 1+)');
+    expect(score.reasons).toContain('segments.atoms empty: 0 (expected 1+)');
+    // score itself can still be high — the regression is that passed=false
+    // even when core/analysis/lora are perfect.
+    expect(score.score).toBeGreaterThanOrEqual(0.7);
+  });
+
+  test('short video, 1 chunk, real to_sec — passes (no MIN_SECTIONS=3 hard cap)', () => {
+    const base = validCoreAnalysisLora();
+    const summary = validateV2Layered({ ...base, segments: ONE_CHUNK_SHORT_VIDEO_SEGMENTS });
+    expect(summary.segments?.sections?.length).toBe(1);
+
+    const score = scoreCompleteness(summary);
+    expect(score.passed).toBe(true);
+  });
+
+  test('all sections to_sec=0 (description-only fallback) → still fails', () => {
+    const base = validCoreAnalysisLora();
+    const summary = validateV2Layered({
+      ...base,
+      segments: {
+        sections: [{ idx: 0, from_sec: 0, to_sec: 0, title: 'Fallback', summary: 'desc only' }],
+        atoms: [{ idx: 0, type: 'fact', text: 'Atom', timestamp_sec: 0 }],
+      },
+    });
+    const score = scoreCompleteness(summary);
+    expect(score.passed).toBe(false);
+    expect(score.reasons).toContain(
+      'segments.sections all have to_sec=0 (description-only fallback)'
+    );
+  });
+});
+
+describe('upsert-direct: mandala_relevance_pct default-0 inject (CP488+)', () => {
+  test('payload missing mandala_relevance_pct → validator throws (route MUST default-0 first)', () => {
+    const base = validCoreAnalysisLora();
+    // Simulate Mac Mini process-one.sh embedded prompt that predates CP462+:
+    // mandala_fit object lacks the field entirely.
+    const broken = {
+      ...base,
+      analysis: {
+        ...base.analysis,
+        mandala_fit: {
+          suggested_goals: base.analysis.mandala_fit.suggested_goals,
+          relevance_rationale: base.analysis.mandala_fit.relevance_rationale,
+          // mandala_relevance_pct deliberately absent
+        },
+      },
+    };
+    let caught: V2ValidationError | null = null;
+    try {
+      validateV2Layered(broken);
+    } catch (err) {
+      caught = err as V2ValidationError;
+    }
+    expect(caught).toBeInstanceOf(V2ValidationError);
+    expect(caught?.path).toBe('analysis.mandala_fit.mandala_relevance_pct');
+
+    // The route applies the default-0 patch BEFORE calling the validator —
+    // this is the contract that keeps the bulk path unblocked.
+    const patched = {
+      ...broken,
+      analysis: {
+        ...broken.analysis,
+        mandala_fit: { ...broken.analysis.mandala_fit, mandala_relevance_pct: 0 },
+      },
+    };
+    expect(() => validateV2Layered(patched)).not.toThrow();
+  });
+});

--- a/tests/unit/api/transcript-direct-upsert.test.ts
+++ b/tests/unit/api/transcript-direct-upsert.test.ts
@@ -58,6 +58,35 @@ function validPayload(): RichSummaryV2Layered {
         { level: 1, q: 'Q5', a: 'A5', context: 'video' },
       ],
     },
+    // CP488+ — scoreCompleteness now requires segments (CP475+ segments gate
+    // added MIN_SECTIONS=1 + MIN_ATOMS=1 + to_sec>0). Without segments here
+    // the "valid payload passes completeness" assertion below was a no-op for
+    // the gate; include realistic segments so the test exercises the full
+    // contract that the upsert-direct route enforces.
+    segments: {
+      sections: [
+        {
+          idx: 0,
+          from_sec: 0,
+          to_sec: 120,
+          title: '도입',
+          summary: '문제 정의',
+          relevance_pct: 60,
+        },
+        {
+          idx: 1,
+          from_sec: 120,
+          to_sec: 300,
+          title: '핵심',
+          summary: '3단계 설명',
+          relevance_pct: 80,
+        },
+      ],
+      atoms: [
+        { idx: 0, type: 'fact', text: '시간관리는 3단계', timestamp_sec: 60 },
+        { idx: 1, type: 'tip', text: '포모도로 25분', timestamp_sec: 180 },
+      ],
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

- **Root cause fix**: `upsert-direct` route 가 `body.segments` 를 `validateV2Layered({core, analysis, lora})` 에 forward 안 해서 모든 Mac Mini payload 가 422 `completeness_below_threshold` (segments empty). CP488+ 3차 backfill 50+ video 0 pass 의 진짜 원인.
- **dryRun mode**: `body.dryRun === true` → DB write 없이 validation + scoreCompleteness 만 돌고 200 `kind: 'dry-run-pass'` 반환. Mac Mini `verify-one.sh` pre-bulk gate 가 사용.
- **Regression test 5종**: 본 버그 reproduction + segments forward 동작 + short-video 1-chunk pass + description-only fallback fail + mandala_relevance_pct default-0 path.

## Fact trace (3차 fail log)

```
{"error":"completeness_below_threshold","score":1,
 "reasons":["segments.sections empty: 0 (expected 1+)",
            "segments.atoms empty: 0 (expected 1+)",
            "segments.sections all have to_sec=0 ..."]}
```

- score = 1.0 (core/analysis/lora 만점)
- Mac Mini sections-enforced log: \`output_count: 2, mismatch: false\` (2 section 보냄)
- prod evaluator: \`sections empty: 0\` ← payload 의 segments 가 evaluation 경로에서 drop

→ payload 는 perfect, receiver 가 일부 필드 누락. 1줄 fix 로 50+ video 백필 unblock.

## Why this slipped

- `body.segments` 는 별도로 `validateV2Segments(body.segments)` (whitelist) 만 호출되어서 type-check 통과.
- `validateV2Layered` 가 segments 를 받으면 `summary.segments` 에 세팅 → scoreCompleteness 가 본다. 안 받으면 undefined → scoreCompleteness 가 sectionCount=0 으로 본다.
- CP475+ (2026-05-20) 에 segments gate (MIN_SECTIONS=1 + sectionHasRealRange) 가 추가됐는데 이 route 의 호출부는 안 따라옴.

## Test plan
- [x] tsc --noEmit clean
- [x] jest `transcript-direct-upsert*.test.ts` 10/10 PASS (5 new + 5 fixed pre-existing)
- [x] health-check L1 PASS (route source grep)
- [ ] CI pipeline green
- [ ] Deploy to prod
- [ ] `bash scripts/health-check-v2-pipeline.sh prod` P1+P2 PASS
- [ ] Mac Mini `verify-one.sh <random_vid>` S1-S5 PASS (dryRun mode 검증)
- [ ] Sample 5 wet → 95%+ pass
- [ ] 448 wet 본격 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)