### PR TITLE
fix(v5): revert per-batch overpick sizing — 68s timeout regression (CP491)

### DIFF
--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -154,12 +154,14 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
   const batches = chunk(survivors, pickerCfg.batchSize);
   const limitedBatches = batches.slice(0, pickerCfg.maxParallel);
   const picker = getVideoPicker();
-  // CP491 short gate — over-pick a buffer so dropping Shorts later still leaves
-  // ~targetPicks. The picker must PRODUCE the buffer, so size per-batch picks to
-  // `overpick` (not targetPicks); final slice to targetPicks happens post-drop.
+  // CP491 short gate — keep a buffer for dropping Shorts via mergePicks(overpick)
+  // below (free: just a wider slice of picks the LLM already produced). Per-batch
+  // maxPicks stays sized to targetPicks: sizing it to `overpick` made the LLM
+  // generate far more per batch → llmMs 67s → 68s timeout (CP491 regression).
+  // Do NOT raise this to overpick (the over-pick trap). Buffer = natural surplus.
   const overpick = Math.ceil(cfg.targetPicks * cfg.shortOverpickFactor);
   const perBatchMaxPicks = Math.max(
-    Math.ceil(overpick / Math.max(limitedBatches.length, 1)) + 2,
+    Math.ceil(cfg.targetPicks / Math.max(limitedBatches.length, 1)) + 2,
     6
   );
 


### PR DESCRIPTION
The short gate's over-pick sized `perBatchMaxPicks` to `overpick` (×1.5) → LLM generated far more per batch → **llmMs 12s→67s → 68s total → 60s client timeout** (add-cards "1차 실패"). 5s picker abort doesn't interrupt the in-flight OpenRouter response.

- Fix: `perBatchMaxPicks` back to `targetPicks`-based → llmMs ~12s.
- Keep `mergePicks(overpick)` (free wider slice, no extra LLM load) → drop buffer preserved.
- Short gate innocent (shortMs 145ms; dropped 15 correctly).
- Does NOT fix card-count shortfall on shorts-heavy pools (separate; no over-pick retry).

**Verify (prod)**: add-cards latency ~12s, timeout 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)