### PR TITLE
feat(v5): executor per-stage instrumentation (F5, CP491)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -381,6 +381,11 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               v5_picks_raw: v5Result.diagnostics.picksRaw,
               v5_llm_batches: v5Result.diagnostics.llmBatches,
               v5_quota_units: v5Result.diagnostics.quotaUnitsApprox,
+              // CP491 F5 — per-stage ms + abort observability (makes the
+              // "videos.list dominant" claim directly measurable in prod).
+              v5_stage_ms: v5Result.diagnostics.stageMs,
+              v5_aborted_batches: v5Result.diagnostics.abortedBatches,
+              v5_picker_timed_out: v5Result.diagnostics.pickerTimedOut,
               // CP489 Phase 6 — emit returned videoIds so the Search Journey
               // Ledger can join per-round trace rows ↔ card_interactions
               // deterministically (no timestamp-window fuzziness). Bounded

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -48,6 +48,20 @@ export interface V5Card {
   reason: string;
 }
 
+/**
+ * Per-stage wall-clock breakdown (ms) of a single executor run. CP491 F5 —
+ * the executor was previously a black box (only total durationMs), so the
+ * "videos.list dominant" claim was elimination-inferred, not measured. These
+ * markers make the dominant stage directly observable in prod traces.
+ */
+export interface V5StageMs {
+  fanoutMs: number;
+  excludeMs: number;
+  llmMs: number;
+  videosMs: number;
+  assembleMs: number;
+}
+
 export interface V5ExecuteResult {
   cards: V5Card[];
   diagnostics: {
@@ -61,6 +75,12 @@ export interface V5ExecuteResult {
     quotaUnitsApprox: number;
     durationMs: number;
     pickerModel: string;
+    /** CP491 F5 — per-stage ms. Stages not reached on an early return are 0. */
+    stageMs: V5StageMs;
+    /** CP491 F5 — batches that returned [] due to the 5s external abort (U2). */
+    abortedBatches: number;
+    /** CP491 F5 — whether the picker batchTimer fired (ac.signal.aborted). */
+    pickerTimedOut: boolean;
   };
 }
 
@@ -69,7 +89,13 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
   const cfg = getV5Config(input.env);
   const pickerCfg = getLlmPickerConfig(input.env);
 
+  // CP491 F5 — per-stage wall-clock markers (stages not reached stay 0).
+  const stage: V5StageMs = { fanoutMs: 0, excludeMs: 0, llmMs: 0, videosMs: 0, assembleMs: 0 };
+  let abortedBatches = 0;
+  let pickerTimedOut = false;
+
   // 1. YouTube fanout
+  const tFanout0 = Date.now();
   const fanout = await runYouTubeFanout({
     centerGoal: input.centerGoal,
     subGoals: input.subGoals,
@@ -78,11 +104,14 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
     language: input.language,
     env: input.env,
   });
+  stage.fanoutMs = Date.now() - tFanout0;
   const afterTitleFilter = fanout.candidates.length;
 
   // 2. exclude BEFORE LLM (save LLM tokens)
+  const tExclude0 = Date.now();
   const survivors = fanout.candidates.filter((c) => !input.excludeVideoIds.has(c.videoId));
   const afterExcludeFilter = survivors.length;
+  stage.excludeMs = Date.now() - tExclude0;
 
   if (survivors.length === 0) {
     log.info(
@@ -94,6 +123,9 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       afterExcludeFilter,
       pickerCfg,
       t0,
+      stage,
+      abortedBatches,
+      pickerTimedOut,
     });
   }
 
@@ -106,6 +138,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
     6
   );
 
+  const tLlm0 = Date.now();
   const ac = new AbortController();
   const batchTimer = setTimeout(() => ac.abort(), pickerCfg.timeoutMs);
   let pickResults: PickResult[][];
@@ -127,7 +160,10 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
             ac.signal
           );
         } catch (err) {
-          log.warn(`v5 picker batch failed: ${err instanceof Error ? err.message : String(err)}`);
+          const msg = err instanceof Error ? err.message : String(err);
+          // CP491 F5 — distinguish abort-induced empty picks (U2) from other failures.
+          if (msg.includes('cancelled by external signal')) abortedBatches += 1;
+          log.warn(`v5 picker batch failed: ${msg}`);
           return [] as PickResult[];
         }
       })
