### PR TITLE
fix(v5/fanout): drop off-language results + regionCode — stop Chinese dramas on Korean queries (CP492)

### DIFF
--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -79,6 +79,27 @@ export function rotateKeys(keys: string[], i: number): string[] {
   return [...keys.slice(offset), ...keys.slice(0, offset)];
 }
 
+/**
+ * Conservative off-language detector. YouTube ignores relevanceLanguage for
+ * sparse queries and backfills high-view global content — a Korean basketball
+ * query surfaced Chinese dramas (彩礼加倍 / 重生换嫁). Drop a title ONLY when it
+ * is dominated by a non-target script, so legitimate content survives:
+ *   - ko: Korean titles always contain Hangul. Zero Hangul + ≥2 CJK ideographs
+ *         (Han) = Chinese/Japanese → drop. English-titled ("[Team Drill]") has
+ *         no Han → kept; Hanja-mixed Korean has Hangul → kept.
+ *   - en: Latin-script. Zero Latin letters + ≥2 Han = CJK content → drop.
+ * Exported for tests.
+ */
+export function isOffLanguageTitle(title: string, lang: 'ko' | 'en'): boolean {
+  const t = title ?? '';
+  const hangul = (t.match(/[가-힣]/g) ?? []).length;
+  const han = (t.match(/[一-鿿]/g) ?? []).length;
+  const latin = (t.match(/[A-Za-z]/g) ?? []).length;
+  if (han < 2) return false; // not CJK-ideograph-dominant → never drop (conservative)
+  if (lang === 'ko') return hangul === 0; // a Korean title would carry Hangul
+  return latin === 0; // en: an English title would carry Latin letters
+}
+
 export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult> {
   const cfg = getV5Config(input.env);
   const apiKeys = resolveSearchApiKeys(input.env);
@@ -131,6 +152,11 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
         apiKey: rotateKeys(apiKeys, i),
         maxResults: cfg.searchMaxResults,
         relevanceLanguage: input.language,
+        // CP492 — region bias (ko→KR, en→US). relevanceLanguage alone is a soft
+        // hint YouTube ignores for sparse queries (it backfilled "드리블 핸들링"
+        // with a high-view Chinese drama). regionCode nudges toward the locale;
+        // the hard guard is the off-language title drop in the loop below.
+        regionCode: input.language === 'ko' ? 'KR' : 'US',
         timeoutMs: cfg.searchTimeoutMs,
         publishedAfter: input.publishedAfter,
       }).then((items) => ({ items, cellIndex: q.cellIndex ?? null }))
@@ -154,6 +180,11 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       if (!cand) continue;
       if (seen.has(cand.videoId)) continue;
       if (titleHitsBlocklist(cand.title) || titleIndicatesShorts(cand.title)) continue;
+      // CP492 — off-language hard drop. YouTube backfills sparse queries with
+      // high-view global content (Chinese dramas on a Korean basketball query).
+      // Conservative: only drop titles dominated by a non-target script (see
+      // isOffLanguageTitle) so English-titled or Hanja-mixed Korean content is kept.
+      if (isOffLanguageTitle(cand.title, input.language)) continue;
       seen.set(cand.videoId, cand);
       if (seen.size >= cfg.dedupHardCap) break;
     }

--- a/tests/unit/skills/video-discover/v5-fanout.test.ts
+++ b/tests/unit/skills/video-discover/v5-fanout.test.ts
@@ -4,7 +4,11 @@
  * of fulfillment (rejected query → rawCount 0, fulfilled false).
  */
 
-import { runYouTubeFanout, rotateKeys } from '@/skills/plugins/video-discover/v5/youtube-fanout';
+import {
+  runYouTubeFanout,
+  rotateKeys,
+  isOffLanguageTitle,
+} from '@/skills/plugins/video-discover/v5/youtube-fanout';
 import { resetV5ConfigForTest } from '@/skills/plugins/video-discover/v5/config';
 
 jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
