### PR TITLE
fix(add-cards-trigger-chip): hotfix prod crash from removed cards field (CP489 Phase 4)

### DIFF
--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsTriggerChip.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsTriggerChip.tsx
@@ -37,7 +37,10 @@ export function AddCardsTriggerChip({ mandalaId }: AddCardsTriggerChipProps) {
       return;
     }
     const stored = loadAddCardsState(mandalaId);
-    setPersistedCount(stored?.cards.length ?? 0);
+    // CP489 Phase 4 — persistence shape changed `cards[]` → `rounds[]`.
+    // Sum across rounds for the badge total.
+    const total = stored?.rounds.reduce((n, r) => n + r.cards.length, 0) ?? 0;
+    setPersistedCount(total);
   }, [mandalaId]);
 
   const count = storeCount ?? persistedCount;


### PR DESCRIPTION
## Hotfix

PR #790 changed persistence v1 (\`cards: AddCardCandidate[]\`) → v2 (\`rounds: AddCardsRound[]\`). \`AddCardsTriggerChip\` was an unmodified consumer that still called \`stored?.cards.length\` — runtime crash on any logged-in user with a non-null stored record (prod blank-page 2026-05-28).

Fix: sum \`rounds[].cards.length\` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)