@@ -135,6 +171,8 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
   } finally {
     clearTimeout(batchTimer);
   }
+  stage.llmMs = Date.now() - tLlm0;
+  pickerTimedOut = ac.signal.aborted;
 
   const picksMerged = mergePicks(pickResults, cfg.targetPicks);
 
@@ -147,10 +185,14 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       pickerCfg,
       t0,
       llmBatches: limitedBatches.length,
+      stage,
+      abortedBatches,
+      pickerTimedOut,
     });
   }
 
   // 4. videos.list for picked only (stats + duration)
+  const tVideos0 = Date.now();
   const fanoutById = new Map(survivors.map((c) => [c.videoId, c]));
   const pickedIds = picksMerged.map((p) => p.videoId);
   const apiKeys = resolveSearchApiKeys(input.env);
@@ -165,13 +207,16 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
     }
   }
   const metaById = new Map(fullMeta.map((m) => [m.id ?? '', m]));
+  stage.videosMs = Date.now() - tVideos0;
 
   // 5. assemble cards in pick order
+  const tAssemble0 = Date.now();
   const cards: V5Card[] = picksMerged.map((p) => {
     const fan = fanoutById.get(p.videoId);
     const meta = metaById.get(p.videoId);
     return assembleCard(p, fan, meta);
   });
+  stage.assembleMs = Date.now() - tAssemble0;
 
   return {
     cards,
@@ -186,6 +231,9 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       quotaUnitsApprox: fanout.quotaUnitsApprox + (pickedIds.length > 0 ? 1 : 0),
       durationMs: Date.now() - t0,
       pickerModel: picker.model,
+      stageMs: stage,
+      abortedBatches,
+      pickerTimedOut,
     },
   };
 }
@@ -202,6 +250,9 @@ function emptyResult(args: {
   pickerCfg: ReturnType<typeof getLlmPickerConfig>;
   t0: number;
   llmBatches?: number;
+  stage: V5StageMs;
+  abortedBatches: number;
+  pickerTimedOut: boolean;
 }): V5ExecuteResult {
   return {
     cards: [],
@@ -216,6 +267,9 @@ function emptyResult(args: {
       quotaUnitsApprox: args.fanout.quotaUnitsApprox,
       durationMs: Date.now() - args.t0,
       pickerModel: args.pickerCfg.model,
+      stageMs: args.stage,
+      abortedBatches: args.abortedBatches,
+      pickerTimedOut: args.pickerTimedOut,
     },
   };
 }

--- a/src/skills/plugins/video-discover/v5/wizard-adapter.ts
+++ b/src/skills/plugins/video-discover/v5/wizard-adapter.ts
@@ -24,6 +24,9 @@
 
 import type { AssembledSlot, EphemeralDiscoverResult } from '../v3/executor';
 import { runV5Executor, type V5ExecuteInput } from './executor';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'video-discover/v5/wizard-adapter' });
 
 export type V5WizardInput = Omit<V5ExecuteInput, 'excludeVideoIds'> & {
   excludeVideoIds?: Set<string>;
@@ -40,6 +43,16 @@ export async function runV5ForWizard(input: V5WizardInput): Promise<EphemeralDis
     excludeVideoIds: input.excludeVideoIds ?? new Set<string>(),
     env: input.env,
   });
