### PR TITLE
feat(v5): supply bridge — promote youtube_videos into video_pool (SUPPLY_YT_BRIDGE_ENABLED, default off) (CP494 ②)

### DIFF
--- a/src/api/routes/internal/video-pool-promote.ts
+++ b/src/api/routes/internal/video-pool-promote.ts
@@ -1,13 +1,20 @@
 /**
- * Internal video-pool promotion endpoint (CP438, 2026-04-29).
+ * Internal video-pool promotion endpoints.
  *
- *   POST /api/v1/internal/video-pool/promote-from-v2
+ *   POST /api/v1/internal/video-pool/promote-from-v2             (CP438)
+ *   POST /api/v1/internal/video-pool/promote-from-youtube-videos (CP494 ②)
  *   Body: { limit?: number; dry_run?: boolean }
  *   Auth: x-internal-token (same secret as bulk-upsert + transcript).
  *
- * Promotes up to `limit` (default 100) v2-summary rows into `video_pool`.
- * Quality tier from completeness (≥0.9 gold else silver). Embedding via
- * Mac Mini Ollama (qwen3-embedding:8b, fail-open if unreachable).
+ * promote-from-v2: up to `limit` (default 100) v2-summary rows → video_pool.
+ * Quality tier from completeness (≥0.9 gold else silver).
+ *
+ * promote-from-youtube-videos (supply bridge): youtube_videos rows (Mac Mini
+ * quota-0 collector sink) → video_pool, source='yt_promoted'. classifyQuality
+ * gate (gold/silver only). Flag-gated by SUPPLY_YT_BRIDGE_ENABLED (default
+ * off → {enabled:false} no-op; the same flag gates the v5 poolSources read).
+ *
+ * Both: embedding via Mac Mini Ollama (qwen3-embedding:8b, fail-open).
  *
  * Hard Rule (CP438):
  *   - No LLM API call in this path (embedding is local Ollama, not paid API).
@@ -16,8 +23,10 @@
 
 import type { FastifyPluginAsync } from 'fastify';
 
+import { config } from '@/config/index';
 import { getInternalBatchToken } from '@/config/internal-auth';
 import { promoteV2ToVideoPool } from '@/modules/video-pool/promote-from-v2';
+import { promoteYoutubeVideosToPool } from '@/modules/video-pool/promote-from-youtube-videos';
 import { logger } from '@/utils/logger';
 
 const log = logger.child({ module: 'api/internal/video-pool-promote' });
@@ -66,4 +75,51 @@ export const internalVideoPoolPromoteRoutes: FastifyPluginAsync = async (fastify
       return reply.code(500).send({ error: msg.slice(0, 300) });
     }
   });
+
+  // CP494 ② supply bridge — youtube_videos → video_pool (source='yt_promoted').
+  fastify.post<{ Body: PromoteBody }>(
+    '/video-pool/promote-from-youtube-videos',
+    async (request, reply) => {
+      const expected = getInternalBatchToken();
+      if (!expected) {
+        return reply.code(503).send({ error: 'internal trigger not configured' });
+      }
+      const got = request.headers['x-internal-token'];
+      if (typeof got !== 'string' || got !== expected) {
+        return reply.code(401).send({ error: 'invalid internal token' });
+      }
+
+      // Flag off (default) = no-op: prod behavior unchanged until ⑤ 누적측정.
+      if (!config.supplyYtBridge.enabled) {
+        return reply.code(200).send({ enabled: false, promoted: 0 });
+      }
+
+      const limit = Math.max(
+        1,
+        Math.min(MAX_LIMIT, typeof request.body?.limit === 'number' ? request.body.limit : 100)
+      );
+      const dryRun = request.body?.dry_run === true;
+
+      try {
+        const result = await promoteYoutubeVideosToPool({ limit, dryRun });
+        log.info('promote-from-youtube-videos endpoint done', {
+          limit,
+          dry_run: dryRun,
+          ...result,
+          errors: result.errors.length,
+        });
+        return reply.code(200).send({
+          enabled: true,
+          limit,
+          dry_run: dryRun,
+          ...result,
+          errors_sample: result.errors.slice(0, 5),
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error('promote-from-youtube-videos endpoint failed', { err: msg });
+        return reply.code(500).send({ error: msg.slice(0, 300) });
+      }
+    }
+  );
 };

--- a/src/api/routes/internal/videos-bulk-upsert.ts
+++ b/src/api/routes/internal/videos-bulk-upsert.ts
@@ -55,6 +55,11 @@ const BLOCKLIST_TOKENS: readonly string[] = [
 interface VideoMeta {
   youtube_video_id?: string;
   title?: string;
+  /** CP494 ② — full description from videos.list snippet (was dropped at
+   *  extraction). Populates youtube_videos.description → video_pool tsvector. */
+  description?: string | null;
+  /** CP494 ② — UC* channel id (snippet.channelId). */
+  channel_id?: string | null;
   channel_title?: string | null;
   duration_seconds?: number | null;
   view_count?: number | null;