@@ -159,5 +163,41 @@ describe('rotateKeys', () => {
   test('0/1-key inputs returned unchanged (no rotation possible)', () => {
     expect(rotateKeys([], 3)).toEqual([]);
     expect(rotateKeys(['only'], 3)).toEqual(['only']);
+  });
+});
+
+/**
+ * CP492 — off-language hard drop. YouTube backfilled sparse Korean queries with
+ * high-view Chinese dramas. Must drop CLEAR off-language titles only (no false
+ * positives on English-titled or Hanja-mixed Korean content).
+ */
+describe('isOffLanguageTitle (CP492)', () => {
+  test('ko: drops Chinese-drama titles (no Hangul + Han-dominant)', () => {
+    expect(isOffLanguageTitle('【MULTISUB】《彩礼加倍？反手向新娘闺蜜求婚》', 'ko')).toBe(true);
+    expect(isOffLanguageTitle('重生换嫁，长命百岁了', 'ko')).toBe(true);
+    expect(isOffLanguageTitle('仙武狂婿都市无敌', 'ko')).toBe(true);
+  });
+
+  test('ko: KEEPS English-titled Korean content (no Han)', () => {
+    expect(isOffLanguageTitle('[Team Drill] Run & Chase Drill (레이업 훈련)', 'ko')).toBe(false);
+    expect(isOffLanguageTitle('농구 훈련 4인 pass cut meet out 연습', 'ko')).toBe(false);
+    expect(isOffLanguageTitle('Basketball Shooting Form Drills', 'ko')).toBe(false);
+  });
+
+  test('ko: KEEPS Hanja-mixed Korean (Hangul present)', () => {
+    expect(isOffLanguageTitle('농구 戰術 훈련법', 'ko')).toBe(false);
+    expect(isOffLanguageTitle('통일 농구 방북단', 'ko')).toBe(false);
+  });
+
+  test('conservative: a single Han char is never dropped', () => {
+    expect(isOffLanguageTitle('球 basketball', 'ko')).toBe(false); // han=1 < 2
+  });
+
+  test('en: drops CJK-dominant titles (no Latin + Han)', () => {
+    expect(isOffLanguageTitle('彩礼加倍反手向新娘', 'en')).toBe(true);
+  });
+
+  test('en: KEEPS Latin titles even with stray Han', () => {
+    expect(isOffLanguageTitle('Kung Fu 功夫 basics', 'en')).toBe(false); // latin present
   });
 });


### PR DESCRIPTION
## Bug
A Korean basketball mandala ("한 달 농구 훈련으로 대회 참석하기") surfaced Chinese wedding/rebirth dramas (彩礼加倍, 重生换嫁, 仙武狂婿) at the top of Add Cards.

## Root cause (measured, not the LLM picker)
- The 8 fanout queries are **correct Korean** ("...드리블 핸들링", "...팀 플레이").
- The raw **search.list response** for the sparse query "드리블 핸들링" (only 1 genuine hit) returned a Chinese drama as #1.
- `relevanceLanguage='ko'` is passed but it's a **soft hint** YouTube ignores for sparse queries; **regionCode was not passed** at all.
- cell_binning only binned what YouTube returned — the garbage entered at the **search response**, not query-gen or binning.

## Fix
1. **regionCode** (ko→KR, en→US) on `search.list` — soft locale bias.
2. **`isOffLanguageTitle` hard drop** (the real guard) — conservative: drop only when the title has **zero target-script chars AND ≥2 Han ideographs**. Korean titles always carry Hangul; English titles carry Latin — so `[Team Drill] (레이업 훈련)`, Hanja-mixed Korean (`농구 戰術 훈련법`), and pure-English titles are KEPT. Only Chinese/Japanese-dominant titles drop. **Zero false positives by design.**

## Verify gate (post-deploy)
Regenerate the basketball mandala → **0 Chinese-drama cards**, legit Korean basketball cards unchanged (no false drop), card count holds (~50, drop doesn't starve volume).

## Tests
`isOffLanguageTitle` ×6 (drops the 3 observed dramas; keeps English-titled / Hanja-mixed Korean / single-Han). 15/15 fanout suite green.

## Scope
fanout only; independent of the key-pool / quota work. (deploy.yml VIDEOS sync for batch-collector separation is a separate change, pending the operator's VIDEOS key.)