### PR TITLE
fix(frontend/ci): pin vitest to exact 3.2.4 (upstream vite-node@3.2.5 unpublished)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,6 +99,6 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^5.4.19",
-    "vitest": "^3.2.4"
+    "vitest": "3.2.4"
   }
 }


### PR DESCRIPTION
## Problem
Frontend CI (`Test Frontend`) started failing **2026-06-01** with:
```
npm error notarget No matching version found for vite-node@3.2.5
```
Not a code change — an **upstream vitest publish-order bug**:

| Fact | Value |
|---|---|
| `vitest: "^3.2.4"` resolves to | vitest@**3.2.5** (published today) |
| vitest@3.2.5 depends on | vite-node@**3.2.5** (exact) |
| vite-node@3.2.5 on registry | **missing** (max published = 3.2.4) |
| CI install | `rm -rf package-lock.json && npm install` → lockfile discarded → `^3.2.4` re-resolves to broken 3.2.5 |

PRs #815–#820 were green (before today's bad publish); only clean-install PRs after it are hit.

## Fix
Pin `vitest` to exact `3.2.4` (verified: vitest@3.2.4 → vite-node@3.2.4 **exact**, which exists). vitest is the only floating source of vite-node in package.json, so this one line is necessary and sufficient.

- Lockfile is **not** the fix here — CI deletes it (intentional, npm/cli#4828 platform-native binaries). The `^` removal in package.json is what stops the float.
- Revert to `^3.2.4` once vite-node@3.2.5 publishes upstream.

## Scope
CI-config fix only (`frontend/package.json`, not `frontend/src/`). Unblocks all frontend CI, not just one PR. Separate from the B-1 backfill PR (#821), whose backend gates already pass.