### PR TITLE
feat(v5): wizard-path observability — per-query + wizard.discover.end trace (F5c, CP491)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -386,6 +386,8 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               v5_stage_ms: v5Result.diagnostics.stageMs,
               v5_aborted_batches: v5Result.diagnostics.abortedBatches,
               v5_picker_timed_out: v5Result.diagnostics.pickerTimedOut,
+              // CP491 F5c — per-query raw count + q_ok (parity with wizard.discover.end).
+              v5_per_query: v5Result.diagnostics.perQuery,
               // CP489 Phase 6 — emit returned videoIds so the Search Journey
               // Ledger can join per-round trace rows ↔ card_interactions
               // deterministically (no timestamp-window fuzziness). Bounded

--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -412,11 +412,37 @@ export async function consumePrecompute(
   // step3 will retry the same logic ~30s later as a safety net.
   try {
     const { maybeAutoAddRecommendations } = await import('./auto-add-recommendations');
-    const { withTraceContext } = await import('@/modules/discover-tracing');
+    const { withTraceContext, recordTrace } = await import('@/modules/discover-tracing');
     // CP457+ bind trace context for auto_add.user_video_states row.
     const autoAddResult = await withTraceContext(
       { mandalaId: input.mandalaId, userId: input.userId },
-      () => maybeAutoAddRecommendations(input.userId, input.mandalaId)
+      () => {
+        // CP491 F5c — emit the v5 discover diagnostics as a trace keyed by
+        // mandala_id (mandala did not exist at precompute time). Mirrors the
+        // /add-cards `add_cards.end` shape so F3 before/after is one query
+        // across both surfaces. Fire-and-forget; does not affect save SLO.
+        const diag = discover?.diagnostics;
+        if (diag) {
+          const cellDistribution: Record<string, number> = {};
+          for (const slot of slots) {
+            const key = String(slot.cellIndex ?? 0);
+            cellDistribution[key] = (cellDistribution[key] ?? 0) + 1;
+          }
+          const durMs = diag['durationMs'];
+          recordTrace({
+            step: 'wizard.discover.end',
+            status: 'ok',
+            response: {
+              cards_count: slots.length,
+              inserted,
+              cell_distribution: cellDistribution,
+              ...diag,
+            },
+            latencyMs: typeof durMs === 'number' ? durMs : discover?.duration_ms,
+          });
+        }
+        return maybeAutoAddRecommendations(input.userId, input.mandalaId);
+      }
     );
     log.info(
       `precompute consume → auto-add inline: ok=${autoAddResult.ok}` +

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -1777,6 +1777,15 @@ export interface EphemeralDiscoverResult {
   tier2_matches: number;
   duration_ms: number;
   debug?: Tier2Debug;
+  /**
+   * CP491 F5c — v5 executor diagnostics (stageMs / perQuery / picksRaw / ...).
+   * Transport only: carried in mandala_wizard_precompute.discover_result so
+   * consumePrecompute can emit a `wizard.discover.end` trace keyed by the
+   * mandala_id (which does not exist yet at precompute time). Final queryable
+   * storage is the trace, not this JSON. Decoupled (Record) to avoid v3↔v5
+   * import coupling.
+   */
+  diagnostics?: Record<string, unknown>;
 }
 
 /**

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -16,7 +16,7 @@
 import { logger } from '@/utils/logger';
 import { videosBatchFullMetadata, resolveSearchApiKeys } from '../v2/youtube-client';
 import type { YouTubeVideoFullMetadata } from '../v2/youtube-client';
-import { runYouTubeFanout, type FanoutCandidate } from './youtube-fanout';
+import { runYouTubeFanout, type FanoutCandidate, type FanoutPerQuery } from './youtube-fanout';
 import { getV5Config } from './config';
 import { getVideoPicker } from '@/modules/llm-picker/registry';
 import { getLlmPickerConfig } from '@/config/llm-picker';
@@ -81,6 +81,8 @@ export interface V5ExecuteResult {
     abortedBatches: number;
     /** CP491 F5 — whether the picker batchTimer fired (ac.signal.aborted). */
     pickerTimedOut: boolean;
+    /** CP491 F5c — per-query raw count + q_ok (from fanout). */
+    perQuery: FanoutPerQuery[];
   };
 }
 
@@ -234,6 +236,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       stageMs: stage,
       abortedBatches,
       pickerTimedOut,
+      perQuery: fanout.perQuery ?? [],
     },
   };
 }
