### PR TITLE
fix(llm): retry transient 429/5xx on OpenRouter with backoff (CP498 PR1)

### DIFF
--- a/src/modules/llm/openrouter.ts
+++ b/src/modules/llm/openrouter.ts
@@ -14,6 +14,33 @@ const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
 const DEFAULT_MAX_TOKENS = 1024;
 const REQUEST_TIMEOUT_MS = 120_000;
 
+// CP498 — retry transient 429 / 5xx with backoff. OpenRouter rate limits are
+// dynamic (credit-based); a parallel Heart / relevance-backfill burst can
+// briefly 429. Network/timeout errors are deliberately NOT retried: a stalled
+// request may have completed server-side, so retrying risks a double
+// generation (and double charge).
+const OPENROUTER_MAX_RETRIES = 3;
+const RETRY_BASE_MS = 1_000;
+const RETRY_CAP_MS = 30_000;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** 429 and 5xx are safe to retry (no generation completed). */
+export function isRetryableStatus(status: number): boolean {
+  return status === 429 || (status >= 500 && status < 600);
+}
+
+/** Honour Retry-After (delta-seconds or HTTP-date) when present; else exponential backoff. */
+export function retryDelayMs(retryAfter: string | null, attempt: number): number {
+  if (retryAfter) {
+    const secs = Number(retryAfter);
+    if (Number.isFinite(secs) && secs >= 0) return Math.min(RETRY_CAP_MS, secs * 1_000);
+    const dateMs = Date.parse(retryAfter);
+    if (!Number.isNaN(dateMs)) return Math.min(RETRY_CAP_MS, Math.max(0, dateMs - Date.now()));
+  }
+  return Math.min(RETRY_CAP_MS, RETRY_BASE_MS * 2 ** attempt);
+}
+
 export class OpenRouterGenerationProvider implements GenerationProvider {
   readonly name = 'openrouter';
   private readonly modelOverride?: string;
@@ -58,70 +85,90 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
       body['reasoning'] = { enabled: false };
     }
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-
     // Forward external abort (e.g. race-fallback discarding the LLM loser)
-    // into the same controller so the underlying fetch is cancelled too.
+    // into the per-attempt controller so the underlying fetch is cancelled too.
     const externalSignal = options?.signal;
-    const onExternalAbort = () => controller.abort();
-    if (externalSignal) {
-      if (externalSignal.aborted) {
-        controller.abort();
-      } else {
-        externalSignal.addEventListener('abort', onExternalAbort, { once: true });
-      }
-    }
 
