### PR TITLE
fix(v5): supply bridge drain hardening — SQL hard-floor prefilter + skip_embeddings (CP494 (5) B-pre)

### DIFF
--- a/src/api/routes/internal/video-pool-promote.ts
+++ b/src/api/routes/internal/video-pool-promote.ts
@@ -34,6 +34,8 @@ const log = logger.child({ module: 'api/internal/video-pool-promote' });
 interface PromoteBody {
   limit?: number;
   dry_run?: boolean;
+  /** yt-bridge only (CP494 ⑤): promote without video_pool_embeddings writes. */
+  skip_embeddings?: boolean;
 }
 
 const MAX_LIMIT = 500;
@@ -99,12 +101,14 @@ export const internalVideoPoolPromoteRoutes: FastifyPluginAsync = async (fastify
         Math.min(MAX_LIMIT, typeof request.body?.limit === 'number' ? request.body.limit : 100)
       );
       const dryRun = request.body?.dry_run === true;
+      const skipEmbeddings = request.body?.skip_embeddings === true;
 
       try {
-        const result = await promoteYoutubeVideosToPool({ limit, dryRun });
+        const result = await promoteYoutubeVideosToPool({ limit, dryRun, skipEmbeddings });
         log.info('promote-from-youtube-videos endpoint done', {
           limit,
           dry_run: dryRun,
+          skip_embeddings: skipEmbeddings,
           ...result,
           errors: result.errors.length,
         });

--- a/src/modules/video-pool/promote-from-youtube-videos.ts
+++ b/src/modules/video-pool/promote-from-youtube-videos.ts
@@ -6,17 +6,25 @@
  * (`video_pool`, what v5 pool-first match reads) never saw those rows —
  * supply and consumption were two disconnected systems. This bridges them:
  *
- *   1. SELECT candidates: youtube_videos with usable metadata
- *      (title + view_count present) AND NOT already in video_pool.
+ *   1. SELECT candidates: youtube_videos with usable metadata AND NOT already
+ *      in video_pool. SQL prefilter mirrors the HARD floors of the JS gate
+ *      (view >= silver floor, duration within range) so definitely-skip rows
+ *      never occupy the recency window — without it, persistent skip rows
+ *      accumulate at the window top and repeated drains stall around ~1.5k
+ *      of ~7k admissible (B-pre dryRun finding, CP494 ⑤). Boundary/blocklist
+ *      judgment stays in classifyQuality (single authority).
  *   2. classifyQuality (batch-video-collector gate, same as reuse-from-v5):
  *      rejected OR bronze → skip. Consumers read gold/silver only, and the
  *      Free Plan 500MB budget shouldn't pay for rows nobody reads.
  *   3. shortGateFields → demote Shorts at promote (CP491 convention).
  *   4. INSERT video_pool with source='yt_promoted' — create-only (no UPDATE,
  *      no DELETE; NOT-EXISTS dedup makes re-runs no-ops).
- *   5. Embedding via Mac Mini Ollama, fail-open (mirrors promote-from-v2:
- *      unreachable/timeout → promote without embeddings, tsvector still
- *      matches immediately; dense rerank can backfill later).
+ *   5. Embedding via Mac Mini Ollama, fail-open (mirrors promote-from-v2).
+ *      `skipEmbeddings` mirrors the reuse-loop (③) precedent instead:
+ *      v5 pool-match is tsvector-based (embedding-free) and the cosine
+ *      readers gate on v2_promoted, so yt_promoted embeddings have no
+ *      consumer today — write them only when one exists (later backfill),
+ *      not at drain time (batch_trend +532MB unread-embeddings lesson).
  *
  * Flag: SUPPLY_YT_BRIDGE_ENABLED (default off) gates the write at the route
  * (video-pool-promote.ts) AND the read in v5 poolSources (v5/config.ts) —
@@ -36,6 +44,11 @@ import {
   MAC_MINI_OLLAMA_DEFAULT_URL,
 } from '@/skills/plugins/iks-scorer/embedding';
 import { classifyQuality } from '@/skills/plugins/batch-video-collector/quality';
+import {
+  QUALITY_SILVER_VIEW_COUNT,
+  MIN_DURATION_SEC,
+  MAX_DURATION_SEC,
+} from '@/skills/plugins/batch-video-collector/manifest';
 import { logger } from '@/utils/logger';
 import { shortGateFields } from './is-short';
 
@@ -86,6 +99,12 @@ export interface YtPromoteOptions {
   limit?: number;
   /** When true, skip writes and return planned action counts only. */
   dryRun?: boolean;
+  /**
+   * When true, promote WITHOUT writing video_pool_embeddings (③ reuse-loop
+   * precedent: tsvector matches immediately, dense rerank via later backfill).
+   * Default false = promote-from-v2 behavior.
+   */
+  skipEmbeddings?: boolean;
   /** Override the Ollama URL (default Mac Mini Tailscale). */
   ollamaUrl?: string;
 }
@@ -99,6 +118,11 @@ export async function promoteYoutubeVideosToPool(
 
   // 1. Candidates: usable metadata + not already pooled. Recency-first so a
   // capped batch drains the freshest supply (collector runs daily).
+  // Hard-floor prefilter (definitely-skip only): skip-class rows are never
+  // inserted, so without this they re-enter every window and repeated drains
+  // stall (~1.5k of ~7k). Floors are the SAME constants the JS gate uses;
+  // boundary semantics match classifyQuality (>= silver floor, 60..3600
+  // inclusive). Blocklist + tier stay JS-side (classifyQuality authority).
   const candidates = await prisma.$queryRaw<CandidateRow[]>(Prisma.sql`
     SELECT
       yv.youtube_video_id   AS video_id,
@@ -114,7 +138,8 @@ export async function promoteYoutubeVideosToPool(
       yv.default_language   AS default_language
     FROM youtube_videos yv
     WHERE yv.title IS NOT NULL
-      AND yv.view_count IS NOT NULL
+      AND yv.view_count >= ${QUALITY_SILVER_VIEW_COUNT}
+      AND yv.duration_seconds BETWEEN ${MIN_DURATION_SEC} AND ${MAX_DURATION_SEC}
       AND NOT EXISTS (
         SELECT 1 FROM video_pool vp WHERE vp.video_id = yv.youtube_video_id
       )
@@ -164,7 +189,9 @@ export async function promoteYoutubeVideosToPool(
   }
 
   // 5(pre). Embeddings up-front, fail-open (promote-from-v2 mirror).
-  const reachable = await isOllamaReachable({ baseUrl: ollamaUrl });
+  // skipEmbeddings short-circuits the whole embed path (③ precedent —
+  // yt_promoted has no embedding consumer today; backfill when one exists).
+  const reachable = opts.skipEmbeddings ? false : await isOllamaReachable({ baseUrl: ollamaUrl });
   let embeddings: (number[] | null)[] = [];
   if (reachable) {
     try {
@@ -183,7 +210,7 @@ export async function promoteYoutubeVideosToPool(
       });
       embeddings = [];
     }
-  } else {
+  } else if (!opts.skipEmbeddings) {
     log.warn('Ollama unreachable — promoting without embeddings');
   }
 
@@ -262,7 +289,8 @@ export async function promoteYoutubeVideosToPool(
     silver,
     skipped_bronze: skippedBronze,
     skipped_rejected: skippedRejected,
-    embeddings_skipped_unreachable: !reachable,
+    // skip-by-request is not "unreachable" — keep the flag truthful.
+    embeddings_skipped_unreachable: opts.skipEmbeddings ? false : !reachable,
     errors,
   };
 }

--- a/tests/unit/api/video-pool-promote-route.test.ts
+++ b/tests/unit/api/video-pool-promote-route.test.ts
@@ -98,10 +98,11 @@ describe('POST /internal/video-pool/promote-from-youtube-videos', () => {
       method: 'POST',
       url: URL,
       headers: HEADERS,
-      payload: { limit: 9999, dry_run: true },
+      payload: { limit: 9999, dry_run: true, skip_embeddings: true },
     });
     expect(res.statusCode).toBe(200);
-    expect(mockPromoteYt).toHaveBeenCalledWith({ limit: 500, dryRun: true }); // MAX_LIMIT clamp
+    // MAX_LIMIT clamp + skip_embeddings pass-through
+    expect(mockPromoteYt).toHaveBeenCalledWith({ limit: 500, dryRun: true, skipEmbeddings: true });
     const body = JSON.parse(res.body) as { enabled: boolean; dry_run: boolean };
     expect(body.enabled).toBe(true);
     expect(body.dry_run).toBe(true);

--- a/tests/unit/modules/video-pool/promote-from-youtube-videos.test.ts
+++ b/tests/unit/modules/video-pool/promote-from-youtube-videos.test.ts
@@ -70,6 +70,30 @@ describe('promoteYoutubeVideosToPool', () => {
     expect(sql).toContain('video_pool');
   });
 
+  test('candidate SQL prefilters hard floors so skip rows never occupy the window', async () => {
+    mockQueryRaw.mockResolvedValueOnce([]);
+    await promoteYoutubeVideosToPool({ limit: 100 });
+    const sql = JSON.stringify(mockQueryRaw.mock.calls[0]);
+    // bound values = same constants the JS gate uses (silver floor + duration range)
+    expect(sql).toContain('view_count >=');
+    expect(sql).toContain('duration_seconds BETWEEN');
+    expect(sql).toContain('10000'); // QUALITY_SILVER_VIEW_COUNT
+    expect(sql).toContain('3600'); // MAX_DURATION_SEC
+  });
+
+  test('skipEmbeddings: no probe, no embed, no embeddings INSERT; flag stays truthful', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { ...baseRow, video_id: 'g1', view_count: BigInt(200_000) },
+    ]);
+    const r = await promoteYoutubeVideosToPool({ limit: 100, skipEmbeddings: true });
+    expect(r.promoted).toBe(1);
+    expect(r.embedded).toBe(0);
+    expect(r.embeddings_skipped_unreachable).toBe(false); // skipped by request ≠ unreachable
+    expect(mockIsOllamaReachable).not.toHaveBeenCalled();
+    expect(mockEmbedBatch).not.toHaveBeenCalled();
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
+  });
+
   test('gold/silver promoted; bronze and rejected skipped', async () => {
     mockQueryRaw.mockResolvedValueOnce([
       { ...baseRow, video_id: 'g1', view_count: BigInt(200_000) }, // gold


### PR DESCRIPTION
## Context

Two findings from the B-pre prod dryRun (limit 500: gold 137 + silver 238 + bronze 72 + rejected 53), both caught BEFORE the first wet drain:

1. **Window stall** — skip-class rows are never inserted, so they permanently occupy the top of the recency window; repeated `limit=500` drains converge at ~1,500 of ~7,253 admissible (geometric: `S_{k+1} = S_k + 0.25(500−S_k)`).
2. **Unread embeddings** — v5 pool-match is tsvector-based (embedding-free) and cosine readers gate on `v2_promoted`, so `yt_promoted` embeddings have **no consumer today**: a full drain would add ~+135MB to a 1,508MB/500MB DB — repeating the batch_trend unread-embeddings anti-pattern. The reuse-loop (#852) already set the embeddings-deferred precedent; the bridge MVP failed to mirror it.

## Changes

- **SQL hard-floor prefilter** on the candidate SELECT: `view_count >= QUALITY_SILVER_VIEW_COUNT AND duration_seconds BETWEEN MIN_DURATION_SEC AND MAX_DURATION_SEC` — same constants the JS gate imports (no magic numbers, no boundary drift). Definitely-skip rows only; blocklist + tier judgment remains in `classifyQuality` (single authority). Bonus: `BETWEEN` also excludes NULL-duration rows, which `classifyQuality` rejects anyway.
- **`skip_embeddings` body option** (route) / `skipEmbeddings` (module), default **false** = current behavior. When true: no Ollama probe, no embedBatch, no embeddings INSERT; `embeddings_skipped_unreachable` stays truthful (skip-by-request ≠ unreachable).

## Verification

- 13/13 unit (incl. 3 new: prefilter bound constants in SQL, skipEmbeddings short-circuit, route pass-through with MAX_LIMIT clamp), `tsc --noEmit` clean.
- Post-merge plan (separately approved): dryRun re-check (admissible should now fill the window — was 375/500) → wet drain with `skip_embeddings=true` → loaded-count report.

## Rollback

Both changes are option/prefilter-level; `skip_embeddings` unset = prior behavior. Bridge remains flag-gated by `SUPPLY_YT_BRIDGE_ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)