### PR TITLE
feat(admin): Content Pool Health 5-section dashboard

### DIFF
--- a/frontend/src/__tests__/smoke/api-url-contract.test.ts
+++ b/frontend/src/__tests__/smoke/api-url-contract.test.ts
@@ -101,4 +101,18 @@ describe('API Client URL Contract', () => {
     );
     expect(block).toContain('encodeURIComponent');
   });
+
+  it('admin pool-health uses /admin/pool-health (no double prefix)', () => {
+    expect(content).toContain('/admin/pool-health');
+    expect(content).not.toMatch(/\/api\/v1\/admin\/pool-health/);
+  });
+
+  it('getAdminPoolHealth exposes refresh bypass via ?refresh=1', () => {
+    const block = content.slice(
+      content.indexOf('async getAdminPoolHealth'),
+      content.indexOf('async getAdminPoolHealth') + 400
+    );
+    expect(block).toContain('/admin/pool-health?refresh=1');
+    expect(block).toContain('/admin/pool-health');
+  });
 });

--- a/frontend/src/app/router/index.tsx
+++ b/frontend/src/app/router/index.tsx
@@ -17,6 +17,7 @@ import { AdminChatbotModels } from '@/pages/admin/ui/AdminChatbotModels';
 import { AdminSearchAlgorithms } from '@/pages/admin/ui/AdminSearchAlgorithms';
 import { AdminV2QualityAudit } from '@/pages/admin/ui/AdminV2QualityAudit';
 import { AdminV4ArbiterRuns } from '@/pages/admin/ui/AdminV4ArbiterRuns';
+import { AdminPoolHealth } from '@/pages/admin/ui/AdminPoolHealth';
 
 const IndexPage = lazy(() => import('@/pages/index'));
 const LoginPage = lazy(() => import('@/pages/login'));