@@ -244,6 +247,7 @@ function emptyResult(args: {
     queriesSucceeded: number;
     rawItemCount: number;
     quotaUnitsApprox: number;
+    perQuery?: FanoutPerQuery[];
   };
   afterTitleFilter: number;
   afterExcludeFilter: number;
@@ -270,6 +274,7 @@ function emptyResult(args: {
       stageMs: args.stage,
       abortedBatches: args.abortedBatches,
       pickerTimedOut: args.pickerTimedOut,
+      perQuery: args.fanout.perQuery ?? [],
     },
   };
 }

--- a/src/skills/plugins/video-discover/v5/wizard-adapter.ts
+++ b/src/skills/plugins/video-discover/v5/wizard-adapter.ts
@@ -77,5 +77,8 @@ export async function runV5ForWizard(input: V5WizardInput): Promise<EphemeralDis
     tier1_matches: 0,
     tier2_matches: result.diagnostics.afterTitleFilter,
     duration_ms: Date.now() - t0,
+    // CP491 F5c — transport diagnostics so consumePrecompute can emit a
+    // mandala-keyed wizard.discover.end trace (see EphemeralDiscoverResult).
+    diagnostics: result.diagnostics as unknown as Record<string, unknown>,
   };
 }

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -46,12 +46,23 @@ export interface FanoutCandidate {
   cellIndex: number | null;
 }
 
+/** CP491 F5c — per-query observability (raw count + q_ok), independent of dedup/hardcap. */
+export interface FanoutPerQuery {
+  query: string;
+  source: string;
+  cellIndex: number | null;
+  rawCount: number;
+  fulfilled: boolean;
+}
+
 export interface FanoutResult {
   candidates: FanoutCandidate[];
   queriesAttempted: number;
   queriesSucceeded: number;
   rawItemCount: number;
   quotaUnitsApprox: number;
+  /** CP491 F5c — one entry per attempted query (order = queries order). */
+  perQuery: FanoutPerQuery[];
 }
 
 export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult> {
@@ -65,6 +76,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       queriesSucceeded: 0,
       rawItemCount: 0,
       quotaUnitsApprox: 0,
+      perQuery: [],
     };
   }
 
@@ -86,6 +98,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       queriesSucceeded: 0,
       rawItemCount: 0,
       quotaUnitsApprox: 0,
+      perQuery: [],
     };
   }
 
@@ -124,12 +137,28 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
     if (seen.size >= cfg.dedupHardCap) break;
   }
 
+  // CP491 F5c — per-query raw count + q_ok, computed independently of the
+  // dedup/hardcap loop above so every attempted query is recorded even when
+  // the cohort hits dedupHardCap early. `results` order == `queries` order
+  // (Promise.allSettled preserves it).
+  const perQuery: FanoutPerQuery[] = results.map((r, i) => {
+    const qm = queries[i]!;
+    return {
+      query: qm.query,
+      source: qm.source,
+      cellIndex: qm.cellIndex ?? null,
+      rawCount: r.status === 'fulfilled' ? r.value.items.length : 0,
+      fulfilled: r.status === 'fulfilled',
+    };
+  });
+
   return {
     candidates: Array.from(seen.values()),
     queriesAttempted: queries.length,
     queriesSucceeded,
     rawItemCount,
     quotaUnitsApprox: queries.length * 100,
+    perQuery,
   };
 }
 

--- a/tests/unit/skills/video-discover/v5-executor.test.ts
+++ b/tests/unit/skills/video-discover/v5-executor.test.ts
@@ -248,4 +248,34 @@ describe('runV5Executor (orchestration smoke)', () => {
     // Only the 'cancelled by external signal' batch is counted.
     expect(result.diagnostics.abortedBatches).toBe(1);
   });
+
+  test('F5c: diagnostics pass through fanout perQuery', async () => {
+    const perQuery = [
+      { query: 'core q', source: 'core', cellIndex: null, rawCount: 4, fulfilled: true },
+      { query: 'sub q', source: 'subgoal', cellIndex: 2, rawCount: 0, fulfilled: false },
+    ];
+    runYouTubeFanout.mockResolvedValue({
+      candidates: [makeFanoutCandidate('a')],
+      queriesAttempted: 2,
+      queriesSucceeded: 1,
+      rawItemCount: 4,
+      quotaUnitsApprox: 200,
+      perQuery,
+    });
+    setVideoPickerForTest(
+      new FakePicker((input) =>
+        input.candidates.map((c) => ({ videoId: c.videoId, score: 0.9, reason: 'ok' }))
+      )
+    );
+    const result = await runV5Executor({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      excludeVideoIds: new Set(),
+      env: {} as NodeJS.ProcessEnv,
+    });
+    expect(result.diagnostics.perQuery).toEqual(perQuery);
+  });
 });

