### PR TITLE
feat(video-pool): shared isShort() detector (step 2/5, CP491)

### DIFF
--- a/src/modules/video-pool/is-short.ts
+++ b/src/modules/video-pool/is-short.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared YouTube Shorts detector (CP491, step 2/5).
+ *
+ * Single source of truth for "is this video a Short?" — called by the async
+ * probe module (step 3) and every video_pool promote gate (step 4). One
+ * implementation, N callers: no per-path drift, no missed gate.
+ *
+ * Method: `GET https://www.youtube.com/shorts/<id>` with manual redirect.
+ *   - 200            → it IS a Short (the /shorts/ page serves it).
+ *   - 3xx → /watch   → NOT a Short (YouTube redirects regular videos).
+ *   This is YouTube's own authoritative classification (validated on 54
+ *   samples, 100% clean separation). No thumbnail/pixel/vision needed.
+ *
+ * Optimization: a Short cannot exceed YouTube's 180s cap, so when a known
+ * duration >= 180s is supplied we return false WITHOUT an HTTP probe.
+ *
+ * Fail-open: probe errors (timeout/network/unexpected status) return
+ * { isShort: false, signal: 'probe_error' } so a flaky probe never blocks a
+ * legitimate video. The caller leaves such rows unprobed for a later retry;
+ * a Short that slips through is corrected by demotion, not lost.
+ *
+ * The returned `signal` strings ARE the values written to
+ * `video_pool.short_signal` (varchar 30) — keep this vocabulary single-source.
+ */
+
+/** Vocabulary shared with `video_pool.short_signal`. Do not diverge. */
+export const SHORT_SIGNAL = {
+  URL_REDIRECT: 'shorts_url_redirect',
+  DURATION_GE_180: 'duration_ge_180',
+  PROBE_ERROR: 'probe_error',
+} as const;
+
+export type ShortSignal = (typeof SHORT_SIGNAL)[keyof typeof SHORT_SIGNAL];
+
+export interface ShortResult {
+  isShort: boolean;
+  signal: ShortSignal;
+}
+
+/** Shorts cannot exceed this (YouTube cap). >= this → definitely not a Short. */
+export const SHORT_MAX_DURATION_SEC = 180;
+
+const DEFAULT_TIMEOUT_MS = 8000;
+const SHORTS_URL = (videoId: string): string =>
+  `https://www.youtube.com/shorts/${encodeURIComponent(videoId)}`;
+
+export interface IsShortOpts {
+  /** Inject fetch for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Per-probe timeout. Default 8s. */
+  timeoutMs?: number;
+}
+
+/**
+ * Probe whether `videoId` is a YouTube Short. Pure (no DB). `durationSec`,
+ * when known and >= 180, short-circuits to false with no HTTP call.
+ */
+export async function isShort(
+  videoId: string,
+  durationSec?: number | null,
+  opts: IsShortOpts = {}
+): Promise<ShortResult> {
+  if (durationSec != null && durationSec >= SHORT_MAX_DURATION_SEC) {
+    return { isShort: false, signal: SHORT_SIGNAL.DURATION_GE_180 };
+  }
+
+  const fetchFn = opts.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const res = await fetchFn(SHORTS_URL(videoId), {
+      method: 'GET',
+      redirect: 'manual', // 3xx (regular video) must NOT auto-follow to /watch
+      signal: controller.signal,
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; InsightaBot/1.0)' },
+    });
+    if (res.status === 200) {
+      return { isShort: true, signal: SHORT_SIGNAL.URL_REDIRECT };
+    }
+    if (res.status >= 300 && res.status < 400) {
+      // Redirect to /watch — a regular video, not a Short.
+      return { isShort: false, signal: SHORT_SIGNAL.URL_REDIRECT };
+    }
+    // Unexpected status (404/5xx/etc) — fail open, leave for retry.
+    return { isShort: false, signal: SHORT_SIGNAL.PROBE_ERROR };
+  } catch {
+    // Timeout / network error — fail open.
+    return { isShort: false, signal: SHORT_SIGNAL.PROBE_ERROR };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/tests/unit/modules/video-pool/is-short.test.ts
+++ b/tests/unit/modules/video-pool/is-short.test.ts
@@ -1,0 +1,44 @@
+/**
+ * isShort() — CP491 step 2. Shorts detector, fetch mocked (no external calls).
+ */
+import { isShort, SHORT_SIGNAL } from '@/modules/video-pool/is-short';
+
+function mockFetch(status: number): typeof fetch {
+  return (async () => ({ status }) as Response) as unknown as typeof fetch;
+}
+
+describe('isShort', () => {
+  test('200 from /shorts/ → Short', async () => {
+    const r = await isShort('vid200', undefined, { fetchImpl: mockFetch(200) });
+    expect(r).toEqual({ isShort: true, signal: SHORT_SIGNAL.URL_REDIRECT });
+  });
+
+  test('303 (redirect to /watch) → not a Short', async () => {
+    const r = await isShort('vid303', undefined, { fetchImpl: mockFetch(303) });
+    expect(r).toEqual({ isShort: false, signal: SHORT_SIGNAL.URL_REDIRECT });
+  });
+
+  test('fetch throws (timeout/network) → fail-open, probe_error', async () => {
+    const throwing = (async () => {
+      throw new Error('aborted');
+    }) as unknown as typeof fetch;
+    const r = await isShort('vidErr', undefined, { fetchImpl: throwing });
+    expect(r).toEqual({ isShort: false, signal: SHORT_SIGNAL.PROBE_ERROR });
+  });
+
+  test('durationSec >= 180 → no HTTP, duration_ge_180', async () => {
+    let called = false;
+    const spy = (async () => {
+      called = true;
+      return { status: 200 } as Response;
+    }) as unknown as typeof fetch;
+    const r = await isShort('vidLong', 300, { fetchImpl: spy });
+    expect(called).toBe(false);
+    expect(r).toEqual({ isShort: false, signal: SHORT_SIGNAL.DURATION_GE_180 });
+  });
+
+  test('unexpected status (404) → fail-open, probe_error', async () => {
+    const r = await isShort('vid404', undefined, { fetchImpl: mockFetch(404) });
+    expect(r).toEqual({ isShort: false, signal: SHORT_SIGNAL.PROBE_ERROR });
+  });
+});


### PR DESCRIPTION
Step 2/5. Shared Shorts detector — single impl for the async probe (step 3) + all 4 promote gates (step 4). No per-path drift.

- `/shorts/<id>` manual-redirect probe (authoritative, 54-sample validated). 200=Short, 3xx→/watch=not.
- `durationSec >= 180` → false with no HTTP (YouTube 180s cap).
- Fail-open on probe error (over-block avoidance; retry later, demote-correct).
- `SHORT_SIGNAL` constants = the exact values step 3 writes to `video_pool.short_signal`.
- Pure (no DB), additive (0 callers). Tests 5/5, fetch mocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)