### PR TITLE
fix(queue): activate enrich-rich-summary concurrency (teamSize:N+teamRefill) (CP498 PR2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -310,6 +310,13 @@ jobs:
           # discovery call). Rollback: unset (or set to false) + redeploy —
           # no code revert needed.
           V3_TRACE_ENABLED: ${{ vars.V3_TRACE_ENABLED }}
+          # CP498 PR2 — enrich-rich-summary (Heart) worker concurrency. unset ⇒
+          # config zod default 4 (the -n guard in the script skips the write, so
+          # no empty value reaches .env → process.env unset → default). Tune /
+          # rollback: `gh variable set RICH_SUMMARY_CONCURRENCY --body 1` (serial)
+          # or `--body 6` (raise) + redeploy — no code revert. Non-secret per
+          # CP392 (tuning knob).
+          RICH_SUMMARY_CONCURRENCY: ${{ vars.RICH_SUMMARY_CONCURRENCY }}
           # Mac Mini transcript proxy. EC2 outbound to YouTube is blocked
           # for caption fetch; the Mac Mini (KR ISP IP, Tailscale 4242)
           # successfully fetches and forwards via x-transcript-token auth.
@@ -321,7 +328,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,YT_VIDEOS_KEY,YT_VIDEOS_KEY_2,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,V2_QUALITY_AUDIT_ENABLED,V2_QUALITY_REGEN_ENABLED,V3_TRACE_ENABLED,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
+          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,YT_VIDEOS_KEY,YT_VIDEOS_KEY_2,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,V2_QUALITY_AUDIT_ENABLED,V2_QUALITY_REGEN_ENABLED,V3_TRACE_ENABLED,RICH_SUMMARY_CONCURRENCY,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
           script: |
             set -e
             cd /opt/tubearchive
@@ -391,6 +398,15 @@ jobs:
             # `gh variable delete V3_TRACE_ENABLED` + redeploy — no code revert.
             if [ -n "${V3_TRACE_ENABLED}" ]; then
               grep -q '^V3_TRACE_ENABLED=' .env 2>/dev/null && sed -i "s|^V3_TRACE_ENABLED=.*|V3_TRACE_ENABLED=${V3_TRACE_ENABLED}|" .env || echo "V3_TRACE_ENABLED=${V3_TRACE_ENABLED}" >> .env
+            fi
+            # CP498 PR2 — enrich-rich-summary worker concurrency. Same idempotent
+            # pattern. When the Variable is unset/empty the conditional skips and
+            # the config zod default (4, src/config/index.ts) stays in effect, so
+            # no empty value is ever written to .env (avoids coerce-of-"" crash).
+            # Tune/rollback via `gh variable set RICH_SUMMARY_CONCURRENCY --body N`
+            # + redeploy — no code revert.
+            if [ -n "${RICH_SUMMARY_CONCURRENCY}" ]; then
+              grep -q '^RICH_SUMMARY_CONCURRENCY=' .env 2>/dev/null && sed -i "s|^RICH_SUMMARY_CONCURRENCY=.*|RICH_SUMMARY_CONCURRENCY=${RICH_SUMMARY_CONCURRENCY}|" .env || echo "RICH_SUMMARY_CONCURRENCY=${RICH_SUMMARY_CONCURRENCY}" >> .env
             fi
             # 2026-04-18 — sync DB URLs from GitHub Secrets so password
             # rotations propagate to prod .env without manual SSH. Was

--- a/docs/handoffs/pr2-v2-quick-parallelize-cp498.md
+++ b/docs/handoffs/pr2-v2-quick-parallelize-cp498.md
@@ -1,0 +1,67 @@
+# PR2 Handoff — Heart rich-summary 동시성 직렬 해소 (CP498)
+
+> 작성: CP498 (2026-06-08). 착수 전 James 검토 → 승인 필요. 코드 우선 — 줄번호·정확한 옵션 위치·현재 값은 **착수 시 코드 재확인 후 확정**(이 문서는 문제·맥락·메커니즘·측정 기준만 고정).
+
+## ▶ 다음 세션 시작 (트리거 — James 확정)
+- 트리거 문구: **"핸드오프 승인. PR2 착수해 — plan 재제시(코드 확인 확정값, env 노출 포함)부터"**
+- 흐름: CC가 **plan 재제시**(아래 "변경" specifics를 코드 확인해 확정값 + env 노출 여부 포함) → James 검토·승인 → **측정 A(before, 구현 전)** 진입 → 구현 → merge/deploy(각 승인) → 측정 B(after)+429율 → done.
+- CC는 plan 작성되면 **즉시 James에게 보여주고** 승인 전 구현 착수 금지.
+
+## 위치
+3-PR A단계("점수 백필 + 병렬화 + 정렬") 중 **PR2**. PR1(#864 OpenRouter 429/5xx backoff)은 ship 완료 = 병렬 버스트 안전판. PR2 = Heart 경로 직렬 해소. PR3 = 셀카드 점수 백필(다음).
+
+## 문제
+Heart 여러 개 동시 클릭 시 v2 rich-summary 생성이 1개씩 순차 처리 = 매우 느림(James 실측). A단계 점수 백필도 같은 워커 경로라 직렬이면 못 씀.
+
+## 🔑 메커니즘 (측정으로 확정 — 빠지면 "숫자만 올려 no-op" 반복하므로 필수 명시)
+- **동시성 설정값(숫자)만 올리는 건 no-op.** 현재 설정값(=10)은 이미 크지만 **죽어 있다.**
+- 원인: worker가 `teamSize:1` + `teamRefill` 부재로 등록됨. pg-boss v9는 매 폴링당 `teamSize − in-flight`개만 fetch하고(=최대 1개), 그 1잡이 **완료될 때까지 다음 fetch를 await로 막는다** → 엄격히 직렬. `teamConcurrency`는 fetch된 배치(항상 크기 1)에만 적용돼 무력.
+- **발동 조건 = `teamSize:N` + `teamRefill:true`** (teamConcurrency:N과 함께). 이 조합이라야 N잡을 동시 in-flight로 유지.
+- **`batchSize`는 부적합** — batchSize는 N잡을 **한 핸들러 콜백에 묶어** 넘기는데, 현 핸들러는 1잡(=1영상) 단위 처리라 호환 안 됨.
+- CP475 "5→10" 변경은 `teamSize:1`을 그대로 둬서 **no-op이었음**(주석이 자기 효과 오판 — PR1에서 주석 교정 완료).
+- → **착수 시 코드 확인 위임**: worker 등록 지점(enrich-rich-summary worker 등록부)의 실제 work-option 줄 + 현재 N 출처(리터럴/env) 확인 후 `teamSize:N + teamRefill:true` 적용.
+
+## 변경 (코드 확인 확정 — PR2 = 2파일, 동시성 활성화만)
+가역성을 config refactor에 안 묶이게 **behavioral change만 격리**:
+1. `src/config/index.ts`: envSchema(`MAX_CONCURRENT_SYNCS` 인근)에 `RICH_SUMMARY_CONCURRENCY: z.coerce.number().int().min(1).default(4)` + config 객체(`sync` 섹션 뒤)에 `queue: { richSummaryConcurrency: env.RICH_SUMMARY_CONCURRENCY }`.
+2. `src/modules/queue/handlers/enrich-rich-summary.ts:68`: `const n = config.queue.richSummaryConcurrency` → work-option `{ teamConcurrency: n, teamSize: n, teamRefill: true }` (현 `{...RICH_SUMMARY_CONCURRENCY, teamSize:1}` 교체) + 로그 `concurrency:n`.
+- **분리 (조정1)**: `QUEUE_CONFIG.RICH_SUMMARY_CONCURRENCY=10` 리터럴(`types.ts:178`, 참조처 worker 2곳뿐)은 PR2 후 미사용(런타임 무영향) → **별도 cleanup PR**에서 제거(+PR1 주석 정리). PR2 diff 미포함.
+- N=4 시작, 측정하며 상향. env = `RICH_SUMMARY_CONCURRENCY`(비밀 아님/CP392 2-질문 통과). 롤백 = `RICH_SUMMARY_CONCURRENCY=1`(코드 revert 무) 또는 PR2 revert(2파일).
+- 범위 = Heart 워커만 (PR3 백필 큐 별도).
+
+## 안전 / 롤백
+- 선행 안전판: PR1 429/5xx backoff 이미 ship(병렬 버스트가 rate limit 쳐도 재시도).
+- 롤백 = work-option 1줄 revert (또는 env N=1). behavior-가역.
+- Heart 인터랙티브 경로는 `retryLimit:0`(사용자 대기)라 backoff(PR1)가 유일 방어 — N 상향 전 429율 측정 필수(아래).
+
+## 📏 측정 (CP467 의무 — 닫는 기준, **2시점 분리**)
+**핵심: `before`는 직렬 baseline이라 구현/배포 前에만 측정 가능 — 배포 후 회상/추정으로 채우면 미충족.**
+순서: **측정 A(before) → 구현 → merge+deploy → 측정 B(after) → done.** (텔레메트리부터 확인해 수동 재현 회피.)
+
+**A. 착수 前 (구현 전) — `before` (직렬 현상태) — ✅ 측정 완료 (CP498, pg-boss 텔레메트리):**
+- 텔레메트리 존재 확인됨: `pgboss.job`/`archive`에 `createdon/startedon/completedon` (timestamptz) → **수동 재현 불요**.
+- **관측 최대 동시성 = 1** (880잡/21d) → 직렬 확정(추론 아님).
+- per-job 실측: **p50 49.6s / p95 143.8s** (가정 87s는 stale — 교정).
+- **실제 Heart 버스트 span (enqueue→last complete, 직렬 baseline):**
+  - 4–5 카드 → **320~490s** (~5–8분)
+  - 10 카드 → **830s** (~14분)
+
+**B. 구현 → merge+deploy 後 — `after` (병렬 4) — 미측정:**
+- **after 측정**: A와 동일(텔레메트리)로 배포 후 유사 규모 버스트 span. 기대: 4–5 카드 ⌈5/4⌉=2-wave ≈ **160~290s**, 10 카드 ⌈10/4⌉=3-wave ≈ **250~430s** (vs 830s) + 관측 최대 동시성 1→4.
+4. **429율**: PR1 backoff 로그(`llm_call_logs` 또는 stdout의 `Retryable <status>; backoff ...` 건수)에서 버스트 중 retryable 발생. **0이면 N 상향 여지** / >0이면 현 N 유지·backoff 여유 확인.
+
+**done 기준 = `before`(배포前) + `after`(배포後) 경과 + 429율 모두 측정값 기록.** 한쪽이라도 추정이면 미충족.
+※ `after`는 Heart=prod 경로라 merge+deploy 후 prod에서만 측정 가능 → merge 승인은 `before`+plan 기준, `after`가 done 게이트(CP467).
+
+## 테스트 / 발동 증명 (조정2)
+- 정적 assert(`teamRefill:true` 포함 / `config.queue.richSummaryConcurrency` default=4) = **배선 확인용일 뿐 발동 증명 아님**. teamRefill 신규라 "옵션 들어감 ≠ 발동"(CP475 5→10 no-op 전례 — 옵션 존재해도 직렬이었음).
+- **done 게이트 = 측정 B(after) 실측** ~520s(직렬)→~174s(병렬4). 구현 시 "assert green = 완료" 착각 금지.
+- 기존 enrich/queue 테스트 회귀 green.
+
+## 진행 규율 (per-step, CP494+1)
+plan 재제시(코드 확인 후 확정값) → James 승인 → **측정 A(`before`, 구현 前 필수)** → 구현 → **merge 승인** → **deploy 승인** → **측정 B(`after`) + 429율** → health 재확인 → done 선언(before+after+429 기록).
+⚠️ **핸드오프 문서는 PR2 브랜치 착수 시 즉시 커밋** (working tree만 두면 손실 — 미루기 금지, CP497 repo-boundary 교훈).
+
+## 의존
+- PR1(#864) merged/deployed = 선결 충족.
+- PR3(점수 백필)는 PR2의 병렬 워커 위에 얹힘 → PR2 먼저.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -48,6 +48,9 @@ const envSchema = z.object({
   // Sync Configuration
   DEFAULT_SYNC_INTERVAL: z.coerce.number().default(3600000), // 1 hour
   MAX_CONCURRENT_SYNCS: z.coerce.number().default(5),
+  // CP498 PR2 — pg-boss enrich-rich-summary (Heart path) worker concurrency.
+  // unset ⇒ 4. Roll back to serial via RICH_SUMMARY_CONCURRENCY=1.
+  RICH_SUMMARY_CONCURRENCY: z.coerce.number().int().min(1).default(4),
   RETRY_ATTEMPTS: z.coerce.number().default(3),
   BACKOFF_MULTIPLIER: z.coerce.number().default(2),
 
@@ -274,6 +277,11 @@ export const config = {
     maxConcurrent: env.MAX_CONCURRENT_SYNCS,
     retryAttempts: env.RETRY_ATTEMPTS,
     backoffMultiplier: env.BACKOFF_MULTIPLIER,
+  },
+
+  // Queue (pg-boss worker concurrency)
+  queue: {
+    richSummaryConcurrency: env.RICH_SUMMARY_CONCURRENCY,
   },
 
   // YouTube API Quota

--- a/src/modules/queue/handlers/enrich-rich-summary.ts
+++ b/src/modules/queue/handlers/enrich-rich-summary.ts
@@ -45,12 +45,9 @@ import { getCaptionExtractor } from '../../caption/extractor';
 import { getPrismaClient } from '../../database/client';
 import { logger } from '../../../utils/logger';
 import { getJobQueue } from '../manager';
-import {
-  JOB_NAMES,
-  QUEUE_CONFIG,
-  RICH_SUMMARY_RETRY_OPTIONS,
-  type EnrichRichSummaryPayload,
-} from '../types';
+import { JOB_NAMES, RICH_SUMMARY_RETRY_OPTIONS, type EnrichRichSummaryPayload } from '../types';
+import { config } from '@/config/index';
+import { richSummaryWorkOptions } from './rich-summary-work-options';
 
 /** Thrown when captions are unavailable so the worker fails fast and the
  *  grid surfaces a retry affordance instead of a description-only row. */
@@ -63,15 +60,15 @@ export const NO_TRANSCRIPT_ERROR = 'NO_TRANSCRIPT';
 export async function registerEnrichRichSummaryWorker(): Promise<void> {
   const boss = getJobQueue().getInstance();
 
+  // N via env (RICH_SUMMARY_CONCURRENCY, default 4). Rollback = set to 1.
+  const concurrency = config.queue.richSummaryConcurrency;
   await boss.work<EnrichRichSummaryPayload>(
     JOB_NAMES.ENRICH_RICH_SUMMARY,
-    { teamConcurrency: QUEUE_CONFIG.RICH_SUMMARY_CONCURRENCY, teamSize: 1 },
+    richSummaryWorkOptions(concurrency),
     handleEnrichRichSummary
   );
 
-  logger.info('enrich-rich-summary worker registered', {
-    concurrency: QUEUE_CONFIG.RICH_SUMMARY_CONCURRENCY,
-  });
+  logger.info('enrich-rich-summary worker registered', { concurrency });
 }
 
 /**

--- a/src/modules/queue/handlers/rich-summary-work-options.ts
+++ b/src/modules/queue/handlers/rich-summary-work-options.ts
@@ -1,0 +1,21 @@
+/**
+ * pg-boss work options that ACTUALLY parallelize the enrich-rich-summary
+ * worker. CP498 PR2. Extracted to a dependency-free module (CP479 pattern) so
+ * the wiring is unit-assertable without loading the heavy worker import chain.
+ *
+ * `teamSize:1` alone left `teamConcurrency` inert: pg-boss fetches
+ * `teamSize - in-flight` (= 1) jobs per poll and awaits that one to completion
+ * before the next fetch → strictly serial (CP475 "5→10" was a no-op). Keeping N
+ * jobs in-flight requires `teamSize:N` + `teamRefill:true` together.
+ *
+ * ⚠️ This helper only proves the OPTION SHAPE. Activation PROOF is the live
+ * concurrency measurement (observed max concurrency 1→N + burst-span drop),
+ * never a static assert — see docs/handoffs/pr2-v2-quick-parallelize-cp498.md.
+ */
+export function richSummaryWorkOptions(concurrency: number): {
+  teamConcurrency: number;
+  teamSize: number;
+  teamRefill: true;
+} {
+  return { teamConcurrency: concurrency, teamSize: concurrency, teamRefill: true };
+}

--- a/tests/smoke/enrich-rich-summary-concurrency.test.ts
+++ b/tests/smoke/enrich-rich-summary-concurrency.test.ts
@@ -1,0 +1,26 @@
+/**
+ * CP498 PR2 — enrich-rich-summary worker concurrency WIRING assert.
+ *
+ * ⚠️ Wiring check, NOT activation proof. `teamRefill` is new to the codebase and
+ * "option present ≠ activated" (CP475 5→10 was a no-op with teamSize:1). The
+ * activation gate is the LIVE measurement (observed max concurrency 1→N +
+ * burst-span drop), not this test. Lives in tests/smoke so CI actually runs it
+ * (CI = `jest --testPathPattern=tests/smoke`).
+ */
+
+import { richSummaryWorkOptions } from '@/modules/queue/handlers/rich-summary-work-options';
+
+describe('richSummaryWorkOptions (CP498 PR2 wiring)', () => {
+  it('returns symmetric teamSize/teamConcurrency = N and teamRefill:true', () => {
+    expect(richSummaryWorkOptions(4)).toEqual({
+      teamConcurrency: 4,
+      teamSize: 4,
+      teamRefill: true,
+    });
+  });
+
+  it('teamRefill is always true — the flag teamSize:1 alone lacked (no-op cause)', () => {
+    expect(richSummaryWorkOptions(1).teamRefill).toBe(true);
+    expect(richSummaryWorkOptions(8).teamSize).toBe(8);
+  });
+});


### PR DESCRIPTION
## What
Activate real concurrency on the Heart-triggered `enrich-rich-summary` pg-boss worker. PR2 of 3 (CP498). PR1 (#864, 429/5xx backoff) already merged as the burst safety net.

## Mechanism (why number-alone was a no-op)
The worker registered `{ teamConcurrency: 10, teamSize: 1 }` with no `teamRefill`. pg-boss v9 fetches `teamSize - in-flight` (= 1) jobs per poll and **awaits that one to completion before the next fetch** → strictly serial. `teamConcurrency` only applies to the fetched batch (always size 1), so it never engaged — the CP475 "5→10" bump was a no-op. Real concurrency requires **`teamSize:N` + `teamRefill:true`** together.

## Change (2 files + 1 helper + 1 test)
- `src/config/index.ts`: `RICH_SUMMARY_CONCURRENCY` zod env (default **4**) → `config.queue.richSummaryConcurrency`.
- `src/modules/queue/handlers/enrich-rich-summary.ts`: register with `richSummaryWorkOptions(N)` = `{ teamConcurrency:N, teamSize:N, teamRefill:true }`. Send-time retry options (`RICH_SUMMARY_RETRY_OPTIONS`, applied in `enqueueEnrichRichSummary`) **untouched**.
- `rich-summary-work-options.ts`: dependency-free pure helper (CP479 pattern) so the wiring is unit-assertable without the heavy worker import chain.
- `tests/smoke/enrich-rich-summary-concurrency.test.ts`: wiring assert (in `tests/smoke` so CI runs it).

`QUEUE_CONFIG.RICH_SUMMARY_CONCURRENCY=10` literal removal is **deferred to a cleanup PR** (decouples concurrency reversibility from the refactor).

## Rollback
`RICH_SUMMARY_CONCURRENCY=1` (env, no code revert) or revert this PR.

## Measurement (CP467) — 2 timepoint
- **before (MEASURED, pg-boss telemetry, 21d):** observed max concurrency = **1** (serial confirmed), per-job p50 49.6s / p95 143.8s, real Heart bursts 4–5 cards 320–490s / 10 cards 830s.
- **after (post-deploy, pending):** observed max concurrency **1→4** + burst-span drop.
- **done gate = observed concurrency 1→N (activation proof) + span drop.** The static assert only checks option SHAPE — `teamRefill` is new and "option present ≠ activated" (CP475 no-op precedent). Expected-after numbers are guides, not thresholds.

## Tests
- Smoke suite green (CI-equivalent), wiring assert included. tsc clean. Frontend /verify N/A (backend-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)