### PR TITLE
feat(relevance): PR3c — relevance_pct read + 관련도순 sort (A-stage complete) (CP498)

### DIFF
--- a/frontend/src/entities/card/model/local-cards.relevance.test.ts
+++ b/frontend/src/entities/card/model/local-cards.relevance.test.ts
@@ -1,0 +1,48 @@
+/**
+ * CP498 PR3c — user-scoped relevance plumbing on the ulc converter
+ * (user_local_cards.relevance_pct → InsightCard.relevancePct).
+ *
+ * Guards that the per-row, user-scoped score flows through — and stays distinct
+ * from the video-keyed v2_mandala_relevance_pct (which must never drive sort).
+ */
+import { describe, it, expect } from 'vitest';
+import { localCardToInsightCard } from './local-cards';
+import type { LocalCard } from './local-cards';
+
+function baseCard(): LocalCard {
+  return {
+    id: 'lc-1',
+    user_id: 'user-1',
+    url: 'https://example.com/article',
+    title: 'An article',
+    thumbnail: null,
+    link_type: 'url',
+    user_note: null,
+    metadata_title: null,
+    metadata_description: null,
+    metadata_image: null,
+    cell_index: 2,
+    level_id: 'root',
+    mandala_id: 'mandala-1',
+    sort_order: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+}
+
+describe('localCardToInsightCard — relevance plumbing', () => {
+  it('maps ulc.relevance_pct → relevancePct', () => {
+    expect(localCardToInsightCard({ ...baseCard(), relevance_pct: 41 }).relevancePct).toBe(41);
+  });
+
+  it('relevancePct defaults to null when relevance_pct is absent', () => {
+    expect(localCardToInsightCard(baseCard()).relevancePct).toBeNull();
+  });
+
+  it('does NOT source relevancePct from the video-keyed v2_mandala_relevance_pct', () => {
+    // v2 (leaky) populated, user-scoped absent ⇒ relevancePct must stay null.
+    const card = localCardToInsightCard({ ...baseCard(), v2_mandala_relevance_pct: 99 });
+    expect(card.relevancePct).toBeNull();
+    expect(card.v2MandalaRelevancePct).toBe(99);
+  });
+});

--- a/frontend/src/entities/card/model/local-cards.ts
+++ b/frontend/src/entities/card/model/local-cards.ts
@@ -66,6 +66,13 @@ export interface LocalCard {
   v2_template_version?: string | null;
   v2_full_landed?: boolean;
   /**
+   * CP498 PR3c — A-stage relevance score (0-100), USER-SCOPED on
+   * user_local_cards (distinct from the video-keyed v2_mandala_relevance_pct
+   * above). Null = not yet backfilled. Added to /local-cards/list SELECT.
+   */
+  relevance_pct?: number | null;
+  relevance_at?: string | null;
+  /**
    * CP475+ — true only when the BE has every foundational field the grid
    * card needs (published_at, duration_seconds for YouTube). False means
    * the youtube_videos pipeline is still catching up; the FE renders the
@@ -172,6 +179,8 @@ export function localCardToInsightCard(card: LocalCard): InsightCard {
     videoSummary: card.video_summary,
     sourceTable: 'user_local_cards',
     pinnedAt: card.pinned_at ?? null,
+    // CP498 PR3c — user-scoped A-stage relevance score (ulc.relevance_pct).
+    relevancePct: card.relevance_pct ?? null,
     // CP475+ — v2 fields from the unified /local-cards/list payload. Older
     // BE responses without these keys leave them undefined, which the
     // grid card treats the same as "no v2 row yet".

--- a/frontend/src/entities/card/model/types.ts
+++ b/frontend/src/entities/card/model/types.ts
@@ -74,6 +74,14 @@ export interface InsightCard {
   v2QualityFlag?: string | null;
   v2FullLanded?: boolean;
   /**
+   * CP498 PR3c — A-stage relevance score (0-100), USER-SCOPED (the per-row
+   * relevance_pct on user_video_states / user_local_cards). Distinct from
+   * v2MandalaRelevancePct above, which is the video-keyed (cross-user-leaky)
+   * column — never use that for sorting. Null = not yet backfilled; drives the
+   * optional "관련도순" sort (NULLS LAST).
+   */
+  relevancePct?: number | null;
+  /**
    * CP475+ — true only when the BE has every foundational field the grid
    * card needs (published_at, duration_seconds for YouTube). False = the
    * youtube_videos pipeline is still catching up; the FE renders the row

--- a/frontend/src/entities/youtube/model/types.ts
+++ b/frontend/src/entities/youtube/model/types.ts
@@ -85,6 +85,13 @@ export interface UserVideoState {
    * never appear as if they were YouTube-synced.
    */
   auto_added?: boolean;
+  /**
+   * CP498 PR3c — A-stage relevance score (0-100) of this card vs its mandala
+   * centerGoal. USER-SCOPED on user_video_states (no cross-user leak).
+   * Null = not yet backfilled. Surfaced by get-all-video-states (SELECT *).
+   */
+  relevance_pct?: number | null;
+  relevance_at?: string | null;
 }
 
 export interface YouTubeSyncHistory {

--- a/frontend/src/features/card-management/lib/youtubeToInsightCard.test.ts
+++ b/frontend/src/features/card-management/lib/youtubeToInsightCard.test.ts
@@ -76,4 +76,15 @@ describe('convertToInsightCard — B2 9-column contract', () => {
     delete (state as { video?: unknown }).video;
     expect(convertToInsightCard(state)).toBeNull();
   });
+
+  // CP498 PR3c — user-scoped relevance plumbing (uvs.relevance_pct → relevancePct).
+  it('maps uvs.relevance_pct → relevancePct', () => {
+    const state = narrowedState();
+    state.relevance_pct = 73;
+    expect(convertToInsightCard(state)!.relevancePct).toBe(73);
+  });
+
+  it('relevancePct defaults to null when relevance_pct is absent', () => {
+    expect(convertToInsightCard(narrowedState())!.relevancePct).toBeNull();
+  });
 });

