### PR TITLE
feat(wizard-precompute): v5 LLM-pick (drop v3 cosine path) (CP490+)

### DIFF
--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -27,10 +27,8 @@ import { Prisma } from '@prisma/client';
 import { getPrismaClient } from '@/modules/database/client';
 import { logger } from '@/utils/logger';
 import { loadWizardPrecomputeConfig } from '@/config/wizard-precompute';
-import {
-  runDiscoverEphemeral,
-  type EphemeralDiscoverResult,
-} from '@/skills/plugins/video-discover/v3/executor';
+import type { EphemeralDiscoverResult } from '@/skills/plugins/video-discover/v3/executor';
+import { runV5ForWizard } from '@/skills/plugins/video-discover/v5/wizard-adapter';
 import { notifyCardAdded, type CardPayload } from '@/modules/recommendations/publisher';
 import { MS_PER_DAY } from '@/utils/time-constants';
 import { randomUUID } from 'crypto';
@@ -112,7 +110,10 @@ export async function startPrecompute(input: StartPrecomputeInput): Promise<void
 
   // Step 3: runDiscoverEphemeral → persist result
   try {
-    const result = await runDiscoverEphemeral({
+    // CP490+ — wizard now uses the v5 LLM-pick path (Haiku via OpenRouter)
+    // for parity with /add-cards. v3 cosine + Mac-mini Ollama dependency
+    // was producing 70s+ runs returning 0 cards.
+    const result = await runV5ForWizard({
       centerGoal: input.goal,
       subGoals: input.subGoals,
       language: input.language,

--- a/src/skills/plugins/video-discover/v5/wizard-adapter.ts
+++ b/src/skills/plugins/video-discover/v5/wizard-adapter.ts
@@ -1,0 +1,68 @@
+/**
+ * v5 → wizard-precompute adapter.
+ *
+ * Returns the same `EphemeralDiscoverResult` shape that
+ * `runDiscoverEphemeral` (v3) returned, so wizard-precompute / consume /
+ * cardPublisher / auto-add code below stays unchanged.
+ *
+ * Mapping (V5Card → AssembledSlot):
+ *   videoId        → videoId
+ *   title          → title
+ *   channelTitle   → channelName
+ *   channelId      → channelId
+ *   thumbnailUrl   → thumbnail
+ *   durationSec    → durationSec
+ *   viewCount      → viewCount
+ *   publishedAt    → publishedAt (Date)
+ *   cellIndex      → cellIndex (defaults to 0 when v5 has no cell hint)
+ *   score          → score
+ *   reason         → (dropped — wizard schema has no field for it)
+ *   description    → null (v5 doesn't surface description in the final card)
+ *   likeCount      → null (v5 skips likeCount fetch to save quota)
+ *   tier           → 'realtime' (all v5 cards come from live YouTube fanout)
+ */
+
+import type { AssembledSlot, EphemeralDiscoverResult } from '../v3/executor';
+import { runV5Executor, type V5ExecuteInput } from './executor';
+
+export type V5WizardInput = Omit<V5ExecuteInput, 'excludeVideoIds'> & {
+  excludeVideoIds?: Set<string>;
+};
+
+export async function runV5ForWizard(input: V5WizardInput): Promise<EphemeralDiscoverResult> {
+  const t0 = Date.now();
+  const result = await runV5Executor({
+    centerGoal: input.centerGoal,
+    subGoals: input.subGoals,
+    focusTags: input.focusTags,
+    targetLevel: input.targetLevel,
+    language: input.language,
+    excludeVideoIds: input.excludeVideoIds ?? new Set<string>(),
+    env: input.env,
+  });
+
+  const slots: AssembledSlot[] = result.cards.map((c) => ({
+    videoId: c.videoId,
+    title: c.title,
+    description: null,
+    channelName: c.channelTitle || null,
+    channelId: c.channelId || null,
+    thumbnail: c.thumbnailUrl || null,
+    viewCount: c.viewCount,
+    likeCount: null,
+    durationSec: c.durationSec,
+    publishedAt: c.publishedAt ? new Date(c.publishedAt) : null,
+    cellIndex: c.cellIndex ?? 0,
+    score: c.score,
+    tier: 'realtime',
+  }));
+
+  return {
+    slots,
+    queriesUsed: result.diagnostics.queriesAttempted,
+    tier0_matches: 0,
+    tier1_matches: 0,
+    tier2_matches: result.diagnostics.afterTitleFilter,
+    duration_ms: Date.now() - t0,
+  };
+}

--- a/tests/unit/modules/wizard-precompute.test.ts
+++ b/tests/unit/modules/wizard-precompute.test.ts
@@ -40,8 +40,8 @@ jest.mock('@prisma/client', () => ({
   },
 }));
 
-jest.mock('@/skills/plugins/video-discover/v3/executor', () => ({
-  runDiscoverEphemeral: mockRunDiscoverEphemeral,
+jest.mock('@/skills/plugins/video-discover/v5/wizard-adapter', () => ({
+  runV5ForWizard: mockRunDiscoverEphemeral,
 }));
 
 jest.mock('@/modules/recommendations/publisher', () => ({


### PR DESCRIPTION
## Summary
- Wizard pre-compute now uses the **v5 LLM-pick** executor (same as /add-cards in #802).
- Drops the v3 cosine + Mac-mini Ollama embedding dependency that was producing **70s+ runs returning 0 cards** in prod.

## Mapping
`runV5ForWizard` adapter (`src/skills/plugins/video-discover/v5/wizard-adapter.ts`) returns the same `EphemeralDiscoverResult` shape so downstream `consumePrecompute` / `cardPublisher` / `auto-add` paths stay unchanged.

`V5Card → AssembledSlot`:
- `channelTitle → channelName`
- `thumbnailUrl → thumbnail`
- `publishedAt → publishedAt (Date)`
- `cellIndex → cellIndex (default 0)`
- `description / likeCount → null` (v5 doesn't surface)
- `tier → 'realtime'`

## Test plan
- [x] `tests/unit/modules/wizard-precompute.test.ts` — mock point migrated v3 → v5/wizard-adapter; pre-existing 2 poll-budget timing failures unchanged
- [x] tsc clean
- [ ] Prod verify: wizard → dashboard 카드 30+, latency ≤ 12s

🤖 Generated with [Claude Code](https://claude.com/claude-code)