### PR TITLE
chore(prod): enable v5 Phase B measurement flags — per_cell + reuse loop + cell skip (CP494 (5))

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -127,6 +127,19 @@ services:
       # Revert: delete this line + redeploy → code default false (bridge
       # no-op + poolSources unchanged). Off after measurement window.
       - SUPPLY_YT_BRIDGE_ENABLED=true
+      # CP494 ⑤ Phase B (measurement window — flags off after ⑤ decision).
+      # Baseline ①: avg 7.95 live calls/req, pool 1.5/8 cells, req_live_zero=0.
+      # Read via video_discover_traces (V3_TRACE_ENABLED already on) —
+      # poolOnlyCells / liveCells / quotaUnitsApprox per request.
+      # per_cell: each cell's own tsquery top-N (kill displacement, #854).
+      # Revert: delete these 3 lines + redeploy → code defaults restore
+      # global match / no reuse write / no cell skip.
+      - V5_POOL_MATCH=per_cell
+      # reuse loop (#852): picked live discoveries upsert back to pool
+      # (source='user_live') + poolSources reads them next request.
+      - V5_REUSE_LOOP=true
+      # full-cell skip (#853): cells with >=12 grid cards skip pool+live search.
+      - V5_CELL_SKIP=true
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the


### PR DESCRIPTION
## What

3-line prod compose change opening the ⑤ Phase B measurement window:

- `V5_POOL_MATCH=per_cell` (#854) — per-cell tsquery, kills displacement
- `V5_REUSE_LOOP=true` (#852) — picked live discoveries return to the pool (`user_live`) + read back
- `V5_CELL_SKIP=true` (#853) — cells with ≥12 grid cards skip search entirely

On top of B-pre state: `V5_POOL_BACKFILL=true` + `SUPPLY_YT_BRIDGE_ENABLED=true`, pool now ~8.7k consumable rows (v2_promoted 1.7k + yt_promoted 6,980).

## Measurement design (approved)

- **on-only vs baseline ①** (avg 7.95 live calls/req, pool 1.5/8 cells, req_live_zero=0), same source: `video_discover_traces` (`V3_TRACE_ENABLED` already on) — `poolOnlyCells` / `liveCells` / `quotaUnitsApprox` per request.
- Window: 2–3 days natural traffic, **≥20 request floor** (extend if under).
- Controlled off/on A/B deferred unless inconclusive.
- Interpretation caveat: `yt_promoted` rows are title-only tsvector (description null until Mac Mini extractor ops deploy) — double handicap acknowledged.

## Rollback

Delete the 3 lines + redeploy → code defaults (global match / no reuse write / no cell skip). All flags go off after the ⑤ decision. Phase C (batch_trend × per-cell A/B) is a separate approval after Phase B results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)