### PR TITLE
fix(deploy): add CP489 D&D recovery migrations to apply-custom-sql.sh allowlist

### DIFF
--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -122,6 +122,22 @@ APPLY_FILES=(
   # calls race-safely upsert one level=0 row per mandala. CREATE UNIQUE
   # INDEX IF NOT EXISTS — idempotent.
   "prisma/migrations/center-goal-cache/001_partial_unique_level0.sql"
+  # CP489 (2026-05-29) — cell_index regression trigger demote escape.
+  # 001 (PR #676) blocked EVERY cell_index >= 0 -> -1 to stop the bookmark
+  # loss incident. 002 adds the explicit-demote escape clause (NEW
+  # level_id='scratchpad' AND mandala_id IS NULL), restoring legitimate
+  # scratchpad/delete moves. CREATE OR REPLACE FUNCTION — atomic swap,
+  # idempotent. 001 is not in this allowlist because it was applied
+  # before this script existed; new deploys re-apply 002 on top of
+  # whatever 001 left in prod, which is fine because 002 is a
+  # function-body swap that keeps the same trigger row binding.
+  "prisma/migrations/user-video-states-guards/002_allow_intentional_scratchpad_move.sql"
+  # CP489 (2026-05-29) — youtube_videos title + channel_title HTML
+  # entity decode at DB boundary. CREATE OR REPLACE FUNCTION x2 +
+  # DROP TRIGGER IF EXISTS + CREATE TRIGGER + bounded UPDATE backfill
+  # (WHERE title/channel_title LIKE '%&%'). The backfill is idempotent
+  # because the decode function is a no-op on already-decoded text.
+  "prisma/migrations/youtube-videos-decode-entities/001_decode_entities.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "


### PR DESCRIPTION
## Summary

PR #796 (CP489 D&D recovery) shipped two raw-SQL migrations but missed adding their paths to `scripts/apply-custom-sql.sh`'s strict allowlist. Result: both migrations applied on dev (manual `docker exec psql -f`) but NEVER ran on prod. User confirmed "dev OK / prod still blocking".

## fact

`gh run view 26642072990 --log | grep -i "002_allow\|decode_entities"` returns no schema-sync hits. The Database Schema Sync step's `apply-custom-sql.sh` iterates only entries in `APPLY_FILES` — anything outside that list silently skips on prod.

## Files added (in order)

1. `prisma/migrations/user-video-states-guards/002_allow_intentional_scratchpad_move.sql`
   - CREATE OR REPLACE FUNCTION — atomic body swap, idempotent.
2. `prisma/migrations/youtube-videos-decode-entities/001_decode_entities.sql`
   - CREATE OR REPLACE FUNCTION x2 + DROP TRIGGER IF EXISTS + CREATE TRIGGER + bounded UPDATE backfill (`WHERE %&%` only). Decode is a no-op on already-decoded text → re-application safe.

## Why this happened

CP488 LEVEL-3 family "raw SQL migration → deploy automation sync" — same shape as the Cross-Layer Propagation rule (grep ALL consumers). I added the migrations under `prisma/migrations/` and verified they applied locally, but did not check that `apply-custom-sql.sh` listed them. The script's allowlist is the single source of truth for which migrations actually ship to prod.

## Test plan

- [ ] After merge, deploy.yml `Database Schema Sync` log should contain both filenames.
- [ ] After deploy, on prod (insighta.one) `verify-db-tables.js` passes.
- [ ] On prod, the 002 + 001 SQL is applied (trigger function body matches CP489 003, decode trigger exists on `youtube_videos`, backfill UPDATE count > 0).
- [ ] User re-tries the cell↔cell move that was failing — should now go through without `cell_index regression blocked` errors in the BE log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)