### PR TITLE
perf(youtube-sync): narrow get-all-video-states embed to 9 columns (wizard 96s root)

### DIFF
--- a/frontend/src/features/card-management/lib/youtubeToInsightCard.test.ts
+++ b/frontend/src/features/card-management/lib/youtubeToInsightCard.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression — convertToInsightCard renders from the B2-narrowed video shape.
+ *
+ * Background: CP492 B2 narrowed the `get-all-video-states` Edge Function
+ * embed from `video:youtube_videos (*)` (all ~35 columns, incl. fat Json
+ * `thumbnails`/`region_restriction` and arrays `tags`/`topic_categories`)
+ * down to the 9 columns the card actually renders. That cut the dominant
+ * cost in the 667kB / multi-second payload for heavy users (5047 rows).
+ *
+ * This test pins the contract: those 9 video columns are *sufficient* to
+ * produce a fully-rendered InsightCard. If a future refactor makes the
+ * converter depend on a column the Edge Function no longer selects, this
+ * breaks — surfacing the silent "card renders blank" regression at CI.
+ */
+import { describe, it, expect } from 'vitest';
+import { convertToInsightCard } from './youtubeToInsightCard';
+import type { UserVideoStateWithVideo } from '@/entities/youtube/model/types';
+
+/** A state row whose `video` carries ONLY the 9 B2-selected columns. */
+function narrowedState(): UserVideoStateWithVideo {
+  return {
+    id: 'state-1',
+    user_id: 'user-1',
+    video_id: 'vid-1',
+    is_in_ideation: false,
+    user_note: 'note',
+    watch_position_seconds: 42,
+    is_watched: false,
+    cell_index: 3,
+    level_id: 'level-1',
+    mandala_id: 'mandala-1',
+    sort_order: 5,
+    added_to_ideation_at: '2026-01-01T00:00:00Z',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-02T00:00:00Z',
+    pinned_at: null,
+    auto_added: false,
+    video: {
+      // The 9 columns B2 selects — no thumbnails/tags/localized_*/etc.
+      youtube_video_id: 'abc123',
+      title: 'How to Learn Anything',
+      description: 'A guide.',
+      thumbnail_url: 'https://img.example/abc123.jpg',
+      channel_title: 'LearnCo',
+      duration_seconds: 615,
+      published_at: '2025-12-01T00:00:00Z',
+      view_count: 12345,
+      like_count: 678,
+    } as UserVideoStateWithVideo['video'],
+  };
+}
+
+describe('convertToInsightCard — B2 9-column contract', () => {
+  it('produces a fully-rendered card from the narrowed video shape', () => {
+    const card = convertToInsightCard(narrowedState());
+    expect(card).not.toBeNull();
+    // Core render fields
+    expect(card!.title).toBe('How to Learn Anything');
+    expect(card!.thumbnail).toBe('https://img.example/abc123.jpg');
+    expect(card!.videoUrl).toBe('https://www.youtube.com/watch?v=abc123');
+    expect(card!.cellIndex).toBe(3);
+    expect(card!.mandalaId).toBe('mandala-1');
+    expect(card!.lastWatchPosition).toBe(42);
+    // Metadata extras the card reads from youtube_videos columns
+    const meta = card!.metadata as Record<string, unknown>;
+    expect(meta.author).toBe('LearnCo');
+    expect(meta['channel_title']).toBe('LearnCo');
+    expect(meta['duration_seconds']).toBe(615);
+    expect(meta['view_count']).toBe(12345);
+    expect(meta['like_count']).toBe(678);
+    expect(meta['published_at']).toBe('2025-12-01T00:00:00Z');
+  });
+
+  it('returns null when video embed is missing (defensive)', () => {
+    const state = narrowedState();
+    delete (state as { video?: unknown }).video;
+    expect(convertToInsightCard(state)).toBeNull();
+  });
+});

--- a/supabase/functions/youtube-sync/index.ts
+++ b/supabase/functions/youtube-sync/index.ts
@@ -650,11 +650,16 @@ Deno.serve(async (req) => {
 
       case 'get-all-video-states': {
         const mandalaId = url.searchParams.get('mandala_id');
+        // B2 (CP492): narrow the embedded youtube_videos select to the 9 columns
+        // convertToInsightCard actually reads. The previous `(*)` pulled all ~35
+        // columns including fat Json (thumbnails, region_restriction) and arrays
+        // (tags, topic_categories) — the dominant cost in the 667kB / multi-second
+        // payload for heavy users (5047 rows). DB-side this is ~20x cheaper.
         let query = supabase
           .from('user_video_states')
           .select(`
             *,
-            video:youtube_videos (*)
+            video:youtube_videos (youtube_video_id, title, description, thumbnail_url, channel_title, duration_seconds, published_at, view_count, like_count)
           `)
           .eq('user_id', user.id)
           .order('added_to_ideation_at', { ascending: false });


### PR DESCRIPTION
## Why
Wizard step-3 → card output took **~96s** for heavy users. Root cause (measured, not guessed):

1. `IndexPage.tsx:266` post-creation poll fires `invalidateQueries(allVideoStates)` **every 2s, up to 90s**.
2. Each invalidate refetches `get-all-video-states`, which embedded `video:youtube_videos (*)` → **all ~35 columns** incl. fat Json (`thumbnails`, `region_restriction`) + arrays (`tags`, `topic_categories`).
3. For the heaviest user (**5047 rows**) the response is 667kB and slow → 2s interval << refetch latency → **serial refetch pileup = the 96s**.

## What
Narrow the embed to the **9 columns `convertToInsightCard` actually renders**:
`youtube_video_id, title, description, thumbnail_url, channel_title, duration_seconds, published_at, view_count, like_count`.

This is the **minimum-blast-radius lever** — Edge Function `.select()` only. **No FE/queryKey/optimistic change** → D&D move + like paths untouched.

## Evidence (prod `EXPLAIN ANALYZE`, top user 5047 rows)
| | DB Execution Time | youtube_videos read |
|--|--|--|
| `(*)` (before) | **1024ms** | width=1648, 888ms (Json/array) |
| 9 columns (after) | **49ms** | width=946, 2.3ms |

DB ~20× cheaper; payload ~5× smaller. (DB was never 15s — the multi-second tail is PostgREST embed serialization + 667kB transfer + browser parse of fat rows, all dominated by the dropped columns.)

## Safety
- FE `YouTubeVideo` type declares **only these 9 columns** — the dropped columns were never typed or read (verified: no consumer reads `video.thumbnails/tags/...`).
- Added converter regression test pinning the 9-column → rendered-card contract.

## Verify
- `/verify` PASS: tsc + vitest (365 tests) + build + browser smoke (`/`, `/mandalas/new` → 200).
- Post-merge: CI auto-deploys `youtube-sync` to prod → measure wizard stopwatch + card render + like/move.

## Rollback
Revert the one-line `.select()` change (additive, safe).

## Follow-up (not in this PR)
- `get-ideation-videos` (same `(*)` embed) — identical sibling, separate decision.
- A2 (poll early-exit) + C (0-card grace) — FE, only if post-deploy measurement still shows residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)