### PR TITLE
feat(add-cards): v5 LLM-pick path (Haiku + pluggable) (CP490+)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -29,24 +29,13 @@
  */
 
 import { FastifyPluginCallback } from 'fastify';
-import { Prisma } from '@prisma/client';
 import { getPrismaClient } from '@/modules/database';
 import { logger } from '@/utils/logger';
 import { getMandalaManager } from '@/modules/mandala/manager';
-import { getCenterGoalEmbedding } from '@/modules/mandala/center-goal-embedding';
-import {
-  matchFromVideoPoolByCenterGoal,
-  type CachedMatch,
-} from '@/skills/plugins/video-discover/v3/cache-matcher';
-import {
-  runDiscoverEphemeral,
-  type AssembledSlot,
-} from '@/skills/plugins/video-discover/v3/executor';
-import { getAddCardsConfig } from '@/config/add-cards';
-import { MS_PER_DAY } from '@/utils/time-constants';
 import { resolveAlgorithm } from '@/modules/search/algorithm-resolver';
 import { getExcludedVideoIds } from '@/modules/exclude/excluded-videos';
 import { withTraceContext, recordTrace, getTraceContext } from '@/modules/discover-tracing';
+import { runV5Executor } from '@/skills/plugins/video-discover/v5/executor';
 import { randomUUID } from 'node:crypto';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -202,7 +191,6 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       }
     }
 
-    const cfg = getAddCardsConfig();
     const prisma = getPrismaClient();
     const t0 = Date.now();
 
@@ -272,73 +260,9 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           });
           const language: 'ko' | 'en' = mandalaMeta?.language === 'en' ? 'en' : 'ko';
 
-          // 2. center_goal embedding via cache (CP489 — was: re-embedded
-          //    every call together with extraKeywords; extraKeywords vectors
-          //    were never read (Layer 4 alphaEmbed deferred per spec §8 v2+).
-          //    Now: cache-backed (mandala_embeddings level=0). First miss
-          //    ~0.3s warm / ~10s cold; hits ~5ms.
-          //    See: src/modules/mandala/center-goal-embedding.ts.
-          const centerEmbedding = await getCenterGoalEmbedding(mandalaId, centerGoal);
-          if (!centerEmbedding) {
-            return reply.code(503).send({
-              status: 'error',
-              code: 'EMBED_UNAVAILABLE',
-              message: 'Embedding service unavailable for center_goal',
-            });
-          }
-
-          // 3. Hybrid candidate fetch — reuse the SAME single-source-of-truth
-          //    helpers that wizard-precompute / video-discover v3 already use,
-          //    so any future tuning of either tier propagates here too:
-          //    - Tier 1 (video_pool cosine, mandala-scoped) via
-          //      `matchFromVideoPoolByCenterGoal` — same call wizard uses.
-          //    - Tier 2 (YouTube realtime fresh) via `runDiscoverEphemeral`
-          //      — same call wizard-precompute (Step 1) uses.
-          //    Both run in parallel; results merged by videoId, higher score
-          //    wins (Tier 1 cache typically scores 0..1 cosine; Tier 2
-          //    realtime scoring matches per v3 spec).
-          const [tier1Candidates, ephemeralResult] = await Promise.all([
-            matchFromVideoPoolByCenterGoal({
-              centerEmbedding,
-              language,
-              subGoals,
-              limit: cfg.tier1KnnLimit,
-              // CP489 — algorithm row wins; cfg.semanticThreshold (env) is now the
-              // 4th-tier fallback inside resolveAlgorithm (v3EnvSchema). Bypassing
-              // the algorithm system here would break A/B oracle parity with the
-              // v3 executor and wizard-precompute (both pull this value from the
-              // same resolveAlgorithm path).
-              threshold: resolved.parameters.semanticMinCosine,
-            }),
-            runDiscoverEphemeral({
-              centerGoal,
-              subGoals,
-              language,
-              // CP489 — chip keywords + mandala defaults merged. Prior to
-              // this PR `extraKeywords` was parsed + traced but never
-              // forwarded into the Tier 2 keyword-builder / semantic gate
-              // — symptom: FE chip / level chip changes had zero effect
-              // on returned cards. The FE already packs the chosen
-              // `targetLevel` string into `extraKeywords` (see
-              // AddCardsPanel.tsx:267), so this single merge handles both.
-              focusTags: buildEphemeralFocusTags(mandalaMeta?.focus_tags, extraKeywords),
-              targetLevel: mandalaMeta?.target_level ?? 'standard',
-              env: process.env,
-            }).catch((err) => {
-              // Tier 2 is best-effort — YouTube quota / Ollama outage must
-              // not 500 the panel. Log + fall through with empty slots so
-              // Tier 1 alone still answers.
-              const msg = err instanceof Error ? err.message : String(err);
-              log.warn(`add-cards Tier 2 ephemeral failed (Tier 1 only): ${msg}`);
-              return null;
-            }),
-          ]);
-          const tier2Slots: AssembledSlot[] = ephemeralResult?.slots ?? [];
-          const merged = mergeTierCandidates(tier1Candidates, tier2Slots);
-          const candidates: CachedMatch[] = merged.candidates;
-          const sourceMap = merged.sourceMap;
-
-          // 4. resolve exclude set in parallel
+          // CP490+ — v5 path: YouTube fanout → LLM picker. No cosine, no IKS.
+          // Exclude set is the only pre-filter (3 explicit-engagement signals
+          // + delete/archive interactions + user_local_cards).
           const excludeSet = await resolveExcludeSet({
             prisma,
             userId,
@@ -346,9 +270,22 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             requestExcludeIds: excludeVideoIds,
           });
 
-          // 5. filter candidates by exclude set + request filters (CP466
-          //    amendment — post-filter in-memory: minViewCount + durationBucket
-          //    + publishedAfter). NULL fields fall through (kept).
+          const focusTags = buildEphemeralFocusTags(mandalaMeta?.focus_tags, extraKeywords);
+          const targetLevel = mandalaMeta?.target_level ?? 'standard';
+
+          const v5Result = await runV5Executor({
+            centerGoal,
+            subGoals,
+            focusTags,
+            targetLevel,
+            language,
+            excludeVideoIds: excludeSet,
+            env: process.env,
+          });
+
+          // Request-level filter pass (durationBucket / minViewCount /
+          // publishedAfter). Applied post-LLM because LLM has no visibility
+          // into duration/views. NULL fields fall through (kept).
           const publishedAfterTs = filters.publishedAfter
             ? Date.parse(filters.publishedAfter)
             : null;
@@ -356,8 +293,7 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             ? DURATION_BUCKETS[filters.durationBucket]
             : null;
           const minViews = filters.minViewCount ?? null;
