### PR TITLE
feat(relevance): PR3b A-stage backfill worker + trigger + admin route (CP498)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -317,6 +317,15 @@ jobs:
           # or `--body 6` (raise) + redeploy — no code revert. Non-secret per
           # CP392 (tuning knob).
           RICH_SUMMARY_CONCURRENCY: ${{ vars.RICH_SUMMARY_CONCURRENCY }}
+          # CP498 PR3b — A-stage relevance backfill. 3 non-secret tuning knobs
+          # (CP392). BACKFILL_RELEVANCE_ENABLED gates the AUTO path (default
+          # OFF); RELEVANCE_BACKFILL_CONCURRENCY = worker pool size (default 4);
+          # RELEVANCE_BACKFILL_CUTOFF = ISO ts (auto path scores only newer
+          # cards). All unset ⇒ config zod defaults; the admin manual route
+          # works regardless of the flag. Rollback: unset/false + redeploy.
+          BACKFILL_RELEVANCE_ENABLED: ${{ vars.BACKFILL_RELEVANCE_ENABLED }}
+          RELEVANCE_BACKFILL_CONCURRENCY: ${{ vars.RELEVANCE_BACKFILL_CONCURRENCY }}
+          RELEVANCE_BACKFILL_CUTOFF: ${{ vars.RELEVANCE_BACKFILL_CUTOFF }}
           # Mac Mini transcript proxy. EC2 outbound to YouTube is blocked
           # for caption fetch; the Mac Mini (KR ISP IP, Tailscale 4242)
           # successfully fetches and forwards via x-transcript-token auth.
@@ -328,7 +337,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,YT_VIDEOS_KEY,YT_VIDEOS_KEY_2,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,V2_QUALITY_AUDIT_ENABLED,V2_QUALITY_REGEN_ENABLED,V3_TRACE_ENABLED,RICH_SUMMARY_CONCURRENCY,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
+          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,YT_VIDEOS_KEY,YT_VIDEOS_KEY_2,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,RICH_SUMMARY_ENABLED,YOUTUBE_METADATA_BACKFILL_ENABLED,V2_QUALITY_AUDIT_ENABLED,V2_QUALITY_REGEN_ENABLED,V3_TRACE_ENABLED,RICH_SUMMARY_CONCURRENCY,BACKFILL_RELEVANCE_ENABLED,RELEVANCE_BACKFILL_CONCURRENCY,RELEVANCE_BACKFILL_CUTOFF,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN
           script: |
             set -e
             cd /opt/tubearchive
@@ -407,6 +416,19 @@ jobs:
             # + redeploy — no code revert.
             if [ -n "${RICH_SUMMARY_CONCURRENCY}" ]; then
               grep -q '^RICH_SUMMARY_CONCURRENCY=' .env 2>/dev/null && sed -i "s|^RICH_SUMMARY_CONCURRENCY=.*|RICH_SUMMARY_CONCURRENCY=${RICH_SUMMARY_CONCURRENCY}|" .env || echo "RICH_SUMMARY_CONCURRENCY=${RICH_SUMMARY_CONCURRENCY}" >> .env
+            fi
+            # CP498 PR3b — A-stage relevance backfill knobs. Same idempotent
+            # pattern. All unset/empty ⇒ conditional skips ⇒ config zod defaults
+            # (enabled=false / concurrency=4 / cutoff=unset). Tune/rollback via
+            # `gh variable set <NAME> --body <v>` + redeploy — no code revert.
+            if [ -n "${BACKFILL_RELEVANCE_ENABLED}" ]; then
+              grep -q '^BACKFILL_RELEVANCE_ENABLED=' .env 2>/dev/null && sed -i "s|^BACKFILL_RELEVANCE_ENABLED=.*|BACKFILL_RELEVANCE_ENABLED=${BACKFILL_RELEVANCE_ENABLED}|" .env || echo "BACKFILL_RELEVANCE_ENABLED=${BACKFILL_RELEVANCE_ENABLED}" >> .env
+            fi
+            if [ -n "${RELEVANCE_BACKFILL_CONCURRENCY}" ]; then
+              grep -q '^RELEVANCE_BACKFILL_CONCURRENCY=' .env 2>/dev/null && sed -i "s|^RELEVANCE_BACKFILL_CONCURRENCY=.*|RELEVANCE_BACKFILL_CONCURRENCY=${RELEVANCE_BACKFILL_CONCURRENCY}|" .env || echo "RELEVANCE_BACKFILL_CONCURRENCY=${RELEVANCE_BACKFILL_CONCURRENCY}" >> .env
+            fi
+            if [ -n "${RELEVANCE_BACKFILL_CUTOFF}" ]; then
+              grep -q '^RELEVANCE_BACKFILL_CUTOFF=' .env 2>/dev/null && sed -i "s|^RELEVANCE_BACKFILL_CUTOFF=.*|RELEVANCE_BACKFILL_CUTOFF=${RELEVANCE_BACKFILL_CUTOFF}|" .env || echo "RELEVANCE_BACKFILL_CUTOFF=${RELEVANCE_BACKFILL_CUTOFF}" >> .env
             fi
             # 2026-04-18 — sync DB URLs from GitHub Secrets so password
             # rotations propagate to prod .env without manual SSH. Was

