### PR TITLE
chore(prod): V5_POOL_SOURCE=all canary (Fork-3 — add batch_trend pool)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -105,6 +105,15 @@ services:
       # Measure: GCP search.list before/after delta + trace v5_pool_backfill.
       # Revert: delete this line + redeploy → code default false (full live).
       - V5_POOL_BACKFILL=true
+      # CP494 Fork-3 canary — expand pool source from v2_promoted (~1.1k ko,
+      # high quality) to ALL (+ batch_trend ~28k, cross-domain). P1 measured
+      # only 2/8 cells reached the floor on v2_promoted (25% quota saved on a
+      # 1-click add-cards: 6 live vs 8). The thicker batch_trend pool should
+      # raise pool_only_cells; noise safety net = the existing off-language /
+      # blocklist / shorts gates the pool candidates already pass.
+      # Measure: same 1-click add-cards → pool_only_cells 2/8 → ? + GCP delta.
+      # Revert: delete this line → code default 'v2_promoted'.
+      - V5_POOL_SOURCE=all
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the


### PR DESCRIPTION
## What
Fork-3 canary: widen `V5_POOL_SOURCE` `v2_promoted` → `all` (adds `batch_trend` ~28k cross-domain to the pool-first gate). flag-only.

## Why
P1 (#847/#848) measured only **2/8 cells** reached the pool floor on `v2_promoted` (~1.1k ko) → 25% quota saved on a 1-click add-cards (6 live vs 8, `units` 601 vs 801; trace + GCP delta agreed). The thicker `batch_trend` pool should raise `pool_only_cells`.

## Noise safety net
Pool candidates still pass the existing **off-language / blocklist / shorts** gates (CP455 noise was the cosine path; this is lexical ts_rank, gold/silver only).

## Measure (same as P1)
Batch-free window (avoid 16:30/04:30 KST ±15m — batch shares the SEARCH key pool) → 1-click add-cards → compare `pool_only_cells` 2/8 → ? + GCP search delta + trace `v5_pool_backfill`.

## Rollback
Delete the `V5_POOL_SOURCE` line → code default `v2_promoted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)