### PR TITLE
fix(v5/fanout): distribute search key per query — stop 429 rate-limit cascade (CP492)

### DIFF
--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -67,6 +67,18 @@ export interface FanoutResult {
   perQuery: FanoutPerQuery[];
 }
 
+/**
+ * Rotate `keys` so index `i` starts at `keys[i % len]`, with the remaining keys
+ * following as failover order. Spreads N parallel queries across N keys so each
+ * key sees ~1 concurrent request instead of N (which 429s on keys[0]). Returns
+ * the array unchanged for 0/1-key inputs. Exported for tests.
+ */
+export function rotateKeys(keys: string[], i: number): string[] {
+  if (keys.length <= 1) return keys;
+  const offset = ((i % keys.length) + keys.length) % keys.length;
+  return [...keys.slice(offset), ...keys.slice(0, offset)];
+}
+
 export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult> {
   const cfg = getV5Config(input.env);
   const apiKeys = resolveSearchApiKeys(input.env);
@@ -105,10 +117,18 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
   }
 
   const results = await Promise.allSettled(
-    queries.map((q) =>
+    queries.map((q, i) =>
       searchVideos({
         query: q.query,
-        apiKey: apiKeys,
+        // CP492 — distribute the primary key per query. searchVideos tries keys
+        // in array order (failover). Passing the same array to all N parallel
+        // queries made every query hammer keys[0] simultaneously → YouTube
+        // 429 rateLimitExceeded → cascade through all keys → queriesSucceeded
+        // collapsed (observed 4/8 normally, 0/8 under burst = the "0 results"
+        // add-cards bug AND a silent ~50% supply loss). Rotating the start
+        // index spreads N queries across N keys (~1 concurrent/key) while
+        // keeping the rest as failover.
+        apiKey: rotateKeys(apiKeys, i),
         maxResults: cfg.searchMaxResults,
         relevanceLanguage: input.language,
         timeoutMs: cfg.searchTimeoutMs,

--- a/tests/unit/skills/video-discover/v5-fanout.test.ts
+++ b/tests/unit/skills/video-discover/v5-fanout.test.ts
@@ -4,7 +4,7 @@
  * of fulfillment (rejected query → rawCount 0, fulfilled false).
  */
 
-import { runYouTubeFanout } from '@/skills/plugins/video-discover/v5/youtube-fanout';
+import { runYouTubeFanout, rotateKeys } from '@/skills/plugins/video-discover/v5/youtube-fanout';
 import { resetV5ConfigForTest } from '@/skills/plugins/video-discover/v5/config';
 
 jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
@@ -118,5 +118,46 @@ describe('runYouTubeFanout — F5c perQuery', () => {
       env: {} as NodeJS.ProcessEnv,
     });
     expect(searchVideos.mock.calls[0]![0].publishedAfter).toBeUndefined();
+  });
+});
+
+/**
+ * CP492 — per-query key rotation. All N parallel queries previously shared the
+ * same key array → every query hit keys[0] first → YouTube 429 rateLimitExceeded
+ * cascade (0 results under burst, ~50% supply loss normally). rotateKeys spreads
+ * the primary key across queries while keeping failover order.
+ */
+describe('rotateKeys', () => {
+  const keys = ['k0', 'k1', 'k2', 'k3'];
+
+  test('query 0 starts at k0 (unchanged order)', () => {
+    expect(rotateKeys(keys, 0)).toEqual(['k0', 'k1', 'k2', 'k3']);
+  });
+
+  test('query i starts at keys[i] with the rest as failover', () => {
+    expect(rotateKeys(keys, 1)).toEqual(['k1', 'k2', 'k3', 'k0']);
+    expect(rotateKeys(keys, 2)).toEqual(['k2', 'k3', 'k0', 'k1']);
+    expect(rotateKeys(keys, 3)).toEqual(['k3', 'k0', 'k1', 'k2']);
+  });
+
+  test('wraps when i >= keyCount (more queries than keys)', () => {
+    expect(rotateKeys(keys, 4)).toEqual(rotateKeys(keys, 0)); // 4 % 4 = 0
+    expect(rotateKeys(keys, 5)).toEqual(rotateKeys(keys, 1));
+  });
+
+  test('N distinct queries get N distinct primary keys (no pile-up on keys[0])', () => {
+    const primaries = Array.from({ length: keys.length }, (_, i) => rotateKeys(keys, i)[0]);
+    expect(new Set(primaries).size).toBe(keys.length); // all distinct
+  });
+
+  test('every rotation is a permutation (failover still covers all keys)', () => {
+    for (let i = 0; i < keys.length; i += 1) {
+      expect([...rotateKeys(keys, i)].sort()).toEqual([...keys].sort());
+    }
+  });
+
+  test('0/1-key inputs returned unchanged (no rotation possible)', () => {
+    expect(rotateKeys([], 3)).toEqual([]);
+    expect(rotateKeys(['only'], 3)).toEqual(['only']);
   });
 });


### PR DESCRIPTION
## Bug (measured)
User keyword add-search returned **0 results** (7/8/9th rounds) with the most permissive filters. Diagnosis:
- All 8 fanout queries `rawCount=0`, `queriesAttempted=8 / queriesSucceeded=0` — including unchanged sub-goal queries → not keyword/filter/exclude, a **global search failure**.
- Direct probe of all 8 keys: **`429 rateLimitExceeded`** (operator console confirmed daily quota at 53% — NOT exhausted). So it's a per-second rate limit, not quota.

## Root cause (file:line)
- `youtube-client.ts:273` — `searchVideos` tries keys in array order (failover from `keys[0]`).
- `youtube-fanout.ts:108-112` — all N parallel queries get the **same** `apiKeys` array → every query hammers `keys[0]` at once → 429 → all failover to `keys[1]` together → cascade → all fail.

**Also a silent supply drain**: the 6th round (normal, not burst) already showed `queriesSucceeded=4/8` — this bug has been killing ~half the fanout queries all along, compounding the card-volume shortfall alongside the dedup collapse.

## Fix
`rotateKeys(apiKeys, i)` — query `i` starts at `keys[i % len]`, the rest follow as failover. N parallel queries → N distinct primary keys → ~1 concurrent request/key → no 429. searchVideos failover logic unchanged (just a rotated start).

## Verify gate (post-deploy)
1. `queriesSucceeded` 4/8 (or 0/8) → **8/8**.
2. Burst (rapid add-cards rounds) no longer returns 0.
3. Wizard `rawItemCount` up (the ~50% recovered supply).

## Tests
`v5-fanout.test.ts` +6 (rotation offset, wrap, N-distinct-primaries, permutation, 0/1-key). 9/9 green.

## Order
Pre-existing (independent of cell_binning / Step 1/3 config). Lands BEFORE the `TARGET_PICKS` cap raise (#828) — raising the cap into a half-starved pool wouldn't reach 50-60.