### PR TITLE
fix(wizard): revert #2 pipeline-status poll (flashed empty state during card load)

### DIFF
--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -7,8 +7,7 @@ import {
   type DragEndEvent,
 } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
-import { Inbox, Loader2 } from 'lucide-react';
-import { apiClient } from '@/shared/lib/api-client';
+import { Inbox } from 'lucide-react';
 import { useAuth } from '@/features/auth/model/useAuth';
 import { BootShell } from '@/shared/ui/BootShell';
 import { trackCardViewed } from '@/shared/lib/posthog';
@@ -292,41 +291,16 @@ function AuthenticatedApp() {
     };
   }, [isNewMandalaActive, queryClient, clearJustCreated]);
 
-  // CP492 #2 — stop polling when the discovery pipeline reports completed,
-  // NOT on the first card. The pipeline (discover + auto-add) lands cards over
-  // ~3-6s; ending at the first card made the count jump (e.g. 18 → 25) with no
-  // loading cue. We poll pipeline-status (the same endpoint CardDiscoveryProgress
-  // uses); on completed/failed we do a final reconcile-refetch so the grid
-  // catches the last arrivals, then clear (which removes the "더 찾는 중"
-  // indicator). The 90s timeout in the poll effect above is the safety net so
-  // the indicator never sticks if the pipeline never reports completed.
+  // Auto-stop polling when cards appear. Keeping isNewMandalaActive true until
+  // the grid actually has cards is what holds the skeleton (isLoading) through
+  // the slow get-all-video-states fetch — clearing it earlier (e.g. on pipeline
+  // status) drops the skeleton before the grid loads and flashes the empty
+  // state. See the isLoading expression on CardListView below.
   useEffect(() => {
-    if (!isNewMandalaActive || !effectiveMandalaId) return;
-    let cancelled = false;
-    let timer: ReturnType<typeof setTimeout>;
-    const check = async () => {
-      try {
-        const res = await apiClient.getPipelineStatus(effectiveMandalaId);
-        if (cancelled) return;
-        if (res.status === 'completed' || res.status === 'failed') {
-          // Final reconcile so the grid reflects every just-landed card before
-          // the indicator disappears (no empty flicker).
-          queryClient.invalidateQueries({ queryKey: youtubeSyncKeys.allVideoStates });
-          queryClient.invalidateQueries({ queryKey: localCardsKeys.all });
-          clearJustCreated(null);
-          return;
-        }
-      } catch {
-        // ignore — 90s timeout (poll effect above) is the safety net.
-      }
-      if (!cancelled) timer = setTimeout(check, 2_000);
-    };
-    timer = setTimeout(check, 1_500);
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
-  }, [isNewMandalaActive, effectiveMandalaId, queryClient, clearJustCreated]);
+    if (isNewMandalaActive && cards.totalCards > 0) {
+      clearJustCreated(null);
+    }
+  }, [isNewMandalaActive, cards.totalCards, clearJustCreated]);
 
   // Patch refs after orchestrator init
   useEffect(() => {
@@ -985,16 +959,6 @@ function AuthenticatedApp() {
                   <>
                     {isNewMandalaActive && cards.totalCards === 0 && effectiveMandalaId && (
                       <CardDiscoveryProgress mandalaId={effectiveMandalaId} isComplete={false} />
-                    )}
-                    {/* CP492 #2 — cards already showing but discovery still running
-                        (pipeline not yet completed). Subtle non-blocking cue so the
-                        sequential 18→25 arrival reads as progress, not a glitch.
-                        Removed when the pipeline-completed effect clears justCreated. */}
-                    {isNewMandalaActive && cards.totalCards > 0 && !search.isSearchActive && (
-                      <div className="mb-2 flex items-center gap-2 px-1 text-xs text-muted-foreground">
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
-                        <span>{t('index.discoveringMore', '관련 영상 더 찾는 중…')}</span>
-                      </div>
                     )}
                     <CardListView
                       cards={search.isSearchActive ? search.results : cards.displayCards}


### PR DESCRIPTION
#841's #2 changed wizard auto-stop from "clear on first card" → "clear on pipeline completed". Pipeline completes ~3-6s but the get-all-video-states grid fetch is ~5-7s, so clearJustCreated fired while the grid was still empty → isNewMandalaActive false → the isLoading skeleton guard dropped → CardList showed "아직 저장된 인사이트가 없습니다" empty state even though server count was 39 (observed).

Restore known-good auto-stop (clear on cards.totalCards > 0) → skeleton holds through the slow fetch until cards land → no empty-state flash. The #2 progress-indicator goal is dropped (untested this run + not worth a worse regression); if revisited, skeleton-gating must be decoupled from the indicator (gate on query isFetching).

/verify PASS (tsc + vitest 365 + build + smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)