--- a/frontend/src/features/card-management/lib/youtubeToInsightCard.ts
+++ b/frontend/src/features/card-management/lib/youtubeToInsightCard.ts
@@ -42,6 +42,8 @@ export function convertToInsightCard(data: UserVideoStateWithVideo): InsightCard
     // CP474 — propagate auto-add origin so the "New Cards" predicate can
     // distinguish sync-engine rows from recommendation rows.
     autoAdded: data.auto_added ?? false,
+    // CP498 PR3c — user-scoped A-stage relevance score (uvs.relevance_pct).
+    relevancePct: data.relevance_pct ?? null,
   };
 }
 

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -675,6 +675,7 @@
     "sortOldest": "Oldest",
     "sortTitleAZ": "Title A-Z",
     "sortTitleZA": "Title Z-A",
+    "sortRelevance": "By relevance",
     "selectSectorFirst": "Select a sector",
     "selectSectorDesc": "Choose a sector from the pills above to assign cards."
   },

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -683,6 +683,7 @@
     "sortOldest": "오래된순",
     "sortTitleAZ": "제목 A-Z",
     "sortTitleZA": "제목 Z-A",
+    "sortRelevance": "관련도순",
     "selectSectorFirst": "섹터를 선택하세요",
     "selectSectorDesc": "카드를 배치할 섹터를 먼저 선택해주세요."
   },

--- a/frontend/src/widgets/card-list-view/ui/CardListView.tsx
+++ b/frontend/src/widgets/card-list-view/ui/CardListView.tsx
@@ -32,11 +32,23 @@ import { Slider } from '@/shared/ui/slider';
 import { ContextHeader, SORT_OPTIONS, type SortMode } from './ContextHeader';
 import { LabelFilterPillsV2 } from './LabelFilterPillsV2';
 
