### PR TITLE
feat(pool): video_pool ToS hygiene job — soft-expire + scrub (CP494 P0)

### DIFF
--- a/.github/workflows/pool-maintenance.yml
+++ b/.github/workflows/pool-maintenance.yml
@@ -1,0 +1,60 @@
+name: pool-maintenance
+
+# CP494 — video_pool ToS hygiene. POSTs to the internal pool-maintenance
+# endpoint on prod; the API container runs two 0-quota DB ops in the
+# background (fire-and-forget pg-boss job):
+#   1. soft-expire  — is_active=false for rows past expires_at (decoupled from
+#      the batch-video-collector success path, which skips its inline copy on
+#      quota-exhaustion / empty-trend days).
+#   2. scrub        — NULL/blank stored YouTube metadata >30 days old
+#      (refreshed_at), keeping video_id + embeddings. Satisfies the YouTube
+#      Developer Policy "refresh OR delete within 30 days".
+#
+# No YouTube quota. Trigger: 03:13 UTC daily (= 12:13 KST), clear of the
+# batch-video-collector windows (07:30 / 19:30 UTC).
+#
+# Manual: `gh workflow run pool-maintenance.yml`.
+#
+# Secrets required:
+#   - INTERNAL_BATCH_TOKEN — shared token matching prod /opt/tubearchive/.env.
+#   - DOMAIN               — already used by Deploy (e.g. insighta.one).
+
+on:
+  schedule:
+    - cron: '13 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    name: Trigger pool-maintenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check secrets
+        run: |
+          if [ -z "${{ secrets.INTERNAL_BATCH_TOKEN }}" ]; then
+            echo "::error::INTERNAL_BATCH_TOKEN is not configured"
+            exit 1
+          fi
+          if [ -z "${{ secrets.DOMAIN }}" ]; then
+            echo "::error::DOMAIN is not configured"
+            exit 1
+          fi
+
+      - name: Run pool-maintenance (soft-expire + scrub)
+        env:
+          TOKEN: ${{ secrets.INTERNAL_BATCH_TOKEN }}
+          DOMAIN: ${{ secrets.DOMAIN }}
+        run: |
+          echo "POST → https://${DOMAIN}/api/v1/internal/pool-maintenance/run"
+          RESPONSE=$(curl -sS --fail --show-error \
+            --max-time 60 \
+            -X POST "https://${DOMAIN}/api/v1/internal/pool-maintenance/run" \
+            -H "content-type: application/json" \
+            -H "x-internal-token: $TOKEN" \
+            -d '{"trigger":"gha-schedule"}')
+          echo "Response: $RESPONSE"
+          echo "$RESPONSE" | jq -e '.accepted == true' >/dev/null || {
+            echo "::error::pool-maintenance enqueue not accepted"
+            exit 1
+          }

--- a/src/api/routes/internal/pool-maintenance.ts
+++ b/src/api/routes/internal/pool-maintenance.ts
@@ -1,0 +1,56 @@
+/**
+ * Internal trigger for the pool-maintenance job (CP494, YouTube ToS hygiene).
+ *
+ * Protected by the shared `INTERNAL_BATCH_TOKEN` so the GitHub Actions cron can
+ * invoke it without a user JWT. Fire-and-forget: enqueues a pg-boss job and
+ * ACKs in milliseconds (the two UPDATEs run in the background worker).
+ *
+ * POST /api/v1/internal/pool-maintenance/run
+ *   Headers: x-internal-token: <token>
+ *   Body: { trigger?: string }
+ *   Response (202): { success: true, accepted: true, jobId: string }
+ */
+
+import type { FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
+import { enqueuePoolMaintenanceRun } from '@/modules/queue';
+import { getInternalBatchToken } from '@/config/internal-auth';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'api/internal/pool-maintenance' });
+
+function verifyInternalToken(request: FastifyRequest, reply: FastifyReply): boolean {
+  const expected = getInternalBatchToken();
+  if (!expected) {
+    log.warn('INTERNAL_BATCH_TOKEN not set — refusing to serve');
+    void reply.code(503).send({ error: 'internal trigger not configured' });
+    return false;
+  }
+  const got = request.headers['x-internal-token'];
+  if (typeof got !== 'string' || got !== expected) {
+    log.warn('internal route rejected: bad token');
+    void reply.code(401).send({ error: 'invalid internal token' });
+    return false;
+  }
+  return true;
+}
+
+export const internalPoolMaintenanceRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post<{ Body: { trigger?: string } }>('/pool-maintenance/run', async (request, reply) => {
+    if (!verifyInternalToken(request, reply)) return reply;
+
+    const trigger = request.body?.trigger ?? 'http';
+    try {
+      const jobId = await enqueuePoolMaintenanceRun({ trigger });
+      if (!jobId) {
+        log.error('enqueue returned null jobId');
+        return reply.code(500).send({ success: false, error: 'failed to enqueue' });
+      }
+      log.info('pool-maintenance: enqueued', { jobId, trigger });
+      return reply.code(202).send({ success: true, accepted: true, jobId });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`pool-maintenance enqueue failed: ${msg}`);
+      return reply.code(500).send({ success: false, error: msg });
+    }
+  });
+};

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -34,6 +34,7 @@ import { billingRoutes } from './routes/billing';
 import ogRoutes from './routes/og';
 import { internalBatchVideoCollectorRoutes } from './routes/internal/batch-video-collector';
 import { internalTrendCollectorRoutes } from './routes/internal/trend-collector';
