### PR TITLE
revert(prod): all v5 pool flags OFF — search relevance incident (CP494 (5) Phase B abort)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -104,7 +104,6 @@ services:
       # (timeout + try/catch → full live fallback). Source default v2_promoted.
       # Measure: GCP search.list before/after delta + trace v5_pool_backfill.
       # Revert: delete this line + redeploy → code default false (full live).
-      - V5_POOL_BACKFILL=true
       # CP494 Fork-3 REJECTED — V5_POOL_SOURCE=all measured WORSE than the
       # v2_promoted default on a same-mandala A/B (poolOnlyCells 2→1, units
       # 601→701). batch_trend (~28k) floods the ts_rank top-128 with generic
@@ -126,7 +125,6 @@ services:
       # so ⑤ cannot be measured on dev (same class as the P0 EXPLAIN read).
       # Revert: delete this line + redeploy → code default false (bridge
       # no-op + poolSources unchanged). Off after measurement window.
-      - SUPPLY_YT_BRIDGE_ENABLED=true
       # CP494 ⑤ Phase B (measurement window — flags off after ⑤ decision).
       # Baseline ①: avg 7.95 live calls/req, pool 1.5/8 cells, req_live_zero=0.
       # Read via video_discover_traces (V3_TRACE_ENABLED already on) —
@@ -134,12 +132,9 @@ services:
       # per_cell: each cell's own tsquery top-N (kill displacement, #854).
       # Revert: delete these 3 lines + redeploy → code defaults restore
       # global match / no reuse write / no cell skip.
-      - V5_POOL_MATCH=per_cell
       # reuse loop (#852): picked live discoveries upsert back to pool
       # (source='user_live') + poolSources reads them next request.
-      - V5_REUSE_LOOP=true
       # full-cell skip (#853): cells with >=12 grid cards skip pool+live search.
-      - V5_CELL_SKIP=true
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the


### PR DESCRIPTION
Emergency revert. Prod relevance broken during Phase B window (unrelated videos on user mandala). EC2 hot-fixed already; this aligns the repo. All 5 flags removed → code defaults (pure live fanout). Culprit isolation proceeds flag-by-flag while OFF. 🤖 Generated with [Claude Code](https://claude.com/claude-code)