### PR TITLE
feat(v5): live shorts gate — post-pick drop + over-pick (CP491)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -393,6 +393,8 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               v5_picker_timed_out: v5Result.diagnostics.pickerTimedOut,
               // CP491 F5c — per-query raw count + q_ok (parity with wizard.discover.end).
               v5_per_query: v5Result.diagnostics.perQuery,
+              // CP491 — Shorts dropped by the post-pick short gate (before→after observability).
+              v5_shorts_dropped: v5Result.diagnostics.shortsDropped,
               // CP489 Phase 6 — emit returned videoIds so the Search Journey
               // Ledger can join per-round trace rows ↔ card_interactions
               // deterministically (no timestamp-window fuzziness). Bounded

--- a/src/modules/video-pool/is-short.ts
+++ b/src/modules/video-pool/is-short.ts
@@ -49,6 +49,12 @@ export interface IsShortOpts {
   fetchImpl?: typeof fetch;
   /** Per-probe timeout. Default 8s. */
   timeoutMs?: number;
+  /**
+   * External abort signal (e.g. a shared deadline across many probes). When it
+   * fires, this probe aborts and fails open (probe_error → not-short). Lets a
+   * caller bound TOTAL wall-clock regardless of how many probes run.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -67,6 +73,13 @@ export async function isShort(
   const fetchFn = opts.fetchImpl ?? fetch;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  // Link an external shared deadline: when it fires, abort this probe too.
+  const ext = opts.signal;
+  const onExt = (): void => controller.abort();
+  if (ext) {
+    if (ext.aborted) controller.abort();
+    else ext.addEventListener('abort', onExt, { once: true });
+  }
   try {
     const res = await fetchFn(SHORTS_URL(videoId), {
       method: 'GET',
@@ -84,9 +97,48 @@ export async function isShort(
     // Unexpected status (404/5xx/etc) — fail open, leave for retry.
     return { isShort: false, signal: SHORT_SIGNAL.PROBE_ERROR };
   } catch {
-    // Timeout / network error — fail open.
+    // Timeout / network error / external-deadline abort — fail open.
     return { isShort: false, signal: SHORT_SIGNAL.PROBE_ERROR };
   } finally {
     clearTimeout(timer);
+    if (ext) ext.removeEventListener('abort', onExt);
   }
+}
+
+// ── In-process result cache (CP491 step "v5-live gate") ──────────────────────
+// Live add-cards/wizard videos are NOT in video_pool, so there is no DB column
+// to cache against. A per-process Map dedupes repeat videos within a container's
+// lifetime (restart = cold; acceptable). No Redis/schema/new write-path. If
+// cross-container dedupe is later needed (rate-limit pressure), promote to Redis.
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h — Short status doesn't change
+const CACHE_MAX = 10_000; // soft cap; clear wholesale if exceeded
+const _cache = new Map<string, { isShort: boolean; signal: ShortSignal; at: number }>();
+
+/**
+ * Memoized {@link isShort}. duration>=180 short-circuits (no HTTP, no cache).
+ * probe_error results are NOT cached (left to retry). Honors opts.signal.
+ */
+export async function isShortCached(
+  videoId: string,
+  durationSec?: number | null,
+  opts: IsShortOpts = {}
+): Promise<ShortResult> {
+  if (durationSec != null && durationSec >= SHORT_MAX_DURATION_SEC) {
+    return { isShort: false, signal: SHORT_SIGNAL.DURATION_GE_180 };
+  }
+  const hit = _cache.get(videoId);
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) {
+    return { isShort: hit.isShort, signal: hit.signal };
+  }
+  const result = await isShort(videoId, durationSec, opts);
+  if (result.signal !== SHORT_SIGNAL.PROBE_ERROR) {
+    if (_cache.size >= CACHE_MAX) _cache.clear();
+    _cache.set(videoId, { isShort: result.isShort, signal: result.signal, at: Date.now() });
+  }
+  return result;
+}
+
+/** Test helper — reset the in-process cache. */
+export function resetShortCacheForTest(): void {
+  _cache.clear();
 }

--- a/src/modules/video-pool/is-short.ts
+++ b/src/modules/video-pool/is-short.ts
@@ -23,6 +23,8 @@
  * `video_pool.short_signal` (varchar 30) — keep this vocabulary single-source.
  */
 
