### PR TITLE
fix(add-cards): wire chip keywords + level chip into Tier 2 focusTags (CP489)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -53,8 +53,45 @@ const YOUTUBE_VIDEO_ID_RE = /^[A-Za-z0-9_-]{11}$/;
 const MAX_EXTRA_KEYWORDS = 10;
 const MAX_EXCLUDE_IDS = 500;
 const MAX_KEYWORD_LEN = 200;
+/**
+ * CP489 — focusTags cap forwarded into runDiscoverEphemeral. Mandala
+ * default `focus_tags` already capped at the helper site; this constant
+ * covers the combined (extraKeywords + mandala defaults) merged list so
+ * the downstream keyword-builder stays predictable.
+ */
+const MAX_FOCUS_TAGS = 10;
 
 const log = logger.child({ module: 'add-cards-routes' });
+
+/**
+ * CP489 — merge user-provided chip keywords with mandala default
+ * focus_tags for forwarding into the Tier 2 ephemeral discover path.
+ *
+ * Order: extraKeywords first (user intent wins), then mandala defaults.
+ * Dedupe by lowercase string. Cap at MAX_FOCUS_TAGS (10).
+ *
+ * Exported so unit tests can verify dedupe / cap / order without
+ * spinning the Fastify handler.
+ */
+export function buildEphemeralFocusTags(
+  mandalaFocusTags: string[] | null | undefined,
+  extraKeywords: string[],
+  cap = MAX_FOCUS_TAGS
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of [...extraKeywords, ...(mandalaFocusTags ?? [])]) {
+    if (typeof raw !== 'string') continue;
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+    if (out.length >= cap) break;
+  }
+  return out;
+}
 
 type DurationBucket = 'short' | 'medium' | 'long' | 'xlong';
 
@@ -275,7 +312,14 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               centerGoal,
               subGoals,
               language,
