### PR TITLE
feat(v5): cell_binning picker mode — no-LLM, 9-cell balanced (CP492 A/B)

### DIFF
--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -23,6 +23,11 @@ const v5EnvSchema = z.object({
   // Hard wall-clock cap for the whole short-probe phase (shared deadline
   // across all probes). 0 disables the gate. Fail-open past this.
   V5_SHORT_PROBE_DEADLINE_MS: z.coerce.number().int().min(0).max(15000).default(8000),
+  // CP492 — picker mode. 'llm' (default, current behavior) runs the OpenRouter
+  // batch picker. 'cell_binning' skips the LLM and round-robins fanout
+  // candidates by query cellIndex (9-cell balance + ~1s discover, no garbage
+  // filter). A/B flag: does cell_binning let YouTube garbage through vs the LLM?
+  V5_PICKER_MODE: z.enum(['llm', 'cell_binning']).default('llm'),
 });
 
 export interface V5Config {
@@ -33,6 +38,7 @@ export interface V5Config {
   dedupHardCap: number;
   shortOverpickFactor: number;
   shortProbeDeadlineMs: number;
+  pickerMode: 'llm' | 'cell_binning';
 }
 
 let cached: V5Config | null = null;
@@ -48,6 +54,7 @@ export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
     dedupHardCap: p.V5_DEDUP_HARDCAP,
     shortOverpickFactor: p.V5_SHORT_OVERPICK_FACTOR,
     shortProbeDeadlineMs: p.V5_SHORT_PROBE_DEADLINE_MS,
+    pickerMode: p.V5_PICKER_MODE,
   };
   return cached;
 }

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -150,68 +150,88 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
     });
   }
 
-  // 3. chunk + parallel LLM picks
-  const batches = chunk(survivors, pickerCfg.batchSize);
-  const limitedBatches = batches.slice(0, pickerCfg.maxParallel);
-  const picker = getVideoPicker();
-  // CP491 short gate — keep a buffer for dropping Shorts via mergePicks(overpick)
-  // below (free: just a wider slice of picks the LLM already produced). Per-batch
-  // maxPicks stays sized to targetPicks: sizing it to `overpick` made the LLM
-  // generate far more per batch → llmMs 67s → 68s timeout (CP491 regression).
-  // Do NOT raise this to overpick (the over-pick trap). Buffer = natural surplus.
-  const overpick = Math.ceil(cfg.targetPicks * cfg.shortOverpickFactor);
-  const perBatchMaxPicks = Math.max(
-    Math.ceil(cfg.targetPicks / Math.max(limitedBatches.length, 1)) + 2,
-    6
-  );
-
+  // 3. pick — LLM curation (default) or cell-binning (V5_PICKER_MODE).
+  // cell_binning skips the LLM entirely: it bins fanout survivors by their
+  // source query's cellIndex and round-robins the top YouTube-relevance items
+  // across the cells, so the downstream targetPicks slice stays cell-balanced.
+  // Goal: discover ~1s (no LLM) + 9-cell balance the LLM picker cannot give
+  // (it optimizes relevance only → clusters in the core cell). Whether the LLM
+  // picker's garbage-filtering is worth keeping is the A/B this flag answers.
   const tLlm0 = Date.now();
-  const ac = new AbortController();
-  const batchTimer = setTimeout(() => ac.abort(), pickerCfg.timeoutMs);
-  let pickResults: PickResult[][];
-  try {
-    pickResults = await Promise.all(
-      limitedBatches.map(async (batch) => {
-        try {
-          return await picker.pick(
-            {
-              cellTopic: input.centerGoal,
-              parentGoal: input.centerGoal,
-              subGoals: input.subGoals,
-              focusTags: input.focusTags,
-              targetLevel: input.targetLevel,
-              language: input.language,
-              candidates: batch.map(toPickCandidate),
-              maxPicks: perBatchMaxPicks,
-            },
-            ac.signal
-          );
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          // CP491 F5 — distinguish abort-induced empty picks (U2) from other failures.
-          if (msg.includes('cancelled by external signal')) abortedBatches += 1;
-          log.warn(`v5 picker batch failed: ${msg}`);
-          return [] as PickResult[];
-        }
-      })
-    );
-  } finally {
-    clearTimeout(batchTimer);
-  }
-  stage.llmMs = Date.now() - tLlm0;
-  pickerTimedOut = ac.signal.aborted;
+  let picksMerged: PickResult[];
+  let llmBatchesCount = 0;
+  let picksRawCount = 0;
+  let pickerModelStr = 'cell_binning';
 