+import { MS_PER_DAY } from '@/utils/time-constants';
+
 /** Vocabulary shared with `video_pool.short_signal`. Do not diverge. */
 export const SHORT_SIGNAL = {
   URL_REDIRECT: 'shorts_url_redirect',
@@ -110,7 +112,7 @@ export async function isShort(
 // to cache against. A per-process Map dedupes repeat videos within a container's
 // lifetime (restart = cold; acceptable). No Redis/schema/new write-path. If
 // cross-container dedupe is later needed (rate-limit pressure), promote to Redis.
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h — Short status doesn't change
+const CACHE_TTL_MS = MS_PER_DAY; // Short status doesn't change
 const CACHE_MAX = 10_000; // soft cap; clear wholesale if exceeded
 const _cache = new Map<string, { isShort: boolean; signal: ShortSignal; at: number }>();
 

--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -17,6 +17,12 @@ const v5EnvSchema = z.object({
   V5_SEARCH_MAX_RESULTS: z.coerce.number().int().min(10).max(50).default(25),
   V5_TARGET_PICKS: z.coerce.number().int().min(10).max(60).default(30),
   V5_DEDUP_HARDCAP: z.coerce.number().int().min(40).max(400).default(120),
+  // CP491 — short gate. Over-pick by this factor before dropping Shorts so
+  // the final count holds at targetPicks (drop happens pre-final-slice).
+  V5_SHORT_OVERPICK_FACTOR: z.coerce.number().min(1).max(3).default(1.5),
+  // Hard wall-clock cap for the whole short-probe phase (shared deadline
+  // across all probes). 0 disables the gate. Fail-open past this.
+  V5_SHORT_PROBE_DEADLINE_MS: z.coerce.number().int().min(0).max(15000).default(8000),
 });
 
 export interface V5Config {
@@ -25,6 +31,8 @@ export interface V5Config {
   searchMaxResults: number;
   targetPicks: number;
   dedupHardCap: number;
+  shortOverpickFactor: number;
+  shortProbeDeadlineMs: number;
 }
 
 let cached: V5Config | null = null;
@@ -38,6 +46,8 @@ export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
     searchMaxResults: p.V5_SEARCH_MAX_RESULTS,
     targetPicks: p.V5_TARGET_PICKS,
     dedupHardCap: p.V5_DEDUP_HARDCAP,
+    shortOverpickFactor: p.V5_SHORT_OVERPICK_FACTOR,
+    shortProbeDeadlineMs: p.V5_SHORT_PROBE_DEADLINE_MS,
   };
   return cached;
 }

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -20,6 +20,7 @@ import { runYouTubeFanout, type FanoutCandidate, type FanoutPerQuery } from './y
 import { getV5Config } from './config';
 import { getVideoPicker } from '@/modules/llm-picker/registry';
 import { getLlmPickerConfig } from '@/config/llm-picker';
+import { isShortCached, SHORT_MAX_DURATION_SEC } from '@/modules/video-pool/is-short';
 import type { PickCandidate, PickResult } from '@/modules/llm-picker/types';
 
 const log = logger.child({ module: 'video-discover/v5/executor' });
@@ -66,6 +67,8 @@ export interface V5StageMs {
   llmMs: number;
   videosMs: number;
   assembleMs: number;
+  /** CP491 — short-gate probe phase (bounded by V5_SHORT_PROBE_DEADLINE_MS). */
+  shortMs: number;
 }
 
 export interface V5ExecuteResult {
@@ -89,6 +92,8 @@ export interface V5ExecuteResult {
     pickerTimedOut: boolean;
     /** CP491 F5c — per-query raw count + q_ok (from fanout). */
     perQuery: FanoutPerQuery[];
+    /** CP491 — Shorts dropped by the post-pick short gate. */
+    shortsDropped: number;
   };
 }
 
@@ -98,7 +103,14 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
   const pickerCfg = getLlmPickerConfig(input.env);
 
   // CP491 F5 — per-stage wall-clock markers (stages not reached stay 0).
-  const stage: V5StageMs = { fanoutMs: 0, excludeMs: 0, llmMs: 0, videosMs: 0, assembleMs: 0 };
+  const stage: V5StageMs = {
+    fanoutMs: 0,
+    excludeMs: 0,
+    llmMs: 0,
+    videosMs: 0,
+    assembleMs: 0,
+    shortMs: 0,
+  };
   let abortedBatches = 0;
   let pickerTimedOut = false;
 
@@ -142,8 +154,12 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
   const batches = chunk(survivors, pickerCfg.batchSize);
   const limitedBatches = batches.slice(0, pickerCfg.maxParallel);
   const picker = getVideoPicker();
+  // CP491 short gate — over-pick a buffer so dropping Shorts later still leaves
+  // ~targetPicks. The picker must PRODUCE the buffer, so size per-batch picks to
+  // `overpick` (not targetPicks); final slice to targetPicks happens post-drop.
+  const overpick = Math.ceil(cfg.targetPicks * cfg.shortOverpickFactor);
   const perBatchMaxPicks = Math.max(
-    Math.ceil(cfg.targetPicks / Math.max(limitedBatches.length, 1)) + 2,
+    Math.ceil(overpick / Math.max(limitedBatches.length, 1)) + 2,
     6
   );
 
@@ -183,7 +199,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
   stage.llmMs = Date.now() - tLlm0;
   pickerTimedOut = ac.signal.aborted;
 
-  const picksMerged = mergePicks(pickResults, cfg.targetPicks);
+  const picksMerged = mergePicks(pickResults, overpick);
 
   if (picksMerged.length === 0) {
     log.info(`v5 executor: picker returned 0 (batches=${limitedBatches.length})`);
@@ -227,8 +243,39 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
   });
   stage.assembleMs = Date.now() - tAssemble0;
 
