### PR TITLE
feat(admin/pool-health): split V1 / V2 enrich + caption pipeline metrics

### DIFF
--- a/frontend/src/pages/admin/ui/AdminPoolHealth.tsx
+++ b/frontend/src/pages/admin/ui/AdminPoolHealth.tsx
@@ -162,36 +162,128 @@ function GaugeBar({ pct, status }: { pct: number; status: PoolHealthMetric['stat
 }
 
 function EnrichSection({ data }: { data: AdminPoolHealthResponse }) {
-  const rs = data.enrich.richSummary;
+  const v1 = data.enrich.richSummaryV1;
+  const v2 = data.enrich.richSummaryV2;
   const em = data.enrich.embedding;
-  const rsStatus = data.metrics.find((m) => m.key === 'richSummaryPct')?.status ?? 'critical';
+  const v1Status = data.metrics.find((m) => m.key === 'richSummaryV1Pct')?.status ?? 'critical';
+  const v1LlmStatus =
+    data.metrics.find((m) => m.key === 'richSummaryV1LlmPct')?.status ?? 'critical';
+  const v2Status = data.metrics.find((m) => m.key === 'richSummaryV2Pct')?.status ?? 'critical';
   const emStatus = data.metrics.find((m) => m.key === 'embeddingPct')?.status ?? 'critical';
   return (
     <section className="rounded-lg border border-border bg-card p-5">
-      <h2 className="text-sm font-semibold text-foreground mb-3">2. Enrich Coverage</h2>
-      <div className="grid grid-cols-2 gap-4 text-sm">
+      <h2 className="text-sm font-semibold text-foreground mb-3">
+        2. Enrich Coverage — V1 (legacy) / V2 (real) / embedding
+      </h2>
+      <div className="grid grid-cols-2 gap-4 text-sm mb-4">
         <div>
           <div className="flex items-center justify-between mb-1">
-            <span className="text-xs text-muted-foreground">rich-summary</span>
-            <PoolHealthBadge status={rsStatus} />
+            <span className="text-xs text-muted-foreground">V1 video_summaries (legacy)</span>
+            <PoolHealthBadge status={v1Status} />
           </div>
-          <div className="text-lg font-semibold text-foreground tabular-nums mb-2">{rs.pct}%</div>
-          <GaugeBar pct={rs.pct} status={rsStatus} />
+          <div className="text-lg font-semibold text-foreground tabular-nums mb-2">{v1.pct}%</div>
+          <GaugeBar pct={v1.pct} status={v1Status} />
           <div className="text-[10px] text-muted-foreground mt-1">
-            {formatNumber(rs.covered)} / {formatNumber(rs.total)} — missing{' '}
-            {formatNumber(rs.missing)}
+            {formatNumber(v1.covered)} / {formatNumber(v1.total)} — missing{' '}
+            {formatNumber(v1.missing)}
+          </div>
+          <div className="mt-2 flex items-center justify-between text-[10px]">
+            <span className="text-muted-foreground">↳ LLM-authored</span>
+            <span className="flex items-center gap-2">
+              <span className="text-foreground tabular-nums">
+                {v1.llmPct}% ({formatNumber(v1.llmCovered)})
+              </span>
+              <PoolHealthBadge status={v1LlmStatus} />
+            </span>
+          </div>
+          <div className="flex items-center justify-between text-[10px]">
+            <span className="text-muted-foreground">↳ metadata fallback (no LLM)</span>
+            <span className="text-foreground tabular-nums">
+              {v1.fallbackPct}% ({formatNumber(v1.fallbackCovered)})
+            </span>
           </div>
         </div>
         <div>
           <div className="flex items-center justify-between mb-1">
-            <span className="text-xs text-muted-foreground">embedding</span>
-            <PoolHealthBadge status={emStatus} />
+            <span className="text-xs text-muted-foreground">V2 video_rich_summaries (pass)</span>
+            <PoolHealthBadge status={v2Status} />
           </div>
-          <div className="text-lg font-semibold text-foreground tabular-nums mb-2">{em.pct}%</div>
-          <GaugeBar pct={em.pct} status={emStatus} />
+          <div className="text-lg font-semibold text-foreground tabular-nums mb-2">{v2.pct}%</div>
+          <GaugeBar pct={v2.pct} status={v2Status} />
           <div className="text-[10px] text-muted-foreground mt-1">
-            {formatNumber(em.covered)} / {formatNumber(em.total)} — missing{' '}
-            {formatNumber(em.missing)}
+            {formatNumber(v2.covered)} / {formatNumber(v2.total)} — missing{' '}
+            {formatNumber(v2.missing)}
+          </div>
+          {v2.modelBreakdown.length > 0 && (
+            <div className="mt-2 space-y-0.5">
+              {v2.modelBreakdown.slice(0, 4).map((m) => (
+                <div key={m.model} className="flex items-center justify-between text-[10px]">
+                  <span className="text-muted-foreground truncate max-w-[200px]">{m.model}</span>
+                  <span className="text-foreground tabular-nums">{formatNumber(m.n)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-xs text-muted-foreground">embedding (video_pool)</span>
+          <PoolHealthBadge status={emStatus} />
+        </div>
+        <div className="text-lg font-semibold text-foreground tabular-nums mb-2">{em.pct}%</div>
+        <GaugeBar pct={em.pct} status={emStatus} />
+        <div className="text-[10px] text-muted-foreground mt-1">
+          {formatNumber(em.covered)} / {formatNumber(em.total)} — missing {formatNumber(em.missing)}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CaptionPipelineSection({ data }: { data: AdminPoolHealthResponse }) {
+  const c = data.captionPipeline;
+  const failStatus = data.metrics.find((m) => m.key === 'captionFailRate7d')?.status ?? 'critical';
+  const fireStatus = data.metrics.find((m) => m.key === 'lastBulkFireHours')?.status ?? 'critical';
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <h2 className="text-sm font-semibold text-foreground mb-3">
+        2b. Caption Pipeline — Mac Mini CC bulk
+      </h2>
+      <div className="grid grid-cols-4 gap-3 text-sm">
+        <div>
+          <div className="text-xs text-muted-foreground">Attempts (7d)</div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {formatNumber(c.attempted7d)}
+          </div>
+          <div className="text-[10px] text-muted-foreground">
+            lifetime {formatNumber(c.attemptedTotal)}
+          </div>
+        </div>
+        <div>
+          <div className="text-xs text-muted-foreground">Pass / Fail (7d)</div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {formatNumber(c.pass7d)} / {formatNumber(c.fail7d)}
+          </div>
+        </div>
+        <div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">Fail rate (7d)</span>
+            <PoolHealthBadge status={failStatus} />
+          </div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">{c.failRate7d}%</div>
+          <div className="text-[10px] text-muted-foreground">awk + webshare mixed</div>
+        </div>
+        <div>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">Last fire</span>
+            <PoolHealthBadge status={fireStatus} />
+          </div>
+          <div className="text-lg font-semibold text-foreground tabular-nums">
+            {c.hoursSinceLastFire.toFixed(1)}h ago
+          </div>
+          <div className="text-[10px] text-muted-foreground">
+            {c.lastAttemptedAt ? new Date(c.lastAttemptedAt).toLocaleString() : 'never'}
           </div>
         </div>
       </div>
@@ -450,6 +542,7 @@ export function AdminPoolHealth() {
           <KnownIssuesBanner issues={data.knownIssues} />
           <VolumeSection data={data} />
           <EnrichSection data={data} />
+          <CaptionPipelineSection data={data} />
           <SourceSection data={data} />
           <ReuseSection data={data} />
           <PromoteSection data={data} />

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -509,8 +509,33 @@ export interface AdminPoolHealthResponse {
     derived: { videoPoolAvgDaily30d: number; videoPoolBlankDays30d: number };
   };
   enrich: {
-    richSummary: { total: number; covered: number; missing: number; pct: number };
+    richSummaryV1: {
+      total: number;
+      covered: number;
+      missing: number;
+      pct: number;
+      llmCovered: number;
+      llmPct: number;
+      fallbackCovered: number;
+      fallbackPct: number;
+    };
+    richSummaryV2: {
+      total: number;
+      covered: number;
+      missing: number;
+      pct: number;
+      modelBreakdown: Array<{ model: string; n: number }>;
+    };
     embedding: { total: number; covered: number; missing: number; pct: number };
+  };
+  captionPipeline: {
+    attemptedTotal: number;
+    attempted7d: number;
+    pass7d: number;
+    fail7d: number;
+    failRate7d: number;
+    lastAttemptedAt: string | null;
+    hoursSinceLastFire: number;
   };
   source: {
     youtube_videos: Array<{ source: string; n: number }>;

--- a/src/api/routes/admin/pool-health.ts
+++ b/src/api/routes/admin/pool-health.ts
@@ -81,8 +81,36 @@ export interface PoolHealthSnapshot {
     };
   };
   enrich: {
-    richSummary: { total: number; covered: number; missing: number; pct: number };
+    /** V1 video_summaries (legacy, mostly metadata-enriched fallback). */
+    richSummaryV1: {
+      total: number;
+      covered: number;
+      missing: number;
+      pct: number;
+      llmCovered: number;
+      llmPct: number;
+      fallbackCovered: number;
+      fallbackPct: number;
+    };
+    /** V2 video_rich_summaries pass-quality coverage — the real enrich gauge. */
+    richSummaryV2: {
+      total: number;
+      covered: number;
+      missing: number;
+      pct: number;
+      modelBreakdown: Array<{ model: string; n: number }>;
+    };
     embedding: { total: number; covered: number; missing: number; pct: number };
+  };
+  /** Mac Mini CC bulk pipeline health (proxy via DB). */
+  captionPipeline: {
+    attemptedTotal: number;
+    attempted7d: number;
+    pass7d: number;
+    fail7d: number;
+    failRate7d: number;
+    lastAttemptedAt: string | null;
+    hoursSinceLastFire: number;
   };
   source: {
     youtube_videos: SourceRow[];
@@ -201,6 +229,9 @@ async function compute(): Promise<PoolHealthSnapshot> {
     statusBreakdown,
     surfacedRow,
     promoteRow,
+    enrichV2,
+    v2ModelBreakdown,
+    captionPipeline,
   ] = await Promise.all([
     queryRows<Record<string, unknown>>(`
       SELECT
@@ -227,11 +258,23 @@ async function compute(): Promise<PoolHealthSnapshot> {
       GROUP BY 1 ORDER BY 1 DESC
     `),
     queryRows<Record<string, unknown>>(`
+      -- V1 video_summaries — split LLM-authored vs metadata-enriched fallback.
+      -- 2026-05-30 prod baseline: 4,289 total, 4,235 metadata-enriched
+      -- (98.7% of covered = LLM never ran). The flat coverage number alone
+      -- was structurally misleading — surface the split.
       SELECT
-        count(*)::int                                             AS total,
-        count(vs.video_id)::int                                   AS covered,
-        (count(*) - count(vs.video_id))::int                      AS missing,
-        round(100.0 * count(vs.video_id) / nullif(count(*),0), 1) AS pct
+        count(*)::int                                                                              AS total,
+        count(vs.video_id)::int                                                                    AS covered,
+        (count(*) - count(vs.video_id))::int                                                       AS missing,
+        round(100.0 * count(vs.video_id) / nullif(count(*),0), 1)                                  AS pct,
+        count(*) FILTER (WHERE vs.model IS NOT NULL
+                          AND vs.model <> 'metadata-enriched'
+                          AND vs.model <> 'no-caption')::int                                       AS llm_covered,
+        round(100.0 * count(*) FILTER (WHERE vs.model IS NOT NULL
+                          AND vs.model <> 'metadata-enriched'
+                          AND vs.model <> 'no-caption') / nullif(count(*),0), 1)                   AS llm_pct,
+        count(*) FILTER (WHERE vs.model = 'metadata-enriched')::int                                AS fallback_covered,
+        round(100.0 * count(*) FILTER (WHERE vs.model = 'metadata-enriched') / nullif(count(*),0), 1) AS fallback_pct
       FROM youtube_videos yv
       LEFT JOIN video_summaries vs ON vs.video_id = yv.youtube_video_id
     `),
@@ -322,11 +365,68 @@ async function compute(): Promise<PoolHealthSnapshot> {
       FROM rec_30d r
       LEFT JOIN auto_30d a USING (user_id, mandala_id)
     `),
+    queryRows<Record<string, unknown>>(`
+      -- V2 video_rich_summaries pass-quality coverage. This is the real
+      -- enrich gauge — V1 above is largely metadata-fallback noise.
+      SELECT
+        count(*)::int                                                                AS total,
+        count(*) FILTER (WHERE vrs.video_id IS NOT NULL
+                          AND vrs.quality_flag = 'pass')::int                        AS covered,
+        (count(*) - count(*) FILTER (WHERE vrs.video_id IS NOT NULL
+                                       AND vrs.quality_flag = 'pass'))::int          AS missing,
+        round(100.0 * count(*) FILTER (WHERE vrs.video_id IS NOT NULL
+                                        AND vrs.quality_flag = 'pass')
+              / nullif(count(*),0), 1)                                               AS pct
+      FROM youtube_videos yv
+      LEFT JOIN video_rich_summaries vrs ON vrs.video_id = yv.youtube_video_id
+    `),
+    queryRows<{ model: string; n: number }>(`
+      -- V2 model breakdown — surfaces the CC-direct vs Sonnet vs Qwen split.
+      -- 2026-05-30 baseline: cc-direct 1,676 / qwen 2,551 / sonnet 43 / null 3.
+      SELECT coalesce(model, '(null)') AS model, count(*)::int AS n
+      FROM video_rich_summaries
+      GROUP BY 1 ORDER BY n DESC
+    `),
+    queryRows<Record<string, unknown>>(`
+      -- Caption-pipeline pulse (Mac Mini bulk path proxy).
+      -- attempted_total = lifetime stamps; 7d window measures recent
+      -- pulse + fail rate. last_attempted_at = the freshest stamp from any
+      -- process-one.sh exit path, used as the launchd-fire proxy.
+      SELECT
+        count(*) FILTER (WHERE yv.transcript_attempted_at IS NOT NULL)::int                                       AS attempted_total,
+        count(*) FILTER (WHERE yv.transcript_attempted_at > now() - interval '7 days')::int                       AS attempted_7d,
+        count(*) FILTER (WHERE yv.transcript_attempted_at > now() - interval '7 days'
+                          AND EXISTS (
+                            SELECT 1 FROM video_rich_summaries vrs
+                            WHERE vrs.video_id = yv.youtube_video_id
+                              AND vrs.quality_flag = 'pass'
+                          ))::int                                                                                 AS pass_7d,
+        count(*) FILTER (WHERE yv.transcript_attempted_at > now() - interval '7 days'
+                          AND NOT EXISTS (
+                            SELECT 1 FROM video_rich_summaries vrs
+                            WHERE vrs.video_id = yv.youtube_video_id
+                              AND vrs.quality_flag = 'pass'
+                          ))::int                                                                                 AS fail_7d,
+        round(
+          100.0 * count(*) FILTER (WHERE yv.transcript_attempted_at > now() - interval '7 days'
+                                     AND NOT EXISTS (
+                                       SELECT 1 FROM video_rich_summaries vrs
+                                       WHERE vrs.video_id = yv.youtube_video_id
+                                         AND vrs.quality_flag = 'pass'
+                                     ))
+          / nullif(count(*) FILTER (WHERE yv.transcript_attempted_at > now() - interval '7 days'), 0)
+        , 1)                                                                                                      AS fail_rate_7d,
+        max(yv.transcript_attempted_at)::text                                                                     AS last_attempted_at,
+        extract(epoch FROM (now() - max(yv.transcript_attempted_at))) / 3600.0                                    AS hours_since
+      FROM youtube_videos yv
+    `),
   ]);
 
   const tot = normalizeRow(totals[0] ?? {});
   const enrSummary = normalizeRow(enrichSummary[0] ?? {});
   const enrEmbed = normalizeRow(enrichEmbedding[0] ?? {});
+  const enrV2 = normalizeRow(enrichV2[0] ?? {});
+  const cap = normalizeRow(captionPipeline[0] ?? {});
   const reuse = normalizeRow(reuseSummary[0] ?? {});
   const surfaced = normalizeRow(surfacedRow[0] ?? {});
   const promote = normalizeRow(promoteRow[0] ?? {});
@@ -340,8 +440,12 @@ async function compute(): Promise<PoolHealthSnapshot> {
     vpDaily30.length > 0 ? Math.round(vpDaily30.reduce((acc, r) => acc + n(r.n), 0) / 30) : 0;
   const videoPoolBlankDays30d = Math.max(0, 30 - vpDaily30.length);
 
-  const richSummaryPct = n(enrSummary['pct']);
+  const richSummaryV1Pct = n(enrSummary['pct']);
+  const richSummaryV1LlmPct = n(enrSummary['llm_pct']);
+  const richSummaryV2Pct = n(enrV2['pct']);
   const embeddingPct = n(enrEmbed['pct']);
+  const captionFailRate7d = n(cap['fail_rate_7d']);
+  const lastBulkFireHours = n(cap['hours_since']);
 
   const vpSourceRows = sourceVp;
   const vpSourceTotal = vpSourceRows.reduce((acc, r) => acc + n(r.n), 0);
@@ -373,8 +477,12 @@ async function compute(): Promise<PoolHealthSnapshot> {
     [
       ['volumeDailyAvg30d', videoPoolAvgDaily30d],
       ['blankDays30d', videoPoolBlankDays30d],
-      ['richSummaryPct', richSummaryPct],
+      ['richSummaryV1Pct', richSummaryV1Pct],
+      ['richSummaryV1LlmPct', richSummaryV1LlmPct],
+      ['richSummaryV2Pct', richSummaryV2Pct],
       ['embeddingPct', embeddingPct],
+      ['captionFailRate7d', captionFailRate7d],
+      ['lastBulkFireHours', lastBulkFireHours],
       ['userInflowPct', userInflowPct],
       ['nullSourcePct', nullSourcePct],
       ['avgReusePerVideo', avgReusePerVideo],
@@ -412,11 +520,22 @@ async function compute(): Promise<PoolHealthSnapshot> {
       derived: { videoPoolAvgDaily30d, videoPoolBlankDays30d },
     },
     enrich: {
-      richSummary: {
+      richSummaryV1: {
         total: n(enrSummary['total']),
         covered: n(enrSummary['covered']),
         missing: n(enrSummary['missing']),
-        pct: richSummaryPct,
+        pct: richSummaryV1Pct,
+        llmCovered: n(enrSummary['llm_covered']),
+        llmPct: richSummaryV1LlmPct,
+        fallbackCovered: n(enrSummary['fallback_covered']),
+        fallbackPct: n(enrSummary['fallback_pct']),
+      },
+      richSummaryV2: {
+        total: n(enrV2['total']),
+        covered: n(enrV2['covered']),
+        missing: n(enrV2['missing']),
+        pct: richSummaryV2Pct,
+        modelBreakdown: v2ModelBreakdown,
       },
       embedding: {
         total: n(enrEmbed['total']),
@@ -424,6 +543,15 @@ async function compute(): Promise<PoolHealthSnapshot> {
         missing: n(enrEmbed['missing']),
         pct: embeddingPct,
       },
+    },
+    captionPipeline: {
+      attemptedTotal: n(cap['attempted_total']),
+      attempted7d: n(cap['attempted_7d']),
+      pass7d: n(cap['pass_7d']),
+      fail7d: n(cap['fail_7d']),
+      failRate7d: captionFailRate7d,
+      lastAttemptedAt: (cap['last_attempted_at'] as string | null) ?? null,
+      hoursSinceLastFire: lastBulkFireHours,
     },
     source: {
       youtube_videos: yvSourceRows,

--- a/src/config/pool-health.ts
+++ b/src/config/pool-health.ts
@@ -43,12 +43,31 @@ export const POOL_HEALTH_THRESHOLDS = {
     unit: 'days',
     label: 'Blank inflow days (30d)',
   },
-  richSummaryPct: {
+  // 2026-05-30 diagnosis: video_summaries (V1, deprecated) was 33.3%
+  // covered but 98.7% of those rows are model='metadata-enriched' (no
+  // LLM call) — measurement was structurally wrong. The real enrich
+  // pipeline writes to video_rich_summaries. Both metrics are surfaced
+  // separately so the v1 → v2 transition stays observable.
+  richSummaryV1Pct: {
+    ok: 50,
+    warn: 30,
+    direction: 'higher_is_better',
+    unit: '%',
+    label: 'V1 video_summaries coverage (legacy)',
+  },
+  richSummaryV1LlmPct: {
+    ok: 30,
+    warn: 5,
+    direction: 'higher_is_better',
+    unit: '%',
+    label: 'V1 LLM-authored share (excl. metadata fallback)',
+  },
+  richSummaryV2Pct: {
     ok: 80,
     warn: 50,
     direction: 'higher_is_better',
     unit: '%',
-    label: 'Rich-summary coverage',
+    label: 'V2 video_rich_summaries pass coverage',
   },
   embeddingPct: {
     ok: 95,
@@ -56,6 +75,28 @@ export const POOL_HEALTH_THRESHOLDS = {
     direction: 'higher_is_better',
     unit: '%',
     label: 'Embedding coverage',
+  },
+  // CC bulk pipeline health — Mac Mini /transcript/candidates path.
+  // Caption fail = transcript_attempted_at stamped but the video has no
+  // v2 row with quality_flag='pass'. Two known root causes mix here
+  // (yt-dlp/WebShare proxy block + BSD-vs-gawk parsing) — split would
+  // require Mac Mini log shipping, future work.
+  captionFailRate7d: {
+    ok: 24,
+    warn: 50,
+    direction: 'lower_is_better',
+    unit: '%',
+    label: 'Caption fail rate (last 7d)',
+  },
+  // Hours since the last Mac Mini bulk-pipeline pulse. Proxy =
+  // max(youtube_videos.transcript_attempted_at) — every Mac Mini
+  // process-one.sh exit path stamps this. > 6h = scheduler likely stuck.
+  lastBulkFireHours: {
+    ok: 2,
+    warn: 6,
+    direction: 'lower_is_better',
+    unit: 'days',
+    label: 'Hours since last bulk fire',
   },
   userInflowPct: {
     ok: 5,
@@ -124,8 +165,16 @@ export function evaluateHealth(value: number, band: HealthBand): HealthStatus {
  */
 export const POOL_HEALTH_KNOWN_ISSUES: ReadonlyArray<{ id: string; text: string }> = [
   {
-    id: 'rich-summary-deficit',
-    text: 'rich-summary 67% 결손 (enrich cron 부진)',
+    id: 'v1-metadata-fallback',
+    text: 'V1 video_summaries — 98.7% metadata-enriched (LLM 안 거친 fallback). 실 enrich 측정은 richSummaryV2Pct.',
+  },
+  {
+    id: 'v2-cron-disabled',
+    text: 'RICH_SUMMARY_V2_CRON_ENABLED=false (prod). V2 backfill 은 Mac Mini bulk path (claude-code-direct).',
+  },
+  {
+    id: 'caption-fail-mixed-cause',
+    text: 'Caption fail = (yt-dlp WebShare proxy block) + (BSD-vs-gawk parsing). awk fail 만 gawk 로 fix 완료 (2026-05-30).',
   },
   {
     id: 'surfaced-at-dead',

--- a/tests/smoke/admin-pool-health.test.ts
+++ b/tests/smoke/admin-pool-health.test.ts
@@ -133,8 +133,28 @@ describe('n() — Prisma raw-query numeric coercion', () => {
 });
 
 describe('POOL_HEALTH_THRESHOLDS — baseline expectations', () => {
-  it('rich-summary 33.3% (2026-05-30 prod) maps to critical', () => {
-    expect(evaluateHealth(33.3, POOL_HEALTH_THRESHOLDS.richSummaryPct)).toBe('critical');
+  it('V1 rich-summary 33.3% (2026-05-30 prod) maps to warn — legacy band', () => {
+    expect(evaluateHealth(33.3, POOL_HEALTH_THRESHOLDS.richSummaryV1Pct)).toBe('warn');
+  });
+
+  it('V1 LLM-only 0.4% (21 of 4,289 rows ran LLM) maps to critical', () => {
+    expect(evaluateHealth(0.4, POOL_HEALTH_THRESHOLDS.richSummaryV1LlmPct)).toBe('critical');
+  });
+
+  it('V2 rich-summary 34.1% (2026-05-30 prod, real enrich) maps to critical', () => {
+    expect(evaluateHealth(34.1, POOL_HEALTH_THRESHOLDS.richSummaryV2Pct)).toBe('critical');
+  });
+
+  it('caption fail rate 58% (2026-05-30 prod, awk + webshare mixed) maps to critical', () => {
+    expect(evaluateHealth(58, POOL_HEALTH_THRESHOLDS.captionFailRate7d)).toBe('critical');
+  });
+
+  it('last bulk fire 0.5h ago maps to ok — pipeline alive', () => {
+    expect(evaluateHealth(0.5, POOL_HEALTH_THRESHOLDS.lastBulkFireHours)).toBe('ok');
+  });
+
+  it('last bulk fire 8h ago maps to critical — scheduler likely stuck', () => {
+    expect(evaluateHealth(8, POOL_HEALTH_THRESHOLDS.lastBulkFireHours)).toBe('critical');
   });
 
   it('embedding 96.8% (2026-05-30 prod) maps to ok', () => {
@@ -160,5 +180,19 @@ describe('POOL_HEALTH_THRESHOLDS — baseline expectations', () => {
 
   it('NULL/legacy 43% (2026-05-30 prod youtube_videos.source) maps to critical', () => {
     expect(evaluateHealth(43, POOL_HEALTH_THRESHOLDS.nullSourcePct)).toBe('critical');
+  });
+
+  it('n() coerces Decimal from caption fail rate path (rounded pct)', () => {
+    // Caption-fail-rate path uses round(..., 1) → Prisma.Decimal. This test
+    // would have caught the original PR #807 Decimal bug if it had existed.
+    const dec = new Prisma.Decimal('58.0');
+    expect(n(dec)).toBe(58);
+    expect(evaluateHealth(n(dec), POOL_HEALTH_THRESHOLDS.captionFailRate7d)).toBe('critical');
+  });
+
+  it('n() coerces hours_since (extract epoch / 3600) — float8 path', () => {
+    // hours_since uses `extract(epoch FROM ...) / 3600.0` → numeric → Decimal.
+    expect(n(new Prisma.Decimal('0.5'))).toBe(0.5);
+    expect(n(new Prisma.Decimal('8.25'))).toBe(8.25);
   });
 });


### PR DESCRIPTION
## Summary

V1 video_summaries was being measured as a single 33.3% coverage gauge,
but **98.7% of covered rows are `model='metadata-enriched'`** (no LLM
ever ran). The dashboard's headline was structurally misleading: V1
enrich pipeline is effectively dead in prod (5 / 12,505 LLM rows =
**0.04%**) and the real enrich gauge is `video_rich_summaries` (V2),
populated by the Mac Mini CC bulk path and a small Sonnet / Heart-click
trickle.

Surfaces five new metrics:

| key | meaning |
|---|---|
| `richSummaryV1Pct` | V1 legacy coverage (kept for parity) |
| `richSummaryV1LlmPct` | V1 LLM-authored share (excl. metadata fallback + no-caption) |
| `richSummaryV2Pct` | V2 pass-quality coverage — **the real enrich gauge** |
| `captionFailRate7d` | Mac Mini bulk pipeline fail rate (awk/webshare mixed; cause-split future work) |
| `lastBulkFireHours` | pulse via `max(youtube_videos.transcript_attempted_at)` |

FE adds a `CaptionPipelineSection` (attempts / pass / fail / fail rate /
hours-since-fire side-by-side) and rebuilds `EnrichSection` to show V1
(with the LLM-vs-fallback split) + V2 (with model breakdown) +
embedding stacked.

Threshold defaults from the 2026-05-30 prod baseline + the Mac Mini
launchd cadence (9 slots/day → 2h ok / 6h warn for last-fire).

## Pre-merge prod live smoke (CP807 Decimal lesson)

Ran the new compute() SQL against prod (read-only) — no Decimal-bug
regression. Values that will render on the dashboard after deploy:

| metric | live value | status |
|---|---|---|
| richSummaryV1Pct | 33.3% | warn |
| richSummaryV1LlmPct | **0.0%** (5 LLM / 12,505) | critical |
| richSummaryV2Pct | **32.7%** | critical |
| captionFailRate7d | **42.3%** (down from 58% baseline) | warn |
| lastBulkFireHours | 0.6h | ok |

V2 model split (live): qwen 2,544 / claude-code-direct 1,691 / sonnet 43 / null 3.

**Note**: the 42.3% includes the gawk-fix-pre window — actual current
rate is better. N tuning for the launchd job will be decided once the
post-fix batch completes its 100-video run.

## Test plan

- [x] BE jest: 26 tests pass (was 19) — 6 new baseline cases + 2 new
  Decimal-coercion regression guards covering `round(pct, 1)` and
  `extract(epoch ...) / 3600.0`.
- [x] FE vitest: 12 URL-contract tests still pass (no surface change).
- [x] BE `tsc --noEmit` clean.
- [x] FE `tsc --noEmit` clean.
- [x] Pre-merge prod live smoke PASS — every metric returns a live
  number, no zero-on-prod regression like PR #807.
- [ ] Post-merge: GET `/api/v1/admin/pool-health` returns the values
  above (V1Llm 0.0% / V2 32.7% / caption 42.3% / fire 0.6h) — manual
  verification per user directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)