### PR TITLE
fix(d-and-d): scratchpad move recovery + youtube title entity decode (CP489)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ prisma/migrations/*
 !prisma/migrations/user-video-states-cleanup/**
 !prisma/migrations/user-video-states-guards/
 !prisma/migrations/user-video-states-guards/**
+!prisma/migrations/youtube-videos-decode-entities/
+!prisma/migrations/youtube-videos-decode-entities/**
 !prisma/migrations/youtube-metadata-completeness/
 !prisma/migrations/youtube-metadata-completeness/**
 !prisma/migrations/search-quality-overhaul/

--- a/docs/dnd-system.md
+++ b/docs/dnd-system.md
@@ -1,0 +1,257 @@
+---
+name: D&D System Architecture & Troubleshooting
+last_updated: 2026-05-29 (CP489)
+applies_to: frontend/src/{shared/lib/dnd,pages/index,widgets/{app-shell,mandala-grid,card-list,card-list-view,sidebar-heat-minimap,scratch-pad,add-cards-panel}}, prisma/migrations/user-video-states-guards
+---
+
+# D&D System Architecture & Troubleshooting
+
+This document is the canonical reference for the drag-and-drop system. It
+exists because every D&D-related session re-discovers the same plumbing
+invariants and recently-broken regressions; future sessions should read
+this BEFORE touching D&D code (CLAUDE.md §D&D Protection enforces this).
+
+The historical record of regressions and recovery is in `memory/troubleshooting.md`
+(LEVEL-1+ entries tagged D&D) and `memory/work-efficiency.md`. This file is the
+*current* state of the system.
+
+---
+
+## 1. Plumbing Invariants (CLAUDE.md §D&D Protection)
+
+Four invariants. Smoke-tested in `frontend/src/__tests__/smoke/dnd-context-structure.test.ts`
+(12 tests) + `collision-detection.test.ts` (4 tests). CI D&D Change Guard
+warns when any of the protected files is touched in a PR.
+
+| # | Invariant | File:line | Guard |
+|---|-----------|-----------|-------|
+| 1 | DndContext lives ONLY in AppShell.tsx — never in IndexPage | `widgets/app-shell/ui/AppShell.tsx:101-135` (single host) + `pages/index/ui/IndexPage.tsx:1116` has DragOverlay only | smoke test "AppShell.tsx must contain DndContext" + "IndexPage.tsx must NOT contain DndContext" |
+| 2 | `dndHandlersRef` is a module-level ref, assigned synchronously during IndexPage render (never via useEffect) | `stores/shellStore.ts:17` exports the ref; `pages/index/ui/IndexPage.tsx:792` writes; `widgets/app-shell/ui/AppShell.tsx:105-108` reads via wrapper callbacks | smoke test "shellStore.ts must export dndHandlersRef" + "IndexPage.tsx must set dndHandlersRef.current during render" |
+| 3 | The `minimapData` useEffect deps array MUST include `cards.cardsByCell` | `pages/index/ui/IndexPage.tsx:822` | smoke test "minimapData useEffect must include cardsByCell in deps" |
+| 4 | Collision detection = `pointerWithinThenClosest` (not raw `rectIntersection` or `closestCenter`) | `shared/lib/dnd/collisionDetection.ts:17` + AppShell:103 | smoke test "collision-detection.test.ts" 4 cases |
+
+### Why invariant 1 exists
+Mounting DndContext inside IndexPage breaks drags between the Sidebar
+minimap and the main grid — the sidebar lives outside IndexPage's tree,
+so a sidebar-mounted draggable cannot reach a grid-mounted droppable.
+Origin incident: CP324 (2026-03-30). Recurrence prevention: smoke test.
+
+### Why invariant 2 exists
+`dndHandlersRef` is the bridge between IndexPage (which owns the dnd-kit
+handlers — they close over `cards`, `navigation`, etc.) and AppShell
+(which mounts DndContext). Sync-via-useEffect introduces a 1-frame delay
+during which the first drag after a state change uses stale handlers.
+The module-level ref pattern is render-time-assigned, which means there
+is no stale window. Same principle reused by `learning/model/noteEditorBridge.ts`.
+
+### Why invariant 3 exists
+`minimapData.cardsByCell` is what the sidebar minimap reads to render
+its 9 heat-indicator dots. Forgetting `cards.cardsByCell` in the deps
+array means the sidebar counts go stale after every drop. Origin: an
+auto-deps-fixer once stripped it. Recurrence prevention: smoke test +
+ESLint override (`prefer-const`, `no-unused-vars` set to `warn` instead
+of `error` so autofix doesn't touch this file).
+
+### Why invariant 4 exists
+Default `rectIntersection` is unreliable when the draggable is much
+smaller than the droppable (e.g. ScratchPad's 80×45 thumbnails dropping
+on full-grid cells). `pointerWithinThenClosest` does:
+1. Try `pointerWithin` — works perfectly when the pointer is inside the
+   droppable rect.
+2. Fall back to `closestCenter`, filtered to exclude `drag-card-*`
+   droppables, so dragging from a docked ScratchPad across the gap to
+   the grid doesn't accidentally land on a nearby sortable card.
+
+---
+
+## 2. Card Source Model (4-source merge with normalizeUrl dedupe)
+
+`useCardOrchestrator.allMandalaCards` is a 4-way merge:
+
+```ts
+const merged = [
+  ...mandalaLocalCards,    // filter of useLocalCards (user_local_cards table)
+  ...mandalaVideoCards,    // filter of useAllVideoStates (user_video_states table)
+  ...pendingMandalaCards,  // optimistic in-flight, pre-server-ack
+  ...streamMandalaCards,   // SSE recommendation_cache backlog
+];
+// dedupe by normalizeUrl(card.videoUrl) — earlier sources win.
+```
+
+### Stream-card id prefix invariant (CP489 fix)
+
+`streamMandalaCards` cards have ids of the form `stream-<recommendation_cache.id>`
+(see `features/recommendation-feed/lib/recommendationToInsightCard.ts:29`).
+These ids are NOT in any of `syncedCards` / `persistedLocalCards` /
+`pendingLocalCards`, so any helper that searches those three source arrays
+will miss stream-origin cards.
+
+`getCardById` therefore takes a 5th argument `streamCards?: InsightCard[] = []`
+(default empty for back-compat). All 5 callsites in `useCardOrchestrator`
+pass `streamMandalaCards`. Smoke test pins this:
+`__tests__/getCardById-stream-source.test.ts`.
+
+### Stream-card mutation contract (CP489 fix)
+
+A stream card cannot directly back a `user_video_states` UPDATE — its id
+doesn't exist as a `user_video_states.id`. Mutations that target a stream
+card must first resolve the stream id to the backing synced/local row by
+`normalizeUrl(videoUrl)`. `resolveStreamCardId` in `useCardOrchestrator.ts`
+implements this:
+
+```ts
+const resolveStreamCardId = useCallback((id: string): string | null => {
+  if (!id.startsWith('stream-')) return id;
+  const streamCard = streamMandalaCards.find((c) => c.id === id);
+  if (!streamCard) return null;
+  const normalized = normalizeUrl(streamCard.videoUrl);
+  const synced = syncedCards.find((c) => normalizeUrl(c.videoUrl) === normalized);
+  if (synced) return synced.id;
+  const local = persistedLocalCards.find((c) => normalizeUrl(c.videoUrl) === normalized);
+  if (local) return local.id;
+  return null;
+}, [streamMandalaCards, syncedCards, persistedLocalCards]);
+```
+
+`handleCardDrop` / `handleScratchPadCardDrop` / `handleScratchPadMultiCardDrop`
+all call this at function entry. If resolution returns `null` (no backing
+row exists yet — the recommendation_cache row hasn't been promoted to
+`user_video_states`), the handler emits a `cardSyncing` toast and returns
+without mutating. The user is asked to wait and retry; no data loss.
+
+### Origin pre-CP489
+The 4th source `streamMandalaCards` was added in PR #666 (CP471,
+2026-05-19) without updating `getCardById`'s signature. For 10 days,
+drags targeting stream-origin cards silently failed (`getCardById === null`
+→ early return; toast never fired). User-visible symptom (CP489):
+"12 cards selected, drag to Idea Spot, toast says '12 moved' but only 1
+actually moved" — the 1 was a non-stream source, the 11 were stream.
+
+Recurrence prevention: smoke test + this section.
+
+---
+
+## 3. cell_index Regression Trigger
+
+Migration: `prisma/migrations/user-video-states-guards/`
+
+### 001_protect_cell_index_regression.sql (PR #676, CP474, 2026-05-19)
+DB trigger blocks any `cell_index >= 0 → -1` UPDATE on `user_video_states`.
+Originally added to stop the `cards.ts /like` ON CONFLICT bookmark-loss
+incident — a buggy UPSERT was overwriting placed cards' cell_index back
+to -1, stranding them in scratchpad.
+
+### 002_allow_intentional_scratchpad_move.sql (CP489, 2026-05-29)
+The 001 trigger blocked EVERY `cell_index >= 0 → -1`, including legitimate
+scratchpad/delete demotions (handleScratchPadCardDrop /
+handleScratchPadMultiCardDrop / handleDeleteCards). The 001 SQL comment
+had promised a "dedicated /unpin-cell endpoint that bypasses this guard
+intentionally," but that endpoint was never implemented — so legitimate
+demote paths silently failed for 10 days. CP489 user-visible symptom:
+batch-update-video-state EF logged 11× `code 23514 cell_index regression
+blocked: was=4 new=-1` while the FE toast still claimed "12 moved" (the
+EF returns 200 with `updatedCount` that the FE ignores).
+
+Recovery without dropping the protection: the 002 migration adds an
+explicit-demote escape clause to the trigger:
+
+```sql
+IF OLD.cell_index >= 0
+   AND NEW.cell_index = -1
+   AND NOT (NEW.level_id = 'scratchpad' AND NEW.mandala_id IS NULL)
+THEN RAISE EXCEPTION ...
+```
+
+The pair `level_id='scratchpad' AND mandala_id IS NULL` is the signature
+of an intentional UI-driven demote. Silent stranding (a bare
+`cell_index=-1` without level/mandala changes) is still blocked.
+
+### Caller compliance
+All current FE/BE/EF callers that demote a synced card to scratchpad
+set the full 4-tuple. Audited 2026-05-29:
+
+| Path | Location | 4-tuple set? |
+|------|----------|--------------|
+| handleScratchPadCardDrop (single synced) | `useCardOrchestrator.ts:1270-1273` | ✓ |
+| handleScratchPadMultiCardDrop (multi synced) | `useCardOrchestrator.ts:1322` → `useBatchMoveCards.ts:53-66` | ✓ |
+| handleDeleteCards (cell card) | `useCardOrchestrator.ts:1477-1480` | ✓ |
+| cards.ts BE user_video_states UPDATE | `src/api/routes/cards.ts:227, 432, 620` | N/A (cell_index never touched) |
+
+Adding a new path that sets `cell_index=-1` MUST set `level_id='scratchpad'`
++ `mandala_id=NULL` together, or the trigger will reject it.
+
+---
+
+## 4. Mutation Path Matrix
+
+| Action | FE handler | BE/EF endpoint | Trigger reaches? | Notes |
+|--------|-----------|----------------|-------------------|-------|
+| Place card on cell (synced) | handleCardDrop | youtube-sync/update-video-state | N (cell_index -1 → N) | Allowed |
+| Move card between cells (synced) | handleCardDrop | youtube-sync/update-video-state | N (cell_index ≥ 0 → ≥ 0) | Allowed |
+| Demote single card to scratchpad (synced) | handleScratchPadCardDrop | youtube-sync/update-video-state | Y | Allowed via 4-tuple |
+| Demote multi cards to scratchpad (synced) | handleScratchPadMultiCardDrop | youtube-sync/batch-update-video-state | Y | Allowed via 4-tuple |
+| Delete cell card (synced) | handleDeleteCards (isInMandala) | youtube-sync/update-video-state | Y | Allowed via 4-tuple |
+| Reorder within cell | handleCardsReorder | useBatchMoveCards | N (cell_index unchanged) | — |
+| All local-card paths | various | local-cards EF | N/A | user_local_cards table, no trigger |
+
+---
+
+## 5. External (HTML5) Drop Paths
+
+Three external drop receivers (URL/file/cardId from outside dnd-kit):
+- `widgets/mandala-grid/ui/MandalaCell.tsx` `handleExternalDrop` (line ~410)
+- `widgets/sidebar-heat-minimap/ui/SidebarHeatMinimap.tsx` `handleExternalDrop`
+- `widgets/card-list-view/ui/CardListView.tsx` `handleExternalDrop`
+
+All three accept `text/uri-list` + `text/plain` + `text/html` for URL
+parsing, plus `application/card-id` + `application/multi-card-ids` for
+intra-app drags. None of them call `stopPropagation` — the document-level
+listener in `useCardDragDrop` MUST fire to reset the overlay state, even
+if the cell-level handler also fires.
+
+### YouTube channel/playlist guard
+`IndexPage:1000-1016` rejects YouTube non-video URLs (channel home,
+playlist that has no video id) with a toast — these used to silently
+create placeholder cards.
+
+---
+
+## 6. Render-Time Defences
+
+### HTML entity decode (CP489 fix)
+YouTube Data API v3 returns `snippet.title` and `snippet.channelTitle`
+with HTML entities escaped (`&quot;`, `&#39;`, `&amp;`, etc.). The DB
+trigger `trg_decode_youtube_videos_titles` (migration
+`prisma/migrations/youtube-videos-decode-entities/001_decode_entities.sql`)
+decodes on every INSERT/UPDATE — so new writes are clean. The FE
+`decodeHtmlEntities` calls at render sites are defence against rows the
+backfill hasn't reached yet:
+- `widgets/card-list/ui/InsightCardItemV2.tsx:598, 684`
+- `widgets/card-list/ui/MandalaCell.tsx:109` (CP489 added)
+- `widgets/add-cards-panel/ui/AddCardsList.tsx:289` (CP489 added)
+
+---
+
+## 7. Regression Watchlist
+
+When touching any of the following, re-read this document AND run
+`npx vitest run src/__tests__/smoke/dnd-context-structure.test.ts`
+`src/__tests__/smoke/collision-detection.test.ts`
+`src/__tests__/getCardById-stream-source.test.ts` BEFORE pushing:
+
+- Adding a new InsightCard source array → update getCardById + detectCardSource callsites in `useCardOrchestrator.ts` (CP488 IT "Cross-Layer Propagation grep ALL consumers")
+- Adding a new path that sets `cell_index=-1` → must also set `level_id='scratchpad' + mandala_id=NULL` together
+- Changing the `dndHandlersRef` write timing (e.g. moving it into useEffect) → invariant 2 broken, first drag after every render is stale
+- Adding a new DndContext anywhere outside AppShell.tsx → invariant 1 broken
+- Removing `cards.cardsByCell` from the minimapData effect deps → invariant 3 broken
+- Changing `pointerWithinThenClosest` → re-run collision-detection.test.ts; the scratchpad-priority and drag-card-* filter rules are not optional
+
+---
+
+## 8. Cross-references
+
+- CLAUDE.md §D&D Protection (Hard Rule)
+- CLAUDE.md §Cross-Layer Propagation (Hard Rule) — getCardById drift was a direct case
+- `memory/troubleshooting.md` LEVEL-1+ entries tagged D&D
+- `memory/work-efficiency.md` "Browser-env specific 진단 first action 순서" (CP489)
+- `tests/regression/dnd-smoke.spec.ts` + `card-dnd.spec.ts` (Playwright)

--- a/frontend/src/__tests__/getCardById-stream-source.test.ts
+++ b/frontend/src/__tests__/getCardById-stream-source.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression — getCardById 4-source signature.
+ *
+ * Background: PR #666 (CP471, 2026-05-19) added a 4th merge source —
+ * `streamMandalaCards` — to `allMandalaCards` in `useCardOrchestrator`,
+ * but `getCardById` was left with its 3-source signature
+ * (syncedCards / persistedLocalCards / pendingLocalCards). SSE-pushed
+ * `recommendation_cache` cards (id format `stream-<uuid>`) were rendered
+ * in the grid but invisible to `getCardById`, causing D&D mutations on
+ * them to silently fail (handleCardDrop: `if (!card) return;`).
+ *
+ * This test pins the 4-arg search so future refactors don't drop
+ * stream-card support again.
+ */
+import { describe, it, expect } from 'vitest';
+import { getCardById } from '@/features/card-management/lib/cardUtils';
+import type { InsightCard } from '@/entities/card/model/types';
+
+function mk(id: string, url = `https://example.com/${id}`): InsightCard {
+  return {
+    id,
+    videoUrl: url,
+    title: id,
+    thumbnail: '',
+    userNote: '',
+    createdAt: new Date(0),
+    cellIndex: 0,
+    levelId: 'root',
+    linkType: 'youtube',
+  };
+}
+
+describe('getCardById — 4-source search (CP489+ stream-card fix)', () => {
+  it('finds a card that lives only in streamCards (4th source)', () => {
+    const stream = [mk('stream-abc')];
+    const got = getCardById('stream-abc', [], [], [], stream);
+    expect(got?.id).toBe('stream-abc');
+  });
+
+  it('returns null when the id is not in any source', () => {
+    expect(getCardById('missing', [], [], [], [])).toBeNull();
+  });
+
+  it('falls through earlier sources before streamCards', () => {
+    const synced = [mk('id-1')];
+    const stream = [mk('id-1', 'https://other.example/id-1')];
+    const got = getCardById('id-1', synced, [], [], stream);
+    expect(got?.videoUrl).toBe('https://example.com/id-1');
+  });
+
+  it('back-compat — 4-arg call still works (streamCards defaults to [])', () => {
+    const synced = [mk('id-1')];
+    const got = getCardById('id-1', synced, [], []);
+    expect(got?.id).toBe('id-1');
+  });
+
+  it('back-compat — missing id with no streamCards returns null', () => {
+    expect(getCardById('stream-x', [], [], [])).toBeNull();
+  });
+});

