### PR TITLE
feat(v5): query-gen telemetry (Track-1 measure+propagate)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -391,6 +391,9 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               v5_stage_ms: v5Result.diagnostics.stageMs,
               v5_aborted_batches: v5Result.diagnostics.abortedBatches,
               v5_picker_timed_out: v5Result.diagnostics.pickerTimedOut,
+              // CP492 Track-1 — query-gen telemetry (mode/model/latency/llmCells/fellBack).
+              // stageMs.queryGenMs already carries the latency via v5_stage_ms.
+              v5_query_gen: v5Result.diagnostics.queryGen,
               // CP491 F5c — per-query raw count + q_ok (parity with wizard.discover.end).
               v5_per_query: v5Result.diagnostics.perQuery,
               // CP491 — Shorts dropped by the post-pick short gate (before→after observability).

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -17,6 +17,7 @@ import { logger } from '@/utils/logger';
 import { videosBatchFullMetadata, resolveVideosApiKeys } from '../v2/youtube-client';
 import type { YouTubeVideoFullMetadata } from '../v2/youtube-client';
 import { runYouTubeFanout, type FanoutCandidate, type FanoutPerQuery } from './youtube-fanout';
+import type { QueryGenMeta } from './llm-query-gen';
 import { getV5Config } from './config';
 import { getVideoPicker } from '@/modules/llm-picker/registry';
 import { getLlmPickerConfig } from '@/config/llm-picker';
@@ -69,6 +70,8 @@ export interface V5StageMs {
   assembleMs: number;
   /** CP491 — short-gate probe phase (bounded by V5_SHORT_PROBE_DEADLINE_MS). */
   shortMs: number;
+  /** CP492 Track-1 — query generation, split out of fanoutMs (which is now search-only). */
+  queryGenMs: number;
 }
 
 export interface V5ExecuteResult {
@@ -94,6 +97,8 @@ export interface V5ExecuteResult {
     perQuery: FanoutPerQuery[];
     /** CP491 — Shorts dropped by the post-pick short gate. */
     shortsDropped: number;
+    /** CP492 Track-1 — query-gen telemetry (mode/model/latency/llmCells/fellBack). */
+    queryGen: QueryGenMeta;
   };
 }
 
@@ -110,6 +115,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
     videosMs: 0,
     assembleMs: 0,
     shortMs: 0,
+    queryGenMs: 0,
   };
   let abortedBatches = 0;
   let pickerTimedOut = false;
@@ -125,7 +131,10 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
     env: input.env,
     publishedAfter: input.publishedAfter,
   });
-  stage.fanoutMs = Date.now() - tFanout0;
+  // CP492 Track-1 — split query-gen out of fanout. fanoutMs is now search-only.
+  // `?? 0` guards older/mocked FanoutResults that predate the queryGenMs field.
+  stage.queryGenMs = fanout.queryGenMs ?? 0;
+  stage.fanoutMs = Date.now() - tFanout0 - (fanout.queryGenMs ?? 0);
   const afterTitleFilter = fanout.candidates.length;
 
   // 2. exclude BEFORE LLM (save LLM tokens)
@@ -314,6 +323,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       abortedBatches,
       pickerTimedOut,
       perQuery: fanout.perQuery ?? [],
+      queryGen: fanout.queryGen,
     },
   };
 }
@@ -325,6 +335,7 @@ function emptyResult(args: {
     rawItemCount: number;
     quotaUnitsApprox: number;
     perQuery?: FanoutPerQuery[];
+    queryGen: QueryGenMeta;
   };
   afterTitleFilter: number;
   afterExcludeFilter: number;
@@ -353,6 +364,7 @@ function emptyResult(args: {
       abortedBatches: args.abortedBatches,
       pickerTimedOut: args.pickerTimedOut,
       perQuery: args.fanout.perQuery ?? [],
+      queryGen: args.fanout.queryGen,
     },
   };
 }