@@ -156,6 +157,8 @@ export function AppRouter() {
           <Route path="v2-quality-audit" element={<AdminV2QualityAudit />} />
           {/* CP489+ — v4 LLM-arbiter PoC runs dashboard (embeds /v4-arbiter-dashboard.html). */}
           <Route path="v4-arbiter-runs" element={<AdminV4ArbiterRuns />} />
+          {/* Content Pool Health — 5-section pool dashboard. */}
+          <Route path="pool-health" element={<AdminPoolHealth />} />
         </Route>
 
         <Route path="*" element={<NotFoundPage />} />

--- a/frontend/src/pages/admin/ui/AdminLayout.tsx
+++ b/frontend/src/pages/admin/ui/AdminLayout.tsx
@@ -13,6 +13,7 @@ import {
   Bot,
   SlidersHorizontal,
   Activity,
+  Gauge,
 } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 
@@ -33,6 +34,8 @@ const NAV_ITEMS = [
   { to: '/admin/v2-quality-audit', icon: Activity, label: 'V2 Quality Audit' },
   // CP489+ — v4 LLM-arbiter PoC runs dashboard (operator-only mockup).
   { to: '/admin/v4-arbiter-runs', icon: Activity, label: 'V4 Arbiter Runs' },
+  // Content Pool Health — 5-section dashboard (volume/enrich/source/reuse/promote).
+  { to: '/admin/pool-health', icon: Gauge, label: 'Pool Health' },
 ] as const;
 
 export function AdminLayout() {

--- a/frontend/src/pages/admin/ui/AdminPoolHealth.tsx
+++ b/frontend/src/pages/admin/ui/AdminPoolHealth.tsx
@@ -1,0 +1,460 @@
+/**
+ * Admin Content Pool Health dashboard.
+ *
+ * Renders five sections (Volume / Enrich / Source / Reuse / Promote) from
+ * `GET /api/v1/admin/pool-health`. Each metric carries a precomputed
+ * status badge (`ok` / `warn` / `critical`) so the user sees the health
+ * judgment at a glance — no raw number scanning required.
+ *
+ * Thresholds live in `src/config/pool-health.ts` and are exported plain
+ * constants so the policy is editable in one place.
+ */
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import {
+  apiClient,
+  type AdminPoolHealthResponse,
+  type PoolHealthMetric,
+} from '@/shared/lib/api-client';
+import { cn } from '@/shared/lib/utils';
+import { PoolHealthBadge } from './PoolHealthBadge';
+
+function formatNumber(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+function formatMetricValue(m: PoolHealthMetric): string {
+  if (m.unit === '%') return `${m.value}%`;
+  if (m.unit === 'ratio') return m.value.toFixed(2);
+  if (m.unit === 'days') return `${m.value} day${m.value === 1 ? '' : 's'}`;
+  return formatNumber(m.value);
+}
+
+function thresholdText(m: PoolHealthMetric): string {
+  const arrow = m.threshold.direction === 'higher_is_better' ? '≥' : '≤';
+  const suffix = m.unit === '%' ? '%' : '';
+  return `${arrow} ${m.threshold.ok}${suffix} ok · ${arrow} ${m.threshold.warn}${suffix} warn`;
+}
+
+function MetricCard({ metric }: { metric: PoolHealthMetric }) {
+  const isNa = metric.status === 'na';
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-xs text-muted-foreground">{metric.label}</span>
+        <PoolHealthBadge status={metric.status} />
+      </div>
+      <div
+        className={cn(
+          'text-2xl font-semibold tabular-nums',
+          isNa ? 'text-muted-foreground' : 'text-foreground'
+        )}
+      >
+        {formatMetricValue(metric)}
+        {isNa && <span className="ml-2 text-xs font-normal">(측정 대기)</span>}
+      </div>
+      <div className="text-[10px] text-muted-foreground mt-1">
+        {isNa ? 'Disabled until launch (see Known Issues)' : thresholdText(metric)}
+      </div>
+    </div>
+  );
+}
+
+function Sparkline({
+  rows,
+  height = 36,
+}: {
+  rows: Array<{ day: string; n: number }>;
+  height?: number;
+}) {
+  if (rows.length === 0) {
+    return <div className="text-xs text-muted-foreground">no data</div>;
+  }
+  const sorted = [...rows].sort((a, b) => (a.day < b.day ? -1 : 1));
+  const max = Math.max(1, ...sorted.map((r) => r.n));
+  const w = Math.max(120, sorted.length * 8);
+  const points = sorted
+    .map((r, i) => {
+      const x = (i / Math.max(1, sorted.length - 1)) * w;
+      const y = height - (r.n / max) * (height - 4) - 2;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+  return (
+    <svg width={w} height={height} className="text-primary">
+      <polyline fill="none" stroke="currentColor" strokeWidth="1.5" points={points} />
+    </svg>
+  );
+}
+
+function VolumeSection({ data }: { data: AdminPoolHealthResponse }) {
+  const { totals, daily30d, derived } = data.volume;
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <h2 className="text-sm font-semibold text-foreground mb-3">1. Volume Trend</h2>
+      <div className="grid grid-cols-3 gap-3 mb-4 text-sm">
+        <div>
+          <div className="text-xs text-muted-foreground">video_pool</div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {formatNumber(totals.video_pool)}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">youtube_videos</div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {formatNumber(totals.youtube_videos)}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">recommendation_cache</div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {formatNumber(totals.recommendation_cache)}
+          </div>
+        </div>
+      </div>
+      <div className="space-y-3">
+        <div>
+          <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
+            <span>video_pool daily inflow (30d)</span>
+            <span>
+              avg{' '}
+              <span className="font-medium text-foreground">{derived.videoPoolAvgDaily30d}</span> ·
+              blank{' '}
+              <span className="font-medium text-foreground">{derived.videoPoolBlankDays30d}</span>d
+            </span>
+          </div>
+          <Sparkline rows={daily30d.video_pool} />
+        </div>
+        <div>
+          <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
+            <span>youtube_videos daily inflow (30d)</span>
+          </div>
+          <Sparkline rows={daily30d.youtube_videos} />
+        </div>
+        <div>
+          <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
+            <span>recommendation_cache daily creation (30d)</span>
+          </div>
+          <Sparkline rows={daily30d.recommendation_cache} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function GaugeBar({ pct, status }: { pct: number; status: PoolHealthMetric['status'] }) {
+  const color =
+    status === 'ok'
+      ? 'bg-emerald-500'
+      : status === 'warn'
+        ? 'bg-amber-500'
+        : status === 'critical'
+          ? 'bg-red-500'
+          : 'bg-zinc-500';
+  const clamped = Math.max(0, Math.min(100, pct));
+  return (
+    <div className="h-2 bg-muted/40 rounded overflow-hidden">
+      <div className={cn('h-full', color)} style={{ width: `${clamped}%` }} />
+    </div>
+  );
+}
+
+function EnrichSection({ data }: { data: AdminPoolHealthResponse }) {
+  const rs = data.enrich.richSummary;
+  const em = data.enrich.embedding;
+  const rsStatus = data.metrics.find((m) => m.key === 'richSummaryPct')?.status ?? 'critical';
+  const emStatus = data.metrics.find((m) => m.key === 'embeddingPct')?.status ?? 'critical';
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <h2 className="text-sm font-semibold text-foreground mb-3">2. Enrich Coverage</h2>
+      <div className="grid grid-cols-2 gap-4 text-sm">
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs text-muted-foreground">rich-summary</span>
+            <PoolHealthBadge status={rsStatus} />
+          </div>
+          <div className="text-lg font-semibold text-foreground tabular-nums mb-2">{rs.pct}%</div>
+          <GaugeBar pct={rs.pct} status={rsStatus} />
+          <div className="text-[10px] text-muted-foreground mt-1">
+            {formatNumber(rs.covered)} / {formatNumber(rs.total)} — missing{' '}
+            {formatNumber(rs.missing)}
+          </div>
+        </div>
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs text-muted-foreground">embedding</span>
+            <PoolHealthBadge status={emStatus} />
+          </div>
+          <div className="text-lg font-semibold text-foreground tabular-nums mb-2">{em.pct}%</div>
+          <GaugeBar pct={em.pct} status={emStatus} />
+          <div className="text-[10px] text-muted-foreground mt-1">
+            {formatNumber(em.covered)} / {formatNumber(em.total)} — missing{' '}
+            {formatNumber(em.missing)}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function SourceRow({ rows, total }: { rows: Array<{ source: string; n: number }>; total: number }) {
+  return (
+    <div className="space-y-1">
+      {rows.map((r) => {
+        const pct = total > 0 ? Math.round((1000 * r.n) / total) / 10 : 0;
+        return (
+          <div key={r.source} className="flex items-center gap-2 text-xs">
+            <span className="w-44 truncate text-muted-foreground">{r.source}</span>
+            <div className="flex-1 h-1.5 bg-muted/40 rounded overflow-hidden">
+              <div className="h-full bg-primary" style={{ width: `${pct}%` }} />
+            </div>
+            <span className="w-16 text-right tabular-nums text-foreground">{pct}%</span>
+            <span className="w-14 text-right tabular-nums text-muted-foreground">
+              {formatNumber(r.n)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function SourceSection({ data }: { data: AdminPoolHealthResponse }) {
+  const yvTotal = data.source.youtube_videos.reduce((a, r) => a + r.n, 0);
+  const vpTotal = data.source.video_pool.reduce((a, r) => a + r.n, 0);
+  const userInflowStatus =
+    data.metrics.find((m) => m.key === 'userInflowPct')?.status ?? 'critical';
+  const nullSourceStatus =
+    data.metrics.find((m) => m.key === 'nullSourcePct')?.status ?? 'critical';
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <h2 className="text-sm font-semibold text-foreground mb-3">3. Source Mix (30d)</h2>
+      <div className="grid grid-cols-2 gap-6">
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs text-muted-foreground">youtube_videos.source</span>
+            <PoolHealthBadge status={nullSourceStatus} />
+          </div>
+          <SourceRow rows={data.source.youtube_videos} total={yvTotal} />
+          <div className="text-[10px] text-muted-foreground mt-2">
+            NULL/legacy share {data.source.derived.nullSourcePct}%
+          </div>
+        </div>
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs text-muted-foreground">video_pool.source</span>
+            <PoolHealthBadge status={userInflowStatus} />
+          </div>
+          <SourceRow rows={data.source.video_pool} total={vpTotal} />
+          <div className="text-[10px] text-muted-foreground mt-2">
+            User inflow share {data.source.derived.userInflowPct}%
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ReuseSection({ data }: { data: AdminPoolHealthResponse }) {
+  const avgStatus = data.metrics.find((m) => m.key === 'avgReusePerVideo')?.status ?? 'critical';
+  const mandalaStatus =
+    data.metrics.find((m) => m.key === 'reuse2PlusMandalaPct')?.status ?? 'critical';
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <h2 className="text-sm font-semibold text-foreground mb-3">4. Reuse / Duplication (30d)</h2>
+      <div className="grid grid-cols-4 gap-3 mb-4 text-sm">
+        <div>
+          <div className="text-xs text-muted-foreground">Total recs</div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {formatNumber(data.reuse.totalRecs30d)}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">Unique videos</div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {formatNumber(data.reuse.uniqueVideos30d)}
+          </div>
+        </div>
+        <div>
+          <div className="flex items-center justify-between mb-0.5">
+            <span className="text-xs text-muted-foreground">Avg reuse</span>
+            <PoolHealthBadge status={avgStatus} />
+          </div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {data.reuse.avgReusePerVideo.toFixed(2)}
+          </div>
+        </div>
+        <div>
+          <div className="flex items-center justify-between mb-0.5">
+            <span className="text-xs text-muted-foreground">2+ mandalas</span>
+            <PoolHealthBadge status={mandalaStatus} />
+          </div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {data.reuse.videosIn2PlusMandalas} ({data.reuse.reuse2PlusMandalaPct}%)
+          </div>
+        </div>
+      </div>
+      <div>
+        <div className="text-xs text-muted-foreground mb-2">Top 15 reuse offenders</div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead className="text-muted-foreground">
+              <tr className="border-b border-border">
+                <th className="text-left py-1.5 pr-2 font-medium">video_id</th>
+                <th className="text-right py-1.5 pr-2 font-medium">mandalas</th>
+                <th className="text-right py-1.5 pr-2 font-medium">users</th>
+                <th className="text-right py-1.5 font-medium">recs</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.reuse.top15.map((r) => (
+                <tr key={r.video_id} className="border-b border-border/60">
+                  <td className="py-1 pr-2 font-mono text-foreground">{r.video_id}</td>
+                  <td className="py-1 pr-2 text-right tabular-nums text-foreground">
+                    {r.mandalas}
+                  </td>
+                  <td className="py-1 pr-2 text-right tabular-nums text-foreground">{r.users}</td>
+                  <td className="py-1 text-right tabular-nums text-foreground">{r.recs}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PromoteSection({ data }: { data: AdminPoolHealthResponse }) {
+  const status = data.metrics.find((m) => m.key === 'promotePct')?.status ?? 'critical';
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <h2 className="text-sm font-semibold text-foreground mb-3">5. Promote Funnel (30d)</h2>
+      <div className="grid grid-cols-4 gap-3 mb-4 text-sm">
+        <div>
+          <div className="text-xs text-muted-foreground">Distinct recs</div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {formatNumber(data.promote.totalDistinctRecs)}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">auto_added rows</div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {formatNumber(data.promote.totalAutoOwned)}
+          </div>
+        </div>
+        <div>
+          <div className="flex items-center justify-between mb-0.5">
+            <span className="text-xs text-muted-foreground">Promote %</span>
+            <PoolHealthBadge status={status} />
+          </div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {data.promote.promotePct}%
+          </div>
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">Mandalas w/ recs</div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {data.promote.mandalasWithRecs}
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2 text-[10px]">
+        {data.promote.statusBreakdown.map((s) => (
+          <span
+            key={s.status}
+            className="px-2 py-1 rounded bg-muted/40 text-muted-foreground tabular-nums"
+          >
+            {s.status}: {formatNumber(s.n)}
+          </span>
+        ))}
+        <span className="px-2 py-1 rounded bg-muted/40 text-muted-foreground tabular-nums">
+          surfaced_at present: {data.promote.surfacedAtPresent} ({data.promote.surfacedAtPct}%)
+        </span>
+      </div>
+    </section>
+  );
+}
+
+function KnownIssuesBanner({ issues }: { issues: ReadonlyArray<{ id: string; text: string }> }) {
+  if (issues.length === 0) return null;
+  return (
+    <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-xs">
+      <div className="flex items-center gap-1.5 text-amber-300 mb-1.5 font-medium">
+        <AlertTriangle className="h-3.5 w-3.5" />
+        Known issues (별건 — dashboard surfaces only, fix tracked separately)
+      </div>
+      <ul className="list-disc list-inside space-y-0.5 text-muted-foreground">
+        {issues.map((i) => (
+          <li key={i.id}>{i.text}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function AdminPoolHealth() {
+  const [refreshTick, setRefreshTick] = useState(0);
+  const { data, isLoading, isFetching, isError, error, refetch } = useQuery({
+    queryKey: ['admin', 'pool-health', refreshTick],
+    queryFn: () => apiClient.getAdminPoolHealth(refreshTick > 0),
+    staleTime: 60_000,
+  });
+
+  return (
+    <div className="p-6 max-w-6xl space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">Content Pool Health</h1>
+          {data && (
+            <p className="text-xs text-muted-foreground mt-1">
+              Generated {new Date(data.generatedAt).toLocaleString()} ·{' '}
+              {data.fromCache ? 'cached' : data.stale ? 'stale snapshot (DB unavailable)' : 'fresh'}
+            </p>
+          )}
+        </div>
+        <button
+          onClick={() => {
+            setRefreshTick((t) => t + 1);
+            void refetch();
+          }}
+          disabled={isFetching}
+          className="flex items-center gap-2 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm disabled:opacity-50"
+        >
+          <RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
+          Refresh
+        </button>
+      </div>
+
+      {isError && (
+        <div className="px-3 py-2 rounded-md bg-red-500/10 text-red-400 text-sm">
+          Failed to load pool health: {(error as Error)?.message ?? 'unknown error'}
+        </div>
+      )}
+
+      {isLoading && !data && (
+        <div className="px-3 py-2 rounded-md bg-muted/20 text-muted-foreground text-sm">
+          Loading…
+        </div>
+      )}
+
+      {data && (
+        <>
+          <div className="grid grid-cols-3 gap-3">
+            {data.metrics.map((m) => (
+              <MetricCard key={m.key} metric={m} />
+            ))}
+          </div>
+          <KnownIssuesBanner issues={data.knownIssues} />
+          <VolumeSection data={data} />
+          <EnrichSection data={data} />
+          <SourceSection data={data} />
+          <ReuseSection data={data} />
+          <PromoteSection data={data} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/ui/PoolHealthBadge.tsx
+++ b/frontend/src/pages/admin/ui/PoolHealthBadge.tsx
@@ -1,0 +1,38 @@
+import { cn } from '@/shared/lib/utils';
+import type { PoolHealthStatus } from '@/shared/lib/api-client';
+
+// Tailwind preset color tokens (no hex literals) — emerald = ok, amber =
+// warn, red = critical, zinc = na (metric disabled by config). Picked to
+// stay legible on the dark admin shell.
+const STATUS_CLASS: Record<PoolHealthStatus, string> = {
+  ok: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+  warn: 'bg-amber-500/15 text-amber-300 border-amber-500/30',
+  critical: 'bg-red-500/15 text-red-300 border-red-500/30',
+  na: 'bg-zinc-500/15 text-zinc-300 border-zinc-500/30',
+};
+
+const STATUS_LABEL: Record<PoolHealthStatus, string> = {
+  ok: 'OK',
+  warn: 'WARN',
+  critical: 'CRITICAL',
+  na: 'N/A',
+};
+
+export interface PoolHealthBadgeProps {
+  status: PoolHealthStatus;
+  className?: string;
+}
+
+export function PoolHealthBadge({ status, className }: PoolHealthBadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center justify-center px-2 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide border',
+        STATUS_CLASS[status],
+        className
+      )}
+    >
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -477,6 +477,67 @@ export class ApiHttpError extends Error {
   }
 }
 
+// Admin Pool Health — kept in sync with src/api/routes/admin/pool-health.ts
+// (PoolHealthSnapshot) + src/config/pool-health.ts (POOL_HEALTH_THRESHOLDS).
+export type PoolHealthStatus = 'ok' | 'warn' | 'critical' | 'na';
+
+export interface PoolHealthMetric {
+  key: string;
+  label: string;
+  value: number;
+  unit: string;
+  status: PoolHealthStatus;
+  threshold: { ok: number; warn: number; direction: string };
+}
+
+export interface AdminPoolHealthResponse {
+  generatedAt: string;
+  fromCache: boolean;
+  stale: boolean;
+  metrics: PoolHealthMetric[];
+  volume: {
+    totals: {
+      video_pool: number;
+      youtube_videos: number;
+      recommendation_cache: number;
+    };
+    daily30d: {
+      video_pool: Array<{ day: string; n: number }>;
+      youtube_videos: Array<{ day: string; n: number }>;
+      recommendation_cache: Array<{ day: string; n: number }>;
+    };
+    derived: { videoPoolAvgDaily30d: number; videoPoolBlankDays30d: number };
+  };
+  enrich: {
+    richSummary: { total: number; covered: number; missing: number; pct: number };
+    embedding: { total: number; covered: number; missing: number; pct: number };
+  };
+  source: {
+    youtube_videos: Array<{ source: string; n: number }>;
+    video_pool: Array<{ source: string; n: number }>;
+    derived: { userInflowPct: number; nullSourcePct: number };
+  };
+  reuse: {
+    totalRecs30d: number;
+    uniqueVideos30d: number;
+    avgReusePerVideo: number;
+    videosIn2PlusMandalas: number;
+    videosIn2PlusUsers: number;
+    reuse2PlusMandalaPct: number;
+    top15: Array<{ video_id: string; mandalas: number; users: number; recs: number }>;
+  };
+  promote: {
+    statusBreakdown: Array<{ status: string; n: number }>;
+    surfacedAtPresent: number;
+    surfacedAtPct: number;
+    mandalasWithRecs: number;
+    totalDistinctRecs: number;
+    totalAutoOwned: number;
+    promotePct: number;
+  };
+  knownIssues: ReadonlyArray<{ id: string; text: string }>;
+}
+
 class ApiClient {
   private baseUrl: string;
   private accessToken: string | null = null;
@@ -2431,6 +2492,16 @@ class ApiClient {
     message?: string;
   }> {
     return this.request('/admin/v2-quality-audit/run-now', { method: 'POST' });
+  }
+
+  // ========================================
+  // Admin Pool Health (5-section content pool dashboard)
+  // ========================================
+
+  async getAdminPoolHealth(refresh = false): Promise<AdminPoolHealthResponse> {
+    return this.request<AdminPoolHealthResponse>(
+      refresh ? '/admin/pool-health?refresh=1' : '/admin/pool-health'
+    );
   }
 
   async bulkUpdateUsers(

--- a/src/api/routes/admin/index.ts
+++ b/src/api/routes/admin/index.ts
@@ -24,6 +24,7 @@ import { adminDiscoverTracesRoutes } from './discover-traces';
 import { adminSearchAlgorithmsRoutes } from './search-algorithms';
 import { adminV2QualityAuditRoutes } from './v2-quality-audit';
 import { adminV4ArbiterRunsRoutes } from './v4-arbiter-runs';
+import { adminPoolHealthRoutes } from './pool-health';
 
 /**
  * Admin routes plugin.
@@ -63,5 +64,8 @@ export async function adminRoutes(fastify: FastifyInstance) {
   await fastify.register(adminV2QualityAuditRoutes, { prefix: '/v2-quality-audit' });
   // CP489+ — v4 LLM-arbiter PoC runs dashboard data source.
   await fastify.register(adminV4ArbiterRunsRoutes, { prefix: '/v4-arbiter-runs' });
+  // Content Pool Health — 5-section dashboard (volume / enrich / source /
+  // reuse / promote) with 5min cache + JSON snapshot fallback.
+  await fastify.register(adminPoolHealthRoutes, { prefix: '/pool-health' });
   // await fastify.register(stripeWebhookRoutes, { prefix: '/webhooks/stripe' });
 }

--- a/src/api/routes/admin/pool-health.ts
+++ b/src/api/routes/admin/pool-health.ts
@@ -1,0 +1,491 @@
+/**
+ * Admin Pool Health dashboard data source.
+ *
+ * `GET /api/v1/admin/pool-health` — returns the 5-section health snapshot
+ * computed from 7 raw SQL aggregations against prod tables (video_pool,
+ * youtube_videos, recommendation_cache, video_summaries,
+ * video_pool_embeddings, user_video_states). No writes, no DDL.
+ *
+ * Caching:
+ *   - 5-minute in-memory cache (process-local).
+ *   - Materialized snapshot on disk so a DB blip or process restart still
+ *     serves the last good payload (`stale: true` flag set).
+ *   - `?refresh=1` bypasses the in-memory cache for one call.
+ *
+ * Health bands and known-issues banner live in `src/config/pool-health.ts`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import { getPrismaClient } from '@/modules/database';
+import { logger } from '@/utils/logger';
+import {
+  POOL_HEALTH_THRESHOLDS,
+  POOL_HEALTH_KNOWN_ISSUES,
+  POOL_HEALTH_CACHE_TTL_MS,
+  evaluateHealth,
+  getPoolHealthSnapshotPath,
+  type HealthStatus,
+  type PoolHealthMetricKey,
+} from '@/config/pool-health';
+
+const log = logger.child({ module: 'api/admin/pool-health' });
+
+interface DailyRow {
+  day: string;
+  n: number;
+}
+
+interface TopReuseRow {
+  video_id: string;
+  mandalas: number;
+  users: number;
+  recs: number;
+}
+
+interface SourceRow {
+  source: string;
+  n: number;
+}
+
+interface MetricStatus {
+  key: PoolHealthMetricKey;
+  label: string;
+  value: number;
+  unit: string;
+  status: HealthStatus;
+  threshold: { ok: number; warn: number; direction: string };
+}
+
+export interface PoolHealthSnapshot {
+  generatedAt: string;
+  fromCache: boolean;
+  stale: boolean;
+  metrics: MetricStatus[];
+  volume: {
+    totals: {
+      video_pool: number;
+      youtube_videos: number;
+      recommendation_cache: number;
+    };
+    daily30d: {
+      video_pool: DailyRow[];
+      youtube_videos: DailyRow[];
+      recommendation_cache: DailyRow[];
+    };
+    derived: {
+      videoPoolAvgDaily30d: number;
+      videoPoolBlankDays30d: number;
+    };
+  };
+  enrich: {
+    richSummary: { total: number; covered: number; missing: number; pct: number };
+    embedding: { total: number; covered: number; missing: number; pct: number };
+  };
+  source: {
+    youtube_videos: SourceRow[];
+    video_pool: SourceRow[];
+    derived: { userInflowPct: number; nullSourcePct: number };
+  };
+  reuse: {
+    totalRecs30d: number;
+    uniqueVideos30d: number;
+    avgReusePerVideo: number;
+    videosIn2PlusMandalas: number;
+    videosIn2PlusUsers: number;
+    reuse2PlusMandalaPct: number;
+    top15: TopReuseRow[];
+  };
+  promote: {
+    statusBreakdown: Array<{ status: string; n: number }>;
+    surfacedAtPresent: number;
+    surfacedAtPct: number;
+    mandalasWithRecs: number;
+    totalDistinctRecs: number;
+    totalAutoOwned: number;
+    promotePct: number;
+  };
+  knownIssues: ReadonlyArray<{ id: string; text: string }>;
+}
+
+let cache: { data: PoolHealthSnapshot; ts: number } | null = null;
+
+function ensureSnapshotDir(filePath: string): void {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+    } catch (err) {
+      log.warn('snapshot dir create failed', {
+        dir,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+function writeSnapshot(data: PoolHealthSnapshot): void {
+  const filePath = getPoolHealthSnapshotPath();
+  ensureSnapshotDir(filePath);
+  try {
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8');
+  } catch (err) {
+    log.warn('snapshot write failed', {
+      filePath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function readSnapshot(): PoolHealthSnapshot | null {
+  const filePath = getPoolHealthSnapshotPath();
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    const txt = fs.readFileSync(filePath, 'utf-8');
+    return JSON.parse(txt) as PoolHealthSnapshot;
+  } catch (err) {
+    log.warn('snapshot read failed', {
+      filePath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+function normalizeRow(r: unknown): Record<string, unknown> {
+  // Prisma returns bigints for COUNT(*); convert to Number for JSON safety.
+  // Caller knows the expected shape and re-asserts via the `n(...)` helper.
+  if (r === null || typeof r !== 'object') return {};
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(r as Record<string, unknown>)) {
+    out[k] = typeof v === 'bigint' ? Number(v) : v;
+  }
+  return out;
+}
+
+function n(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  if (typeof value === 'bigint') return Number(value);
+  return fallback;
+}
+
+async function compute(): Promise<PoolHealthSnapshot> {
+  const prisma = getPrismaClient();
+
+  // $queryRawUnsafe returns unknown[] under our tsconfig; cast at the
+  // boundary and re-assert numeric fields via the `n(...)` helper.
+  const queryRows = async <T>(sql: string): Promise<T[]> => await prisma.$queryRawUnsafe(sql);
+
+  const [
+    totals,
+    daily30dVp,
+    daily30dYv,
+    daily30dRc,
+    enrichSummary,
+    enrichEmbedding,
+    sourceYv,
+    sourceVp,
+    reuseSummary,
+    reuseTop,
+    statusBreakdown,
+    surfacedRow,
+    promoteRow,
+  ] = await Promise.all([
+    queryRows<Record<string, unknown>>(`
+      SELECT
+        (SELECT count(*) FROM video_pool)::bigint           AS video_pool_total,
+        (SELECT count(*) FROM youtube_videos)::bigint       AS youtube_videos_total,
+        (SELECT count(*) FROM recommendation_cache)::bigint AS recommendation_cache_total
+    `),
+    queryRows<DailyRow>(`
+      SELECT date_trunc('day', cached_at)::date::text AS day, count(*)::int AS n
+      FROM video_pool
+      WHERE cached_at >= now() - interval '30 days'
+      GROUP BY 1 ORDER BY 1 DESC
+    `),
+    queryRows<DailyRow>(`
+      SELECT date_trunc('day', created_at)::date::text AS day, count(*)::int AS n
+      FROM youtube_videos
+      WHERE created_at >= now() - interval '30 days'
+      GROUP BY 1 ORDER BY 1 DESC
+    `),
+    queryRows<DailyRow>(`
+      SELECT date_trunc('day', created_at)::date::text AS day, count(*)::int AS n
+      FROM recommendation_cache
+      WHERE created_at >= now() - interval '30 days'
+      GROUP BY 1 ORDER BY 1 DESC
+    `),
+    queryRows<Record<string, unknown>>(`
+      SELECT
+        count(*)::int                                             AS total,
+        count(vs.video_id)::int                                   AS covered,
+        (count(*) - count(vs.video_id))::int                      AS missing,
+        round(100.0 * count(vs.video_id) / nullif(count(*),0), 1) AS pct
+      FROM youtube_videos yv
+      LEFT JOIN video_summaries vs ON vs.video_id = yv.youtube_video_id
+    `),
+    queryRows<Record<string, unknown>>(`
+      SELECT
+        count(*)::int                                              AS total,
+        count(vpe.video_id)::int                                   AS covered,
+        (count(*) - count(vpe.video_id))::int                      AS missing,
+        round(100.0 * count(vpe.video_id) / nullif(count(*),0), 1) AS pct
+      FROM video_pool vp
+      LEFT JOIN (SELECT DISTINCT video_id FROM video_pool_embeddings) vpe
+        ON vpe.video_id = vp.video_id
+    `),
+    queryRows<SourceRow>(`
+      SELECT coalesce(source, '(null/legacy)') AS source, count(*)::int AS n
+      FROM youtube_videos
+      WHERE created_at >= now() - interval '30 days'
+      GROUP BY 1 ORDER BY n DESC
+    `),
+    queryRows<SourceRow>(`
+      SELECT source, count(*)::int AS n
+      FROM video_pool
+      WHERE cached_at >= now() - interval '30 days'
+      GROUP BY 1 ORDER BY n DESC
+    `),
+    queryRows<Record<string, unknown>>(`
+      WITH last30 AS (
+        SELECT video_id, user_id, mandala_id
+        FROM recommendation_cache
+        WHERE created_at >= now() - interval '30 days'
+      )
+      SELECT
+        count(*)::int                                                       AS total_recs,
+        count(DISTINCT video_id)::int                                       AS unique_videos,
+        round(1.0 * count(*) / nullif(count(DISTINCT video_id), 0), 2)      AS avg_reuse,
+        (SELECT count(*) FROM (
+           SELECT video_id FROM last30 GROUP BY video_id HAVING count(DISTINCT mandala_id) > 1
+        ) t)::int                                                           AS videos_in_2plus_mandalas,
+        (SELECT count(*) FROM (
+           SELECT video_id FROM last30 GROUP BY video_id HAVING count(DISTINCT user_id) > 1
+        ) t)::int                                                           AS videos_in_2plus_users
+      FROM last30
+    `),
+    queryRows<TopReuseRow>(`
+      SELECT video_id,
+             count(DISTINCT mandala_id)::int AS mandalas,
+             count(DISTINCT user_id)::int    AS users,
+             count(*)::int                   AS recs
+      FROM recommendation_cache
+      WHERE created_at >= now() - interval '30 days'
+      GROUP BY video_id
+      ORDER BY mandalas DESC, recs DESC
+      LIMIT 15
+    `),
+    queryRows<{ status: string; n: number }>(`
+      SELECT status, count(*)::int AS n
+      FROM recommendation_cache
+      WHERE created_at >= now() - interval '30 days'
+      GROUP BY status ORDER BY n DESC
+    `),
+    queryRows<Record<string, unknown>>(`
+      SELECT
+        count(*)::int                                                                          AS total,
+        (count(*) FILTER (WHERE surfaced_at IS NOT NULL))::int                                 AS surfaced,
+        round(100.0 * count(*) FILTER (WHERE surfaced_at IS NOT NULL) / nullif(count(*),0), 1) AS pct
+      FROM recommendation_cache
+      WHERE created_at >= now() - interval '30 days'
+    `),
+    queryRows<Record<string, unknown>>(`
+      WITH rec_30d AS (
+        SELECT user_id, mandala_id, count(DISTINCT video_id) AS recs
+        FROM recommendation_cache
+        WHERE created_at >= now() - interval '30 days'
+        GROUP BY 1, 2
+      ),
+      auto_30d AS (
+        SELECT user_id, mandala_id, count(*) AS auto_owned
+        FROM user_video_states
+        WHERE auto_added = true AND created_at >= now() - interval '30 days'
+        GROUP BY 1, 2
+      )
+      SELECT
+        count(*)::int                                                            AS mandalas_with_recs,
+        coalesce(sum(r.recs), 0)::int                                            AS total_distinct_recs,
+        coalesce(sum(coalesce(a.auto_owned, 0)), 0)::int                         AS total_auto_owned,
+        round(100.0 * coalesce(sum(coalesce(a.auto_owned, 0)), 0) /
+              nullif(coalesce(sum(r.recs), 0), 0), 1)                            AS pct
+      FROM rec_30d r
+      LEFT JOIN auto_30d a USING (user_id, mandala_id)
+    `),
+  ]);
+
+  const tot = normalizeRow(totals[0] ?? {});
+  const enrSummary = normalizeRow(enrichSummary[0] ?? {});
+  const enrEmbed = normalizeRow(enrichEmbedding[0] ?? {});
+  const reuse = normalizeRow(reuseSummary[0] ?? {});
+  const surfaced = normalizeRow(surfacedRow[0] ?? {});
+  const promote = normalizeRow(promoteRow[0] ?? {});
+
+  // Daily-inflow rows are ::int already — no bigint normalize needed.
+  const vpDaily30 = daily30dVp;
+  const yvDaily30 = daily30dYv;
+  const rcDaily30 = daily30dRc;
+
+  const videoPoolAvgDaily30d =
+    vpDaily30.length > 0 ? Math.round(vpDaily30.reduce((acc, r) => acc + n(r.n), 0) / 30) : 0;
+  const videoPoolBlankDays30d = Math.max(0, 30 - vpDaily30.length);
+
+  const richSummaryPct = n(enrSummary['pct']);
+  const embeddingPct = n(enrEmbed['pct']);
+
+  const vpSourceRows = sourceVp;
+  const vpSourceTotal = vpSourceRows.reduce((acc, r) => acc + n(r.n), 0);
+  const userInflowRows = vpSourceRows.filter(
+    (r) => r.source === 'user_curated' || r.source === 'user_playlist' || r.source === 'user_add'
+  );
+  const userInflowPct =
+    vpSourceTotal > 0
+      ? Math.round((1000 * userInflowRows.reduce((acc, r) => acc + n(r.n), 0)) / vpSourceTotal) / 10
+      : 0;
+
+  const yvSourceRows = sourceYv;
+  const yvSourceTotal = yvSourceRows.reduce((acc, r) => acc + n(r.n), 0);
+  const nullSourceRow = yvSourceRows.find((r) => r.source === '(null/legacy)');
+  const nullSourcePct =
+    yvSourceTotal > 0 && nullSourceRow
+      ? Math.round((1000 * n(nullSourceRow.n)) / yvSourceTotal) / 10
+      : 0;
+
+  const avgReusePerVideo = n(reuse['avg_reuse']);
+  const videosIn2PlusMandalas = n(reuse['videos_in_2plus_mandalas']);
+  const uniqueVideos30d = n(reuse['unique_videos']);
+  const reuse2PlusMandalaPct =
+    uniqueVideos30d > 0 ? Math.round((1000 * videosIn2PlusMandalas) / uniqueVideos30d) / 10 : 0;
+
+  const promotePct = n(promote['pct']);
+
+  const metrics: MetricStatus[] = (
+    [
+      ['volumeDailyAvg30d', videoPoolAvgDaily30d],
+      ['blankDays30d', videoPoolBlankDays30d],
+      ['richSummaryPct', richSummaryPct],
+      ['embeddingPct', embeddingPct],
+      ['userInflowPct', userInflowPct],
+      ['nullSourcePct', nullSourcePct],
+      ['avgReusePerVideo', avgReusePerVideo],
+      ['reuse2PlusMandalaPct', reuse2PlusMandalaPct],
+      ['promotePct', promotePct],
+    ] as ReadonlyArray<[PoolHealthMetricKey, number]>
+  ).map(([key, value]) => {
+    const band = POOL_HEALTH_THRESHOLDS[key];
+    return {
+      key,
+      label: band.label,
+      value,
+      unit: band.unit,
+      status: evaluateHealth(value, band),
+      threshold: { ok: band.ok, warn: band.warn, direction: band.direction },
+    };
+  });
+
+  return {
+    generatedAt: new Date().toISOString(),
+    fromCache: false,
+    stale: false,
+    metrics,
+    volume: {
+      totals: {
+        video_pool: n(tot['video_pool_total']),
+        youtube_videos: n(tot['youtube_videos_total']),
+        recommendation_cache: n(tot['recommendation_cache_total']),
+      },
+      daily30d: {
+        video_pool: vpDaily30,
+        youtube_videos: yvDaily30,
+        recommendation_cache: rcDaily30,
+      },
+      derived: { videoPoolAvgDaily30d, videoPoolBlankDays30d },
+    },
+    enrich: {
+      richSummary: {
+        total: n(enrSummary['total']),
+        covered: n(enrSummary['covered']),
+        missing: n(enrSummary['missing']),
+        pct: richSummaryPct,
+      },
+      embedding: {
+        total: n(enrEmbed['total']),
+        covered: n(enrEmbed['covered']),
+        missing: n(enrEmbed['missing']),
+        pct: embeddingPct,
+      },
+    },
+    source: {
+      youtube_videos: yvSourceRows,
+      video_pool: vpSourceRows,
+      derived: { userInflowPct, nullSourcePct },
+    },
+    reuse: {
+      totalRecs30d: n(reuse['total_recs']),
+      uniqueVideos30d,
+      avgReusePerVideo,
+      videosIn2PlusMandalas,
+      videosIn2PlusUsers: n(reuse['videos_in_2plus_users']),
+      reuse2PlusMandalaPct,
+      top15: reuseTop,
+    },
+    promote: {
+      statusBreakdown: statusBreakdown,
+      surfacedAtPresent: n(surfaced['surfaced']),
+      surfacedAtPct: n(surfaced['pct']),
+      mandalasWithRecs: n(promote['mandalas_with_recs']),
+      totalDistinctRecs: n(promote['total_distinct_recs']),
+      totalAutoOwned: n(promote['total_auto_owned']),
+      promotePct,
+    },
+    knownIssues: POOL_HEALTH_KNOWN_ISSUES,
+  };
+}
+
+export async function adminPoolHealthRoutes(fastify: FastifyInstance) {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  fastify.get<{ Querystring: { refresh?: string } }>(
+    '/',
+    adminAuth,
+    async (request: FastifyRequest<{ Querystring: { refresh?: string } }>, reply: FastifyReply) => {
+      const wantRefresh = request.query?.refresh === '1';
+      const now = Date.now();
+
+      if (!wantRefresh && cache && now - cache.ts < POOL_HEALTH_CACHE_TTL_MS) {
+        return reply.send({ ...cache.data, fromCache: true });
+      }
+
+      try {
+        const data = await compute();
+        cache = { data, ts: now };
+        writeSnapshot(data);
+        return reply.send(data);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error('pool-health compute failed', { error: message });
+
+        const snap = readSnapshot();
+        if (snap) {
+          return reply.send({ ...snap, stale: true, fromCache: false });
+        }
+        return reply.code(503).send({
+          status: 'error',
+          code: 'POOL_HEALTH_UNAVAILABLE',
+          message,
+        });
+      }
+    }
+  );
+}
+
+// Test-only export — lets unit tests assert cache behaviour without
+// reaching into module-private state.
+export function _resetPoolHealthCacheForTest(): void {
+  cache = null;
+}

--- a/src/config/pool-health.ts
+++ b/src/config/pool-health.ts
@@ -1,0 +1,153 @@
+/**
+ * Admin Pool Health dashboard thresholds.
+ *
+ * Each metric exposes a band {ok, warn, direction}. The dashboard maps
+ * the live value to 'ok' | 'warn' | 'critical' via `evaluateHealth`.
+ * Defaults are chosen from the 2026-05-30 prod baseline measurement and
+ * are intentionally exported as plain constants so they can be edited in
+ * one place when policy changes (no env knob — these are not secrets and
+ * not per-deploy tunables).
+ */
+
+export type HealthDirection = 'higher_is_better' | 'lower_is_better';
+
+export interface HealthBand {
+  readonly ok: number;
+  readonly warn: number;
+  readonly direction: HealthDirection;
+  readonly unit: '%' | 'count' | 'ratio' | 'days';
+  readonly label: string;
+  /**
+   * Optional kill-switch. When `false`, the metric is shown but its status
+   * is forced to 'na' (gray) regardless of value. Used for measurements
+   * that are structurally not meaningful yet — e.g. pre-launch user
+   * inflow share where N=0 users makes 0% the correct steady state, not
+   * an error. Flip to `true` (or remove the field) once the signal turns
+   * on. Defaults to `true` if omitted.
+   */
+  readonly enabled?: boolean;
+}
+
+export const POOL_HEALTH_THRESHOLDS = {
+  volumeDailyAvg30d: {
+    ok: 100,
+    warn: 30,
+    direction: 'higher_is_better',
+    unit: 'count',
+    label: 'Avg daily inflow (30d)',
+  },
+  blankDays30d: {
+    ok: 2,
+    warn: 5,
+    direction: 'lower_is_better',
+    unit: 'days',
+    label: 'Blank inflow days (30d)',
+  },
+  richSummaryPct: {
+    ok: 80,
+    warn: 50,
+    direction: 'higher_is_better',
+    unit: '%',
+    label: 'Rich-summary coverage',
+  },
+  embeddingPct: {
+    ok: 95,
+    warn: 80,
+    direction: 'higher_is_better',
+    unit: '%',
+    label: 'Embedding coverage',
+  },
+  userInflowPct: {
+    ok: 5,
+    warn: 1,
+    direction: 'higher_is_better',
+    unit: '%',
+    label: 'User inflow share (video_pool)',
+    // Pre-launch: 0 users means 0% is the structurally correct value, so
+    // CRITICAL would be a permanent false alarm (alarm fatigue). Flip to
+    // `true` once launch fills the user_curated / user_playlist / user_add
+    // funnel. The raw value is still computed and displayed; only the
+    // status badge is suppressed.
+    enabled: false,
+  },
+  nullSourcePct: {
+    ok: 10,
+    warn: 30,
+    direction: 'lower_is_better',
+    unit: '%',
+    label: 'NULL/legacy source share',
+  },
+  avgReusePerVideo: {
+    ok: 1.3,
+    warn: 1.8,
+    direction: 'lower_is_better',
+    unit: 'ratio',
+    label: 'Avg reuse per video (30d)',
+  },
+  reuse2PlusMandalaPct: {
+    ok: 10,
+    warn: 20,
+    direction: 'lower_is_better',
+    unit: '%',
+    label: 'Videos in 2+ mandalas (30d)',
+  },
+  promotePct: {
+    ok: 50,
+    warn: 30,
+    direction: 'higher_is_better',
+    unit: '%',
+    label: 'Recs → auto_added promote %',
+  },
+} as const satisfies Record<string, HealthBand>;
+
+export type PoolHealthMetricKey = keyof typeof POOL_HEALTH_THRESHOLDS;
+
+export type HealthStatus = 'ok' | 'warn' | 'critical' | 'na';
+
+export function evaluateHealth(value: number, band: HealthBand): HealthStatus {
+  if (band.enabled === false) return 'na';
+  if (!Number.isFinite(value)) return 'critical';
+  if (band.direction === 'higher_is_better') {
+    if (value >= band.ok) return 'ok';
+    if (value >= band.warn) return 'warn';
+    return 'critical';
+  }
+  if (value <= band.ok) return 'ok';
+  if (value <= band.warn) return 'warn';
+  return 'critical';
+}
+
+/**
+ * Out-of-scope known issues surfaced on the dashboard as a static "Known
+ * Issues" banner. Listed here so the FE can render them without hard-coding
+ * the text and so the next /retro can track when they get resolved.
+ */
+export const POOL_HEALTH_KNOWN_ISSUES: ReadonlyArray<{ id: string; text: string }> = [
+  {
+    id: 'rich-summary-deficit',
+    text: 'rich-summary 67% 결손 (enrich cron 부진)',
+  },
+  {
+    id: 'surfaced-at-dead',
+    text: 'recommendation_cache.surfaced_at 항상 NULL (CP488 backlog 미작동)',
+  },
+  {
+    id: 'source-null-legacy',
+    text: 'youtube_videos.source NULL/legacy 비중 43% (collector 일부 경로 미식별)',
+  },
+  {
+    id: 'user-inflow-pre-launch',
+    text: 'User inflow share — pre-launch (0 users), 헬스 등급 비활성 (POOL_HEALTH_THRESHOLDS.userInflowPct.enabled=false). launch 후 활성화.',
+  },
+];
+
+/**
+ * Snapshot file path — disk fallback when live SQL fails (e.g. DB blip).
+ * Default lives outside the app dir so a container rebuild does not wipe
+ * the last-good snapshot. Override via env when needed (test/CI).
+ */
+export function getPoolHealthSnapshotPath(env: NodeJS.ProcessEnv = process.env): string {
+  return env['POOL_HEALTH_SNAPSHOT_PATH'] || '/var/insighta/pool-health-snapshot.json';
+}
+
+export const POOL_HEALTH_CACHE_TTL_MS = 5 * 60 * 1000;

--- a/tests/smoke/admin-pool-health.test.ts
+++ b/tests/smoke/admin-pool-health.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Admin Pool Health — unit + threshold smoke tests.
+ *
+ * Verifies the health-band evaluation maths and the baseline thresholds
+ * picked from the 2026-05-30 prod measurement. No DB, no network.
+ */
+
+import { POOL_HEALTH_THRESHOLDS, evaluateHealth, type HealthBand } from '@/config/pool-health';
+
+describe('evaluateHealth — higher_is_better', () => {
+  const band: HealthBand = {
+    ok: 80,
+    warn: 50,
+    direction: 'higher_is_better',
+    unit: '%',
+    label: 'demo',
+  };
+
+  it('returns ok at or above ok threshold', () => {
+    expect(evaluateHealth(80, band)).toBe('ok');
+    expect(evaluateHealth(100, band)).toBe('ok');
+  });
+
+  it('returns warn between warn and ok thresholds', () => {
+    expect(evaluateHealth(50, band)).toBe('warn');
+    expect(evaluateHealth(79.9, band)).toBe('warn');
+  });
+
+  it('returns critical below warn threshold', () => {
+    expect(evaluateHealth(49.9, band)).toBe('critical');
+    expect(evaluateHealth(0, band)).toBe('critical');
+  });
+});
+
+describe('evaluateHealth — lower_is_better', () => {
+  const band: HealthBand = {
+    ok: 10,
+    warn: 30,
+    direction: 'lower_is_better',
+    unit: '%',
+    label: 'demo',
+  };
+
+  it('returns ok at or below ok threshold', () => {
+    expect(evaluateHealth(10, band)).toBe('ok');
+    expect(evaluateHealth(0, band)).toBe('ok');
+  });
+
+  it('returns warn between ok and warn thresholds', () => {
+    expect(evaluateHealth(10.1, band)).toBe('warn');
+    expect(evaluateHealth(30, band)).toBe('warn');
+  });
+
+  it('returns critical above warn threshold', () => {
+    expect(evaluateHealth(30.1, band)).toBe('critical');
+    expect(evaluateHealth(100, band)).toBe('critical');
+  });
+});
+
+describe('evaluateHealth — invalid input', () => {
+  const band: HealthBand = {
+    ok: 80,
+    warn: 50,
+    direction: 'higher_is_better',
+    unit: '%',
+    label: 'demo',
+  };
+
+  it('treats NaN / Infinity as critical', () => {
+    expect(evaluateHealth(Number.NaN, band)).toBe('critical');
+    expect(evaluateHealth(Number.POSITIVE_INFINITY, band)).toBe('critical');
+  });
+});
+
+describe('POOL_HEALTH_THRESHOLDS — baseline expectations', () => {
+  it('rich-summary 33.3% (2026-05-30 prod) maps to critical', () => {
+    expect(evaluateHealth(33.3, POOL_HEALTH_THRESHOLDS.richSummaryPct)).toBe('critical');
+  });
+
+  it('embedding 96.8% (2026-05-30 prod) maps to ok', () => {
+    expect(evaluateHealth(96.8, POOL_HEALTH_THRESHOLDS.embeddingPct)).toBe('ok');
+  });
+
+  it('user inflow 0.03% (2026-05-30 prod video_pool user share) maps to na — pre-launch kill-switch', () => {
+    expect(POOL_HEALTH_THRESHOLDS.userInflowPct.enabled).toBe(false);
+    expect(evaluateHealth(0.03, POOL_HEALTH_THRESHOLDS.userInflowPct)).toBe('na');
+  });
+
+  it('na kill-switch overrides numeric value — even a 100% inflow still na while disabled', () => {
+    expect(evaluateHealth(100, POOL_HEALTH_THRESHOLDS.userInflowPct)).toBe('na');
+  });
+
+  it('avg reuse 1.21 (2026-05-30 prod) maps to ok', () => {
+    expect(evaluateHealth(1.21, POOL_HEALTH_THRESHOLDS.avgReusePerVideo)).toBe('ok');
+  });
+
+  it('promote 90.6% (2026-05-30 prod) maps to ok', () => {
+    expect(evaluateHealth(90.6, POOL_HEALTH_THRESHOLDS.promotePct)).toBe('ok');
+  });
+
+  it('NULL/legacy 43% (2026-05-30 prod youtube_videos.source) maps to critical', () => {
+    expect(evaluateHealth(43, POOL_HEALTH_THRESHOLDS.nullSourcePct)).toBe('critical');
+  });
+});


### PR DESCRIPTION
## Summary

- New admin route `GET /api/v1/admin/pool-health` runs 7 raw aggregations against `video_pool` / `youtube_videos` / `recommendation_cache` / `video_summaries` / `video_pool_embeddings` / `user_video_states` and returns a precomputed health snapshot with 9 metric bands (`ok` / `warn` / `critical` / `na`).
- FE page `/admin/pool-health` renders 5 sections — Volume / Enrich / Source / Reuse / Promote — plus a Known Issues banner. CSS+SVG sparkline (no recharts), Tailwind preset colors (no hex literals).
- 5-minute in-memory cache plus a disk-resident JSON snapshot at `POOL_HEALTH_SNAPSHOT_PATH` (default `/var/insighta/pool-health-snapshot.json`). On SQL failure the route returns the snapshot with `stale: true` instead of 503. `?refresh=1` bypasses the cache for one call.
- Thresholds live in `src/config/pool-health.ts` as exported constants. The `userInflowPct` band ships with `enabled=false` because pre-launch 0% is the structurally correct value, not an alarm; the metric is still computed and surfaced in the Known Issues banner. Flip the flag once launch fills the `user_curated` / `user_playlist` / `user_add` funnel.
- Known Issues banner (3 items) is data, not narrative — listed in the config so the next `/retro` can track resolution: rich-summary 67% deficit, `recommendation_cache.surfaced_at` always NULL (CP488 backlog inactive), `youtube_videos.source` NULL/legacy 43%.

## Baseline parity check (vs 2026-05-30 prod read-only measurement)

Dashboard SQL is byte-equivalent to the baseline session except for `coalesce(..., 0)` empty-set guards (value unchanged):

| Metric | Baseline value | Dashboard band | Status |
|---|---|---|---|
| video_pool total | 23,612 | — | — |
| richSummary % | 33.3 | ok ≥80, warn ≥50 | **CRITICAL** |
| embedding % | 96.8 | ok ≥95, warn ≥80 | OK |
| userInflowPct | 0.03 | enabled=false | N/A |
| nullSourcePct | 43 (30d window) | ok ≤10, warn ≤30 | **CRITICAL** |
| avgReusePerVideo | 1.21 | ok ≤1.3, warn ≤1.8 | OK |
| reuse2PlusMandalaPct | 12.8 | ok ≤10, warn ≤20 | WARN |
| promotePct | 90.6 (mandalas_with_recs=69) | ok ≥50, warn ≥30 | OK |

`nullSourcePct` denominator is already last-30d new rows (`WHERE created_at >= now() - interval '30 days'`), so the metric reflects current collector behaviour rather than legacy backlog.

`promotePct` numerator/denominator match the baseline Q5c exactly (`sum(r.recs)` per `(user_id, mandala_id)` with `mandalas_with_recs=69` narrow set).

## Out of scope

Dashboard surfaces the signals only — the three Known Issues are tracked as separate work items (`POOL_HEALTH_KNOWN_ISSUES` constant). No DB schema changes, no recharts, no `/var/insighta/v4-runs/`-style file-dependency anti-pattern, no LLM API calls.

## Test plan

- [x] BE jest: 14 unit tests on `evaluateHealth` higher/lower/invalid + 6 baseline expectations + 2 `enabled=false` kill-switch checks (`tests/smoke/admin-pool-health.test.ts`).
- [x] FE vitest: 12 URL contract tests including new `/admin/pool-health` + `?refresh=1` assertions (`frontend/src/__tests__/smoke/api-url-contract.test.ts`).
- [x] BE `tsc --noEmit` clean (`src/config/pool-health.ts` + `src/api/routes/admin/pool-health.ts`).
- [x] FE `tsc --noEmit` clean (`AdminPoolHealth.tsx` + `PoolHealthBadge.tsx` + `api-client.ts`).
- [x] `eslint --fix` BE: 0 errors, 2 warnings (Fastify plugin pattern, matches existing `v4-arbiter-runs.ts`).
- [ ] Browser smoke: `/admin/pool-health` loads, badges render, sparkline draws, Refresh button bypasses cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)