### PR TITLE
feat(v5): pool-first backfill gate to cut search.list quota (V5_POOL_BACKFILL, default off)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -397,6 +397,10 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               // CP492 2차 gate — off-language candidates dropped (Arabic/Thai/Cyrillic/
               // CJK/Turkish). English is intentionally NOT dropped (Track 3 topic fit).
               v5_off_lang_dropped: v5Result.diagnostics.offLangDropped,
+              // CP494 — pool-first backfill telemetry: quota delta (liveCells ×
+              // 100 spent vs poolOnlyCells × 100 saved), poolQueryMs latency, and
+              // poolOnlyCells (Fork-2(A) 100%-lexical quality tradeoff surface).
+              v5_pool_backfill: v5Result.diagnostics.poolBackfill,
               // CP491 F5c — per-query raw count + q_ok (parity with wizard.discover.end).
               v5_per_query: v5Result.diagnostics.perQuery,
               // CP491 — Shorts dropped by the post-pick short gate (before→after observability).

--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -11,6 +11,14 @@
 
 import { z } from 'zod';
 
+// Env boolean: "true" (case-insensitive) → true, anything else → false.
+// Mirrors the v3/config.ts booleanFlag pattern (no z.coerce.boolean, which
+// treats the string "false" as true).
+const booleanFlag = z.preprocess(
+  (v) => (typeof v === 'string' ? v.trim().toLowerCase() === 'true' : Boolean(v)),
+  z.boolean()
+);
+
 const v5EnvSchema = z.object({
   V5_MAX_QUERIES: z.coerce.number().int().min(1).max(20).default(8),
   V5_SEARCH_TIMEOUT_MS: z.coerce.number().int().min(500).max(8000).default(2000),
@@ -36,6 +44,22 @@ const v5EnvSchema = z.object({
   // self-help / EN-AR leak). LLM translates each cell label into a focused
   // searchable query. unset = 'rule' = no-op (flag-off rollback).
   V5_QUERY_GEN: z.enum(['rule', 'llm']).default('rule'),
+  // CP494 — pool-first backfill gate. When on, fill cells from the quota-FREE +
+  // embedding-FREE video_pool tsvector match BEFORE live search; a cell the pool
+  // satisfies (≥ V5_POOL_MIN_PER_CELL gold/silver candidates) drops its live
+  // search.list query → quota saved. Covers wizard + add-cards (shared executor).
+  // unset = false = no-op (full live fanout, flag-off rollback).
+  V5_POOL_BACKFILL: booleanFlag.optional().default(false as unknown as string),
+  // CP494 — pool source range (Fork 3). 'v2_promoted' = ~1.1k high-quality ko
+  // only; 'all' = + batch_trend (~28k, cross-domain; downstream gates are the
+  // noise safety net). Canary starts at v2_promoted, expand after measuring.
+  V5_POOL_SOURCE: z.enum(['v2_promoted', 'all']).default('v2_promoted'),
+  // CP494 — quality floor N. A cell needs ≥ this many pool candidates to skip
+  // live search. Do NOT raise on speculation (measure pool_only_cells first).
+  V5_POOL_MIN_PER_CELL: z.coerce.number().int().min(1).max(20).default(3),
+  // CP494 — hot-path safety: pool query timeout (ms). On timeout/throw → full
+  // live fanout fallback. tsvector on ~1.1k rows is sub-100ms; cap conservatively.
+  V5_POOL_TIMEOUT_MS: z.coerce.number().int().min(200).max(5000).default(1500),
 });
 
 export interface V5Config {
@@ -48,6 +72,16 @@ export interface V5Config {
   shortProbeDeadlineMs: number;
   pickerMode: 'llm' | 'cell_binning';
   queryGen: 'rule' | 'llm';
+  /** CP494 — pool-first backfill gate enabled. */
+  poolBackfill: boolean;
+  /** CP494 — resolved video_pool source filter (tsvector match). */
+  poolSources: string[];
+  /** CP494 — raw V5_POOL_SOURCE value, for trace observability. */
+  poolSourceLabel: string;
+  /** CP494 — quality floor: pool candidates per cell to skip live search. */
+  poolMinPerCell: number;
+  /** CP494 — pool query timeout (ms) before full-live fallback. */
+  poolTimeoutMs: number;
 }
 
 let cached: V5Config | null = null;
@@ -65,6 +99,11 @@ export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
     shortProbeDeadlineMs: p.V5_SHORT_PROBE_DEADLINE_MS,
     pickerMode: p.V5_PICKER_MODE,
     queryGen: p.V5_QUERY_GEN,
+    poolBackfill: p.V5_POOL_BACKFILL,
+    poolSources: p.V5_POOL_SOURCE === 'all' ? ['v2_promoted', 'batch_trend'] : ['v2_promoted'],
+    poolSourceLabel: p.V5_POOL_SOURCE,
+    poolMinPerCell: p.V5_POOL_MIN_PER_CELL,
+    poolTimeoutMs: p.V5_POOL_TIMEOUT_MS,
   };
   return cached;
 }

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -21,6 +21,7 @@ import {
   type FanoutCandidate,
   type FanoutPerQuery,
   type PrecomputedQuery,
+  type PoolBackfillMeta,
 } from './youtube-fanout';
 import type { QueryGenMeta } from './llm-query-gen';
 import { getV5Config } from './config';
@@ -111,6 +112,8 @@ export interface V5ExecuteResult {
     queryGen: QueryGenMeta;
     /** CP492 2차 gate — candidates dropped by the off-language script filter. */
     offLangDropped: number;
+    /** CP494 — pool-first backfill telemetry (quota delta + Fork-2 quality surface). */
+    poolBackfill: PoolBackfillMeta;
   };
 }
 
