### PR TITLE
fix(dashboard): add-cards count instant reflect (#1) + wizard discovery-in-progress cue (#2)

### DIFF
--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -7,7 +7,8 @@ import {
   type DragEndEvent,
 } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
-import { Inbox } from 'lucide-react';
+import { Inbox, Loader2 } from 'lucide-react';
+import { apiClient } from '@/shared/lib/api-client';
 import { useAuth } from '@/features/auth/model/useAuth';
 import { BootShell } from '@/shared/ui/BootShell';
 import { trackCardViewed } from '@/shared/lib/posthog';
@@ -291,12 +292,41 @@ function AuthenticatedApp() {
     };
   }, [isNewMandalaActive, queryClient, clearJustCreated]);
 
-  // Auto-stop polling when cards appear
+  // CP492 #2 — stop polling when the discovery pipeline reports completed,
+  // NOT on the first card. The pipeline (discover + auto-add) lands cards over
+  // ~3-6s; ending at the first card made the count jump (e.g. 18 → 25) with no
+  // loading cue. We poll pipeline-status (the same endpoint CardDiscoveryProgress
+  // uses); on completed/failed we do a final reconcile-refetch so the grid
+  // catches the last arrivals, then clear (which removes the "더 찾는 중"
+  // indicator). The 90s timeout in the poll effect above is the safety net so
+  // the indicator never sticks if the pipeline never reports completed.
   useEffect(() => {
-    if (isNewMandalaActive && cards.totalCards > 0) {
-      clearJustCreated(null);
-    }
-  }, [isNewMandalaActive, cards.totalCards, clearJustCreated]);
+    if (!isNewMandalaActive || !effectiveMandalaId) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const check = async () => {
+      try {
+        const res = await apiClient.getPipelineStatus(effectiveMandalaId);
+        if (cancelled) return;
+        if (res.status === 'completed' || res.status === 'failed') {
+          // Final reconcile so the grid reflects every just-landed card before
+          // the indicator disappears (no empty flicker).
+          queryClient.invalidateQueries({ queryKey: youtubeSyncKeys.allVideoStates });
+          queryClient.invalidateQueries({ queryKey: localCardsKeys.all });
+          clearJustCreated(null);
+          return;
+        }
+      } catch {
+        // ignore — 90s timeout (poll effect above) is the safety net.
+      }
+      if (!cancelled) timer = setTimeout(check, 2_000);
+    };
+    timer = setTimeout(check, 1_500);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [isNewMandalaActive, effectiveMandalaId, queryClient, clearJustCreated]);
 
   // Patch refs after orchestrator init
   useEffect(() => {
@@ -955,6 +985,16 @@ function AuthenticatedApp() {
                   <>
                     {isNewMandalaActive && cards.totalCards === 0 && effectiveMandalaId && (
                       <CardDiscoveryProgress mandalaId={effectiveMandalaId} isComplete={false} />
+                    )}
+                    {/* CP492 #2 — cards already showing but discovery still running
+                        (pipeline not yet completed). Subtle non-blocking cue so the
+                        sequential 18→25 arrival reads as progress, not a glitch.
+                        Removed when the pipeline-completed effect clears justCreated. */}
+                    {isNewMandalaActive && cards.totalCards > 0 && !search.isSearchActive && (
+                      <div className="mb-2 flex items-center gap-2 px-1 text-xs text-muted-foreground">
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                        <span>{t('index.discoveringMore', '관련 영상 더 찾는 중…')}</span>
+                      </div>
                     )}
                     <CardListView
                       cards={search.isSearchActive ? search.results : cards.displayCards}

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/shared/lib/utils';
 import { useLikeCard } from '@/features/card-management/model/useLikeCard';
 import { localCardsKeys } from '@/features/card-management/model/useLocalCards';
 import { useAllVideoStates, youtubeSyncKeys } from '@/features/youtube-sync/model/useYouTubeSync';
+import { queryKeys } from '@/shared/config/query-client';
 import { useAddCardsPanelStore } from '../model/useAddCardsPanelStore';
 import { useAddCards, type AddCardCandidate } from '../model/useAddCards';
 import {
@@ -233,6 +234,11 @@ export function AddCardsPanel() {
             queryClient.invalidateQueries({ queryKey: localCardsKeys.list() });
             queryClient.invalidateQueries({ queryKey: youtubeSyncKeys.allVideoStates });
             queryClient.invalidateQueries({ queryKey: ['mandala', 'recommendations', mandalaId] });
+            // CP492 #1 — the header count is mandalaMeta.cardCount (server-truth,
+            // staleTime 5min). Without this it stayed stale until reload while
+            // allVideoStates (the grid) slowly refetched. Invalidating the mandala
+            // detail re-runs the cheap server COUNT → header reflects +N immediately.
+            queryClient.invalidateQueries({ queryKey: queryKeys.mandala.detail(mandalaId) });
             // Card stays in the panel list — DO NOT strip from
             // localStorage. `pickedSet` (server picks ∪ local picks)
             // drives the disabled overlay so the user can see what was


### PR DESCRIPTION
## #1 — Add Cards "+N → only +1, needs reload"
Header count = `mandalaMeta.cardCount` (server-truth, **staleTime 5min**). Add-cards invalidated `allVideoStates` (the slow ~5-7s grid fetch) but NOT the mandala detail query → count stayed stale until full reload. Fix: also invalidate `queryKeys.mandala.detail(mandalaId)` on add → cheap server COUNT re-runs → **count reflects +N immediately**. Grid catches up via the existing allVideoStates invalidate. No optimistic shape, no B1, no D&D path.

## #2 — wizard count jump (18 → 25) with no loading cue
Poll stopped on the FIRST card, but the pipeline (discover + auto-add) lands cards over **~3-6s (measured)**. Fix: poll `pipeline-status` (same endpoint CardDiscoveryProgress uses), stop on `status` completed/failed + a final reconcile-refetch (grid shows late arrivals before the cue clears). While cards present but pipeline still running → subtle non-blocking **"관련 영상 더 찾는 중…"** indicator → sequential arrival reads as progress. 90s timeout = safety net (cue never sticks). A2 isFetching guard unchanged (no pileup).

## Safety
FE-only, IndexPage poll + AddCardsPanel invalidate + AddCardsPanel header indicator. No queryKey-scope / optimistic / D&D changes. `/verify` PASS (tsc + vitest 365 + build + browser smoke).

## Verify (prod)
- add 3 cards → count +3 immediately (no reload).
- wizard → cards arrive sequentially WITH "더 찾는 중" cue (~3-6s) → completed + final refetch → all cards, cue gone (no missing, no flicker).
- pipeline never completes → 90s timeout clears cue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)