### PR TITLE
fix(add-cards): exclude this mandala's live feed — stop re-surfacing wizard cards (CP492)

### DIFF
--- a/src/modules/exclude/excluded-videos.ts
+++ b/src/modules/exclude/excluded-videos.ts
@@ -57,7 +57,7 @@ export interface ExcludeSetOpts {
  */
 export async function getExcludedVideoIds(opts: ExcludeSetOpts): Promise<Set<string>> {
   const { prisma, userId, mandalaId, requestExcludeIds = [] } = opts;
-  const [ownLocal, ownStates, deleteSignals, archiveSignals] = await Promise.all([
+  const [ownLocal, ownStates, deleteSignals, archiveSignals, liveFeed] = await Promise.all([
     prisma.user_local_cards.findMany({
       where: { user_id: userId },
       select: { video_id: true },
@@ -82,6 +82,18 @@ export async function getExcludedVideoIds(opts: ExcludeSetOpts): Promise<Set<str
       where: { user_id: userId, signal: 'archive', mandala_id: mandalaId },
       select: { video_id: true },
     }),
+    // CP492 — cards currently in THIS mandala's feed (wizard pre-fill + already
+    // added). Without this, Add Cards re-surfaces the wizard's own cards (85-93%
+    // overlap measured). MANDALA-SCOPED + non-expired only — distinct from the
+    // CP489 user_video_states ghost policy (different source), so it does NOT
+    // re-introduce CP489's starvation (that was 58 static ghost rows; this is
+    // ~30 cards out of a fresh ~120-candidate Tier 2 fanout) and causes NO
+    // cross-mandala bleed (other mandalas' cards still surface). Expired rows
+    // are left re-surfaceable (not a permanent exclude).
+    prisma.recommendation_cache.findMany({
+      where: { user_id: userId, mandala_id: mandalaId, expires_at: { gt: new Date() } },
+      select: { video_id: true },
+    }),
   ]);
   const excludeSet = new Set<string>();
   for (const id of requestExcludeIds) excludeSet.add(id);
@@ -89,5 +101,6 @@ export async function getExcludedVideoIds(opts: ExcludeSetOpts): Promise<Set<str
   for (const r of ownStates) excludeSet.add(r.youtube_video_id);
   for (const r of deleteSignals) excludeSet.add(r.video_id);
   for (const r of archiveSignals) excludeSet.add(r.video_id);
+  for (const r of liveFeed) if (r.video_id) excludeSet.add(r.video_id);
   return excludeSet;
 }

--- a/tests/unit/modules/exclude/excluded-videos.test.ts
+++ b/tests/unit/modules/exclude/excluded-videos.test.ts
@@ -19,21 +19,32 @@ interface StateRow {
 
 interface MockPrismaCalls {
   rawWhere: string[];
+  /** Captured `where` args from recommendation_cache.findMany (CP492 live-feed exclude). */
+  recCacheWhere: Array<Record<string, unknown>>;
 }
 
 /**
  * Build a minimal mock prisma that captures the raw SQL filter, returns
- * configured rows for user_video_states (=$queryRaw), and empty arrays
- * for the other 3 sources (user_local_cards, deleteSignals, archiveSignals).
+ * configured rows for user_video_states (=$queryRaw) + recommendation_cache,
+ * and empty arrays for the other sources (user_local_cards, delete/archive).
  */
-function makeMockPrisma(returnedStateRows: StateRow[]): {
+function makeMockPrisma(
+  returnedStateRows: StateRow[],
+  recCacheRows: Array<{ video_id: string }> = []
+): {
   prisma: Parameters<typeof getExcludedVideoIds>[0]['prisma'];
   calls: MockPrismaCalls;
 } {
-  const calls: MockPrismaCalls = { rawWhere: [] };
+  const calls: MockPrismaCalls = { rawWhere: [], recCacheWhere: [] };
   const prisma = {
     user_local_cards: { findMany: async () => [] },
     card_interactions: { findMany: async () => [] },
+    recommendation_cache: {
+      findMany: async (args: { where: Record<string, unknown> }) => {
+        calls.recCacheWhere.push(args.where);
+        return recCacheRows;
+      },
+    },
     $queryRaw: async (sqlTagged: { strings: string[]; values: unknown[] }) => {
       const joined = sqlTagged.strings.join(' ');
       calls.rawWhere.push(joined);
@@ -160,5 +171,43 @@ describe('getExcludedVideoIds — documented row classes (intent guard)', () => 
       mandalaId: '00000000-0000-0000-0000-000000000002',
     });
     expect(calls.rawWhere.join(' ')).not.toContain('auto_added = FALSE');
+  });
+});
+
+/**
+ * CP492 — live-feed dedup. Add Cards re-surfaced the wizard's own cards
+ * (85-93% overlap measured) because the exclude set never included the
+ * mandala's current recommendation_cache. The fix adds it MANDALA-SCOPED +
+ * non-expired only, distinct from the CP489 user_video_states ghost policy.
+ */
+describe('getExcludedVideoIds — live-feed dedup (CP492)', () => {
+  const userId = '00000000-0000-0000-0000-000000000001';
+  const mandalaId = '00000000-0000-0000-0000-000000000002';
+
+  test('recommendation_cache video_ids for this mandala are excluded', async () => {
+    const { prisma } = makeMockPrisma([], [{ video_id: 'wizardVid1' }, { video_id: 'wizardVid2' }]);
+    const excluded = await getExcludedVideoIds({ prisma, userId, mandalaId });
+    expect(excluded.has('wizardVid1')).toBe(true);
+    expect(excluded.has('wizardVid2')).toBe(true);
+  });
+
+  test('rec_cache query is MANDALA-SCOPED (no cross-mandala bleed)', async () => {
+    const { prisma, calls } = makeMockPrisma([], []);
+    await getExcludedVideoIds({ prisma, userId, mandalaId });
+    expect(calls.recCacheWhere).toHaveLength(1);
+    expect(calls.recCacheWhere[0]).toMatchObject({ user_id: userId, mandala_id: mandalaId });
+  });
+
+  test('rec_cache query filters expires_at > now (expired cards re-surfaceable, not permanent)', async () => {
+    const { prisma, calls } = makeMockPrisma([], []);
+    await getExcludedVideoIds({ prisma, userId, mandalaId });
+    const where = calls.recCacheWhere[0] as { expires_at?: { gt?: Date } };
+    expect(where.expires_at?.gt).toBeInstanceOf(Date);
+  });
+
+  test('empty rec_cache (fresh mandala) adds nothing — no starvation source', async () => {
+    const { prisma } = makeMockPrisma([], []);
+    const excluded = await getExcludedVideoIds({ prisma, userId, mandalaId });
+    expect(excluded.size).toBe(0);
   });
 });


### PR DESCRIPTION
## Bug (measured)
Add Cards re-surfaces the wizard's own cards. Empirical overlap (add-cards `returned_video_ids` ∩ mandala `recommendation_cache`):
- mandala cde6326d (cell_binning): **28/30 wizard cards (93%)** re-appeared
- mandala 58d3bf5b (LLM): **17/20 (85%)**

Pre-existing — both LLM and cell_binning mandalas hit it, so **not** caused by the cell_binning A/B.

## Root cause (file:line)
`getExcludedVideoIds` (`src/modules/exclude/excluded-videos.ts`) excluded `user_local_cards` + engaged `user_video_states` (watched/pinned/note) + delete/archive signals + `requestExcludeIds` — but **never `recommendation_cache`**. CP489 had deliberately removed wizard-prefill exclusion (`add-cards.ts:452-453`) — but that fix targeted a **different source**: `user_video_states` rows where 54/58 (93%) were `auto_added=true` zero-engagement ghosts permanently excluding the pool (Add Cards → 0-7 cards). CP489 never touched `recommendation_cache`.

## Fix
Add a 5th exclude source: the mandala's `recommendation_cache`, **mandala-scoped + non-expired**.
- Distinct source from CP489's `user_video_states` ghost policy → **no CP489 regression** (that policy is unchanged).
- mandala_id-scoped → **no cross-mandala bleed** (other mandalas still surface).
- `expires_at > now` → expired cards stay re-surfaceable (not a permanent exclude).
- ~30 feed cards out of a fresh ~120-candidate Tier 2 fanout → **no starvation** (unlike CP489's 58 static ghosts).

## Verification gate (prod, post-deploy)
1. Add Cards wizard overlap **85-93% → ~0**.
2. Cross-mandala: other mandalas' cards still surface (CP489 intent intact).
3. Add Cards not starved — `cards_count` healthy, no 0-7 regression.

## Tests
`excluded-videos.test.ts` +4 (rec_cache excluded / mandala-scoped / expires_at>now / empty-feed adds nothing). 13/13 green, no regression to the 9 CP489/490 policy guards.