@@ -338,6 +341,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       perQuery: fanout.perQuery ?? [],
       queryGen: fanout.queryGen,
       offLangDropped: fanout.offLangDropped ?? 0,
+      poolBackfill: fanout.poolBackfill,
     },
   };
 }
@@ -351,6 +355,7 @@ function emptyResult(args: {
     perQuery?: FanoutPerQuery[];
     queryGen: QueryGenMeta;
     offLangDropped?: number;
+    poolBackfill: PoolBackfillMeta;
   };
   afterTitleFilter: number;
   afterExcludeFilter: number;
@@ -381,6 +386,7 @@ function emptyResult(args: {
       perQuery: args.fanout.perQuery ?? [],
       queryGen: args.fanout.queryGen,
       offLangDropped: args.fanout.offLangDropped ?? 0,
+      poolBackfill: args.fanout.poolBackfill,
     },
   };
 }

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -25,6 +25,7 @@ import { buildRuleBasedQueriesSync, type SearchQuery } from '../v2/keyword-build
 import { buildLLMQueriesPerCell, type QueryGenMeta } from './llm-query-gen';
 import { getV5Config } from './config';
 import { MERGED_GEN_MODEL } from '@/prompts/mandala-with-queries-generator';
+import { tsvectorKeywordCandidates, type KeywordCandidate } from '../v3/hybrid-rerank';
 
 const log = logger.child({ module: 'video-discover/v5/youtube-fanout' });
 
@@ -89,6 +90,76 @@ export interface FanoutResult {
   queryGen: QueryGenMeta;
   /** CP492 2차 gate — candidates dropped by the off-language script filter. */
   offLangDropped: number;
+  /** CP494 — pool-first backfill telemetry (quota delta + Fork-2 quality tradeoff). */
+  poolBackfill: PoolBackfillMeta;
+}
+
+/**
+ * CP494 — pool-first gate observability. `poolOnlyCells` = cells that went 100%
+ * lexical (live query dropped) → the Fork-2(A) quality tradeoff surface.
+ * `liveCells` × 100 ≈ quota spent; (totalCells − liveCells) × 100 ≈ quota saved.
+ */
+export interface PoolBackfillMeta {
+  /** flag on (V5_POOL_BACKFILL). */
+  enabled: boolean;
+  /** pool query timed out or threw → fell back to full live fanout (hot-path safety). */
+  fellBackToLive: boolean;
+  /** pool tsvector query wall-time (ms). */
+  poolQueryMs: number;
+  /** pool candidates kept after the same blocklist/shorts/off-language gates as live. */
+  poolCandidates: number;
+  /** cells the pool satisfied (≥ poolMinPerCell) → live query dropped (100% lexical). */
+  poolOnlyCells: number;
+  /** cells whose live search.list query still ran. */
+  liveCells: number;
+  /** resolved pool source label (v2_promoted | all). */
+  source: string;
+}
+
+/** CP494 — no-op meta for the flag-off / pre-gate paths. */
+const POOL_BACKFILL_OFF = (liveCells: number): PoolBackfillMeta => ({
+  enabled: false,
+  fellBackToLive: false,
+  poolQueryMs: 0,
+  poolCandidates: 0,
+  poolOnlyCells: 0,
+  liveCells,
+  source: 'off',
+});
+
+/**
+ * CP494 — reject after `ms` so a slow pool query never blocks the discover
+ * hot path. The underlying Postgres query is not cancelled (it completes and is
+ * discarded), but the caller falls through to full live fanout.
+ */
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`pool query timeout after ${ms}ms`)), ms);
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      }
+    );
+  });
+}
+
+/** CP494 — map a video_pool KeywordCandidate to the fanout candidate contract. */
+function keywordCandidateToFanoutCandidate(kc: KeywordCandidate): FanoutCandidate {
+  return {
+    videoId: kc.videoId,
+    title: kc.title,
+    description: kc.description ?? '',
+    channelTitle: kc.channelName ?? '',
+    channelId: kc.channelId ?? '',
+    publishedAt: kc.publishedAt ? kc.publishedAt.toISOString() : '',
+    thumbnailUrl: kc.thumbnail ?? '',
+    cellIndex: kc.cellIndex,
+  };
 }
 
 /** CP492 Track-1 — meta for the rule branch (LLM never attempted). */
