### PR TITLE
chore(deploy): sync YOUTUBE_API_KEY_VIDEOS to .env — activate batch-collector key separation (CP492)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -222,6 +222,8 @@ jobs:
           YT_SEARCH_KEY_6: ${{ secrets.YOUTUBE_API_KEY_SEARCH_6 }}
           YT_SEARCH_KEY_7: ${{ secrets.YOUTUBE_API_KEY_SEARCH_7 }}
           YT_SEARCH_KEY_8: ${{ secrets.YOUTUBE_API_KEY_SEARCH_8 }}
+          YT_VIDEOS_KEY: ${{ secrets.YOUTUBE_API_KEY_VIDEOS }}
+          YT_VIDEOS_KEY_2: ${{ secrets.YOUTUBE_API_KEY_VIDEOS_2 }}
           DB_URL: ${{ secrets.DATABASE_URL }}
           DB_DIRECT: ${{ secrets.DIRECT_URL }}
           REDIS_ADMIN_PW: ${{ secrets.REDIS_ADMIN_PASSWORD }}
@@ -319,7 +321,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,V2_QUALITY_AUDIT_ENABLED,V2_QUALITY_REGEN_ENABLED,V3_TRACE_ENABLED,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
+          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,YT_VIDEOS_KEY,YT_VIDEOS_KEY_2,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,V2_QUALITY_AUDIT_ENABLED,V2_QUALITY_REGEN_ENABLED,V3_TRACE_ENABLED,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
           script: |
             set -e
             cd /opt/tubearchive
@@ -437,6 +439,15 @@ jobs:
             fi
             if [ -n "${YT_SEARCH_KEY_8}" ]; then
               grep -q '^YOUTUBE_API_KEY_SEARCH_8=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_SEARCH_8=.*|YOUTUBE_API_KEY_SEARCH_8=${YT_SEARCH_KEY_8}|" .env || echo "YOUTUBE_API_KEY_SEARCH_8=${YT_SEARCH_KEY_8}" >> .env
+            fi
+            # CP492 — dedicated VIDEOS pool (videos.list / batch-video-collector via
+            # resolveVideosApiKeys). Separate Google projects so bulk videos.list does
+            # not burn the user-facing search.list projects' daily Queries quota.
+            if [ -n "${YT_VIDEOS_KEY}" ]; then
+              grep -q '^YOUTUBE_API_KEY_VIDEOS=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_VIDEOS=.*|YOUTUBE_API_KEY_VIDEOS=${YT_VIDEOS_KEY}|" .env || echo "YOUTUBE_API_KEY_VIDEOS=${YT_VIDEOS_KEY}" >> .env
+            fi
+            if [ -n "${YT_VIDEOS_KEY_2}" ]; then
+              grep -q '^YOUTUBE_API_KEY_VIDEOS_2=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_VIDEOS_2=.*|YOUTUBE_API_KEY_VIDEOS_2=${YT_VIDEOS_KEY_2}|" .env || echo "YOUTUBE_API_KEY_VIDEOS_2=${YT_VIDEOS_KEY_2}" >> .env
             fi
             # CP395 — Redis (video dictionary) ACL passwords + Tailscale IP.
             # Passwords consumed by docker/redis/entrypoint.sh via envsubst


### PR DESCRIPTION
## What
Sync the newly-provisioned `YOUTUBE_API_KEY_VIDEOS` secret (+ optional `_2`) to `.env` on deploy, mirroring the `YT_SEARCH_KEY_*` pattern (mapping + envs passthrough + idempotent add-or-update).

## Why
#830 added `resolveVideosApiKeys` so videos.list (v5/v3/v2 stats) + **batch-video-collector** (the bulk burner) use a dedicated VIDEOS pool — but it falls back to the search pool until VIDEOS keys exist. The operator has now created a dedicated VIDEOS Google project + key. This sync activates the separation:
- bulk videos.list → VIDEOS project's quota
- the 7 search projects' daily Queries → reserved for the user-facing wizard search.list (prevents the 0/8 re-exhaustion).

## Verify (post-deploy)
1. Container `.env` has `YOUTUBE_API_KEY_VIDEOS` (name matches `resolveVideosApiKeys`).
2. Run batch-collector → search projects' Search/Queries quota does NOT rise; only the VIDEOS project consumes.
3. Wizard `queriesSucceeded` 8/8 holds.

## Scope
deploy.yml env-sync only (additive). Secret name verified against the code (`env['YOUTUBE_API_KEY_VIDEOS']`).