### PR TITLE
fix(youtube): separate videos.list key pool from search.list — stop quota cross-burn (CP492)

### DIFF
--- a/src/skills/plugins/batch-video-collector/executor.ts
+++ b/src/skills/plugins/batch-video-collector/executor.ts
@@ -43,6 +43,7 @@ import {
   videosBatch,
   parseIsoDuration,
   resolveSearchApiKeys,
+  resolveVideosApiKeys,
   VIDEOS_LIST_MAX_IDS_PER_CALL,
   type YouTubeSearchItem,
   type YouTubeVideoStatsItem,
@@ -63,6 +64,10 @@ const DEFAULT_RUN_TYPE = 'daily_trend';
 
 interface HydratedState {
   apiKeys: string[];
+  /** CP492 — separate pool for bulk videos.list so it doesn't drain the
+   *  user-facing search.list Queries quota. Falls back to apiKeys when no
+   *  dedicated YOUTUBE_API_KEY_VIDEOS keys exist. */
+  videosApiKeys: string[];
   ollamaUrl: string;
   limit: number;
   offset: number;
@@ -131,7 +136,8 @@ export const executor: SkillExecutor = {
         ? parseInt(envOffset, 10)
         : computeRotationOffset(Date.now(), limit, BATCH_COLLECTOR_ROTATION_DAYS);
 
-    const state: HydratedState = { apiKeys, ollamaUrl, limit, offset, runType };
+    const videosApiKeys = resolveVideosApiKeys(ctx.env);
+    const state: HydratedState = { apiKeys, videosApiKeys, ollamaUrl, limit, offset, runType };
     return { ok: true, hydrated: state as unknown as Record<string, unknown> };
   },
 
@@ -217,7 +223,7 @@ export const executor: SkillExecutor = {
       const allIds = Array.from(hitsByVideoId.keys());
       let stats: YouTubeVideoStatsItem[] = [];
       try {
-        stats = await videosBatch({ videoIds: allIds, apiKey: state.apiKeys });
+        stats = await videosBatch({ videoIds: allIds, apiKey: state.videosApiKeys });
         quotaUsed += Math.ceil(allIds.length / VIDEOS_LIST_MAX_IDS_PER_CALL);
       } catch (err) {
         log.warn(

--- a/src/skills/plugins/video-discover/v2/executor.ts
+++ b/src/skills/plugins/video-discover/v2/executor.ts
@@ -38,6 +38,7 @@ import { totalAssigned, type CellAssignment } from './cell-assigner';
 import {
   searchVideos,
   videosBatch,
+  resolveVideosApiKeys,
   parseIsoDuration,
   isShortsByDuration,
   titleIndicatesShorts,
@@ -230,7 +231,9 @@ export const executor: SkillExecutor = {
     const videoIds = pool.map((p) => p.videoId);
     let stats: YouTubeVideoStatsItem[] = [];
     try {
-      stats = await videosBatch({ videoIds, apiKey });
+      // CP492 — videos.list on the separate VIDEOS pool (falls back to search
+      // keys until dedicated YOUTUBE_API_KEY_VIDEOS keys are provisioned).
+      stats = await videosBatch({ videoIds, apiKey: resolveVideosApiKeys(ctx.env ?? {}) });
     } catch (err) {
       log.warn(`videos.list failed: ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/src/skills/plugins/video-discover/v2/youtube-client.ts
+++ b/src/skills/plugins/video-discover/v2/youtube-client.ts
@@ -181,6 +181,30 @@ export function resolveSearchApiKeys(env: Readonly<Record<string, string | undef
   return keys;
 }
 
+/**
+ * Resolve the key pool for NON-search calls — videos.list (stats/duration) and
+ * bulk pool collection (batch-video-collector). CP492: these share each Google
+ * project's daily Queries quota with search.list (search.list = 100 units/call;
+ * videos.list = 1 unit). A pool-build run (thousands of videos.list) drained the
+ * search projects' Queries → user-facing wizard search.list got 429 → 0 cards.
+ *
+ * Reads YOUTUBE_API_KEY_VIDEOS / _2..N (dedicated projects for the cheap,
+ * high-volume videos.list). Falls back to the SEARCH pool when no dedicated
+ * VIDEOS keys are configured — so behavior is unchanged until the operator
+ * provisions separate video projects (then the separation actually takes hold).
+ */
+export function resolveVideosApiKeys(env: Readonly<Record<string, string | undefined>>): string[] {
+  const keys: string[] = [];
+  const primary = env['YOUTUBE_API_KEY_VIDEOS']?.trim();
+  if (primary) keys.push(primary);
+  for (let i = 2; i <= MAX_SEARCH_KEY_SLOTS; i++) {
+    const k = env[`YOUTUBE_API_KEY_VIDEOS_${i}`]?.trim();
+    if (k) keys.push(k);
+  }
+  if (keys.length === 0) return resolveSearchApiKeys(env); // unchanged until VIDEOS keys exist
+  return keys;
+}
+
 function isQuotaError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return msg.includes('search.list HTTP 403') || msg.includes('search.list HTTP 429');

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -66,6 +66,7 @@ import {
   titleIndicatesShorts,
   titleHitsBlocklist,
   resolveSearchApiKeys,
+  resolveVideosApiKeys,
   type YouTubeVideoStatsItem,
   type YouTubeSearchItem,
 } from '../v2/youtube-client';
@@ -573,6 +574,7 @@ async function executeImpl(
       deficitCells,
       state,
       apiKeys,
+      videosApiKeys: resolveVideosApiKeys(ctx.env ?? {}),
       openRouterApiKey: openRouterApiKey || undefined,
       openRouterModel,
       existingVideoIds,
@@ -794,6 +796,9 @@ export async function maybeApplyWhitelistGate(
 interface Tier2Input {
   deficitCells: Array<{ cellIndex: number; need: number }>;
   state: HydratedState;
+  /** CP492 — separate pool for videos.list (falls back to apiKeys until
+   *  YOUTUBE_API_KEY_VIDEOS keys are provisioned). */
+  videosApiKeys: string[];
   /** Ordered API keys — rotated on quota (403) errors. */
   apiKeys: string[];
   openRouterApiKey?: string;
@@ -1000,7 +1005,7 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   try {
     stats = await videosBatch({
       videoIds: combined.map((p) => p.videoId),
-      apiKey: input.apiKeys,
+      apiKey: input.videosApiKeys,
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -1991,6 +1996,7 @@ async function runDiscoverEphemeralImpl(
         targetLevel: input.targetLevel,
       },
       apiKeys,
+      videosApiKeys: resolveVideosApiKeys(input.env),
       openRouterApiKey: openRouterApiKey || undefined,
       openRouterModel,
       existingVideoIds,

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -14,7 +14,7 @@
  */
 
 import { logger } from '@/utils/logger';
-import { videosBatchFullMetadata, resolveSearchApiKeys } from '../v2/youtube-client';
+import { videosBatchFullMetadata, resolveVideosApiKeys } from '../v2/youtube-client';
 import type { YouTubeVideoFullMetadata } from '../v2/youtube-client';
 import { runYouTubeFanout, type FanoutCandidate, type FanoutPerQuery } from './youtube-fanout';
 import { getV5Config } from './config';
@@ -242,7 +242,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
   const tVideos0 = Date.now();
   const fanoutById = new Map(survivors.map((c) => [c.videoId, c]));
   const pickedIds = picksMerged.map((p) => p.videoId);
-  const apiKeys = resolveSearchApiKeys(input.env);
+  const apiKeys = resolveVideosApiKeys(input.env);
   let fullMeta: YouTubeVideoFullMetadata[] = [];
   if (apiKeys.length > 0) {
     try {

--- a/tests/unit/skills/video-discover/v5-executor.test.ts
+++ b/tests/unit/skills/video-discover/v5-executor.test.ts
@@ -19,6 +19,7 @@ jest.mock('@/skills/plugins/video-discover/v5/youtube-fanout', () => ({
 jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
   videosBatchFullMetadata: jest.fn().mockResolvedValue([]),
   resolveSearchApiKeys: jest.fn().mockReturnValue([]),
+  resolveVideosApiKeys: jest.fn().mockReturnValue([]),
 }));
 
 // CP491 short gate — mock the detector so orchestration tests never hit the

--- a/tests/unit/skills/video-discover/youtube-key-pools.test.ts
+++ b/tests/unit/skills/video-discover/youtube-key-pools.test.ts
@@ -1,0 +1,51 @@
+/**
+ * CP492 — search vs videos key-pool separation. Bulk videos.list
+ * (batch-video-collector) shared the search key pool and drained each Google
+ * project's daily Queries quota, 429-ing the user-facing wizard search.list.
+ * resolveVideosApiKeys gives videos.list its own pool, falling back to the
+ * search pool until dedicated VIDEOS keys are provisioned (no behavior change).
+ */
+
+import {
+  resolveSearchApiKeys,
+  resolveVideosApiKeys,
+} from '@/skills/plugins/video-discover/v2/youtube-client';
+
+describe('resolveVideosApiKeys (CP492)', () => {
+  test('uses dedicated YOUTUBE_API_KEY_VIDEOS_* pool when present', () => {
+    const env = {
+      YOUTUBE_API_KEY_SEARCH: 's1',
+      YOUTUBE_API_KEY_SEARCH_2: 's2',
+      YOUTUBE_API_KEY_VIDEOS: 'v1',
+      YOUTUBE_API_KEY_VIDEOS_2: 'v2',
+      YOUTUBE_API_KEY_VIDEOS_3: 'v3',
+    };
+    expect(resolveVideosApiKeys(env)).toEqual(['v1', 'v2', 'v3']);
+    // search pool stays its own — separation holds
+    expect(resolveSearchApiKeys(env)).toEqual(['s1', 's2']);
+  });
+
+  test('falls back to the SEARCH pool when no VIDEOS keys (behavior unchanged)', () => {
+    const env = { YOUTUBE_API_KEY_SEARCH: 's1', YOUTUBE_API_KEY_SEARCH_2: 's2' };
+    expect(resolveVideosApiKeys(env)).toEqual(['s1', 's2']);
+  });
+
+  test('falls back to legacy YOUTUBE_API_KEY when neither pool set', () => {
+    const env = { YOUTUBE_API_KEY: 'legacy' };
+    expect(resolveVideosApiKeys(env)).toEqual(['legacy']);
+  });
+
+  test('VIDEOS pool ignores SEARCH keys (no cross-contamination)', () => {
+    const env = { YOUTUBE_API_KEY_VIDEOS: 'v1', YOUTUBE_API_KEY_SEARCH: 's1' };
+    expect(resolveVideosApiKeys(env)).toEqual(['v1']);
+    expect(resolveSearchApiKeys(env)).toEqual(['s1']);
+  });
+
+  test('preserves slot order and skips gaps', () => {
+    const env = {
+      YOUTUBE_API_KEY_VIDEOS: 'v1',
+      YOUTUBE_API_KEY_VIDEOS_3: 'v3', // gap at _2
+    };
+    expect(resolveVideosApiKeys(env)).toEqual(['v1', 'v3']);
+  });
+});


### PR DESCRIPTION
## Bug (measured, launch-blocker)
A single user's wizard session returned **0 cards** — `add_cards.end` showed `queriesSucceeded=0/8`, all fanout queries 429. Operator console: the search keys' projects were quota-blown while an unrelated project sat at 53%.

## Root cause (file:line)
**No key-role separation.** ALL YouTube calls share one pool (`resolveSearchApiKeys`):
- search.list (fanout) — 100 quota units/call
- videos.list (v5:229, v3, v2) + **batch-video-collector pool-builder (executor.ts:111 resolve, :220 bulk `videosBatch`)** — 1 unit/call

Each Google project has **two** daily limits: Search Queries=100 **and** Queries=10,000. The collector's bulk videos.list (thousands of 1-unit calls) drained the search projects' 10k Queries (`alert-arbor`/`nomadic`: Queries 10k exhausted, Search ~0) → the wizard's search.list 429'd there. Probe confirmed all 8 keys → 6 projects, 429 body = `"Search Queries per day" exceeded` per `project_number`.

## Fix
`resolveVideosApiKeys` (`YOUTUBE_API_KEY_VIDEOS_*`) — route **all** videos.list through it (batch-video-collector + v5/v3/v2 stats). search.list keeps `resolveSearchApiKeys`. **Falls back to the search pool** when no VIDEOS keys exist → zero behavior change on deploy; the separation activates once the operator provisions dedicated VIDEOS projects.

## Scope / safety
- Pre-existing (independent of cell_binning #824 / key-rotation #829 — both preserved; v5 diff is 2 lines).
- Fallback = current behavior until VIDEOS keys added. No revert risk.
- Tests: `youtube-key-pools.test.ts` (5 — dedicated pool / fallback / legacy / no cross-contamination / slot order); v5-executor mock updated; 23/23 green.

## Order (operator follow-up)
This is **fix 1**. Fix 3 (move the idle projects `0486`/`0223` into the search pool, drop the duplicate keys `SEARCH_5=SEARCH_2`, `SEARCH_6=SEARCH_4`) is operator-side env work after this merges. Fix 2 (cache search.list) is the scale lever.