### PR TITLE
feat(v5): full-cell skip — don't search cells already filled (V5_CELL_SKIP, default off)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -36,6 +36,8 @@ import { resolveAlgorithm } from '@/modules/search/algorithm-resolver';
 import { getExcludedVideoIds } from '@/modules/exclude/excluded-videos';
 import { withTraceContext, recordTrace, getTraceContext } from '@/modules/discover-tracing';
 import { runV5Executor } from '@/skills/plugins/video-discover/v5/executor';
+import { getV5Config } from '@/skills/plugins/video-discover/v5/config';
+import { getFullCellIndices } from '@/modules/mandala/cell-fill';
 import { randomUUID } from 'node:crypto';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -273,6 +275,17 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           const focusTags = buildEphemeralFocusTags(mandalaMeta?.focus_tags, extraKeywords);
           const targetLevel = mandalaMeta?.target_level ?? 'standard';
 
+          // CP494 ④-1 full-cell skip — don't search cells the user already
+          // filled (≥ threshold). flag-gated; off → undefined → search all.
+          // DB error → [] (safe: no skip). fire-before to keep it off the
+          // executor's hot-path measurement.
+          const v5cfg = getV5Config(process.env);
+          const fullCellIndices = v5cfg.cellSkip
+            ? await getFullCellIndices(prisma, userId, mandalaId, v5cfg.cellSkipThreshold).catch(
+                () => [] as number[]
+              )
+            : undefined;
+
           const v5Result = await runV5Executor({
             centerGoal,
             subGoals,
@@ -281,6 +294,7 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             language,
             excludeVideoIds: excludeSet,
             env: process.env,
+            fullCellIndices,
             // CP491 ROI1 — push the date filter into search.list so YouTube
             // returns date-valid candidates instead of fetch-then-discard at
             // the post-pick filter below. Post-pick filter retained as a
@@ -401,6 +415,8 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               // 100 spent vs poolOnlyCells × 100 saved), poolQueryMs latency, and
               // poolOnlyCells (Fork-2(A) 100%-lexical quality tradeoff surface).
               v5_pool_backfill: v5Result.diagnostics.poolBackfill,
+              // CP494 ④-1 — cell queries skipped (cell already ≥ threshold full).
+              v5_skipped_full_cells: v5Result.diagnostics.skippedFullCells,
               // CP491 F5c — per-query raw count + q_ok (parity with wizard.discover.end).
               v5_per_query: v5Result.diagnostics.perQuery,
               // CP491 — Shorts dropped by the post-pick short gate (before→after observability).

--- a/src/modules/mandala/cell-fill.ts
+++ b/src/modules/mandala/cell-fill.ts
@@ -1,0 +1,65 @@
+/**
+ * Per-cell card-fill counting (CP494 ④-1 full-cell skip).
+ *
+ * Mirrors MandalaManager.computeCardCount's "grid card" definition
+ * (user_local_cards ∪ user_video_states, cell_index >= 0, non-scratchpad,
+ * dedup by video_id/url) but GROUPed BY cell_index, so add-cards can skip
+ * searching cells the user has already filled. Uses the existing
+ * idx_user_video_states_auto_add_lookup [mandala_id, cell_index, auto_added].
+ *
+ * READ-ONLY. Threshold filter is applied in JS (not SQL HAVING) so it is
+ * unit-testable with a mocked client.
+ */
+
+/** Minimal raw-query surface (real PrismaClient + jest mock both satisfy it). */
+export interface CellCountClient {
+  $queryRaw<T = unknown>(query: TemplateStringsArray, ...values: unknown[]): Promise<T>;
+}
+
+interface CellCountRow {
+  cell_index: number;
+  c: number;
+}
+
+/**
+ * Return the cellIndices (0-7) whose grid-card count is >= threshold. These
+ * cells are "full enough" → add-cards skips searching them (pool + live).
+ * Empty / sparse cells are not returned (normal search proceeds).
+ */
+export async function getFullCellIndices(
+  prisma: CellCountClient,
+  userId: string,
+  mandalaId: string,
+  threshold: number
+): Promise<number[]> {
+  const rows = await prisma.$queryRaw<CellCountRow[]>`
+    WITH all_cards AS (
+      SELECT cell_index, COALESCE(video_id, url) AS dedup_key
+        FROM public.user_local_cards
+       WHERE user_id = ${userId}::uuid
+         AND mandala_id = ${mandalaId}::uuid
+         AND cell_index IS NOT NULL AND cell_index >= 0
+         AND (level_id IS NULL OR level_id <> 'scratchpad')
+      UNION
+      SELECT uvs.cell_index, yv.youtube_video_id AS dedup_key
+        FROM public.user_video_states uvs
+        JOIN public.youtube_videos yv ON yv.id = uvs.video_id
+       WHERE uvs.user_id = ${userId}::uuid
+         AND uvs.mandala_id = ${mandalaId}::uuid
+         AND uvs.cell_index >= 0
+         AND uvs.level_id <> 'scratchpad'
+    )
+    SELECT cell_index, COUNT(DISTINCT dedup_key)::int AS c
+    FROM all_cards
+    GROUP BY cell_index
+  `;
+  return filterFullCells(rows, threshold);
+}
+
+/** Pure threshold filter — exported for unit tests. */
+export function filterFullCells(rows: CellCountRow[], threshold: number): number[] {
+  return rows.filter((r) => r.c >= threshold).map((r) => r.cell_index);
+}
+
+/** Re-export the row type for callers/tests. */
+export type { CellCountRow };

--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -65,6 +65,14 @@ const v5EnvSchema = z.object({
   // pool-first match reads 'user_live' so the next request reuses them
   // (write↔read pair = loop closed). unset = false = no-op (write 0 = current).
   V5_REUSE_LOOP: booleanFlag.optional().default(false as unknown as string),
+  // CP494 ④-1 full-cell skip. When on, add-cards skips searching (pool + live)
+  // any cell whose existing grid-card count ≥ V5_CELL_SKIP_THRESHOLD — no
+  // candidate generation for "full enough" cells (pure quota/latency save; the
+  // cell's cards are already excluded anyway). unset = false = no-op.
+  V5_CELL_SKIP: booleanFlag.optional().default(false as unknown as string),
+  // CP494 ④-1 — per-cell "full" threshold. ≥ this many grid cards → skip.
+  // 12 favors "user may want to see more" (cells with 7-11 still searched).
+  V5_CELL_SKIP_THRESHOLD: z.coerce.number().int().min(1).max(60).default(12),
 });
 
 export interface V5Config {
@@ -89,6 +97,10 @@ export interface V5Config {
   poolTimeoutMs: number;
   /** CP494 ③ — reuse loop enabled (write picked → pool + read 'user_live'). */
   reuseLoop: boolean;
+  /** CP494 ④-1 — full-cell skip enabled. */
+  cellSkip: boolean;
+  /** CP494 ④-1 — per-cell card count threshold for skip. */
+  cellSkipThreshold: number;
 }
 
 let cached: V5Config | null = null;
@@ -117,6 +129,8 @@ export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
     poolMinPerCell: p.V5_POOL_MIN_PER_CELL,
     poolTimeoutMs: p.V5_POOL_TIMEOUT_MS,
     reuseLoop: p.V5_REUSE_LOOP,
+    cellSkip: p.V5_CELL_SKIP,
+    cellSkipThreshold: p.V5_CELL_SKIP_THRESHOLD,
   };
   return cached;
 }

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -52,6 +52,11 @@ export interface V5ExecuteInput {
    * uses them verbatim and skips its own query-gen. Undefined = legacy.
    */
   precomputedQueries?: PrecomputedQuery[];
+  /**
+   * CP494 ④-1 — cellIndices already filled (≥ threshold) → fanout skips them
+   * (pool + live). Computed by the caller (add-cards). Undefined = search all.
+   */
+  fullCellIndices?: number[];
 }
 
 export interface V5Card {
@@ -115,6 +120,8 @@ export interface V5ExecuteResult {
     offLangDropped: number;
     /** CP494 — pool-first backfill telemetry (quota delta + Fork-2 quality surface). */
     poolBackfill: PoolBackfillMeta;
+    /** CP494 ④-1 — # cell queries skipped (cell already full). */
+    skippedFullCells: number;
   };
 }
 
@@ -147,6 +154,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
     env: input.env,
     publishedAfter: input.publishedAfter,
     precomputedQueries: input.precomputedQueries,
+    fullCellIndices: input.fullCellIndices,
   });
   // CP492 Track-1 — split query-gen out of fanout. fanoutMs is now search-only.
   // `?? 0` guards older/mocked FanoutResults that predate the queryGenMs field.