--- a/docs/handoffs/pr3-relevance-backfill-cp498.md
+++ b/docs/handoffs/pr3-relevance-backfill-cp498.md
@@ -2,6 +2,19 @@
 
 > 작성 CP498 (2026-06-08). PR1(#864 429 backoff)·PR2(#865 동시성, prod verified) 완료 위. 착수 전 James 검토. 코드 우선 — 줄·값은 착수 시 재확인.
 
+## ⚠️ PR3b 정정 — DUAL-TABLE (전제 뒤집힌 실측)
+- **placed 카드 비중 (실측)**: `user_video_states` **6034** vs `user_local_cards` **77** (uvs가 98.7%). 파이프라인 추천카드=uvs, 수동/D&D=ulc. → PR3a "81% null"은 ulc 77만 본 것 = 모집단 1.3%. **PR3는 반드시 uvs 타겟.**
+- **uvs user-scoped 확인**: unique `(user_id, video_id)` → relevance write 누수 0 (ulc와 동일 안전).
+- **uvs metadata = youtube_videos JOIN** (`video_id → youtube_videos.id`, FK ON DELETE CASCADE = row 항상 존재, **skip 0**). 실측 채움률 **title 100% / desc 1.1%** → uvs는 **title-only 관련도**(thin). ulc는 자체 title/metadata_description. `compute-card-relevance`(인자 기반)가 둘 다 처리.
+- **스코프**: relevance_pct를 uvs(주) + ulc(PR3a 유지, 수동 77) 둘 다. dual-table 백필(rich-summary-trigger 미러). PR3a ulc 컬럼 = 불충분이나 inert·무해 → revert 불필요.
+- **title-only (a) 수용** (A단계=정렬, directional이면 충분; transcript 보강은 캡션 전제 위배 비권고).
+
+## 📏 측정해석 게이트 (title-only 판정 — eyeball 금지, measurement B 교훈)
+1만다라 admin 백필 측정 항목 = 채움수 / skip(title 없음) / per-job / 동시성 / 429 **+ 아래 2개가 title-only 실제 게이트**:
+- **변별력 = 점수 분산**: 1만다라 카드 relevance_pct 분포(min/max/stddev). 다 뭉치면(예 70±5) 정렬 무의미 = title-only 부족.
+- **순서정합 = 고정표본**: 명백히 관련높은 3 + 빗나간 3을 **사전 지정**, 점수가 그 순서대로 나오나(전체 인상 아님).
+- **done 해석**: 분산 있음 + 고정표본 순서 맞음 → title-only 충분, 진행. 아니면 → 보강 재고(transcript 아니라 **uvs desc가 왜 1.1%만 찼나**부터 — 별도 질문).
+
 ## 왜 (measurement B 결론)
 A단계 "전체 카드 관련도 정렬"의 진짜 선결조건 = **점수 부재**(셀 배치 카드 81% relevance 없음, 배치는 v2 미트리거). measurement B(PR2 동시성 live)에서 Heart 경로(quick+Sonnet full 결합)는 concurrency 4 떠도 Sonnet 100-257s contention으로 체감 느림 → A단계는 **quick Haiku만(~1-3s)** 필요. + 누수 위험(아래).
 

--- a/prisma/migrations/relevance-backfill/002_uvs_relevance.sql
+++ b/prisma/migrations/relevance-backfill/002_uvs_relevance.sql
@@ -1,0 +1,16 @@
+-- CP498 PR3b — A-stage relevance on user_video_states (the dominant placed-card
+-- store: 6034 placed vs 77 in user_local_cards). Same pattern as PR3a's
+-- 001_add_relevance.sql (user_local_cards): idempotent, nullable, user-scoped.
+--
+-- user_video_states is keyed unique (user_id, video_id) → the score is
+-- user-scoped, so it never leaks across users (unlike the video-keyed
+-- video_rich_summaries.mandala_relevance_pct).
+--
+-- Apply to local + prod, verify `\d user_video_states` on BOTH (Supabase
+-- prisma db push silent-fail path, CLAUDE.md). NULL = not yet backfilled.
+
+ALTER TABLE public.user_video_states
+  ADD COLUMN IF NOT EXISTS relevance_pct INTEGER;
+
+ALTER TABLE public.user_video_states
+  ADD COLUMN IF NOT EXISTS relevance_at TIMESTAMPTZ;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,11 @@ model UserVideoState {
   /// NULL = never surfaced. Layer 1 Coverage prefers un-surfaced rows
   /// for diversity (도배 회피). Spec: docs/design/add-cards-2026-05-18.md.
   surfaced_at            DateTime?      @db.Timestamptz(6)
+  /// CP498 PR3b — A-stage relevance: Haiku score (0-100) of this card vs its
+  /// mandala centerGoal. USER-SCOPED (unique user_id+videoId) — no cross-user
+  /// leak. NULL = not yet backfilled; filled by the relevance-backfill queue.
+  relevance_pct          Int?
+  relevance_at           DateTime?      @db.Timestamptz(6)
   createdAt              DateTime       @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt              DateTime       @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
   users                  users          @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)

--- a/src/api/routes/admin/index.ts
+++ b/src/api/routes/admin/index.ts
@@ -25,6 +25,7 @@ import { adminSearchAlgorithmsRoutes } from './search-algorithms';
 import { adminV2QualityAuditRoutes } from './v2-quality-audit';
 import { adminV4ArbiterRunsRoutes } from './v4-arbiter-runs';
 import { adminPoolHealthRoutes } from './pool-health';
+import { adminRelevanceBackfillRoutes } from './relevance-backfill';
 
 /**
  * Admin routes plugin.
@@ -67,5 +68,8 @@ export async function adminRoutes(fastify: FastifyInstance) {
   // Content Pool Health — 5-section dashboard (volume / enrich / source /
   // reuse / promote) with 5min cache + JSON snapshot fallback.
   await fastify.register(adminPoolHealthRoutes, { prefix: '/pool-health' });
+  // CP498 PR3b — A-stage relevance backfill manual trigger (1-mandala
+  // measurement surface; bypasses BACKFILL_RELEVANCE_ENABLED + cutoff).
+  await fastify.register(adminRelevanceBackfillRoutes, { prefix: '/relevance-backfill' });
   // await fastify.register(stripeWebhookRoutes, { prefix: '/webhooks/stripe' });
 }

--- a/src/api/routes/admin/relevance-backfill.ts
+++ b/src/api/routes/admin/relevance-backfill.ts
@@ -1,0 +1,49 @@
+/**
+ * Admin Relevance Backfill route — CP498 PR3b (A-stage).
+ *
+ * Manual entrypoint to score a single mandala's unscored placed cards. This is
+ * the controlled 1-mandala measurement surface: it deliberately bypasses both
+ * the BACKFILL_RELEVANCE_ENABLED flag and the created_at cutoff, so the backfill
+ * can be measured on one mandala while the auto path stays off in prod.
+ *
+ * Guarded by `fastify.authenticate + fastify.authenticateAdmin` per the admin
+ * convention (see v2-quality-audit.ts:38).
+ *
+ *   POST /api/v1/admin/relevance-backfill/run   body { userId, mandalaId }
+ */
+
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+import { createSuccessResponse } from '../../schemas/common.schema';
+import { enqueueRelevanceBackfillForMandala } from '@/modules/relevance/relevance-backfill-trigger';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'AdminRelevanceBackfill' });
+
+const RunBodySchema = z.object({
+  userId: z.string().uuid(),
+  mandalaId: z.string().uuid(),
+});
+
+export async function adminRelevanceBackfillRoutes(fastify: FastifyInstance) {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  /**
+   * POST /api/v1/admin/relevance-backfill/run
+   * Fan out relevance-quick jobs for every unscored placed card in the target
+   * mandala (cutoff ignored, flag bypassed). Returns enqueue/skip counts.
+   */
+  fastify.post('/run', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
+    const { userId, mandalaId } = RunBodySchema.parse(request.body ?? {});
+
+    const result = await enqueueRelevanceBackfillForMandala({
+      userId,
+      mandalaId,
+      applyCutoff: false,
+    });
+
+    log.info('admin relevance backfill run', { userId, mandalaId, ...result });
+    return reply.send(createSuccessResponse(result));
+  });
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -201,6 +201,23 @@ const envSchema = z.object({
   SUPPLY_YT_BRIDGE_ENABLED: z
     .preprocess((v) => String(v).toLowerCase() === 'true', z.boolean())
     .default(false),
+
+  // CP498 PR3b — A-stage relevance backfill (user-scoped score on uvs/ulc).
+  // Gates the AUTO path only (pipeline-runner uvs + add-cards ulc). Default
+  // OFF ⇒ no automatic scoring fires. The admin manual route deliberately
+  // bypasses this flag so a controlled 1-mandala measurement can run while it
+  // stays off (config-only rollback, no code revert).
+  BACKFILL_RELEVANCE_ENABLED: z
+    .preprocess((v) => String(v).toLowerCase() === 'true', z.boolean())
+    .default(false),
+  // Worker concurrency for the enrich-relevance-quick pool. Independent from
+  // RICH_SUMMARY_CONCURRENCY (Heart path); both hit the same t3.medium, so
+  // lower this if measurement B's CPU ceiling reappears. unset ⇒ 4.
+  RELEVANCE_BACKFILL_CONCURRENCY: z.coerce.number().int().min(1).default(4),
+  // ISO timestamp — the AUTO path only scores cards created strictly after
+  // this (new cards only; existing cards are never auto-backfilled). Unset ⇒
+  // the auto path applies no cutoff filter. The admin manual route ignores it.
+  RELEVANCE_BACKFILL_CUTOFF: z.string().optional(),
 });
 
 type Env = z.infer<typeof envSchema>;