-    let response: Response;
-    try {
-      response = await fetch(OPENROUTER_API_URL, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-          'HTTP-Referer': 'https://insighta.one',
-          'X-Title': 'Insighta',
-        },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
-    } catch (err) {
-      const latencyMs = Date.now() - startTime;
-      if ((err as Error).name === 'AbortError') {
-        // Distinguish "external cancel" from internal timeout for clearer logs.
-        if (externalSignal?.aborted) {
+    // CP498 — retry loop for transient 429 / 5xx. A fresh AbortController +
+    // timeout is created per attempt (abort is terminal). The loop always
+    // assigns `response` or throws before breaking.
+    let response!: Response;
+    for (let attempt = 0; ; attempt++) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+      const onExternalAbort = () => controller.abort();
+      if (externalSignal) {
+        if (externalSignal.aborted) {
+          controller.abort();
+        } else {
+          externalSignal.addEventListener('abort', onExternalAbort, { once: true });
+        }
+      }
+
+      try {
+        response = await fetch(OPENROUTER_API_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+            'HTTP-Referer': 'https://insighta.one',
+            'X-Title': 'Insighta',
+          },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+      } catch (err) {
+        const latencyMs = Date.now() - startTime;
+        if ((err as Error).name === 'AbortError') {
+          // Distinguish "external cancel" from internal timeout for clearer logs.
+          if (externalSignal?.aborted) {
+            logLLMCall({
+              module: 'openrouter',
+              model: this.model,
+              latencyMs,
+              status: 'error',
+              errorMessage: 'Request cancelled by external signal',
+            }).catch(() => {});
+            throw new Error('OpenRouter request cancelled by external signal');
+          }
           logLLMCall({
             module: 'openrouter',
             model: this.model,
             latencyMs,
             status: 'error',
-            errorMessage: 'Request cancelled by external signal',
+            errorMessage: `Request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`,
           }).catch(() => {});
-          throw new Error('OpenRouter request cancelled by external signal');
+          throw new Error(`OpenRouter request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`);
         }
         logLLMCall({
           module: 'openrouter',
           model: this.model,
           latencyMs,
           status: 'error',
-          errorMessage: `Request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`,
+          errorMessage: err instanceof Error ? err.message : String(err),
         }).catch(() => {});
-        throw new Error(`OpenRouter request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`);
+        throw err;
+      } finally {
+        clearTimeout(timeout);
+        if (externalSignal) {
+          externalSignal.removeEventListener('abort', onExternalAbort);
+        }
       }
-      logLLMCall({
-        module: 'openrouter',
-        model: this.model,
-        latencyMs,
-        status: 'error',
-        errorMessage: err instanceof Error ? err.message : String(err),
-      }).catch(() => {});
-      throw err;
-    } finally {
-      clearTimeout(timeout);
-      if (externalSignal) {
-        externalSignal.removeEventListener('abort', onExternalAbort);
+
+      // Transient 429 / 5xx → backoff and retry (no generation completed).
+      if (!response.ok && isRetryableStatus(response.status) && attempt < OPENROUTER_MAX_RETRIES) {
+        const delayMs = retryDelayMs(response.headers?.get?.('retry-after') ?? null, attempt);
+        logLLMCall({
+          module: 'openrouter',
+          model: this.model,
+          latencyMs: Date.now() - startTime,
+          status: 'error',
+          errorMessage: `Retryable ${response.status}; backoff ${delayMs}ms (attempt ${attempt + 1}/${OPENROUTER_MAX_RETRIES})`,
+        }).catch(() => {});
+        await sleep(delayMs);
+        continue;
       }
+      break;
     }
 
     if (!response.ok) {

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -162,19 +162,20 @@ export const QUEUE_CONFIG = {
   /** Max concurrent enrichment workers */
   ENRICH_CONCURRENCY: 1,
   /**
-   * Max concurrent Heart-triggered rich-summary workers. CP462+ Issue #649.
-   * Independent pool from ENRICH_CONCURRENCY so batch backfill cannot starve
-   * interactive Heart clicks. Override via BULLMQ_ENRICH_CONCURRENCY env
-   * (legacy name retained for compatibility even though pg-boss replaced BullMQ).
+   * Concurrency ceiling for Heart-triggered rich-summary workers (CP462+
+   * Issue #649). Independent pool from ENRICH_CONCURRENCY so batch backfill
+   * cannot starve interactive Heart clicks.
    *
-   * CP475+ — raised 5 → 10 after the 2026-05-20 user report that liking 6
-   * cards in quick succession felt serial. p95 v2 job = 87s (CP475 measurement);
-   * 10 workers absorb a 6-10 card burst without blocking. Sonnet/OpenRouter
-   * tier headroom checked against the wizard path, which keeps its own quota.
+   * ⚠️ NOTE (CP498): this value is currently INERT. The worker registers with
+   * `teamSize:1` and no `teamRefill`, so pg-boss fetches exactly one job per
+   * poll and awaits it to completion before the next fetch — `teamConcurrency`
+   * never engages (see enrich-rich-summary.ts + pg-boss manager.js fetch =
+   * `teamSize - queueSize`). The CP475 "raised 5→10" change was therefore a
+   * no-op. Activating real concurrency requires `teamSize:N` + `teamRefill:true`
+   * at the registration site. There is NO env override despite older comments —
+   * this is a plain literal.
    */
   RICH_SUMMARY_CONCURRENCY: 10,
-  /** Delay between polling for new jobs (seconds) */
-  POLL_INTERVAL_SECONDS: 10,
   /** How long to keep completed jobs (days) */
   ARCHIVE_COMPLETED_AFTER_DAYS: 7,
   /** How long to keep failed jobs (days) */

--- a/tests/unit/modules/openrouter-429-backoff.test.ts
+++ b/tests/unit/modules/openrouter-429-backoff.test.ts
@@ -1,0 +1,107 @@
+/**
+ * OpenRouter generation — transient 429 / 5xx backoff retry (CP498).
+ *
+ * Before CP498 the provider threw immediately on any `!response.ok`, so a
+ * parallel Heart / relevance-backfill burst that tripped OpenRouter's dynamic
+ * (credit-based) rate limit failed the user's job with no retry. These tests
+ * pin: retry on 429 / 5xx, honour Retry-After, no retry on deterministic 4xx,
+ * and exhaustion after OPENROUTER_MAX_RETRIES.
+ */
+
+const mockConfig = {
+  openrouter: { apiKey: 'test-key', model: 'anthropic/claude-haiku-4.5' },
+};
+
+jest.mock('@/config/index', () => ({ config: mockConfig }));
+jest.mock('@/modules/llm/call-logger', () => ({ logLLMCall: jest.fn(() => Promise.resolve()) }));
+
+import {
+  OpenRouterGenerationProvider,
+  isRetryableStatus,
+  retryDelayMs,
+} from '@/modules/llm/openrouter';
+
+const ok = (content: string): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({ choices: [{ message: { content } }], usage: {} }),
+  }) as unknown as Response;
+
+const httpErr = (status: number, retryAfter: string | null = '0'): Response =>
+  ({
+    ok: false,
+    status,
+    headers: { get: (h: string) => (h.toLowerCase() === 'retry-after' ? retryAfter : null) },
+    text: async () => `${status} error`,
+  }) as unknown as Response;
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('OpenRouterGenerationProvider — 429/5xx backoff', () => {
+  it('retries a transient 429 (Retry-After) then succeeds', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(httpErr(429))
+      .mockResolvedValueOnce(ok('{"mandala_relevance_pct":80}')) as unknown as typeof fetch;
+
+    const provider = new OpenRouterGenerationProvider('anthropic/claude-haiku-4.5');
+    const out = await provider.generate('hi', { format: 'json' });
+
+    expect(out).toBe('{"mandala_relevance_pct":80}');
+    expect(global.fetch).toHaveBeenCalledTimes(2); // 1 × 429 + 1 × success
+  });
+
+  it('retries a transient 503 then succeeds', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(httpErr(503))
+      .mockResolvedValueOnce(ok('{"ok":1}')) as unknown as typeof fetch;
+
+    const provider = new OpenRouterGenerationProvider('m');
+    expect(await provider.generate('hi')).toBe('{"ok":1}');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry a deterministic 400 — throws after one attempt', async () => {
+    global.fetch = jest.fn().mockResolvedValue(httpErr(400)) as unknown as typeof fetch;
+
+    const provider = new OpenRouterGenerationProvider('m');
+    await expect(provider.generate('hi')).rejects.toThrow(/error 400/);
+    expect(global.fetch).toHaveBeenCalledTimes(1); // 400 is non-retryable
+  });
+
+  it('exhausts retries on a persistent 429 then throws', async () => {
+    global.fetch = jest.fn().mockResolvedValue(httpErr(429)) as unknown as typeof fetch;
+
+    const provider = new OpenRouterGenerationProvider('m');
+    await expect(provider.generate('hi')).rejects.toThrow(/error 429/);
+    expect(global.fetch).toHaveBeenCalledTimes(4); // initial + OPENROUTER_MAX_RETRIES(3)
+  });
+});
+
+describe('retry helpers (pure)', () => {
+  it('isRetryableStatus: 429 + 5xx true, 4xx-other false', () => {
+    expect(isRetryableStatus(429)).toBe(true);
+    expect(isRetryableStatus(500)).toBe(true);
+    expect(isRetryableStatus(503)).toBe(true);
+    expect(isRetryableStatus(400)).toBe(false);
+    expect(isRetryableStatus(404)).toBe(false);
+    expect(isRetryableStatus(200)).toBe(false);
+  });
+
+  it('retryDelayMs: Retry-After delta-seconds honoured (capped)', () => {
+    expect(retryDelayMs('5', 0)).toBe(5_000);
+    expect(retryDelayMs('0', 0)).toBe(0);
+    expect(retryDelayMs('9999', 0)).toBe(30_000); // capped at RETRY_CAP_MS
+  });
+
+  it('retryDelayMs: exponential backoff when no Retry-After', () => {
+    expect(retryDelayMs(null, 0)).toBe(1_000);
+    expect(retryDelayMs(null, 1)).toBe(2_000);
+    expect(retryDelayMs(null, 2)).toBe(4_000);
+    expect(retryDelayMs(null, 10)).toBe(30_000); // capped
+  });
+});


### PR DESCRIPTION
## What
Wrap `OpenRouterGenerationProvider.generate()` in a backoff retry loop for transient **429 / 5xx** responses. Part 1 of 3 (CP498) toward parallelizing v2 rich-summary generation.

## Why
OpenRouter rate limits are dynamic (credit-based). PR2 raises Heart-worker concurrency and PR3 adds a relevance-backfill burst — without 429 handling, a parallel burst would 429 and fail the user's job with **no retry** (interactive path is `retryLimit:0`). This PR is the **safety net that must land before** PR2/PR3.

## Behavior
- **Retry** on 429 / 5xx: honour `Retry-After` (delta-seconds or HTTP-date), else exponential backoff. `max 3 retries, cap 30s`.
- **No retry** on network/timeout errors — a stalled request may have completed server-side, so retrying risks a double generation + double charge.
- **Success path unchanged** (loop runs once, breaks) — additive, reversible, behavior-neutral.

## Dead-config cleanup
- Remove unused `POLL_INTERVAL_SECONDS` (never wired into `boss.work`).
- Correct the `RICH_SUMMARY_CONCURRENCY` comment: the value is currently **inert** (`teamSize:1` + no `teamRefill` makes `teamConcurrency` a no-op — the CP475 "5→10" change was a no-op). The false "override via env" claim is removed. Concurrency is actually activated in PR2.

## Tests
- 7 new (`tests/unit/modules/openrouter-429-backoff.test.ts`): retry 429/503 → success, no-retry on 400, exhaustion after max, pure `isRetryableStatus`/`retryDelayMs`.
- 43 regression green (embedding-retry, llm-cost-tracking, openrouter-picker).

## CP467 measurement
PR1 is a resilience addition (not a limit bump) → verified by retry-behavior tests. p95 / 429-rate before/after measurement lands with **PR2** (the actual concurrency raise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)