### PR TITLE
feat(v5): reuse loop — return picked live discoveries to video_pool (V5_REUSE_LOOP, default off)

### DIFF
--- a/src/modules/video-pool/reuse-from-v5.ts
+++ b/src/modules/video-pool/reuse-from-v5.ts
@@ -25,13 +25,14 @@ import { Prisma } from '@prisma/client';
 import { classifyQuality } from '@/skills/plugins/batch-video-collector/quality';
 import { shortGateFields } from '@/modules/video-pool/is-short';
 import { getPrismaClient } from '@/modules/database/client';
+import { MS_PER_DAY } from '@/utils/time-constants';
 import { logger } from '@/utils/logger';
 
 const log = logger.child({ module: 'video-pool/reuse-from-v5' });
 
 export const REUSE_SOURCE = 'user_live';
 const TTL_DAYS = 30;
-const ttlFromNow = () => new Date(Date.now() + TTL_DAYS * 24 * 60 * 60 * 1000);
+const ttlFromNow = () => new Date(Date.now() + TTL_DAYS * MS_PER_DAY);
 
 /** Minimal picked-card shape (structural — avoids importing V5Card from executor). */
 export interface ReuseCard {

--- a/src/modules/video-pool/reuse-from-v5.ts
+++ b/src/modules/video-pool/reuse-from-v5.ts
@@ -1,0 +1,188 @@
+/**
+ * Reuse loop (CP494, keystone) — return v5 live-discovered picks to video_pool.
+ *
+ * v5 (wizard + add-cards) discovers videos via live search.list but never wrote
+ * them back to the pool (DIAG7a), so user A's discovery vanished and user B
+ * re-searched → user↑ = API↑ linear. This closes the loop: the PICKED cards
+ * (LLM-chosen, videos.list-enriched = full metadata) are upserted to video_pool
+ * with source='user_live' so the next request's pool-first match reuses them.
+ *
+ * Scope (CP494 decisions):
+ *   - picked only (survivors are search snippet, no view/duration → can't quality-gate).
+ *   - source='user_live' (user_* convention; provenance distinct → reuse contribution
+ *     is measurable). Consumer (v5 poolSources) reads it ONLY when V5_REUSE_LOOP=on.
+ *   - embeddings deferred (tsvector(title/desc) matches immediately; dense rerank
+ *     via a later embed backfill). No embedding write here.
+ *   - blast radius: upsert keyed by video_id; update NEVER overwrites source
+ *     (preserves a more-authoritative existing source like v2_promoted), only
+ *     refreshes freshness + revives (is_active) + restores scrubbed title/desc.
+ *   - fire-and-forget at the call site → zero hot-path impact (12s add-cards cap).
+ *
+ * Flag-gated by V5_REUSE_LOOP (default off → no write, current behavior).
+ */
+
+import { Prisma } from '@prisma/client';
+import { classifyQuality } from '@/skills/plugins/batch-video-collector/quality';
+import { shortGateFields } from '@/modules/video-pool/is-short';
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'video-pool/reuse-from-v5' });
+
+export const REUSE_SOURCE = 'user_live';
+const TTL_DAYS = 30;
+const ttlFromNow = () => new Date(Date.now() + TTL_DAYS * 24 * 60 * 60 * 1000);
+
+/** Minimal picked-card shape (structural — avoids importing V5Card from executor). */
+export interface ReuseCard {
+  videoId: string;
+  title: string;
+  channelTitle: string;
+  channelId: string;
+  thumbnailUrl: string;
+  publishedAt: string | null;
+  durationSec: number | null;
+  viewCount: number | null;
+}
+
+export interface ReuseInput {
+  cards: ReadonlyArray<ReuseCard>;
+  /** survivor fanout candidates (carry description that V5Card drops). */
+  fanoutById: Map<string, { description?: string | null }>;
+  /** videos.list full metadata (carries like_count that V5Card drops). */
+  metaById: Map<string, { statistics?: { likeCount?: string } }>;
+  language: 'ko' | 'en';
+}
+
+interface ShortGate {
+  is_short?: boolean;
+  short_signal?: string;
+  short_probed_at?: Date;
+}
+
+/** Explicit row shapes (named fields → dot-accessible in tests; cast to Prisma at upsert). */
+export interface ReuseCreate extends ShortGate {
+  video_id: string;
+  title: string;
+  description: string | null;
+  channel_name: string | null;
+  channel_id: string | null;
+  view_count: bigint;
+  like_count: bigint;
+  duration_seconds: number | null;
+  published_at: Date | null;
+  thumbnail_url: string | null;
+  language: string;
+  quality_tier: string;
+  source: string;
+  is_active: boolean;
+  expires_at: Date;
+}
+export interface ReuseUpdate {
+  title: string;
+  description: string | null;
+  refreshed_at: Date;
+  expires_at: Date;
+  is_active: boolean;
+  is_short?: boolean;
+}
+
+/**
+ * Pure builder — quality-gate + field assembly for one card. Returns the
+ * create/update payloads, or null when the card fails the quality gate (only
+ * pool-worthy videos are reused). shortGate is injected so this stays DB-free
+ * and unit-testable. Revival: update revives is_active (unless Short) and
+ * restores title/description (a P0-scrubbed row has title='' → fresh live
+ * restores it); source is deliberately omitted from update.
+ */
+export function prepareReuseRow(
+  card: ReuseCard,
+  fanoutById: ReuseInput['fanoutById'],
+  metaById: ReuseInput['metaById'],
+  language: 'ko' | 'en',
+  shortGate: ShortGate
+): { create: ReuseCreate; update: ReuseUpdate } | null {
+  const verdict = classifyQuality({
+    title: card.title,
+    viewCount: card.viewCount,
+    durationSec: card.durationSec,
+  });
+  if (!verdict.accepted || !verdict.tier) return null; // don't pool low-quality / missing-meta picks
+
+  const description = (fanoutById.get(card.videoId)?.description ?? '').slice(0, 5000) || null;
+  const likeRaw = metaById.get(card.videoId)?.statistics?.likeCount;
+  const likeCount = likeRaw != null ? BigInt(likeRaw) : BigInt(0);
+  const title = card.title.slice(0, 5000);
+  const isShort = shortGate.is_short === true;
+
+  return {
+    create: {
+      ...shortGate,
+      video_id: card.videoId,
+      title,
+      description,
+      channel_name: card.channelTitle?.slice(0, 200) || null,
+      channel_id: card.channelId?.slice(0, 30) || null,
+      view_count: card.viewCount != null ? BigInt(card.viewCount) : BigInt(0),
+      like_count: likeCount,
+      duration_seconds: card.durationSec,
+      published_at: card.publishedAt ? new Date(card.publishedAt) : null,
+      thumbnail_url: card.thumbnailUrl || null,
+      language: language.slice(0, 5),
+      quality_tier: verdict.tier,
+      source: REUSE_SOURCE,
+      is_active: !isShort,
+      expires_at: ttlFromNow(),
+    },
+    update: {
+      // Revive + restore scrubbed text + refresh freshness. NEVER touch source.
+      title,
+      description,
+      refreshed_at: new Date(),
+      expires_at: ttlFromNow(),
+      is_active: !isShort, // short re-gate guard (don't revive a Short)
+      ...(shortGate.is_short !== undefined ? { is_short: shortGate.is_short } : {}),
+    },
+  };
+}
+
+/**
+ * Upsert picked cards back to video_pool. Fire-and-forget from the executor —
+ * never awaited in the hot path. Returns counts for logging/tests.
+ */
+export async function reusePickedToPool(
+  input: ReuseInput
+): Promise<{ reused: number; skipped: number }> {
+  const prisma = getPrismaClient();
+  let reused = 0;
+  let skipped = 0;
+  for (const card of input.cards) {
+    try {
+      const shortGate = (await shortGateFields(card.videoId, card.durationSec)) as ShortGate;
+      const row = prepareReuseRow(
+        card,
+        input.fanoutById,
+        input.metaById,
+        input.language,
+        shortGate
+      );
+      if (!row) {
+        skipped += 1;
+        continue;
+      }
+      await prisma.video_pool.upsert({
+        where: { video_id: card.videoId },
+        create: row.create as unknown as Prisma.video_poolUncheckedCreateInput,
+        update: row.update as unknown as Prisma.video_poolUncheckedUpdateInput,
+      });
+      reused += 1;
+    } catch (err) {
+      skipped += 1;
+      log.warn(
+        `reuse upsert failed for ${card.videoId}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+  log.info('reuse-loop done', { reused, skipped, source: REUSE_SOURCE });
+  return { reused, skipped };
+}

--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -60,6 +60,11 @@ const v5EnvSchema = z.object({
   // CP494 — hot-path safety: pool query timeout (ms). On timeout/throw → full
   // live fanout fallback. tsvector on ~1.1k rows is sub-100ms; cap conservatively.
   V5_POOL_TIMEOUT_MS: z.coerce.number().int().min(200).max(5000).default(1500),
+  // CP494 ③ reuse loop (keystone). When on, v5 upserts PICKED live-discovered
+  // cards back to video_pool (source='user_live', fire-and-forget) AND the v5
+  // pool-first match reads 'user_live' so the next request reuses them
+  // (write↔read pair = loop closed). unset = false = no-op (write 0 = current).
+  V5_REUSE_LOOP: booleanFlag.optional().default(false as unknown as string),
 });
 
 export interface V5Config {
@@ -82,6 +87,8 @@ export interface V5Config {
   poolMinPerCell: number;
   /** CP494 — pool query timeout (ms) before full-live fallback. */
   poolTimeoutMs: number;
+  /** CP494 ③ — reuse loop enabled (write picked → pool + read 'user_live'). */
+  reuseLoop: boolean;
 }
 
 let cached: V5Config | null = null;
@@ -100,10 +107,16 @@ export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
     pickerMode: p.V5_PICKER_MODE,
     queryGen: p.V5_QUERY_GEN,
     poolBackfill: p.V5_POOL_BACKFILL,
-    poolSources: p.V5_POOL_SOURCE === 'all' ? ['v2_promoted', 'batch_trend'] : ['v2_promoted'],
+    // CP494 ③ — when reuse loop is on, the pool-first match ALSO reads
+    // 'user_live' so reused picks are consumed next request (loop closed).
+    poolSources: [
+      ...(p.V5_POOL_SOURCE === 'all' ? ['v2_promoted', 'batch_trend'] : ['v2_promoted']),
+      ...(p.V5_REUSE_LOOP ? ['user_live'] : []),
+    ],
     poolSourceLabel: p.V5_POOL_SOURCE,
     poolMinPerCell: p.V5_POOL_MIN_PER_CELL,
     poolTimeoutMs: p.V5_POOL_TIMEOUT_MS,
+    reuseLoop: p.V5_REUSE_LOOP,
   };
   return cached;
 }

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -28,6 +28,7 @@ import { getV5Config } from './config';
 import { getVideoPicker } from '@/modules/llm-picker/registry';
 import { getLlmPickerConfig } from '@/config/llm-picker';
 import { isShortCached, SHORT_MAX_DURATION_SEC } from '@/modules/video-pool/is-short';
+import { reusePickedToPool } from '@/modules/video-pool/reuse-from-v5';
 import type { PickCandidate, PickResult } from '@/modules/llm-picker/types';
 
 const log = logger.child({ module: 'video-discover/v5/executor' });
@@ -320,6 +321,19 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
 
   // 7. Final slice to targetPicks (cards are score-sorted; filter preserved order).
   const finalCards = gatedCards.slice(0, cfg.targetPicks);
+
+  // CP494 ③ reuse loop (keystone) — return picked live discoveries to video_pool
+  // so the next request's pool-first match reuses them (user↑ ≠ API↑). Fire-and-
+  // forget: NEVER awaited → zero hot-path impact (12s add-cards cap). flag-gated;
+  // off = write 0 (current behavior). Consumer reads 'user_live' only when on.
+  if (cfg.reuseLoop && finalCards.length > 0) {
+    void reusePickedToPool({
+      cards: finalCards,
+      fanoutById,
+      metaById,
+      language: input.language,
+    }).catch((e) => log.warn(`reuse-loop failed: ${e instanceof Error ? e.message : String(e)}`));
+  }
 
   return {
     cards: finalCards,

--- a/tests/unit/modules/reuse-from-v5.test.ts
+++ b/tests/unit/modules/reuse-from-v5.test.ts
@@ -1,0 +1,68 @@
+/**
+ * CP494 ③ reuse loop — prepareReuseRow pure builder.
+ * Quality gate, dropped-field re-extraction (description/like_count), source tag,
+ * short re-gate revival guard, scrub-restore (title/desc in update), no source overwrite.
+ */
+
+import { prepareReuseRow, REUSE_SOURCE } from '@/modules/video-pool/reuse-from-v5';
+
+const card = (over = {}) => ({
+  videoId: 'vid12345678',
+  title: '도커 컨테이너 입문 강의',
+  channelTitle: 'devchan',
+  channelId: 'UC_x',
+  thumbnailUrl: 'https://t/x.jpg',
+  publishedAt: '2026-05-01T00:00:00Z',
+  durationSec: 600,
+  viewCount: 50000,
+  ...over,
+});
+const fanout = (desc = '도커 설명') => new Map([['vid12345678', { description: desc }]]);
+const meta = (like = '321') => new Map([['vid12345678', { statistics: { likeCount: like } }]]);
+
+describe('prepareReuseRow (CP494 reuse loop)', () => {
+  test('accepted pick → builds row, source=user_live, re-extracts desc/like, silver tier', () => {
+    const r = prepareReuseRow(card(), fanout(), meta(), 'ko', { is_short: false });
+    expect(r).not.toBeNull();
+    expect(r!.create.source).toBe(REUSE_SOURCE);
+    expect(r!.create.source).toBe('user_live');
+    expect(r!.create.description).toBe('도커 설명'); // re-extracted (V5Card drops it)
+    expect(r!.create.like_count).toBe(BigInt(321)); // re-extracted from metaById
+    expect(r!.create.quality_tier).toBe('silver'); // 50k views
+    expect(r!.create.is_active).toBe(true); // non-short
+    expect(r!.create.video_id).toBe('vid12345678');
+  });
+
+  test('update payload: revives + restores title/desc, but NEVER overwrites source', () => {
+    const r = prepareReuseRow(card(), fanout('새 설명'), meta(), 'ko', { is_short: false });
+    expect(r!.update).not.toHaveProperty('source'); // preserve existing authoritative source
+    expect(r!.update.title).toBe('도커 컨테이너 입문 강의'); // scrub-restore (P0 title='' → fresh)
+    expect(r!.update.description).toBe('새 설명');
+    expect(r!.update.is_active).toBe(true);
+    expect(r!.update.refreshed_at).toBeInstanceOf(Date);
+    expect(r!.update.expires_at).toBeInstanceOf(Date);
+  });
+
+  test('quality reject (viewCount null = missing meta) → null (not pooled)', () => {
+    expect(prepareReuseRow(card({ viewCount: null }), fanout(), meta(), 'ko', {})).toBeNull();
+  });
+
+  test('quality reject (below view floor) → null', () => {
+    expect(
+      prepareReuseRow(card({ viewCount: 50 }), fanout(), meta(), 'ko', { is_short: false })
+    ).toBeNull();
+  });
+
+  test('short re-gate guard: is_short=true → is_active=false in both create and update', () => {
+    const r = prepareReuseRow(card(), fanout(), meta(), 'ko', { is_short: true });
+    expect(r!.create.is_active).toBe(false);
+    expect(r!.update.is_active).toBe(false);
+    expect(r!.update.is_short).toBe(true);
+  });
+
+  test('missing fanout/meta → description null, like 0 (graceful)', () => {
+    const r = prepareReuseRow(card(), new Map(), new Map(), 'ko', { is_short: false });
+    expect(r!.create.description).toBeNull();
+    expect(r!.create.like_count).toBe(BigInt(0));
+  });
+});


### PR DESCRIPTION
## What (CP494 ③ keystone)
v5 (wizard + add-cards) discovered videos via live search.list but **never wrote them back** (DIAG7a) → user A's discovery vanished, user B re-searched → **user↑ = API↑ linear**. This closes the loop: PICKED cards (LLM-chosen, videos.list-enriched) are upserted to `video_pool` (`source='user_live'`, fire-and-forget) AND the v5 pool-first match reads `'user_live'` when the flag is on → next request reuses them. **write↔read pair = loop closed** (distinct source → measurable).

## Verified (dev write↔read keystone proof)
```
WRITE: reusePickedToPool → 3 user_live rows (silver/gold/silver, is_active=true)
READ:  tsvectorKeywordCandidates(sources=['user_live']) → matched the 도커 rows (cell0/cell1);
       unrelated 쿠버네티스 row correctly NOT matched
VERDICT: loop_closed=true   (cleanup: rows deleted)
```
Data-layer closure proven on dev DB. End-to-end savings (poolOnlyCells↑/units↓) deferred to ⑤ cumulative measurement (with ②④, avoids per-stage full runs).

## Design
- new `reuse-from-v5.ts` (promote-from-v2 pattern, blast-isolated). picked only (survivors = snippet, no view/duration). classifyQuality recalc; description/like_count re-extracted (V5Card drops them); embeddings deferred (tsvector matches immediately).
- upsert keyed by video_id; **update never overwrites source** (preserves authoritative source); revives is_active (short re-gate guard) + restores scrubbed title/desc (P0 interaction) + refreshes expires_at.
- fire-and-forget at executor seam → zero hot-path impact (12s cap).
- **flag `V5_REUSE_LOOP` default off** (= write 0 = current). MVP: v5 poolSources only (write↔read pair); v3/cache-matcher source extension deferred to avoid read-without-write asymmetry.

## Tests
6 unit (quality gate / source=user_live / desc+like re-extract / short revival guard / scrub-restore / no source overwrite) + dev integration (above). tsc clean, video-discover 67/67.

## Rollback
flag default off → merge is behavior-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)