@@ -282,6 +299,13 @@ export const config = {
   // Queue (pg-boss worker concurrency)
   queue: {
     richSummaryConcurrency: env.RICH_SUMMARY_CONCURRENCY,
+    relevanceBackfillConcurrency: env.RELEVANCE_BACKFILL_CONCURRENCY,
+  },
+
+  // CP498 PR3b — A-stage relevance backfill (auto-path gate + cutoff).
+  relevanceBackfill: {
+    enabled: env.BACKFILL_RELEVANCE_ENABLED,
+    cutoff: env.RELEVANCE_BACKFILL_CUTOFF,
   },
 
   // YouTube API Quota

--- a/src/modules/queue/handlers/enrich-relevance-quick.ts
+++ b/src/modules/queue/handlers/enrich-relevance-quick.ts
@@ -1,0 +1,107 @@
+/**
+ * Enrich Relevance Quick — CP498 PR3b (A-stage).
+ *
+ * One quick-Haiku relevance score (0-100) per user-scoped card ROW, persisted
+ * to that row (UserVideoState.relevance_pct or user_local_cards.relevance_pct).
+ *
+ * Design invariant (the thing NOT to get wrong): relevance is a RELATION
+ * (video × this user's centerGoal), not a property of the video. So the unit
+ * of work is the row PK, NEVER the video id — the same video in two rows gets
+ * two scores. This worker updates `where: { id: rowId }`; it must never key by
+ * video_id. compute-card-relevance.ts is import-pure (no Prisma, no
+ * youtube_videos read), so this persist step is the only leak surface.
+ *
+ * Concurrency: reuses richSummaryWorkOptions(N) (PR2 #865) — teamSize:N +
+ * teamRefill so pg-boss actually parallelises (teamSize:1 alone is inert).
+ */
+
+import type PgBoss from 'pg-boss';
+
+import { computeCardRelevance } from '@/modules/relevance/compute-card-relevance';
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+import { getJobQueue } from '../manager';
+import { JOB_NAMES, RELEVANCE_QUICK_RETRY_OPTIONS, type RelevanceQuickPayload } from '../types';
+import { config } from '@/config/index';
+import { richSummaryWorkOptions } from './rich-summary-work-options';
+
+/**
+ * Register the enrich-relevance-quick worker with pg-boss. Must be called
+ * after JobQueue.start().
+ */
+export async function registerEnrichRelevanceQuickWorker(): Promise<void> {
+  const boss = getJobQueue().getInstance();
+
+  // N via env (RELEVANCE_BACKFILL_CONCURRENCY, default 4). Rollback = set to 1.
+  const concurrency = config.queue.relevanceBackfillConcurrency;
+  await boss.work<RelevanceQuickPayload>(
+    JOB_NAMES.ENRICH_RELEVANCE_QUICK,
+    richSummaryWorkOptions(concurrency),
+    handleEnrichRelevanceQuick
+  );
+
+  logger.info('enrich-relevance-quick worker registered', { concurrency });
+}
+
+/**
+ * Score one card row. no_title ⇒ legitimate skip (null-metadata card) — log
+ * and return, do not throw. Other compute failures (provider/validation) throw
+ * so pg-boss retries once per RELEVANCE_QUICK_RETRY_OPTIONS.
+ */
+async function handleEnrichRelevanceQuick(job: PgBoss.Job<RelevanceQuickPayload>): Promise<void> {
+  const { table, rowId, title, description, centerGoal } = job.data;
+
+  const result = await computeCardRelevance({ title, description, centerGoal });
+
+  if (!result.ok) {
+    if (result.reason === 'no_title') {
+      logger.info('enrich-relevance-quick: skipped (no_title)', {
+        jobId: job.id,
+        table,
+        rowId,
+      });
+      return;
+    }
+    logger.warn('enrich-relevance-quick: compute failed', {
+      jobId: job.id,
+      table,
+      rowId,
+      reason: result.reason,
+    });
+    throw new Error(`relevance_compute_failed: ${result.reason}`);
+  }
+
+  const prisma = getPrismaClient();
+  const data = { relevance_pct: result.relevancePct, relevance_at: new Date() };
+
+  // Persist keyed by ROW PK — never by video_id (relation-not-attribute
+  // invariant). Each row carries its own centerGoal-scoped score.
+  if (table === 'uvs') {
+    await prisma.userVideoState.update({ where: { id: rowId }, data });
+  } else {
+    await prisma.user_local_cards.update({ where: { id: rowId }, data });
+  }
+
+  logger.info('enrich-relevance-quick: scored', {
+    jobId: job.id,
+    table,
+    rowId,
+    relevancePct: result.relevancePct,
+  });
+}
+
+/**
+ * Enqueue a single relevance-quick job. Returns the pg-boss job id (or null
+ * when the queue is unavailable). The trigger counts a null return as skipped.
+ */
+export async function enqueueRelevanceQuick(
+  payload: RelevanceQuickPayload,
+  options?: PgBoss.SendOptions
+): Promise<string | null> {
+  const boss = getJobQueue().getInstance();
+
+  return boss.send(JOB_NAMES.ENRICH_RELEVANCE_QUICK, payload, {
+    ...RELEVANCE_QUICK_RETRY_OPTIONS,
+    ...options,
+  });
+}

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -15,11 +15,13 @@ export type {
   EnrichRichSummaryPayload,
   BatchVideoCollectorRunPayload,
   PoolMaintenanceRunPayload,
+  RelevanceQuickPayload,
 } from './types';
 export { enqueueEnrichVideo } from './handlers/enrich-video';
 export { enqueueEnrichRichSummary } from './handlers/enrich-rich-summary';
 export { enqueueBatchVideoCollectorRun } from './handlers/batch-video-collector';
 export { enqueuePoolMaintenanceRun } from './handlers/pool-maintenance';
+export { enqueueRelevanceQuick } from './handlers/enrich-relevance-quick';
 
 import { getJobQueue } from './manager';
 import { registerEnrichVideoWorker } from './handlers/enrich-video';
@@ -27,6 +29,7 @@ import { registerBatchScanWorker } from './handlers/batch-scan';
 import { registerEnrichRichSummaryWorker } from './handlers/enrich-rich-summary';
 import { registerBatchVideoCollectorWorker } from './handlers/batch-video-collector';
 import { registerPoolMaintenanceWorker } from './handlers/pool-maintenance';
+import { registerEnrichRelevanceQuickWorker } from './handlers/enrich-relevance-quick';
 import { logger } from '../../utils/logger';
 
 /**
@@ -46,6 +49,7 @@ export async function initJobQueue(): Promise<void> {
   await registerEnrichRichSummaryWorker();
   await registerBatchVideoCollectorWorker();
   await registerPoolMaintenanceWorker();
+  await registerEnrichRelevanceQuickWorker();
 
-  logger.info('Job queue fully initialized (pg-boss + 5 workers)');
+  logger.info('Job queue fully initialized (pg-boss + 6 workers)');
 }

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -25,6 +25,14 @@ export const JOB_NAMES = {
    * stale YouTube metadata, decoupled from the collector success path. 0 quota.
    */
   POOL_MAINTENANCE_RUN: 'pool-maintenance-run',
+  /**
+   * CP498 PR3b — A-stage relevance backfill. One quick-Haiku score (0-100) per
+   * user-scoped card ROW (user_video_states or user_local_cards). NOT
+   * video-keyed: relevance is a relation (video × this row's centerGoal), so
+   * the unit of work is the row, never the video. See
+   * docs/handoffs/pr3-relevance-backfill-cp498.md.
+   */
+  ENRICH_RELEVANCE_QUICK: 'enrich-relevance-quick',
 } as const;
 
 export type JobName = (typeof JOB_NAMES)[keyof typeof JOB_NAMES];
