### PR TITLE
feat(video-pool): is_short detection columns (step 1/5, CP491)

### DIFF
--- a/prisma/migrations/video-pool-is-short/001_add_columns.sql
+++ b/prisma/migrations/video-pool-is-short/001_add_columns.sql
@@ -1,0 +1,24 @@
+-- CP491 — YouTube Shorts detection columns on video_pool.
+-- Raw SQL DDL companion (prisma db push silent-fails on Supabase auth-owned
+-- tables; these ADDs must be applied + verified directly per CLAUDE.md Hard Rule).
+--
+-- is_short:        true = YouTube Short (demoted, never promoted to search/pick).
+--                  NULL = not yet probed OR >=180s (cannot be a Short — YT cap).
+-- short_signal:    detection source, e.g. 'shorts_url_redirect' (authoritative).
+-- short_probed_at: when the probe ran (for re-probe TTL / audit).
+--
+-- Apply order: local (docker exec supabase-db-dev) -> verify \d -> NOTIFY pgrst
+-- -> restart supabase-rest-dev -> PR -> CI migrate prod -> verify prod \d.
+
+ALTER TABLE public.video_pool ADD COLUMN IF NOT EXISTS is_short boolean;
+ALTER TABLE public.video_pool ADD COLUMN IF NOT EXISTS short_signal text;
+ALTER TABLE public.video_pool ADD COLUMN IF NOT EXISTS short_probed_at timestamptz;
+
+-- Partial index: only rows still pending a probe within the shorts-eligible
+-- duration band (<180s). Keeps backfill + ongoing probe scans cheap.
+CREATE INDEX IF NOT EXISTS idx_vpool_short_probe_pending
+  ON public.video_pool (duration_seconds)
+  WHERE is_short IS NULL AND duration_seconds < 180;
+
+-- PostgREST schema cache reload so the new columns are visible to the API layer.
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2102,6 +2102,15 @@ model video_pool {
   /// CP488+ — content type tag. Values: 'tutorial' | 'lecture' | 'vlog' | 'interview' | 'documentary' | 'review' | NULL.
   content_type           String?   @db.VarChar(20)
 
+  /// CP491 — YouTube Shorts detection. is_short=true rows are demoted
+  /// (is_active=false), never promoted to search/pick. NULL = not yet probed.
+  /// Only <180s videos can be shorts (YouTube cap); >=180s left NULL = non-short.
+  /// Signal: /shorts/<id> redirect probe (authoritative). Raw SQL DDL:
+  /// prisma/migrations/video-pool-is-short/001_add_columns.sql
+  is_short        Boolean?
+  short_signal    String?   @db.VarChar(30)
+  short_probed_at DateTime? @db.Timestamptz(6)
+
   embeddings  video_pool_embeddings[]
   domain_tags video_pool_domain_tags[]
 


### PR DESCRIPTION
Step 1/5 of shorts-blocking. Schema only — adds `is_short` / `short_signal` / `short_probed_at` to `video_pool` (nullable, additive).

- `is_short` lives on **video_pool** (not youtube_videos) — video_pool (26k) ⊄ youtube_videos (12.6k); batch_trend writes video_pool directly (4-path convergence point).
- Raw SQL DDL included (`prisma/migrations/video-pool-is-short/001_add_columns.sql`) — prisma db push silent-fails on Supabase auth tables. Applied + verified on local via information_schema (not prisma).
- Partial index on `(duration_seconds) WHERE is_short IS NULL AND duration_seconds < 180` for cheap probe scans.

Post-merge: **verify prod `\d video_pool`** + apply raw DDL manually if prisma db push silent-failed the columns.

Next (separate PRs): shared `isShort()` helper → async probe module → 4-path promote gate → backfill (<180s, ~2,200 est).

🤖 Generated with [Claude Code](https://claude.com/claude-code)