### PR TITLE
perf(batch-video-collector): 2×/day cron + limit 60→200 + TTL 30→60 (CP489)

### DIFF
--- a/.github/workflows/batch-video-collector.yml
+++ b/.github/workflows/batch-video-collector.yml
@@ -22,7 +22,14 @@ name: batch-video-collector
 
 on:
   schedule:
+    # CP489 — 1×/day → 2×/day to double pool-growth rate toward the
+    # 30k-active target. 07:30 UTC (= 16:30 KST) right after the YouTube
+    # quota reset (00:00 PT), 19:30 UTC (= 04:30 KST) 12h later. Quota
+    # impact 6k/day → 12k/day at default limit=60, still safely under
+    # the 80k/day headroom (8 keys × 10k). With CP489 manifest bump to
+    # limit=200 the total becomes 40k/day — same headroom.
     - cron: '30 7 * * *'
+    - cron: '30 19 * * *'
   workflow_dispatch:
     inputs:
       limit:

--- a/src/skills/plugins/batch-video-collector/manifest.ts
+++ b/src/skills/plugins/batch-video-collector/manifest.ts
@@ -16,24 +16,36 @@ import type { SkillManifest } from '@/skills/_shared/types';
 import { defineManifest } from '@/skills/_shared/runtime';
 
 /**
- * Full trend keyword pool target (9 domains × ~20). Source of truth for
- * the *total* surface area we want covered across a rotation cycle.
+ * Full trend keyword pool target. CP489 expansion: 180 → 600 (200 keywords
+ * × 3-day rotation). Probe-verified video_pool baseline 2026-05-28:
+ *   - active rows: 14,551
+ *   - last 14d avg videos_new/day: 464
+ *   - quota/day used: 6,035 of 80,000 available (8 API keys × 10k)
+ * 200/day × 100 units = 20k quota/day still safely under the headroom,
+ * even when paired with the 2×/day cron schedule (40k total).
  */
-export const BATCH_COLLECTOR_KEYWORD_POOL_SIZE = 180;
+export const BATCH_COLLECTOR_KEYWORD_POOL_SIZE = 600;
 /**
- * Keywords processed per daily run. 180/3 = 60 keeps each day's quota
- * under 6k units (60 × 100 search.list) + ~200 for videos.list, fitting
- * comfortably in the 10k/day limit while still refreshing the full pool
- * every 3 days.
+ * Keywords processed per daily run. CP489: 60 → 200. With the 2×/day
+ * cron schedule (07:30 + 19:30 UTC) net raw new ≈ 1,856/day vs prior
+ * 464/day. Combined with the TTL bump below the steady-state pool size
+ * targets ≥ 30,000 active rows within ~30 days.
  */
-export const BATCH_COLLECTOR_DAILY_KEYWORD_LIMIT = 60;
-/** Cycle length (days) — 60 × 3 covers the 180-keyword pool. */
+export const BATCH_COLLECTOR_DAILY_KEYWORD_LIMIT = 200;
+/** Cycle length (days) — 200 × 3 covers the 600-keyword pool. */
 export const BATCH_COLLECTOR_ROTATION_DAYS = 3;
 /** Kept for backwards compat with existing tests / callers. */
 export const BATCH_COLLECTOR_KEYWORD_LIMIT = BATCH_COLLECTOR_DAILY_KEYWORD_LIMIT;
 export const BATCH_COLLECTOR_SEARCH_MAX_RESULTS = 30;
 export const BATCH_COLLECTOR_SEARCH_PARALLELISM = 5;
-export const BATCH_COLLECTOR_TTL_DAYS = 30;
+/**
+ * CP489: 30 → 60. Doubles steady-state pool size at the same raw-new
+ * rate. video_pool already partitions by language + quality_tier + source,
+ * so older rows continue to provide useful coverage long after the
+ * trend-cron horizon. Soft-delete via is_active=false still happens
+ * on expires_at, so the change does not affect retrieval correctness.
+ */
+export const BATCH_COLLECTOR_TTL_DAYS = 60;
 
 // Quality tier thresholds (view_count)
 export const QUALITY_GOLD_VIEW_COUNT = 100_000;


### PR DESCRIPTION
## Summary
Triple lever to push \`video_pool\` from current **14,551 active** rows to the CP489 target of **≥ 30,000 active** within ~30 days, all within existing API quota headroom.

## Probe-verified baseline (2026-05-28)
- video_pool active rows: **14,551**
- last 14d avg videos_new/day: **464**
- quota/day used: **6,035 of 80,000** (8 API keys × 10k)

## Changes
1. **Cron 1×/day → 2×/day** (`07:30 + 19:30 UTC`)
   - .github/workflows/batch-video-collector.yml
   - Doubles raw collection at the same per-run keyword limit
2. **Daily keyword limit 60 → 200** (`BATCH_COLLECTOR_DAILY_KEYWORD_LIMIT`)
   - src/skills/plugins/batch-video-collector/manifest.ts
   - Per-run candidate pool ~3× larger
3. **Pool TTL 30d → 60d** (`BATCH_COLLECTOR_TTL_DAYS`)
   - Same file
   - Doubles steady-state at the same net-new rate

## Quota safety (factual)
| state | keyword/day | quota/day | 80k cap? |
|---|---|---|---|
| pre-PR | 60 (1×) | 6k | 8% used |
| post-PR | 200 × 2 = 400 | 40k | 50% used |

Still leaves 40k/day headroom for interactive add-cards traffic + admin retries.

## Projected steady state
At baseline 464 net-new/day, multiply by 2× (cron) × ~3.3× (limit) = ~3k/day net at silver+ tier. With TTL 60d retention, steady-state pool size lands at **~50-60k active rows** — exceeds the 30k target with margin.

## Verification
- ✅ \`tsc --noEmit\`: clean
- ✅ \`eslint\`: no new warnings

## Out of scope (separate backlog issues)
- Admin \`/video-pool/stats\` dashboard for ramp measurement
- E-4: pool quality filter at ingest
- E-5: user_mandalas → trend_signals auto-inject
- Eviction policy for quarterly cleanup of unused videos
- Mandala-aware evaluation metrics (coverage / diversity / freshness)

## Test plan (post-merge)
- [ ] Verify GHA \`batch-video-collector.yml\` schedule shows both cron entries
- [ ] After first 07:30 run, query \`video_pool_collection_runs\` for the latest \`videos_new\` and confirm it's ≥ 3× baseline (≥ 1,400)
- [ ] After 7 days, compare \`SELECT count(*) FROM video_pool WHERE is_active=true\` against the projected ramp curve
- [ ] Track quota_used per run to ensure no key exhausts

🤖 Generated with [Claude Code](https://claude.com/claude-code)