--- a/src/skills/plugins/video-discover/v5/llm-query-gen.ts
+++ b/src/skills/plugins/video-discover/v5/llm-query-gen.ts
@@ -45,6 +45,34 @@ export interface LLMQueryGenOpts {
 }
 
 /**
+ * CP492 Track-1 — query-gen telemetry. Emitted on EVERY path (success, partial,
+ * no-key, parse-fail, throw) so admin traces can compare rule vs llm and surface
+ * latency / fallback rate. `mode` is 'llm' whenever the LLM was attempted (even
+ * if it then fell back); the fanout sets 'rule' when V5_QUERY_GEN=rule and this
+ * function is never called.
+ */
+export interface QueryGenMeta {
+  mode: 'rule' | 'llm';
+  /** SEARCH_QUERY_MODEL when the LLM was attempted; undefined otherwise. */
+  model?: string;
+  /** LLM call wall-time (ms). 0 when no LLM call was made (no-key / rule). */
+  latencyMs: number;
+  /** Cells that received an LLM-generated query. */
+  llmCells: number;
+  /** Sub-goal (cell) count. */
+  totalCells: number;
+  /** True when the LLM was attempted but did not fully cover all cells. */
+  fellBack: boolean;
+  /** 'no-key' | 'parse-fail' | 'empty-merge' | 'partial' | 'error:<msg>' | 'empty-center'. */
+  fallbackReason?: string;
+}
+
+export interface QueryGenResult {
+  queries: SearchQuery[];
+  meta: QueryGenMeta;
+}
+
+/**
  * Parse + validate the LLM JSON object `{ "0": "q", ... }`. Tolerates code
  * fences and surrounding prose. Returns a cellIndex→query map of trimmed,
  * non-empty, non-sentence-length entries, or null when nothing usable parses.
@@ -83,16 +111,42 @@ export function parsePerCellResponse(raw: string, cellCount: number): Map<number
 export async function buildLLMQueriesPerCell(
   input: KeywordBuilderInput,
   opts: LLMQueryGenOpts = {}
-): Promise<SearchQuery[]> {
+): Promise<QueryGenResult> {
   const center = input.centerGoal.trim();
-  if (!center) return [];
+  const subLabels = input.subGoals.map((s) => s.trim()).filter(Boolean);
+  const totalCells = subLabels.length;
+
+  if (!center) {
+    return {
+      queries: [],
+      meta: {
+        mode: 'llm',
+        latencyMs: 0,
+        llmCells: 0,
+        totalCells,
+        fellBack: true,
+        fallbackReason: 'empty-center',
+      },
+    };
+  }
 
   // Fallback floor — always available, never throws.
   const ruleQueries = buildRuleBasedQueriesSync(input, opts.maxQueries);
-  const subLabels = input.subGoals.map((s) => s.trim()).filter(Boolean);
 
   // No key / no labels → current rule-based behavior (flag-off-equivalent).
-  if (!opts.openRouterApiKey || subLabels.length === 0) return ruleQueries;
+  if (!opts.openRouterApiKey || totalCells === 0) {
+    return {
+      queries: ruleQueries,
+      meta: {
+        mode: 'llm',
+        latencyMs: 0,
+        llmCells: 0,
+        totalCells,
+        fellBack: true,
+        fallbackReason: 'no-key',
+      },
+    };
+  }
 
   // Rule query indexed by cell, for gap-filling cells the LLM missed.
   const ruleByCell = new Map<number, SearchQuery>();
@@ -118,17 +172,29 @@ export async function buildLLMQueriesPerCell(
       maxTokens: SEARCH_QUERY_MAX_TOKENS,
       format: 'json',
     });
+    const latencyMs = Date.now() - t0;
 
-    const parsed = parsePerCellResponse(raw, subLabels.length);
+    const parsed = parsePerCellResponse(raw, totalCells);
     if (!parsed) {
       log.warn('v5 llm-query-gen: parse/validate failed — rule-based fallback');
-      return ruleQueries;
+      return {
+        queries: ruleQueries,
+        meta: {
+          mode: 'llm',
+          model: SEARCH_QUERY_MODEL,
+          latencyMs,
+          llmCells: 0,
+          totalCells,
+          fellBack: true,
+          fallbackReason: 'parse-fail',
+        },
+      };
     }
 
     // One query per cell: LLM where valid, rule for the gaps.
     const out: SearchQuery[] = [];
     let llmCells = 0;
-    for (let i = 0; i < subLabels.length; i++) {
+    for (let i = 0; i < totalCells; i++) {
       const llmQ = parsed.get(i);
       if (llmQ) {
         out.push({ query: llmQ, source: 'llm', cellIndex: i });
@@ -138,14 +204,51 @@ export async function buildLLMQueriesPerCell(
         if (r) out.push(r);
       }
     }
-    log.info(
-      `v5 llm-query-gen: ${llmCells}/${subLabels.length} cells from LLM (${Date.now() - t0}ms)`
-    );
-    return out.length > 0 ? out : ruleQueries;
+
+    if (out.length === 0) {
+      return {
+        queries: ruleQueries,
+        meta: {
+          mode: 'llm',
+          model: SEARCH_QUERY_MODEL,
+          latencyMs,
+          llmCells: 0,
+          totalCells,
+          fellBack: true,
+          fallbackReason: 'empty-merge',
+        },
+      };
+    }
+
+    const fellBack = llmCells < totalCells;
+    log.info(`v5 llm-query-gen: ${llmCells}/${totalCells} cells from LLM (${latencyMs}ms)`);
+    return {
+      queries: out,
+      meta: {
+        mode: 'llm',
+        model: SEARCH_QUERY_MODEL,
+        latencyMs,
+        llmCells,
+        totalCells,
+        fellBack,
+        fallbackReason: fellBack ? 'partial' : undefined,
+      },
+    };
   } catch (err) {
-    log.warn(
-      `v5 llm-query-gen failed (${err instanceof Error ? err.message : String(err)}) — rule-based fallback`
-    );
-    return ruleQueries;
+    const latencyMs = Date.now() - t0;
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`v5 llm-query-gen failed (${msg}) — rule-based fallback`);
+    return {
+      queries: ruleQueries,
+      meta: {
+        mode: 'llm',
+        model: SEARCH_QUERY_MODEL,
+        latencyMs,
+        llmCells: 0,
+        totalCells,
+        fellBack: true,
+        fallbackReason: `error:${msg.slice(0, 40)}`,
+      },
+    };
   }
 }

--- a/src/skills/plugins/video-discover/v5/wizard-adapter.ts
+++ b/src/skills/plugins/video-discover/v5/wizard-adapter.ts
@@ -48,9 +48,12 @@ export async function runV5ForWizard(input: V5WizardInput): Promise<EphemeralDis
   // (same runV5Executor as /add-cards, C8). Lets prod logs show whether
   // videos.list dominates the wizard discover_ms without a separate trace.
   const s = result.diagnostics.stageMs;
+  const qg = result.diagnostics.queryGen;
   log.info(
-    `v5 wizard stages ms: fanout=${s.fanoutMs} exclude=${s.excludeMs} llm=${s.llmMs} ` +
+    `v5 wizard stages ms: queryGen=${s.queryGenMs} fanout=${s.fanoutMs} exclude=${s.excludeMs} llm=${s.llmMs} ` +
       `videos=${s.videosMs} assemble=${s.assembleMs} short=${s.shortMs} total=${result.diagnostics.durationMs} ` +
+      `queryGenMode=${qg.mode} llmCells=${qg.llmCells}/${qg.totalCells} fellBack=${qg.fellBack}` +
+      `${qg.fallbackReason ? '(' + qg.fallbackReason + ')' : ''} ` +
       `shortsDropped=${result.diagnostics.shortsDropped} ` +
       `abortedBatches=${result.diagnostics.abortedBatches} pickerTimedOut=${result.diagnostics.pickerTimedOut}`
   );

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -21,8 +21,8 @@ import {
   titleHitsBlocklist,
   type YouTubeSearchItem,
 } from '../v2/youtube-client';
-import { buildRuleBasedQueriesSync } from '../v2/keyword-builder';
-import { buildLLMQueriesPerCell } from './llm-query-gen';
+import { buildRuleBasedQueriesSync, type SearchQuery } from '../v2/keyword-builder';
+import { buildLLMQueriesPerCell, type QueryGenMeta } from './llm-query-gen';
 import { getV5Config } from './config';
 
 const log = logger.child({ module: 'video-discover/v5/youtube-fanout' });
@@ -66,7 +66,20 @@ export interface FanoutResult {
   quotaUnitsApprox: number;
   /** CP491 F5c — one entry per attempted query (order = queries order). */
   perQuery: FanoutPerQuery[];
