### PR TITLE
feat(relevance): user-scoped A-stage relevance scorer + schema (CP498 PR3a)

### DIFF
--- a/docs/handoffs/pr3-relevance-backfill-cp498.md
+++ b/docs/handoffs/pr3-relevance-backfill-cp498.md
@@ -1,0 +1,32 @@
+# PR3 Handoff — A-stage relevance backfill (user-scoped, card-metadata, quick-only) — CP498
+
+> 작성 CP498 (2026-06-08). PR1(#864 429 backoff)·PR2(#865 동시성, prod verified) 완료 위. 착수 전 James 검토. 코드 우선 — 줄·값은 착수 시 재확인.
+
+## 왜 (measurement B 결론)
+A단계 "전체 카드 관련도 정렬"의 진짜 선결조건 = **점수 부재**(셀 배치 카드 81% relevance 없음, 배치는 v2 미트리거). measurement B(PR2 동시성 live)에서 Heart 경로(quick+Sonnet full 결합)는 concurrency 4 떠도 Sonnet 100-257s contention으로 체감 느림 → A단계는 **quick Haiku만(~1-3s)** 필요. + 누수 위험(아래).
+
+## 🔒 데이터 격리 (PR3 핵심 제약)
+- `video_rich_summaries.mandala_relevance_pct` = **PK video_id 단독** + `GET /v2-summaries`(cards.ts:931) user 필터 없음 → 그 컬럼에 백필하면 **유저 간 점수 누수**(A 점수가 B 카드에 보임). cards.ts:878-882 주석이 명시.
+- → **PR3는 그 컬럼 안 씀.** `user_local_cards`(user+mandala+video+cell 키)에 relevance 컬럼 추가 = user-scoped, 누수 구조적 0.
+- `user_local_cards`는 `title`/`metadata_title`/`metadata_description` 자체 저장(schema:679/683/684) → **youtube_videos 의존 제거** (placed 카드 56/59가 youtube_videos에 없는 갭 해소) + transcript-optional(title+desc fallback, CP498 전제).
+
+## sub-PR (의존 순서 = 위험 격리)
+- **PR3a (토대, 무해·가역)**: schema 컬럼 2개(nullable) + 마이그레이션 raw SQL + `compute-card-relevance.ts`(순수 함수, DB write 0·youtube_videos 안 읽음·Sonnet 미탑승) + smoke. 아무도 안 부름 → 동작 변화 0.
+- **PR3b (동작·측정·flag)**: quick 큐(ENRICH_RELEVANCE_QUICK) + 워커(카드 read→compute→user_local_cards write) + 백필 엔트리포인트(mandala_id→null-relevance 셀카드→fan-out, created_at>cutoff+admin, flag BACKFILL_RELEVANCE_ENABLED off) + config env(RELEVANCE_BACKFILL_CONCURRENCY=4) + deploy.yml B-path 배선 + work-option richSummaryWorkOptions(N) 재사용. 1만다라 측정.
+- **PR3c (정렬)**: BE cards 응답 += relevance_pct + FE "관련도순"(명시, ORDER BY relevance_pct DESC NULLS LAST). user_local_cards 읽음(글로벌 ❌).
+
+## 백로그
+- quick 큐(N)+Heart 큐(4)=t3.medium 동시 8 → measurement B CPU 천장 재현 가능 → N=RELEVANCE_BACKFILL_CONCURRENCY env 조정(시작 4, 경합 시 낮춤) + instance 부하 모니터.
+- /v2-summaries Heart 배지 좁은 누수 = user-aware 필터 별도 fix.
+- null-metadata 카드(title+desc 둘 다 null) = skip + 카운트 로깅.
+
+## 측정 (CP467, PR3b)
+1만다라 백필 → 채워진 카드 수 / skip(null-metadata) 수 / per-job(quick ~1-3s) / 동시성 / 429.
+
+## ⚠️ 마이그레이션 force-track 컨벤션 (PR3b도 적용 — 안 막히게)
+- `.gitignore:29 prisma/migrations/*`가 **신규 untracked DDL 파일을 ignore**한다. 단 기존 feature DDL(add-cards/billing/rich-summary-v2/...)은 전부 tracked = **수동 DDL은 force-track이 컨벤션** (ignore는 prisma auto-gen 폴더용; tracked 파일은 gitignore 면제).
+- CLAUDE.md silent-fail 규칙이 raw DDL의 repo 추적을 요구 → 신규 DDL은 **`git add -f <단일 파일>`** (폴더/와일드카드 `-f` 금지 — phase4 등 untracked 빨려들 위험).
+- PR3a 적용: `git add -f prisma/migrations/relevance-backfill/001_add_relevance.sql`. PR3b 마이그레이션도 동일.
+
+## 진행 규율 (per-step)
+각 sub-PR: plan→승인→측정 A(필요시)→구현→/verify→diff→merge 승인→deploy 승인. 핸드오프는 PR3a 브랜치 착수 시 즉시 커밋.

--- a/prisma/migrations/relevance-backfill/001_add_relevance.sql
+++ b/prisma/migrations/relevance-backfill/001_add_relevance.sql
@@ -1,0 +1,17 @@
+-- CP498 PR3a — A-stage relevance, user-scoped on user_local_cards.
+-- Idempotent (ADD COLUMN IF NOT EXISTS) to survive the Supabase `prisma db push`
+-- silent-fail path (CLAUDE.md rule): apply this raw DDL to local + prod, then
+-- verify with `\d user_local_cards` on both before relying on the columns.
+--
+-- relevance_pct: Haiku score 0-100 of the card vs its mandala centerGoal.
+--   USER-SCOPED (the row is keyed by user_id+mandala_id+video_id+cell), so a
+--   score never leaks across users — unlike the video-keyed
+--   video_rich_summaries.mandala_relevance_pct.
+-- NULL = not yet backfilled (existing rows start NULL; the relevance-backfill
+--   queue in PR3b fills them).
+
+ALTER TABLE public.user_local_cards
+  ADD COLUMN IF NOT EXISTS relevance_pct INTEGER;
+
+ALTER TABLE public.user_local_cards
+  ADD COLUMN IF NOT EXISTS relevance_at TIMESTAMPTZ;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -688,6 +688,12 @@ model user_local_cards {
   mandala_id           String?        @db.Uuid
   sort_order           Int?
   video_id             String?        @db.VarChar(11)
+  /// CP498 PR3 — A-stage relevance: Haiku score (0-100) of this card vs its
+  /// mandala centerGoal. USER-SCOPED here (NOT the video-keyed
+  /// video_rich_summaries.mandala_relevance_pct, which leaks across users).
+  /// NULL = not yet backfilled; filled by the relevance-backfill queue (PR3b).
+  relevance_pct        Int?
+  relevance_at         DateTime?      @db.Timestamptz(6)
   created_at           DateTime?      @default(now()) @db.Timestamptz(6)
   updated_at           DateTime?      @default(now()) @db.Timestamptz(6)
   /// CP457+ pin/bookmark: NULL = unpinned, timestamp = pinned moment.

--- a/src/modules/relevance/compute-card-relevance.ts
+++ b/src/modules/relevance/compute-card-relevance.ts
@@ -1,0 +1,120 @@
+/**
+ * A-stage card relevance — CP498 PR3a.
+ *
+ * Computes a Haiku relevance score (0-100) of a card vs its mandala center
+ * goal, from CARD-PROVIDED metadata (title/description) — caller passes the
+ * text. This module is deliberately:
+ *
+ *   - PURE / side-effect-free: NO Prisma, NO DB write. The caller (PR3b worker)
+ *     decides where to persist (user_local_cards.relevance_pct — user-scoped).
+ *     It NEVER touches video_rich_summaries (the video-keyed column that leaks
+ *     across users).
+ *   - youtube_videos-INDEPENDENT: title/description come from the argument, not
+ *     a youtube_videos lookup (placed cards are often absent from that table).
+ *   - transcript-OPTIONAL: transcript defaults to '' → buildV2QuickPrompt falls
+ *     back to title+description (CP498 premise: backfill works caption-free; a
+ *     transcript only raises quality when present).
+ *   - quick-only: a single Haiku call. The Sonnet full path is never invoked.
+ *
+ * Reuses the quick-path prompt + validator so the scoring instruction is a
+ * single source of truth with the Heart path.
+ */
+
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import {
+  buildV2QuickPrompt,
+  validateV2Quick,
+  V2QuickValidationError,
+} from '@/modules/skills/rich-summary-v2-quick-prompt';
+
+const HAIKU_MODEL = 'anthropic/claude-haiku-4.5';
+const MAX_TOKENS = 800;
+const TEMPERATURE = 0.2;
+
+const HANGUL_RANGE = /[가-힣]/g;
+const LATIN_RANGE = /[A-Za-z]/g;
+
+/** Best-effort ko/en hint from the card title (default ko). */
+function detectLanguage(title: string): 'ko' | 'en' {
+  const stripped = title.replace(/\s+/g, '');
+  if (stripped.length === 0) return 'ko';
+  const hangul = (stripped.match(HANGUL_RANGE) ?? []).length / stripped.length;
+  const latin = (stripped.match(LATIN_RANGE) ?? []).length / stripped.length;
+  if (hangul >= 0.2) return 'ko';
+  if (latin >= 0.5 && hangul < 0.05) return 'en';
+  return 'ko';
+}
+
+export interface CardRelevanceInput {
+  /** Card title (required — the minimal signal). */
+  title: string;
+  /** Card description / metadata_description (optional). */
+  description?: string;
+  /** The card's mandala centerGoal. Empty ⇒ model returns 0 per the prompt. */
+  centerGoal: string;
+  /** Optional transcript; '' ⇒ prompt uses title+description fallback. */
+  transcript?: string;
+}
+
+export type CardRelevanceResult =
+  | { ok: true; relevancePct: number }
+  | { ok: false; reason: string };
+
+/** Compute a 0-100 relevance score. No persistence — caller writes the result. */
+export async function computeCardRelevance(
+  input: CardRelevanceInput
+): Promise<CardRelevanceResult> {
+  if (!input.title || input.title.trim().length === 0) {
+    return { ok: false, reason: 'no_title' };
+  }
+
+  const language = detectLanguage(input.title);
+  const prompt = buildV2QuickPrompt({
+    title: input.title,
+    description: input.description ?? '',
+    channel: '',
+    language,
+    transcript: input.transcript ?? '',
+    mandalaCenterGoal: input.centerGoal,
+  });
+
+  let raw: string;
+  try {
+    raw = await new OpenRouterGenerationProvider(HAIKU_MODEL).generate(prompt, {
+      format: 'json',
+      temperature: TEMPERATURE,
+      maxTokens: MAX_TOKENS,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `provider_error: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // Haiku sometimes wraps JSON in a ```json fence even when told not to — strip
+  // it before parsing (same handling as the quick generator).
+  const stripped = raw
+    .trim()
+    .replace(/^\s*```(?:json)?\s*\n?/i, '')
+    .replace(/\n?\s*```\s*$/i, '')
+    .trim();
+
+  let json: unknown;
+  try {
+    json = JSON.parse(stripped);
+  } catch (err) {
+    return { ok: false, reason: `json_parse: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  try {
+    const parsed = validateV2Quick(json);
+    return { ok: true, relevancePct: parsed.analysis.mandala_fit.mandala_relevance_pct };
+  } catch (err) {
+    const reason =
+      err instanceof V2QuickValidationError
+        ? `validation: ${err.path}: ${err.message}`
+        : `validation_threw: ${err instanceof Error ? err.message : String(err)}`;
+    return { ok: false, reason };
+  }
+}

--- a/tests/smoke/compute-card-relevance.test.ts
+++ b/tests/smoke/compute-card-relevance.test.ts
@@ -1,0 +1,82 @@
+/**
+ * CP498 PR3a — computeCardRelevance: pure A-stage relevance scorer.
+ *
+ * Pins the PR3a guarantees: (1) no DB write (pure — no prisma import to mock),
+ * (2) youtube_videos-independent (title/desc are arguments), (3) transcript-
+ * optional (works with transcript omitted → title+desc fallback), (4) a single
+ * Haiku call (no Sonnet). The score is whatever the LLM returns; we mock fetch.
+ */
+
+const mockConfig = {
+  openrouter: { apiKey: 'test-key', model: 'anthropic/claude-haiku-4.5' },
+};
+jest.mock('@/config/index', () => ({ config: mockConfig }));
+jest.mock('@/modules/llm/call-logger', () => ({ logLLMCall: jest.fn(() => Promise.resolve()) }));
+
+import { computeCardRelevance } from '@/modules/relevance/compute-card-relevance';
+
+const haikuJson = (pct: number) =>
+  JSON.stringify({
+    core: { one_liner: '기초 체력' },
+    analysis: {
+      core_argument: '기초 체력은 모든 운동의 토대다.',
+      mandala_fit: { mandala_relevance_pct: pct },
+    },
+  });
+
+const okResponse = (content: string): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({ choices: [{ message: { content } }], usage: {} }),
+  }) as unknown as Response;
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('computeCardRelevance (CP498 PR3a)', () => {
+  it('returns the Haiku relevance score from card title+description (no transcript)', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(okResponse(haikuJson(82))) as unknown as typeof fetch;
+
+    const out = await computeCardRelevance({
+      title: '기초 체력 기르기',
+      description: '맨몸 운동 루틴',
+      centerGoal: '운동 습관 만들기',
+      // transcript intentionally omitted — title+desc fallback
+    });
+
+    expect(out).toEqual({ ok: true, relevancePct: 82 });
+    expect(global.fetch).toHaveBeenCalledTimes(1); // single Haiku call, no Sonnet
+  });
+
+  it('uses transcript when provided (still one call)', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(okResponse(haikuJson(40))) as unknown as typeof fetch;
+    const out = await computeCardRelevance({
+      title: 'Deep work explained',
+      centerGoal: 'focus habits',
+      transcript: 'In this video we discuss focus and deep work...',
+    });
+    expect(out).toEqual({ ok: true, relevancePct: 40 });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects empty title without calling the LLM', async () => {
+    global.fetch = jest.fn() as unknown as typeof fetch;
+    const out = await computeCardRelevance({ title: '   ', centerGoal: 'x' });
+    expect(out).toEqual({ ok: false, reason: 'no_title' });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('strips a ```json fence before parsing', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        okResponse('```json\n' + haikuJson(55) + '\n```')
+      ) as unknown as typeof fetch;
+    const out = await computeCardRelevance({ title: 'T', centerGoal: 'g' });
+    expect(out).toEqual({ ok: true, relevancePct: 55 });
+  });
+});


### PR DESCRIPTION
## What
PR3a of 3 — **foundation, inert** (nothing calls it yet → zero behavior change, fully reversible). Adds the pieces A-stage relevance backfill needs.

## Why user-scoped (the leak this avoids)
`video_rich_summaries.mandala_relevance_pct` is **video-keyed** (PK = video_id) and `GET /v2-summaries` reads it **without a user filter** → user A's score (vs A's mandala goal) leaks to user B's card. PR3 stores relevance on **`user_local_cards`** (keyed by user+mandala+video+cell) = no cross-user leak.

## Changes (4 files)
- `prisma/schema.prisma`: `user_local_cards += relevance_pct (Int?) + relevance_at`. Existing rows start NULL; PR3b backfill fills them.
- `prisma/migrations/relevance-backfill/001_add_relevance.sql`: idempotent raw DDL (`ADD COLUMN IF NOT EXISTS`) for the Supabase `prisma db push` silent-fail path (apply local+prod, verify `\d`). Force-tracked (the `prisma/migrations/*` ignore is for prisma auto-gen; manual feature DDLs are tracked — see existing add-cards/billing/rich-summary-v2 DDLs).
- `src/modules/relevance/compute-card-relevance.ts`: pure Haiku scorer. **NO Prisma import** (DB write physically impossible) → never touches `video_rich_summaries`; reads title/description from its **argument** (no `youtube_videos` lookup — placed cards are often absent there); **transcript-optional** (empty ⇒ title+desc fallback); **single Haiku call** (Sonnet never invoked). Reuses the quick-path prompt+validator.
- `tests/smoke/compute-card-relevance.test.ts`: 4 cases (title+desc-only, transcript path, empty-title reject, fence strip).

## Verify
prisma validate ok · tsc clean · full smoke suite green (4 new). No deploy.yml change. Inert → no measurement needed (PR3b calls + measures it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)