+  // 6. Short gate (CP491) — drop YouTube Shorts. Probe only <180s cards
+  // (YouTube cap; >=180s short-circuits with no HTTP). A single shared
+  // AbortController deadline bounds TOTAL wall-clock regardless of probe
+  // count/waves; probes still in-flight at the deadline fail open (kept).
+  const tShort0 = Date.now();
+  let shortsDropped = 0;
+  let gatedCards = cards;
+  if (cfg.shortProbeDeadlineMs > 0 && cards.length > 0) {
+    const shortCtl = new AbortController();
+    const shortTimer = setTimeout(() => shortCtl.abort(), cfg.shortProbeDeadlineMs);
+    try {
+      const shortFlags = await Promise.all(
+        cards.map(async (c) => {
+          if (c.durationSec != null && c.durationSec >= SHORT_MAX_DURATION_SEC) return false;
+          const { isShort } = await isShortCached(c.videoId, c.durationSec, {
+            signal: shortCtl.signal,
+          });
+          return isShort;
+        })
+      );
+      gatedCards = cards.filter((_, i) => !shortFlags[i]);
+      shortsDropped = cards.length - gatedCards.length;
+    } finally {
+      clearTimeout(shortTimer);
+    }
+  }
+  stage.shortMs = Date.now() - tShort0;
+
+  // 7. Final slice to targetPicks (cards are score-sorted; filter preserved order).
+  const finalCards = gatedCards.slice(0, cfg.targetPicks);
+
   return {
-    cards,
+    cards: finalCards,
     diagnostics: {
       queriesAttempted: fanout.queriesAttempted,
       queriesSucceeded: fanout.queriesSucceeded,
@@ -240,6 +287,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       quotaUnitsApprox: fanout.quotaUnitsApprox + (pickedIds.length > 0 ? 1 : 0),
       durationMs: Date.now() - t0,
       pickerModel: picker.model,
+      shortsDropped,
       stageMs: stage,
       abortedBatches,
       pickerTimedOut,
@@ -278,6 +326,7 @@ function emptyResult(args: {
       quotaUnitsApprox: args.fanout.quotaUnitsApprox,
       durationMs: Date.now() - args.t0,
       pickerModel: args.pickerCfg.model,
+      shortsDropped: 0,
       stageMs: args.stage,
       abortedBatches: args.abortedBatches,
       pickerTimedOut: args.pickerTimedOut,

--- a/src/skills/plugins/video-discover/v5/wizard-adapter.ts
+++ b/src/skills/plugins/video-discover/v5/wizard-adapter.ts
@@ -50,7 +50,8 @@ export async function runV5ForWizard(input: V5WizardInput): Promise<EphemeralDis
   const s = result.diagnostics.stageMs;
   log.info(
     `v5 wizard stages ms: fanout=${s.fanoutMs} exclude=${s.excludeMs} llm=${s.llmMs} ` +
-      `videos=${s.videosMs} assemble=${s.assembleMs} total=${result.diagnostics.durationMs} ` +
+      `videos=${s.videosMs} assemble=${s.assembleMs} short=${s.shortMs} total=${result.diagnostics.durationMs} ` +
+      `shortsDropped=${result.diagnostics.shortsDropped} ` +
       `abortedBatches=${result.diagnostics.abortedBatches} pickerTimedOut=${result.diagnostics.pickerTimedOut}`
   );
 

--- a/tests/unit/modules/video-pool/is-short.test.ts
+++ b/tests/unit/modules/video-pool/is-short.test.ts
@@ -1,7 +1,12 @@
 /**
  * isShort() — CP491 step 2. Shorts detector, fetch mocked (no external calls).
  */
-import { isShort, SHORT_SIGNAL } from '@/modules/video-pool/is-short';
+import {
+  isShort,
+  isShortCached,
+  resetShortCacheForTest,
+  SHORT_SIGNAL,
+} from '@/modules/video-pool/is-short';
 
 function mockFetch(status: number): typeof fetch {
   return (async () => ({ status }) as Response) as unknown as typeof fetch;
@@ -40,5 +45,44 @@ describe('isShort', () => {
   test('unexpected status (404) → fail-open, probe_error', async () => {
     const r = await isShort('vid404', undefined, { fetchImpl: mockFetch(404) });
     expect(r).toEqual({ isShort: false, signal: SHORT_SIGNAL.PROBE_ERROR });
+  });
+});
+
+describe('isShortCached', () => {
+  beforeEach(() => resetShortCacheForTest());
+
+  test('memoizes — second call for same id does not re-fetch', async () => {
+    let calls = 0;
+    const counting = (async () => {
+      calls += 1;
+      return { status: 200 } as Response;
+    }) as unknown as typeof fetch;
+    const a = await isShortCached('memo1', undefined, { fetchImpl: counting });
+    const b = await isShortCached('memo1', undefined, { fetchImpl: counting });
+    expect(a).toEqual({ isShort: true, signal: SHORT_SIGNAL.URL_REDIRECT });
+    expect(b).toEqual(a);
+    expect(calls).toBe(1); // cached
+  });
+
+  test('durationSec >= 180 short-circuits (no fetch, no cache)', async () => {
+    let calls = 0;
+    const counting = (async () => {
+      calls += 1;
+      return { status: 200 } as Response;
+    }) as unknown as typeof fetch;
+    const r = await isShortCached('long1', 240, { fetchImpl: counting });
+    expect(r).toEqual({ isShort: false, signal: SHORT_SIGNAL.DURATION_GE_180 });
+    expect(calls).toBe(0);
+  });
+
+  test('probe_error is NOT cached (retried next call)', async () => {
+    let calls = 0;
+    const failing = (async () => {
+      calls += 1;
+      throw new Error('boom');
+    }) as unknown as typeof fetch;
+    await isShortCached('err1', undefined, { fetchImpl: failing });
+    await isShortCached('err1', undefined, { fetchImpl: failing });
+    expect(calls).toBe(2); // not cached → re-probed
   });
 });

--- a/tests/unit/skills/video-discover/v5-executor.test.ts
+++ b/tests/unit/skills/video-discover/v5-executor.test.ts
@@ -21,7 +21,15 @@ jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
   resolveSearchApiKeys: jest.fn().mockReturnValue([]),
 }));
 
+// CP491 short gate — mock the detector so orchestration tests never hit the
+// network. Default: everything is non-short (no drops).
+jest.mock('@/modules/video-pool/is-short', () => ({
+  isShortCached: jest.fn(),
+  SHORT_MAX_DURATION_SEC: 180,
+}));
+
 const { runYouTubeFanout } = jest.requireMock('@/skills/plugins/video-discover/v5/youtube-fanout');
+const { isShortCached } = jest.requireMock('@/modules/video-pool/is-short');
 
 function makeFanoutCandidate(id: string, title = `Title ${id}`) {
   return {
@@ -51,6 +59,8 @@ describe('runV5Executor (orchestration smoke)', () => {
     resetLlmPickerConfigForTest();
     resetVideoPickerForTest();
     runYouTubeFanout.mockReset();
+    isShortCached.mockReset();
+    isShortCached.mockResolvedValue({ isShort: false, signal: 'shorts_url_redirect' });
   });
 
   afterAll(() => {
@@ -277,5 +287,75 @@ describe('runV5Executor (orchestration smoke)', () => {
       env: {} as NodeJS.ProcessEnv,
     });
     expect(result.diagnostics.perQuery).toEqual(perQuery);
+  });
+
+  // CP491 — short gate: drop Shorts after pick; over-pick buffer preserves count.
+  test('short gate drops Shorts and reports shortsDropped', async () => {
+    runYouTubeFanout.mockResolvedValue({
+      candidates: Array.from({ length: 24 }, (_, i) => makeFanoutCandidate(`v${i}`)),
+      queriesAttempted: 1,
+      queriesSucceeded: 1,
+      rawItemCount: 24,
+      quotaUnitsApprox: 100,
+      perQuery: [],
+    });
+    setVideoPickerForTest(
+      new FakePicker((input) =>
+        input.candidates.map((c, i) => ({ videoId: c.videoId, score: 0.9 - i * 0.01, reason: 'p' }))
+      )
+    );
+    // v0, v1, v2 are Shorts; everything else is not.
+    isShortCached.mockImplementation(async (videoId: string) => ({
+      isShort: ['v0', 'v1', 'v2'].includes(videoId),
+      signal: 'shorts_url_redirect',
+    }));
+
+    const result = await runV5Executor({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      excludeVideoIds: new Set(),
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(result.diagnostics.shortsDropped).toBe(3);
+    const ids = result.cards.map((c) => c.videoId);
+    expect(ids).not.toContain('v0');
+    expect(ids).not.toContain('v1');
+    expect(ids).not.toContain('v2');
+    expect(typeof result.diagnostics.stageMs.shortMs).toBe('number');
+  });
+
+  test('short gate disabled via V5_SHORT_PROBE_DEADLINE_MS=0 → no probe, no drop', async () => {
+    runYouTubeFanout.mockResolvedValue({
+      candidates: [makeFanoutCandidate('a'), makeFanoutCandidate('b')],
+      queriesAttempted: 1,
+      queriesSucceeded: 1,
+      rawItemCount: 2,
+      quotaUnitsApprox: 100,
+      perQuery: [],
+    });
+    setVideoPickerForTest(
+      new FakePicker((input) =>
+        input.candidates.map((c) => ({ videoId: c.videoId, score: 0.9, reason: 'p' }))
+      )
+    );
+    isShortCached.mockResolvedValue({ isShort: true, signal: 'shorts_url_redirect' });
+
+    const result = await runV5Executor({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      excludeVideoIds: new Set(),
+      env: { V5_SHORT_PROBE_DEADLINE_MS: '0' } as unknown as NodeJS.ProcessEnv,
+    });
+
+    expect(result.diagnostics.shortsDropped).toBe(0); // gate off → nothing dropped
+    expect(isShortCached).not.toHaveBeenCalled();
+    expect(result.cards.length).toBe(2);
   });
 });


### PR DESCRIPTION
Observed Shorts (add-cards 23-33%, wizard 40%) come from v5 **live fanout** (bypasses video_pool). This adds an inline short gate in `runV5Executor` — covers add-cards AND wizard (shared executor).

- **Position**: post-pick (cards have duration). Only `<180s` cards probed (≥180s short-circuits, no HTTP).
- **Latency bound**: ONE shared AbortController deadline across all probes → total ≤ `V5_SHORT_PROBE_DEADLINE_MS` (8s) regardless of wave count; in-flight fail-open (kept).
- **Count preserved**: over-pick buffer ×1.5 (picker sized to it) → drop Shorts → slice to targetPicks. videos.list 45≤50 = 1 call.
- **Cache**: in-process Map TTL (no Redis/schema — live videos not in pool).
- `shortsDropped` + `stageMs.shortMs` in add_cards.end trace + wizard log.

Shape: cards V5Card[] (fewer), diagnostics additive, Input unchanged. Tests 25.

**Verify gate (prod)**: Shorts ratio before(40%/23-33%)→after + shortsDropped via user click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)