+  /** CP492 Track-1 — query-gen wall-time (ms), split out of the search portion. */
+  queryGenMs: number;
+  /** CP492 Track-1 — query-gen telemetry (mode/model/latency/fallback). */
+  queryGen: QueryGenMeta;
 }
+
+/** CP492 Track-1 — meta for the rule branch (LLM never attempted). */
+const RULE_QUERY_GEN_META = (totalCells: number): QueryGenMeta => ({
+  mode: 'rule',
+  latencyMs: 0,
+  llmCells: 0,
+  totalCells,
+  fellBack: false,
+});
 
 /**
  * Rotate `keys` so index `i` starts at `keys[i % len]`, with the remaining keys
@@ -113,6 +126,8 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       rawItemCount: 0,
       quotaUnitsApprox: 0,
       perQuery: [],
+      queryGenMs: 0,
+      queryGen: RULE_QUERY_GEN_META(0),
     };
   }
 
@@ -127,13 +142,22 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
   // searchable query (1 Haiku call, per-cell rule fallback). Default 'rule'
   // keeps the synchronous rule-based concat. buildLLMQueriesPerCell never
   // throws — it returns rule-based queries on any failure.
-  const queries =
-    cfg.queryGen === 'llm'
-      ? await buildLLMQueriesPerCell(queryInput, {
-          openRouterApiKey: input.env['OPENROUTER_API_KEY'],
-          maxQueries: cfg.maxQueries,
-        })
-      : buildRuleBasedQueriesSync(queryInput, cfg.maxQueries);
+  const totalCells = queryInput.subGoals.map((s) => s.trim()).filter(Boolean).length;
+  const tQueryGen0 = Date.now();
+  let queries: SearchQuery[];
+  let queryGen: QueryGenMeta;
+  if (cfg.queryGen === 'llm') {
+    const r = await buildLLMQueriesPerCell(queryInput, {
+      openRouterApiKey: input.env['OPENROUTER_API_KEY'],
+      maxQueries: cfg.maxQueries,
+    });
+    queries = r.queries;
+    queryGen = r.meta;
+  } else {
+    queries = buildRuleBasedQueriesSync(queryInput, cfg.maxQueries);
+    queryGen = RULE_QUERY_GEN_META(totalCells);
+  }
+  const queryGenMs = Date.now() - tQueryGen0;
 
   if (queries.length === 0) {
     return {
@@ -143,6 +167,8 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       rawItemCount: 0,
       quotaUnitsApprox: 0,
       perQuery: [],
+      queryGenMs,
+      queryGen,
     };
   }
 
@@ -222,6 +248,8 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
     rawItemCount,
     quotaUnitsApprox: queries.length * 100,
     perQuery,
+    queryGenMs,
+    queryGen,
   };
 }
 

--- a/tests/unit/skills/video-discover/v5-llm-query-gen.test.ts
+++ b/tests/unit/skills/video-discover/v5-llm-query-gen.test.ts
@@ -60,61 +60,79 @@ describe('parsePerCellResponse', () => {
 });
 
 describe('buildLLMQueriesPerCell', () => {
-  it('uses LLM queries per cell on good JSON', async () => {
-    const out = await buildLLMQueriesPerCell(INPUT, {
+  it('uses LLM queries per cell on good JSON + meta', async () => {
+    const { queries, meta } = await buildLLMQueriesPerCell(INPUT, {
       openRouterApiKey: 'k',
       generateImpl: async () => GOOD_JSON,
     });
-    const llm = out.filter((q) => q.source === 'llm');
+    const llm = queries.filter((q) => q.source === 'llm');
     expect(llm).toHaveLength(3);
     expect(llm.find((q) => q.cellIndex === 0)?.query).toBe('공부 시간관리 루틴');
     expect(llm.find((q) => q.cellIndex === 2)?.query).toBe('창업 아이디어 시장 검증');
+    // meta: full LLM coverage → not fellBack
+    expect(meta.mode).toBe('llm');
+    expect(meta.llmCells).toBe(3);
+    expect(meta.totalCells).toBe(3);
+    expect(meta.fellBack).toBe(false);
+    expect(meta.model).toBe('anthropic/claude-haiku-4.5');
   });
 
-  it('falls back to rule-based when no API key', async () => {
-    const out = await buildLLMQueriesPerCell(INPUT, { generateImpl: async () => GOOD_JSON });
-    expect(out.every((q) => q.source !== 'llm')).toBe(true);
-    expect(out.length).toBeGreaterThan(0);
+  it('falls back to rule-based when no API key (meta: no-key)', async () => {
+    const { queries, meta } = await buildLLMQueriesPerCell(INPUT, {
+      generateImpl: async () => GOOD_JSON,
+    });
+    expect(queries.every((q) => q.source !== 'llm')).toBe(true);
+    expect(queries.length).toBeGreaterThan(0);
+    expect(meta.fellBack).toBe(true);
+    expect(meta.fallbackReason).toBe('no-key');
+    expect(meta.latencyMs).toBe(0);
   });
 
-  it('falls back to rule-based on unparseable LLM output', async () => {
-    const out = await buildLLMQueriesPerCell(INPUT, {
+  it('falls back to rule-based on unparseable LLM output (meta: parse-fail)', async () => {
+    const { queries, meta } = await buildLLMQueriesPerCell(INPUT, {
       openRouterApiKey: 'k',
       generateImpl: async () => 'garbage not json',
     });
-    expect(out.every((q) => q.source !== 'llm')).toBe(true);
+    expect(queries.every((q) => q.source !== 'llm')).toBe(true);
+    expect(meta.fellBack).toBe(true);
+    expect(meta.fallbackReason).toBe('parse-fail');
   });
 
-  it('falls back to rule-based when the LLM call throws', async () => {
-    const out = await buildLLMQueriesPerCell(INPUT, {
+  it('falls back to rule-based when the LLM call throws (meta: error)', async () => {
+    const { queries, meta } = await buildLLMQueriesPerCell(INPUT, {
       openRouterApiKey: 'k',
       generateImpl: async () => {
         throw new Error('timeout');
       },
     });
-    expect(out.every((q) => q.source !== 'llm')).toBe(true);
-    expect(out.length).toBeGreaterThan(0);
+    expect(queries.every((q) => q.source !== 'llm')).toBe(true);
+    expect(queries.length).toBeGreaterThan(0);
+    expect(meta.fellBack).toBe(true);
+    expect(meta.fallbackReason).toMatch(/^error:/);
   });
 
-  it('per-cell fallback: LLM for present cells, rule for missing cells', async () => {
+  it('per-cell fallback: LLM for present cells, rule for missing (meta: partial)', async () => {
     // LLM only returns cell 0 → cells 1,2 should be filled from rule-based.
-    const out = await buildLLMQueriesPerCell(INPUT, {
+    const { queries, meta } = await buildLLMQueriesPerCell(INPUT, {
       openRouterApiKey: 'k',
       generateImpl: async () => JSON.stringify({ '0': '공부 시간관리 루틴' }),
     });
-    const cell0 = out.find((q) => q.cellIndex === 0);
+    const cell0 = queries.find((q) => q.cellIndex === 0);
     expect(cell0?.source).toBe('llm');
     expect(cell0?.query).toBe('공부 시간관리 루틴');
-    // cells 1 and 2 present from rule fallback (source 'subgoal')
-    expect(out.find((q) => q.cellIndex === 1)?.source).toBe('subgoal');
-    expect(out.find((q) => q.cellIndex === 2)?.source).toBe('subgoal');
+    expect(queries.find((q) => q.cellIndex === 1)?.source).toBe('subgoal');
+    expect(queries.find((q) => q.cellIndex === 2)?.source).toBe('subgoal');
+    expect(meta.llmCells).toBe(1);
+    expect(meta.fellBack).toBe(true);
+    expect(meta.fallbackReason).toBe('partial');
   });
 
-  it('returns [] for empty centerGoal', async () => {
-    const out = await buildLLMQueriesPerCell(
+  it('returns [] for empty centerGoal (meta: empty-center)', async () => {
+    const { queries, meta } = await buildLLMQueriesPerCell(
       { ...INPUT, centerGoal: '  ' },
       { openRouterApiKey: 'k' }
     );
-    expect(out).toEqual([]);
+    expect(queries).toEqual([]);
+    expect(meta.fallbackReason).toBe('empty-center');
   });
 });


### PR DESCRIPTION
CP492 Track-1 (measure→propagate→expose; **this PR = measure+propagate**, FE expose page is a separate PR).

## Why
Today query-gen latency / wizard total time were **invisible** — winston `info` not surfacing to docker stdout. We confirmed card QUALITY from prod cards but not the PERFORMANCE numbers. buildLLMQueriesPerCell was already computing latency/llmCells and throwing them away in a `log.info`. This captures them.

## Measure
- `buildLLMQueriesPerCell` → returns `{ queries, meta: QueryGenMeta }` on **every** path (success/partial/no-key/parse-fail/throw): mode, model, latencyMs, llmCells, totalCells, fellBack, fallbackReason.
- `FanoutResult`: + queryGenMs (wall-time) + queryGen meta.
- V5 diagnostics: `stageMs.queryGenMs` **split out of fanoutMs** (now search-only) + `diagnostics.queryGen`.
- **Flag-independent**: rule branch also emits meta (mode='rule', latency≈0, fellBack=false) → rule-vs-llm comparison data accrues automatically = Track 2/3 foundation, free.

## Propagate
- `wizard.discover.end` spreads `...diag` → queryGen + queryGenMs **auto-recorded** to video_discover_traces (V3_TRACE_ENABLED=true confirmed in prod).
- `add_cards.end`: + `v5_query_gen` field.
- wizard-adapter log line: queryGen=Xms + mode/llmCells/fellBack.

## Safety
Pure observability — **no behavior change**. Defensive `?? 0` on `fanout.queryGenMs`. 45 v5 unit tests pass, tsc clean.

## Scope honesty
Surfaces **PERFORMANCE only** (latency/fallback/cell-fill via stageMs). Card **QUALITY** (garbage rate / cell-card fit) = Track 3, not here.

## Verify
Post-merge: prod wizard 1회 → `psql` confirm `video_discover_traces` carries queryGen fields + stageMs.queryGenMs (today's unmeasured total time finally visible in trace). FE Discover-perf page = Phase 1c (next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)