+import { internalPoolMaintenanceRoutes } from './routes/internal/pool-maintenance';
 import { internalTranscriptRoutes } from './routes/internal/transcript';
 import { internalVideosBulkUpsertRoutes } from './routes/internal/videos-bulk-upsert';
 import { v2SummaryPartialPatchRoutes } from './routes/internal/v2-summary-partial-patch';
@@ -359,6 +360,10 @@ export async function buildServer() {
       });
       // CP437 — Mac Mini transcript pipeline (yt-dlp memory-only).
       await instance.register(internalTranscriptRoutes, {
+        prefix: '/internal',
+      });
+      // CP494 — video_pool ToS hygiene (soft-expire + scrub) via GHA cron.
+      await instance.register(internalPoolMaintenanceRoutes, {
         prefix: '/internal',
       });
       // CP438 — Mac Mini new-collector bulk video metadata upsert.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -183,6 +183,13 @@ const envSchema = z.object({
   V3_TRACE_ENABLED: z
     .preprocess((v) => String(v).toLowerCase() === 'true', z.boolean())
     .default(false),
+
+  // CP494 — video_pool ToS hygiene cron (soft-expire + scrub of stale metadata).
+  // Default true: this is a compliance job. Kill-switch only — set 'false' to
+  // pause the maintenance worker (the GHA cron will then no-op at the handler).
+  POOL_MAINTENANCE_ENABLED: z
+    .preprocess((v) => String(v).toLowerCase() !== 'false', z.boolean())
+    .default(true),
 });
 
 type Env = z.infer<typeof envSchema>;