@@ -356,6 +364,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       queryGen: fanout.queryGen,
       offLangDropped: fanout.offLangDropped ?? 0,
       poolBackfill: fanout.poolBackfill,
+      skippedFullCells: fanout.skippedFullCells,
     },
   };
 }
@@ -370,6 +379,7 @@ function emptyResult(args: {
     queryGen: QueryGenMeta;
     offLangDropped?: number;
     poolBackfill: PoolBackfillMeta;
+    skippedFullCells?: number;
   };
   afterTitleFilter: number;
   afterExcludeFilter: number;
@@ -401,6 +411,7 @@ function emptyResult(args: {
       queryGen: args.fanout.queryGen,
       offLangDropped: args.fanout.offLangDropped ?? 0,
       poolBackfill: args.fanout.poolBackfill,
+      skippedFullCells: args.fanout.skippedFullCells ?? 0,
     },
   };
 }

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -54,6 +54,12 @@ export interface FanoutInput {
    * call), preserving the goal-structure context. Absent = legacy query-gen.
    */
   precomputedQueries?: PrecomputedQuery[];
+  /**
+   * CP494 ④-1 — cellIndices the user has already filled (≥ threshold). Their
+   * queries are dropped upstream of the pool gate (searched neither pool nor
+   * live). Empty/absent = search all cells (current behavior).
+   */
+  fullCellIndices?: number[];
 }
 
 export interface FanoutCandidate {
@@ -92,6 +98,8 @@ export interface FanoutResult {
   offLangDropped: number;
   /** CP494 — pool-first backfill telemetry (quota delta + Fork-2 quality tradeoff). */
   poolBackfill: PoolBackfillMeta;
+  /** CP494 ④-1 — # of cell queries skipped because the cell was already full. */
+  skippedFullCells: number;
 }
 
 /**
@@ -256,6 +264,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       queryGen: RULE_QUERY_GEN_META(0),
       offLangDropped: 0,
       poolBackfill: POOL_BACKFILL_OFF(0),
+      skippedFullCells: 0,
     };
   }
 
@@ -317,6 +326,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       queryGen,
       offLangDropped: 0,
       poolBackfill: POOL_BACKFILL_OFF(0),
+      skippedFullCells: 0,
     };
   }
 
@@ -326,9 +336,20 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
   // (non-negotiable): timeout + try/catch → ANY failure falls back to full live
   // fanout. Pool candidates pass the SAME blocklist/shorts/off-language gates as
   // live below (lexical match = supplier; existing gates = quality judge).
-  let liveQueries: SearchQuery[] = queries;
+  // CP494 ④-1 full-cell skip — drop queries for cells the user already filled
+  // (≥ threshold), UPSTREAM of the pool gate so the cell is searched neither in
+  // pool nor live. Separate counter (not pool 'satisfied') → no meta pollution.
+  const fullCellSet = new Set<number>(input.fullCellIndices ?? []);
+  const skippedFullCells = fullCellSet.size
+    ? queries.filter((q) => q.cellIndex != null && fullCellSet.has(q.cellIndex)).length
+    : 0;
+  const activeQueries: SearchQuery[] = fullCellSet.size
+    ? queries.filter((q) => !(q.cellIndex != null && fullCellSet.has(q.cellIndex)))
+    : queries;
+
+  let liveQueries: SearchQuery[] = activeQueries;
   const poolSeed: FanoutCandidate[] = [];
-  let poolMeta: PoolBackfillMeta = POOL_BACKFILL_OFF(queries.length);
+  let poolMeta: PoolBackfillMeta = POOL_BACKFILL_OFF(activeQueries.length);
   if (cfg.poolBackfill) {
     const tPool0 = Date.now();
     try {
@@ -358,7 +379,9 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
         poolSeed.push(...cands);
         if (cands.length >= cfg.poolMinPerCell) satisfied.add(ci);
       }
-      liveQueries = queries.filter((q) => !(q.cellIndex != null && satisfied.has(q.cellIndex)));
+      liveQueries = activeQueries.filter(
+        (q) => !(q.cellIndex != null && satisfied.has(q.cellIndex))
+      );
       poolMeta = {
         enabled: true,
         fellBackToLive: false,
@@ -369,8 +392,8 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
         source: cfg.poolSourceLabel,
       };
     } catch (err) {
-      // Hot-path safety: any pool failure → full live fanout (current behavior).
-      liveQueries = queries;
+      // Hot-path safety: any pool failure → full live fanout (active cells only).
+      liveQueries = activeQueries;
       poolSeed.length = 0;
       poolMeta = {
         enabled: true,
@@ -378,7 +401,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
         poolQueryMs: Date.now() - tPool0,
         poolCandidates: 0,
         poolOnlyCells: 0,
-        liveCells: queries.length,
+        liveCells: activeQueries.length,
         source: cfg.poolSourceLabel,
       };
       log.warn(
@@ -480,6 +503,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
     queryGen,
     offLangDropped,
     poolBackfill: poolMeta,
+    skippedFullCells,
   };
 }
 

--- a/tests/unit/modules/cell-fill.test.ts
+++ b/tests/unit/modules/cell-fill.test.ts
@@ -1,0 +1,32 @@
+/**
+ * CP494 ④-1 — per-cell fill counting. filterFullCells (pure threshold) +
+ * getFullCellIndices (mocked client → JS-side threshold).
+ */
+
+import { filterFullCells, getFullCellIndices } from '@/modules/mandala/cell-fill';
+
+describe('cell-fill (CP494 ④-1)', () => {
+  test('filterFullCells: returns only cells at/above threshold', () => {
+    const rows = [
+      { cell_index: 0, c: 15 },
+      { cell_index: 1, c: 5 },
+      { cell_index: 2, c: 12 }, // exactly threshold
+      { cell_index: 3, c: 11 }, // just below
+    ];
+    expect(filterFullCells(rows, 12)).toEqual([0, 2]);
+  });
+
+  test('filterFullCells: empty when none reach threshold', () => {
+    expect(filterFullCells([{ cell_index: 0, c: 3 }], 12)).toEqual([]);
+  });
+
+  test('getFullCellIndices: queries once, applies threshold to returned counts', async () => {
+    const $queryRaw = jest.fn().mockResolvedValue([
+      { cell_index: 4, c: 20 },
+      { cell_index: 5, c: 8 },
+    ]);
+    const out = await getFullCellIndices({ $queryRaw } as never, 'u', 'm', 12);
+    expect($queryRaw).toHaveBeenCalledTimes(1);
+    expect(out).toEqual([4]); // 20 >= 12, 8 < 12
+  });
+});

--- a/tests/unit/skills/video-discover/v5-cell-skip.test.ts
+++ b/tests/unit/skills/video-discover/v5-cell-skip.test.ts
@@ -1,0 +1,87 @@
+/**
+ * CP494 ④-1 — fanout full-cell skip. Cells in fullCellIndices are searched
+ * neither in pool nor live (queries dropped upstream). Separate counter
+ * (skippedFullCells), distinct from pool-backfill meta.
+ */
+
+import { runYouTubeFanout } from '@/skills/plugins/video-discover/v5/youtube-fanout';
+import { resetV5ConfigForTest } from '@/skills/plugins/video-discover/v5/config';
+
+jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
+  searchVideos: jest.fn(),
+  resolveSearchApiKeys: jest.fn().mockReturnValue(['key1']),
+  titleIndicatesShorts: jest.fn().mockReturnValue(false),
+  titleHitsBlocklist: jest.fn().mockReturnValue(false),
+}));
+jest.mock('@/skills/plugins/video-discover/v3/hybrid-rerank', () => ({
+  tsvectorKeywordCandidates: jest.fn(),
+}));
+
+const { searchVideos } = jest.requireMock('@/skills/plugins/video-discover/v2/youtube-client');
+
+function items(prefix: string) {
+  return [
+    {
+      id: { videoId: `${prefix}_0` },
+      snippet: {
+        title: `T${prefix}`,
+        description: 'd',
+        channelTitle: 'c',
+        channelId: 'ch',
+        publishedAt: '2026-01-01T00:00:00Z',
+        thumbnails: { high: { url: 'u' } },
+      },
+    },
+  ];
+}
+
+function input(fullCellIndices?: number[]) {
+  return {
+    centerGoal: 'goal',
+    subGoals: ['a', 'b', 'c'],
+    focusTags: [],
+    targetLevel: 'standard',
+    language: 'en' as const,
+    env: {} as NodeJS.ProcessEnv, // pool-backfill off (default) → live path only
+    precomputedQueries: [
+      { cellIndex: 0, query: 'q0' },
+      { cellIndex: 1, query: 'q1' },
+      { cellIndex: 2, query: 'q2' },
+    ],
+    fullCellIndices,
+  };
+}
+
+describe('runYouTubeFanout — CP494 ④-1 full-cell skip', () => {
+  beforeEach(() => {
+    resetV5ConfigForTest();
+    searchVideos.mockReset();
+    searchVideos.mockImplementation(({ query }: { query: string }) =>
+      Promise.resolve(items(query))
+    );
+  });
+
+  test('no fullCellIndices → all cells searched, skippedFullCells=0', async () => {
+    const res = await runYouTubeFanout(input());
+    expect(searchVideos).toHaveBeenCalledTimes(3);
+    expect(res.skippedFullCells).toBe(0);
+    expect(res.queriesAttempted).toBe(3);
+  });
+
+  test('full cell dropped: cell 1 not searched (pool nor live), skippedFullCells=1', async () => {
+    const res = await runYouTubeFanout(input([1]));
+    const searched = searchVideos.mock.calls.map((c: [{ query: string }]) => c[0].query).sort();
+    expect(searched).toEqual(['q0', 'q2']); // q1 (cell 1) skipped
+    expect(res.skippedFullCells).toBe(1);
+    expect(res.queriesAttempted).toBe(2);
+    expect(res.quotaUnitsApprox).toBe(200); // 2 live × 100
+  });
+
+  test('all cells full → no search, skippedFullCells=3, empty candidates', async () => {
+    const res = await runYouTubeFanout(input([0, 1, 2]));
+    expect(searchVideos).not.toHaveBeenCalled();
+    expect(res.skippedFullCells).toBe(3);
+    expect(res.queriesAttempted).toBe(0);
+    expect(res.candidates).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
CP494 **④-1 full-cell skip**. When add-cards refills a mandala, skip searching cells the user has **already filled** (>= `V5_CELL_SKIP_THRESHOLD`, default 12) in **both pool and live** fanout. Cuts search.list quota on partial refills (the common case once a mandala matures).

Part of the video-supply redesign: 공급(supply) / 소비(consume) / 재사용(reuse). This is the first **소비(consume)** lever — ③ reuse loop (#852) and P1 pool-backfill (#848) already merged.

## Changes (backend-only, 7 files)
| File | Change |
|---|---|
| `src/modules/mandala/cell-fill.ts` (new) | `getFullCellIndices` (per-cell `COUNT(DISTINCT ...)`, mirrors `computeCardCount`'s grid-card definition: `user_local_cards ∪ user_video_states`, `cell_index >= 0`, non-scratchpad, dedup) + `GROUP BY cell_index`; `filterFullCells` (pure JS threshold, unit-testable) |
| `v5/config.ts` | `V5_CELL_SKIP` (default off) + `V5_CELL_SKIP_THRESHOLD` (default 12) |
| `v5/youtube-fanout.ts` | separate `fullCellSet` filter → `activeQueries` **upstream of both** pool-backfill and live; `skippedFullCells` counter (distinct from pool-backfill meta) |
| `v5/executor.ts` | `V5ExecuteInput.fullCellIndices` passthrough + `diagnostics.skippedFullCells` |
| `src/api/routes/add-cards.ts` | call `getFullCellIndices` when `cfg.cellSkip` + `v5_skipped_full_cells` trace |
| tests | `cell-fill.test.ts` (3) + `v5-cell-skip.test.ts` (3) |

## Safety
- **Flag default off** → no-op (all cells searched = current behavior). Deploy-safe.
- **Rollback** = unset `V5_CELL_SKIP` (code revert not required).
- Separate filter branch → no contamination of pool-backfill meta.

## Verification
- `tsc --noEmit` clean · `hardcode-audit` clean · **9 suites / 69 tests** pass
- **dev SQL proof**: seeded cell 0 with 12 cards → `getFullCellIndices` returns `[0]`; cell 1 with 5 cards → excluded at threshold 12. SQL executes against real dev schema.

## Scope
④-1 "Done" = **skip mechanism** confirmed (SQL + fanout). End-to-end units-down / trace measurement → ⑤ cumulative-measurement phase (consistent with ③'s scope split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)