@@ -184,6 +255,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       queryGenMs: 0,
       queryGen: RULE_QUERY_GEN_META(0),
       offLangDropped: 0,
+      poolBackfill: POOL_BACKFILL_OFF(0),
     };
   }
 
@@ -244,11 +316,79 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       queryGenMs,
       queryGen,
       offLangDropped: 0,
+      poolBackfill: POOL_BACKFILL_OFF(0),
     };
   }
 
+  // CP494 — pool-first gate. Fill cells from the quota-FREE + embedding-FREE
+  // video_pool tsvector match BEFORE live search; cells the pool satisfies
+  // (≥ poolMinPerCell) drop their live query → quota saved. Hot-path safety
+  // (non-negotiable): timeout + try/catch → ANY failure falls back to full live
+  // fanout. Pool candidates pass the SAME blocklist/shorts/off-language gates as
+  // live below (lexical match = supplier; existing gates = quality judge).
+  let liveQueries: SearchQuery[] = queries;
+  const poolSeed: FanoutCandidate[] = [];
+  let poolMeta: PoolBackfillMeta = POOL_BACKFILL_OFF(queries.length);
+  if (cfg.poolBackfill) {
+    const tPool0 = Date.now();
+    try {
+      const poolLimit = totalCells * (cfg.poolMinPerCell + 5);
+      const pool = await withTimeout(
+        // exclude=[] — the executor applies excludeVideoIds AFTER fanout, so
+        // already-owned cards are dropped downstream (minor pool waste, no bug).
+        tsvectorKeywordCandidates(input.centerGoal, input.subGoals, [], poolLimit, cfg.poolSources),
+        cfg.poolTimeoutMs
+      );
+      const byCell = new Map<number, FanoutCandidate[]>();
+      for (const kc of pool) {
+        const cand = keywordCandidateToFanoutCandidate(kc);
+        // Fork-1 caveat: pool candidates run the SAME gates as live items.
+        if (titleHitsBlocklist(cand.title) || titleIndicatesShorts(cand.title)) continue;
+        if (isOffLanguageTitle(cand.title, input.language)) continue;
+        const ci = cand.cellIndex ?? -1;
+        if (ci < 0) continue;
+        const bucket = byCell.get(ci);
+        if (bucket) bucket.push(cand);
+        else byCell.set(ci, [cand]);
+      }
+      const satisfied = new Set<number>();
+      for (const [ci, cands] of byCell) {
+        // ALL pool candidates feed supply (deficit cells get pool + live);
+        // only cells at/above the floor drop their live query.
+        poolSeed.push(...cands);
+        if (cands.length >= cfg.poolMinPerCell) satisfied.add(ci);
+      }
+      liveQueries = queries.filter((q) => !(q.cellIndex != null && satisfied.has(q.cellIndex)));
+      poolMeta = {
+        enabled: true,
+        fellBackToLive: false,
+        poolQueryMs: Date.now() - tPool0,
+        poolCandidates: poolSeed.length,
+        poolOnlyCells: satisfied.size,
+        liveCells: liveQueries.length,
+        source: cfg.poolSourceLabel,
+      };
+    } catch (err) {
+      // Hot-path safety: any pool failure → full live fanout (current behavior).
+      liveQueries = queries;
+      poolSeed.length = 0;
+      poolMeta = {
+        enabled: true,
+        fellBackToLive: true,
+        poolQueryMs: Date.now() - tPool0,
+        poolCandidates: 0,
+        poolOnlyCells: 0,
+        liveCells: queries.length,
+        source: cfg.poolSourceLabel,
+      };
+      log.warn(
+        `v5 fanout: pool backfill failed → full live fallback: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
   const results = await Promise.allSettled(
-    queries.map((q, i) =>
+    liveQueries.map((q, i) =>
       searchVideos({
         query: q.query,
         // CP492 — distribute the primary key per query. searchVideos tries keys
@@ -277,6 +417,13 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
   let queriesSucceeded = 0;
   let offLangDropped = 0;
   const seen = new Map<string, FanoutCandidate>();
+
+  // CP494 — seed pool candidates first (already gate-filtered above) so they get
+  // priority position in the dedup map; live results merge in after.
+  for (const cand of poolSeed) {
+    if (seen.size >= cfg.dedupHardCap) break;
+    if (!seen.has(cand.videoId)) seen.set(cand.videoId, cand);
+  }
 
   for (const r of results) {
     if (r.status !== 'fulfilled') {
@@ -310,7 +457,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
   // the cohort hits dedupHardCap early. `results` order == `queries` order
   // (Promise.allSettled preserves it).
   const perQuery: FanoutPerQuery[] = results.map((r, i) => {
-    const qm = queries[i]!;
+    const qm = liveQueries[i]!;
     return {
       query: qm.query,
       source: qm.source,
@@ -322,14 +469,17 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
 
   return {
     candidates: Array.from(seen.values()),
-    queriesAttempted: queries.length,
+    // CP494 — attempted/quota now reflect ONLY the live queries actually fired
+    // (pool-satisfied cells dropped theirs). poolBackfill carries the delta.
+    queriesAttempted: liveQueries.length,
     queriesSucceeded,
     rawItemCount,
-    quotaUnitsApprox: queries.length * 100,
+    quotaUnitsApprox: liveQueries.length * 100,
     perQuery,
     queryGenMs,
     queryGen,
     offLangDropped,
+    poolBackfill: poolMeta,
   };
 }
 

--- a/tests/unit/skills/video-discover/v5-pool-backfill.test.ts
+++ b/tests/unit/skills/video-discover/v5-pool-backfill.test.ts
@@ -1,0 +1,187 @@
+/**
+ * CP494 — v5 pool-first backfill gate (V5_POOL_BACKFILL).
+ *
+ * Verifies the quota-saving gate: cells the video_pool satisfies (≥
+ * V5_POOL_MIN_PER_CELL gold/silver tsvector candidates) drop their live
+ * search.list query, while deficit cells still go live. Plus hot-path safety
+ * (timeout/throw → full live fallback) and the Fork-1 contract (pool candidates
+ * pass the SAME off-language gate as live items).
+ */
+
+import { runYouTubeFanout } from '@/skills/plugins/video-discover/v5/youtube-fanout';
+import { resetV5ConfigForTest } from '@/skills/plugins/video-discover/v5/config';
+
+jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
+  searchVideos: jest.fn(),
+  resolveSearchApiKeys: jest.fn().mockReturnValue(['key1']),
+  titleIndicatesShorts: jest.fn().mockReturnValue(false),
+  titleHitsBlocklist: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('@/skills/plugins/video-discover/v3/hybrid-rerank', () => ({
+  tsvectorKeywordCandidates: jest.fn(),
+}));
+
+const { searchVideos } = jest.requireMock('@/skills/plugins/video-discover/v2/youtube-client');
+const { tsvectorKeywordCandidates } = jest.requireMock(
+  '@/skills/plugins/video-discover/v3/hybrid-rerank'
+);
+
+/** YouTube search.list result items (live path). */
+function items(n: number, prefix: string) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: { videoId: `${prefix}_${i}` },
+    snippet: {
+      title: `T${prefix}${i}`,
+      description: 'd',
+      channelTitle: 'c',
+      channelId: 'ch',
+      publishedAt: '2026-01-01T00:00:00Z',
+      thumbnails: { high: { url: 'u' } },
+    },
+  }));
+}
+
+/** video_pool KeywordCandidate rows (lexical supplier). */
+function poolCand(cellIndex: number, id: string, title = `pool ${id}`) {
+  return {
+    videoId: id,
+    title,
+    description: null,
+    channelName: 'pc',
+    channelId: 'pch',
+    thumbnail: 'pu',
+    viewCount: 10,
+    likeCount: 1,
+    durationSec: 300,
+    publishedAt: null,
+    cellIndex,
+    rec_score: 0.5,
+  };
+}
+
+/** Three cells (0,1,2), one merged query each, en language. */
+function fanoutInput(env: Record<string, string> = {}) {
+  return {
+    centerGoal: 'goal',
+    subGoals: ['a', 'b', 'c'],
+    focusTags: [],
+    targetLevel: 'standard',
+    language: 'en' as const,
+    env: env as unknown as NodeJS.ProcessEnv,
+    precomputedQueries: [
+      { cellIndex: 0, query: 'q0' },
+      { cellIndex: 1, query: 'q1' },
+      { cellIndex: 2, query: 'q2' },
+    ],
+  };
+}
+
+describe('runYouTubeFanout — CP494 pool-first backfill', () => {
+  beforeEach(() => {
+    resetV5ConfigForTest();
+    searchVideos.mockReset();
+    tsvectorKeywordCandidates.mockReset();
+    searchVideos.mockImplementation(({ query }: { query: string }) =>
+      Promise.resolve(items(3, query))
+    );
+  });
+
+  test('flag off (default) → no pool call, all queries live, unchanged behavior', async () => {
+    const res = await runYouTubeFanout(fanoutInput({}));
+
+    expect(tsvectorKeywordCandidates).not.toHaveBeenCalled();
+    expect(searchVideos).toHaveBeenCalledTimes(3);
+    expect(res.queriesAttempted).toBe(3);
+    expect(res.quotaUnitsApprox).toBe(300);
+    expect(res.poolBackfill.enabled).toBe(false);
+    expect(res.poolBackfill.liveCells).toBe(3);
+    expect(res.poolBackfill.poolOnlyCells).toBe(0);
+  });
+
+  test('pool satisfies a cell (≥ floor) → that live query is dropped (quota saved)', async () => {
+    // cell 0 gets 3 pool candidates (= floor) → satisfied; cells 1,2 get none.
+    tsvectorKeywordCandidates.mockResolvedValue([
+      poolCand(0, 'p0a'),
+      poolCand(0, 'p0b'),
+      poolCand(0, 'p0c'),
+    ]);
+
+    const res = await runYouTubeFanout(fanoutInput({ V5_POOL_BACKFILL: 'true' }));
+
+    expect(tsvectorKeywordCandidates).toHaveBeenCalledTimes(1);
+    // cell 0 dropped → only q1, q2 hit live.
+    expect(searchVideos).toHaveBeenCalledTimes(2);
+    const liveQueries = searchVideos.mock.calls.map((c: [{ query: string }]) => c[0].query).sort();
+    expect(liveQueries).toEqual(['q1', 'q2']);
+    expect(res.poolBackfill).toMatchObject({
+      enabled: true,
+      fellBackToLive: false,
+      poolOnlyCells: 1,
+      liveCells: 2,
+      poolCandidates: 3,
+      source: 'v2_promoted',
+    });
+    expect(res.queriesAttempted).toBe(2);
+    expect(res.quotaUnitsApprox).toBe(200); // 800→ saved 1 cell
+    // pool cell-0 candidates present in the merged candidate set.
+    expect(res.candidates.map((c) => c.videoId)).toEqual(
+      expect.arrayContaining(['p0a', 'p0b', 'p0c'])
+    );
+  });
+
+  test('deficit cell (< floor) → query kept, but pool candidates still feed supply', async () => {
+    // cell 0 gets only 2 (< floor 3) → NOT satisfied → q0 still goes live.
+    tsvectorKeywordCandidates.mockResolvedValue([poolCand(0, 'p0a'), poolCand(0, 'p0b')]);
+
+    const res = await runYouTubeFanout(fanoutInput({ V5_POOL_BACKFILL: 'true' }));
+
+    expect(searchVideos).toHaveBeenCalledTimes(3); // all cells live
+    expect(res.poolBackfill.poolOnlyCells).toBe(0);
+    expect(res.poolBackfill.liveCells).toBe(3);
+    expect(res.poolBackfill.poolCandidates).toBe(2); // still seeded
+    expect(res.candidates.map((c) => c.videoId)).toEqual(expect.arrayContaining(['p0a', 'p0b']));
+  });
+
+  test('pool throws → full live fallback (hot-path safety)', async () => {
+    tsvectorKeywordCandidates.mockRejectedValue(new Error('pg down'));
+
+    const res = await runYouTubeFanout(fanoutInput({ V5_POOL_BACKFILL: 'true' }));
+
+    expect(searchVideos).toHaveBeenCalledTimes(3); // all live, nothing dropped
+    expect(res.poolBackfill.fellBackToLive).toBe(true);
+    expect(res.poolBackfill.poolCandidates).toBe(0);
+    expect(res.poolBackfill.liveCells).toBe(3);
+    expect(res.queriesAttempted).toBe(3);
+  });
+
+  test('pool timeout → full live fallback', async () => {
+    tsvectorKeywordCandidates.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const res = await runYouTubeFanout(
+      fanoutInput({ V5_POOL_BACKFILL: 'true', V5_POOL_TIMEOUT_MS: '200' })
+    );
+
+    expect(res.poolBackfill.fellBackToLive).toBe(true);
+    expect(searchVideos).toHaveBeenCalledTimes(3);
+    expect(res.poolBackfill.poolQueryMs).toBeGreaterThanOrEqual(180);
+  });
+
+  test('Fork-1 gate: off-language pool candidate is dropped before counting toward the floor', async () => {
+    // ko mandala: 2 valid + 1 Chinese-only title. Off-lang drop leaves 2 (< floor 3)
+    // → cell NOT satisfied → q0 stays live, off-lang row absent from candidates.
+    const koInput = { ...fanoutInput({ V5_POOL_BACKFILL: 'true' }), language: 'ko' as const };
+    tsvectorKeywordCandidates.mockResolvedValue([
+      poolCand(0, 'p0a', '한국어 제목 A'),
+      poolCand(0, 'p0b', '한국어 제목 B'),
+      poolCand(0, 'p0bad', '彩礼加倍重生'), // ≥2 Han, no Hangul → off-language drop
+    ]);
+
+    const res = await runYouTubeFanout(koInput);
+
+    expect(searchVideos).toHaveBeenCalledTimes(3); // floor not met → q0 live
+    expect(res.poolBackfill.poolCandidates).toBe(2); // off-lang dropped
+    expect(res.candidates.map((c) => c.videoId)).not.toContain('p0bad');
+    expect(res.candidates.map((c) => c.videoId)).toEqual(expect.arrayContaining(['p0a', 'p0b']));
+  });
+});


### PR DESCRIPTION
## What
P1 of the v5 supply-resilience design (CP493/CP494). Injects a **pool-first gate** into `runYouTubeFanout`: cells the `video_pool` satisfies (≥ `V5_POOL_MIN_PER_CELL` gold/silver tsvector candidates) **drop their live `search.list` query** → quota saved. One injection point covers **wizard + add-cards** (shared `runV5Executor`).

## Why
Trace reconcile (2 days, 1 user) attributed the recent ~70k quota burn (7 GCP projects × 10k) primarily to **add-cards** (44 clicks × 8 = 352 calls = 35,200 units). v3 double-bill was effectively absent (2 pipeline runs). v5 had **zero** reuse of the ~30k pool — every generation/click spends 8×100=800 fresh units.

## Decisions
- **Fork 1**: `tsvectorKeywordCandidates` (lexical, quota+embedding-free) — NOT `matchFromVideoPool` (cosine, 10-54s embedding cold-start = the v3 wizard slowness). Pool candidates pass the **same** blocklist/shorts/off-language gates as live (supplier vs judge).
- **Fork 2(A)**: pool-first **with a quality floor** — only cells with ≥N pool candidates skip live; deficit cells still go live (no naive pool-fill).
- **Fork 3**: `V5_POOL_SOURCE` flag (`v2_promoted` | `all`) — canary `v2_promoted`, expand after measuring.

## Safety
- Pool query has `withTimeout` + try/catch → **any failure → full live fallback** (current behavior).
- **Flag default false** → merge is behavior-identical; env-flip rollback.

## Observability (for canary measurement)
`pool_query_ms`, `pool_only_cells` (100%-lexical = Fork-2 quality tradeoff), `liveCells`, `poolCandidates`, `fellBackToLive` on the add-cards/wizard trace.

## Tests
6 new (flag-off no-op / cell-satisfied→query-dropped / deficit→kept / throw→fallback / timeout→fallback / off-language pool drop). video-discover 57/57.

## NOT done until measured
Per the Done definition: canary (flag on) + 1 add-cards click → measure `pool_query_ms` + quota delta + `pool_only_cells` before declaring success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)