### PR TITLE
feat(video-discover): Phase 1 — ingest Tier 2 raw candidates into video_pool (CP489+)

### DIFF
--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -49,6 +49,7 @@ import { filterByQualityGate } from './quality-gate';
 import { applyHybridRerank } from './hybrid-rerank';
 import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
 import { getCenterGoalEmbedding } from '@/modules/mandala/center-goal-embedding';
+import { ingestEnrichedToPool } from './pool-ingest';
 import { withTraceContext, recordTrace } from '@/modules/discover-tracing';
 import { resolveLanguage } from '@/utils/detect-language';
 
@@ -1041,6 +1042,49 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   }
   debug.timing.filterMs = Date.now() - tFilterStart;
   debug.afterFilter = enriched.length;
+
+  // CP489 Phase 1 — fire-and-forget ingest Tier 2 raw (post-shorts/lang
+  // filter, pre-mandala-filter) into video_pool so the same videos hit
+  // the Tier 1 cache on subsequent searches. Measured baseline (CP489):
+  // GLOBAL Tier 2 → video_pool hit rate 3.6% / niche-mandala 1.5%.
+  // Persisting survivors here breaks the cold-fetch loop without
+  // affecting the in-flight discovery latency.
+  //
+  // Source tag distinguishes wizard precompute (`wizard_realtime`) from
+  // add-cards path (`add_cards_realtime`) — detected via the same
+  // `mandalaId` signal Tier2Input already carries for the center-goal
+  // cache (undefined ⇒ ephemeral wizard precompute).
+  void (async () => {
+    try {
+      const ingestSource: 'wizard_realtime' | 'add_cards_realtime' = input.mandalaId
+        ? 'add_cards_realtime'
+        : 'wizard_realtime';
+      const result = await ingestEnrichedToPool({
+        prisma: getPrismaClient(),
+        candidates: enriched.map((e) => ({
+          videoId: e.videoId,
+          title: e.title,
+          description: e.description ?? null,
+          channelTitle: e.channelTitle ?? null,
+          channelId: e.channelId ?? null,
+          thumbnail: e.thumbnail ?? null,
+          viewCount: e.viewCount,
+          likeCount: e.likeCount,
+          durationSec: e.durationSec,
+          publishedDate: e.publishedDate,
+        })),
+        language: input.state.language,
+        source: ingestSource,
+      });
+      log.info(
+        `pool-ingest: source=${ingestSource} attempted=${result.attempted} inserted=${result.inserted} errors=${result.errors}`
+      );
+    } catch (err) {
+      log.warn(
+        `pool-ingest threw (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  })();
 
   // Tier 2 quality gate — pure filter, flag-controlled. See quality-gate.ts.
   if (v3Config.enableQualityGate) {

--- a/src/skills/plugins/video-discover/v3/pool-ingest.ts
+++ b/src/skills/plugins/video-discover/v3/pool-ingest.ts
@@ -1,0 +1,121 @@
+/**
+ * CP489 Phase 1 — Tier 2 raw candidate → video_pool ingest helper.
+ *
+ * Background: every v3 discovery run (wizard precompute + add-cards) fetches
+ * ~30 candidates per cell from YouTube `search.list`, enriches with
+ * `videos.list` (viewCount / duration), filters shorts / blocklist / lang,
+ * then passes the survivors into mandala-filter. CP489 measurement showed
+ * the survivors are mostly NEW relative to `video_pool` (GLOBAL hit 3.6%,
+ * niche-mandala 1.5%) — most Tier 2 calls embed cold and waste the work.
+ *
+ * This helper persists the enriched-but-not-yet-mandala-filtered list into
+ * `video_pool` so the same videos hit cache on subsequent searches. Same
+ * fire-and-forget UPSERT pattern as the user_curated path in cards.ts:480,
+ * with a distinct `source` tag for diagnostic separation.
+ *
+ * Failure mode: every error logged + swallowed. Pool ingest must NEVER
+ * affect user-facing latency or correctness — the helper is best-effort
+ * background work.
+ */
+
+import type { PrismaClient } from '@prisma/client';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'video-discover/v3/pool-ingest' });
+
+/**
+ * Minimum shape of an enriched Tier 2 candidate needed for video_pool
+ * UPSERT. Mirrors the `Enriched` type local to executor.ts.
+ */
+export interface IngestCandidate {
+  videoId: string;
+  title: string;
+  description?: string | null;
+  channelTitle?: string | null;
+  channelId?: string | null;
+  thumbnail?: string | null;
+  viewCount: number | null;
+  likeCount: number | null;
+  durationSec: number | null;
+  publishedDate: Date | null;
+}
+
+export interface IngestPoolOpts {
+  prisma: PrismaClient;
+  candidates: ReadonlyArray<IngestCandidate>;
+  language: 'ko' | 'en';
+  source: 'wizard_realtime' | 'add_cards_realtime';
+}
+
+export interface IngestPoolResult {
+  attempted: number;
+  inserted: number;
+  errors: number;
+}
+
+/**
+ * Quality tier classification — mirrors batch-video-collector/manifest.ts
+ * thresholds so a video's tier stays consistent across ingest paths.
+ */
+function classifyQualityTier(viewCount: number | null): 'gold' | 'silver' | 'bronze' {
+  const v = viewCount ?? 0;
+  if (v >= 100_000) return 'gold';
+  if (v >= 10_000) return 'silver';
+  return 'bronze';
+}
+
+/**
+ * Upsert each enriched candidate into video_pool. Idempotent via PK; if a
+ * row already exists with a more authoritative source ('v2_promoted',
+ * 'batch_trend', etc.) the `source` column is preserved by the UPDATE
+ * branch (only `refreshed_at` is bumped). Same conservative semantics as
+ * the user_curated path.
+ *
+ * Returns counts but never throws. Per-row failure is logged at warn level.
+ */
+export async function ingestEnrichedToPool(opts: IngestPoolOpts): Promise<IngestPoolResult> {
+  const { prisma, candidates, language, source } = opts;
+  const result: IngestPoolResult = { attempted: 0, inserted: 0, errors: 0 };
+
+  if (candidates.length === 0) return result;
+
+  for (const c of candidates) {
+    if (!c.videoId || !c.title) continue;
+    result.attempted += 1;
+    const qualityTier = classifyQualityTier(c.viewCount);
+    try {
+      await prisma.video_pool.upsert({
+        where: { video_id: c.videoId },
+        create: {
+          video_id: c.videoId,
+          title: c.title,
+          description: c.description ?? null,
+          channel_name: c.channelTitle ?? null,
+          channel_id: c.channelId ?? null,
+          view_count: c.viewCount != null ? BigInt(c.viewCount) : 0n,
+          like_count: c.likeCount != null ? BigInt(c.likeCount) : 0n,
+          duration_seconds: c.durationSec,
+          published_at: c.publishedDate,
+          thumbnail_url: c.thumbnail ?? null,
+          language,
+          quality_tier: qualityTier,
+          source,
+          is_active: true,
+        },
+        update: {
+          refreshed_at: new Date(),
+        },
+      });
+      result.inserted += 1;
+    } catch (err) {
+      result.errors += 1;
+      log.warn(
+        `pool-ingest upsert failed (non-fatal): videoId=${c.videoId} source=${source} err=${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
+  return result;
+}

--- a/tests/unit/skills/video-discover/pool-ingest.test.ts
+++ b/tests/unit/skills/video-discover/pool-ingest.test.ts
@@ -1,0 +1,182 @@
+/**
+ * CP489 Phase 1 — Unit tests for ingestEnrichedToPool.
+ *
+ * Pin the upsert contract so future refactors cannot accidentally:
+ *   - skip the quality_tier classification
+ *   - mutate the conservative `source` preservation policy
+ *   - swallow per-row failures (every error must increment .errors and
+ *     resolve, not throw out of the helper)
+ */
+
+import {
+  ingestEnrichedToPool,
+  type IngestCandidate,
+} from '../../../../src/skills/plugins/video-discover/v3/pool-ingest';
+
+type UpsertCall = {
+  where: { video_id: string };
+  create: {
+    video_id: string;
+    title: string;
+    view_count: bigint;
+    quality_tier: string;
+    source: string;
+    language: string;
+    is_active: boolean;
+  };
+  update: { refreshed_at: Date };
+};
+
+interface FakePrisma {
+  video_pool: {
+    upsert: jest.Mock;
+  };
+}
+
+function fakePrisma(opts?: { throwForVideoId?: string }): {
+  prisma: FakePrisma;
+  calls: UpsertCall[];
+} {
+  const calls: UpsertCall[] = [];
+  return {
+    calls,
+    prisma: {
+      video_pool: {
+        upsert: jest.fn(async (args: UpsertCall) => {
+          if (opts?.throwForVideoId && args.where.video_id === opts.throwForVideoId) {
+            throw new Error('simulated DB write failure');
+          }
+          calls.push(args);
+          return { video_id: args.where.video_id };
+        }),
+      },
+    },
+  };
+}
+
+function sample(videoId: string, overrides: Partial<IngestCandidate> = {}): IngestCandidate {
+  return {
+    videoId,
+    title: `title-${videoId}`,
+    description: null,
+    channelTitle: null,
+    channelId: null,
+    thumbnail: null,
+    viewCount: 50_000,
+    likeCount: 200,
+    durationSec: 600,
+    publishedDate: new Date('2026-05-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('ingestEnrichedToPool (CP489 Phase 1)', () => {
+  it('returns zero counts on empty input', async () => {
+    const { prisma } = fakePrisma();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const r = await ingestEnrichedToPool({
+      prisma: prisma as any,
+      candidates: [],
+      language: 'ko',
+      source: 'wizard_realtime',
+    });
+    expect(r).toEqual({ attempted: 0, inserted: 0, errors: 0 });
+  });
+
+  it('upserts each candidate and classifies quality_tier correctly', async () => {
+    const { prisma, calls } = fakePrisma();
+    const r = await ingestEnrichedToPool({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma: prisma as any,
+      candidates: [
+        sample('vid-gold', { viewCount: 200_000 }),
+        sample('vid-silver', { viewCount: 50_000 }),
+        sample('vid-bronze', { viewCount: 500 }),
+        sample('vid-null', { viewCount: null }),
+      ],
+      language: 'ko',
+      source: 'wizard_realtime',
+    });
+    expect(r).toEqual({ attempted: 4, inserted: 4, errors: 0 });
+    expect(calls.map((c) => c.create.quality_tier)).toEqual(['gold', 'silver', 'bronze', 'bronze']);
+  });
+
+  it('skips entries with empty videoId or empty title (defensive)', async () => {
+    const { prisma } = fakePrisma();
+    const r = await ingestEnrichedToPool({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma: prisma as any,
+      candidates: [sample(''), sample('vid-1', { title: '' }), sample('vid-2')],
+      language: 'ko',
+      source: 'wizard_realtime',
+    });
+    expect(r.attempted).toBe(1);
+    expect(r.inserted).toBe(1);
+  });
+
+  it('forwards source tag distinguishing wizard vs add-cards', async () => {
+    const { prisma, calls } = fakePrisma();
+    await ingestEnrichedToPool({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma: prisma as any,
+      candidates: [sample('vid-w')],
+      language: 'ko',
+      source: 'wizard_realtime',
+    });
+    await ingestEnrichedToPool({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma: prisma as any,
+      candidates: [sample('vid-a')],
+      language: 'en',
+      source: 'add_cards_realtime',
+    });
+    expect(calls.map((c) => c.create.source)).toEqual(['wizard_realtime', 'add_cards_realtime']);
+    expect(calls.map((c) => c.create.language)).toEqual(['ko', 'en']);
+  });
+
+  it('UPDATE branch is conservative — refreshed_at only (source preserved)', async () => {
+    const { prisma, calls } = fakePrisma();
+    await ingestEnrichedToPool({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma: prisma as any,
+      candidates: [sample('vid-1')],
+      language: 'ko',
+      source: 'add_cards_realtime',
+    });
+    const update = calls[0]!.update;
+    expect(Object.keys(update)).toEqual(['refreshed_at']);
+    expect(update.refreshed_at).toBeInstanceOf(Date);
+  });
+
+  it('records errors and continues on per-row failure (does not throw)', async () => {
+    const { prisma } = fakePrisma({ throwForVideoId: 'vid-bad' });
+    const r = await ingestEnrichedToPool({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma: prisma as any,
+      candidates: [sample('vid-ok-1'), sample('vid-bad'), sample('vid-ok-2')],
+      language: 'ko',
+      source: 'wizard_realtime',
+    });
+    expect(r).toEqual({ attempted: 3, inserted: 2, errors: 1 });
+  });
+
+  it('handles null viewCount / likeCount / durationSec / publishedDate without throwing', async () => {
+    const { prisma, calls } = fakePrisma();
+    const r = await ingestEnrichedToPool({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma: prisma as any,
+      candidates: [
+        sample('vid-nulls', {
+          viewCount: null,
+          likeCount: null,
+          durationSec: null,
+          publishedDate: null,
+        }),
+      ],
+      language: 'ko',
+      source: 'wizard_realtime',
+    });
+    expect(r.inserted).toBe(1);
+    expect(calls[0]!.create.view_count).toBe(0n);
+  });
+});


### PR DESCRIPTION
## Summary
CP489+ structural redesign **Phase 1 of 6**. Persists every wizard / add-cards Tier 2 raw fetch into \`video_pool\` so the same videos hit cache on subsequent searches. Breaks the cold-fetch loop that CP489 measurement quantified at **3.6% global / 1.5% niche-mandala** Tier 2 hit rate.

## Mechanism
After Tier 2 \`search.list\` + \`videos.list\` enrichment + shorts/blocklist/language filter, the surviving (but not yet mandala-filtered) candidates are upserted into \`video_pool\` via fire-and-forget. Same pattern as the existing user_curated path in \`cards.ts:480\`. The discovery hot path is unaffected — ingest runs in a detached promise.

## Files
| file | change |
|---|---|
| \`src/skills/plugins/video-discover/v3/pool-ingest.ts\` | NEW (120 lines) — \`ingestEnrichedToPool({prisma, candidates, language, source})\` + quality_tier classification + conservative UPDATE branch |
| \`src/skills/plugins/video-discover/v3/executor.ts\` | +47 lines — fire-and-forget call after \`enriched\` array is filled |
| \`tests/unit/skills/video-discover/pool-ingest.test.ts\` | NEW — 7 cases pinning the upsert contract |

## Source tag
- \`wizard_realtime\` when \`Tier2Input.mandalaId\` is undefined (ephemeral wizard precompute)
- \`add_cards_realtime\` otherwise
- Distinct from \`v2_promoted\` / \`batch_trend\` / \`user_curated\` for diagnostic separation in admin dashboards / measurement queries

## Expected impact
- Each wizard run: +50-200 new rows to \`video_pool\` (mandala + language dependent)
- Each add-cards run: similar magnitude
- Combined with PR #782 (batch-collector 2x/day + N=200 + TTL 60d), steady-state pool growth accelerates toward 30k+ target
- Tier 1 hit rate climbs as users repeat search rounds — prerequisite for #785 (ADD model)

## Verification
- ✅ \`tsc --noEmit\`: clean
- ✅ \`eslint\`: 0 errors (warnings are intentional test mock \`any\` casts marked with eslint-disable)
- ✅ \`jest tests/unit/skills/video-discover/pool-ingest\`: **7/7 PASS**
- ✅ \`scripts/audit/hardcode-audit.ts\`: baseline 33 unchanged

## Out of scope (next phases per agreed plan, Option A)
- Phase 2/3: surfaced-but-not-picked persistence + reuse priority
- Phase 6: Mandala Search Journey Ledger (debugging + quality measurement, prioritized BEFORE Phase 4 per user direction)
- Phase 4: ADD model + round-separator UI (#785)
- Phase 5: measurement + further ramp

## Test plan (post-merge)
- [ ] After 1 wizard run on a fresh mandala, count NEW \`video_pool\` rows tagged \`source='wizard_realtime'\` in the run window (target: 50-200)
- [ ] After 5 add-cards rounds on coin mandala, count NEW rows tagged \`source='add_cards_realtime'\` (target: monotonic growth, no UPDATE-only churn)
- [ ] Verify \`video_pool.source\` value for the same videoId previously seen as \`v2_promoted\` / \`batch_trend\` is preserved (conservative UPDATE policy)
- [ ] Coin mandala Tier 1 hit rate at +7d (target: lift from baseline 1.5% to ≥ 10%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)