+/**
+ * CP498 PR3c — A-stage relevance comparator: DESC, NULLS LAST. `?? -1` sinks
+ * null/undefined relevancePct below any real 0-100 score. Pure + exported so
+ * the ordering contract (highest-first, unscored-last) is unit-tested against a
+ * sign-flip regression. NEVER reads the video-keyed v2MandalaRelevancePct.
+ */
+export const compareByRelevanceDesc = (a: InsightCard, b: InsightCard): number =>
+  (b.relevancePct ?? -1) - (a.relevancePct ?? -1);
+
 const SORT_ICON_BY_VALUE: Record<SortMode, typeof ArrowDownWideNarrow> = {
   latest: ArrowDownWideNarrow,
   oldest: ArrowUpWideNarrow,
   'title-asc': ArrowDownAZ,
   'title-desc': ArrowDownZA,
+  // CP498 PR3c — reuse the descending icon; a dedicated relevance glyph /
+  // numeric badge is deferred (visual signal = later per spec).
+  'relevance-desc': ArrowDownWideNarrow,
 };
 
 const MIN_GRID_COLUMNS = 2;
@@ -328,6 +340,10 @@ export function CardListView({
         return arr.sort((a, b) => (a.title || '').localeCompare(b.title || ''));
       case 'title-desc':
         return arr.sort((a, b) => (b.title || '').localeCompare(a.title || ''));
+      case 'relevance-desc':
+        // CP498 PR3c — A-stage relevance: highest first, unscored cards last
+        // (DESC NULLS LAST). Cards are reordered, never removed (reversible).
+        return arr.sort(compareByRelevanceDesc);
       default:
         return arr;
     }

--- a/frontend/src/widgets/card-list-view/ui/ContextHeader.tsx
+++ b/frontend/src/widgets/card-list-view/ui/ContextHeader.tsx
@@ -3,13 +3,15 @@ import { Trash2 } from 'lucide-react';
 import type { ViewMode } from '@/entities/user/model/types';
 import { ViewSwitcher } from '@/features/view-mode';
 
-export type SortMode = 'latest' | 'oldest' | 'title-asc' | 'title-desc';
+export type SortMode = 'latest' | 'oldest' | 'title-asc' | 'title-desc' | 'relevance-desc';
 
 export const SORT_OPTIONS: { value: SortMode; labelKey: string }[] = [
   { value: 'latest', labelKey: 'contextHeader.sortLatest' },
   { value: 'oldest', labelKey: 'contextHeader.sortOldest' },
   { value: 'title-asc', labelKey: 'contextHeader.sortTitleAZ' },
   { value: 'title-desc', labelKey: 'contextHeader.sortTitleZA' },
+  // CP498 PR3c — A-stage relevance. Opt-in only (default stays 'latest').
+  { value: 'relevance-desc', labelKey: 'contextHeader.sortRelevance' },
 ];
 
 interface ContextHeaderProps {

--- a/frontend/src/widgets/card-list-view/ui/cardSort.relevance.test.ts
+++ b/frontend/src/widgets/card-list-view/ui/cardSort.relevance.test.ts
@@ -1,0 +1,62 @@
+/**
+ * CP498 PR3c — "관련도순" comparator: DESC, NULLS LAST.
+ *
+ * Locks the ordering contract against a sign-flip / null-handling regression:
+ *   - higher relevancePct ranks first;
+ *   - cards with null/undefined relevancePct sink to the bottom (never removed).
+ */
+import { describe, it, expect } from 'vitest';
+import { compareByRelevanceDesc } from './CardListView';
+import type { InsightCard } from '@/entities/card/model/types';
+
+function card(id: string, relevancePct: number | null | undefined): InsightCard {
+  return {
+    id,
+    videoUrl: `https://x/${id}`,
+    title: id,
+    thumbnail: '',
+    userNote: '',
+    createdAt: new Date('2026-01-01'),
+    cellIndex: 0,
+    levelId: 'root',
+    relevancePct,
+  } as InsightCard;
+}
+
+describe('compareByRelevanceDesc — DESC NULLS LAST', () => {
+  it('orders by relevancePct descending, unscored last', () => {
+    const arr = [
+      card('off-low', 5),
+      card('null-a', null),
+      card('rel-high', 82),
+      card('undef', undefined),
+      card('mid', 62),
+    ];
+    const sorted = [...arr].sort(compareByRelevanceDesc).map((c) => c.id);
+    // 82 > 62 > 5 > (null/undefined at the bottom, in any order among themselves)
+    expect(sorted.slice(0, 3)).toEqual(['rel-high', 'mid', 'off-low']);
+    expect(sorted.slice(3).sort()).toEqual(['null-a', 'undef']);
+  });
+
+  it('a real 0 still ranks above null (0 is a score, null is "unscored")', () => {
+    const sorted = [card('null', null), card('zero', 0)]
+      .sort(compareByRelevanceDesc)
+      .map((c) => c.id);
+    expect(sorted).toEqual(['zero', 'null']);
+  });
+
+  it('mirrors the measured fixed-sample ordering (relevant cluster above off-target)', () => {
+    // From the 1-mandala gate: relevant 72-82 must all rank above off-target 5-62.
+    const arr = [
+      card('off-젠레스', 5),
+      card('rel-8가지', 82),
+      card('off-수능체대', 62),
+      card('rel-결심', 72),
+      card('off-미식', 15),
+      card('rel-성공이유', 72),
+    ];
+    const sorted = [...arr].sort(compareByRelevanceDesc).map((c) => c.id);
+    const firstThree = new Set(sorted.slice(0, 3));
+    expect(firstThree).toEqual(new Set(['rel-8가지', 'rel-결심', 'rel-성공이유']));
+  });
+});

--- a/supabase/functions/local-cards/index.ts
+++ b/supabase/functions/local-cards/index.ts
@@ -242,7 +242,7 @@ Deno.serve(async (req) => {
         // Parallel fetch: subscription + cards
         let cardsQuery = supabase
           .from('user_local_cards')
-          .select('id, url, title, thumbnail, link_type, user_note, metadata_title, metadata_description, metadata_image, cell_index, level_id, mandala_id, sort_order, video_id, created_at, updated_at, pinned_at')
+          .select('id, url, title, thumbnail, link_type, user_note, metadata_title, metadata_description, metadata_image, cell_index, level_id, mandala_id, sort_order, video_id, created_at, updated_at, pinned_at, relevance_pct, relevance_at')
           .eq('user_id', user.id)
           // CP457+ deterministic tie-break + pinned_at column. sort_order
           // is null for many cards (never touched by D&D); without a


### PR DESCRIPTION
## What
Completes the A-stage (PR3a scorer → PR3b backfill → **PR3c read + sort**). Surfaces the user-scoped `relevance_pct` to the card list and adds an opt-in "관련도순" sort.

## Read — leak gate (user-scoped, the invariant held to the end)
- **ulc** `local-cards` EF `list`: SELECT += `relevance_pct, relevance_at`, with `.eq('user_id', user.id)` (`local-cards/index.ts:246`). `...card` spread surfaces it.
- **uvs** `youtube-sync` `get-all-video-states`: already returns it via `SELECT *` + `.eq('user_id', user.id)` (`:664`) — no change.
- **Never** reads the video-keyed `video_rich_summaries.mandala_relevance_pct` (cross-user leaky). A dedicated test locks this ("does NOT source from v2 column").
- EF **dual-impl**: canonical `supabase/functions/local-cards/index.ts` (deploys via deploy.yml) + `superbase/.../main/index.ts` dispatcher mirrored for local dev.

## Sort — opt-in, reversible (measurement-nuance honored)
- `compareByRelevanceDesc` (exported, pure): **DESC, NULLS LAST** — unscored cards sink to bottom, never removed.
- Default sort stays `'latest'`; relevance applies **only on explicit user selection**. Client-side over loaded cards (no card removal/hide).
- Copy = plain "관련도순" / "By relevance" — value is demoting off-target; the relevant cluster staying tight (title-only ceiling) is expected, not over-claimed.

## Tests
converter plumbing (uvs+ulc) + anti-leak + comparator DESC-NULLS-LAST + the measured fixed-sample ordering (relevant 72–82 above off-target 5–62). tsc clean + vitest 373/373.

## Verify
Pre-push: tsc + vitest(373) + build PASS. The real-score ordering smoke runs **post-deploy on prod mandala `5ffb458f`** (scored in the PR3b 1-mandala gate) — flag `BACKFILL_RELEVANCE_ENABLED` stays OFF so only that mandala has scores.

## No workflow change
`deploy.yml` untouched (PR3b added the env wiring). `local-cards` EF auto-deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)