### PR TITLE
feat(v5): per-cell LLM query generation (V5_QUERY_GEN flag) — fixes card quality root cause

### DIFF
--- a/src/prompts/search-query-generator.ts
+++ b/src/prompts/search-query-generator.ts
@@ -87,3 +87,68 @@ how-to / stories / tools / mistakes / routine
 JSON array only:
 ["query1", "query2", "query3", "query4", "query5"]`;
 }
+
+export interface PerCellSearchQueryPromptInput {
+  centerGoal: string;
+  /** Cell labels in cell order (index 0..N-1). */
+  subLabels: string[];
+  language: string;
+  focusTags?: string[];
+}
+
+/**
+ * Per-cell query generation: ONE prompt → ONE searchable query per cell, as a
+ * JSON object keyed by cell index. A single LLM call sees all cells at once, so
+ * it keeps the center context consistent and avoids cross-cell duplicate queries
+ * (the rule-based path emitted e.g. center+"세계 일주" duplicating the center).
+ *
+ * Same anti-failure guidance as buildSearchQueryPrompt: each query 12-20 chars,
+ * goal+area combined — never too-short (→ generic self-help) nor sentence-long
+ * (→ no YouTube match → high-view global backfill). Verified (CP492): Haiku 4.5
+ * produced clean per-cell queries in ~2.2s, JSON-stable, search.list pools 5-10/10
+ * relevant vs rule-based 0/4 garbage.
+ */
+export function buildPerCellSearchQueryPrompt(input: PerCellSearchQueryPromptInput): string {
+  const { centerGoal, subLabels, language, focusTags } = input;
+  const n = subLabels.length;
+  const areas = subLabels.map((l, i) => `${i}. ${l}`).join('\n');
+  const focusLine = focusTags?.length
+    ? language === 'ko'
+      ? `- 집중 분야: ${focusTags.join(', ')}`
+      : `- Focus: ${focusTags.join(', ')}`
+    : '';
+
+  if (language === 'ko') {
+    return `당신은 YouTube 검색어 생성기입니다. 목표와 ${n}개 세부영역이 주어집니다. 각 세부영역마다 실제 사용자가 YouTube 검색창에 입력할 한국어 검색어 1개를 만드세요.
+
+목표: "${centerGoal}"
+세부영역:
+${areas}
+${focusLine ? '\n' + focusLine : ''}
+
+[규칙]
+- 각 검색어 12~20자. {목표 핵심어 1~2개} + {세부영역 핵심어 1~2개} 결합. 의미가 살아있는 검색가능한 표현.
+- 너무 짧으면(예: "시간 관리", "보험") 일반 콘텐츠로 확산 → 금지.
+- 너무 길거나 문장형(예: "매일 학습할 수 있는 시간 블록 설정하는 방법")이면 YouTube 매칭 실패 → 금지.
+- 세부영역의 실제 의도를 반영 (예: "시간 블록 설정"→"공부 시간관리 루틴", "프로토타입 개발"→"노코드 MVP 제작").
+
+[출력] JSON 객체만, 키는 세부영역 번호(문자열 "0"~"${n - 1}"), 값은 검색어:
+{"0":"검색어", ..., "${n - 1}":"검색어"}`;
+  }
+
+  return `You are a YouTube search query generator. Given a goal and ${n} sub-areas, write ONE search query a real user would type, for each sub-area.
+
+Goal: "${centerGoal}"
+Sub-areas:
+${areas}
+${focusLine ? '\n' + focusLine : ''}
+
+[Rules]
+- Each query 3-6 words. {goal keyword 1-2} + {area keyword 1-2}. A real, searchable phrase.
+- Too short (e.g. "time management", "insurance") → spreads to generic content → forbidden.
+- Too long / sentence-like → no YouTube match → forbidden.
+- Reflect the sub-area's real intent (e.g. "prototype dev" → "no-code MVP build").
+
+[Output] JSON object only, keys are sub-area indices (strings "0".."${n - 1}"), values are queries:
+{"0":"query", ..., "${n - 1}":"query"}`;
+}

--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -28,6 +28,14 @@ const v5EnvSchema = z.object({
   // candidates by query cellIndex (9-cell balance + ~1s discover, no garbage
   // filter). A/B flag: does cell_binning let YouTube garbage through vs the LLM?
   V5_PICKER_MODE: z.enum(['llm', 'cell_binning']).default('llm'),
+  // CP492 — query generation mode. 'rule' (default, current behavior) uses the
+  // synchronous rule-based concat (buildRuleBasedQueriesSync). 'llm' generates
+  // one searchable query per cell via a single OpenRouter Haiku call (zod-validated,
+  // per-cell rule fallback). Rule-based concat produced broad/garbage queries
+  // ("...학습할 수", 9-word) → YouTube sparse backfill (Chinese drama / generic
+  // self-help / EN-AR leak). LLM translates each cell label into a focused
+  // searchable query. unset = 'rule' = no-op (flag-off rollback).
+  V5_QUERY_GEN: z.enum(['rule', 'llm']).default('rule'),
 });
 
 export interface V5Config {
@@ -39,6 +47,7 @@ export interface V5Config {
   shortOverpickFactor: number;
   shortProbeDeadlineMs: number;
   pickerMode: 'llm' | 'cell_binning';
+  queryGen: 'rule' | 'llm';
 }
 
 let cached: V5Config | null = null;
@@ -55,6 +64,7 @@ export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
     shortOverpickFactor: p.V5_SHORT_OVERPICK_FACTOR,
     shortProbeDeadlineMs: p.V5_SHORT_PROBE_DEADLINE_MS,
     pickerMode: p.V5_PICKER_MODE,
+    queryGen: p.V5_QUERY_GEN,
   };
   return cached;
 }

--- a/src/skills/plugins/video-discover/v5/llm-query-gen.ts
+++ b/src/skills/plugins/video-discover/v5/llm-query-gen.ts
@@ -1,0 +1,151 @@
+/**
+ * v5 per-cell LLM query generation (CP492).
+ *
+ * Rule-based concat (buildRuleBasedQueriesSync) collapses a cell label into a
+ * 1-2 bare-noun tail appended to the full center goal, producing broad/garbage
+ * queries ("...학습할 수", 9-word) that YouTube can't match → sparse → high-view
+ * global backfill (Chinese drama / generic self-help / EN-AR leak). This module
+ * translates each cell label into ONE focused, searchable query via a single
+ * OpenRouter Haiku call.
+ *
+ * Safety: rule-based is always computed first as the fallback floor. No API key,
+ * parse failure, validation failure, or any thrown error → rule-based queries
+ * (worst case == current behavior). Per-cell: a missing/invalid cell falls back
+ * to that cell's rule query. Gated behind V5_QUERY_GEN=llm (default 'rule').
+ */
+
+import { z } from 'zod';
+import { logger } from '@/utils/logger';
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import {
+  SEARCH_QUERY_MODEL,
+  SEARCH_QUERY_TEMPERATURE,
+  SEARCH_QUERY_MAX_TOKENS,
+  buildPerCellSearchQueryPrompt,
+} from '@/prompts/search-query-generator';
+import {
+  buildRuleBasedQueriesSync,
+  type SearchQuery,
+  type KeywordBuilderInput,
+} from '../v2/keyword-builder';
+
+const log = logger.child({ module: 'video-discover/v5/llm-query-gen' });
+
+/** A query longer than this is sentence-like → reject (the failure mode we fix). */
+const MAX_LLM_QUERY_CHARS = 60;
+
+export interface LLMQueryGenOpts {
+  openRouterApiKey?: string;
+  maxQueries?: number;
+  /** Test injection — bypasses OpenRouter so unit tests never hit the network. */
+  generateImpl?: (
+    prompt: string,
+    options?: { temperature?: number; maxTokens?: number; format?: 'json' }
+  ) => Promise<string>;
+}
+
+/**
+ * Parse + validate the LLM JSON object `{ "0": "q", ... }`. Tolerates code
+ * fences and surrounding prose. Returns a cellIndex→query map of trimmed,
+ * non-empty, non-sentence-length entries, or null when nothing usable parses.
+ */
+export function parsePerCellResponse(raw: string, cellCount: number): Map<number, string> | null {
+  let text = (raw ?? '').trim();
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fence?.[1]) text = fence[1].trim();
+  const brace = text.match(/\{[\s\S]*\}/);
+  if (brace) text = brace[0];
+
+  let obj: unknown;
+  try {
+    obj = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  const parsed = z.record(z.string()).safeParse(obj);
+  if (!parsed.success) return null;
+
+  const out = new Map<number, string>();
+  for (const [k, v] of Object.entries(parsed.data)) {
+    const idx = Number(k);
+    if (!Number.isInteger(idx) || idx < 0 || idx >= cellCount) continue;
+    const q = v.trim();
+    if (q.length === 0 || q.length > MAX_LLM_QUERY_CHARS) continue;
+    out.set(idx, q);
+  }
+  return out.size > 0 ? out : null;
+}
+
+/**
+ * Generate one searchable query per cell via a single LLM call, with per-cell
+ * rule fallback. Never throws. Returns rule-based queries on any failure.
+ */
+export async function buildLLMQueriesPerCell(
+  input: KeywordBuilderInput,
+  opts: LLMQueryGenOpts = {}
+): Promise<SearchQuery[]> {
+  const center = input.centerGoal.trim();
+  if (!center) return [];
+
+  // Fallback floor — always available, never throws.
+  const ruleQueries = buildRuleBasedQueriesSync(input, opts.maxQueries);
+  const subLabels = input.subGoals.map((s) => s.trim()).filter(Boolean);
+
+  // No key / no labels → current rule-based behavior (flag-off-equivalent).
+  if (!opts.openRouterApiKey || subLabels.length === 0) return ruleQueries;
+
+  // Rule query indexed by cell, for gap-filling cells the LLM missed.
+  const ruleByCell = new Map<number, SearchQuery>();
+  for (const q of ruleQueries) {
+    if (typeof q.cellIndex === 'number') ruleByCell.set(q.cellIndex, q);
+  }
+
+  const t0 = Date.now();
+  try {
+    const prompt = buildPerCellSearchQueryPrompt({
+      centerGoal: center,
+      subLabels,
+      language: input.language,
+      focusTags: input.focusTags,
+    });
+    const generate =
+      opts.generateImpl ??
+      ((p: string, o?: { temperature?: number; maxTokens?: number; format?: 'json' }) =>
+        new OpenRouterGenerationProvider(SEARCH_QUERY_MODEL).generate(p, o));
+
+    const raw = await generate(prompt, {
+      temperature: SEARCH_QUERY_TEMPERATURE,
+      maxTokens: SEARCH_QUERY_MAX_TOKENS,
+      format: 'json',
+    });
+
+    const parsed = parsePerCellResponse(raw, subLabels.length);
+    if (!parsed) {
+      log.warn('v5 llm-query-gen: parse/validate failed — rule-based fallback');
+      return ruleQueries;
+    }
+
+    // One query per cell: LLM where valid, rule for the gaps.
+    const out: SearchQuery[] = [];
+    let llmCells = 0;
+    for (let i = 0; i < subLabels.length; i++) {
+      const llmQ = parsed.get(i);
+      if (llmQ) {
+        out.push({ query: llmQ, source: 'llm', cellIndex: i });
+        llmCells++;
+      } else {
+        const r = ruleByCell.get(i);
+        if (r) out.push(r);
+      }
+    }
+    log.info(
+      `v5 llm-query-gen: ${llmCells}/${subLabels.length} cells from LLM (${Date.now() - t0}ms)`
+    );
+    return out.length > 0 ? out : ruleQueries;
+  } catch (err) {
+    log.warn(
+      `v5 llm-query-gen failed (${err instanceof Error ? err.message : String(err)}) — rule-based fallback`
+    );
+    return ruleQueries;
+  }
+}

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -22,6 +22,7 @@ import {
   type YouTubeSearchItem,
 } from '../v2/youtube-client';
 import { buildRuleBasedQueriesSync } from '../v2/keyword-builder';
+import { buildLLMQueriesPerCell } from './llm-query-gen';
 import { getV5Config } from './config';
 
 const log = logger.child({ module: 'video-discover/v5/youtube-fanout' });
@@ -115,16 +116,24 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
     };
   }
 
-  const queries = buildRuleBasedQueriesSync(
-    {
-      centerGoal: input.centerGoal,
-      subGoals: input.subGoals,
-      focusTags: input.focusTags,
-      targetLevel: input.targetLevel,
-      language: input.language,
-    },
-    cfg.maxQueries
-  );
+  const queryInput = {
+    centerGoal: input.centerGoal,
+    subGoals: input.subGoals,
+    focusTags: input.focusTags,
+    targetLevel: input.targetLevel,
+    language: input.language,
+  };
+  // CP492 — V5_QUERY_GEN=llm translates each cell label into a focused,
+  // searchable query (1 Haiku call, per-cell rule fallback). Default 'rule'
+  // keeps the synchronous rule-based concat. buildLLMQueriesPerCell never
+  // throws — it returns rule-based queries on any failure.
+  const queries =
+    cfg.queryGen === 'llm'
+      ? await buildLLMQueriesPerCell(queryInput, {
+          openRouterApiKey: input.env['OPENROUTER_API_KEY'],
+          maxQueries: cfg.maxQueries,
+        })
+      : buildRuleBasedQueriesSync(queryInput, cfg.maxQueries);
 
   if (queries.length === 0) {
     return {

--- a/tests/unit/skills/video-discover/v5-llm-query-gen.test.ts
+++ b/tests/unit/skills/video-discover/v5-llm-query-gen.test.ts
@@ -1,0 +1,120 @@
+/**
+ * v5 per-cell LLM query generation (CP492).
+ * Verifies: good JSON → per-cell LLM queries; broken/partial/missing-key/throw
+ * → rule-based fallback (per-cell + whole-call). No network (generateImpl inject).
+ */
+
+import {
+  buildLLMQueriesPerCell,
+  parsePerCellResponse,
+} from '@/skills/plugins/video-discover/v5/llm-query-gen';
+
+const INPUT = {
+  centerGoal: '데일리 루틴으로 꾸준히 학습하며 온라인 창업하기',
+  subGoals: [
+    '매일 학습할 수 있는 시간 블록 설정 및 환경 구축',
+    '온라인 창업에 필요한 핵심 기술 스택 선정',
+    '창업 아이디어 발굴 및 시장 타당성 검증',
+  ],
+  focusTags: [] as string[],
+  targetLevel: 'standard',
+  language: 'ko' as const,
+};
+
+const GOOD_JSON = JSON.stringify({
+  '0': '공부 시간관리 루틴',
+  '1': '온라인 창업 기술 스택',
+  '2': '창업 아이디어 시장 검증',
+});
+
+describe('parsePerCellResponse', () => {
+  it('parses a plain JSON object', () => {
+    const m = parsePerCellResponse(GOOD_JSON, 3);
+    expect(m).not.toBeNull();
+    expect(m!.get(0)).toBe('공부 시간관리 루틴');
+    expect(m!.size).toBe(3);
+  });
+
+  it('tolerates code fences and surrounding prose', () => {
+    const raw = 'Here you go:\n```json\n' + GOOD_JSON + '\n```\nDone.';
+    const m = parsePerCellResponse(raw, 3);
+    expect(m!.get(2)).toBe('창업 아이디어 시장 검증');
+  });
+
+  it('rejects out-of-range keys, empty and sentence-length values', () => {
+    const raw = JSON.stringify({
+      '0': '공부 시간관리 루틴',
+      '1': '   ',
+      '2': 'x'.repeat(80),
+      '9': '범위 밖',
+    });
+    const m = parsePerCellResponse(raw, 3);
+    expect(m!.size).toBe(1);
+    expect(m!.get(0)).toBe('공부 시간관리 루틴');
+  });
+
+  it('returns null on unparseable input', () => {
+    expect(parsePerCellResponse('not json at all', 3)).toBeNull();
+    expect(parsePerCellResponse('', 3)).toBeNull();
+  });
+});
+
+describe('buildLLMQueriesPerCell', () => {
+  it('uses LLM queries per cell on good JSON', async () => {
+    const out = await buildLLMQueriesPerCell(INPUT, {
+      openRouterApiKey: 'k',
+      generateImpl: async () => GOOD_JSON,
+    });
+    const llm = out.filter((q) => q.source === 'llm');
+    expect(llm).toHaveLength(3);
+    expect(llm.find((q) => q.cellIndex === 0)?.query).toBe('공부 시간관리 루틴');
+    expect(llm.find((q) => q.cellIndex === 2)?.query).toBe('창업 아이디어 시장 검증');
+  });
+
+  it('falls back to rule-based when no API key', async () => {
+    const out = await buildLLMQueriesPerCell(INPUT, { generateImpl: async () => GOOD_JSON });
+    expect(out.every((q) => q.source !== 'llm')).toBe(true);
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to rule-based on unparseable LLM output', async () => {
+    const out = await buildLLMQueriesPerCell(INPUT, {
+      openRouterApiKey: 'k',
+      generateImpl: async () => 'garbage not json',
+    });
+    expect(out.every((q) => q.source !== 'llm')).toBe(true);
+  });
+
+  it('falls back to rule-based when the LLM call throws', async () => {
+    const out = await buildLLMQueriesPerCell(INPUT, {
+      openRouterApiKey: 'k',
+      generateImpl: async () => {
+        throw new Error('timeout');
+      },
+    });
+    expect(out.every((q) => q.source !== 'llm')).toBe(true);
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('per-cell fallback: LLM for present cells, rule for missing cells', async () => {
+    // LLM only returns cell 0 → cells 1,2 should be filled from rule-based.
+    const out = await buildLLMQueriesPerCell(INPUT, {
+      openRouterApiKey: 'k',
+      generateImpl: async () => JSON.stringify({ '0': '공부 시간관리 루틴' }),
+    });
+    const cell0 = out.find((q) => q.cellIndex === 0);
+    expect(cell0?.source).toBe('llm');
+    expect(cell0?.query).toBe('공부 시간관리 루틴');
+    // cells 1 and 2 present from rule fallback (source 'subgoal')
+    expect(out.find((q) => q.cellIndex === 1)?.source).toBe('subgoal');
+    expect(out.find((q) => q.cellIndex === 2)?.source).toBe('subgoal');
+  });
+
+  it('returns [] for empty centerGoal', async () => {
+    const out = await buildLLMQueriesPerCell(
+      { ...INPUT, centerGoal: '  ' },
+      { openRouterApiKey: 'k' }
+    );
+    expect(out).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Root cause (measured, 2 mandalas)
Rule-based query concat (`buildRuleBasedQueriesSync`) collapses each cell label into a 1-2 bare-noun tail on the full center goal → broad/garbage queries YouTube can't match → **sparse → high-view global backfill** (Chinese drama / generic self-help / EN-AR leak).

Evidence:
- `"시간 관리"` cell actual q = `"데일리 루틴으로 꾸준히 학습하며 온라인 창업하기 학습할 수"` (11 words, broken extract) → search.list **0/4 relevant** (all Get-Rich/drama). = exactly the dismal cards James saw.
- Same pattern across `"세계 일주"` mandala (Chinese drama in 건강보험 cell).

## Fix (입구 치료 — query, not filter)
ONE OpenRouter Haiku call translates `center + N cell labels` → one focused, searchable query per cell (12-20 chars, goal+area). Reuses the anti-failure guidance already in `buildSearchQueryPrompt` (never too-short → generic, never sentence-long → no match).

**Verified end-to-end:**
- Haiku 4.5: 1 call, ~2.2s, JSON-stable (8/8 cells)
- generated queries → search.list: **7/8 cells relevant-dominant** (incl. abstract cells 커뮤니티/진도관리), 1 borderline-adjacent, **0 garbage** — vs rule-based 0/4.
- Korean queries → Korean results → EN/AR backfill disappears (language fixed at the entrance, not the exit).

## Safety
- `V5_QUERY_GEN` flag, **default `'rule'` (current behavior)**. unset = no-op rollback.
- `buildLLMQueriesPerCell` **never throws**: no key / parse fail / zod-validation fail / timeout → rule-based queries (**worst case == current behavior**).
- Per-cell: a missing/invalid cell falls back to that cell's rule query.
- zod-validated; rejects empty / out-of-range / sentence-length values.

## Test
13 unit tests (parse + per-cell fallback + whole-call fallback + no-key + throw), generateImpl injection (no network). All green + tsc clean.

## Next (not in this PR)
- dev/canary total wizard-time measurement (discover 1.1s → ~4.7s with query-gen) before `V5_QUERY_GEN=llm` in prod.
- language gate (2nd safety net): extend off-language drop for scripts that still slip through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)