### PR TITLE
chore(prod): enable WIZARD_MERGED_GEN canary

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -201,6 +201,18 @@ services:
       # Table: mandala_wizard_precompute (10min TTL, pg_cron sweep */5 min).
       # Revert: delete this line → feature no-ops.
       - WIZARD_PRECOMPUTE_ENABLED=true
+      # CP493 (2026-06-03) — merged structure+queries generation (canary). ONE
+      # Haiku call yields the mandala structure AND a searchable per-cell query
+      # in a single continuous context, replacing the two disconnected calls
+      # (structure-gen at creation + query-gen at fanout). The query inherits
+      # the goal-structure reasoning instead of re-interpreting a bare cell
+      # label → diverse, non-clustered queries (fixes the near-duplicate
+      # clustering noise — a cell filled with same-brand videos). Wizard path
+      # only; add-cards unaffected. 3-stage fallback: partial cell coverage →
+      # fanout query-gen; merged throw → legacy structure-gen; never dies.
+      # Revert: delete this line and redeploy → code default off restores the
+      # two-call path bit-identically (no code revert).
+      - WIZARD_MERGED_GEN=true
       # CP426 (2026-04-25) — Switch pipeline executor from v1 (3 recs/cell,
       # max 24 with channel diversity drop → ~5 actual) to v3 (12/cell target,
       # 96 max). v3 degrades gracefully to Tier 2 when video_pool is empty.


### PR DESCRIPTION
## What

Turns on the merged structure+queries generation in prod (code shipped **off** in #845). Adds `WIZARD_MERGED_GEN=true` to `docker-compose.prod.yml`.

One Haiku call now produces the mandala structure + per-cell YouTube search queries in a single continuous context for the **wizard path**, replacing the two disconnected calls. add-cards unaffected. 3-stage fallback (partial → fanout query-gen; throw → legacy structure-gen) keeps the wizard alive.

## Canary scope

Wizard creation only. Verification (live, post-deploy): per-cell query **searchability (results > 0) AND channel diversity (no clustering)**, sparse-backfill non-regression, "러닝"-style homonym handling, degrade frequency + merged latency — via `video_discover_traces` (`queryGen.mode`, `cell_distribution`, queries).

## Rollback

Delete the `WIZARD_MERGED_GEN` line and redeploy → code default off restores the two-call path bit-identically. No code revert.

Depends on #845 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)