@@ -325,6 +332,11 @@ export const config = {
   // Discover-pipeline tracing (CP457+).
   discoverTracing: {
     enabled: env.V3_TRACE_ENABLED,
+  },
+
+  // video_pool ToS hygiene cron (CP494).
+  poolMaintenance: {
+    enabled: env.POOL_MAINTENANCE_ENABLED,
   },
 
   // Gemini

--- a/src/modules/queue/handlers/pool-maintenance.ts
+++ b/src/modules/queue/handlers/pool-maintenance.ts
@@ -1,0 +1,140 @@
+/**
+ * Pool Maintenance — fire-and-forget worker (CP494, YouTube ToS hygiene).
+ *
+ * Two 0-quota DB ops, run unconditionally on an independent cron so they no
+ * longer depend on the batch-video-collector success path (which skips its
+ * inline soft-expire on early-return / quota-exhaustion days):
+ *
+ *   Op1 soft-expire : is_active=false for rows past expires_at. Robustness —
+ *                     guarantees no expired row is served even on collector-fail
+ *                     days. (The collector keeps its own copy as a backstop.)
+ *   Op2 scrub       : NULL/blank the stored YouTube metadata of rows whose
+ *                     metadata is >30 days old (refreshed_at), keeping video_id
+ *                     + embeddings + domain_tags. Satisfies the YouTube
+ *                     Developer Policy "refresh OR delete within 30 days"
+ *                     (we delete the regulated metadata; video_id is permanently
+ *                     storable). scrub (not hard-DELETE) because
+ *                     video_pool_embeddings/domain_tags cascade-delete on row
+ *                     removal — scrub preserves the expensive 4096d embeddings.
+ *
+ * No YouTube quota, no DDL. Reviving scrubbed rows (re-fetching text) is a
+ * separate P1.1 supply concern, NOT this job.
+ *
+ * Job flow: GHA cron POST → route enqueues `pool-maintenance-run` → this worker.
+ */
+
+import PgBoss from 'pg-boss';
+import { config } from '@/config/index';
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+import { getJobQueue } from '../manager';
+import { JOB_NAMES, POOL_MAINTENANCE_RUN_OPTIONS, type PoolMaintenanceRunPayload } from '../types';
+
+const log = logger.child({ module: 'queue/pool-maintenance' });
+
+const WORKER_CONCURRENCY = 1;
+
+/** ToS metadata age limit — stored YouTube metadata older than this is scrubbed. */
+export const METADATA_TTL_DAYS = 30;
+
+/**
+ * Op1 — deactivate rows past their TTL so they are never served. is_active is
+ * the only serving gate (cache-matcher / hybrid-rerank / pool-provider), so
+ * this is sufficient to keep the served set compliant.
+ */
+export const EXPIRE_SQL = `
+  UPDATE public.video_pool
+     SET is_active = false
+   WHERE is_active = true AND expires_at < now()
+`;
+
+/**
+ * Op2 — scrub regulated YouTube metadata from rows whose metadata is older than
+ * the TTL. NULL where the column is nullable; '' / 0 where NOT NULL (title,
+ * view_count, like_count). video_id / language / quality_tier / embeddings /
+ * domain_tags are preserved. Idempotency guard `title <> ''`: already-scrubbed
+ * rows (title='') are skipped, so re-runs scrub 0 rows.
+ */
+export const SCRUB_SQL = `
+  UPDATE public.video_pool
+     SET title = '', description = NULL, channel_name = NULL, channel_id = NULL,
+         view_count = 0, like_count = 0, duration_seconds = NULL,
+         published_at = NULL, thumbnail_url = NULL
+   WHERE refreshed_at < now() - interval '${METADATA_TTL_DAYS} days' AND title <> ''
+`;
+
+export interface PoolMaintenanceResult {
+  skipped: boolean;
+  expired: number;
+  scrubbed: number;
+}
+
+/**
+ * Minimal raw-exec surface — satisfied by both the real PrismaClient
+ * (`$executeRawUnsafe` returns a PrismaPromise<number>, assignable to
+ * Promise<number>) and a plain jest mock, so the core logic stays DB-free
+ * in tests.
+ */
+export interface RawExecutor {
+  $executeRawUnsafe(query: string, ...values: unknown[]): Promise<number>;
+}
+
+/**
+ * Core logic — pure over an injected raw executor so it is unit-testable
+ * without a DB. Op1 then Op2 (disjoint WHERE clauses; order is immaterial).
+ */
+export async function runPoolMaintenance(
+  prisma: RawExecutor,
+  opts: { enabled: boolean }
+): Promise<PoolMaintenanceResult> {
+  if (!opts.enabled) {
+    return { skipped: true, expired: 0, scrubbed: 0 };
+  }
+  const expired = Number(await prisma.$executeRawUnsafe(EXPIRE_SQL));
+  const scrubbed = Number(await prisma.$executeRawUnsafe(SCRUB_SQL));
+  return { skipped: false, expired, scrubbed };
+}
+
+export async function registerPoolMaintenanceWorker(): Promise<void> {
+  const boss = getJobQueue().getInstance();
+  await boss.work<PoolMaintenanceRunPayload>(
+    JOB_NAMES.POOL_MAINTENANCE_RUN,
+    { teamConcurrency: WORKER_CONCURRENCY, teamSize: 1 },
+    handlePoolMaintenanceRun
+  );
+  log.info('pool-maintenance worker registered', { concurrency: WORKER_CONCURRENCY });
+}
+
+async function handlePoolMaintenanceRun(job: PgBoss.Job<PoolMaintenanceRunPayload>): Promise<void> {
+  const startedAt = Date.now();
+  const enabled = config.poolMaintenance.enabled;
+  log.info('pool-maintenance: starting', { jobId: job.id, enabled, trigger: job.data?.trigger });
+
+  try {
+    const result = await runPoolMaintenance(getPrismaClient(), { enabled });
+    log.info('pool-maintenance: completed', {
+      jobId: job.id,
+      ...result,
+      durationMs: Date.now() - startedAt,
+    });
+  } catch (err) {
+    log.error('pool-maintenance: failed', {
+      jobId: job.id,
+      durationMs: Date.now() - startedAt,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}
+
+/** Enqueue a single pool-maintenance run. Returns the pg-boss job id or null. */
+export async function enqueuePoolMaintenanceRun(
+  payload: PoolMaintenanceRunPayload = {},
+  options?: PgBoss.SendOptions
+): Promise<string | null> {
+  const boss = getJobQueue().getInstance();
+  return boss.send(JOB_NAMES.POOL_MAINTENANCE_RUN, payload, {
+    ...POOL_MAINTENANCE_RUN_OPTIONS,
+    ...options,
+  });
+}

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -14,16 +14,19 @@ export type {
   BatchScanPayload,
   EnrichRichSummaryPayload,
   BatchVideoCollectorRunPayload,
+  PoolMaintenanceRunPayload,
 } from './types';
 export { enqueueEnrichVideo } from './handlers/enrich-video';
 export { enqueueEnrichRichSummary } from './handlers/enrich-rich-summary';
 export { enqueueBatchVideoCollectorRun } from './handlers/batch-video-collector';
+export { enqueuePoolMaintenanceRun } from './handlers/pool-maintenance';
 
 import { getJobQueue } from './manager';
 import { registerEnrichVideoWorker } from './handlers/enrich-video';
 import { registerBatchScanWorker } from './handlers/batch-scan';
 import { registerEnrichRichSummaryWorker } from './handlers/enrich-rich-summary';
 import { registerBatchVideoCollectorWorker } from './handlers/batch-video-collector';
+import { registerPoolMaintenanceWorker } from './handlers/pool-maintenance';
 import { logger } from '../../utils/logger';
 
 /**
@@ -42,6 +45,7 @@ export async function initJobQueue(): Promise<void> {
   await registerBatchScanWorker();
   await registerEnrichRichSummaryWorker();
   await registerBatchVideoCollectorWorker();
+  await registerPoolMaintenanceWorker();
 
-  logger.info('Job queue fully initialized (pg-boss + 4 workers)');
+  logger.info('Job queue fully initialized (pg-boss + 5 workers)');
 }

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -20,6 +20,11 @@ export const JOB_NAMES = {
    * GitHub Actions step when limit=200 takes >180s.
    */
   BATCH_VIDEO_COLLECTOR_RUN: 'batch-video-collector-run',
+  /**
+   * CP494 — video_pool ToS hygiene (independent cron). Soft-expire + scrub of
+   * stale YouTube metadata, decoupled from the collector success path. 0 quota.
+   */
+  POOL_MAINTENANCE_RUN: 'pool-maintenance-run',
 } as const;
 
 export type JobName = (typeof JOB_NAMES)[keyof typeof JOB_NAMES];
@@ -81,6 +86,11 @@ export interface BatchVideoCollectorRunPayload {
   trigger?: string;
 }
 
+/** CP494 — payload for POOL_MAINTENANCE_RUN. Source tag for logs only. */
+export interface PoolMaintenanceRunPayload {
+  trigger?: string;
+}
+
 // ============================================================================
 // Job Options
 // ============================================================================
@@ -131,6 +141,15 @@ export const BATCH_SCAN_OPTIONS = {
 export const BATCH_VIDEO_COLLECTOR_RUN_OPTIONS = {
   retryLimit: 0,
   expireInMinutes: 30,
+} as const;
+
+/**
+ * Pool maintenance: no retries (daily cron is the retry surface). Two bounded
+ * UPDATEs over video_pool — fast, but give headroom for a large scrub backlog.
+ */
+export const POOL_MAINTENANCE_RUN_OPTIONS = {
+  retryLimit: 0,
+  expireInMinutes: 10,
 } as const;
 
 // ============================================================================

--- a/tests/unit/modules/pool-maintenance.test.ts
+++ b/tests/unit/modules/pool-maintenance.test.ts
@@ -1,0 +1,73 @@
+/**
+ * CP494 — pool-maintenance core logic (video_pool ToS hygiene).
+ * Verifies the two 0-quota UPDATEs run when enabled, no-op when disabled,
+ * counts flow through, and the SQL carries the compliance guards
+ * (idempotency `title <> ''`, 30-day TTL, is_active serving gate).
+ */
+
+import {
+  runPoolMaintenance,
+  EXPIRE_SQL,
+  SCRUB_SQL,
+  METADATA_TTL_DAYS,
+} from '@/modules/queue/handlers/pool-maintenance';
+
+function mockPrisma(expired: number, scrubbed: number) {
+  const calls: string[] = [];
+  const $executeRawUnsafe = jest.fn((sql: string) => {
+    calls.push(sql);
+    // First call = EXPIRE, second = SCRUB (handler runs in that order).
+    return Promise.resolve(calls.length === 1 ? expired : scrubbed);
+  });
+  return { prisma: { $executeRawUnsafe }, calls, $executeRawUnsafe };
+}
+
+describe('runPoolMaintenance (CP494)', () => {
+  test('enabled → runs both UPDATEs (expire then scrub), returns counts', async () => {
+    const { prisma, calls, $executeRawUnsafe } = mockPrisma(12, 4644);
+    const res = await runPoolMaintenance(prisma, { enabled: true });
+
+    expect(res).toEqual({ skipped: false, expired: 12, scrubbed: 4644 });
+    expect($executeRawUnsafe).toHaveBeenCalledTimes(2);
+    // Call order: EXPIRE first, SCRUB second.
+    expect(calls[0]).toContain('is_active = false');
+    expect(calls[0]).toContain('expires_at < now()');
+    expect(calls[1]).toContain("title = ''");
+    expect(calls[1]).toContain('refreshed_at < now()');
+  });
+
+  test('disabled → no DB calls, skipped=true', async () => {
+    const { prisma, $executeRawUnsafe } = mockPrisma(99, 99);
+    const res = await runPoolMaintenance(prisma, { enabled: false });
+
+    expect(res).toEqual({ skipped: true, expired: 0, scrubbed: 0 });
+    expect($executeRawUnsafe).not.toHaveBeenCalled();
+  });
+
+  test('SCRUB_SQL is idempotent (guards on empty title) and uses the 30-day TTL', () => {
+    expect(SCRUB_SQL).toContain("title <> ''");
+    expect(SCRUB_SQL).toContain(`${METADATA_TTL_DAYS} days`);
+    // Preserves the FK-cascade assets — must NOT touch video_id / embeddings.
+    expect(SCRUB_SQL).not.toContain('video_id');
+    // Regulated YouTube metadata fields are all cleared.
+    for (const f of [
+      'title',
+      'description',
+      'channel_name',
+      'channel_id',
+      'view_count',
+      'like_count',
+      'duration_seconds',
+      'published_at',
+      'thumbnail_url',
+    ]) {
+      expect(SCRUB_SQL).toContain(f);
+    }
+  });
+
+  test('EXPIRE_SQL only deactivates currently-active rows past expires_at', () => {
+    expect(EXPIRE_SQL).toContain('is_active = false');
+    expect(EXPIRE_SQL).toContain('is_active = true');
+    expect(EXPIRE_SQL).toContain('expires_at < now()');
+  });
+});


### PR DESCRIPTION
## What
Independent `pool-maintenance` cron — two **0-quota, no-DDL** DB ops on `video_pool`, decoupled from the batch-video-collector success path:
- **Op1 soft-expire**: `is_active=false WHERE expires_at < now()` — guarantees no expired row is served even on collector-fail / quota-exhaustion days (`is_active` is the only serving gate: cache-matcher / hybrid-rerank / pool-provider).
- **Op2 scrub**: NULL/blank stored YouTube metadata of rows whose metadata is >30d old (`refreshed_at`), keeping `video_id` + embeddings + domain_tags. Idempotent (`title <> ''` guard).

## Why (prod measured, CP494)
**No standing ToS violation** — 0 served (`is_active=true`) rows are stale/expired; the 4,644 stale rows are all `is_active=false`. This closes two gaps for commercial readiness: (a) intermittent robustness (collector skips its inline soft-expire on failure days), (b) strict-storage gray-zone (stale YouTube metadata retained >30d in DB). YouTube Developer Policy = "refresh OR delete within 30 days" → we delete the regulated metadata; `video_id` is permanently storable.

**scrub, not hard-DELETE**: `video_pool_embeddings` / `video_pool_domain_tags` cascade-delete on row removal (`schema.prisma:2139,2157`) → DELETE would destroy ~4,551 expensive 4096d embeddings. scrub preserves them.

## Wiring
pg-boss job `pool-maintenance-run` + internal endpoint `POST /api/v1/internal/pool-maintenance/run` (`INTERNAL_BATCH_TOKEN`) + GHA cron `pool-maintenance.yml` (03:13 UTC daily, clear of batch windows). Flag `POOL_MAINTENANCE_ENABLED` (default true, kill-switch). Collector's inline soft-expire kept as a backstop.

## Out of scope
Reviving scrubbed rows (re-fetching text via videos.list) = P1.1 supply. **Constraint**: revival MUST restore title/description first (empty title → tsvector miss; old-text embeddings → ghost-match).

## Tests
4 unit (enabled→both UPDATEs / disabled→no-op / scrub idempotency+30d-TTL+field-guards / expire serving-gate). tsc clean. (queue-handlers.test `initJobQueue` failure is **pre-existing** — `logger.child` mock issue, confirmed via stash A/B, unrelated.)

## Done = prod verified
Post-deploy 1 run → `SELECT count(*) WHERE refreshed_at < now()-30d AND title<>''` → 0 + `still_expired_active=0`.

Design: `docs/design/v5-pool-displacement-p1.1-cp494.md` (local — `docs/design/` is gitignored, see PR discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)