### PR TITLE
fix(add-cards): 추가 검색 cumulative round + reset 보조 분리 (CP489+)

### DIFF
--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1895,6 +1895,7 @@
       "keywordPlaceholder": "Add keyword…",
       "removeKeyword": "Remove keyword {{keyword}}",
       "searchButton": "Search",
+      "findMoreButton": "Find more",
       "resetButton": "Reset",
       "restorePrevious": "Show previous results",
       "resultCount": "{{count}} matches",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1903,6 +1903,7 @@
       "keywordPlaceholder": "키워드 추가…",
       "removeKeyword": "키워드 {{keyword}} 제거",
       "searchButton": "검색",
+      "findMoreButton": "추가 검색",
       "resetButton": "초기화",
       "restorePrevious": "이전 결과 보기",
       "resultCount": "{{count}}개 결과",

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -323,13 +323,12 @@ export function AddCardsPanel() {
     saveSessionPicks(mandalaId, resetHistory.picks);
     setResetHistory(null);
   }, [resetHistory, mandalaId]);
-  const triggerSearch = useCallback(() => {
-    if (cards.length > 0) {
-      resetResults();
-      return;
-    }
-    runSearch();
-  }, [cards.length, resetResults, runSearch]);
+  // CP489+ — single primary button always runs a new search. When cards
+  // are present the search response appends as Round N+1 (cumulative,
+  // per setRounds PREPEND logic above). Reset is now a separate secondary
+  // action so users can explicitly clear without conflating it with the
+  // primary "find more" intent.
+  const triggerSearch = runSearch;
 
   // Race-free close: keep mount during the 200ms slide-out so the grid never flashes.
   const [isClosingLocal, setIsClosingLocal] = useState(false);
