### PR TITLE
feat(v5): 2nd-tier off-language gate (Arabic/Thai/Cyrillic/Turkish) + telemetry

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -394,6 +394,9 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               // CP492 Track-1 — query-gen telemetry (mode/model/latency/llmCells/fellBack).
               // stageMs.queryGenMs already carries the latency via v5_stage_ms.
               v5_query_gen: v5Result.diagnostics.queryGen,
+              // CP492 2차 gate — off-language candidates dropped (Arabic/Thai/Cyrillic/
+              // CJK/Turkish). English is intentionally NOT dropped (Track 3 topic fit).
+              v5_off_lang_dropped: v5Result.diagnostics.offLangDropped,
               // CP491 F5c — per-query raw count + q_ok (parity with wizard.discover.end).
               v5_per_query: v5Result.diagnostics.perQuery,
               // CP491 — Shorts dropped by the post-pick short gate (before→after observability).

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -99,6 +99,8 @@ export interface V5ExecuteResult {
     shortsDropped: number;
     /** CP492 Track-1 — query-gen telemetry (mode/model/latency/llmCells/fellBack). */
     queryGen: QueryGenMeta;
+    /** CP492 2차 gate — candidates dropped by the off-language script filter. */
+    offLangDropped: number;
   };
 }
 
@@ -324,6 +326,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       pickerTimedOut,
       perQuery: fanout.perQuery ?? [],
       queryGen: fanout.queryGen,
+      offLangDropped: fanout.offLangDropped ?? 0,
     },
   };
 }
@@ -336,6 +339,7 @@ function emptyResult(args: {
     quotaUnitsApprox: number;
     perQuery?: FanoutPerQuery[];
     queryGen: QueryGenMeta;
+    offLangDropped?: number;
   };
   afterTitleFilter: number;
   afterExcludeFilter: number;
@@ -365,6 +369,7 @@ function emptyResult(args: {
       pickerTimedOut: args.pickerTimedOut,
       perQuery: args.fanout.perQuery ?? [],
       queryGen: args.fanout.queryGen,
+      offLangDropped: args.fanout.offLangDropped ?? 0,
     },
   };
 }

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -70,6 +70,8 @@ export interface FanoutResult {
   queryGenMs: number;
   /** CP492 Track-1 — query-gen telemetry (mode/model/latency/fallback). */
   queryGen: QueryGenMeta;
+  /** CP492 2차 gate — candidates dropped by the off-language script filter. */
+  offLangDropped: number;
 }
 
 /** CP492 Track-1 — meta for the rule branch (LLM never attempted). */
@@ -109,9 +111,45 @@ export function isOffLanguageTitle(title: string, lang: 'ko' | 'en'): boolean {
   const hangul = (t.match(/[가-힣]/g) ?? []).length;
   const han = (t.match(/[一-鿿]/g) ?? []).length;
   const latin = (t.match(/[A-Za-z]/g) ?? []).length;
-  if (han < 2) return false; // not CJK-ideograph-dominant → never drop (conservative)
-  if (lang === 'ko') return hangul === 0; // a Korean title would carry Hangul
-  return latin === 0; // en: an English title would carry Latin letters
+
+  if (lang === 'ko') {
+    // A legitimate Korean title carries Hangul (incl. English-titled or
+    // Hanja-mixed Korean) → always keep.
+    if (hangul > 0) return false;
+    // No Hangul + dominated by a clearly-foreign script → drop.
+    //  - CJK ideographs (CP491 #831): Chinese / Japanese.
+    //  - T1 (CP492): Arabic / Thai / Cyrillic / Devanagari / Hebrew.
+    //  - T2 (CP492): Turkish is Latin-based (script-invisible); its diacritics
+    //    (çÇıİşŞğĞ) are the only cheap signal — ≥2 keeps false positives near
+    //    zero (a Korean/English title virtually never carries 2+ of these).
+    const arabic = (t.match(/[؀-ۿ]/g) ?? []).length;
+    const thai = (t.match(/[฀-๿]/g) ?? []).length;
+    const cyrillic = (t.match(/[Ѐ-ӿ]/g) ?? []).length;
+    const devanagari = (t.match(/[ऀ-ॿ]/g) ?? []).length;
+    const hebrew = (t.match(/[֐-׿]/g) ?? []).length;
+    const turkish = (t.match(/[çÇıİşŞğĞ]/g) ?? []).length;
+    if (
+      han >= 2 ||
+      arabic >= 2 ||
+      thai >= 2 ||
+      cyrillic >= 2 ||
+      devanagari >= 2 ||
+      hebrew >= 2 ||
+      turkish >= 2
+    ) {
+      return true;
+    }
+    // Pure Latin / English (no Hangul) is a TOPIC-relevance question — off-topic
+    // English like "Inside SpaceX's Flywheel" is VALID English, just wrong topic.
+    // That is NOT a language drop; it is handled by Track 3 (cell-card semantic
+    // fit). English is intentionally NEVER dropped here (would also false-drop
+    // English-titled Korean content + valid English for AI/global mandalas).
+    return false;
+  }
+
+  // en mandala — unchanged conservative behavior (CP491 #831).
+  if (han < 2) return false;
+  return latin === 0; // an English title would carry Latin letters
 }
 
 export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult> {
@@ -128,6 +166,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       perQuery: [],
       queryGenMs: 0,
       queryGen: RULE_QUERY_GEN_META(0),
+      offLangDropped: 0,
     };
   }
 
