### PR TITLE
fix(db): short_signal varchar(30) in migration to match Prisma schema (CP492)

### DIFF
--- a/prisma/migrations/video-pool-is-short/001_add_columns.sql
+++ b/prisma/migrations/video-pool-is-short/001_add_columns.sql
@@ -11,8 +11,15 @@
 -- -> restart supabase-rest-dev -> PR -> CI migrate prod -> verify prod \d.
 
 ALTER TABLE public.video_pool ADD COLUMN IF NOT EXISTS is_short boolean;
-ALTER TABLE public.video_pool ADD COLUMN IF NOT EXISTS short_signal text;
+ALTER TABLE public.video_pool ADD COLUMN IF NOT EXISTS short_signal varchar(30);
 ALTER TABLE public.video_pool ADD COLUMN IF NOT EXISTS short_probed_at timestamptz;
+
+-- short_signal must match the Prisma schema (@db.VarChar(30)). Earlier applies
+-- of this file created it as `text`, which made `prisma db push` (deploy schema
+-- sync) demand --accept-data-loss on the text->varchar cast and fail the deploy.
+-- Coerce idempotently: a no-op where it is already varchar(30); safe cast where
+-- it is still text (all signal slugs are <=30 chars).
+ALTER TABLE public.video_pool ALTER COLUMN short_signal TYPE varchar(30);
 
 -- Partial index: only rows still pending a probe within the shorts-eligible
 -- duration band (<180s). Keeps backfill + ongoing probe scans cheap.


### PR DESCRIPTION
## Problem
Deploy (`Database Schema Sync`) failed for #821/#822 merges:
```
⚠️ alter column `short_signal` on `video_pool` ... cast from `Text` to `VarChar(30)`
Error: Use the --accept-data-loss flag ...
```
Root cause (my step-1 bug): the migration `001_add_columns.sql` created
`short_signal` as **`text`**, while the Prisma schema declares
`@db.VarChar(30)`. Every deploy's `prisma db push` therefore wanted to alter
text→varchar(30) and refused without `--accept-data-loss` → exit 1 →
**Deploy to EC2 skipped**. (#820 had slipped through via the auth-owned-table
fallback path; this surfaced once the push advanced further.)

## Fix
- Prod already hand-altered + **verified directly** (type query: `text` →
  `character varying(30)`, NOTIFY pgrst sent) so the next deploy's schema sync
  is a no-op.
- This PR aligns the **migration source**: line 14 `text` → `varchar(30)`, plus
  an idempotent `ALTER COLUMN ... TYPE varchar(30)` so any env that already
  created it as text converges (no-op where already varchar(30)). Safe cast —
  the only non-null value is `duration_ge_180` (15 chars ≤ 30).

## Scope / rollback
`prisma/migrations/` only (not frontend/src/, not runtime code). Reversible
(varchar(30)→text). Unblocks all deploys.