### PR TITLE
chore(prod): enable V5_POOL_BACKFILL canary (pool-first quota gate)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -97,6 +97,14 @@ services:
       # Revert: delete both lines → code defaults 30 / 120.
       - V5_TARGET_PICKS=60
       - V5_DEDUP_HARDCAP=180
+      # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
+      # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
+      # a cell with ≥3 pool candidates drops its live search.list query → quota
+      # saved. Covers wizard + add-cards (shared v5 executor). Hot-path safe
+      # (timeout + try/catch → full live fallback). Source default v2_promoted.
+      # Measure: GCP search.list before/after delta + trace v5_pool_backfill.
+      # Revert: delete this line + redeploy → code default false (full live).
+      - V5_POOL_BACKFILL=true
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the


### PR DESCRIPTION
## What
Enables the CP494 pool-first backfill gate in prod (code shipped **off** in #847). `V5_POOL_BACKFILL=true` in `docker-compose.prod.yml`.

## Effect
Cells the `video_pool` satisfies (≥3 gold/silver tsvector candidates, `v2_promoted` source) **drop their live search.list query** → quota saved. Covers wizard + add-cards (shared v5 executor). Hot-path safe (timeout + try/catch → full live fallback).

## ⚠️ Do NOT merge until measurement is staged
**Done criterion = GCP console search.list before/after delta** (not trace self-report).

Pre-merge checklist (James):
1. **Quota headroom** — at least one search-key GCP project has remaining daily quota (the 7 projects were exhausted; may need post-reset, midnight PT).
2. **Record baseline** — GCP console per-project "Queries per day" used units (sum = baseline).
3. Merge this PR → deploy.
4. **1 add-cards click** on a pool-fillable mandala (common ko topic overlapping the ~1.1k v2_promoted pool).
5. **Record after** → delta = after − baseline. Compare vs 800 (full-live). Cross-check trace `v5_pool_backfill` (liveCells×100 + 1 ≈ delta).

## Rollback
Delete the `V5_POOL_BACKFILL` line + redeploy → code default off (full live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)