@@ -180,6 +185,8 @@ export const internalVideosBulkUpsertRoutes: FastifyPluginAsync = async (fastify
               INSERT INTO youtube_videos (
                 youtube_video_id,
                 title,
+                description,
+                channel_id,
                 channel_title,
                 duration_seconds,
                 view_count,
@@ -192,6 +199,8 @@ export const internalVideosBulkUpsertRoutes: FastifyPluginAsync = async (fastify
               VALUES (
                 ${v.youtube_video_id},
                 ${v.title},
+                ${v.description ?? null},
+                ${v.channel_id ?? null},
                 ${v.channel_title ?? null},
                 ${v.duration_seconds ?? null},
                 ${v.view_count ?? null},
@@ -202,7 +211,12 @@ export const internalVideosBulkUpsertRoutes: FastifyPluginAsync = async (fastify
                 ${v.source ?? null}
               )
               ON CONFLICT (youtube_video_id) DO UPDATE
-                SET source = COALESCE(EXCLUDED.source, youtube_videos.source)
+                SET source = COALESCE(EXCLUDED.source, youtube_videos.source),
+                    -- CP494 ② — backfill description/channel_id when a re-submit
+                    -- carries them and the existing row is NULL (prefer existing
+                    -- non-null so a stale dump can't blank a populated row).
+                    description = COALESCE(youtube_videos.description, EXCLUDED.description),
+                    channel_id = COALESCE(youtube_videos.channel_id, EXCLUDED.channel_id)
               RETURNING (xmax = 0) AS inserted
             `);
           if (result.length > 0 && result[0]!.inserted) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -190,6 +190,14 @@ const envSchema = z.object({
   POOL_MAINTENANCE_ENABLED: z
     .preprocess((v) => String(v).toLowerCase() !== 'false', z.boolean())
     .default(true),
+
+  // CP494 ② — supply bridge: promote youtube_videos (Mac Mini quota-0 sink)
+  // into video_pool (source='yt_promoted'). ONE flag controls the write↔read
+  // pair: off = promote endpoint no-ops AND v5 poolSources omits 'yt_promoted'
+  // (current behavior, code-revert-free rollback). See v5/config.ts.
+  SUPPLY_YT_BRIDGE_ENABLED: z
+    .preprocess((v) => String(v).toLowerCase() === 'true', z.boolean())
+    .default(false),
 });
 
 type Env = z.infer<typeof envSchema>;
@@ -337,6 +345,11 @@ export const config = {
   // video_pool ToS hygiene cron (CP494).
   poolMaintenance: {
     enabled: env.POOL_MAINTENANCE_ENABLED,
+  },
+
+  // Supply bridge: youtube_videos → video_pool promotion (CP494 ②).
+  supplyYtBridge: {
+    enabled: env.SUPPLY_YT_BRIDGE_ENABLED,
   },
 
   // Gemini

--- a/src/modules/video-pool/promote-from-v2.ts
+++ b/src/modules/video-pool/promote-from-v2.ts
@@ -225,9 +225,10 @@ export async function promoteV2ToVideoPool(opts: PromoteOptions = {}): Promise<P
           title: titleSafe,
           description: descSafe,
           channel_name: channelSafe,
-          // channel_id intentionally null — youtube_videos table doesn't
-          // store the channel UC* id (only channel_title). Could be
-          // backfilled later via a separate metadata-enrich pass.
+          // channel_id intentionally null here — this query doesn't select it.
+          // (youtube_videos DOES have a channel_id column since CP494 ②; the
+          // supply bridge promote-from-youtube-videos.ts carries it. A v2-path
+          // backfill can follow once coverage matters.)
           channel_id: null,
           view_count: c.yv_view_count ?? BigInt(0),
           like_count: c.yv_like_count ?? BigInt(0),

--- a/src/modules/video-pool/promote-from-youtube-videos.ts
+++ b/src/modules/video-pool/promote-from-youtube-videos.ts
@@ -1,0 +1,268 @@
+/**
+ * Promote youtube_videos rows into video_pool (CP494 ② supply bridge MVP).
+ *
+ * The Mac Mini collector (yt-dlp discovery = quota 0, videos.list enrich =
+ * 1u/50 videos) sinks into `youtube_videos`, but the consumption pool
+ * (`video_pool`, what v5 pool-first match reads) never saw those rows —
+ * supply and consumption were two disconnected systems. This bridges them:
+ *
+ *   1. SELECT candidates: youtube_videos with usable metadata
+ *      (title + view_count present) AND NOT already in video_pool.
+ *   2. classifyQuality (batch-video-collector gate, same as reuse-from-v5):
+ *      rejected OR bronze → skip. Consumers read gold/silver only, and the
+ *      Free Plan 500MB budget shouldn't pay for rows nobody reads.
+ *   3. shortGateFields → demote Shorts at promote (CP491 convention).
+ *   4. INSERT video_pool with source='yt_promoted' — create-only (no UPDATE,
+ *      no DELETE; NOT-EXISTS dedup makes re-runs no-ops).
+ *   5. Embedding via Mac Mini Ollama, fail-open (mirrors promote-from-v2:
+ *      unreachable/timeout → promote without embeddings, tsvector still
+ *      matches immediately; dense rerank can backfill later).
+ *
+ * Flag: SUPPLY_YT_BRIDGE_ENABLED (default off) gates the write at the route
+ * (video-pool-promote.ts) AND the read in v5 poolSources (v5/config.ts) —
+ * one flag, write↔read pair, off = current behavior.
+ *
+ * Blast radius: video_pool + video_pool_embeddings INSERT only.
+ */
+
+import { Prisma } from '@prisma/client';
+
+import { getPrismaClient } from '@/modules/database/client';
+import {
+  embedBatch,
+  isOllamaReachable,
+  vectorToLiteral,
+  QWEN3_EMBED_MODEL,
+  MAC_MINI_OLLAMA_DEFAULT_URL,
+} from '@/skills/plugins/iks-scorer/embedding';
+import { classifyQuality } from '@/skills/plugins/batch-video-collector/quality';
+import { logger } from '@/utils/logger';
+import { shortGateFields } from './is-short';
+
+const log = logger.child({ module: 'modules/video-pool/promote-from-youtube-videos' });
+
+export const YT_PROMOTED_SOURCE = 'yt_promoted';
+const DEFAULT_BATCH_LIMIT = 100;
+const TEXT_INPUT_MAX_CHARS = 2000;
+
+export interface YtPromoteResult {
+  candidates: number;
+  promoted: number;
+  embedded: number;
+  gold: number;
+  silver: number;
+  /** classifyQuality accepted but tier=bronze — not pool-worthy (consumers read gold/silver). */
+  skipped_bronze: number;
+  /** classifyQuality rejected (view floor / duration / blocklist / missing metadata). */
+  skipped_rejected: number;
+  embeddings_skipped_unreachable: boolean;
+  errors: { video_id: string; error: string }[];
+}
+
+interface CandidateRow {
+  video_id: string;
+  title: string;
+  description: string | null;
+  channel_title: string | null;
+  channel_id: string | null;
+  view_count: bigint;
+  like_count: bigint | null;
+  duration_seconds: number | null;
+  published_at: Date | null;
+  thumbnail_url: string | null;
+  default_language: string | null;
+}
+
+function buildEmbedText(row: CandidateRow): string {
+  // No v2 one_liner/core_argument here — title + description is the densest
+  // signal youtube_videos carries (same fields the tsvector GIN indexes).
+  const parts: string[] = [row.title];
+  if (row.description) parts.push(row.description);
+  return parts.join('\n').slice(0, TEXT_INPUT_MAX_CHARS);
+}
+
+export interface YtPromoteOptions {
+  /** Max candidates to evaluate per call (default 100, cap 500 at the route). */
+  limit?: number;
+  /** When true, skip writes and return planned action counts only. */
+  dryRun?: boolean;
+  /** Override the Ollama URL (default Mac Mini Tailscale). */
+  ollamaUrl?: string;
+}
+
+export async function promoteYoutubeVideosToPool(
+  opts: YtPromoteOptions = {}
+): Promise<YtPromoteResult> {
+  const limit = Math.max(1, Math.min(500, opts.limit ?? DEFAULT_BATCH_LIMIT));
+  const ollamaUrl = opts.ollamaUrl ?? MAC_MINI_OLLAMA_DEFAULT_URL;
+  const prisma = getPrismaClient();
+
+  // 1. Candidates: usable metadata + not already pooled. Recency-first so a
+  // capped batch drains the freshest supply (collector runs daily).
+  const candidates = await prisma.$queryRaw<CandidateRow[]>(Prisma.sql`
+    SELECT
+      yv.youtube_video_id   AS video_id,
+      yv.title              AS title,
+      yv.description        AS description,
+      yv.channel_title      AS channel_title,
+      yv.channel_id         AS channel_id,
+      yv.view_count         AS view_count,
+      yv.like_count         AS like_count,
+      yv.duration_seconds   AS duration_seconds,
+      yv.published_at       AS published_at,
+      yv.thumbnail_url      AS thumbnail_url,
+      yv.default_language   AS default_language
+    FROM youtube_videos yv
+    WHERE yv.title IS NOT NULL
+      AND yv.view_count IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM video_pool vp WHERE vp.video_id = yv.youtube_video_id
+      )
+    ORDER BY yv.published_at DESC NULLS LAST
+    LIMIT ${limit}
+  `);
+
+  const empty: YtPromoteResult = {
+    candidates: 0,
+    promoted: 0,
+    embedded: 0,
+    gold: 0,
+    silver: 0,
+    skipped_bronze: 0,
+    skipped_rejected: 0,
+    embeddings_skipped_unreachable: false,
+    errors: [],
+  };
+  if (candidates.length === 0) return empty;
+
+  // 2. Quality gate up-front (pure, no I/O) — dryRun shares the exact gate.
+  const gated = candidates.map((c) => ({
+    row: c,
+    verdict: classifyQuality({
+      title: c.title,
+      viewCount: c.view_count != null ? Number(c.view_count) : null,
+      durationSec: c.duration_seconds,
+    }),
+  }));
+  const admissible = gated.filter(
+    (g) => g.verdict.accepted && (g.verdict.tier === 'gold' || g.verdict.tier === 'silver')
+  );
+  const skippedBronze = gated.filter(
+    (g) => g.verdict.accepted && g.verdict.tier === 'bronze'
+  ).length;
+  const skippedRejected = gated.filter((g) => !g.verdict.accepted).length;
+
+  if (opts.dryRun) {
+    return {
+      ...empty,
+      candidates: candidates.length,
+      gold: admissible.filter((g) => g.verdict.tier === 'gold').length,
+      silver: admissible.filter((g) => g.verdict.tier === 'silver').length,
+      skipped_bronze: skippedBronze,
+      skipped_rejected: skippedRejected,
+    };
+  }
+
+  // 5(pre). Embeddings up-front, fail-open (promote-from-v2 mirror).
+  const reachable = await isOllamaReachable({ baseUrl: ollamaUrl });
+  let embeddings: (number[] | null)[] = [];
+  if (reachable) {
+    try {
+      const inputs = admissible.map((g) => buildEmbedText(g.row));
+      embeddings = await embedBatch(inputs, { baseUrl: ollamaUrl });
+      if (embeddings.length !== admissible.length) {
+        log.warn('embed_count_mismatch', {
+          got: embeddings.length,
+          expected: admissible.length,
+        });
+        embeddings = [];
+      }
+    } catch (err) {
+      log.warn('embedBatch failed — continuing without embeddings', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      embeddings = [];
+    }
+  } else {
+    log.warn('Ollama unreachable — promoting without embeddings');
+  }
+
+  // 3+4+5. Insert video_pool (+embeddings) per admissible row.
+  const errors: { video_id: string; error: string }[] = [];
+  let promoted = 0;
+  let embedded = 0;
+  let gold = 0;
+  let silver = 0;
+
+  for (let i = 0; i < admissible.length; i += 1) {
+    const { row: c, verdict } = admissible[i]!;
+    const tier = verdict.tier!;
+    try {
+      const titleSafe = c.title.slice(0, 5000);
+      const descSafe = c.description ? c.description.slice(0, 5000) : null;
+      const channelSafe = c.channel_title ? c.channel_title.slice(0, 200) : null;
+      const channelIdSafe = c.channel_id ? c.channel_id.slice(0, 30) : null;
+      const langSafe = (c.default_language ?? 'ko').slice(0, 5);
+
+      // CP491 — short gate (demote Shorts at promote; consumers filter is_active).
+      const shortGate = await shortGateFields(c.video_id, c.duration_seconds);
+      await prisma.video_pool.create({
+        data: {
+          ...shortGate,
+          video_id: c.video_id,
+          title: titleSafe,
+          description: descSafe,
+          channel_name: channelSafe,
+          channel_id: channelIdSafe,
+          view_count: c.view_count ?? BigInt(0),
+          like_count: c.like_count ?? BigInt(0),
+          duration_seconds: c.duration_seconds,
+          published_at: c.published_at,
+          thumbnail_url: c.thumbnail_url,
+          language: langSafe,
+          quality_tier: tier,
+          source: YT_PROMOTED_SOURCE,
+        },
+      });
+      promoted += 1;
+      if (tier === 'gold') gold += 1;
+      else silver += 1;
+
+      const vec = embeddings[i];
+      if (vec && vec.length > 0) {
+        await prisma.$executeRaw(Prisma.sql`
+          INSERT INTO public.video_pool_embeddings (video_id, embedding, text_input, model_version)
+          VALUES (${c.video_id}, ${vectorToLiteral(vec)}::vector, ${buildEmbedText(c)}, ${QWEN3_EMBED_MODEL})
+          ON CONFLICT (video_id, model_version) DO NOTHING
+        `);
+        embedded += 1;
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push({ video_id: c.video_id, error: msg.slice(0, 200) });
+    }
+  }
+
+  log.info('promote-from-youtube-videos done', {
+    candidates: candidates.length,
+    promoted,
+    embedded,
+    gold,
+    silver,
+    skipped_bronze: skippedBronze,
+    skipped_rejected: skippedRejected,
+    errors: errors.length,
+  });
+
+  return {
+    candidates: candidates.length,
+    promoted,
+    embedded,
+    gold,
+    silver,
+    skipped_bronze: skippedBronze,
+    skipped_rejected: skippedRejected,
+    embeddings_skipped_unreachable: !reachable,
+    errors,
+  };
+}

--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -80,6 +80,12 @@ const v5EnvSchema = z.object({
   // cellIndex comes from the query (no argmax-overlap drop). unset = 'global' =
   // no-op. Only takes effect when V5_POOL_BACKFILL is on.
   V5_POOL_MATCH: z.enum(['global', 'per_cell']).default('global'),
+  // CP494 ② supply bridge — SAME env var the promote endpoint reads
+  // (src/config/index.ts). When on, the pool-first match ALSO reads
+  // 'yt_promoted' rows so bridged supply is consumable (write↔read pair —
+  // the ③ reuse-loop lesson: a pool source nobody reads is a dead write).
+  // unset = false = no-op (poolSources unchanged).
+  SUPPLY_YT_BRIDGE_ENABLED: booleanFlag.optional().default(false as unknown as string),
 });
 
 export interface V5Config {
@@ -130,9 +136,12 @@ export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
     poolBackfill: p.V5_POOL_BACKFILL,
     // CP494 ③ — when reuse loop is on, the pool-first match ALSO reads
     // 'user_live' so reused picks are consumed next request (loop closed).
+    // CP494 ② — when the supply bridge is on, ALSO read 'yt_promoted'
+    // (single flag controls the bridge's write AND this read).
     poolSources: [
       ...(p.V5_POOL_SOURCE === 'all' ? ['v2_promoted', 'batch_trend'] : ['v2_promoted']),
       ...(p.V5_REUSE_LOOP ? ['user_live'] : []),
+      ...(p.SUPPLY_YT_BRIDGE_ENABLED ? ['yt_promoted'] : []),
     ],
     poolSourceLabel: p.V5_POOL_SOURCE,
     poolMinPerCell: p.V5_POOL_MIN_PER_CELL,

--- a/tests/unit/api/video-pool-promote-route.test.ts
+++ b/tests/unit/api/video-pool-promote-route.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Route tests for /internal/video-pool/promote-from-youtube-videos (CP494 ②).
+ *
+ * The contract under test: token auth, and the SUPPLY_YT_BRIDGE_ENABLED
+ * default-off no-op ({enabled:false, promoted:0} without touching the
+ * promote module) — flag off must mean prod behavior unchanged.
+ */
+
+import Fastify, { type FastifyInstance } from 'fastify';
+
+jest.mock('@/config/internal-auth', () => ({
+  getInternalBatchToken: () => 'test-token',
+}));
+
+// Mutable flag the route reads through config.supplyYtBridge.enabled.
+// Keep the REAL config (logger reads config.paths at import time) and
+// override only the bridge flag.
+const flagState = { enabled: false };
+jest.mock('@/config/index', () => {
+  const actual = jest.requireActual('@/config/index') as { config: Record<string, unknown> };
+  return {
+    ...actual,
+    config: {
+      ...actual.config,
+      supplyYtBridge: {
+        get enabled() {
+          return flagState.enabled;
+        },
+      },
+    },
+  };
+});
+
+const mockPromoteYt = jest.fn();
+jest.mock('@/modules/video-pool/promote-from-youtube-videos', () => ({
+  promoteYoutubeVideosToPool: (...args: unknown[]) => mockPromoteYt(...args),
+}));
+const mockPromoteV2 = jest.fn();
+jest.mock('@/modules/video-pool/promote-from-v2', () => ({
+  promoteV2ToVideoPool: (...args: unknown[]) => mockPromoteV2(...args),
+}));
+
+import { internalVideoPoolPromoteRoutes } from '@/api/routes/internal/video-pool-promote';
+
+async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify();
+  await app.register(internalVideoPoolPromoteRoutes, { prefix: '/internal' });
+  return app;
+}
+
+const URL = '/internal/video-pool/promote-from-youtube-videos';
+const HEADERS = { 'x-internal-token': 'test-token', 'content-type': 'application/json' };
+
+beforeEach(() => {
+  flagState.enabled = false;
+  mockPromoteYt.mockReset();
+  mockPromoteV2.mockReset();
+});
+
+describe('POST /internal/video-pool/promote-from-youtube-videos', () => {
+  test('rejects without internal token', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: URL,
+      headers: { 'content-type': 'application/json' },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(401);
+    expect(mockPromoteYt).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  test('flag off (default) → {enabled:false, promoted:0} no-op', async () => {
+    const app = await buildApp();
+    const res = await app.inject({ method: 'POST', url: URL, headers: HEADERS, payload: {} });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ enabled: false, promoted: 0 });
+    expect(mockPromoteYt).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  test('flag on → delegates with clamped limit + dry_run', async () => {
+    flagState.enabled = true;
+    mockPromoteYt.mockResolvedValueOnce({
+      candidates: 1,
+      promoted: 0,
+      embedded: 0,
+      gold: 1,
+      silver: 0,
+      skipped_bronze: 0,
+      skipped_rejected: 0,
+      embeddings_skipped_unreachable: false,
+      errors: [],
+    });
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: URL,
+      headers: HEADERS,
+      payload: { limit: 9999, dry_run: true },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(mockPromoteYt).toHaveBeenCalledWith({ limit: 500, dryRun: true }); // MAX_LIMIT clamp
+    const body = JSON.parse(res.body) as { enabled: boolean; dry_run: boolean };
+    expect(body.enabled).toBe(true);
+    expect(body.dry_run).toBe(true);
+    await app.close();
+  });
+});

--- a/tests/unit/api/videos-bulk-upsert.test.ts
+++ b/tests/unit/api/videos-bulk-upsert.test.ts
@@ -225,4 +225,58 @@ describe('POST /internal/videos/bulk-upsert', () => {
     expect(body.inserted).toBe(1);
     await app.close();
   });
+
+  // CP494 ② — description/channel_id flow into the INSERT + COALESCE backfill.
+  test('description and channel_id are bound into the INSERT', async () => {
+    mockQueryRaw.mockResolvedValue([{ inserted: true }]);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/videos/bulk-upsert',
+      headers: HEADERS,
+      payload: {
+        videos: [
+          {
+            youtube_video_id: 'withdesc',
+            title: 'a long enough title here',
+            duration_seconds: 600,
+            description: 'full snippet description text body',
+            channel_id: 'UCdescchannel1',
+          },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const sql = JSON.stringify(mockQueryRaw.mock.calls[0]);
+    // values bound
+    expect(sql).toContain('full snippet description text body');
+    expect(sql).toContain('UCdescchannel1');
+    // NULL-only backfill: existing non-null wins over a stale re-submit
+    expect(sql).toContain('COALESCE(youtube_videos.description, EXCLUDED.description)');
+    expect(sql).toContain('COALESCE(youtube_videos.channel_id, EXCLUDED.channel_id)');
+    await app.close();
+  });
+
+  test('omitted description/channel_id bind as null (legacy callers unaffected)', async () => {
+    mockQueryRaw.mockResolvedValue([{ inserted: true }]);
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/videos/bulk-upsert',
+      headers: HEADERS,
+      payload: {
+        videos: [
+          {
+            youtube_video_id: 'nodesc',
+            title: 'a long enough title here',
+            duration_seconds: 600,
+          },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as { inserted: number };
+    expect(body.inserted).toBe(1);
+    await app.close();
+  });
 });

--- a/tests/unit/modules/video-pool/promote-from-youtube-videos.test.ts
+++ b/tests/unit/modules/video-pool/promote-from-youtube-videos.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for promote-from-youtube-videos (CP494 ② supply bridge).
+ *
+ * Mocks Prisma + the embedding helpers (promote-from-v2.test.ts mirror).
+ * classifyQuality runs REAL — the gold/silver admit + bronze/rejected skip
+ * gate is the subject under test. Durations are ≥180s so shortGateFields
+ * short-circuits without an HTTP probe.
+ */
+
+const mockQueryRaw = jest.fn();
+const mockExecuteRaw = jest.fn();
+const mockVideoPoolCreate = jest.fn();
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
+    $executeRaw: (...args: unknown[]) => mockExecuteRaw(...args),
+    video_pool: { create: (...args: unknown[]) => mockVideoPoolCreate(...args) },
+  }),
+}));
+
+const mockEmbedBatch = jest.fn();
+const mockIsOllamaReachable = jest.fn();
+jest.mock('@/skills/plugins/iks-scorer/embedding', () => ({
+  embedBatch: (...args: unknown[]) => mockEmbedBatch(...args),
+  isOllamaReachable: (...args: unknown[]) => mockIsOllamaReachable(...args),
+  vectorToLiteral: (vec: number[]) => `[${vec.join(',')}]`,
+  QWEN3_EMBED_MODEL: 'qwen3-embedding:8b',
+  MAC_MINI_OLLAMA_DEFAULT_URL: 'http://test',
+}));
+
+import { promoteYoutubeVideosToPool } from '@/modules/video-pool/promote-from-youtube-videos';
+
+// view_count floors (batch-video-collector manifest): gold ≥100K, silver ≥10K,
+// bronze ≥1K, rejected <1K. duration valid range 60..3600s.
+const baseRow = {
+  title: 'A perfectly reasonable video title',
+  description: 'full snippet description text',
+  channel_title: 'Channel',
+  channel_id: 'UCabc123',
+  like_count: BigInt(10),
+  duration_seconds: 600,
+  published_at: null,
+  thumbnail_url: null,
+  default_language: null,
+};
+
+beforeEach(() => {
+  mockQueryRaw.mockReset();
+  mockExecuteRaw.mockReset();
+  mockVideoPoolCreate.mockReset();
+  mockEmbedBatch.mockReset();
+  mockIsOllamaReachable.mockReset();
+});
+
+describe('promoteYoutubeVideosToPool', () => {
+  test('zero candidates returns counts of zero', async () => {
+    mockQueryRaw.mockResolvedValueOnce([]);
+    const r = await promoteYoutubeVideosToPool({ limit: 100 });
+    expect(r.candidates).toBe(0);
+    expect(r.promoted).toBe(0);
+    expect(mockVideoPoolCreate).not.toHaveBeenCalled();
+    expect(mockIsOllamaReachable).not.toHaveBeenCalled();
+  });
+
+  test('candidate SQL dedupes via NOT EXISTS against video_pool', async () => {
+    mockQueryRaw.mockResolvedValueOnce([]);
+    await promoteYoutubeVideosToPool({ limit: 100 });
+    const sql = JSON.stringify(mockQueryRaw.mock.calls[0]);
+    expect(sql).toContain('NOT EXISTS');
+    expect(sql).toContain('video_pool');
+  });
+
+  test('gold/silver promoted; bronze and rejected skipped', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { ...baseRow, video_id: 'g1', view_count: BigInt(200_000) }, // gold
+      { ...baseRow, video_id: 's1', view_count: BigInt(50_000) }, // silver
+      { ...baseRow, video_id: 'b1', view_count: BigInt(5_000) }, // bronze → skip
+      { ...baseRow, video_id: 'r1', view_count: BigInt(500) }, // below floor → skip
+      { ...baseRow, video_id: 'r2', view_count: BigInt(50_000), duration_seconds: 30 }, // too short → skip
+    ]);
+    mockIsOllamaReachable.mockResolvedValueOnce(false);
+    const r = await promoteYoutubeVideosToPool({ limit: 100 });
+    expect(r.candidates).toBe(5);
+    expect(r.promoted).toBe(2);
+    expect(r.gold).toBe(1);
+    expect(r.silver).toBe(1);
+    expect(r.skipped_bronze).toBe(1);
+    expect(r.skipped_rejected).toBe(2);
+    expect(mockVideoPoolCreate).toHaveBeenCalledTimes(2);
+    const ids = mockVideoPoolCreate.mock.calls.map(
+      (c) => (c[0] as { data: { video_id: string } }).data.video_id
+    );
+    expect(ids).toEqual(['g1', 's1']);
+  });
+
+  test('create carries description, channel_id, source=yt_promoted, language fallback ko', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { ...baseRow, video_id: 'v1', view_count: BigInt(200_000) },
+    ]);
+    mockIsOllamaReachable.mockResolvedValueOnce(false);
+    const r = await promoteYoutubeVideosToPool({ limit: 100 });
+    expect(r.promoted).toBe(1);
+    const data = (
+      mockVideoPoolCreate.mock.calls[0]![0] as {
+        data: {
+          description: string | null;
+          channel_id: string | null;
+          source: string;
+          language: string;
+          quality_tier: string;
+        };
+      }
+    ).data;
+    expect(data.description).toBe('full snippet description text');
+    expect(data.channel_id).toBe('UCabc123');
+    expect(data.source).toBe('yt_promoted');
+    expect(data.language).toBe('ko'); // default_language null → fallback
+    expect(data.quality_tier).toBe('gold');
+  });
+
+  test('embeddings index admissible rows, not raw candidates (skip offset safety)', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { ...baseRow, video_id: 'r1', view_count: BigInt(100) }, // rejected (index 0 of candidates)
+      { ...baseRow, video_id: 'g1', view_count: BigInt(200_000) }, // gold (index 0 of admissible)
+    ]);
+    mockIsOllamaReachable.mockResolvedValueOnce(true);
+    mockEmbedBatch.mockResolvedValueOnce([[0.1]]); // ONE vector for ONE admissible row
+    const r = await promoteYoutubeVideosToPool({ limit: 100 });
+    expect(r.promoted).toBe(1);
+    expect(r.embedded).toBe(1);
+    // embedBatch received only the admissible row's text
+    const inputs = mockEmbedBatch.mock.calls[0]![0] as string[];
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0]).toContain('A perfectly reasonable video title');
+    // the embedding INSERT targeted the gold row
+    expect(JSON.stringify(mockExecuteRaw.mock.calls[0])).toContain('g1');
+  });
+
+  test('Ollama unreachable → promote without embeddings', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { ...baseRow, video_id: 'g1', view_count: BigInt(200_000) },
+    ]);
+    mockIsOllamaReachable.mockResolvedValueOnce(false);
+    const r = await promoteYoutubeVideosToPool({ limit: 100 });
+    expect(r.promoted).toBe(1);
+    expect(r.embedded).toBe(0);
+    expect(r.embeddings_skipped_unreachable).toBe(true);
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
+  });
+
+  test('dry-run returns gate counts without any write or probe', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { ...baseRow, video_id: 'g1', view_count: BigInt(200_000) },
+      { ...baseRow, video_id: 's1', view_count: BigInt(50_000) },
+      { ...baseRow, video_id: 'b1', view_count: BigInt(5_000) },
+      { ...baseRow, video_id: 'r1', view_count: BigInt(1) },
+    ]);
+    const r = await promoteYoutubeVideosToPool({ limit: 100, dryRun: true });
+    expect(r.candidates).toBe(4);
+    expect(r.promoted).toBe(0);
+    expect(r.gold).toBe(1);
+    expect(r.silver).toBe(1);
+    expect(r.skipped_bronze).toBe(1);
+    expect(r.skipped_rejected).toBe(1);
+    expect(mockVideoPoolCreate).not.toHaveBeenCalled();
+    expect(mockIsOllamaReachable).not.toHaveBeenCalled();
+  });
+
+  test('per-row create failure is collected, not thrown', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { ...baseRow, video_id: 'g1', view_count: BigInt(200_000) },
+      { ...baseRow, video_id: 'g2', view_count: BigInt(200_000) },
+    ]);
+    mockIsOllamaReachable.mockResolvedValueOnce(false);
+    mockVideoPoolCreate.mockRejectedValueOnce(new Error('duplicate key')).mockResolvedValueOnce({});
+    const r = await promoteYoutubeVideosToPool({ limit: 100 });
+    expect(r.promoted).toBe(1);
+    expect(r.errors).toEqual([{ video_id: 'g1', error: 'duplicate key' }]);
+  });
+});

--- a/tests/unit/skills/video-discover/v5-config-supply-bridge.test.ts
+++ b/tests/unit/skills/video-discover/v5-config-supply-bridge.test.ts
@@ -1,0 +1,38 @@
+/**
+ * CP494 ② — v5 poolSources read-side gating by SUPPLY_YT_BRIDGE_ENABLED.
+ *
+ * The supply bridge writes video_pool rows with source='yt_promoted'; the
+ * SAME flag must open the consumption read, or the bridge is a dead write
+ * (the ③ reuse-loop lesson). Off = poolSources unchanged (current behavior).
+ */
+
+import { getV5Config, resetV5ConfigForTest } from '@/skills/plugins/video-discover/v5/config';
+
+afterEach(() => resetV5ConfigForTest());
+beforeEach(() => resetV5ConfigForTest());
+
+describe('v5 poolSources × SUPPLY_YT_BRIDGE_ENABLED', () => {
+  test('flag unset → yt_promoted NOT read (current behavior)', () => {
+    const cfg = getV5Config({} as NodeJS.ProcessEnv);
+    expect(cfg.poolSources).toEqual(['v2_promoted']);
+  });
+
+  test('flag off explicitly → yt_promoted NOT read', () => {
+    const cfg = getV5Config({ SUPPLY_YT_BRIDGE_ENABLED: 'false' } as NodeJS.ProcessEnv);
+    expect(cfg.poolSources).not.toContain('yt_promoted');
+  });
+
+  test('flag on → yt_promoted appended to poolSources', () => {
+    const cfg = getV5Config({ SUPPLY_YT_BRIDGE_ENABLED: 'true' } as NodeJS.ProcessEnv);
+    expect(cfg.poolSources).toEqual(['v2_promoted', 'yt_promoted']);
+  });
+
+  test('composes with V5_POOL_SOURCE=all and V5_REUSE_LOOP', () => {
+    const cfg = getV5Config({
+      V5_POOL_SOURCE: 'all',
+      V5_REUSE_LOOP: 'true',
+      SUPPLY_YT_BRIDGE_ENABLED: 'true',
+    } as NodeJS.ProcessEnv);
+    expect(cfg.poolSources).toEqual(['v2_promoted', 'batch_trend', 'user_live', 'yt_promoted']);
+  });
+});


### PR DESCRIPTION
## Context

CP494 supply diagnosis confirmed TWO supply systems: the Mac Mini collector (yt-dlp discovery = quota 0, videos.list enrich) sinks into `youtube_videos`, while the consumption pool (`video_pool`, what the v5 pool-first match reads) never saw those rows. This MVP bridges them so quota-free supply raises pool hit rate. (The 40k/day lever — migrating the server batch-collector off search.list — is a separate PR before ⑤.)

## Changes

**Part A — description/channel_id flow (quota 0, schema 0)**
- `internal/videos-bulk-upsert.ts`: `VideoMeta` + INSERT now carry `description`/`channel_id` (videos.list snippet already returns both; extraction simply dropped them).
- `ON CONFLICT` backfill via `COALESCE(existing, EXCLUDED)` — a stale re-submit never blanks a populated row.
- Mac Mini extractor edits are gitignored (`mac-mini/`) — deployed via separate ops.

**Part B — bridge (create-only, flag-gated)**
- NEW `src/modules/video-pool/promote-from-youtube-videos.ts`: NOT-EXISTS dedup, `classifyQuality` gate (**gold/silver only** — bronze/rejected skipped; consumers read gold/silver and the 500MB plan shouldn't pay for unread rows), short gate, Ollama embedding fail-open. Mirrors `promote-from-v2.ts`.
- NEW route `POST /api/v1/internal/video-pool/promote-from-youtube-videos` (same file as the v2 route): `x-internal-token`, MAX_LIMIT 500, flag off → `{enabled:false, promoted:0}` no-op.
- `SUPPLY_YT_BRIDGE_ENABLED` (default **false**): ONE flag gates the write (route) **and** the read (`v5/config.ts` `poolSources` += `'yt_promoted'`) — write↔read pair, so the bridge is never a dead write (reuse-loop ③ lesson).
- `promote-from-v2.ts`: stale comment fix only (`youtube_videos.channel_id` exists).

## Verification (dev)

- description/channel_id flow: POST → row populated; stale re-submit preserved existing non-null (COALESCE).
- 4-tier seed → **gold/silver-only** promote, `source='yt_promoted'`, description/channel_id carried; dedup re-run promoted 0 of the seeds, 0 duplicate-key errors; embeddings 3/3 (Mac Mini reachable); live flag-off no-op verified; all test data cleaned to zero residue.
- Unit: 24/24 across 4 suites (bridge module, route flag/no-op/clamp, bulk-upsert field flow, v5 poolSources gating). `tsc --noEmit` clean.

## Rollback

Flag off (default) = current behavior on both write and read. No code revert needed. Activation is deferred to the ⑤ cumulative measurement (together with `V5_POOL_MATCH`/`V5_REUSE_LOOP`/`V5_CELL_SKIP`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)