--- a/tests/unit/skills/video-discover/v5-fanout.test.ts
+++ b/tests/unit/skills/video-discover/v5-fanout.test.ts
@@ -1,0 +1,86 @@
+/**
+ * v5 fanout — CP491 F5c per-query observability.
+ * Verifies perQuery records raw count + q_ok per attempted query, independent
+ * of fulfillment (rejected query → rawCount 0, fulfilled false).
+ */
+
+import { runYouTubeFanout } from '@/skills/plugins/video-discover/v5/youtube-fanout';
+import { resetV5ConfigForTest } from '@/skills/plugins/video-discover/v5/config';
+
+jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
+  searchVideos: jest.fn(),
+  resolveSearchApiKeys: jest.fn().mockReturnValue(['key1']),
+  titleIndicatesShorts: jest.fn().mockReturnValue(false),
+  titleHitsBlocklist: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('@/skills/plugins/video-discover/v2/keyword-builder', () => ({
+  buildRuleBasedQueriesSync: jest.fn(),
+}));
+
+const { searchVideos } = jest.requireMock('@/skills/plugins/video-discover/v2/youtube-client');
+const { buildRuleBasedQueriesSync } = jest.requireMock(
+  '@/skills/plugins/video-discover/v2/keyword-builder'
+);
+
+function items(n: number, prefix: string) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: { videoId: `${prefix}_${i}` },
+    snippet: {
+      title: `T${prefix}${i}`,
+      description: 'd',
+      channelTitle: 'c',
+      channelId: 'ch',
+      publishedAt: '2026-01-01T00:00:00Z',
+      thumbnails: { high: { url: 'u' } },
+    },
+  }));
+}
+
+describe('runYouTubeFanout — F5c perQuery', () => {
+  beforeEach(() => {
+    resetV5ConfigForTest();
+    searchVideos.mockReset();
+    buildRuleBasedQueriesSync.mockReset();
+  });
+
+  test('perQuery records raw count + q_ok per query, including rejected', async () => {
+    buildRuleBasedQueriesSync.mockReturnValue([
+      { query: 'q0', source: 'core', cellIndex: null },
+      { query: 'q1', source: 'subgoal', cellIndex: 1 },
+      { query: 'q2', source: 'subgoal', cellIndex: 2 },
+    ]);
+    searchVideos.mockImplementation(({ query }: { query: string }) => {
+      if (query === 'q1') return Promise.reject(new Error('quota'));
+      return Promise.resolve(items(query === 'q0' ? 5 : 3, query));
+    });
+
+    const res = await runYouTubeFanout({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(res.perQuery).toHaveLength(3);
+    expect(res.perQuery[0]).toEqual({
+      query: 'q0',
+      source: 'core',
+      cellIndex: null,
+      rawCount: 5,
+      fulfilled: true,
+    });
+    expect(res.perQuery[1]).toEqual({
+      query: 'q1',
+      source: 'subgoal',
+      cellIndex: 1,
+      rawCount: 0,
+      fulfilled: false,
+    });
+    expect(res.perQuery[2]).toMatchObject({ query: 'q2', rawCount: 3, fulfilled: true });
+    expect(res.queriesSucceeded).toBe(2);
+    expect(res.candidates).toHaveLength(8); // 5 + 3, all unique
+  });
+});


### PR DESCRIPTION
Closes the wizard observability gap (F5 instrumented add-cards only; wizard was a black box). Pure observation, additive, no behavior/shape change (diff-verified).

- fanout `perQuery` (per-query raw count + q_ok, independent of dedup/hardcap)
- executor `diagnostics.perQuery` pass-through
- `EphemeralDiscoverResult.diagnostics?` (optional transport)
- consume emits `wizard.discover.end` trace **keyed by mandala_id** → same `video_discover_traces` table as `add_cards.end`, so F3 before/after is one query across both surfaces
- add-cards `v5_per_query`

Enables F3 (cell-placement LLM) before/after baseline. Tests 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)