@@ -169,6 +208,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       perQuery: [],
       queryGenMs,
       queryGen,
+      offLangDropped: 0,
     };
   }
 
@@ -200,6 +240,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
 
   let rawItemCount = 0;
   let queriesSucceeded = 0;
+  let offLangDropped = 0;
   const seen = new Map<string, FanoutCandidate>();
 
   for (const r of results) {
@@ -219,7 +260,10 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       // high-view global content (Chinese dramas on a Korean basketball query).
       // Conservative: only drop titles dominated by a non-target script (see
       // isOffLanguageTitle) so English-titled or Hanja-mixed Korean content is kept.
-      if (isOffLanguageTitle(cand.title, input.language)) continue;
+      if (isOffLanguageTitle(cand.title, input.language)) {
+        offLangDropped += 1;
+        continue;
+      }
       seen.set(cand.videoId, cand);
       if (seen.size >= cfg.dedupHardCap) break;
     }
@@ -250,6 +294,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
     perQuery,
     queryGenMs,
     queryGen,
+    offLangDropped,
   };
 }
 

--- a/tests/unit/skills/video-discover/v5-fanout.test.ts
+++ b/tests/unit/skills/video-discover/v5-fanout.test.ts
@@ -200,4 +200,34 @@ describe('isOffLanguageTitle (CP492)', () => {
   test('en: KEEPS Latin titles even with stray Han', () => {
     expect(isOffLanguageTitle('Kung Fu 功夫 basics', 'en')).toBe(false); // latin present
   });
+
+  // CP492 2차 gate — T1 (non-Latin foreign scripts) + T2 (Turkish diacritics).
+  test('ko T1: drops Arabic / Thai / Cyrillic / Devanagari / Hebrew (no Hangul)', () => {
+    expect(isOffLanguageTitle('استرجع شغفك في الحياة', 'ko')).toBe(true); // Arabic
+    expect(isOffLanguageTitle('วิธีเรียนรู้ทักษะใหม่อย่างรวดเร็ว', 'ko')).toBe(true); // Thai
+    expect(isOffLanguageTitle('Как быстро выучить навык', 'ko')).toBe(true); // Cyrillic
+    expect(isOffLanguageTitle('कौशल कैसे सीखें', 'ko')).toBe(true); // Devanagari
+  });
+
+  test('ko T2: drops Turkish (Latin-based) via ≥2 Turkish diacritics', () => {
+    // Real leaked title — mostly Latin, but Çıktı/İndirimler carry ç/ı/İ.
+    expect(
+      isOffLanguageTitle('Star Atlas Town Hall - C4 PTR Çıktı, UE5 ve Dev İndirimler!', 'ko')
+    ).toBe(true);
+  });
+
+  test('ko: KEEPS off-topic ENGLISH (Track 3, not a language drop)', () => {
+    // Off-topic but valid English → kept here; topic relevance is Track 3.
+    expect(isOffLanguageTitle("Inside SpaceX's Flywheel: What Tesla Investors Missed", 'ko')).toBe(
+      false
+    );
+    expect(isOffLanguageTitle('Part 5 How Influencer Helped Rebuild After Disaster', 'ko')).toBe(
+      false
+    );
+  });
+
+  test('ko T2 conservative: a single stray Turkish diacritic is NOT dropped', () => {
+    // façade-style loanword (one ç) must not false-drop English.
+    expect(isOffLanguageTitle('The façade of productivity', 'ko')).toBe(false); // turkish=1 < 2
+  });
 });


### PR DESCRIPTION
CP492 2차 gate. Stacks on the query-gen (1st tier) fix.

## Why
query-gen produces clean Korean queries (prod trace: 8/8 cells Korean, 0 English queries), but YouTube backfills LOW-result Korean queries (raw 2-5) with high-view global content. The existing off-language drop only caught CJK → **Arabic + Turkish** ("Star Atlas Town Hall - C4 PTR Çıktı") slipped through.

## What
`isOffLanguageTitle(ko)` drops a **no-Hangul** title dominated by a clearly foreign script:
- **T1**: Arabic / Thai / Cyrillic / Devanagari / Hebrew (≥2) — clean, ~0 FP.
- **T2**: Turkish is Latin-based (script-invisible) → its diacritics `çÇıİşŞğĞ` (≥2) are the signal. Single stray `ç` (façade) NOT dropped.
- Korean (Hangul) + English (pure Latin) **never dropped**.

## English is NOT here (Track 3)
Off-topic English ("Inside SpaceX's Flywheel") is **valid English, wrong topic** = a semantic-fit problem → **Track 3**, not a language drop. Dropping English would false-drop English-titled Korean + valid English (AI/global mandalas). Marked in code+tests so a future "English still leaks" routes to Track 3.

## Telemetry
`offLangDropped` → diagnostics → trace (wizard `...diag`; add-cards `v5_off_lang_dropped`). Measures gate effect + watches the **low-raw-cell trade-off** (dropping all of a raw=5 cell empties it — better empty than garbage, but cell-fill is trace-observable → over-emptying signals a separate volume lever).

## Safety
Always-on (like the existing Han drop), conservative. 49 v5 tests pass (Arabic/Thai/Cyrillic/Devanagari drop + English/Korean/Hanja keep, FP 0). tsc clean. Revert = revert PR.

## Verify
Prod wizard → trace `offLangDropped` count + Arabic/Turkish cards gone + cell-fill impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)