-  const picksMerged = mergePicks(pickResults, overpick);
+  if (cfg.pickerMode === 'cell_binning') {
+    picksMerged = binByCells(survivors, cfg.targetPicks, cfg.shortOverpickFactor);
+    picksRawCount = picksMerged.length;
+    stage.llmMs = Date.now() - tLlm0; // ~0 — no network call
+  } else {
+    // chunk + parallel LLM picks
+    const batches = chunk(survivors, pickerCfg.batchSize);
+    const limitedBatches = batches.slice(0, pickerCfg.maxParallel);
+    const picker = getVideoPicker();
+    pickerModelStr = picker.model;
+    // CP491 short gate — keep a buffer for dropping Shorts via mergePicks(overpick)
+    // below (free: just a wider slice of picks the LLM already produced). Per-batch
+    // maxPicks stays sized to targetPicks: sizing it to `overpick` made the LLM
+    // generate far more per batch → llmMs 67s → 68s timeout (CP491 regression).
+    // Do NOT raise this to overpick (the over-pick trap). Buffer = natural surplus.
+    const overpick = Math.ceil(cfg.targetPicks * cfg.shortOverpickFactor);
+    const perBatchMaxPicks = Math.max(
+      Math.ceil(cfg.targetPicks / Math.max(limitedBatches.length, 1)) + 2,
+      6
+    );
+
+    const ac = new AbortController();
+    const batchTimer = setTimeout(() => ac.abort(), pickerCfg.timeoutMs);
+    let pickResults: PickResult[][];
+    try {
+      pickResults = await Promise.all(
+        limitedBatches.map(async (batch) => {
+          try {
+            return await picker.pick(
+              {
+                cellTopic: input.centerGoal,
+                parentGoal: input.centerGoal,
+                subGoals: input.subGoals,
+                focusTags: input.focusTags,
+                targetLevel: input.targetLevel,
+                language: input.language,
+                candidates: batch.map(toPickCandidate),
+                maxPicks: perBatchMaxPicks,
+              },
+              ac.signal
+            );
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            // CP491 F5 — distinguish abort-induced empty picks (U2) from other failures.
+            if (msg.includes('cancelled by external signal')) abortedBatches += 1;
+            log.warn(`v5 picker batch failed: ${msg}`);
+            return [] as PickResult[];
+          }
+        })
+      );
+    } finally {
+      clearTimeout(batchTimer);
+    }
+    stage.llmMs = Date.now() - tLlm0;
+    pickerTimedOut = ac.signal.aborted;
+    picksMerged = mergePicks(pickResults, overpick);
+    llmBatchesCount = limitedBatches.length;
+    picksRawCount = pickResults.reduce((acc, b) => acc + b.length, 0);
+  }
 
   if (picksMerged.length === 0) {
-    log.info(`v5 executor: picker returned 0 (batches=${limitedBatches.length})`);
+    log.info(`v5 executor: picker returned 0 (batches=${llmBatchesCount})`);
     return emptyResult({
       fanout,
       afterTitleFilter,
       afterExcludeFilter,
       pickerCfg,
       t0,
-      llmBatches: limitedBatches.length,
+      llmBatches: llmBatchesCount,
       stage,
       abortedBatches,
       pickerTimedOut,
@@ -284,11 +304,11 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       rawItemCount: fanout.rawItemCount,
       afterTitleFilter,
       afterExcludeFilter,
-      llmBatches: limitedBatches.length,
-      picksRaw: pickResults.reduce((acc, b) => acc + b.length, 0),
+      llmBatches: llmBatchesCount,
+      picksRaw: picksRawCount,
       quotaUnitsApprox: fanout.quotaUnitsApprox + (pickedIds.length > 0 ? 1 : 0),
       durationMs: Date.now() - t0,
-      pickerModel: picker.model,
+      pickerModel: pickerModelStr,
       shortsDropped,
       stageMs: stage,
       abortedBatches,
@@ -350,6 +370,45 @@ function chunk<T>(arr: T[], size: number): T[][] {
   if (size <= 0) return [arr];
   const out: T[][] = [];
   for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+/**
+ * cell_binning picker (V5_PICKER_MODE=cell_binning) — no LLM. Bins fanout
+ * survivors by their source query's cellIndex and round-robins the top
+ * YouTube-relevance items across cells. Round-robin order means the downstream
+ * `slice(0, targetPicks)` drops the deepest per-cell rank last, so every cell
+ * stays represented (vs the LLM picker clustering all picks in the core cell).
+ *
+ * survivors preserve search.list relevance order within each cell, so taking
+ * index r across cells = the r-th best per cell. Score decreases with rank so
+ * the FE's score-desc display sort stays sensible. `reason` is empty (no LLM).
+ * overpickFactor widens the slice so the short gate has surplus to drop without
+ * unbalancing the final targetPicks.
+ */
+export function binByCells(
+  survivors: FanoutCandidate[],
+  targetPicks: number,
+  overpickFactor: number
+): PickResult[] {
+  const byCell = new Map<number, FanoutCandidate[]>();
+  for (const c of survivors) {
+    const key = c.cellIndex ?? -1; // -1 = center/core (null cellIndex query)
+    const bucket = byCell.get(key);
+    if (bucket) bucket.push(c);
+    else byCell.set(key, [c]);
+  }
+  const cells = Array.from(byCell.keys()).sort((a, b) => a - b);
+  const perCell = Math.ceil((targetPicks * overpickFactor) / Math.max(cells.length, 1));
+
+  const out: PickResult[] = [];
+  for (let r = 0; r < perCell; r += 1) {
+    for (const cell of cells) {
+      const cand = byCell.get(cell)![r];
+      if (!cand) continue;
+      out.push({ videoId: cand.videoId, score: 1 - r / (perCell + 1), reason: '' });
+    }
+  }
   return out;
 }
 

--- a/tests/unit/skills/video-discover/v5-cell-binning.test.ts
+++ b/tests/unit/skills/video-discover/v5-cell-binning.test.ts
@@ -1,0 +1,94 @@
+/**
+ * binByCells (CP492 V5_PICKER_MODE=cell_binning) — no-LLM picker that round-robins
+ * fanout survivors across cells. Validates: 9-cell balance, round-robin order,
+ * per-cell top-N relevance, under-filled cells, null cellIndex = center bucket.
+ */
+
+import { binByCells } from '@/skills/plugins/video-discover/v5/executor';
+import type { FanoutCandidate } from '@/skills/plugins/video-discover/v5/youtube-fanout';
+
+function cand(videoId: string, cellIndex: number | null): FanoutCandidate {
+  return {
+    videoId,
+    title: videoId,
+    description: '',
+    channelTitle: '',
+    channelId: '',
+    publishedAt: '2026-01-01T00:00:00Z',
+    thumbnailUrl: '',
+    cellIndex,
+  };
+}
+
+/** Build `perCell` candidates for each of `cells` cells, in relevance order. */
+function survivorsFor(cells: number[], perCell: number): FanoutCandidate[] {
+  const out: FanoutCandidate[] = [];
+  for (const c of cells) {
+    for (let i = 0; i < perCell; i += 1) out.push(cand(`c${c}_v${i}`, c));
+  }
+  return out;
+}
+
+function cellOf(videoId: string): number {
+  return Number(videoId.slice(1, videoId.indexOf('_')));
+}
+
+describe('binByCells', () => {
+  test('balances across all cells — every cell represented, none dominates', () => {
+    const survivors = survivorsFor([0, 1, 2, 3, 4, 5, 6, 7, 8], 10); // 9 cells × 10
+    const picks = binByCells(survivors, 30, 1.5);
+    const counts = new Map<number, number>();
+    for (const p of picks) counts.set(cellOf(p.videoId), (counts.get(cellOf(p.videoId)) ?? 0) + 1);
+    // all 9 cells present
+    expect(counts.size).toBe(9);
+    // max-min spread <= 1 (round-robin is even when cells are equally rich)
+    const vals = [...counts.values()];
+    expect(Math.max(...vals) - Math.min(...vals)).toBeLessThanOrEqual(1);
+  });
+
+  test('round-robin order — first N picks are one per cell (rank 0)', () => {
+    const survivors = survivorsFor([0, 1, 2], 5);
+    const picks = binByCells(survivors, 9, 1); // perCell = ceil(9/3) = 3
+    // first 3 = rank-0 from each cell, distinct cells
+    const firstThreeCells = picks.slice(0, 3).map((p) => cellOf(p.videoId));
+    expect(new Set(firstThreeCells)).toEqual(new Set([0, 1, 2]));
+    // and they are the v0 (top relevance) of each cell
+    expect(picks.slice(0, 3).every((p) => p.videoId.endsWith('_v0'))).toBe(true);
+  });
+
+  test('per-cell takes top-relevance first (v0 before v1)', () => {
+    const survivors = survivorsFor([0], 5);
+    const picks = binByCells(survivors, 9, 1); // 1 cell → perCell = 9, only 5 exist
+    // single cell → relevance order preserved, all available taken
+    expect(picks.map((p) => p.videoId)).toEqual(['c0_v0', 'c0_v1', 'c0_v2', 'c0_v3', 'c0_v4']);
+  });
+
+  test('under-filled cell contributes what it has, others still fill', () => {
+    // cell 0 has 1 candidate, cell 1 has 5
+    const survivors = [cand('c0_v0', 0), ...survivorsFor([1], 5)];
+    const picks = binByCells(survivors, 6, 1); // perCell = ceil(6/2) = 3
+    const byCell = new Map<number, number>();
+    for (const p of picks) byCell.set(cellOf(p.videoId), (byCell.get(cellOf(p.videoId)) ?? 0) + 1);
+    expect(byCell.get(0)).toBe(1); // only had 1
+    expect(byCell.get(1)).toBe(3); // perCell
+  });
+
+  test('null cellIndex grouped as a single center bucket', () => {
+    const survivors = [
+      { ...cand('core_v0', null) },
+      { ...cand('core_v1', null) },
+      ...survivorsFor([0], 2),
+    ];
+    const picks = binByCells(survivors, 9, 1);
+    const coreCount = picks.filter((p) => p.videoId.startsWith('core')).length;
+    expect(coreCount).toBe(2); // both null-cell candidates kept, one bucket
+  });
+
+  test('score decreases with rank so FE score-desc sort stays sensible', () => {
+    const survivors = survivorsFor([0], 3);
+    const picks = binByCells(survivors, 9, 1);
+    expect(picks[0]!.score).toBeGreaterThan(picks[1]!.score);
+    expect(picks[1]!.score).toBeGreaterThan(picks[2]!.score);
+    expect(picks.every((p) => p.reason === '')).toBe(true); // no LLM rationale
+  });
+});


### PR DESCRIPTION
## Why (measured)
Diagnosing the wizard 110s latency surfaced the LLM picker as the root issue on two axes:

**Speed** — `wizard.discover.end` traces: picker `llmMs` = **5.8-7.7s = 85-90% of discover** (fanout/videos/short all sub-second). The 5s picker timeout is **cosmetic**: `pickerTimedOut=true` but `abortedBatches=0` and `llmMs` runs to completion (the abort cuts the connection, not the in-flight body stream). So discover is 7-8.5s > the 6s precompute poll → structural MISS → v3 fallback (30-46s).

**Balance** — the picker ignores `cellIndex`, so its output fills only **1-4 of 9 cells** (one mandala: all 30 cards in a single cell). The 9-cell first impression is broken. The fanout queries are *already* cell-tagged (core + 8 sub-goals → 9 cells); the picker discards that and selects by relevance only → clusters in the core cell.

## What
`V5_PICKER_MODE` env (`'llm'` default = unchanged | `'cell_binning'`). `cell_binning`:
- Skips the OpenRouter picker entirely → `llmMs ~0` → discover ~1s → **precompute MISS disappears** (poll budget irrelevant).
- Bins fanout survivors by `cellIndex` and **round-robins** the top YouTube-relevance items across cells. Round-robin order means the downstream `slice(0, targetPicks)` keeps every cell represented (verified by test).
- Downstream (videos.list, assemble, short gate, slice) unchanged — `picksMerged` is the same shape from either mode.

## A/B question (why this is a flag, not a replacement)
YouTube relevance includes garbage — filtering it is the picker's original purpose. cell_binning gives balance + speed but **may let garbage through**. This flag exists so the two outputs can be judged on real wizard creations:
- garbage filtered OK + balanced → **remove the picker** (speed + balance solved).
- garbage returns → **step 2: per-cell thumbnail vision filter** (reuse the shorts minimap-vision infra) — balance + filter + binning + speed.

## Safety / rollback
- Default `'llm'` → unset = current behavior, zero change. Flag-off rollback (no code revert).
- No LLM calls added (cell_binning has none; A/B toggling does not call the picker for experiments — `'llm'` mode is normal production service).
- Tests: `v5-cell-binning.test.ts` (6) — balance, round-robin order, per-cell top-N, under-filled cells, null=center bucket, score-desc. v5-executor regression 9/9 green.

## Toggle
Global env `V5_PICKER_MODE=cell_binning` (container) for the A/B comparison.