--- a/frontend/src/features/card-management/lib/cardUtils.ts
+++ b/frontend/src/features/card-management/lib/cardUtils.ts
@@ -92,24 +92,26 @@ export function detectCardSourceFast(
 }
 
 /**
- * Get a card by ID from multiple sources
+ * Get a card by ID from multiple sources.
  *
- * @param cardId - The card ID to find
- * @param syncedCards - YouTube synced cards
- * @param persistedLocalCards - Persisted local cards
- * @param pendingCards - Pending local cards
- * @returns The card if found, null otherwise
+ * `streamCards` covers SSE-pushed recommendation_cache rows that are
+ * rendered in the grid via `streamMandalaCards` but whose ids carry the
+ * `stream-` prefix (see `recommendationToInsightCard`). Omitting this
+ * source caused multi-card D&D to silently drop stream-origin cards
+ * (handleCardDrop returned early on `getCardById === null`).
  */
 export function getCardById(
   cardId: string,
   syncedCards: InsightCard[],
   persistedLocalCards: InsightCard[],
-  pendingCards: InsightCard[]
+  pendingCards: InsightCard[],
+  streamCards: InsightCard[] = []
 ): InsightCard | null {
   return (
     syncedCards.find((c) => c.id === cardId) ||
     persistedLocalCards.find((c) => c.id === cardId) ||
     pendingCards.find((c) => c.id === cardId) ||
+    streamCards.find((c) => c.id === cardId) ||
     null
   );
 }