+
+  // CP491 F5 — surface the per-stage breakdown for the wizard path too
+  // (same runV5Executor as /add-cards, C8). Lets prod logs show whether
+  // videos.list dominates the wizard discover_ms without a separate trace.
+  const s = result.diagnostics.stageMs;
+  log.info(
+    `v5 wizard stages ms: fanout=${s.fanoutMs} exclude=${s.excludeMs} llm=${s.llmMs} ` +
+      `videos=${s.videosMs} assemble=${s.assembleMs} total=${result.diagnostics.durationMs} ` +
+      `abortedBatches=${result.diagnostics.abortedBatches} pickerTimedOut=${result.diagnostics.pickerTimedOut}`
+  );
 
   const slots: AssembledSlot[] = result.cards.map((c) => ({
     videoId: c.videoId,

--- a/tests/unit/skills/video-discover/v5-executor.test.ts
+++ b/tests/unit/skills/video-discover/v5-executor.test.ts
@@ -182,4 +182,70 @@ describe('runV5Executor (orchestration smoke)', () => {
     });
     expect(result.cards.length).toBeGreaterThan(0);
   });
+
+  // CP491 F5 — instrumentation: per-stage ms + abort observability.
+  test('F5: diagnostics expose per-stage ms for all 5 stages', async () => {
+    runYouTubeFanout.mockResolvedValue({
+      candidates: [makeFanoutCandidate('a'), makeFanoutCandidate('b')],
+      queriesAttempted: 1,
+      queriesSucceeded: 1,
+      rawItemCount: 2,
+      quotaUnitsApprox: 100,
+    });
+    setVideoPickerForTest(
+      new FakePicker((input) =>
+        input.candidates.map((c) => ({ videoId: c.videoId, score: 0.9, reason: 'ok' }))
+      )
+    );
+    const result = await runV5Executor({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      excludeVideoIds: new Set(),
+      env: {} as NodeJS.ProcessEnv,
+    });
+    const s = result.diagnostics.stageMs;
+    expect(s).toBeDefined();
+    for (const k of ['fanoutMs', 'excludeMs', 'llmMs', 'videosMs', 'assembleMs'] as const) {
+      expect(typeof s[k]).toBe('number');
+      expect(s[k]).toBeGreaterThanOrEqual(0);
+    }
+    expect(result.diagnostics.pickerTimedOut).toBe(false);
+    expect(result.diagnostics.abortedBatches).toBe(0);
+  });
+
+  test('F5: abortedBatches counts only external-abort errors, not generic failures', async () => {
+    runYouTubeFanout.mockResolvedValue({
+      candidates: Array.from({ length: 24 }, (_, i) => makeFanoutCandidate(`v${i}`)),
+      queriesAttempted: 1,
+      queriesSucceeded: 1,
+      rawItemCount: 24,
+      quotaUnitsApprox: 100,
+    });
+    // 24 candidates / batchSize 12 = 2 batches: one external-abort, one generic.
+    let callCount = 0;
+    setVideoPickerForTest(
+      new FakePicker((input) => {
+        callCount += 1;
+        if (callCount === 1) throw new Error('OpenRouter request cancelled by external signal');
+        if (callCount === 2) throw new Error('boom generic');
+        return input.candidates
+          .slice(0, 2)
+          .map((c) => ({ videoId: c.videoId, score: 0.8, reason: 'ok' }));
+      })
+    );
+    const result = await runV5Executor({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      excludeVideoIds: new Set(),
+      env: {} as NodeJS.ProcessEnv,
+    });
+    // Only the 'cancelled by external signal' batch is counted.
+    expect(result.diagnostics.abortedBatches).toBe(1);
+  });
 });


### PR DESCRIPTION
F5 of the v5 redesign. Pure observation, no behavior/shape change (diff-verified).

- executor: `stageMs {fanout,exclude,llm,videos,assemble}` + `abortedBatches` (external-abort only) + `pickerTimedOut`. Additive diagnostics; control flow + return shape unchanged.
- add-cards: surfaces `v5_stage_ms` / `v5_aborted_batches` / `v5_picker_timed_out` in the `add_cards.end` trace. HTTP response payload unchanged.
- wizard-adapter: logs per-stage breakdown (same executor, C8). Ephemeral shape unchanged.

**Gate**: makes the "videos.list dominant" claim (diagnosis §C1, elimination-inferred) directly measurable in prod before F1. Ref `docs/handoffs/v5-redesign-diagnosis-cp491.md` §7. Quota recording = F5b follow-up.

Tests: 6/6 (2 new — stageMs presence + abort counting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)