### PR TITLE
fix(wizard): guard post-creation poll against in-flight refetch pileup (96s root)

### DIFF
--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -270,6 +270,13 @@ function AuthenticatedApp() {
     const POLL_TIMEOUT_MS = 90_000;
 
     const interval = setInterval(() => {
+      // A2 (CP492): skip this tick while an allVideoStates refetch is in
+      // flight. Invalidating an in-flight query queues ANOTHER refetch, and
+      // with a 5-7s response the 2s ticks stacked into a serial pileup — the
+      // wizard's ~96s symptom. Non-overlapping ticks = no pileup; the next
+      // free tick re-invalidates within POLL_INTERVAL_MS so cards still get
+      // picked up promptly. Auto-stop (cards.totalCards > 0) still ends it.
+      if (queryClient.isFetching({ queryKey: youtubeSyncKeys.allVideoStates })) return;
       queryClient.invalidateQueries({ queryKey: youtubeSyncKeys.allVideoStates });
       queryClient.invalidateQueries({ queryKey: localCardsKeys.all });
     }, POLL_INTERVAL_MS);


### PR DESCRIPTION
## Why
Wizard step-3 → card output took **~96s** ("0 cards + skeleton"). Measured root cause:

`IndexPage` post-creation poll fired `invalidateQueries(allVideoStates)` **every 2s for 90s**. `get-all-video-states` takes **5-7s in the browser** (measured: Edge Function hop 3.1s + 613kB transfer + browser concurrency). Invalidating an **in-flight** query queues another refetch → 2s ticks stacked into a **serial pileup** (dozens of 5-7s calls in James's Network tab = the 96s).

PR #833 (B2 column narrowing) did **not** fix this — measured: response is still 613kB gzip / 1000 rows / 9 cols. Columns weren't the bottleneck; **frequency (this PR) and row count (#834 B1)** are.

## What
Guard each poll tick with `queryClient.isFetching({ queryKey: allVideoStates })` — skip while a refetch is in flight. Non-overlapping ticks → no pileup. The existing auto-stop (`cards.totalCards > 0 → clearJustCreated`) still ends polling once cards land.

**FE-only, IndexPage poll only. No queryKey / optimistic / D&D changes.**

## Scope honesty
This removes the **pileup**, not the per-call 5-7s latency. Expected: 96s → **~5-10s** (one non-overlapping refetch picks up the cards), NOT 0s. Residual per-call cost (1000-row global fetch + Edge hop) = #834 (B1 mandala scope), to be measured next if 5-7s still bothers.

## Verify
`/verify` PASS: tsc + vitest (365) + build + browser smoke (`/`, `/mandalas/new` → 200).
Post-merge prod measure: wizard stopwatch (96s→?), `(pending)` rows gone (non-overlap), poll stops when cards appear (early-exit).

## Rollback
Revert the 1-line guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)