-              focusTags: (mandalaMeta?.focus_tags ?? []).slice(0, 10),
+              // CP489 — chip keywords + mandala defaults merged. Prior to
+              // this PR `extraKeywords` was parsed + traced but never
+              // forwarded into the Tier 2 keyword-builder / semantic gate
+              // — symptom: FE chip / level chip changes had zero effect
+              // on returned cards. The FE already packs the chosen
+              // `targetLevel` string into `extraKeywords` (see
+              // AddCardsPanel.tsx:267), so this single merge handles both.
+              focusTags: buildEphemeralFocusTags(mandalaMeta?.focus_tags, extraKeywords),
               targetLevel: mandalaMeta?.target_level ?? 'standard',
               env: process.env,
             }).catch((err) => {

--- a/tests/unit/api/add-cards-focus-tags.test.ts
+++ b/tests/unit/api/add-cards-focus-tags.test.ts
@@ -1,0 +1,63 @@
+/**
+ * CP489 — Unit tests for buildEphemeralFocusTags.
+ *
+ * Why: the wiring this helper fixes was silent (FE chip keyword
+ * `extraKeywords` was parsed + traced but never forwarded into the
+ * Tier 2 keyword-builder). This test pins the merge contract so a
+ * future refactor cannot revert to the silent behavior.
+ */
+
+import { buildEphemeralFocusTags } from '../../../src/api/routes/add-cards';
+
+describe('buildEphemeralFocusTags (CP489 chip→focusTags wiring)', () => {
+  it('returns empty array when both inputs are empty', () => {
+    expect(buildEphemeralFocusTags([], [])).toEqual([]);
+    expect(buildEphemeralFocusTags(null, [])).toEqual([]);
+    expect(buildEphemeralFocusTags(undefined, [])).toEqual([]);
+  });
+
+  it('returns only mandala defaults when extraKeywords is empty', () => {
+    expect(buildEphemeralFocusTags(['뇌과학', '학습법'], [])).toEqual(['뇌과학', '학습법']);
+  });
+
+  it('returns only extraKeywords when mandala defaults are empty', () => {
+    expect(buildEphemeralFocusTags(null, ['오태민', '심화'])).toEqual(['오태민', '심화']);
+  });
+
+  it('puts extraKeywords first (user intent wins over mandala defaults)', () => {
+    const out = buildEphemeralFocusTags(['뇌과학'], ['오태민']);
+    expect(out).toEqual(['오태민', '뇌과학']);
+  });
+
+  it('dedupes case-insensitively across both lists', () => {
+    const out = buildEphemeralFocusTags(['Brain'], ['brain', 'BRAIN']);
+    expect(out).toEqual(['brain']);
+  });
+
+  it('drops empty / whitespace-only / non-string entries', () => {
+    const out = buildEphemeralFocusTags(
+      ['', '   ', null as unknown as string, '뇌과학'],
+      [undefined as unknown as string, '   ', '오태민']
+    );
+    expect(out).toEqual(['오태민', '뇌과학']);
+  });
+
+  it('caps the merged list at the default cap (10)', () => {
+    const mandala = Array.from({ length: 8 }, (_, i) => `m${i}`);
+    const extras = Array.from({ length: 8 }, (_, i) => `e${i}`);
+    const out = buildEphemeralFocusTags(mandala, extras);
+    expect(out).toHaveLength(10);
+    // extras win on the first 8 slots, then the first 2 mandala defaults
+    expect(out).toEqual(['e0', 'e1', 'e2', 'e3', 'e4', 'e5', 'e6', 'e7', 'm0', 'm1']);
+  });
+
+  it('honors a custom cap parameter', () => {
+    const out = buildEphemeralFocusTags(['m0', 'm1', 'm2'], ['e0', 'e1', 'e2'], 3);
+    expect(out).toEqual(['e0', 'e1', 'e2']);
+  });
+
+  it('trims surrounding whitespace before dedupe', () => {
+    const out = buildEphemeralFocusTags(['  뇌과학  '], ['뇌과학']);
+    expect(out).toEqual(['뇌과학']);
+  });
+});


### PR DESCRIPTION
## Summary
FE \`AddCardsPanel\` packs user chip keywords AND the chosen target-level string into \`request.body.extraKeywords\` (per [AddCardsPanel.tsx:267](https://github.com/JK42JJ/insighta/blob/main/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx#L267)). The BE handler parsed + traced the array but then dropped it on the floor — \`runDiscoverEphemeral\` received \`mandalaMeta?.focus_tags\` only. **Symptom: chip / level chip changes had zero effect on returned cards** (user-reported "options don't change results — is the BE a fake?").

## Fix
- New helper \`buildEphemeralFocusTags(mandalaTags, extraKeywords)\` in \`add-cards.ts\`:
  - extraKeywords first (user intent wins), then mandala defaults
  - case-insensitive dedupe
  - cap 10 (\`MAX_FOCUS_TAGS\`)
- Exported so unit tests verify the contract without spinning the Fastify handler.
- \`runDiscoverEphemeral\` call now passes the merged result instead of \`mandalaMeta?.focus_tags ?? []\`.

## Diff
\`+108 / -1\`, 2 files. Logic-only diff ~12 lines + helper + tests.

## Tests
\`tests/unit/api/add-cards-focus-tags.test.ts\` — 9 cases:
- empty + null + undefined inputs
- mandala-only / extras-only
- extras-win ordering
- case-insensitive dedupe
- whitespace / non-string filtering
- default cap (10) + custom cap
- trim-before-dedupe

\`\`\`
PASS tests/unit/api/add-cards-focus-tags.test.ts
Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
\`\`\`

## Verification
- ✅ \`tsc --noEmit\`: clean
- ✅ \`eslint\`: 0 errors (1 pre-existing warning on unrelated line)
- ✅ \`jest tests/unit/api/add-cards-focus-tags\`: 9/9 PASS
- ✅ \`scripts/audit/hardcode-audit.ts\`: baseline unchanged (33)

## Out of scope (separate backlog)
- **Result accumulation across rounds** (cards-exhaustion UX) — user-flagged P0, requires FE state + BE response schema change
- **Round-separator UI** (YouTube "최신순/관련성" pattern, newest-first) — user-flagged P1
- **Filter-strict-zero handling** — post-filter drops Tier 1+Tier 2 to 0 ⇒ FE empty state

## Test plan (post-merge)
- [ ] Coin mandala "카드 더 찾기" → chip "오태민" 추가 → 검색 → trace 의 \`mandala_filter.semantic_gate.ephemeral\` step request 에 focusTags 가 \`["오태민", ...]\` 시작하는지 SQL 확인
- [ ] 같은 mandala → 난이도 chip "심화" 선택 → trace 의 focusTags 에 "심화" 포함 확인
- [ ] 결과 카드가 chip 미적용 baseline 과 다른지 visual 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)