### PR TITLE
fix(admin/pool-health): coerce Prisma.Decimal in numeric extraction

### DIFF
--- a/src/api/routes/admin/pool-health.ts
+++ b/src/api/routes/admin/pool-health.ts
@@ -165,14 +165,19 @@ function normalizeRow(r: unknown): Record<string, unknown> {
   return out;
 }
 
-function n(value: unknown, fallback = 0): number {
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (typeof value === 'string') {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  if (typeof value === 'bigint') return Number(value);
-  return fallback;
+// Exported for unit testing — accepts every numeric shape Prisma's
+// raw-query path actually returns: JS number, string, bigint, or
+// Prisma.Decimal (a class instance with `valueOf` / `toString`).
+//
+// `Number(v)` delegates to `valueOf` for Decimal, parses strings, and
+// widens bigints — single funnel for every shape. The first ship only
+// branched on number/string/bigint, so Decimal fell to fallback 0
+// silently, zeroing every rounded pct in the payload
+// (richSummary / embedding / avgReuse / promote).
+export function n(value: unknown, fallback = 0): number {
+  if (value === null || value === undefined) return fallback;
+  const parsed = Number(value as never);
+  return Number.isFinite(parsed) ? parsed : fallback;
 }
 
 async function compute(): Promise<PoolHealthSnapshot> {

--- a/tests/smoke/admin-pool-health.test.ts
+++ b/tests/smoke/admin-pool-health.test.ts
@@ -5,7 +5,9 @@
  * picked from the 2026-05-30 prod measurement. No DB, no network.
  */
 
+import { Prisma } from '@prisma/client';
 import { POOL_HEALTH_THRESHOLDS, evaluateHealth, type HealthBand } from '@/config/pool-health';
+import { n } from '@/api/routes/admin/pool-health';
 
 describe('evaluateHealth — higher_is_better', () => {
   const band: HealthBand = {
@@ -69,6 +71,64 @@ describe('evaluateHealth — invalid input', () => {
   it('treats NaN / Infinity as critical', () => {
     expect(evaluateHealth(Number.NaN, band)).toBe('critical');
     expect(evaluateHealth(Number.POSITIVE_INFINITY, band)).toBe('critical');
+  });
+});
+
+describe('n() — Prisma raw-query numeric coercion', () => {
+  // Root cause of the first-ship hotfix: PG `round(numeric, 1)` arrives
+  // through Prisma's raw-query path as a `Prisma.Decimal` instance, not
+  // a string. Fixture strings like '33.3' will not reproduce the bug —
+  // the test MUST use the real Decimal class so a regression that drops
+  // the valueOf-funnel re-zeros the metric.
+
+  it('extracts the numeric value from a Prisma.Decimal instance', () => {
+    const dec = new Prisma.Decimal('33.3');
+    // Sanity: the instance carries the documented internal shape
+    // (constructor + sign / exponent / digit-array). If Prisma drops
+    // these, the test still asserts behaviour via Number().
+    expect(typeof dec).toBe('object');
+    expect(typeof dec.toString).toBe('function');
+    expect(typeof dec.valueOf).toBe('function');
+    expect(n(dec)).toBe(33.3);
+  });
+
+  it('extracts the numeric value from a fresh Decimal that round() would emit', () => {
+    // Mirrors `round(100.0 * count(...) / nullif(count(*), 0), 1)` →
+    // Decimal('96.8') in the embedding coverage path.
+    expect(n(new Prisma.Decimal('96.8'))).toBe(96.8);
+    expect(n(new Prisma.Decimal('1.21'))).toBe(1.21);
+    expect(n(new Prisma.Decimal('90.6'))).toBe(90.6);
+  });
+
+  it('extracts the numeric value from a Decimal-shaped duck-typed object', () => {
+    // Same internal shape Prisma.Decimal exposes ({s, e, d, valueOf,
+    // toString}) — guards against a future Prisma rewrite that keeps
+    // the contract but swaps the class.
+    const duck = {
+      s: 1,
+      e: 1,
+      d: [33, 3000000],
+      toString(): string {
+        return '33.3';
+      },
+      valueOf(): number {
+        return 33.3;
+      },
+    };
+    expect(n(duck)).toBe(33.3);
+  });
+
+  it('returns fallback for null / undefined / unparseable', () => {
+    expect(n(null)).toBe(0);
+    expect(n(undefined)).toBe(0);
+    expect(n({ not: 'numeric' })).toBe(0);
+    expect(n(null, 42)).toBe(42);
+  });
+
+  it('still handles the original number / string / bigint shapes', () => {
+    expect(n(33.3)).toBe(33.3);
+    expect(n('33.3')).toBe(33.3);
+    expect(n(BigInt(12505))).toBe(12505);
   });
 });
 


### PR DESCRIPTION
## Summary

Hotfix for PR #807. After deploy the live dashboard rendered four
metrics as 0 — `richSummaryPct`, `embeddingPct`, `avgReusePerVideo`,
`promotePct` — because PG `round(numeric, 1)` arrives through
Prisma's raw-query path as a `Prisma.Decimal` instance
(`typeof === 'object'`), not a string. The original `n()` only
branched on number / string / bigint, so Decimal fell to fallback 0
silently.

`Number(value)` delegates to `Decimal.valueOf`, parses strings, and
widens bigints — single funnel covers every shape Prisma actually
returns.

## Why a fixture-string test missed the bug

The original 14 tests passed `'33.3'` as the input. PG's
raw-query path returns a real `Prisma.Decimal` instance with
internal shape `{s, e, d, valueOf, toString}`. The new test imports
`Prisma.Decimal` directly and constructs `new Prisma.Decimal('33.3')`
— a regression that drops the valueOf-funnel re-zeros the metric and
fails the test.

## Test plan

- [x] BE jest: 19 tests pass — 5 new `n()` cases (Prisma.Decimal
  instance + duck-typed Decimal shape + null/undefined fallback +
  original number/string/bigint), 14 original.
- [x] BE `tsc --noEmit` clean.
- [x] FE `tsc --noEmit` clean.
- [ ] Live smoke after deploy: dashboard renders 33.3% / 96.8% / 1.21
  / 90.6% for the four affected metrics. **This is the merge-gate per
  user directive — green tests are not enough.**

## Out of scope

`userInflowPct` was 2.1% (not 0.03%) on the live run because
baseline measurement only counted `user_curated` (6 rows) in the
numerator; `user_playlist` (386 rows) should be in too. Live value
is correct. `na` kill-switch fires regardless of value, so no fix
needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)