### PR TITLE
chore(prod): V5_PICKER_MODE=cell_binning — A/B toggle ON (CP492)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -50,6 +50,19 @@ services:
       # top-N cap before embed (e.g. top 30), (c) domain-tuned embedding.
       # See docs/design/realtime-search-pipeline.md (Phase 3A).
       - V3_CENTER_GATE_MODE=subword
+      # CP492 (2026-06-01) — A/B: cell_binning picker. Default in code is 'llm'
+      # (current OpenRouter Haiku batch picker). Measured problems with 'llm':
+      # it is the discover bottleneck (llmMs 5.8-7.7s = 85-90% of discover; its
+      # 5s abort is cosmetic — pickerTimedOut=true while llmMs runs full) AND it
+      # ignores cellIndex, so output fills only 1-4 of 9 cells (cell skew). This
+      # flag skips the LLM and round-robins fanout candidates by query cellIndex
+      # → ~1s discover (precompute MISS disappears) + 9-cell balance. Open A/B
+      # question this exists to answer: does dropping the LLM let YouTube garbage
+      # through (the picker's original purpose)? Affects BOTH wizard precompute
+      # AND add-cards (shared runV5Executor).
+      # Revert: delete this line and redeploy — code default 'llm' restores the
+      # batch picker bit-identically.
+      - V5_PICKER_MODE=cell_binning
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the


### PR DESCRIPTION
## What
Sets `V5_PICKER_MODE=cell_binning` in the prod api `environment:` (next to `V3_CENTER_GATE_MODE`, same tuning-knob pattern with revert instructions). Activates the cell_binning picker merged in #824 (default `'llm'` = unchanged until this flag).

## Why (measured, this session)
The LLM picker is the wizard/add-cards root issue on two axes:
- **Speed**: `llmMs` 5.8-7.7s = **85-90% of discover**; the 5s abort is cosmetic (`pickerTimedOut=true`, `abortedBatches=0`, llmMs runs full). discover 7-8.5s > 6s precompute poll → structural MISS → v3 fallback 30-46s. add-cards: same picker, 6-7s/round.
- **Balance**: picker ignores `cellIndex` → fills only **1-4 of 9 cells** (live mandala 58d3bf5b: 14 cards in 3 cells, 6 empty). add-cards: cell7 empty every round.

cell_binning: skip LLM → discover ~1s (MISS gone) + round-robin by cellIndex → 9-cell balance. Covers both surfaces (shared `runV5Executor`).

## A/B (this is why it's a flag)
YouTube relevance includes garbage — filtering it is the picker's original purpose. cell_binning may let garbage through. Judge on real output:
- garbage filtered OK + balanced → **remove the picker**.
- garbage returns → **per-cell thumbnail vision filter** (reuse shorts minimap-vision infra).

## Scope / rollback
- **Global** — all wizard creations + add-cards while ON. Revert = delete the line + redeploy (code default `'llm'`).
- No new LLM calls (cell_binning has none).
- Activation verified post-deploy via discover trace: `pickerModel=cell_binning`, `llmMs ~0`.