### PR TITLE
feat(wizard): merged structure+queries generation (WIZARD_MERGED_GEN, default off)

### DIFF
--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -6,11 +6,13 @@ import { getPrismaClient } from '../../modules/database/client';
 import {
   generateMandalaRace,
   generateMandalaStructure,
+  generateMandalaWithQueries,
   generateLabels,
   getCachedMandala,
   setCachedMandala,
   MandalaGenError,
 } from '../../modules/mandala/generator';
+import { loadWizardMergedGenConfig } from '../../config/wizard-merged-gen';
 import { searchMandalasByGoal, MandalaSearchError } from '../../modules/mandala/search';
 import {
   EXPLORE_SOURCES,
@@ -860,13 +862,42 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           return [];
         });
 
-      const structurePromise = generateMandalaStructure({
-        goal: trimmedGoal,
-        language: lang,
-        focusTags,
-        targetLevel,
-      })
-        .then((structure) => {
+      // CP493 — structure source. WIZARD_MERGED_GEN on → ONE Haiku call yields
+      // structure + per-cell queries (goal-context continuous, anti-clustering);
+      // the queries flow to precompute so fanout skips its own query-gen. On
+      // merged failure, fall back to the legacy structure-only call (fanout then
+      // runs query-gen) so the wizard never dies. Off → legacy path unchanged.
+      const resolveStructure = async (): Promise<{
+        structure: Awaited<ReturnType<typeof generateMandalaStructure>>;
+        cellQueries?: { cellIndex: number; query: string }[];
+      }> => {
+        if (loadWizardMergedGenConfig().enabled) {
+          try {
+            const merged = await generateMandalaWithQueries({
+              goal: trimmedGoal,
+              language: lang,
+              focusTags,
+              targetLevel,
+            });
+            return { structure: merged.structure, cellQueries: merged.cellQueries };
+          } catch (err) {
+            request.log.warn(
+              { err },
+              'wizard merged-gen failed — falling back to structure-gen + fanout query-gen'
+            );
+          }
+        }
+        const structure = await generateMandalaStructure({
+          goal: trimmedGoal,
+          language: lang,
+          focusTags,
+          targetLevel,
+        });
+        return { structure };
+      };
+
+      const structurePromise = resolveStructure()
+        .then(({ structure, cellQueries }) => {
           write('structure_ready', {
             structure,
             duration_ms: Date.now() - t0,
@@ -875,7 +906,8 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           // resolves so we have real sub_goals. No await: the wizard SSE stream
           // is not blocked by discover latency (Tier 2 YouTube search ~5-15s).
           // Feature-flag + session_id gated inside startPrecompute; callers pass
-          // unconditionally.
+          // unconditionally. CP493 — cellQueries forwarded when merged-gen
+          // produced full coverage (undefined → fanout query-gen).
           if (sessionId && Array.isArray(structure.sub_goals) && structure.sub_goals.length === 8) {
             setImmediate(() => {
               // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -888,6 +920,7 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
                   focusTags: focusTags ?? [],
                   targetLevel,
                   subGoals: structure.sub_goals,
+                  cellQueries,
                 }).catch((err) => {
                   request.log.warn(
                     { err, sessionId, userId },

--- a/src/config/wizard-merged-gen.ts
+++ b/src/config/wizard-merged-gen.ts
@@ -1,0 +1,47 @@
+/**
+ * Wizard merged-generation config (CP493).
+ *
+ * Single feature flag gates the merged structure+queries generation path:
+ * - /wizard-stream: when enabled → ONE Haiku call produces the mandala
+ *   structure AND the per-cell YouTube search queries in a single continuous
+ *   context, instead of the two disconnected calls (structure-gen at creation
+ *   + query-gen at fanout). The merged queries are forwarded to precompute as
+ *   `precomputedQueries`, so fanout skips its own query-gen.
+ *
+ * Why: measured (CP492/CP493) the two-call split re-interprets bare cell
+ * labels with no goal-structure reasoning → near-duplicate clustering noise
+ * (e.g. a cell filled with 6 same-brand videos). A merged single call keeps
+ * the center-goal context continuous → diverse, non-clustered queries.
+ *
+ * Default: OFF (unset = legacy two-call behavior). Rollback = flip env; no
+ * code revert. On merged failure the route falls back to the legacy
+ * generateMandalaStructure + fanout query-gen path (graceful degrade).
+ */
+
+import { z } from 'zod';
+
+const boolFlag = z.preprocess((v) => {
+  if (v == null || v === '') return false;
+  const s = String(v).trim().toLowerCase();
+  return s === 'true' || s === '1' || s === 'yes';
+}, z.boolean());
+
+export const wizardMergedGenEnvSchema = z.object({
+  WIZARD_MERGED_GEN: boolFlag.default(false as unknown as string),
+});
+
+export interface WizardMergedGenConfig {
+  enabled: boolean;
+}
+
+export function loadWizardMergedGenConfig(
+  env: NodeJS.ProcessEnv = process.env
+): WizardMergedGenConfig {
+  const parsed = wizardMergedGenEnvSchema.safeParse({
+    WIZARD_MERGED_GEN: env['WIZARD_MERGED_GEN'],
+  });
+  if (!parsed.success) {
+    return { enabled: false };
+  }
+  return { enabled: parsed.data.WIZARD_MERGED_GEN };
+}

--- a/src/modules/mandala/generator.ts
+++ b/src/modules/mandala/generator.ts
@@ -21,6 +21,12 @@ import {
   STRUCTURE_MAX_TOKENS as PROMPT_STRUCTURE_MAX_TOKENS,
 } from '@/prompts/structure-generator';
 import {
+  buildMandalaWithQueriesPrompt,
+  MERGED_GEN_MODEL,
+  MERGED_GEN_TEMPERATURE,
+  MERGED_GEN_MAX_TOKENS,
+} from '@/prompts/mandala-with-queries-generator';
+import {
   buildActionsPrompt,
   ACTIONS_MODEL,
   ACTIONS_TEMPERATURE,
@@ -640,6 +646,183 @@ export async function generateMandalaStructure(
   );
 
   return parsed;
+}
+
+// ─── Merged structure + per-cell queries (CP493, WIZARD_MERGED_GEN) ───
+
+/** A query longer than this is sentence-like → reject (same guard as v5 query-gen). */
+const MAX_MERGED_QUERY_CHARS = 60;
+
+/** Plain per-cell query shape — kept skills-type-free so generator has no v5 dep. */
+export interface CellQuery {
+  cellIndex: number;
+  query: string;
+}
+
+export interface MandalaWithQueriesResult {
+  structure: GeneratedMandala;
+  /**
+   * Per-cell search queries, one per sub_goal, ONLY when the LLM covered ALL
+   * cells. Undefined (degraded) when queries were missing/invalid/partial — the
+   * caller then leaves fanout to run its own query-gen (no sparse-cell risk).
+   */
+  cellQueries?: CellQuery[];
+  meta: {
+    latencyMs: number;
+    totalCells: number;
+    cellQueryCount: number;
+    /** True when structure parsed but full-coverage queries did not → fanout query-gen. */
+    degraded: boolean;
+  };
+}
+
+/**
+ * Parse the merged JSON. `extractJsonRobust` JSON.parses the whole object, so
+ * the extra `cell_queries` key survives on the (cast) result — we read it back
+ * untyped and validate. Returns null only when the STRUCTURE itself fails to
+ * parse (caller falls back to legacy generateMandalaStructure).
+ *
+ * Exported for unit testing the parse/validate/degrade logic without a network
+ * call (mirrors parsePerCellResponse in llm-query-gen.ts).
+ */
+export function parseMergedResponse(
+  raw: string,
+  cellCount = 8
+): { structure: GeneratedMandala; cellQueries: Map<number, string> | null } | null {
+  const structure = extractJsonRobust(raw);
+  if (!structure) return null;
+  const rawCq = (structure as unknown as Record<string, unknown>)['cell_queries'];
+  const cellQueries = parseCellQueriesMap(rawCq, cellCount);
+  return { structure, cellQueries };
+}
+
+function parseCellQueriesMap(rawCq: unknown, cellCount: number): Map<number, string> | null {
+  if (!rawCq || typeof rawCq !== 'object' || Array.isArray(rawCq)) return null;
+  const out = new Map<number, string>();
+  for (const [k, v] of Object.entries(rawCq as Record<string, unknown>)) {
+    if (typeof v !== 'string') continue;
+    const idx = Number(k);
+    if (!Number.isInteger(idx) || idx < 0 || idx >= cellCount) continue;
+    const q = v.trim();
+    if (q.length === 0 || q.length > MAX_MERGED_QUERY_CHARS) continue;
+    out.set(idx, q);
+  }
+  return out.size > 0 ? out : null;
+}
+
+export interface GenerateMergedOpts {
+  /** Test injection — bypasses OpenRouter so unit tests never hit the network. */
+  generateImpl?: (
+    prompt: string,
+    options?: { temperature?: number; maxTokens?: number; format?: 'json' }
+  ) => Promise<string>;
+}
+
+/**
+ * CP493 — ONE Haiku call producing the mandala structure AND a searchable
+ * YouTube query per cell in a single continuous context. Replaces the two
+ * disconnected calls (structure-gen here + query-gen at fanout) for the wizard
+ * path, so each query inherits the goal-structure reasoning instead of
+ * re-interpreting a bare label (the split that produced clustering noise).
+ *
+ * Structure validation matches generateMandalaStructure (same HARD RULE:
+ * center_goal := user goal). On structure parse/validation failure this THROWS
+ * — the route catches and falls back to generateMandalaStructure. Query
+ * coverage is best-effort: full coverage → cellQueries returned; otherwise
+ * degraded (undefined) so fanout runs its own query-gen (no sparse cells).
+ *
+ * Gated by WIZARD_MERGED_GEN at the call site (src/config/wizard-merged-gen.ts).
+ */
+export async function generateMandalaWithQueries(
+  input: MandalaGenerateInput,
+  opts: GenerateMergedOpts = {}
+): Promise<MandalaWithQueriesResult> {
+  const t0 = Date.now();
+  logger.info(`Mandala merged structure+queries generation started: goal="${input.goal}"`);
+
+  const similar = await searchMandalasByGoal(input.goal, {
+    limit: 1,
+    threshold: 0.4,
+    language: input.language,
+  });
+
+  const lang = input.language ?? 'ko';
+  const domain = input.domain ?? 'general';
+  const ref = similar[0];
+  const reference = ref
+    ? `Reference:\n{"center_goal":"${ref.center_goal}","center_label":"${ref.center_label ?? ''}","sub_goals":${JSON.stringify((ref.sub_goals ?? []).slice(0, 4))},"sub_labels":${JSON.stringify((ref.sub_labels ?? []).slice(0, 4))}}`
+    : undefined;
+
+  const prompt = buildMandalaWithQueriesPrompt({
+    goal: input.goal,
+    domain,
+    language: lang,
+    reference,
+    focusTags: input.focusTags,
+    targetLevel: input.targetLevel,
+  });
+
+  const generate =
+    opts.generateImpl ??
+    ((p: string, o?: { temperature?: number; maxTokens?: number; format?: 'json' }) =>
+      new OpenRouterGenerationProvider(MERGED_GEN_MODEL).generate(p, o));
+
+  const raw = await generate(prompt, {
+    temperature: MERGED_GEN_TEMPERATURE,
+    maxTokens: MERGED_GEN_MAX_TOKENS,
+    format: 'json',
+  });
+  const latencyMs = Date.now() - t0;
+
+  const merged = parseMergedResponse(raw);
+  if (!merged) {
+    throw new MandalaGenError('Merged generation: failed to parse JSON', 'PARSE_FAILED');
+  }
+  const parsed = merged.structure;
+
+  if (!parsed.center_goal || !Array.isArray(parsed.sub_goals) || parsed.sub_goals.length !== 8) {
+    throw new MandalaGenError(
+      `Merged generation: invalid structure — sub_goals=${parsed.sub_goals?.length ?? 0}`,
+      'VALIDATION_FAILED'
+    );
+  }
+
+  // HARD RULE (same as generateMandalaStructure): center_goal := user goal.
+  parsed.center_goal = input.goal;
+  if (!parsed.actions) parsed.actions = {};
+  if (!parsed.language) parsed.language = lang;
+  if (!parsed.domain) parsed.domain = domain;
+  // Strip the merged-only key so the persisted structure shape is unchanged.
+  delete (parsed as unknown as Record<string, unknown>)['cell_queries'];
+
+  normalizeStructureLabels(parsed, lang);
+
+  const totalCells = parsed.sub_goals.length;
+  const cqMap = merged.cellQueries;
+  const cellQueryCount = cqMap?.size ?? 0;
+  // Use merged queries ONLY at full coverage — a partial set would starve the
+  // uncovered cells (fewer search.list calls → sparse backfill). Partial =
+  // degrade to fanout query-gen, which always emits one query per cell.
+  let cellQueries: CellQuery[] | undefined;
+  if (cqMap && cellQueryCount === totalCells) {
+    cellQueries = [];
+    for (let i = 0; i < totalCells; i++) {
+      const q = cqMap.get(i);
+      if (q) cellQueries.push({ cellIndex: i, query: q });
+    }
+  }
+  const degraded = !cellQueries;
+
+  logger.info(
+    `[TIMING] merged-gen: ${latencyMs}ms | cellQueries=${cellQueryCount}/${totalCells} ` +
+      `degraded=${degraded}`
+  );
+
+  return {
+    structure: parsed,
+    cellQueries,
+    meta: { latencyMs, totalCells, cellQueryCount, degraded },
+  };
 }
 
 /**

--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -51,6 +51,13 @@ export interface StartPrecomputeInput {
   focusTags: string[];
   targetLevel?: string;
   subGoals: string[]; // length 8 — from Haiku structure response
+  /**
+   * CP493 — merged-gen per-cell queries (one per cell, full coverage) produced
+   * in the SAME Haiku call as the structure. When present, forwarded to fanout
+   * as precomputedQueries → fanout skips its own query-gen. Undefined = legacy
+   * (fanout runs V5_QUERY_GEN).
+   */
+  cellQueries?: { cellIndex: number; query: string }[];
 }
 
 /**
@@ -120,6 +127,8 @@ export async function startPrecompute(input: StartPrecomputeInput): Promise<void
       focusTags: input.focusTags,
       targetLevel: input.targetLevel ?? 'standard',
       env: process.env,
+      // CP493 — when WIZARD_MERGED_GEN produced full per-cell coverage.
+      precomputedQueries: input.cellQueries,
     });
 
     await db.mandala_wizard_precompute.update({

--- a/src/prompts/mandala-with-queries-generator.ts
+++ b/src/prompts/mandala-with-queries-generator.ts
@@ -1,0 +1,86 @@
+/**
+ * Prompt #1-merged: Mandala structure + per-cell YouTube search queries in ONE
+ * continuous-context Haiku call (CP493).
+ *
+ * Combines the structure rules of buildStructurePrompt (structure-generator.ts)
+ * with the searchable per-cell query rules of buildPerCellSearchQueryPrompt
+ * (search-query-generator.ts). The model generates each sub_goal AND its search
+ * query in the same pass, so the query inherits the goal-structure reasoning
+ * instead of re-interpreting a bare label downstream (the two-call split that
+ * produced near-duplicate clustering noise).
+ *
+ * Output (single JSON):
+ *   { center_goal, center_label, language, domain,
+ *     sub_goals[8], sub_labels[8], cell_queries:{"0":..,"7":..} }
+ *
+ * Same model/temp as structure-gen; max tokens raised for the extra queries.
+ *
+ * @see src/config/wizard-merged-gen.ts (WIZARD_MERGED_GEN flag)
+ */
+
+export const MERGED_GEN_MODEL = 'anthropic/claude-haiku-4.5';
+export const MERGED_GEN_TEMPERATURE = 0.7;
+/**
+ * Structure (~520) + 8 search queries (~80) + cell_queries JSON keys (~30) ≈
+ * 630 tokens. 1000 gives headroom so neither sub_labels nor cell_queries is
+ * silently truncated (the 500→700 truncation lesson from structure-gen).
+ */
+export const MERGED_GEN_MAX_TOKENS = 1000;
+
+export interface MergedGenPromptInput {
+  goal: string;
+  domain: string;
+  language: string;
+  focusTags?: string[];
+  targetLevel?: string;
+  /** Optional few-shot reference from pgvector search (structure only). */
+  reference?: string;
+}
+
+export function buildMandalaWithQueriesPrompt(input: MergedGenPromptInput): string {
+  const { goal, domain, language, focusTags, targetLevel, reference } = input;
+  const level = targetLevel ?? 'standard';
+  const example = reference ? `${reference}\n` : '';
+
+  if (language === 'ko') {
+    const koFocusLine = focusTags?.length ? `- 집중 영역: ${focusTags.join(', ')}` : '';
+    return `만다라트 구조 + 각 영역의 YouTube 검색어를 한 번에 생성합니다 (actions 없이).
+
+[1단계 — 구조]
+- center_goal: 사용자가 입력한 목표를 그대로 사용. 절대 재작성/확장/축약하지 말 것.
+- center_label: center_goal의 2-4단어 요약 (최대 10자). 단어 사이 공백 (예: "미국 주식 1억" ✅).
+- sub_goals: 함께 모이면 목표를 달성하는 8개의 구체적이고 실행 가능한 영역. 목표 수준(${level})에 맞게 설계.
+${koFocusLine ? '  - ' + koFocusLine.slice(2) + '을 자연스럽게 반영\n' : ''}- sub_labels: 각 sub_goal의 의미를 담은 짧은 라벨 (4-10자, 무의미한 축약/앞글자 자르기 금지, 단어 사이 공백).
+
+[2단계 — 검색어] 각 sub_goal마다, 그 영역을 다루는 영상을 찾을 실제 YouTube 검색어 1개.
+- 각 검색어 12~20자. {목표 핵심어 1~2개} + {세부영역 핵심어 1~2개} 결합. 의미가 살아있는 검색가능한 표현.
+- 너무 짧으면(예: "시간 관리", "보험") 일반 콘텐츠로 확산 → 금지.
+- 너무 길거나 문장형(예: "매일 학습할 수 있는 시간 블록 설정하는 방법")이면 YouTube 매칭 실패 → 금지.
+- 8개 검색어는 서로 다른 각도(방법론/경험담/도구/실수방지/루틴 등)로 분산 — 같은 표현 반복 금지 (한 셀이 동일 브랜드/채널로 뭉치는 노이즈 방지).
+
+${example}JSON만 출력 (cell_queries 키는 sub_goals 순서 "0"~"7"):
+{"center_goal":"...","center_label":"...","language":"ko","domain":"${domain}","sub_goals":["8개"],"sub_labels":["8개"],"cell_queries":{"0":"검색어",...,"7":"검색어"}}
+
+목표: ${goal}`;
+  }
+
+  const focusLine = focusTags?.length ? `- Focus areas: ${focusTags.join(', ')}` : '';
+  return `Generate the mandala structure AND a YouTube search query per area in ONE pass (NO actions).
+
+[Step 1 — structure]
+- center_goal: Use the user's goal EXACTLY as given. NEVER rewrite, expand, or shorten it.
+- center_label: 2-4 word summary (max 15 chars).
+- sub_goals: 8 distinct, specific, actionable areas that TOGETHER achieve the center goal. Design to REACH the target level (${level}).
+${focusLine ? '  - Incorporate focus areas naturally: ' + (focusTags ?? []).join(', ') + '\n' : ''}- sub_labels: short meaningful label per sub_goal (4-15 chars; NEVER meaningless abbreviation / camelCase compound).
+
+[Step 2 — queries] For each sub_goal, ONE real YouTube search query that finds videos covering that area.
+- Each query 3-6 words. {goal keyword 1-2} + {area keyword 1-2}. A real, searchable phrase.
+- Too short (e.g. "time management") → generic content → forbidden.
+- Too long / sentence-like → no YouTube match → forbidden.
+- Spread the 8 queries across different angles (how-to / stories / tools / mistakes / routine) — never repeat a phrase (prevents a cell clustering on one brand/channel).
+
+${example}JSON only (cell_queries keys are sub_goals order "0".."7"):
+{"center_goal":"...","center_label":"...","language":"en","domain":"${domain}","sub_goals":["8 items"],"sub_labels":["8 items"],"cell_queries":{"0":"query",...,"7":"query"}}
+
+Goal: ${goal}`;
+}

--- a/src/skills/plugins/video-discover/v2/keyword-builder.ts
+++ b/src/skills/plugins/video-discover/v2/keyword-builder.ts
@@ -71,7 +71,7 @@ export interface KeywordBuilderOpts {
   maxQueries?: number;
 }
 
-export type QuerySource = 'core' | 'llm' | 'focus' | 'level' | 'subgoal';
+export type QuerySource = 'core' | 'llm' | 'focus' | 'level' | 'subgoal' | 'merged';
 
 export interface SearchQuery {
   query: string;

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -16,7 +16,12 @@
 import { logger } from '@/utils/logger';
 import { videosBatchFullMetadata, resolveVideosApiKeys } from '../v2/youtube-client';
 import type { YouTubeVideoFullMetadata } from '../v2/youtube-client';
-import { runYouTubeFanout, type FanoutCandidate, type FanoutPerQuery } from './youtube-fanout';
+import {
+  runYouTubeFanout,
+  type FanoutCandidate,
+  type FanoutPerQuery,
+  type PrecomputedQuery,
+} from './youtube-fanout';
 import type { QueryGenMeta } from './llm-query-gen';
 import { getV5Config } from './config';
 import { getVideoPicker } from '@/modules/llm-picker/registry';
@@ -40,6 +45,11 @@ export interface V5ExecuteInput {
    * discarded post-pick. Undefined = no date filter (unchanged behavior).
    */
   publishedAfter?: string;
+  /**
+   * CP493 — merged-gen per-cell queries (full coverage). When present, fanout
+   * uses them verbatim and skips its own query-gen. Undefined = legacy.
+   */
+  precomputedQueries?: PrecomputedQuery[];
 }
 
 export interface V5Card {
@@ -132,6 +142,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
     language: input.language,
     env: input.env,
     publishedAfter: input.publishedAfter,
+    precomputedQueries: input.precomputedQueries,
   });
   // CP492 Track-1 — split query-gen out of fanout. fanoutMs is now search-only.
   // `?? 0` guards older/mocked FanoutResults that predate the queryGenMs field.

--- a/src/skills/plugins/video-discover/v5/llm-query-gen.ts
+++ b/src/skills/plugins/video-discover/v5/llm-query-gen.ts
@@ -52,7 +52,7 @@ export interface LLMQueryGenOpts {
  * function is never called.
  */
 export interface QueryGenMeta {
-  mode: 'rule' | 'llm';
+  mode: 'rule' | 'llm' | 'merged';
   /** SEARCH_QUERY_MODEL when the LLM was attempted; undefined otherwise. */
   model?: string;
   /** LLM call wall-time (ms). 0 when no LLM call was made (no-key / rule). */

--- a/src/skills/plugins/video-discover/v5/wizard-adapter.ts
+++ b/src/skills/plugins/video-discover/v5/wizard-adapter.ts
@@ -42,6 +42,8 @@ export async function runV5ForWizard(input: V5WizardInput): Promise<EphemeralDis
     language: input.language,
     excludeVideoIds: input.excludeVideoIds ?? new Set<string>(),
     env: input.env,
+    // CP493 — merged-gen queries (when WIZARD_MERGED_GEN produced full coverage).
+    precomputedQueries: input.precomputedQueries,
   });
 
   // CP491 F5 — surface the per-stage breakdown for the wizard path too

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -24,8 +24,19 @@ import {
 import { buildRuleBasedQueriesSync, type SearchQuery } from '../v2/keyword-builder';
 import { buildLLMQueriesPerCell, type QueryGenMeta } from './llm-query-gen';
 import { getV5Config } from './config';
+import { MERGED_GEN_MODEL } from '@/prompts/mandala-with-queries-generator';
 
 const log = logger.child({ module: 'video-discover/v5/youtube-fanout' });
+
+/**
+ * CP493 — a per-cell query produced upstream by the merged structure+queries
+ * generation (generateMandalaWithQueries). Structurally identical to the
+ * generator's CellQuery; kept local so the v5 layer owns its own input type.
+ */
+export interface PrecomputedQuery {
+  cellIndex: number;
+  query: string;
+}
 
 export interface FanoutInput {
   centerGoal: string;
@@ -36,6 +47,12 @@ export interface FanoutInput {
   env: NodeJS.ProcessEnv;
   /** CP491 ROI1 — forwarded to search.list publishedAfter (ISO date). */
   publishedAfter?: string;
+  /**
+   * CP493 — merged-gen queries (one per cell, full coverage). When present,
+   * fanout uses these verbatim and SKIPS query-gen (the disconnected Haiku #2
+   * call), preserving the goal-structure context. Absent = legacy query-gen.
+   */
+  precomputedQueries?: PrecomputedQuery[];
 }
 
 export interface FanoutCandidate {
@@ -185,7 +202,25 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
   const tQueryGen0 = Date.now();
   let queries: SearchQuery[];
   let queryGen: QueryGenMeta;
-  if (cfg.queryGen === 'llm') {
+  const precomputed = input.precomputedQueries;
+  if (precomputed && precomputed.length > 0) {
+    // CP493 — merged-gen path: queries were generated upstream in the SAME
+    // Haiku call as the structure (goal-context continuous). Use verbatim, skip
+    // the disconnected query-gen call. latencyMs=0 here (cost was at gen time).
+    queries = precomputed.map((p) => ({
+      query: p.query,
+      source: 'merged' as const,
+      cellIndex: p.cellIndex,
+    }));
+    queryGen = {
+      mode: 'merged',
+      model: MERGED_GEN_MODEL,
+      latencyMs: 0,
+      llmCells: precomputed.length,
+      totalCells,
+      fellBack: false,
+    };
+  } else if (cfg.queryGen === 'llm') {
     const r = await buildLLMQueriesPerCell(queryInput, {
       openRouterApiKey: input.env['OPENROUTER_API_KEY'],
       maxQueries: cfg.maxQueries,

--- a/tests/unit/modules/mandala-merged-gen.test.ts
+++ b/tests/unit/modules/mandala-merged-gen.test.ts
@@ -1,0 +1,115 @@
+/**
+ * CP493 — merged structure+queries generation (generateMandalaWithQueries).
+ *
+ * One Haiku call yields the mandala structure AND a searchable per-cell query,
+ * so the query inherits the goal-structure context (anti-clustering). Tests the
+ * parse/validate/degrade/override logic with an injected generate impl — no
+ * network. searchMandalasByGoal is mocked (no pgvector).
+ */
+
+jest.mock('@/modules/mandala/search', () => ({
+  searchMandalasByGoal: jest.fn().mockResolvedValue([]),
+  formatMandalasForFewShot: jest.fn().mockReturnValue(''),
+}));
+
+import {
+  parseMergedResponse,
+  generateMandalaWithQueries,
+  MandalaGenError,
+} from '@/modules/mandala/generator';
+
+const SUB_GOALS = Array.from({ length: 8 }, (_, i) => `sub goal ${i}`);
+const SUB_LABELS = Array.from({ length: 8 }, (_, i) => `label ${i}`);
+
+function mergedJson(cellQueries: Record<string, string> | null, subGoals = SUB_GOALS): string {
+  const obj: Record<string, unknown> = {
+    center_goal: 'IGNORED_BY_OVERRIDE',
+    center_label: 'short',
+    language: 'ko',
+    domain: 'general',
+    sub_goals: subGoals,
+    sub_labels: SUB_LABELS,
+  };
+  if (cellQueries) obj['cell_queries'] = cellQueries;
+  return JSON.stringify(obj);
+}
+
+const FULL_CQ: Record<string, string> = Object.fromEntries(
+  Array.from({ length: 8 }, (_, i) => [String(i), `검색어${i} 키워드`])
+);
+
+describe('parseMergedResponse', () => {
+  test('valid merged JSON → structure + full cellQueries map', () => {
+    const out = parseMergedResponse(mergedJson(FULL_CQ));
+    expect(out).not.toBeNull();
+    expect(out!.structure.sub_goals).toHaveLength(8);
+    expect(out!.cellQueries?.size).toBe(8);
+    expect(out!.cellQueries?.get(0)).toBe('검색어0 키워드');
+  });
+
+  test('missing cell_queries → structure present, cellQueries null (degrade)', () => {
+    const out = parseMergedResponse(mergedJson(null));
+    expect(out).not.toBeNull();
+    expect(out!.structure.sub_goals).toHaveLength(8);
+    expect(out!.cellQueries).toBeNull();
+  });
+
+  test('drops out-of-range / empty / over-long query entries', () => {
+    const cq = {
+      '0': 'ok query',
+      '1': '   ', // empty after trim
+      '9': 'out of range',
+      '2': 'x'.repeat(61), // > MAX 60 chars
+      '3': 'fine query',
+    };
+    const out = parseMergedResponse(mergedJson(cq));
+    expect(out!.cellQueries?.size).toBe(2); // only 0 and 3
+    expect(out!.cellQueries?.has(1)).toBe(false);
+    expect(out!.cellQueries?.has(9 as number)).toBe(false);
+    expect(out!.cellQueries?.has(2)).toBe(false);
+  });
+
+  test('unparseable structure → null', () => {
+    expect(parseMergedResponse('not json at all')).toBeNull();
+  });
+});
+
+describe('generateMandalaWithQueries', () => {
+  const baseInput = { goal: '한국어 목표', language: 'ko' as const };
+
+  test('full coverage → 8 cellQueries, not degraded, center_goal overridden', async () => {
+    const res = await generateMandalaWithQueries(baseInput, {
+      generateImpl: async () => mergedJson(FULL_CQ),
+    });
+    expect(res.structure.center_goal).toBe('한국어 목표'); // HARD RULE override
+    expect(res.cellQueries).toHaveLength(8);
+    expect(res.cellQueries?.[0]).toEqual({ cellIndex: 0, query: '검색어0 키워드' });
+    expect(res.meta.degraded).toBe(false);
+    expect(res.meta.cellQueryCount).toBe(8);
+  });
+
+  test('partial coverage → cellQueries undefined (degraded), structure still returned', async () => {
+    const partial = { '0': '검색어0 키워드', '1': '검색어1 키워드', '2': '검색어2 키워드' };
+    const res = await generateMandalaWithQueries(baseInput, {
+      generateImpl: async () => mergedJson(partial),
+    });
+    expect(res.cellQueries).toBeUndefined(); // partial → fanout runs query-gen
+    expect(res.meta.degraded).toBe(true);
+    expect(res.meta.cellQueryCount).toBe(3);
+    expect(res.structure.sub_goals).toHaveLength(8);
+  });
+
+  test('invalid structure (sub_goals != 8) → throws MandalaGenError', async () => {
+    await expect(
+      generateMandalaWithQueries(baseInput, {
+        generateImpl: async () => mergedJson(FULL_CQ, ['only', 'five', 'sub', 'goals', 'here']),
+      })
+    ).rejects.toThrow(MandalaGenError);
+  });
+
+  test('unparseable response → throws MandalaGenError', async () => {
+    await expect(
+      generateMandalaWithQueries(baseInput, { generateImpl: async () => 'garbage' })
+    ).rejects.toThrow(MandalaGenError);
+  });
+});

--- a/tests/unit/skills/video-discover/v5-fanout.test.ts
+++ b/tests/unit/skills/video-discover/v5-fanout.test.ts
@@ -126,6 +126,64 @@ describe('runYouTubeFanout — F5c perQuery', () => {
 });
 
 /**
+ * CP493 — merged-gen precomputedQueries. When the wizard's merged structure+
+ * queries call produced full per-cell coverage, fanout must use those queries
+ * verbatim and SKIP its own query-gen (preserving goal-context continuity).
+ */
+describe('runYouTubeFanout — CP493 precomputedQueries (merged-gen)', () => {
+  beforeEach(() => {
+    resetV5ConfigForTest();
+    searchVideos.mockReset();
+    buildRuleBasedQueriesSync.mockReset();
+  });
+
+  test('uses precomputedQueries verbatim, skips query-gen, mode=merged', async () => {
+    searchVideos.mockImplementation(({ query }: { query: string }) =>
+      Promise.resolve(items(3, query))
+    );
+    const res = await runYouTubeFanout({
+      centerGoal: 'goal',
+      subGoals: ['a', 'b'],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      env: {} as NodeJS.ProcessEnv,
+      precomputedQueries: [
+        { cellIndex: 0, query: 'merged q0' },
+        { cellIndex: 1, query: 'merged q1' },
+      ],
+    });
+    // query-gen must NOT be invoked when precomputed queries are supplied.
+    expect(buildRuleBasedQueriesSync).not.toHaveBeenCalled();
+    const searched = searchVideos.mock.calls.map(
+      (c: unknown[]) => (c[0] as { query: string }).query
+    );
+    expect(searched.sort()).toEqual(['merged q0', 'merged q1']);
+    expect(res.queryGen.mode).toBe('merged');
+    expect(res.queryGen.llmCells).toBe(2);
+    expect(res.queryGen.fellBack).toBe(false);
+    expect(res.perQuery.map((p) => p.source)).toEqual(['merged', 'merged']);
+    expect(res.perQuery.map((p) => p.cellIndex)).toEqual([0, 1]);
+  });
+
+  test('empty precomputedQueries → falls through to rule query-gen (unchanged)', async () => {
+    buildRuleBasedQueriesSync.mockReturnValue([{ query: 'rq', source: 'core', cellIndex: null }]);
+    searchVideos.mockResolvedValue(items(2, 'rq'));
+    const res = await runYouTubeFanout({
+      centerGoal: 'goal',
+      subGoals: ['a'],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      env: {} as NodeJS.ProcessEnv,
+      precomputedQueries: [],
+    });
+    expect(buildRuleBasedQueriesSync).toHaveBeenCalled();
+    expect(res.queryGen.mode).toBe('rule');
+  });
+});
+
+/**
  * CP492 — per-query key rotation. All N parallel queries previously shared the
  * same key array → every query hit keys[0] first → YouTube 429 rateLimitExceeded
  * cascade (0 results under burst, ~50% supply loss normally). rotateKeys spreads


### PR DESCRIPTION
## What

One Haiku call produces the mandala **structure AND per-cell YouTube search queries** in a single continuous context (`generateMandalaWithQueries`), replacing the two disconnected calls — structure-gen at creation + query-gen at fanout. The query now inherits the goal-structure reasoning instead of re-interpreting a bare cell label downstream — the split that produced **near-duplicate clustering noise** (a cell filled with same-brand videos).

**Wizard path only. add-cards unaffected** (still runs its own query-gen via the shared fanout).

## How

- `generateMandalaWithQueries` + `parseMergedResponse` (generator.ts)
- merged prompt carries the v5 searchable per-cell guidance (12–20 chars, anti-too-short/long, no repeated phrasing → anti-clustering)
- `precomputedQueries` threaded `fanout → executor → adapter → precompute`; fanout uses them verbatim and **skips its own query-gen** at full coverage (`queryGen.mode=merged`)
- **3-stage fallback**: partial cell coverage → degrade to fanout query-gen (no sparse cells); merged throw → legacy `generateMandalaStructure`; flag off → behavior unchanged
- `WIZARD_MERGED_GEN` flag (**default off**, env-flip rollback, no code revert)

## Safety

- Flag **off by default** → merging this PR is a **no-op in prod** (code lands, behavior unchanged). Canary is enabled separately by adding `WIZARD_MERGED_GEN=true` to `docker-compose.prod.yml` (follow-up PR).
- `'merged'` added to `QuerySource` / `QueryGenMeta.mode` — no exhaustive switches depend on these (verified).

## Measured (CP492/CP493)

- merged single call **3.78s** (replaces two ~5–6s calls), JSON stable
- cell query returned **7/8 unique channels** (no clustering) vs the split-path Omnisend ×6 cluster
- prod canary verifies searchability + diversity across more cells

## Tests

`parseMergedResponse` + `generateMandalaWithQueries` (extract / partial-degrade / invalid-throw) + fanout `precomputedQueries` (verbatim / skip query-gen / mode=merged). **29/29 pass.** tsc clean for changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)