@@ -462,31 +461,35 @@ export function AddCardsPanel() {
           <AddCardsFilters />
           <TargetLevelChips />
 
-          <div className="flex items-center justify-end px-5 py-2.5 sm:px-6">
+          <div className="flex items-center justify-end gap-2 px-5 py-2.5 sm:px-6">
+            {cards.length > 0 && (
+              <button
+                type="button"
+                onClick={resetResults}
+                disabled={mutation.isPending}
+                className="inline-flex items-center gap-1 h-8 px-3 rounded-full text-[12px] font-medium text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors disabled:opacity-50"
+              >
+                <RotateCcw className="h-3.5 w-3.5" strokeWidth={2.2} />
+                <span>{t('addCards.panel.resetButton', 'Reset')}</span>
+              </button>
+            )}
             <button
               type="button"
               onClick={triggerSearch}
               disabled={mutation.isPending}
               className={cn(
                 'inline-flex items-center gap-1.5 h-8 rounded-full text-[12px] font-medium px-3.5 transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2',
-                cards.length > 0
-                  ? // Reset state — secondary tone so it reads as
-                    // "clear/return", visually distinct from "search".
-                    'bg-secondary text-secondary-foreground hover:bg-secondary/80 focus-visible:ring-foreground/20'
-                  : // Search state — primary CTA.
-                    'bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-primary/30'
+                'bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-primary/30'
               )}
             >
               {mutation.isPending ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : cards.length > 0 ? (
-                <RotateCcw className="h-3.5 w-3.5" strokeWidth={2.2} />
               ) : (
                 <Search className="h-3.5 w-3.5" strokeWidth={2.2} />
               )}
               <span>
                 {cards.length > 0
-                  ? t('addCards.panel.resetButton', 'Reset')
+                  ? t('addCards.panel.findMoreButton', 'Find more')
                   : t('addCards.panel.searchButton', 'Search')}
               </span>
             </button>
@@ -497,27 +500,31 @@ export function AddCardsPanel() {
           <div className="flex items-center gap-2 px-5 py-2 border-b border-border/40 text-[11.5px] text-muted-foreground sm:px-6">
             <Lock className="h-3 w-3 shrink-0" />
             <span className="truncate flex-1 text-foreground/80">{centerGoal || '…'}</span>
+            {cards.length > 0 && (
+              <button
+                type="button"
+                onClick={resetResults}
+                disabled={mutation.isPending}
+                className="inline-flex items-center gap-1 h-6 px-2 rounded text-[11px] text-muted-foreground hover:text-foreground hover:bg-foreground/[0.06] transition-colors"
+              >
+                <RotateCcw className="h-3 w-3" strokeWidth={2.2} />
+                <span>{t('addCards.panel.resetButton', 'Reset')}</span>
+              </button>
+            )}
             <button
               type="button"
               onClick={triggerSearch}
               disabled={mutation.isPending}
-              className={cn(
-                'inline-flex items-center gap-1 h-6 px-2 rounded text-[11px] transition-colors',
-                cards.length > 0
-                  ? 'text-foreground/80 hover:bg-foreground/[0.06]'
-                  : 'text-foreground hover:bg-foreground/[0.06]'
-              )}
+              className="inline-flex items-center gap-1 h-6 px-2 rounded text-[11px] text-foreground hover:bg-foreground/[0.06] transition-colors"
             >
               {mutation.isPending ? (
                 <Loader2 className="h-3 w-3 animate-spin" />
-              ) : cards.length > 0 ? (
-                <RotateCcw className="h-3 w-3" strokeWidth={2.2} />
               ) : (
                 <Search className="h-3 w-3" strokeWidth={2.2} />
               )}
               <span>
                 {cards.length > 0
-                  ? t('addCards.panel.resetButton', 'Reset')
+                  ? t('addCards.panel.findMoreButton', 'Find more')
                   : t('addCards.panel.searchButton', 'Search')}
               </span>
             </button>

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -107,6 +107,13 @@ export function AddCardsPanel() {
 
   // Server-truth set of mandala-pre-existing videoIds. Used as a list
   // filter (not an overlay) to cover the localStorage-restored path.
+  //
+  // CP489+ — Explicit > Inferred (v0 decision #2) applied here too: wizard
+  // pre-fill rows (auto_added=true with no engagement) are NOT treated as
+  // "picked". Without this, every new candidate that happens to also be in
+  // the wizard pre-fill set is shown with the "추가됨" overlay even though
+  // the user never engaged with it. Mirrors the backend exclude policy
+  // (modules/exclude/excluded-videos.ts).
   const { data: allVideoStates } = useAllVideoStates();
   const serverPickedSet = useMemo(() => {
     if (!mandalaId) return new Set<string>();
@@ -114,7 +121,16 @@ export function AddCardsPanel() {
     for (const s of allVideoStates ?? []) {
       if (s.mandala_id !== mandalaId) continue;
       const yvid = s.video?.youtube_video_id;
-      if (yvid) set.add(yvid);
+      if (!yvid) continue;
+      const isWizardGhost =
+        s.auto_added === true &&
+        s.is_watched === false &&
+        s.is_in_ideation === false &&
+        !s.user_note &&
+        (s.watch_position_seconds ?? 0) === 0 &&
+        !s.pinned_at;
+      if (isWizardGhost) continue;
+      set.add(yvid);
     }
     return set;
   }, [allVideoStates, mandalaId]);


### PR DESCRIPTION
## Summary

User-reported UX bug: clicking the search button after first round wipes all rounds instead of accumulating Round 2/3/N. The backend's \`setRounds\` PREPEND logic was dead code — UI never reached it.

## Root cause

\`AddCardsPanel.tsx:326-332\` had a dual-mode primary button:
\`\`\`ts
const triggerSearch = useCallback(() => {
  if (cards.length > 0) {
    resetResults();   // wipe!
    return;
  }
  runSearch();
}, [...]);
\`\`\`

So users got: click → Round 1 → click again → empty → click → fresh Round 1 (no accumulation).

## Fix

| Before | After |
|---|---|
| 1 button, dual-mode | 2 buttons: primary (search/find more) + secondary (reset) |
| Reset hidden inside primary | Reset visible only when cards exist, secondary tone |
| Dead PREPEND logic | Primary always runs new search → BE PREPENDs as Round N+1 |

### Labels
- ko: "검색" → cards 없을 때 / "추가 검색" → cards 있을 때 / "초기화" → 보조
- en: "Search" → empty / "Find more" → cards present / "Reset" → secondary

### Files
- \`frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx\` — triggerSearch 단순화 + 보조 reset 버튼 추가 (collapsed header 동일 패턴)
- \`frontend/src/shared/i18n/locales/{ko,en}.json\` — \`findMoreButton\` 추가

## User scenario after fix

1. Click → Round 1 (N cards)
2. Click "추가 검색" → Round 2 prepended, Round 1 preserved
3. Click "추가 검색" → Round 3 prepended (cumulative across rounds)
4. Explicit "초기화" → 모든 round 삭제 (이전 결과 보기 undo 가능)

## Backend compatibility (PR #788)

매 round 의 cards 가 자연스럽게 \`surfaced\` 신호로 기록 → reuse-priority-boost 가 진짜 활용 (이전엔 도달 불가).

## Out of scope
- Round divider visualization tuning
- Per-round timestamp display polish
- Visual aging of older rounds (opacity 0.7 등)

## Test plan
- [x] tsc --noEmit clean
- [ ] CI green
- [ ] Deploy
- [ ] User Add Cards 1차 → Round 1 표시
- [ ] User "추가 검색" → Round 2 prepended (Round 1 below, visible)
- [ ] User "초기화" → 모든 round 삭제 + "이전 결과 보기" undo 보임

🤖 Generated with [Claude Code](https://claude.com/claude-code)