@@ -91,6 +99,24 @@ export interface PoolMaintenanceRunPayload {
   trigger?: string;
 }
 
+/**
+ * CP498 PR3b — payload for ENRICH_RELEVANCE_QUICK.
+ *
+ * Carries ALL scoring inputs so the worker does ZERO DB reads before its
+ * single write. `rowId` is the PK of the user-scoped row
+ * (UserVideoState.id for table='uvs', user_local_cards.id for table='ulc').
+ * The fan-out unit is the ROW, never the video id — the same video placed in
+ * two rows/cells gets two independent scores against each row's centerGoal, so
+ * the score never collapses into a video attribute (= no cross-user leak).
+ */
+export interface RelevanceQuickPayload {
+  table: 'uvs' | 'ulc';
+  rowId: string;
+  title: string;
+  description?: string;
+  centerGoal: string;
+}
+
 // ============================================================================
 // Job Options
 // ============================================================================
@@ -150,6 +176,16 @@ export const BATCH_VIDEO_COLLECTOR_RUN_OPTIONS = {
 export const POOL_MAINTENANCE_RUN_OPTIONS = {
   retryLimit: 0,
   expireInMinutes: 10,
+} as const;
+
+/**
+ * Relevance backfill — quick Haiku only (~1-3s), not interactive. Short expiry;
+ * one retry absorbs a transient 429/5xx that slips past the OpenRouter backoff
+ * (PR1 #864). A second failure (or no_title) is handled in the worker.
+ */
+export const RELEVANCE_QUICK_RETRY_OPTIONS = {
+  retryLimit: 1,
+  expireInMinutes: 5,
 } as const;
 
 // ============================================================================

--- a/src/modules/relevance/relevance-backfill-trigger.ts
+++ b/src/modules/relevance/relevance-backfill-trigger.ts
@@ -1,0 +1,150 @@
+/**
+ * Relevance backfill trigger — CP498 PR3b (A-stage).
+ *
+ * Fans out one enrich-relevance-quick job per UNSCORED placed card row in a
+ * mandala, across both user-scoped tables (user_video_states + user_local_cards).
+ *
+ * ⚠️ ONE deliberate divergence from rich-summary-trigger.ts: NO video-id dedup.
+ * rich-summary-trigger collapses both tables into a Map keyed by YouTube video
+ * id (one enrich job per video) — correct there, because a rich summary IS a
+ * video attribute. It is WRONG for relevance: relevance is a relation
+ * (video × this row's centerGoal), so the fan-out unit MUST be the ROW
+ * (table, id). The same video placed in two cells/mandalas → two jobs → two
+ * independent scores. Collapsing to video would re-introduce the cross-user
+ * leak that PR3a's import-purity closed. The regression test
+ * (relevance-backfill-trigger.test.ts) locks this: two rows, same video_id,
+ * two enqueues.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { getMandalaManager } from '@/modules/mandala/manager';
+import { enqueueRelevanceQuick } from '@/modules/queue/handlers/enrich-relevance-quick';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'RelevanceBackfillTrigger' });
+
+export interface RelevanceBackfillResult {
+  enqueued: number;
+  skipped: number;
+  uvsRows: number;
+  ulcRows: number;
+}
+
+/**
+ * Enqueue relevance-quick jobs for a mandala's unscored placed cards.
+ *
+ * @param applyCutoff true = AUTO path: only score cards created strictly after
+ *   `cutoff` (new cards). false = admin manual: all unscored placed cards,
+ *   cutoff ignored. The BACKFILL_RELEVANCE_ENABLED flag is checked by the AUTO
+ *   call sites, NOT here — the admin route must work while the flag is off so a
+ *   controlled 1-mandala measurement can run.
+ */
+export async function enqueueRelevanceBackfillForMandala(params: {
+  userId: string;
+  mandalaId: string;
+  applyCutoff: boolean;
+  cutoff?: string;
+}): Promise<RelevanceBackfillResult> {
+  const prisma = getPrismaClient();
+
+  // Resolve the mandala centerGoal once (root level depth=0) — same source as
+  // enrich-rich-summary.ts:174. Empty ⇒ compute returns 0 per the quick prompt.
+  let centerGoal = '';
+  try {
+    const mandala = await getMandalaManager().getMandalaById(params.userId, params.mandalaId);
+    centerGoal = mandala?.levels[0]?.centerGoal ?? '';
+  } catch (err) {
+    log.warn('mandala lookup failed (continuing with empty centerGoal)', {
+      userId: params.userId,
+      mandalaId: params.mandalaId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  const cutoffDate = params.applyCutoff && params.cutoff ? new Date(params.cutoff) : undefined;
+
+  // Placed (cell_index >= 0), not-yet-scored cards in this mandala. NO dedup —
+  // one job per ROW. uvs createdAt is mapped from created_at; ulc is created_at.
+  const [videoStates, localCards] = await Promise.all([
+    prisma.userVideoState.findMany({
+      where: {
+        user_id: params.userId,
+        mandala_id: params.mandalaId,
+        cell_index: { gte: 0 },
+        relevance_pct: null,
+        ...(cutoffDate ? { createdAt: { gt: cutoffDate } } : {}),
+      },
+      select: { id: true, video: { select: { title: true } } },
+    }),
+    prisma.user_local_cards.findMany({
+      where: {
+        user_id: params.userId,
+        mandala_id: params.mandalaId,
+        cell_index: { gte: 0 },
+        relevance_pct: null,
+        ...(cutoffDate ? { created_at: { gt: cutoffDate } } : {}),
+      },
+      select: { id: true, title: true, metadata_title: true, metadata_description: true },
+    }),
+  ]);
+
+  let enqueued = 0;
+  let skipped = 0;
+
+  // uvs = title-only relevance (no description stored on the row; handoff).
+  for (const row of videoStates) {
+    try {
+      const jobId = await enqueueRelevanceQuick({
+        table: 'uvs',
+        rowId: row.id,
+        title: row.video?.title ?? '',
+        centerGoal,
+      });
+      if (jobId) enqueued += 1;
+      else skipped += 1;
+    } catch (err) {
+      skipped += 1;
+      log.warn('enqueue failed (uvs row, non-fatal)', {
+        rowId: row.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // ulc carries its own metadata (title / metadata_title + metadata_description).
+  for (const row of localCards) {
+    try {
+      const jobId = await enqueueRelevanceQuick({
+        table: 'ulc',
+        rowId: row.id,
+        title: row.title ?? row.metadata_title ?? '',
+        description: row.metadata_description ?? undefined,
+        centerGoal,
+      });
+      if (jobId) enqueued += 1;
+      else skipped += 1;
+    } catch (err) {
+      skipped += 1;
+      log.warn('enqueue failed (ulc row, non-fatal)', {
+        rowId: row.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const result: RelevanceBackfillResult = {
+    enqueued,
+    skipped,
+    uvsRows: videoStates.length,
+    ulcRows: localCards.length,
+  };
+
+  log.info('relevance backfill trigger fired', {
+    userId: params.userId,
+    mandalaId: params.mandalaId,
+    applyCutoff: params.applyCutoff,
+    ...result,
+  });
+
+  return result;
+}

--- a/tests/unit/modules/enrich-relevance-quick.test.ts
+++ b/tests/unit/modules/enrich-relevance-quick.test.ts
@@ -1,0 +1,192 @@
+/**
+ * enrich-relevance-quick worker tests — CP498 PR3b.
+ *
+ * Locks the worker invariants:
+ *   - persists keyed by ROW PK (where:{id:rowId}) to the table named in the
+ *     payload — NEVER by video_id (relation-not-attribute);
+ *   - no_title ⇒ skip (no DB write, no throw);
+ *   - other compute failures ⇒ throw (pg-boss retries once);
+ *   - registration uses richSummaryWorkOptions(N) (real concurrency, PR2);
+ *   - enqueue carries RELEVANCE_QUICK_RETRY_OPTIONS.
+ */
+
+// ============================================================================
+// Mocks (before imports)
+// ============================================================================
+
+const mockBossInstance = {
+  start: jest.fn().mockResolvedValue(undefined),
+  stop: jest.fn().mockResolvedValue(undefined),
+  on: jest.fn(),
+  work: jest.fn().mockResolvedValue('worker-id'),
+  send: jest.fn().mockResolvedValue('job-123'),
+  schedule: jest.fn().mockResolvedValue(undefined),
+  getQueueSize: jest.fn().mockResolvedValue(0),
+};
+
+jest.mock('pg-boss', () => jest.fn().mockImplementation(() => mockBossInstance));
+
+const mockUvsUpdate = jest.fn().mockResolvedValue({});
+const mockUlcUpdate = jest.fn().mockResolvedValue({});
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    userVideoState: { update: mockUvsUpdate },
+    user_local_cards: { update: mockUlcUpdate },
+  }),
+}));
+
+const mockCompute = jest.fn();
+jest.mock('@/modules/relevance/compute-card-relevance', () => ({
+  computeCardRelevance: (...args: unknown[]) => mockCompute(...args),
+}));
+
+jest.mock('@/config/index', () => ({
+  config: {
+    database: { url: 'postgresql://postgres:pass@127.0.0.1:5432/postgres', directUrl: undefined },
+    app: { isDevelopment: true, isProduction: false, isTest: true },
+    queue: { relevanceBackfillConcurrency: 4 },
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+// ============================================================================
+// Imports (after mocks)
+// ============================================================================
+
+import { getJobQueue } from '../../../src/modules/queue/manager';
+import {
+  registerEnrichRelevanceQuickWorker,
+  enqueueRelevanceQuick,
+} from '../../../src/modules/queue/handlers/enrich-relevance-quick';
+import {
+  JOB_NAMES,
+  RELEVANCE_QUICK_RETRY_OPTIONS,
+  type RelevanceQuickPayload,
+} from '../../../src/modules/queue/types';
+
+type Handler = (job: { id: string; data: RelevanceQuickPayload }) => Promise<void>;
+
+beforeAll(async () => {
+  await getJobQueue().start();
+});
+afterAll(async () => {
+  await getJobQueue().stop();
+});
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+/** Register once and return the captured pg-boss work handler. */
+async function getHandler(): Promise<Handler> {
+  await registerEnrichRelevanceQuickWorker();
+  const call = mockBossInstance.work.mock.calls.find(
+    (c) => c[0] === JOB_NAMES.ENRICH_RELEVANCE_QUICK
+  );
+  if (!call) throw new Error('worker not registered');
+  return call[2] as Handler;
+}
+
+describe('registerEnrichRelevanceQuickWorker', () => {
+  test('registers with richSummaryWorkOptions(N) — real concurrency, not inert', async () => {
+    await registerEnrichRelevanceQuickWorker();
+    expect(mockBossInstance.work).toHaveBeenCalledWith(
+      JOB_NAMES.ENRICH_RELEVANCE_QUICK,
+      { teamConcurrency: 4, teamSize: 4, teamRefill: true },
+      expect.any(Function)
+    );
+  });
+});
+
+describe('handleEnrichRelevanceQuick', () => {
+  test('uvs: writes relevance_pct to userVideoState by row id (never video_id)', async () => {
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 73 });
+    const handler = await getHandler();
+
+    await handler({
+      id: 'j1',
+      data: { table: 'uvs', rowId: 'row-uvs-1', title: 'T', centerGoal: 'G' },
+    });
+
+    expect(mockUvsUpdate).toHaveBeenCalledWith({
+      where: { id: 'row-uvs-1' },
+      data: expect.objectContaining({ relevance_pct: 73, relevance_at: expect.any(Date) }),
+    });
+    expect(mockUlcUpdate).not.toHaveBeenCalled();
+    // guard: the update key is the row PK, not a video_id field
+    expect(mockUvsUpdate.mock.calls[0][0].where).toEqual({ id: 'row-uvs-1' });
+  });
+
+  test('ulc: writes relevance_pct to user_local_cards by row id', async () => {
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 41 });
+    const handler = await getHandler();
+
+    await handler({
+      id: 'j2',
+      data: { table: 'ulc', rowId: 'row-ulc-1', title: 'T', description: 'D', centerGoal: 'G' },
+    });
+
+    expect(mockUlcUpdate).toHaveBeenCalledWith({
+      where: { id: 'row-ulc-1' },
+      data: expect.objectContaining({ relevance_pct: 41, relevance_at: expect.any(Date) }),
+    });
+    expect(mockUvsUpdate).not.toHaveBeenCalled();
+  });
+
+  test('no_title ⇒ skip: no DB write, no throw', async () => {
+    mockCompute.mockResolvedValueOnce({ ok: false, reason: 'no_title' });
+    const handler = await getHandler();
+
+    await expect(
+      handler({ id: 'j3', data: { table: 'uvs', rowId: 'row-x', title: '', centerGoal: 'G' } })
+    ).resolves.toBeUndefined();
+
+    expect(mockUvsUpdate).not.toHaveBeenCalled();
+    expect(mockUlcUpdate).not.toHaveBeenCalled();
+  });
+
+  test('provider/validation failure ⇒ throws (pg-boss retries once)', async () => {
+    mockCompute.mockResolvedValueOnce({ ok: false, reason: 'provider_error: boom' });
+    const handler = await getHandler();
+
+    await expect(
+      handler({ id: 'j4', data: { table: 'uvs', rowId: 'row-y', title: 'T', centerGoal: 'G' } })
+    ).rejects.toThrow(/relevance_compute_failed/);
+    expect(mockUvsUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('enqueueRelevanceQuick', () => {
+  test('sends with RELEVANCE_QUICK_RETRY_OPTIONS', async () => {
+    const payload: RelevanceQuickPayload = {
+      table: 'uvs',
+      rowId: 'r',
+      title: 'T',
+      centerGoal: 'G',
+    };
+    const id = await enqueueRelevanceQuick(payload);
+
+    expect(id).toBe('job-123');
+    expect(mockBossInstance.send).toHaveBeenCalledWith(
+      JOB_NAMES.ENRICH_RELEVANCE_QUICK,
+      payload,
+      expect.objectContaining({
+        retryLimit: RELEVANCE_QUICK_RETRY_OPTIONS.retryLimit,
+        expireInMinutes: RELEVANCE_QUICK_RETRY_OPTIONS.expireInMinutes,
+      })
+    );
+  });
+
+  test('returns null when send fails', async () => {
+    mockBossInstance.send.mockResolvedValueOnce(null);
+    const result = await enqueueRelevanceQuick({
+      table: 'ulc',
+      rowId: 'r',
+      title: 'T',
+      centerGoal: 'G',
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/tests/unit/modules/queue-handlers.test.ts
+++ b/tests/unit/modules/queue-handlers.test.ts
@@ -30,17 +30,24 @@ jest.mock('../../../src/config', () => ({
       directUrl: undefined,
     },
     app: { isDevelopment: true, isProduction: false, isTest: true },
+    // CP498: enrich-rich-summary (PR2) + enrich-relevance-quick (PR3b) workers
+    // read these at registration.
+    queue: { richSummaryConcurrency: 4, relevanceBackfillConcurrency: 4 },
   },
 }));
 
-jest.mock('../../../src/utils/logger', () => ({
-  logger: {
+jest.mock('../../../src/utils/logger', () => {
+  // call-logger.ts (imported transitively via the rich-summary handler chain
+  // when queue/index.ts is required) calls logger.child() at module load.
+  const base: Record<string, unknown> = {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
     debug: jest.fn(),
-  },
-}));
+  };
+  base['child'] = jest.fn(() => base);
+  return { logger: base };
+});
 
 jest.mock('../../../src/modules/database/client', () => ({
   getPrismaClient: jest.fn().mockReturnValue({
@@ -190,7 +197,7 @@ describe('batch-scan handler', () => {
 // ============================================================================
 
 describe('initJobQueue integration', () => {
-  test('initJobQueue registers both workers', async () => {
+  test('initJobQueue registers all workers', async () => {
     // Reset mocks to count fresh
     mockBossInstance.work.mockClear();
     mockBossInstance.schedule.mockClear();
@@ -198,8 +205,10 @@ describe('initJobQueue integration', () => {
     const { initJobQueue } = require('../../../src/modules/queue');
     await initJobQueue();
 
-    // Should register 2 workers
-    expect(mockBossInstance.work).toHaveBeenCalledTimes(2);
+    // Should register all 6 workers: enrich-video, batch-scan,
+    // enrich-rich-summary, batch-video-collector, pool-maintenance,
+    // enrich-relevance-quick (CP498 PR3b).
+    expect(mockBossInstance.work).toHaveBeenCalledTimes(6);
 
     // Should schedule batch-scan
     expect(mockBossInstance.schedule).toHaveBeenCalledTimes(1);

--- a/tests/unit/modules/relevance-backfill-trigger.test.ts
+++ b/tests/unit/modules/relevance-backfill-trigger.test.ts
@@ -1,0 +1,144 @@
+/**
+ * relevance-backfill-trigger tests — CP498 PR3b.
+ *
+ * THE regression guard (James, CP499): relevance is a relation
+ * (video × this row's centerGoal), not a video attribute. So the fan-out unit
+ * MUST be the ROW, never the video id. If anyone re-introduces a
+ * rich-summary-trigger-style uniqueByVideo dedup, the "same video in two rows ⇒
+ * two enqueues" test below breaks. Also locks: dual-table fan-out, centerGoal
+ * passthrough, and the cutoff filter (auto vs admin).
+ */
+
+// ============================================================================
+// Mocks (before imports)
+// ============================================================================
+
+const mockUvsFindMany = jest.fn();
+const mockUlcFindMany = jest.fn();
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    userVideoState: { findMany: mockUvsFindMany },
+    user_local_cards: { findMany: mockUlcFindMany },
+  }),
+}));
+
+const mockGetMandalaById = jest.fn();
+jest.mock('@/modules/mandala/manager', () => ({
+  getMandalaManager: () => ({ getMandalaById: mockGetMandalaById }),
+}));
+
+const mockEnqueue = jest.fn().mockResolvedValue('job-id');
+jest.mock('@/modules/queue/handlers/enrich-relevance-quick', () => ({
+  enqueueRelevanceQuick: (...args: unknown[]) => mockEnqueue(...args),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+  },
+}));
+
+// ============================================================================
+// Imports (after mocks)
+// ============================================================================
+
+import { enqueueRelevanceBackfillForMandala } from '../../../src/modules/relevance/relevance-backfill-trigger';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetMandalaById.mockResolvedValue({ levels: [{ centerGoal: 'become a better engineer' }] });
+  mockUvsFindMany.mockResolvedValue([]);
+  mockUlcFindMany.mockResolvedValue([]);
+});
+
+describe('enqueueRelevanceBackfillForMandala — row-not-video fan-out (regression guard)', () => {
+  test('same video_id in two uvs rows ⇒ TWO enqueues with distinct rowIds (no video dedup)', async () => {
+    // Both rows are the SAME underlying video (same title) in different cells.
+    // A uniqueByVideo dedup would collapse these to one enqueue — that is the
+    // bug this test exists to catch.
+    mockUvsFindMany.mockResolvedValueOnce([
+      { id: 'uvs-row-A', video: { title: 'Same Video Title' } },
+      { id: 'uvs-row-B', video: { title: 'Same Video Title' } },
+    ]);
+
+    const result = await enqueueRelevanceBackfillForMandala({
+      userId: 'u1',
+      mandalaId: 'm1',
+      applyCutoff: false,
+    });
+
+    expect(mockEnqueue).toHaveBeenCalledTimes(2);
+    const rowIds = mockEnqueue.mock.calls.map((c) => (c[0] as { rowId: string }).rowId).sort();
+    expect(rowIds).toEqual(['uvs-row-A', 'uvs-row-B']);
+    // each carries table=uvs + the shared centerGoal
+    for (const call of mockEnqueue.mock.calls) {
+      expect(call[0]).toMatchObject({ table: 'uvs', centerGoal: 'become a better engineer' });
+    }
+    expect(result.enqueued).toBe(2);
+    expect(result.uvsRows).toBe(2);
+  });
+
+  test('dual-table: uvs (title-only) + ulc (title + description) both fan out', async () => {
+    mockUvsFindMany.mockResolvedValueOnce([{ id: 'uvs-1', video: { title: 'UVS title' } }]);
+    mockUlcFindMany.mockResolvedValueOnce([
+      { id: 'ulc-1', title: 'ULC title', metadata_title: null, metadata_description: 'ULC desc' },
+    ]);
+
+    const result = await enqueueRelevanceBackfillForMandala({
+      userId: 'u1',
+      mandalaId: 'm1',
+      applyCutoff: false,
+    });
+
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ table: 'uvs', rowId: 'uvs-1', title: 'UVS title' })
+    );
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        table: 'ulc',
+        rowId: 'ulc-1',
+        title: 'ULC title',
+        description: 'ULC desc',
+      })
+    );
+    expect(result).toMatchObject({ enqueued: 2, uvsRows: 1, ulcRows: 1 });
+  });
+
+  test('ulc title falls back to metadata_title when title is null', async () => {
+    mockUlcFindMany.mockResolvedValueOnce([
+      { id: 'ulc-2', title: null, metadata_title: 'Meta Title', metadata_description: null },
+    ]);
+
+    await enqueueRelevanceBackfillForMandala({ userId: 'u1', mandalaId: 'm1', applyCutoff: false });
+
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ table: 'ulc', rowId: 'ulc-2', title: 'Meta Title' })
+    );
+  });
+});
+
+describe('cutoff filter (auto vs admin)', () => {
+  test('applyCutoff=true ⇒ both queries filter created_at > cutoff', async () => {
+    await enqueueRelevanceBackfillForMandala({
+      userId: 'u1',
+      mandalaId: 'm1',
+      applyCutoff: true,
+      cutoff: '2026-06-08T00:00:00.000Z',
+    });
+
+    const uvsWhere = mockUvsFindMany.mock.calls[0][0].where;
+    const ulcWhere = mockUlcFindMany.mock.calls[0][0].where;
+    expect(uvsWhere.createdAt).toEqual({ gt: new Date('2026-06-08T00:00:00.000Z') });
+    expect(ulcWhere.created_at).toEqual({ gt: new Date('2026-06-08T00:00:00.000Z') });
+    // always-on filters
+    expect(uvsWhere).toMatchObject({ cell_index: { gte: 0 }, relevance_pct: null });
+    expect(ulcWhere).toMatchObject({ cell_index: { gte: 0 }, relevance_pct: null });
+  });
+
+  test('applyCutoff=false (admin) ⇒ no created_at filter on either table', async () => {
+    await enqueueRelevanceBackfillForMandala({ userId: 'u1', mandalaId: 'm1', applyCutoff: false });
+
+    expect(mockUvsFindMany.mock.calls[0][0].where.createdAt).toBeUndefined();
+    expect(mockUlcFindMany.mock.calls[0][0].where.created_at).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What
A-stage relevance backfill (CP498 PR3b) — score placed cards by relevance to their mandala centerGoal, **user-scoped, sort-not-gate**. Builds on PR3a (#866, pure scorer + ulc schema).

## Core invariant (the design)
Relevance is a **relation** (video × *this row's* centerGoal), not a video attribute. Two consequences, both enforced:
- **Sort, not gate** — score is reversible ordering, never a keep/drop filter.
- **user-scoped storage** — written to `user_video_states` / `user_local_cards` (row-keyed), never the video-keyed `video_rich_summaries.mandala_relevance_pct` (which leaks across users).

## Guard against the one failure mode
`relevance-backfill-trigger.ts` mirrors `rich-summary-trigger` but **deliberately drops the `uniqueByVideo` dedup**: fan-out unit = `(table, rowId)`, never video_id. Same video in 2 cells/mandalas → 2 independent scores. Worker updates `where:{id:rowId}` (row PK), never video_id. Locked by regression test (`same video_id in two rows ⇒ two enqueues`).

## Pieces
- `enrich-relevance-quick` queue: quick Haiku only (~1-3s), DB-read-0 worker, `richSummaryWorkOptions(N)` real concurrency (PR2 #865).
- dual-table trigger: uvs (title-only) + ulc (title + metadata_description), unscored placed cards, centerGoal fetched once.
- admin route `POST /api/v1/admin/relevance-backfill/run` — bypasses flag + cutoff for the **1-mandala measurement gate**.
- config: 3 env (`BACKFILL_RELEVANCE_ENABLED` default **OFF**, `RELEVANCE_BACKFILL_CONCURRENCY`=4, `RELEVANCE_BACKFILL_CUTOFF`) + deploy.yml B-path (3 GH Variables, default-safe).
- migration `002_uvs_relevance.sql` + schema (uvs `relevance_pct`/`relevance_at`). **Prod DDL applied manually before the 1-mandala run** (uvs is `supabase_admin`-owned; idempotent, nullable).

## Deferred (not dropped)
Auto-hooks (pipeline-runner uvs / add-cards ulc, flag+cutoff guarded) → wired **after** the 1-mandala measurement gate passes. Config flag/cutoff already present.

## Tests
- New: 8 worker + 4 trigger (incl. regression guard) = 12, all green.
- Repaired pre-existing `queue-handlers.test` breakage from **PR2 #865** (logger.child mock + config.queue mock + worker count 2→6 — was red at HEAD, unrelated to this PR's logic).

## Verify (local)
tsc clean for all PR3b files; full unit suite's 6 unrelated failures proven pre-existing (identical at HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)