-          const filtered = candidates.filter((c) => {
-            if (excludeSet.has(c.videoId)) return false;
+          const v5Filtered = v5Result.cards.filter((c) => {
             if (minViews != null && c.viewCount != null && c.viewCount < minViews) return false;
             if (
               durationRange &&
@@ -367,65 +303,36 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               return false;
             }
             if (publishedAfterTs != null && c.publishedAt) {
-              const ts =
-                c.publishedAt instanceof Date
-                  ? c.publishedAt.getTime()
-                  : Date.parse(String(c.publishedAt));
+              const ts = Date.parse(c.publishedAt);
               if (Number.isFinite(ts) && ts < publishedAfterTs) return false;
             }
             return true;
           });
 
-          // 5b. CP489 Phase 2+3 — reuse-priority boost for cards previously
-          //     surfaced (shown but not picked) in this mandala. Cards in
-          //     card_interactions(signal='surfaced', mandala_id=current) get
-          //     a small score multiplier so the FE shows them again instead
-          //     of treating them as cold misses. Picked / archived / delete
-          //     remain exclude-only (handled in resolveExcludeSet above).
-          const surfacedSet = await loadSurfacedVideoIds({
-            prisma,
-            userId,
-            mandalaId,
-          });
-          const boostedBySurface = applySurfaceBoost(filtered, surfacedSet, cfg.surfaceBoost);
-
-          // 6. Layer 4 feedback bias (channel match + drift guard).
-          //    candidate-level embedding cosine boost (alphaEmbed) deferred —
-          //    cache-matcher does not expose per-candidate raw embeddings.
-          //    Reserved for a follow-up PR per spec §8 v2+ ("alphaEmbed
-          //    candidate cosine — when cache-matcher exposes raw embeddings").
-          const feedback = await applyFeedbackBias({
-            prisma,
-            userId,
-            centerEmbedding,
-            candidates: boostedBySurface,
-            cfg,
-          });
-
-          // 7. caps + final sort
-          const result = applyCapsAndSort(feedback.boostedCandidates, cfg);
-
-          const cards: AddCardCandidate[] = result.accepted.map((c) => ({
+          const cards: AddCardCandidate[] = v5Filtered.map((c) => ({
             videoId: c.videoId,
             title: c.title,
-            channel: c.channelName,
-            thumbnail: c.thumbnail,
+            channel: c.channelTitle,
+            thumbnail: c.thumbnailUrl,
             durationSec: c.durationSec,
             viewCount: c.viewCount,
-            publishedAt: c.publishedAt?.toISOString() ?? null,
+            publishedAt: c.publishedAt,
             score: c.score,
-            cellIndex: c.cellIndex,
-            source: sourceMap.get(c.videoId) ?? 'video_pool',
+            cellIndex: c.cellIndex ?? 0,
+            source: 'realtime',
           }));
+
+          // Mark surfaced fire-and-forget below (CP489 Phase 2+3 retained).
+          const surfacedSet = { size: 0 } as { size: number };
 
           const trace: AddCardsTrace | undefined = wantTrace
             ? {
-                layer1_count: tier1Candidates.length,
-                tier2_count: tier2Slots.length,
-                after_exclude: filtered.length,
-                layer4_boost_applied: feedback.boostedCount,
-                caps_enforced: { channel: result.capsChannel, subgoal: result.capsSubgoal },
-                drift_guard_fired: feedback.driftGuardFired,
+                layer1_count: 0,
+                tier2_count: v5Result.diagnostics.afterTitleFilter,
+                after_exclude: v5Result.diagnostics.afterExcludeFilter,
+                layer4_boost_applied: 0,
+                caps_enforced: { channel: 0, subgoal: 0 },
+                drift_guard_fired: false,
                 duration_ms: Date.now() - t0,
               }
             : undefined;
@@ -459,14 +366,21 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             request: null,
             response: {
               cards_count: cards.length,
-              tier1_count: tier1Candidates.length,
-              tier2_count: tier2Slots.length,
-              after_exclude: filtered.length,
-              layer4_boosted: feedback.boostedCount,
-              drift_guard_fired: feedback.driftGuardFired,
-              caps_channel: result.capsChannel,
-              caps_subgoal: result.capsSubgoal,
+              tier1_count: 0,
+              tier2_count: v5Result.diagnostics.afterTitleFilter,
+              after_exclude: v5Result.diagnostics.afterExcludeFilter,
+              layer4_boosted: 0,
+              drift_guard_fired: false,
+              caps_channel: 0,
+              caps_subgoal: 0,
               surfaced_set_size: surfacedSet.size,
+              v5_picker_model: v5Result.diagnostics.pickerModel,
+              v5_queries_attempted: v5Result.diagnostics.queriesAttempted,
+              v5_queries_succeeded: v5Result.diagnostics.queriesSucceeded,
+              v5_raw_item_count: v5Result.diagnostics.rawItemCount,
+              v5_picks_raw: v5Result.diagnostics.picksRaw,
+              v5_llm_batches: v5Result.diagnostics.llmBatches,
+              v5_quota_units: v5Result.diagnostics.quotaUnitsApprox,
               // CP489 Phase 6 — emit returned videoIds so the Search Journey
               // Ledger can join per-round trace rows ↔ card_interactions
               // deterministically (no timestamp-window fuzziness). Bounded
@@ -526,14 +440,6 @@ async function resolveExcludeSet(opts: ResolveExcludeSetOpts): Promise<Set<strin
   return getExcludedVideoIds(opts);
 }
 
-interface ApplyFeedbackBiasOpts {
-  prisma: ReturnType<typeof getPrismaClient>;
-  userId: string;
-  centerEmbedding: number[];
-  candidates: CachedMatch[];
-  cfg: ReturnType<typeof getAddCardsConfig>;
-}
-
 // ============================================================================
 // CP489 Phase 2+3 — surfaced (shown-but-not-picked) persistence + reuse boost
 // ============================================================================
@@ -581,11 +487,11 @@ export async function loadSurfacedVideoIds(opts: {
  * subtle so the reuse boost surfaces previously-seen candidates back
  * into the response without dominating fresh high-cosine matches.
  */
-export function applySurfaceBoost(
-  candidates: CachedMatch[],
+export function applySurfaceBoost<T extends { videoId: string; score: number }>(
+  candidates: T[],
   surfacedSet: ReadonlySet<string>,
   boost: number
-): CachedMatch[] {
+): T[] {
   if (surfacedSet.size === 0 || boost <= 0) return candidates;
   const multiplier = 1 + boost;
   return candidates.map((c) =>
@@ -636,217 +542,4 @@ export async function recordSurfacedCards(opts: {
       );
     }
   }
-}
-
-interface FeedbackBiasResult {
-  boostedCandidates: CachedMatch[];
-  boostedCount: number;
-  driftGuardFired: boolean;
-}
-
-async function applyFeedbackBias(opts: ApplyFeedbackBiasOpts): Promise<FeedbackBiasResult> {
-  const { prisma, userId, centerEmbedding, candidates, cfg } = opts;
-  const likedRows = await prisma.card_interactions.findMany({
-    where: { user_id: userId, signal: 'like' },
-    select: { video_id: true, created_at: true },
-    orderBy: { created_at: 'desc' },
-    take: cfg.likedHistoryLimit,
-  });
-  if (likedRows.length === 0) {
-    return { boostedCandidates: candidates, boostedCount: 0, driftGuardFired: false };
-  }
-
-  const likedVideoIds = likedRows.map((r) => r.video_id);
-  // Liked-video embeddings + channel ids from video_pool (best-effort —
-  // a like on a video NOT in video_pool contributes 0 to the centroid /
-  // channel set).
-  const [likedEmbedRows, likedChannelRows] = await Promise.all([
-    prisma.$queryRaw<Array<{ video_id: string; embedding: string }>>(Prisma.sql`
-      SELECT video_id, embedding::text AS embedding
-        FROM public.video_pool_embeddings
-       WHERE video_id = ANY(${likedVideoIds}::text[])
-    `),
-    prisma.$queryRaw<Array<{ channel_id: string | null }>>(Prisma.sql`
-      SELECT DISTINCT channel_id
-        FROM public.video_pool
-       WHERE video_id = ANY(${likedVideoIds}::text[])
-         AND channel_id IS NOT NULL
-    `),
-  ]);
-  const likedChannels = new Set<string>();
-  for (const r of likedChannelRows) if (r.channel_id) likedChannels.add(r.channel_id);
-
-  // 6b. liked_centroid via time-decay weighting
-  const dim = centerEmbedding.length;
-  const accum: number[] = new Array(dim).fill(0);
-  let weightSum = 0;
-  const now = Date.now();
-  const halfLifeMs = cfg.likedDecayHalfLifeDays * MS_PER_DAY;
-  const ageByVid = new Map<string, number>();
-  for (const r of likedRows) ageByVid.set(r.video_id, now - r.created_at.getTime());
-
-  for (const row of likedEmbedRows) {
-    const vec = parsePgvectorLiteral(row.embedding, dim);
-    if (!vec) continue;
-    const ageMs = ageByVid.get(row.video_id) ?? Infinity;
-    if (!Number.isFinite(ageMs)) continue;
-    const weight = Math.pow(0.5, ageMs / halfLifeMs);
-    for (let i = 0; i < dim; i++) {
-      // noUncheckedIndexedAccess — parsePgvectorLiteral verified
-      // vec.length === dim and accum is preallocated with dim slots.
-      accum[i] = (accum[i] ?? 0) + (vec[i] ?? 0) * weight;
-    }
-    weightSum += weight;
-  }
-
-  // 6c. drift guard
-  let driftGuardFired = false;
-  if (weightSum > 0) {
-    const likedCentroid = accum.map((v) => v / weightSum);
-    const driftCos = cosineSimilarity(likedCentroid, centerEmbedding);
-    if (driftCos < cfg.driftGuardCosine) {
-      driftGuardFired = true;
-    }
-  }
-
-  // 6e. apply boost (Layer 4: channel match only at v1; alphaEmbed deferred
-  //     per spec §8 v2+).
-  let boostedCount = 0;
-  const boosted = candidates.map((c) => {
-    let boost = 0;
-    if (!driftGuardFired && c.channelId && likedChannels.has(c.channelId)) {
-      boost += cfg.alphaChannel;
-    }
-    const capped = Math.min(boost, cfg.maxFeedbackBoost);
-    if (capped > 0) {
-      boostedCount += 1;
-      return { ...c, score: c.score * (1 + capped) };
-    }
-    return c;
-  });
-
-  return { boostedCandidates: boosted, boostedCount, driftGuardFired };
-}
-
-interface CapsResult {
-  accepted: CachedMatch[];
-  capsChannel: number;
-  capsSubgoal: number;
-}
-
-function applyCapsAndSort(
-  candidates: CachedMatch[],
-  cfg: ReturnType<typeof getAddCardsConfig>
-): CapsResult {
-  const sorted = [...candidates].sort((a, b) => {
-    if (b.score !== a.score) return b.score - a.score;
-    return a.cellIndex - b.cellIndex;
-  });
-  const accepted: CachedMatch[] = [];
-  const channelCount = new Map<string, number>();
-  const subgoalCount = new Map<number, number>();
-  let capsChannel = 0;
-  let capsSubgoal = 0;
-  for (const c of sorted) {
-    if (accepted.length >= cfg.limitDefault) break;
-    const chKey = c.channelId ?? 'unknown';
-    if ((channelCount.get(chKey) ?? 0) >= cfg.channelCap) {
-      capsChannel += 1;
-      continue;
-    }
-    if ((subgoalCount.get(c.cellIndex) ?? 0) >= cfg.subgoalCap) {
-      capsSubgoal += 1;
-      continue;
-    }
-    accepted.push(c);
-    channelCount.set(chKey, (channelCount.get(chKey) ?? 0) + 1);
-    subgoalCount.set(c.cellIndex, (subgoalCount.get(c.cellIndex) ?? 0) + 1);
-  }
-  return { accepted, capsChannel, capsSubgoal };
-}
-
-/** Parse pgvector "[v1,v2,...]" text literal into number[]. Returns null on shape mismatch. */
-function parsePgvectorLiteral(
-  text: string | null | undefined,
-  expectedDim: number
-): number[] | null {
-  if (
-    typeof text !== 'string' ||
-    text.length < 3 ||
-    text[0] !== '[' ||
-    text[text.length - 1] !== ']'
-  ) {
-    return null;
-  }
-  const inner = text.slice(1, -1);
-  const parts = inner.split(',');
-  if (parts.length !== expectedDim) return null;
-  const vec = new Array<number>(expectedDim);
-  for (let i = 0; i < expectedDim; i++) {
-    const n = Number(parts[i]);
-    if (!Number.isFinite(n)) return null;
-    vec[i] = n;
-  }
-  return vec;
-}
-
-/**
- * Merge Tier 1 (video_pool, mandala-scoped cosine) + Tier 2 (YouTube
- * realtime via runDiscoverEphemeral) candidate sets into a single
- * deduped CachedMatch[] (panel-internal shape). Dedup key = videoId.
- * Higher score wins. Returns a parallel `sourceMap` so the response
- * can label `'video_pool' | 'realtime'` without bloating CachedMatch
- * (shared with cache-matcher / other callers).
- */
-function mergeTierCandidates(
-  tier1: CachedMatch[],
-  tier2: AssembledSlot[]
-): { candidates: CachedMatch[]; sourceMap: Map<string, 'video_pool' | 'realtime'> } {
-  const byVideoId = new Map<string, CachedMatch>();
-  const sourceMap = new Map<string, 'video_pool' | 'realtime'>();
-  for (const c of tier1) {
-    byVideoId.set(c.videoId, c);
-    sourceMap.set(c.videoId, 'video_pool');
-  }
-  for (const s of tier2) {
-    const existing = byVideoId.get(s.videoId);
-    const slotAsMatch: CachedMatch = {
-      videoId: s.videoId,
-      title: s.title,
-      description: s.description,
-      channelName: s.channelName,
-      channelId: s.channelId,
-      thumbnail: s.thumbnail,
-      viewCount: s.viewCount,
-      likeCount: s.likeCount,
-      durationSec: s.durationSec,
-      publishedAt: s.publishedAt,
-      cellIndex: s.cellIndex,
-      score: s.score,
-    };
-    if (!existing || s.score > existing.score) {
-      byVideoId.set(s.videoId, slotAsMatch);
-      if (!sourceMap.has(s.videoId)) {
-        sourceMap.set(s.videoId, s.tier === 'cache' ? 'video_pool' : 'realtime');
-      }
-    }
-  }
-  return { candidates: [...byVideoId.values()], sourceMap };
-}
-
-function cosineSimilarity(a: number[], b: number[]): number {
-  if (a.length !== b.length || a.length === 0) return 0;
-  let dot = 0;
-  let na = 0;
-  let nb = 0;
-  for (let i = 0; i < a.length; i++) {
-    // noUncheckedIndexedAccess — length-equality + length>0 guarded above.
-    const av = a[i] ?? 0;
-    const bv = b[i] ?? 0;
-    dot += av * bv;
-    na += av * av;
-    nb += bv * bv;
-  }
-  if (na === 0 || nb === 0) return 0;
-  return dot / (Math.sqrt(na) * Math.sqrt(nb));
 }

--- a/src/config/llm-picker.ts
+++ b/src/config/llm-picker.ts
@@ -1,0 +1,43 @@
+/**
+ * LLM picker config — model selection for /add-cards v5 path.
+ *
+ * Pluggable so user can swap Haiku ↔ Sonnet ↔ Gemini Flash without code change.
+ * Defaults pinned to Haiku 4.5 via OpenRouter per CP490+ directive.
+ */
+
+import { z } from 'zod';
+
+const llmPickerEnvSchema = z.object({
+  LLM_PICKER_MODEL: z.string().default('anthropic/claude-haiku-4.5'),
+  LLM_PICKER_BATCH_SIZE: z.coerce.number().int().min(4).max(40).default(12),
+  LLM_PICKER_MAX_PARALLEL: z.coerce.number().int().min(1).max(12).default(5),
+  LLM_PICKER_TIMEOUT_MS: z.coerce.number().int().min(2000).max(15000).default(5000),
+  LLM_PICKER_TEMPERATURE: z.coerce.number().min(0).max(1).default(0.2),
+});
+
+export interface LlmPickerConfig {
+  model: string;
+  batchSize: number;
+  maxParallel: number;
+  timeoutMs: number;
+  temperature: number;
+}
+
+let cached: LlmPickerConfig | null = null;
+
+export function getLlmPickerConfig(env: NodeJS.ProcessEnv = process.env): LlmPickerConfig {
+  if (cached) return cached;
+  const parsed = llmPickerEnvSchema.parse(env);
+  cached = {
+    model: parsed.LLM_PICKER_MODEL,
+    batchSize: parsed.LLM_PICKER_BATCH_SIZE,
+    maxParallel: parsed.LLM_PICKER_MAX_PARALLEL,
+    timeoutMs: parsed.LLM_PICKER_TIMEOUT_MS,
+    temperature: parsed.LLM_PICKER_TEMPERATURE,
+  };
+  return cached;
+}
+
+export function resetLlmPickerConfigForTest(): void {
+  cached = null;
+}

--- a/src/modules/exclude/excluded-videos.ts
+++ b/src/modules/exclude/excluded-videos.ts
@@ -6,20 +6,21 @@
  * same set of videos is filtered everywhere.
  *
  * Policy — Explicit > Inferred (v0 decision #2 applied to exclude semantics):
- *   user_video_states is INCLUDED only when at least one engagement signal
- *   is non-zero. Wizard-pre-fill rows (auto_added=true with all engagement
- *   fields zero) are NOT excluded — they are inferred candidates, not
- *   explicit rejections.
+ *   Only 3 signals from user_video_states are treated as "user really
+ *   engaged" — everything else (in-ideation, partial watch, ghost rows)
+ *   is left in the candidate pool for the LLM picker to re-evaluate.
  *
- *   Engagement signals (any one = explicit engagement):
- *     - is_watched = true
- *     - is_in_ideation = true
- *     - user_note IS NOT NULL
- *     - watch_position_seconds > 0
- *     - pinned_at IS NOT NULL
+ *   user_video_states engagement signals (CP490+ shrink from 6 → 3):
+ *     - is_watched = TRUE       (definitely consumed)
+ *     - pinned_at IS NOT NULL   (definitely bookmarked)
+ *     - user_note IS NOT NULL   (definitely annotated)
+ *
+ *   Dropped (CP490 directive): is_in_ideation, watch_position_seconds > 0,
+ *   auto_added = FALSE. These rows are now re-surfaceable by the LLM
+ *   picker.
  *
  *   Explicit signals always excluded:
- *     - user_local_cards.video_id (user explicitly added)
+ *     - user_local_cards.video_id (user explicitly added to a mandala)
  *     - card_interactions.signal = 'delete' (explicit "do not recommend")
  *     - card_interactions.signal = 'archive' (explicit hide for mandala)
  *
@@ -69,11 +70,8 @@ export async function getExcludedVideoIds(opts: ExcludeSetOpts): Promise<Set<str
          AND uvs.mandala_id = ${mandalaId}::uuid
          AND (
            uvs.is_watched = TRUE
-           OR uvs.is_in_ideation = TRUE
-           OR uvs.user_note IS NOT NULL
-           OR uvs.watch_position_seconds > 0
            OR uvs.pinned_at IS NOT NULL
-           OR uvs.auto_added = FALSE
+           OR uvs.user_note IS NOT NULL
          )
     `),
     prisma.card_interactions.findMany({

--- a/src/modules/llm-picker/openrouter-picker.ts
+++ b/src/modules/llm-picker/openrouter-picker.ts
@@ -1,0 +1,144 @@
+/**
+ * OpenRouter-backed VideoPicker — works for any chat model on OpenRouter.
+ *
+ * Default model = anthropic/claude-haiku-4.5 (CP490+ directive).
+ * Swap via env LLM_PICKER_MODEL = anthropic/claude-sonnet-4.6
+ *                               | google/gemini-2.5-flash
+ *                               | any OpenRouter slug.
+ */
+
+import { OpenRouterGenerationProvider } from '../llm/openrouter';
+import { logger } from '../../utils/logger';
+import { getLlmPickerConfig } from '../../config/llm-picker';
+import type { PickInput, PickResult, VideoPicker } from './types';
+
+const log = logger.child({ module: 'llm-picker/openrouter' });
+
+interface RawPickItem {
+  videoId?: string;
+  video_id?: string;
+  id?: string;
+  score?: number;
+  reason?: string;
+}
+
+interface RawPickPayload {
+  picks?: RawPickItem[];
+  results?: RawPickItem[];
+}
+
+export class OpenRouterVideoPicker implements VideoPicker {
+  readonly name = 'openrouter-picker';
+  private readonly provider: OpenRouterGenerationProvider;
+  private readonly modelSlug: string;
+
+  constructor(modelSlug?: string) {
+    const cfg = getLlmPickerConfig();
+    this.modelSlug = modelSlug ?? cfg.model;
+    this.provider = new OpenRouterGenerationProvider(this.modelSlug);
+  }
+
+  get model(): string {
+    return this.modelSlug;
+  }
+
+  async pick(input: PickInput, signal?: AbortSignal): Promise<PickResult[]> {
+    const cfg = getLlmPickerConfig();
+    const prompt = buildPrompt(input);
+
+    const raw = await this.provider.generate(prompt, {
+      temperature: cfg.temperature,
+      maxTokens: 1024,
+      format: 'json',
+      signal,
+    });
+
+    return parsePicks(raw, input.candidates, input.maxPicks);
+  }
+}
+
+function buildPrompt(input: PickInput): string {
+  const lang = input.language === 'ko' ? 'Korean' : 'English';
+  const candList = input.candidates
+    .map(
+      (c, i) =>
+        `${i + 1}. id=${c.videoId} | title="${truncate(c.title, 140)}" | channel="${truncate(c.channelTitle, 60)}" | desc="${truncate(c.description, 220)}"`
+    )
+    .join('\n');
+
+  const subGoalsLine = input.subGoals.length ? input.subGoals.join(', ') : '(none)';
+  const focusLine = input.focusTags.length ? input.focusTags.join(', ') : '(none)';
+
+  return `You are a curator selecting YouTube videos for a learner's mandala-art study cell.
+
+# Learner context (${lang})
+- Parent goal: ${input.parentGoal}
+- Current cell topic: ${input.cellTopic}
+- Sub-goals around the parent: ${subGoalsLine}
+- User-chosen focus tags: ${focusLine}
+- Target level: ${input.targetLevel}
+
+# Candidates (${input.candidates.length})
+${candList}
+
+# Task
+Pick up to ${input.maxPicks} videos that BEST match the current cell topic.
+Reject off-topic clickbait, ads, irrelevant compilations.
+Prefer concrete educational/practical videos over generic "top 10" lists.
+Score each pick on a 0..1 scale (1 = perfect match).
+
+# Output format (strict JSON)
+{
+  "picks": [
+    { "videoId": "<exact id from list>", "score": 0.0_to_1.0, "reason": "<one short sentence>" }
+  ]
+}
+Return ONLY the JSON object. No prose.`;
+}
+
+function truncate(s: string, n: number): string {
+  if (!s) return '';
+  const clean = s.replace(/\s+/g, ' ').trim();
+  return clean.length <= n ? clean : clean.slice(0, n - 1) + '…';
+}
+
+function parsePicks(
+  raw: string,
+  candidates: PickInput['candidates'],
+  maxPicks: number
+): PickResult[] {
+  const validIds = new Set(candidates.map((c) => c.videoId));
+  let payload: RawPickPayload;
+  try {
+    payload = JSON.parse(extractJson(raw)) as RawPickPayload;
+  } catch (err) {
+    log.warn(`picker JSON parse failed: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+  const items = payload.picks ?? payload.results ?? [];
+  const out: PickResult[] = [];
+  const seen = new Set<string>();
+  for (const it of items) {
+    const id = (it.videoId ?? it.video_id ?? it.id ?? '').trim();
+    if (!id || !validIds.has(id) || seen.has(id)) continue;
+    const score =
+      typeof it.score === 'number' && Number.isFinite(it.score)
+        ? Math.max(0, Math.min(1, it.score))
+        : 0.5;
+    const reason = typeof it.reason === 'string' ? it.reason.slice(0, 240) : '';
+    out.push({ videoId: id, score, reason });
+    seen.add(id);
+    if (out.length >= maxPicks) break;
+  }
+  return out;
+}
+
+function extractJson(raw: string): string {
+  const trimmed = raw.trim();
+  const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenceMatch) return fenceMatch[1]!.trim();
+  const objStart = trimmed.indexOf('{');
+  const objEnd = trimmed.lastIndexOf('}');
+  if (objStart >= 0 && objEnd > objStart) return trimmed.slice(objStart, objEnd + 1);
+  return trimmed;
+}

--- a/src/modules/llm-picker/registry.ts
+++ b/src/modules/llm-picker/registry.ts
@@ -1,0 +1,28 @@
+/**
+ * VideoPicker registry — resolve impl by env LLM_PICKER_MODEL slug.
+ *
+ * Current impls: OpenRouter-backed (covers Haiku / Sonnet / Gemini / etc).
+ * Future direct-API impls (Anthropic Messages / Gemini API) can register here
+ * without touching the executor.
+ */
+
+import { OpenRouterVideoPicker } from './openrouter-picker';
+import { getLlmPickerConfig } from '../../config/llm-picker';
+import type { VideoPicker } from './types';
+
+let cached: VideoPicker | null = null;
+
+export function getVideoPicker(): VideoPicker {
+  if (cached) return cached;
+  const cfg = getLlmPickerConfig();
+  cached = new OpenRouterVideoPicker(cfg.model);
+  return cached;
+}
+
+export function resetVideoPickerForTest(): void {
+  cached = null;
+}
+
+export function setVideoPickerForTest(picker: VideoPicker): void {
+  cached = picker;
+}

--- a/src/modules/llm-picker/types.ts
+++ b/src/modules/llm-picker/types.ts
@@ -1,0 +1,36 @@
+/**
+ * VideoPicker — model-agnostic interface for the /add-cards v5 path.
+ *
+ * Replaces cosine + IKS scoring with LLM-driven cell↔video matching.
+ * Swap implementations via registry without touching call sites.
+ */
+
+export interface PickCandidate {
+  videoId: string;
+  title: string;
+  description: string;
+  channelTitle: string;
+}
+
+export interface PickInput {
+  cellTopic: string;
+  parentGoal: string;
+  subGoals: string[];
+  focusTags: string[];
+  targetLevel: string;
+  language: 'ko' | 'en';
+  candidates: PickCandidate[];
+  maxPicks: number;
+}
+
+export interface PickResult {
+  videoId: string;
+  score: number;
+  reason: string;
+}
+
+export interface VideoPicker {
+  readonly name: string;
+  readonly model: string;
+  pick(input: PickInput, signal?: AbortSignal): Promise<PickResult[]>;
+}

--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -1,0 +1,47 @@
+/**
+ * v5 (LLM-pick) budget knobs.
+ *
+ * Latency target: 12s total. Breakdown:
+ *   - YouTube fanout: ≤ 2.5s   (8 parallel × 1.5s each, allSettled)
+ *   - LLM batches:    ≤ 3.5s   (5 parallel Haiku calls)
+ *   - videos.list:    ≤ 0.8s   (1 call, picked ids only)
+ *   - DB exclude:     ≤ 0.5s
+ *   - buffer:         ≥ 4.7s
+ */
+
+import { z } from 'zod';
+
+const v5EnvSchema = z.object({
+  V5_MAX_QUERIES: z.coerce.number().int().min(1).max(20).default(8),
+  V5_SEARCH_TIMEOUT_MS: z.coerce.number().int().min(500).max(8000).default(2000),
+  V5_SEARCH_MAX_RESULTS: z.coerce.number().int().min(10).max(50).default(25),
+  V5_TARGET_PICKS: z.coerce.number().int().min(10).max(60).default(30),
+  V5_DEDUP_HARDCAP: z.coerce.number().int().min(40).max(400).default(120),
+});
+
+export interface V5Config {
+  maxQueries: number;
+  searchTimeoutMs: number;
+  searchMaxResults: number;
+  targetPicks: number;
+  dedupHardCap: number;
+}
+
+let cached: V5Config | null = null;
+
+export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
+  if (cached) return cached;
+  const p = v5EnvSchema.parse(env);
+  cached = {
+    maxQueries: p.V5_MAX_QUERIES,
+    searchTimeoutMs: p.V5_SEARCH_TIMEOUT_MS,
+    searchMaxResults: p.V5_SEARCH_MAX_RESULTS,
+    targetPicks: p.V5_TARGET_PICKS,
+    dedupHardCap: p.V5_DEDUP_HARDCAP,
+  };
+  return cached;
+}
+
+export function resetV5ConfigForTest(): void {
+  cached = null;
+}

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -1,0 +1,293 @@
+/**
+ * v5 add-cards executor — YouTube fanout + LLM picker, no cosine, no IKS.
+ *
+ * Pipeline:
+ *   1. YouTube parallel search.list (8 queries × allSettled)
+ *   2. Title heuristic prune (shorts + blocklist) — no videos.list yet
+ *   3. Exclude policy applied BEFORE LLM (cheaper than after)
+ *   4. Chunk → N parallel LLM picker calls (default Haiku via OpenRouter)
+ *   5. Score-sort + dedup picks
+ *   6. videos.list ONCE for the picked set → full stats / duration
+ *   7. Assemble AddCardCandidate[] with score + reason
+ *
+ * Latency target: 12s hard cap (see config.ts comment).
+ */
+
+import { logger } from '@/utils/logger';
+import { videosBatchFullMetadata, resolveSearchApiKeys } from '../v2/youtube-client';
+import type { YouTubeVideoFullMetadata } from '../v2/youtube-client';
+import { runYouTubeFanout, type FanoutCandidate } from './youtube-fanout';
+import { getV5Config } from './config';
+import { getVideoPicker } from '@/modules/llm-picker/registry';
+import { getLlmPickerConfig } from '@/config/llm-picker';
+import type { PickCandidate, PickResult } from '@/modules/llm-picker/types';
+
+const log = logger.child({ module: 'video-discover/v5/executor' });
+
+export interface V5ExecuteInput {
+  centerGoal: string;
+  subGoals: string[];
+  focusTags: string[];
+  targetLevel: string;
+  language: 'ko' | 'en';
+  excludeVideoIds: Set<string>;
+  env: NodeJS.ProcessEnv;
+}
+
+export interface V5Card {
+  videoId: string;
+  title: string;
+  channelTitle: string;
+  channelId: string;
+  thumbnailUrl: string;
+  publishedAt: string | null;
+  durationSec: number | null;
+  viewCount: number | null;
+  cellIndex: number | null;
+  score: number;
+  reason: string;
+}
+
+export interface V5ExecuteResult {
+  cards: V5Card[];
+  diagnostics: {
+    queriesAttempted: number;
+    queriesSucceeded: number;
+    rawItemCount: number;
+    afterTitleFilter: number;
+    afterExcludeFilter: number;
+    llmBatches: number;
+    picksRaw: number;
+    quotaUnitsApprox: number;
+    durationMs: number;
+    pickerModel: string;
+  };
+}
+
+export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteResult> {
+  const t0 = Date.now();
+  const cfg = getV5Config(input.env);
+  const pickerCfg = getLlmPickerConfig(input.env);
+
+  // 1. YouTube fanout
+  const fanout = await runYouTubeFanout({
+    centerGoal: input.centerGoal,
+    subGoals: input.subGoals,
+    focusTags: input.focusTags,
+    targetLevel: input.targetLevel,
+    language: input.language,
+    env: input.env,
+  });
+  const afterTitleFilter = fanout.candidates.length;
+
+  // 2. exclude BEFORE LLM (save LLM tokens)
+  const survivors = fanout.candidates.filter((c) => !input.excludeVideoIds.has(c.videoId));
+  const afterExcludeFilter = survivors.length;
+
+  if (survivors.length === 0) {
+    log.info(
+      `v5 executor: no candidates after exclude (raw=${fanout.rawItemCount}, title=${afterTitleFilter})`
+    );
+    return emptyResult({
+      fanout,
+      afterTitleFilter,
+      afterExcludeFilter,
+      pickerCfg,
+      t0,
+    });
+  }
+
+  // 3. chunk + parallel LLM picks
+  const batches = chunk(survivors, pickerCfg.batchSize);
+  const limitedBatches = batches.slice(0, pickerCfg.maxParallel);
+  const picker = getVideoPicker();
+  const perBatchMaxPicks = Math.max(
+    Math.ceil(cfg.targetPicks / Math.max(limitedBatches.length, 1)) + 2,
+    6
+  );
+
+  const ac = new AbortController();
+  const batchTimer = setTimeout(() => ac.abort(), pickerCfg.timeoutMs);
+  let pickResults: PickResult[][];
+  try {
+    pickResults = await Promise.all(
+      limitedBatches.map(async (batch) => {
+        try {
+          return await picker.pick(
+            {
+              cellTopic: input.centerGoal,
+              parentGoal: input.centerGoal,
+              subGoals: input.subGoals,
+              focusTags: input.focusTags,
+              targetLevel: input.targetLevel,
+              language: input.language,
+              candidates: batch.map(toPickCandidate),
+              maxPicks: perBatchMaxPicks,
+            },
+            ac.signal
+          );
+        } catch (err) {
+          log.warn(`v5 picker batch failed: ${err instanceof Error ? err.message : String(err)}`);
+          return [] as PickResult[];
+        }
+      })
+    );
+  } finally {
+    clearTimeout(batchTimer);
+  }
+
+  const picksMerged = mergePicks(pickResults, cfg.targetPicks);
+
+  if (picksMerged.length === 0) {
+    log.info(`v5 executor: picker returned 0 (batches=${limitedBatches.length})`);
+    return emptyResult({
+      fanout,
+      afterTitleFilter,
+      afterExcludeFilter,
+      pickerCfg,
+      t0,
+      llmBatches: limitedBatches.length,
+    });
+  }
+
+  // 4. videos.list for picked only (stats + duration)
+  const fanoutById = new Map(survivors.map((c) => [c.videoId, c]));
+  const pickedIds = picksMerged.map((p) => p.videoId);
+  const apiKeys = resolveSearchApiKeys(input.env);
+  let fullMeta: YouTubeVideoFullMetadata[] = [];
+  if (apiKeys.length > 0) {
+    try {
+      fullMeta = await videosBatchFullMetadata({ videoIds: pickedIds, apiKey: apiKeys });
+    } catch (err) {
+      log.warn(
+        `v5 videos.list failed (degraded to search-only meta): ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+  const metaById = new Map(fullMeta.map((m) => [m.id ?? '', m]));
+
+  // 5. assemble cards in pick order
+  const cards: V5Card[] = picksMerged.map((p) => {
+    const fan = fanoutById.get(p.videoId);
+    const meta = metaById.get(p.videoId);
+    return assembleCard(p, fan, meta);
+  });
+
+  return {
+    cards,
+    diagnostics: {
+      queriesAttempted: fanout.queriesAttempted,
+      queriesSucceeded: fanout.queriesSucceeded,
+      rawItemCount: fanout.rawItemCount,
+      afterTitleFilter,
+      afterExcludeFilter,
+      llmBatches: limitedBatches.length,
+      picksRaw: pickResults.reduce((acc, b) => acc + b.length, 0),
+      quotaUnitsApprox: fanout.quotaUnitsApprox + (pickedIds.length > 0 ? 1 : 0),
+      durationMs: Date.now() - t0,
+      pickerModel: picker.model,
+    },
+  };
+}
+
+function emptyResult(args: {
+  fanout: {
+    queriesAttempted: number;
+    queriesSucceeded: number;
+    rawItemCount: number;
+    quotaUnitsApprox: number;
+  };
+  afterTitleFilter: number;
+  afterExcludeFilter: number;
+  pickerCfg: ReturnType<typeof getLlmPickerConfig>;
+  t0: number;
+  llmBatches?: number;
+}): V5ExecuteResult {
+  return {
+    cards: [],
+    diagnostics: {
+      queriesAttempted: args.fanout.queriesAttempted,
+      queriesSucceeded: args.fanout.queriesSucceeded,
+      rawItemCount: args.fanout.rawItemCount,
+      afterTitleFilter: args.afterTitleFilter,
+      afterExcludeFilter: args.afterExcludeFilter,
+      llmBatches: args.llmBatches ?? 0,
+      picksRaw: 0,
+      quotaUnitsApprox: args.fanout.quotaUnitsApprox,
+      durationMs: Date.now() - args.t0,
+      pickerModel: args.pickerCfg.model,
+    },
+  };
+}
+
+function toPickCandidate(c: FanoutCandidate): PickCandidate {
+  return {
+    videoId: c.videoId,
+    title: c.title,
+    description: c.description,
+    channelTitle: c.channelTitle,
+  };
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  if (size <= 0) return [arr];
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+function mergePicks(batches: PickResult[][], targetCount: number): PickResult[] {
+  const seen = new Map<string, PickResult>();
+  for (const batch of batches) {
+    for (const p of batch) {
+      const prev = seen.get(p.videoId);
+      if (!prev || p.score > prev.score) seen.set(p.videoId, p);
+    }
+  }
+  return Array.from(seen.values())
+    .sort((a, b) => b.score - a.score)
+    .slice(0, targetCount);
+}
+
+function assembleCard(
+  pick: PickResult,
+  fan: FanoutCandidate | undefined,
+  meta: YouTubeVideoFullMetadata | undefined
+): V5Card {
+  const title = meta?.snippet?.title ?? fan?.title ?? '';
+  const channelTitle = meta?.snippet?.channelTitle ?? fan?.channelTitle ?? '';
+  const channelId = meta?.snippet?.channelId ?? fan?.channelId ?? '';
+  const thumbnailUrl =
+    meta?.snippet?.thumbnails?.high?.url ??
+    meta?.snippet?.thumbnails?.medium?.url ??
+    fan?.thumbnailUrl ??
+    '';
+  const publishedAt = meta?.snippet?.publishedAt ?? fan?.publishedAt ?? null;
+  const durationSec = parseIsoDurationSeconds(meta?.contentDetails?.duration);
+  const viewCountStr = meta?.statistics?.viewCount;
+  const viewCount = viewCountStr ? Number(viewCountStr) : null;
+
+  return {
+    videoId: pick.videoId,
+    title,
+    channelTitle,
+    channelId,
+    thumbnailUrl,
+    publishedAt,
+    durationSec,
+    viewCount: Number.isFinite(viewCount) ? viewCount : null,
+    cellIndex: fan?.cellIndex ?? null,
+    score: pick.score,
+    reason: pick.reason,
+  };
+}
+
+function parseIsoDurationSeconds(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const m = iso.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/);
+  if (!m) return null;
+  const h = m[1] ? parseInt(m[1], 10) : 0;
+  const min = m[2] ? parseInt(m[2], 10) : 0;
+  const s = m[3] ? parseInt(m[3], 10) : 0;
+  return h * 3600 + min * 60 + s;
+}

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -1,0 +1,153 @@
+/**
+ * v5 YouTube fanout — parallel search.list across rule-based queries.
+ *
+ * Strategy:
+ *   - buildRuleBasedQueriesSync (no LLM; sub-ms) → N queries
+ *   - Promise.allSettled with per-call timeout (single slow query never
+ *     blocks the cohort)
+ *   - Dedup by videoId, drop Shorts via title heuristic (cheap; no
+ *     videos.list call in the hot path)
+ *   - Cap raw pool to dedupHardCap (default 120) before handing to LLM
+ *
+ * Quota cost (worst case): maxQueries × 100 units. With default 8 →
+ * 800 units / Add Cards call.
+ */
+
+import { logger } from '@/utils/logger';
+import {
+  searchVideos,
+  resolveSearchApiKeys,
+  titleIndicatesShorts,
+  titleHitsBlocklist,
+  type YouTubeSearchItem,
+} from '../v2/youtube-client';
+import { buildRuleBasedQueriesSync } from '../v2/keyword-builder';
+import { getV5Config } from './config';
+
+const log = logger.child({ module: 'video-discover/v5/youtube-fanout' });
+
+export interface FanoutInput {
+  centerGoal: string;
+  subGoals: string[];
+  focusTags: string[];
+  targetLevel: string;
+  language: 'ko' | 'en';
+  env: NodeJS.ProcessEnv;
+}
+
+export interface FanoutCandidate {
+  videoId: string;
+  title: string;
+  description: string;
+  channelTitle: string;
+  channelId: string;
+  publishedAt: string;
+  thumbnailUrl: string;
+  cellIndex: number | null;
+}
+
+export interface FanoutResult {
+  candidates: FanoutCandidate[];
+  queriesAttempted: number;
+  queriesSucceeded: number;
+  rawItemCount: number;
+  quotaUnitsApprox: number;
+}
+
+export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult> {
+  const cfg = getV5Config(input.env);
+  const apiKeys = resolveSearchApiKeys(input.env);
+  if (apiKeys.length === 0) {
+    log.warn('v5 fanout: no YouTube API keys configured');
+    return {
+      candidates: [],
+      queriesAttempted: 0,
+      queriesSucceeded: 0,
+      rawItemCount: 0,
+      quotaUnitsApprox: 0,
+    };
+  }
+
+  const queries = buildRuleBasedQueriesSync(
+    {
+      centerGoal: input.centerGoal,
+      subGoals: input.subGoals,
+      focusTags: input.focusTags,
+      targetLevel: input.targetLevel,
+      language: input.language,
+    },
+    cfg.maxQueries
+  );
+
+  if (queries.length === 0) {
+    return {
+      candidates: [],
+      queriesAttempted: 0,
+      queriesSucceeded: 0,
+      rawItemCount: 0,
+      quotaUnitsApprox: 0,
+    };
+  }
+
+  const results = await Promise.allSettled(
+    queries.map((q) =>
+      searchVideos({
+        query: q.query,
+        apiKey: apiKeys,
+        maxResults: cfg.searchMaxResults,
+        relevanceLanguage: input.language,
+        timeoutMs: cfg.searchTimeoutMs,
+      }).then((items) => ({ items, cellIndex: q.cellIndex ?? null }))
+    )
+  );
+
+  let rawItemCount = 0;
+  let queriesSucceeded = 0;
+  const seen = new Map<string, FanoutCandidate>();
+
+  for (const r of results) {
+    if (r.status !== 'fulfilled') {
+      log.debug(`v5 fanout query rejected: ${String(r.reason)}`);
+      continue;
+    }
+    queriesSucceeded += 1;
+    const { items, cellIndex } = r.value;
+    for (const it of items) {
+      rawItemCount += 1;
+      const cand = toFanoutCandidate(it, cellIndex);
+      if (!cand) continue;
+      if (seen.has(cand.videoId)) continue;
+      if (titleHitsBlocklist(cand.title) || titleIndicatesShorts(cand.title)) continue;
+      seen.set(cand.videoId, cand);
+      if (seen.size >= cfg.dedupHardCap) break;
+    }
+    if (seen.size >= cfg.dedupHardCap) break;
+  }
+
+  return {
+    candidates: Array.from(seen.values()),
+    queriesAttempted: queries.length,
+    queriesSucceeded,
+    rawItemCount,
+    quotaUnitsApprox: queries.length * 100,
+  };
+}
+
+function toFanoutCandidate(
+  item: YouTubeSearchItem,
+  cellIndex: number | null
+): FanoutCandidate | null {
+  const videoId = item.id?.videoId;
+  if (!videoId) return null;
+  const sn = item.snippet ?? {};
+  return {
+    videoId,
+    title: sn.title ?? '',
+    description: sn.description ?? '',
+    channelTitle: sn.channelTitle ?? '',
+    channelId: sn.channelId ?? '',
+    publishedAt: sn.publishedAt ?? '',
+    thumbnailUrl: sn.thumbnails?.high?.url ?? '',
+    cellIndex,
+  };
+}

--- a/tests/unit/modules/exclude/excluded-videos.test.ts
+++ b/tests/unit/modules/exclude/excluded-videos.test.ts
@@ -44,7 +44,7 @@ function makeMockPrisma(returnedStateRows: StateRow[]): {
 }
 
 describe('getExcludedVideoIds — Explicit > Inferred policy (CP489+)', () => {
-  test('SQL filter includes all 6 engagement clauses + auto_added=FALSE', async () => {
+  test('SQL filter includes the 3 explicit engagement clauses (CP490+)', async () => {
     const { prisma, calls } = makeMockPrisma([]);
     await getExcludedVideoIds({
       prisma,
@@ -53,11 +53,21 @@ describe('getExcludedVideoIds — Explicit > Inferred policy (CP489+)', () => {
     });
     const sql = calls.rawWhere.join(' ');
     expect(sql).toMatch(/is_watched\s*=\s*TRUE/);
-    expect(sql).toMatch(/is_in_ideation\s*=\s*TRUE/);
-    expect(sql).toMatch(/user_note\s+IS\s+NOT\s+NULL/);
-    expect(sql).toMatch(/watch_position_seconds\s*>\s*0/);
     expect(sql).toMatch(/pinned_at\s+IS\s+NOT\s+NULL/);
-    expect(sql).toMatch(/auto_added\s*=\s*FALSE/);
+    expect(sql).toMatch(/user_note\s+IS\s+NOT\s+NULL/);
+  });
+
+  test('SQL filter does NOT include the dropped CP490 clauses', async () => {
+    const { prisma, calls } = makeMockPrisma([]);
+    await getExcludedVideoIds({
+      prisma,
+      userId: '00000000-0000-0000-0000-000000000001',
+      mandalaId: '00000000-0000-0000-0000-000000000002',
+    });
+    const sql = calls.rawWhere.join(' ');
+    expect(sql).not.toMatch(/is_in_ideation/);
+    expect(sql).not.toMatch(/watch_position_seconds/);
+    expect(sql).not.toMatch(/auto_added\s*=\s*FALSE/);
   });
 
   test('rows returned by SQL filter are added to the exclude set verbatim', async () => {
@@ -127,13 +137,8 @@ describe('getExcludedVideoIds — documented row classes (intent guard)', () => 
   });
 
   test('auto_added=true with all engagement zero is NO LONGER excluded (wizard pre-fill ghost)', async () => {
-    // The wizard pre-fill row pattern is:
-    //   auto_added=true, is_watched=false, is_in_ideation=false,
-    //   user_note=NULL, watch_position_seconds=0, pinned_at=NULL
-    // None of the 6 OR clauses match → row falls outside the SELECT.
-    // Tested structurally by confirming NONE of the engagement clauses
-    // would match such a row (verified by inspecting the SQL — actual
-    // DB filtering is exercised by integration tests / prod measurement).
+    // Wizard pre-fill row = auto_added=true + 0 engagement → none of the
+    // 3 CP490+ OR clauses match → row stays in pool for LLM re-evaluation.
     const { prisma, calls } = makeMockPrisma([]);
     await getExcludedVideoIds({
       prisma,
@@ -141,23 +146,19 @@ describe('getExcludedVideoIds — documented row classes (intent guard)', () => 
       mandalaId: '00000000-0000-0000-0000-000000000002',
     });
     const sql = calls.rawWhere.join(' ');
-    // The fix is: the SELECT has an AND clause that requires at least one
-    // engagement-or-explicit signal. Without that AND, wizard pre-fill is
-    // included → dedup bleed. Verify the AND structure.
     expect(sql).toMatch(/AND\s*\(/);
-    expect(sql).toMatch(/auto_added\s*=\s*FALSE/);
   });
 
-  test('auto_added=false with all engagement zero IS still excluded (user-created row, intentional)', async () => {
-    // user explicitly created the row even without engagement = explicit
-    // signal of intent → exclude path remains. Verified by the auto_added
-    // = FALSE clause being part of the OR.
+  test('auto_added=false zero-engagement is NO LONGER excluded (CP490+ relaxation)', async () => {
+    // CP490 directive: user_local_cards + delete/archive signals are the
+    // only explicit-add exclude sources; user_video_states row without one
+    // of the 3 engagement signals is re-surfaceable.
     const { prisma, calls } = makeMockPrisma([]);
     await getExcludedVideoIds({
       prisma,
       userId: '00000000-0000-0000-0000-000000000001',
       mandalaId: '00000000-0000-0000-0000-000000000002',
     });
-    expect(calls.rawWhere.join(' ')).toContain('auto_added = FALSE');
+    expect(calls.rawWhere.join(' ')).not.toContain('auto_added = FALSE');
   });
 });

--- a/tests/unit/modules/llm-picker/openrouter-picker.test.ts
+++ b/tests/unit/modules/llm-picker/openrouter-picker.test.ts
@@ -1,0 +1,143 @@
+/**
+ * OpenRouterVideoPicker — JSON parse + invariants.
+ *
+ * The HTTP transport (OpenRouterGenerationProvider) is mocked. We exercise
+ * the picker's prompt-build → JSON-parse → result-validation contract so a
+ * future prompt refactor cannot silently break the assemble path.
+ */
+
+import { OpenRouterVideoPicker } from '@/modules/llm-picker/openrouter-picker';
+import type { PickInput } from '@/modules/llm-picker/types';
+
+jest.mock('@/modules/llm/openrouter', () => {
+  return {
+    OpenRouterGenerationProvider: jest.fn().mockImplementation(() => ({
+      get model() {
+        return 'openrouter/anthropic/claude-haiku-4.5';
+      },
+      generate: jest.fn(),
+    })),
+  };
+});
+
+const { OpenRouterGenerationProvider } = jest.requireMock('@/modules/llm/openrouter');
+
+function makeInput(extra: Partial<PickInput> = {}): PickInput {
+  return {
+    cellTopic: 'Learn React hooks',
+    parentGoal: 'Become a senior frontend engineer',
+    subGoals: ['Master TS', 'Master React'],
+    focusTags: ['hooks', 'context'],
+    targetLevel: 'standard',
+    language: 'en',
+    candidates: [
+      { videoId: 'v1', title: 'useEffect Deep Dive', description: 'desc1', channelTitle: 'C1' },
+      { videoId: 'v2', title: 'useState Tutorial', description: 'desc2', channelTitle: 'C2' },
+      { videoId: 'v3', title: 'Random Cat Video', description: 'desc3', channelTitle: 'C3' },
+    ],
+    maxPicks: 2,
+    ...extra,
+  };
+}
+
+describe('OpenRouterVideoPicker', () => {
+  let mockGenerate: jest.Mock;
+
+  beforeEach(() => {
+    mockGenerate = jest.fn();
+    OpenRouterGenerationProvider.mockImplementation(() => ({
+      get model() {
+        return 'openrouter/anthropic/claude-haiku-4.5';
+      },
+      generate: mockGenerate,
+    }));
+  });
+
+  test('parses valid JSON picks and clamps score to [0,1]', async () => {
+    mockGenerate.mockResolvedValue(
+      JSON.stringify({
+        picks: [
+          { videoId: 'v1', score: 0.9, reason: 'r1' },
+          { videoId: 'v2', score: 1.5, reason: 'r2' },
+        ],
+      })
+    );
+    const picker = new OpenRouterVideoPicker();
+    const out = await picker.pick(makeInput());
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual({ videoId: 'v1', score: 0.9, reason: 'r1' });
+    expect(out[1]).toEqual({ videoId: 'v2', score: 1, reason: 'r2' });
+  });
+
+  test('drops picks whose videoId is not in the input set', async () => {
+    mockGenerate.mockResolvedValue(
+      JSON.stringify({
+        picks: [
+          { videoId: 'v1', score: 0.9, reason: 'ok' },
+          { videoId: 'BOGUS', score: 0.8, reason: 'hallucinated' },
+        ],
+      })
+    );
+    const picker = new OpenRouterVideoPicker();
+    const out = await picker.pick(makeInput());
+    expect(out.map((p) => p.videoId)).toEqual(['v1']);
+  });
+
+  test('dedupes within a single response by videoId', async () => {
+    mockGenerate.mockResolvedValue(
+      JSON.stringify({
+        picks: [
+          { videoId: 'v1', score: 0.9, reason: 'first' },
+          { videoId: 'v1', score: 0.8, reason: 'second' },
+          { videoId: 'v2', score: 0.7, reason: 'ok' },
+        ],
+      })
+    );
+    const picker = new OpenRouterVideoPicker();
+    const out = await picker.pick(makeInput());
+    expect(out.map((p) => p.videoId)).toEqual(['v1', 'v2']);
+    expect(out[0]!.reason).toBe('first');
+  });
+
+  test('respects maxPicks cap', async () => {
+    mockGenerate.mockResolvedValue(
+      JSON.stringify({
+        picks: [
+          { videoId: 'v1', score: 0.9, reason: 'r1' },
+          { videoId: 'v2', score: 0.8, reason: 'r2' },
+          { videoId: 'v3', score: 0.7, reason: 'r3' },
+        ],
+      })
+    );
+    const picker = new OpenRouterVideoPicker();
+    const out = await picker.pick(makeInput({ maxPicks: 2 }));
+    expect(out).toHaveLength(2);
+  });
+
+  test('handles JSON wrapped in markdown code fences', async () => {
+    mockGenerate.mockResolvedValue(
+      '```json\n{"picks":[{"videoId":"v1","score":0.9,"reason":"ok"}]}\n```'
+    );
+    const picker = new OpenRouterVideoPicker();
+    const out = await picker.pick(makeInput());
+    expect(out.map((p) => p.videoId)).toEqual(['v1']);
+  });
+
+  test('returns empty array on malformed JSON (no throw)', async () => {
+    mockGenerate.mockResolvedValue('not valid json at all');
+    const picker = new OpenRouterVideoPicker();
+    const out = await picker.pick(makeInput());
+    expect(out).toEqual([]);
+  });
+
+  test('passes signal through to the underlying provider', async () => {
+    mockGenerate.mockResolvedValue(JSON.stringify({ picks: [] }));
+    const picker = new OpenRouterVideoPicker();
+    const ac = new AbortController();
+    await picker.pick(makeInput(), ac.signal);
+    expect(mockGenerate).toHaveBeenCalledWith(
+      expect.stringContaining('Candidates'),
+      expect.objectContaining({ signal: ac.signal, format: 'json' })
+    );
+  });
+});

--- a/tests/unit/skills/video-discover/v5-executor.test.ts
+++ b/tests/unit/skills/video-discover/v5-executor.test.ts
@@ -1,0 +1,185 @@
+/**
+ * v5 executor smoke — mocked fanout + picker, validates orchestration:
+ *   - exclude applied before LLM
+ *   - chunk + parallel batches
+ *   - merge picks by score, dedupe by videoId
+ *   - assemble cards in pick order
+ */
+
+import { runV5Executor } from '@/skills/plugins/video-discover/v5/executor';
+import { resetV5ConfigForTest } from '@/skills/plugins/video-discover/v5/config';
+import { resetLlmPickerConfigForTest } from '@/config/llm-picker';
+import { setVideoPickerForTest, resetVideoPickerForTest } from '@/modules/llm-picker/registry';
+import type { VideoPicker, PickInput, PickResult } from '@/modules/llm-picker/types';
+
+jest.mock('@/skills/plugins/video-discover/v5/youtube-fanout', () => ({
+  runYouTubeFanout: jest.fn(),
+}));
+
+jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
+  videosBatchFullMetadata: jest.fn().mockResolvedValue([]),
+  resolveSearchApiKeys: jest.fn().mockReturnValue([]),
+}));
+
+const { runYouTubeFanout } = jest.requireMock('@/skills/plugins/video-discover/v5/youtube-fanout');
+
+function makeFanoutCandidate(id: string, title = `Title ${id}`) {
+  return {
+    videoId: id,
+    title,
+    description: `Desc ${id}`,
+    channelTitle: `Channel ${id}`,
+    channelId: `CH${id}`,
+    publishedAt: '2026-05-01T00:00:00Z',
+    thumbnailUrl: `https://thumb/${id}.jpg`,
+    cellIndex: 0,
+  };
+}
+
+class FakePicker implements VideoPicker {
+  readonly name = 'fake';
+  readonly model = 'fake/test';
+  constructor(private readonly impl: (input: PickInput) => PickResult[]) {}
+  async pick(input: PickInput): Promise<PickResult[]> {
+    return this.impl(input);
+  }
+}
+
+describe('runV5Executor (orchestration smoke)', () => {
+  beforeEach(() => {
+    resetV5ConfigForTest();
+    resetLlmPickerConfigForTest();
+    resetVideoPickerForTest();
+    runYouTubeFanout.mockReset();
+  });
+
+  afterAll(() => {
+    resetVideoPickerForTest();
+  });
+
+  test('applies exclude BEFORE LLM (excluded ids never reach picker)', async () => {
+    runYouTubeFanout.mockResolvedValue({
+      candidates: [makeFanoutCandidate('a'), makeFanoutCandidate('b'), makeFanoutCandidate('c')],
+      queriesAttempted: 1,
+      queriesSucceeded: 1,
+      rawItemCount: 3,
+      quotaUnitsApprox: 100,
+    });
+    const seenInputs: PickInput[] = [];
+    setVideoPickerForTest(
+      new FakePicker((input) => {
+        seenInputs.push(input);
+        return input.candidates.map((c, i) => ({
+          videoId: c.videoId,
+          score: 1 - i * 0.1,
+          reason: 'ok',
+        }));
+      })
+    );
+
+    await runV5Executor({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      excludeVideoIds: new Set(['b']),
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(seenInputs).toHaveLength(1);
+    const passed = seenInputs[0]!.candidates.map((c) => c.videoId);
+    expect(passed).toEqual(['a', 'c']);
+  });
+
+  test('merges picks across batches and sorts by score desc', async () => {
+    runYouTubeFanout.mockResolvedValue({
+      candidates: Array.from({ length: 24 }, (_, i) => makeFanoutCandidate(`v${i}`)),
+      queriesAttempted: 1,
+      queriesSucceeded: 1,
+      rawItemCount: 24,
+      quotaUnitsApprox: 100,
+    });
+    setVideoPickerForTest(
+      new FakePicker((input) => {
+        // each batch picks the first 4 with descending scores
+        return input.candidates.slice(0, 4).map((c, i) => ({
+          videoId: c.videoId,
+          score: 0.95 - i * 0.05,
+          reason: 'pick',
+        }));
+      })
+    );
+
+    const result = await runV5Executor({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      excludeVideoIds: new Set(),
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(result.cards.length).toBeGreaterThan(0);
+    const scores = result.cards.map((c) => c.score);
+    const sorted = [...scores].sort((a, b) => b - a);
+    expect(scores).toEqual(sorted);
+    const ids = result.cards.map((c) => c.videoId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test('returns empty cards when fanout yields nothing', async () => {
+    runYouTubeFanout.mockResolvedValue({
+      candidates: [],
+      queriesAttempted: 0,
+      queriesSucceeded: 0,
+      rawItemCount: 0,
+      quotaUnitsApprox: 0,
+    });
+    setVideoPickerForTest(new FakePicker(() => []));
+    const result = await runV5Executor({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      excludeVideoIds: new Set(),
+      env: {} as NodeJS.ProcessEnv,
+    });
+    expect(result.cards).toEqual([]);
+    expect(result.diagnostics.afterExcludeFilter).toBe(0);
+  });
+
+  test('continues when one batch picker throws', async () => {
+    runYouTubeFanout.mockResolvedValue({
+      candidates: Array.from({ length: 24 }, (_, i) => makeFanoutCandidate(`v${i}`)),
+      queriesAttempted: 1,
+      queriesSucceeded: 1,
+      rawItemCount: 24,
+      quotaUnitsApprox: 100,
+    });
+    let callCount = 0;
+    setVideoPickerForTest(
+      new FakePicker((input) => {
+        callCount += 1;
+        if (callCount === 2) throw new Error('boom');
+        return input.candidates.slice(0, 2).map((c) => ({
+          videoId: c.videoId,
+          score: 0.8,
+          reason: 'ok',
+        }));
+      })
+    );
+    const result = await runV5Executor({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      excludeVideoIds: new Set(),
+      env: {} as NodeJS.ProcessEnv,
+    });
+    expect(result.cards.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- /add-cards is now **YouTube fanout → LLM picker** — no cosine, no IKS, no 6-signal exclude bleed.
- Default picker = **Claude Haiku 4.5 via OpenRouter**, swappable via `LLM_PICKER_MODEL` env (Sonnet / Gemini Flash / any OpenRouter slug — no code change).
- Latency target **12s hard cap** via parallel slicing (search × 8, picker × 5).
- Exclude shrunk from 6 → 3 explicit-engagement signals (`is_watched=TRUE OR pinned_at IS NOT NULL OR user_note IS NOT NULL`).

## Architecture

```
[Add Cards click]
  → YouTube search.list × 8 parallel (allSettled, 2.0s budget)
  → title heuristic prune (shorts + blocklist)
  → exclude BEFORE LLM (save tokens)
  → chunk into N batches × parallel Haiku calls (3.0s budget)
  → score-sort + dedupe picks
  → videos.list ONCE for picked set (0.8s)
  → assemble cards with score + reason
```

## Pluggable picker

- `src/modules/llm-picker/types.ts` — `VideoPicker` interface
- `src/modules/llm-picker/openrouter-picker.ts` — OpenRouter-backed impl (covers all Anthropic / Google / Qwen models)
- `src/modules/llm-picker/registry.ts` — env-driven swap
- `src/config/llm-picker.ts` — zod-validated knobs (model / batch / parallel / timeout / temp)

## Removed (dead after swap)
- `matchFromVideoPoolByCenterGoal` call (Tier 1 cosine)
- `runDiscoverEphemeral` call (Tier 2 keyword + scoring)
- `applyFeedbackBias` (Layer 4 channel match + drift guard)
- `applyCapsAndSort` (echo-chamber caps)
- `parsePgvectorLiteral`, `cosineSimilarity`, `mergeTierCandidates` helpers
- `getCenterGoalEmbedding` cache call (no embedding in hot path anymore)

## Kept
- `loadSurfacedVideoIds` + `recordSurfacedCards` (FE round tracking)
- `applySurfaceBoost` (generic-typed, exercised by existing tests)
- `resolveAlgorithm` (trace context tagging)
- `getExcludedVideoIds` shared helper (now 3-signal)

## Test plan
- [x] `tests/unit/modules/llm-picker/openrouter-picker.test.ts` — 7 tests: JSON parse, score clamp, dedupe, maxPicks, fence stripping, malformed-graceful, signal forwarding
- [x] `tests/unit/skills/video-discover/v5-executor.test.ts` — 4 tests: exclude-before-LLM, merge-and-sort, empty-fanout, picker-throw-resilient
- [x] `tests/unit/modules/exclude/excluded-videos.test.ts` — updated for 3-signal policy
- [x] `tests/unit/api/add-cards-surfaced.test.ts` — applySurfaceBoost still passes (generic refactor)
- [x] `tsc --noEmit` clean (pre-existing sales-resources Prisma errors unrelated)
- [ ] Prod verify: 25+ cards per click, round accumulation works, "추가됨" overlay only on real engagement
- [ ] Latency: <12s p95 on prod

## Env knobs (all optional)
- `LLM_PICKER_MODEL` (default: `anthropic/claude-haiku-4.5`)
- `LLM_PICKER_BATCH_SIZE` (default: 12)
- `LLM_PICKER_MAX_PARALLEL` (default: 5)
- `LLM_PICKER_TIMEOUT_MS` (default: 5000)
- `V5_MAX_QUERIES` (default: 8)
- `V5_TARGET_PICKS` (default: 30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)