### PR TITLE
feat(v5): publishedAfter to search.list not post-pick discard (ROI1, CP491)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -281,6 +281,11 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             language,
             excludeVideoIds: excludeSet,
             env: process.env,
+            // CP491 ROI1 — push the date filter into search.list so YouTube
+            // returns date-valid candidates instead of fetch-then-discard at
+            // the post-pick filter below. Post-pick filter retained as a
+            // safety net (no-op once search already filters).
+            publishedAfter: filters.publishedAfter,
           });
 
           // Request-level filter pass (durationBucket / minViewCount /

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -32,6 +32,12 @@ export interface V5ExecuteInput {
   language: 'ko' | 'en';
   excludeVideoIds: Set<string>;
   env: NodeJS.ProcessEnv;
+  /**
+   * CP491 ROI1 — ISO date passed to YouTube search.list (publishedAfter) so
+   * date-filtered candidates are fetched at SEARCH stage, not fetched-then-
+   * discarded post-pick. Undefined = no date filter (unchanged behavior).
+   */
+  publishedAfter?: string;
 }
 
 export interface V5Card {
@@ -105,6 +111,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
     targetLevel: input.targetLevel,
     language: input.language,
     env: input.env,
+    publishedAfter: input.publishedAfter,
   });
   stage.fanoutMs = Date.now() - tFanout0;
   const afterTitleFilter = fanout.candidates.length;

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -33,6 +33,8 @@ export interface FanoutInput {
   targetLevel: string;
   language: 'ko' | 'en';
   env: NodeJS.ProcessEnv;
+  /** CP491 ROI1 — forwarded to search.list publishedAfter (ISO date). */
+  publishedAfter?: string;
 }
 
 export interface FanoutCandidate {
@@ -110,6 +112,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
         maxResults: cfg.searchMaxResults,
         relevanceLanguage: input.language,
         timeoutMs: cfg.searchTimeoutMs,
+        publishedAfter: input.publishedAfter,
       }).then((items) => ({ items, cellIndex: q.cellIndex ?? null }))
     )
   );

--- a/tests/unit/skills/video-discover/v5-fanout.test.ts
+++ b/tests/unit/skills/video-discover/v5-fanout.test.ts
@@ -83,4 +83,40 @@ describe('runYouTubeFanout — F5c perQuery', () => {
     expect(res.queriesSucceeded).toBe(2);
     expect(res.candidates).toHaveLength(8); // 5 + 3, all unique
   });
+
+  test('ROI1: forwards publishedAfter to every searchVideos call', async () => {
+    buildRuleBasedQueriesSync.mockReturnValue([
+      { query: 'q0', source: 'core', cellIndex: null },
+      { query: 'q1', source: 'subgoal', cellIndex: 1 },
+    ]);
+    searchVideos.mockResolvedValue(items(2, 'q'));
+    const iso = '2025-06-01T00:00:00.000Z';
+    await runYouTubeFanout({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      env: {} as NodeJS.ProcessEnv,
+      publishedAfter: iso,
+    });
+    expect(searchVideos).toHaveBeenCalled();
+    for (const call of searchVideos.mock.calls) {
+      expect(call[0]).toMatchObject({ publishedAfter: iso });
+    }
+  });
+
+  test('ROI1: publishedAfter undefined when not provided (unchanged behavior)', async () => {
+    buildRuleBasedQueriesSync.mockReturnValue([{ query: 'q0', source: 'core', cellIndex: null }]);
+    searchVideos.mockResolvedValue(items(2, 'q'));
+    await runYouTubeFanout({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      env: {} as NodeJS.ProcessEnv,
+    });
+    expect(searchVideos.mock.calls[0]![0].publishedAfter).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Add Cards date filter was applied **post-pick** → YouTube returned all-time candidates, picker picked 30, then ~27 discarded by publishedAfter (measured: picks 30 → cards 2-3). `searchVideos` already supports `publishedAfter` (youtube-client.ts:131,205) but v5 fanout never forwarded it.

Threads `publishedAfter` through `V5ExecuteInput → FanoutInput → searchVideos` so YouTube filters at the **search stage**. Post-pick filter kept as no-op safety net. Additive optional param: unset = unchanged; wizard unaffected.

**Verify gate**: with "1년" filter on, Add Cards should return ~30 (was 2-3). Confirm via add_cards.end trace raw/picks/cards.

Tests 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)