### PR TITLE
chore(prod): V5_SEARCH_MAX_RESULTS 25→40 — card-volume supply lift Step 1 (CP492)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -63,6 +63,17 @@ services:
       # Revert: delete this line and redeploy — code default 'llm' restores the
       # batch picker bit-identically.
       - V5_PICKER_MODE=cell_binning
+      # CP492 Step 1 (2026-06-02) — card-volume supply lift. Wizard/add-cards
+      # under-fill (30 / 17 vs 50-70 target). Measured root: the 8 cell queries
+      # all share the full center-goal prefix → YouTube returns overlapping
+      # results → dedup collapses raw 200 → 68 unique (the supply ceiling).
+      # search.list quota is 100 units PER CALL regardless of maxResults, so
+      # raising maxResults 25→40 grows the per-query result set (+60% raw) at
+      # ZERO added quota (still 8 calls = 801 units) and no extra latency (same
+      # 1 call per query, fanout stays sub-second). Measure-first lever before
+      # the riskier query-diversification or the TARGET_PICKS cap raise.
+      # Revert: delete this line → code default 25.
+      - V5_SEARCH_MAX_RESULTS=40
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the


### PR DESCRIPTION
## Why
Wizard fills ~30 cards, add-cards ~17 — far short of the 50-70 target. Funnel measurement (`wizard.discover.end` traces):
```
raw 200 → titleFilter 68 (-66% dedup) → picks 33-36 → inserted 21-30
```
The **dedup collapse 200→68 is the supply ceiling** — the 8 cell queries (`buildRuleBasedQueries`, keyword-builder.ts:298) all prepend the full center goal, so YouTube returns overlapping results across queries. Only ~68 unique survive.

## What
`V5_SEARCH_MAX_RESULTS` 25→40 (env, default 25). search.list quota is **100 units per call regardless of maxResults** (youtube-fanout.ts:163 `queries.length × 100`), so this:
- grows the raw result set per query +60% → more unique survive the cross-query dedup,
- adds **ZERO quota** (still 8 calls = ~801 units/wizard),
- adds **no latency** (same 1 call/query; fanout stays sub-second, currently 0.4-0.9s).

Cheapest + lowest-risk supply lever. Comes BEFORE query-diversification (relevance risk, Issue #543: the center prefix anchors topic) and the `V5_TARGET_PICKS` cap raise (meaningless until supply grows).

## Measure gate (post-deploy)
1. unique-after-dedup 68 → ? (supply grew?)
2. fanoutMs (sub-second maintained — no latency regression)
3. cards count (wizard/add-cards)
4. quotaUnitsApprox 801 (unchanged — zero added)

Branch: unique 100+ & cards up → Step 3 (TARGET_PICKS 30→60). Still <80 → Step 2 (MAX_QUERIES↑ or query diversification, each measured).

## Scope/rollback
Single env line (docker-compose prod, V5_PICKER_MODE pattern). Revert = delete → code default 25. No code change.