### PR TITLE
chore(prod): V5_TARGET_PICKS 30→60 + DEDUP_HARDCAP 120→180 — volume cap raise Step 3 (CP492)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -74,6 +74,18 @@ services:
       # the riskier query-diversification or the TARGET_PICKS cap raise.
       # Revert: delete this line → code default 25.
       - V5_SEARCH_MAX_RESULTS=40
+      # CP492 Step 3 (2026-06-02) — card-volume cap raise. After Step 1 lifted
+      # unique supply 68→120 (now DEDUP_HARDCAP-bound), the bottleneck moved to
+      # the targetPicks slice (30) + Shorts drop: wizard still inserted ~23.
+      # Raise the slice to 60 (binByCells over-picks 60×1.5=90 → Shorts drop →
+      # ~50-60). MUST raise DEDUP_HARDCAP in lockstep: at targetPicks 60 with
+      # ~40% Shorts, 120 unique → ~72 non-short → only just clears 60; 180 gives
+      # headroom. Raising targetPicks alone would re-hit the 120 unique wall.
+      # No quota change (caps are post-fetch). Latency: a wider dedup keep +
+      # bigger binning set — measure fanoutMs stays sub-second post-deploy.
+      # Revert: delete both lines → code defaults 30 / 120.
+      - V5_TARGET_PICKS=60
+      - V5_DEDUP_HARDCAP=180
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the


### PR DESCRIPTION
## Why
Step 1 (`SEARCH_MAX_RESULTS` 25→40) lifted unique supply **68→120** (verified) — but the wizard still inserts ~23 cards and the board shows 4/9 cells empty + one cell skewed to 11. The bottleneck **moved from supply to the cap**: `V5_TARGET_PICKS=30` slices the output, and Shorts drop eats the rest.

## What
- `V5_TARGET_PICKS` 30→60 (config default 30). binByCells over-picks 60×1.5=90 from the 120-unique pool → Shorts drop → ~50-60 final.
- `V5_DEDUP_HARDCAP` 120→180 **in lockstep**. unique is now 120-bound; at 60 picks with ~40% Shorts, 120 unique → ~72 non-short (barely clears 60). 180 gives headroom — raising targetPicks alone would re-hit the 120 unique wall.

No quota change (both caps are post-fetch; fanout still 8 calls = 801 units).

## Measure gate (post-deploy)
1. wizard cards 23 → ? (target 50-60)
2. cell distribution — skew eased (more cells filled, less single-cell pile-up)?
3. fanoutMs sub-second (HARDCAP↑ = wider dedup keep + bigger binning set — confirm no latency regression vs cell_binning's ~1s)
4. quota 801 unchanged

## Scope/rollback
Two env lines (docker-compose prod). Revert = delete → code defaults 30/120. No code change.

## Out of scope (next)
add-cards round exhaustion (6/0/0 by round 3) = Step 2 (`MAX_QUERIES`↑ for per-round fanout supply) — separate.