### PR TITLE
feat(add-cards): surfaced persistence + reuse-priority boost (CP489 Phase 2+3)

### DIFF
--- a/prisma/migrations/card-interactions/002_add_surfaced_signal.sql
+++ b/prisma/migrations/card-interactions/002_add_surfaced_signal.sql
@@ -1,0 +1,16 @@
+-- ============================================================================
+-- CP489 Phase 2+3 — add 'surfaced' value to card_signal enum
+-- ============================================================================
+-- Purpose: track which videos have been shown to a user in a given mandala
+-- via add-cards without being acted on (not picked / archived / deleted).
+-- The reuse-priority policy in src/api/routes/add-cards.ts then boosts these
+-- candidates on subsequent searches instead of treating them as cold misses.
+--
+-- Idempotent: PostgreSQL 9.6+ supports ADD VALUE IF NOT EXISTS for enums.
+-- Note: ALTER TYPE ... ADD VALUE cannot run inside a transaction block on
+-- some PostgreSQL versions, so this file is shipped standalone (no BEGIN/
+-- COMMIT wrapper). The apply-custom-sql.sh runner already invokes psql
+-- per-file without forcing a transaction.
+-- ============================================================================
+
+ALTER TYPE public.card_signal ADD VALUE IF NOT EXISTS 'surfaced';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -759,6 +759,7 @@ enum CardSignal {
   delete
   watch_complete
   skip
+  surfaced
 
   @@map("card_signal")
   @@schema("public")

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -76,6 +76,11 @@ APPLY_FILES=(
   # IF NOT EXISTS / DO $$ EXCEPTION duplicate_object NULL — idempotent
   # re-application is safe.
   "prisma/migrations/card-interactions/001_create_table.sql"
+  # CP489 Phase 2+3 — add 'surfaced' value to card_signal enum so
+  # add-cards can record per-mandala "shown but not picked" history
+  # for reuse-priority scoring on subsequent searches. ADD VALUE IF
+  # NOT EXISTS — idempotent.
+  "prisma/migrations/card-interactions/002_add_surfaced_signal.sql"
   "prisma/migrations/rich-summary-v2/005_mandala_relevance_pct.sql"
   # CP474 — v2 regen gate based on transcript_used (boolean). ADD COLUMN
   # IF NOT EXISTS + idempotent backfill (WHERE transcript_used = false).

--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -374,6 +374,19 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             return true;
           });
 
+          // 5b. CP489 Phase 2+3 — reuse-priority boost for cards previously
+          //     surfaced (shown but not picked) in this mandala. Cards in
+          //     card_interactions(signal='surfaced', mandala_id=current) get
+          //     a small score multiplier so the FE shows them again instead
+          //     of treating them as cold misses. Picked / archived / delete
+          //     remain exclude-only (handled in resolveExcludeSet above).
+          const surfacedSet = await loadSurfacedVideoIds({
+            prisma,
+            userId,
+            mandalaId,
+          });
+          const boostedBySurface = applySurfaceBoost(filtered, surfacedSet, cfg.surfaceBoost);
+
           // 6. Layer 4 feedback bias (channel match + drift guard).
           //    candidate-level embedding cosine boost (alphaEmbed) deferred —
           //    cache-matcher does not expose per-candidate raw embeddings.
@@ -383,7 +396,7 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             prisma,
             userId,
             centerEmbedding,
-            candidates: filtered,
+            candidates: boostedBySurface,
             cfg,
           });
 
@@ -443,8 +456,26 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               drift_guard_fired: feedback.driftGuardFired,
               caps_channel: result.capsChannel,
               caps_subgoal: result.capsSubgoal,
+              surfaced_set_size: surfacedSet.size,
             },
             latencyMs: Date.now() - t0,
