### PR TITLE
chore(prod): re-enable V5_CELL_SKIP alone — full-cell skip canary (CP497 (1))

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -135,6 +135,11 @@ services:
       # reuse loop (#852): picked live discoveries upsert back to pool
       # (source='user_live') + poolSources reads them next request.
       # full-cell skip (#853): cells with >=12 grid cards skip pool+live search.
+      # CP497 isolated re-enable — cell skip ONLY; all pool flags stay OFF.
+      # Incident-independent: removes queries upstream of the pool gate,
+      # injects no content. Canary: trace v5_skipped_full_cells + quota delta.
+      # Revert: delete this line + redeploy → code default false (search all).
+      - V5_CELL_SKIP=true
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the


### PR DESCRIPTION
## Summary
Re-enable ONLY the full-cell skip flag (`V5_CELL_SKIP=true`, #853) from the five flags batch-reverted in #859.

## Why this is incident-independent
- The #859 relevance incident's culprit was **pool-first lexical content injection** (no relevance gate).
- Cell skip **injects no content** — it removes the search queries of cells the user already filled (>= `V5_CELL_SKIP_THRESHOLD`, default 12), **upstream of the pool gate** (`youtube-fanout.ts:374`).
- All `V5_POOL_*` / `V5_REUSE_LOOP` / `SUPPLY_YT_BRIDGE_ENABLED` stay OFF — #859's commit message explicitly planned one-flag-at-a-time isolation; this is that step for the safe flag.

## Quota math
Each skipped cell saves one search.list (100u) per add-cards round (3 full cells: 800 → 500u).

## Canary plan (post-deploy)
1. One prod add-cards click on a filled mandala.
2. Read `v5_skipped_full_cells` + `v5_quota_units` from `video_discover_traces`.
3. **Interpretation guard**: real mandalas hold ~1-7 cards/cell — `skipped=0` likely means threshold (12) sits above the actual distribution, NOT an implementation gap. Threshold tuning then follows measured card distribution (measure-then-tune).

## Rollback
Delete the compose line + redeploy → code default `false` (search all cells, current behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)