--- a/frontend/src/pages/index/model/useCardOrchestrator.ts
+++ b/frontend/src/pages/index/model/useCardOrchestrator.ts
@@ -759,6 +759,29 @@ export function useCardOrchestrator(
     [toast, t, queryClient, mandalaId, triggerAutoEnrich]
   );
 
+  // CP489+ — Stream-card id resolution. SSE-pushed `recommendation_cache`
+  // backlog rows are surfaced in the grid as InsightCards with `stream-`
+  // prefixed ids (see `recommendationToInsightCard`). They are not present
+  // in syncedCards / persistedLocalCards / pendingLocalCards, so D&D
+  // mutations targeting them used to silently fail (getCardById === null
+  // → early return). Resolve them to the matching syncedCards /
+  // persistedLocalCards row by normalized videoUrl; return null when no
+  // backing row exists yet (the user must wait for the row to settle).
+  const resolveStreamCardId = useCallback(
+    (id: string): string | null => {
+      if (!id.startsWith('stream-')) return id;
+      const streamCard = streamMandalaCards.find((c) => c.id === id);
+      if (!streamCard) return null;
+      const normalized = normalizeUrl(streamCard.videoUrl);
+      const synced = syncedCards.find((c) => normalizeUrl(c.videoUrl) === normalized);
+      if (synced) return synced.id;
+      const local = persistedLocalCards.find((c) => normalizeUrl(c.videoUrl) === normalized);
+      if (local) return local.id;
+      return null;
+    },
+    [streamMandalaCards, syncedCards, persistedLocalCards]
+  );
+
   // Card drop on mandala cell
   const handleCardDrop = useCallback(
     (
@@ -772,6 +795,42 @@ export function useCardOrchestrator(
       if (files && files.length > 0) {
         handleFileDrop(cellIndex, files);
         return;
+      }
+
+      // CP489+ stream-card id resolution (see resolveStreamCardId comment).
+      if (cardId) {
+        const resolved = resolveStreamCardId(cardId);
+        if (resolved === null) {
+          toast({
+            title: t('index.cardSyncing', 'Card still syncing'),
+            description: t(
+              'index.cardSyncingDesc',
+              'Wait a moment for the card to settle, then try again.'
+            ),
+            variant: 'destructive',
+          });
+          return;
+        }
+        cardId = resolved;
+      }
+      if (multiCardIds && multiCardIds.length > 0) {
+        const resolved: string[] = [];
+        for (const id of multiCardIds) {
+          const r = resolveStreamCardId(id);
+          if (r === null) {
+            toast({
+              title: t('index.cardSyncing', 'Card still syncing'),
+              description: t(
+                'index.cardSyncingDesc',
+                'Wait a moment for the card to settle, then try again.'
+              ),
+              variant: 'destructive',
+            });
+            return;
+          }
+          resolved.push(r);
+        }
+        multiCardIds = resolved;
       }
 
       // Multi-card drop
@@ -789,7 +848,13 @@ export function useCardOrchestrator(
         }
 
         const pendingIds = multiCardIds.filter((id) => {
-          const c = getCardById(id, syncedCards, persistedLocalCards, pendingLocalCards);
+          const c = getCardById(
+            id,
+            syncedCards,
+            persistedLocalCards,
+            pendingLocalCards,
+            streamMandalaCards
+          );
           return detectCardSource(id, syncedCards, persistedLocalCards, c) === 'pending';
         });
         if (pendingIds.length > 0 && !canAddCard) {
@@ -803,7 +868,13 @@ export function useCardOrchestrator(
 
         const batchItems = multiCardIds
           .map((id) => {
-            const card = getCardById(id, syncedCards, persistedLocalCards, pendingLocalCards);
+            const card = getCardById(
+              id,
+              syncedCards,
+              persistedLocalCards,
+              pendingLocalCards,
+              streamMandalaCards
+            );
             if (!card) return null;
             const source = detectCardSource(id, syncedCards, persistedLocalCards, card);
             return { card, source, cellIndex, levelId: currentLevelId, mandalaId };
@@ -849,7 +920,13 @@ export function useCardOrchestrator(
           return;
         }
 
-        const card = getCardById(cardId, syncedCards, persistedLocalCards, pendingLocalCards);
+        const card = getCardById(
+          cardId,
+          syncedCards,
+          persistedLocalCards,
+          pendingLocalCards,
+          streamMandalaCards
+        );
         if (!card) return;
         const source = detectCardSource(cardId, syncedCards, persistedLocalCards, card);
 
@@ -1061,6 +1138,8 @@ export function useCardOrchestrator(
       syncedCards,
       persistedLocalCards,
       pendingLocalCards,
+      streamMandalaCards,
+      resolveStreamCardId,
       toast,
       currentLevelId,
       handleFileDrop,
@@ -1173,7 +1252,26 @@ export function useCardOrchestrator(
   // Move card from mandala back to scratchpad
   const handleScratchPadCardDrop = useCallback(
     (cardId: string) => {
-      const card = getCardById(cardId, syncedCards, persistedLocalCards, pendingLocalCards);
+      const resolvedCardId = resolveStreamCardId(cardId);
+      if (resolvedCardId === null) {
+        toast({
+          title: t('index.cardSyncing', 'Card still syncing'),
+          description: t(
+            'index.cardSyncingDesc',
+            'Wait a moment for the card to settle, then try again.'
+          ),
+          variant: 'destructive',
+        });
+        return;
+      }
+      cardId = resolvedCardId;
+      const card = getCardById(
+        cardId,
+        syncedCards,
+        persistedLocalCards,
+        pendingLocalCards,
+        streamMandalaCards
+      );
       if (!card) return;
       const source = detectCardSource(cardId, syncedCards, persistedLocalCards, card);
 
@@ -1211,6 +1309,8 @@ export function useCardOrchestrator(
       syncedCards,
       persistedLocalCards,
       pendingLocalCards,
+      streamMandalaCards,
+      resolveStreamCardId,
       updateVideoState,
       updateLocalCard,
       toast,
@@ -1221,9 +1321,32 @@ export function useCardOrchestrator(
   // Multi-card drop to scratchpad
   const handleScratchPadMultiCardDrop = useCallback(
     (cardIds: string[]) => {
+      const resolved: string[] = [];
+      for (const id of cardIds) {
+        const r = resolveStreamCardId(id);
+        if (r === null) {
+          toast({
+            title: t('index.cardSyncing', 'Card still syncing'),
+            description: t(
+              'index.cardSyncingDesc',
+              'Wait a moment for the card to settle, then try again.'
+            ),
+            variant: 'destructive',
+          });
+          return;
+        }
+        resolved.push(r);
+      }
+      cardIds = resolved;
       const batchItems = cardIds
         .map((cardId) => {
-          const card = getCardById(cardId, syncedCards, persistedLocalCards, pendingLocalCards);
+          const card = getCardById(
+            cardId,
+            syncedCards,
+            persistedLocalCards,
+            pendingLocalCards,
+            streamMandalaCards
+          );
           if (!card) return null;
           const source = detectCardSource(cardId, syncedCards, persistedLocalCards, card);
           return { card, source, cellIndex: -1, levelId: 'scratchpad', mandalaId: null };
@@ -1249,7 +1372,16 @@ export function useCardOrchestrator(
         }
       );
     },
-    [syncedCards, persistedLocalCards, pendingLocalCards, batchMoveCards, toast, t]
+    [
+      syncedCards,
+      persistedLocalCards,
+      pendingLocalCards,
+      streamMandalaCards,
+      resolveStreamCardId,
+      batchMoveCards,
+      toast,
+      t,
+    ]
   );
 
   // Save note

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
@@ -20,6 +20,7 @@
 import { useTranslation } from 'react-i18next';
 import { AlertCircle, Bookmark, Check, Loader2, RotateCw, X } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
+import { decodeHtmlEntities } from '@/shared/lib/decode-html-entities';
 import { formatRelativeDate } from '@/shared/lib/format-date';
 import { formatDuration, formatViewCount } from '@/shared/lib/format-number';
 import { handleThumbnailError, handleThumbnailLoad } from '@/shared/lib/image-utils';
@@ -286,7 +287,7 @@ function CardItem({
             isPicked && 'text-muted-foreground'
           )}
         >
-          {card.title}
+          {decodeHtmlEntities(card.title)}
         </h4>
         {card.channel && (
           <p className="text-[9.5px] text-muted-foreground line-clamp-1">{card.channel}</p>

--- a/frontend/src/widgets/mandala-grid/ui/MandalaCell.tsx
+++ b/frontend/src/widgets/mandala-grid/ui/MandalaCell.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo, useState, useCallback } from 'react';
 import { cn } from '@/shared/lib/utils';
+import { decodeHtmlEntities } from '@/shared/lib/decode-html-entities';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 import { GripVertical, Plus, Play, FileText, Link as LinkIcon } from 'lucide-react';
 import {
@@ -103,10 +104,12 @@ function TileTooltipContent({
           <Play className="w-5 h-5 text-primary/30" />
         </div>
       )}
-      {/* Title — below thumbnail */}
+      {/* Title — below thumbnail. decodeHtmlEntities defends against YouTube
+          snippet.title entity-escaped rows the BE backfill hasn't reached yet
+          (DB trigger handles new writes; this is render-time defence). */}
       <div className="px-2.5 py-2">
         <p className="text-[11px] font-medium leading-snug line-clamp-2 text-foreground/85">
-          {card.title}
+          {decodeHtmlEntities(card.title)}
         </p>
       </div>
     </TooltipContent>

--- a/prisma/migrations/user-video-states-guards/002_allow_intentional_scratchpad_move.sql
+++ b/prisma/migrations/user-video-states-guards/002_allow_intentional_scratchpad_move.sql
@@ -1,0 +1,77 @@
+-- =========================================================================
+-- Regression fix (CP489, 2026-05-29):
+--   The 001_protect_cell_index_regression.sql trigger (PR #676, CP474,
+--   2026-05-19) blocks ANY `cell_index >= 0 -> -1` UPDATE at the DB
+--   boundary to prevent the `cards.ts /like` ON CONFLICT bookmark-data-loss
+--   incident. The original comment promised a dedicated `/unpin-cell`
+--   endpoint as the bypass for intentional scratchpad demotion, but that
+--   endpoint was never implemented — so every legitimate scratchpad/delete
+--   move (handleScratchPadCardDrop / handleScratchPadMultiCardDrop /
+--   handleDeleteCards isInMandala) has been silently failing since 5/19.
+--
+--   User-reported symptom (CP489): "12개 카드 selected -> 아이디어스팟 drag
+--   -> toast '12개 이동' but only 1 card actually moved". BE log showed 11x
+--   `code 23514 cell_index regression blocked: was=4 new=-1`. The 1 success
+--   was a local/pending card (user_local_cards table, no trigger).
+--
+--   This migration internalises the SQL comment's promise INTO the trigger
+--   itself: the trigger now skips the regression check when the UPDATE
+--   carries the full intentional-demotion signature
+--   (`level_id='scratchpad' AND mandala_id IS NULL`). Silent stranding
+--   (cell_index=-1 alone, level_id retained, mandala_id retained) is still
+--   blocked — the original protection intent is preserved.
+--
+-- Allowed transitions:
+--   * INSERT with any cell_index (including -1)                  — fine (unchanged).
+--   * UPDATE cell_index from -1 to >= 0                          — fine (place a card; unchanged).
+--   * UPDATE cell_index from >= 0 to >= 0 (move between cells)   — fine (unchanged).
+--   * UPDATE cell_index from >= 0 to -1
+--       WITH level_id='scratchpad' AND mandala_id IS NULL        — fine (intentional demote; NEW).
+--   * UPDATE cell_index from >= 0 to -1
+--       WITHOUT the full demote signature                        — BLOCKED (silent stranding).
+--
+-- All current FE/BE/EF callers that demote a card to scratchpad already
+-- set the full 4-tuple (cell_index=-1 + is_in_ideation + level_id='scratchpad'
+-- + mandala_id=NULL) — verified by exhaustive grep before authoring this
+-- migration:
+--   * useCardOrchestrator.ts:1270-1273 (handleScratchPadCardDrop synced)
+--   * useCardOrchestrator.ts:1322 (handleScratchPadMultiCardDrop batchItems)
+--     -> useBatchMoveCards.ts:53-66 batch-update-video-state EF item
+--   * useCardOrchestrator.ts:1477-1480 (handleDeleteCards isInMandala)
+--
+-- Apply (local):
+--   docker exec -i supabase-db-dev psql -U postgres -d postgres \
+--     -f prisma/migrations/user-video-states-guards/002_allow_intentional_scratchpad_move.sql
+--
+-- Apply (prod): handled by CI/CD deploy.yml schema-sync step. CREATE OR
+-- REPLACE FUNCTION is idempotent — safe to re-apply.
+-- =========================================================================
+
+CREATE OR REPLACE FUNCTION public.protect_cell_index_regression()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.cell_index IS NOT NULL
+     AND OLD.cell_index >= 0
+     AND NEW.cell_index = -1
+     -- Allow intentional scratchpad/delete demotion: the explicit pair
+     -- (level_id='scratchpad' AND mandala_id IS NULL) signals a UI-driven
+     -- move via handleScratchPadCardDrop / handleScratchPadMultiCardDrop /
+     -- handleDeleteCards. Silent stranding (cell_index=-1 alone) still
+     -- blocked.
+     AND NOT (NEW.level_id = 'scratchpad' AND NEW.mandala_id IS NULL)
+  THEN
+    RAISE EXCEPTION
+      'cell_index regression blocked: was=% new=% (set level_id=scratchpad + mandala_id=NULL together to demote intentionally; partial UPSERT still blocked)',
+      OLD.cell_index, NEW.cell_index
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- Trigger row binding is unchanged (FOR EACH ROW + BEFORE UPDATE + WHEN
+-- (OLD.cell_index IS DISTINCT FROM NEW.cell_index) already established
+-- by 001). Only the function body changes — CREATE OR REPLACE swaps it
+-- atomically without DROP TRIGGER / CREATE TRIGGER. Idempotent.

--- a/prisma/migrations/youtube-videos-decode-entities/001_decode_entities.sql
+++ b/prisma/migrations/youtube-videos-decode-entities/001_decode_entities.sql
@@ -1,0 +1,83 @@
+-- =========================================================================
+-- DB-level HTML entity decode for youtube_videos.title + channel_title
+--
+-- Background: YouTube Data API v3 returns `snippet.title` /
+-- `snippet.channelTitle` with HTML entities ESCAPED (`&quot;`, `&#39;`,
+-- `&amp;`, `&lt;`, etc.). FE/BE write paths store the raw entity-escaped
+-- form, so any FE render position that doesn't explicitly call
+-- `decodeHtmlEntities` displays raw `&quot;` / `&#39;` to the user (CP489
+-- user-report: image #51 MandalaCell tooltip, image #52 AddCardsList).
+--
+-- Strategy: handle the decode at the DB boundary so every consumer
+-- (FE/BE/EF/chatbot/share/export) receives clean text without per-callsite
+-- decode discipline. Idempotent — re-running on already-decoded rows is a
+-- no-op.
+--
+-- Components:
+--   1. `public.decode_html_entities(text)` — pure SQL function, idempotent.
+--   2. `public.decode_youtube_videos_titles()` — BEFORE INSERT/UPDATE
+--      trigger that auto-decodes the two columns on every write.
+--   3. One-shot backfill of existing rows that still carry entity markup.
+--
+-- Apply (local):
+--   docker exec -i supabase-db-dev psql -U postgres -d postgres \
+--     -f prisma/migrations/youtube-videos-decode-entities/001_decode_entities.sql
+--
+-- Apply (prod): handled by CI/CD deploy.yml schema-sync. CREATE OR REPLACE
+-- everywhere — safe to re-apply.
+-- =========================================================================
+
+-- ---------- 1. Pure decode function ----------
+CREATE OR REPLACE FUNCTION public.decode_html_entities(input text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+  -- Covers the 8 entities YouTube actually produces in snippet.title /
+  -- channelTitle. Mirror of frontend/src/shared/lib/decode-html-entities.ts
+  -- (CP468 origin) for parity.
+  -- IMPORTANT: '&amp;' must run LAST so we don't double-decode entities
+  -- like '&amp;quot;' → '&quot;' → '"' (good) without corrupting a literal
+  -- '&amp;' that should become a single '&'.
+  SELECT CASE
+    WHEN input IS NULL THEN NULL
+    ELSE replace(replace(replace(replace(replace(replace(replace(replace(
+      input,
+      '&quot;', '"'),
+      '&#39;',  ''''),
+      '&apos;', ''''),
+      '&#x27;', ''''),
+      '&lt;',   '<'),
+      '&gt;',   '>'),
+      '&nbsp;', ' '),
+      '&amp;',  '&')
+  END;
+$$;
+
+-- ---------- 2. BEFORE INSERT/UPDATE trigger on youtube_videos ----------
+CREATE OR REPLACE FUNCTION public.decode_youtube_videos_titles()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.title := public.decode_html_entities(NEW.title);
+  NEW.channel_title := public.decode_html_entities(NEW.channel_title);
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_decode_youtube_videos_titles ON public.youtube_videos;
+
+CREATE TRIGGER trg_decode_youtube_videos_titles
+  BEFORE INSERT OR UPDATE ON public.youtube_videos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.decode_youtube_videos_titles();
+
+-- ---------- 3. One-shot backfill of existing rows ----------
+-- Only touch rows that still carry entity markup — bounded UPDATE.
+UPDATE public.youtube_videos
+SET    title         = public.decode_html_entities(title),
+       channel_title = public.decode_html_entities(channel_title)
+WHERE  title         LIKE '%&%'
+   OR  channel_title LIKE '%&%';


### PR DESCRIPTION
## Summary

Two coupled D&D regressions + a YouTube title encoding bug + canonical D&D doc.

- **Stream-card silent drop** (PR #666 origin, 2026-05-19): `getCardById` was left on its 3-source signature when `streamMandalaCards` became the 4th merge source — every drag targeting a SSE-pushed `recommendation_cache` card silently failed for 10 days. User-visible: "12 cards selected, drag to Idea Spot, toast says 12 moved but only 1 actually moves." Fix adds the 4th source + `resolveStreamCardId` URL-based redirect at handler entry.
- **`cell_index` regression trigger blocked legitimate demotions** (PR #676 origin, 2026-05-19): the 001 trigger blocked EVERY `cell_index >= 0 → -1` to stop the bookmark-loss incident. The SQL comment promised a `/unpin-cell` bypass endpoint that was never implemented, so all scratchpad/delete moves on synced cards have been silently failing for 10 days. BE log filled with `code 23514 cell_index regression blocked`; FE toast still claimed success because it reads `batchItems.length` not BE `updatedCount`. The 002 migration adds an explicit-demote escape: trigger skips when `NEW.level_id='scratchpad' AND NEW.mandala_id IS NULL`. Silent stranding still blocked.
- **YouTube title HTML entity raw display**: `snippet.title`/`channelTitle` arrive entity-escaped (`&quot;`, `&#39;`, ...). FE had `decodeHtmlEntities` only on `InsightCardItemV2`; other render positions (MandalaCell tooltip, AddCardsList) showed raw `&quot;`. Fix handles the decode at the DB boundary (PG function + BEFORE INSERT/UPDATE trigger + 121-row backfill) — every future write is clean. FE adds defence at the two visible render positions.
- **`docs/dnd-system.md`** (NEW): canonical reference for D&D plumbing invariants, card source model, cell_index trigger contract, mutation path matrix, regression watchlist. Read this BEFORE touching D&D code next session.

## Files

| File | Change |
|------|--------|
| `cardUtils.ts` | `getCardById` 5th arg `streamCards` (back-compat default `[]`) |
| `useCardOrchestrator.ts` | `resolveStreamCardId` helper + handler-entry resolution + 5 callsite + deps |
| `__tests__/getCardById-stream-source.test.ts` (NEW) | 5 regression cases |
| `MandalaCell.tsx` | `decodeHtmlEntities` at tooltip title |
| `AddCardsList.tsx` | `decodeHtmlEntities` at title |
| `002_allow_intentional_scratchpad_move.sql` (NEW) | trigger demote escape clause |
| `001_decode_entities.sql` (NEW) | PG decode function + auto-decode trigger + backfill |
| `docs/dnd-system.md` (NEW) | canonical D&D architecture doc |
| `.gitignore` | 2-line negate so `youtube-videos-decode-entities/` migration ships |

## Verification

- [x] `tsc --noEmit`: 0 errors
- [x] `vitest`: 37 files / 359 tests PASS (+ 5 new regression cases)
- [x] `dnd-context-structure` smoke: 12/12 PASS (invariants unchanged)
- [x] `collision-detection` smoke: 4/4 PASS
- [x] `npm run build`: PASS
- [x] Local DB 002 applied; 12-card multi scratchpad move runs clean (user-confirmed "테스트 정상")
- [x] Local DB 001_decode_entities applied; 121-row backfill; 0 entity-encoded rows remaining (the 53 `%&%` matches are all literal text — "S&P500", "Steve Jobs & Bill Gates", etc.)

## Test plan

- [ ] After deploy, on prod (insighta.one): drag 5+ stream-origin cards (those with the cardSyncing-eligible state) from a sector to Idea Spot — all should move, toast count matches actual.
- [ ] Delete a placed card on a cell — should remove from grid (handleDeleteCards isInMandala path).
- [ ] Single-card scratchpad move on a synced card — should work without `cell_index regression blocked` errors in BE log.
- [ ] Verify YouTube videos with `"` or `'` in title now render the literal character (not `&quot;` / `&#39;`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)