+          });
+
+          // CP489 Phase 2+3 — fire-and-forget record of the surfaced cards
+          // so the NEXT add-cards round can reuse-priority-boost them and
+          // skip cold re-embed. UPSERT (latest wins) on the existing
+          // unique (user_id, video_id, signal) so the row count stays
+          // bounded — one row per user × video × signal regardless of
+          // how many rounds have surfaced the same video.
+          void recordSurfacedCards({
+            prisma,
+            userId,
+            mandalaId,
+            videoIds: cards.map((c) => c.videoId),
+          }).catch((err) => {
+            log.warn(
+              `surfaced recording failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+            );
           });
 
           return reply.code(200).send({ status: 'ok', data: payload });
@@ -511,6 +542,110 @@ interface ApplyFeedbackBiasOpts {
   centerEmbedding: number[];
   candidates: CachedMatch[];
   cfg: ReturnType<typeof getAddCardsConfig>;
+}
+
+// ============================================================================
+// CP489 Phase 2+3 — surfaced (shown-but-not-picked) persistence + reuse boost
+// ============================================================================
+
+/**
+ * Load the set of videoIds previously surfaced to this user in this mandala
+ * (signal='surfaced'). Returns Set<string> for O(1) membership check during
+ * the candidate boost loop. Failure-quiet: any DB error returns empty set
+ * — the boost simply degrades to "no reuse priority" rather than blocking
+ * the response.
+ */
+export async function loadSurfacedVideoIds(opts: {
+  prisma: ReturnType<typeof getPrismaClient>;
+  userId: string;
+  mandalaId: string;
+}): Promise<Set<string>> {
+  try {
+    const rows = await opts.prisma.card_interactions.findMany({
+      where: {
+        user_id: opts.userId,
+        mandala_id: opts.mandalaId,
+        signal: 'surfaced',
+      },
+      select: { video_id: true },
+    });
+    const out = new Set<string>();
+    for (const r of rows) if (r.video_id) out.add(r.video_id);
+    return out;
+  } catch (err) {
+    log.warn(
+      `loadSurfacedVideoIds failed (non-fatal, returning empty set): ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return new Set();
+  }
+}
+
+/**
+ * Multiply the score of every candidate already in `surfacedSet` by
+ * `1 + boost`. Pure function — no DB, no side-effects, safe to unit
+ * test. Returns a new array (input unchanged).
+ *
+ * The score multiplier policy (small +5% by default) is deliberately
+ * subtle so the reuse boost surfaces previously-seen candidates back
+ * into the response without dominating fresh high-cosine matches.
+ */
+export function applySurfaceBoost(
+  candidates: CachedMatch[],
+  surfacedSet: ReadonlySet<string>,
+  boost: number
+): CachedMatch[] {
+  if (surfacedSet.size === 0 || boost <= 0) return candidates;
+  const multiplier = 1 + boost;
+  return candidates.map((c) =>
+    surfacedSet.has(c.videoId) ? { ...c, score: c.score * multiplier } : c
+  );
+}
+
+/**
+ * UPSERT the list of just-surfaced videoIds into card_interactions as
+ * signal='surfaced'. Fire-and-forget contract — caller MUST `.catch()`
+ * to keep response unblocked. Idempotent via the existing
+ * (user_id, video_id, signal) unique constraint.
+ *
+ * Empty input is a no-op.
+ */
+export async function recordSurfacedCards(opts: {
+  prisma: ReturnType<typeof getPrismaClient>;
+  userId: string;
+  mandalaId: string;
+  videoIds: string[];
+}): Promise<void> {
+  if (opts.videoIds.length === 0) return;
+  for (const videoId of opts.videoIds) {
+    try {
+      await opts.prisma.card_interactions.upsert({
+        where: {
+          user_id_video_id_signal: {
+            user_id: opts.userId,
+            video_id: videoId,
+            signal: 'surfaced',
+          },
+        },
+        create: {
+          user_id: opts.userId,
+          mandala_id: opts.mandalaId,
+          video_id: videoId,
+          signal: 'surfaced',
+        },
+        update: {
+          mandala_id: opts.mandalaId,
+        },
+      });
+    } catch (err) {
+      log.warn(
+        `recordSurfacedCards upsert failed (non-fatal): videoId=${videoId} err=${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
 }
 
 interface FeedbackBiasResult {

--- a/src/config/add-cards.ts
+++ b/src/config/add-cards.ts
@@ -77,6 +77,13 @@ export const addCardsEnvSchema = z.object({
   // Older likes contribute less. Aligned with card-refresh-strategy.md §3
   // "Explicit Like → 14 days (exp)".
   ADD_CARDS_LIKED_DECAY_HALF_LIFE_DAYS: positiveNumber.transform((v) => v ?? 14),
+
+  // CP489 Phase 2+3 — reuse boost for previously surfaced (shown-but-not-picked)
+  // cards in the same mandala. Multiplies candidate score by (1 + boost) when
+  // candidate.videoId is in the surfacedSet. Default 0.05 (+5%) — small enough
+  // that fresh high-cosine matches still win, large enough that a borderline
+  // candidate surfaces back into the cumulative response across search rounds.
+  ADD_CARDS_SURFACE_BOOST: cosineRange.transform((v) => v ?? 0.05),
 });
 
 export interface AddCardsConfig {
@@ -91,6 +98,7 @@ export interface AddCardsConfig {
   semanticThreshold: number;
   likedHistoryLimit: number;
   likedDecayHalfLifeDays: number;
+  surfaceBoost: number;
 }
 
 const FALLBACK_CONFIG: AddCardsConfig = {
@@ -105,6 +113,7 @@ const FALLBACK_CONFIG: AddCardsConfig = {
   semanticThreshold: 0.45,
   likedHistoryLimit: 100,
   likedDecayHalfLifeDays: 14,
+  surfaceBoost: 0.05,
 };
 
 let cached: AddCardsConfig | null = null;
@@ -125,6 +134,7 @@ export function getAddCardsConfig(env: NodeJS.ProcessEnv = process.env): AddCard
       semanticThreshold: parsed.ADD_CARDS_SEMANTIC_THRESHOLD,
       likedHistoryLimit: parsed.ADD_CARDS_LIKED_HISTORY_LIMIT,
       likedDecayHalfLifeDays: parsed.ADD_CARDS_LIKED_DECAY_HALF_LIFE_DAYS,
+      surfaceBoost: parsed.ADD_CARDS_SURFACE_BOOST,
     };
   } catch {
     cached = FALLBACK_CONFIG;

--- a/tests/unit/api/add-cards-surfaced.test.ts
+++ b/tests/unit/api/add-cards-surfaced.test.ts
@@ -1,0 +1,180 @@
+/**
+ * CP489 Phase 2+3 — Unit tests for surfaced (shown-but-not-picked) persistence
+ * + reuse-priority boost.
+ *
+ * Why: per user directive "이전 라운드에서 안 픽한 카드 버리지 말 것", add-cards
+ * now records every shown videoId as card_interactions(signal='surfaced') and
+ * boosts those candidates on subsequent searches. This file pins:
+ *   1. The pure scoring contract (applySurfaceBoost) so a refactor cannot
+ *      silently drop the reuse-priority behaviour.
+ *   2. The two DB-touching helpers (loadSurfacedVideoIds + recordSurfacedCards)
+ *      with mocked prisma so we exercise the failure-quiet contract without
+ *      a real DB.
+ */
+
+import {
+  applySurfaceBoost,
+  loadSurfacedVideoIds,
+  recordSurfacedCards,
+} from '../../../src/api/routes/add-cards';
+
+type CandidateLike = {
+  videoId: string;
+  score: number;
+  title: string;
+  channelName: string;
+};
+
+function makeCandidate(videoId: string, score: number): CandidateLike {
+  return { videoId, score, title: `t-${videoId}`, channelName: `c-${videoId}` };
+}
+
+describe('applySurfaceBoost (pure scoring contract)', () => {
+  it('returns the same array reference shape when set is empty', () => {
+    const input = [makeCandidate('a', 0.5), makeCandidate('b', 0.3)];
+    const out = applySurfaceBoost(input as never, new Set(), 0.05);
+    expect(out).toBe(input);
+  });
+
+  it('returns the same array when boost <= 0 (no-op)', () => {
+    const input = [makeCandidate('a', 0.5)];
+    const surfaced = new Set(['a']);
+    expect(applySurfaceBoost(input as never, surfaced, 0)).toBe(input);
+    expect(applySurfaceBoost(input as never, surfaced, -0.1)).toBe(input);
+  });
+
+  it('multiplies score by (1 + boost) only for surfaced videoIds', () => {
+    const input = [makeCandidate('a', 0.5), makeCandidate('b', 0.4)];
+    const surfaced = new Set(['a']);
+    const out = applySurfaceBoost(input as never, surfaced, 0.1) as CandidateLike[];
+    expect(out[0]!.score).toBeCloseTo(0.55, 10);
+    expect(out[1]!.score).toBe(0.4);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [makeCandidate('a', 0.5)];
+    const original = JSON.parse(JSON.stringify(input));
+    applySurfaceBoost(input as never, new Set(['a']), 0.05);
+    expect(input).toEqual(original);
+  });
+
+  it('preserves order of candidates after boost', () => {
+    const input = [makeCandidate('a', 0.5), makeCandidate('b', 0.4), makeCandidate('c', 0.3)];
+    const out = applySurfaceBoost(input as never, new Set(['b']), 0.05);
+    expect(out.map((c) => c.videoId)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('loadSurfacedVideoIds', () => {
+  it('returns a Set of video_id strings from card_interactions rows', async () => {
+    const findMany = jest
+      .fn()
+      .mockResolvedValue([{ video_id: 'v1' }, { video_id: 'v2' }, { video_id: 'v3' }]);
+    const prisma = { card_interactions: { findMany } } as never;
+    const out = await loadSurfacedVideoIds({
+      prisma,
+      userId: 'u1',
+      mandalaId: 'm1',
+    });
+    expect(out).toEqual(new Set(['v1', 'v2', 'v3']));
+    expect(findMany).toHaveBeenCalledWith({
+      where: { user_id: 'u1', mandala_id: 'm1', signal: 'surfaced' },
+      select: { video_id: true },
+    });
+  });
+
+  it('returns empty set when no rows match', async () => {
+    const findMany = jest.fn().mockResolvedValue([]);
+    const prisma = { card_interactions: { findMany } } as never;
+    const out = await loadSurfacedVideoIds({
+      prisma,
+      userId: 'u1',
+      mandalaId: 'm1',
+    });
+    expect(out.size).toBe(0);
+  });
+
+  it('returns empty set (failure-quiet) when prisma throws', async () => {
+    const findMany = jest.fn().mockRejectedValue(new Error('db down'));
+    const prisma = { card_interactions: { findMany } } as never;
+    const out = await loadSurfacedVideoIds({
+      prisma,
+      userId: 'u1',
+      mandalaId: 'm1',
+    });
+    expect(out).toEqual(new Set());
+  });
+
+  it('skips null video_id rows defensively', async () => {
+    const findMany = jest
+      .fn()
+      .mockResolvedValue([{ video_id: 'v1' }, { video_id: null }, { video_id: 'v2' }]);
+    const prisma = { card_interactions: { findMany } } as never;
+    const out = await loadSurfacedVideoIds({
+      prisma,
+      userId: 'u1',
+      mandalaId: 'm1',
+    });
+    expect(out).toEqual(new Set(['v1', 'v2']));
+  });
+});
+
+describe('recordSurfacedCards', () => {
+  it('no-ops when videoIds is empty', async () => {
+    const upsert = jest.fn();
+    const prisma = { card_interactions: { upsert } } as never;
+    await recordSurfacedCards({
+      prisma,
+      userId: 'u1',
+      mandalaId: 'm1',
+      videoIds: [],
+    });
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('issues one upsert per videoId with signal=surfaced', async () => {
+    const upsert = jest.fn().mockResolvedValue({});
+    const prisma = { card_interactions: { upsert } } as never;
+    await recordSurfacedCards({
+      prisma,
+      userId: 'u1',
+      mandalaId: 'm1',
+      videoIds: ['v1', 'v2'],
+    });
+    expect(upsert).toHaveBeenCalledTimes(2);
+    expect(upsert).toHaveBeenNthCalledWith(1, {
+      where: {
+        user_id_video_id_signal: {
+          user_id: 'u1',
+          video_id: 'v1',
+          signal: 'surfaced',
+        },
+      },
+      create: {
+        user_id: 'u1',
+        mandala_id: 'm1',
+        video_id: 'v1',
+        signal: 'surfaced',
+      },
+      update: { mandala_id: 'm1' },
+    });
+  });
+
+  it('continues after a single upsert failure (failure-quiet contract)', async () => {
+    const upsert = jest
+      .fn()
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('unique violation'))
+      .mockResolvedValueOnce({});
+    const prisma = { card_interactions: { upsert } } as never;
+    await expect(
+      recordSurfacedCards({
+        prisma,
+        userId: 'u1',
+        mandalaId: 'm1',
+        videoIds: ['v1', 'v2', 'v3'],
+      })
+    ).resolves.toBeUndefined();
+    expect(upsert).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary

User directive: *"이전 라운드에서 안 픽한 카드 버리지 말 것."* (Don't throw away previously surfaced-but-not-picked cards.)

Today `/api/v1/add-cards` returns a fresh re-rank every search round, so any video shown in round N that the user didn't pick can silently disappear in round N+1 — wasted compute and the user reports "검색이 반복되면 추천할 카드가 없는 것 아닌가" / "엉뚱한 카드 vs 같은 영상 2번 추천" dilemma.

This PR persists every shown videoId as `card_interactions(signal='surfaced', mandala_id=…)` and applies a small score multiplier (default +5%) to surfaced candidates on subsequent searches in the same mandala. Picked / archived / delete remain exclude-only (`resolveExcludeSet` unchanged).

## Changes

- `prisma/schema.prisma` — extend `CardSignal` enum with `surfaced`.
- `prisma/migrations/card-interactions/002_add_surfaced_signal.sql` — `ALTER TYPE … ADD VALUE IF NOT EXISTS` (idempotent, no transaction).
- `scripts/apply-custom-sql.sh` — register new migration in `APPLY_FILES`.
- `src/config/add-cards.ts` — `ADD_CARDS_SURFACE_BOOST` env (default 0.05).
- `src/api/routes/add-cards.ts` — three new helpers wired pre/post the existing feedback-bias pipeline:
  - `loadSurfacedVideoIds({prisma, userId, mandalaId})` — returns `Set<string>` (failure-quiet, empty set on error).
  - `applySurfaceBoost(candidates, set, boost)` — pure: multiplies score by `1 + boost` for set members, no-op on empty set or `boost <= 0`.
  - `recordSurfacedCards({prisma, userId, mandalaId, videoIds})` — UPSERT one row per videoId (signal=surfaced) using the existing `(user_id, video_id, signal)` unique constraint. Fire-and-forget call site `.catch()`-wrapped.
- `tests/unit/api/add-cards-surfaced.test.ts` — 12 cases pinning the pure scoring contract + mocked prisma failure-quiet behaviour.

## Test plan

- [x] `npx tsc --noEmit` (excluding pre-existing `sales_resources` errors unrelated to this PR) — 0 errors related to changes.
- [x] `npx jest tests/unit/api/add-cards-surfaced.test.ts` — 12/12 pass.
- [x] `npx eslint --fix` — 0 errors, 2 pre-existing warnings only.
- [x] `npx tsx scripts/audit/hardcode-audit.ts` — total 33 (baseline, no new violations).
- [ ] Post-merge: prod deploy runs `apply-custom-sql.sh` → `002_add_surfaced_signal.sql` extends enum on Supabase Cloud (idempotent re-run safe).
- [ ] Post-deploy: trigger add-cards round 1 → reload → round 2 → confirm at least one round-1 videoId reappears in round 2.

## Rollback

- Disable the boost at runtime: set `ADD_CARDS_SURFACE_BOOST=0` → `applySurfaceBoost` becomes a no-op (helpers still execute but do not change scoring).
- Hard rollback: revert this PR; the orphan `surfaced` enum value remains in the DB (no impact — PostgreSQL has no `DROP VALUE`, idle enum values are harmless).

## CP489 Sequence

(A) Phase 1 (PR #787 — merged) → **Phase 2+3 (this PR)** → Phase 6 (search journey ledger) → Phase 4 (ADD model + round separator #785) → Phase 5 (measurement + ramp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)