### PR TITLE
fix(card-list): ListView respect host sort + 관련도순 dropdown position (CP498 PR3c)

### DIFF
--- a/frontend/src/widgets/card-list-view/ui/ContextHeader.tsx
+++ b/frontend/src/widgets/card-list-view/ui/ContextHeader.tsx
@@ -7,11 +7,13 @@ export type SortMode = 'latest' | 'oldest' | 'title-asc' | 'title-desc' | 'relev
 
 export const SORT_OPTIONS: { value: SortMode; labelKey: string }[] = [
   { value: 'latest', labelKey: 'contextHeader.sortLatest' },
+  // CP498 PR3c — A-stage relevance placed 2nd (right after the familiar default
+  // 최신순, above title sorts): "핵심이지만 명시 선택" signal. Default selection
+  // stays 'latest' (CardListView sortMode default) — position only, not default.
+  { value: 'relevance-desc', labelKey: 'contextHeader.sortRelevance' },
   { value: 'oldest', labelKey: 'contextHeader.sortOldest' },
   { value: 'title-asc', labelKey: 'contextHeader.sortTitleAZ' },
   { value: 'title-desc', labelKey: 'contextHeader.sortTitleZA' },
-  // CP498 PR3c — A-stage relevance. Opt-in only (default stays 'latest').
-  { value: 'relevance-desc', labelKey: 'contextHeader.sortRelevance' },
 ];
 
 interface ContextHeaderProps {

--- a/frontend/src/widgets/list-view/ui/ListView.order.test.tsx
+++ b/frontend/src/widgets/list-view/ui/ListView.order.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * CP498 PR3c — ListView must render cards in the order the HOST gives them.
+ *
+ * Regression guard for the relevance-sort bug: CardListView (the host) applies
+ * the user's sortMode chip (latest/oldest/title/relevance); ListView previously
+ * re-sorted the `cards` prop by `sortOrder` internally, silently overriding ALL
+ * host sorts (off-target cards floated to the top under "관련도순"). The fix is
+ * `const sortedCards = cards` — render as given. If anyone re-adds an internal
+ * sort, this test breaks.
+ *
+ * The virtualizer is mocked to materialize every row (happy-dom has no layout
+ * height, so the real virtualizer would render nothing).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { ListView } from './ListView';
+import type { InsightCard } from '@/entities/card/model/types';
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    scrollToIndex: () => {},
+    getTotalSize: () => count * 56,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index,
+        size: 56,
+        start: index * 56,
+      })),
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, fallback?: string) => fallback ?? _k }),
+}));
+
+function card(id: string, sortOrder: number, relevancePct: number): InsightCard {
+  return {
+    id,
+    videoUrl: `https://example.com/${id}`,
+    title: id,
+    thumbnail: '',
+    userNote: '',
+    createdAt: new Date('2026-01-01'),
+    cellIndex: 0,
+    levelId: 'root',
+    sortOrder,
+    relevancePct,
+  } as InsightCard;
+}
+
+describe('ListView — respects host order (no internal re-sort)', () => {
+  it('renders in given array order even when sortOrder disagrees (the bug)', () => {
+    // Host already sorted by relevance DESC → [82, 72, 5]. Their sortOrder is the
+    // REVERSE (2,1,0): the old internal `a.sortOrder - b.sortOrder` would have
+    // floated the relevance-5 card to the top. DOM order must equal input order.
+    const cards = [card('rel-82', 2, 82), card('rel-72', 1, 72), card('off-5', 0, 5)];
+    const { container } = render(
+      <ListView cards={cards} activeCardId={null} onCardSelect={() => {}} />
+    );
+    const text = container.textContent || '';
+    const iHigh = text.indexOf('rel-82');
+    const iMid = text.indexOf('rel-72');
+    const iLow = text.indexOf('off-5');
+    expect(iHigh).toBeGreaterThanOrEqual(0);
+    expect(iHigh).toBeLessThan(iMid); // 82 before 72
+    expect(iMid).toBeLessThan(iLow); // 72 before 5  → host DESC preserved
+  });
+});

--- a/frontend/src/widgets/list-view/ui/ListView.tsx
+++ b/frontend/src/widgets/list-view/ui/ListView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useMemo, useEffect } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useTranslation } from 'react-i18next';
 import { FileVideo } from 'lucide-react';
@@ -18,14 +18,14 @@ export function ListView({ cards, activeCardId, onCardSelect, onCardClick }: Lis
   const [activeIndex, setActiveIndex] = useState(0);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-  const sortedCards = useMemo(() => {
-    return [...cards].sort((a, b) => {
-      if (a.sortOrder !== undefined && b.sortOrder !== undefined) {
-        return a.sortOrder - b.sortOrder;
-      }
-      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-    });
-  }, [cards]);
+  // CP498 PR3c — cards arrive ALREADY sorted by the host (CardListView applies
+  // the user's sortMode chip: latest / oldest / title / relevance). Re-sorting
+  // here by sortOrder silently overrode ALL of those — the new "관련도순" sort
+  // surfaced it (off-target cards floated to the top). This is the same bug
+  // CardList (grid) already fixed ("5d ago in the middle"); ListView was the
+  // one place it was missed. Render in the order given — do NOT re-sort here.
+  // The regression test pins this: a pre-sorted input must come out unchanged.
+  const sortedCards = cards;
 
   const virtualizer = useVirtualizer({
     count: sortedCards.length,


### PR DESCRIPTION
## Why
PR3c (#868) browser smoke FAILED — "관련도순" showed off-target cards on top. Root cause (diagnosed by code, not the comparator):

`ListView` re-sorted the `cards` prop by `sortOrder` internally, **silently overriding the host's sort** (latest/oldest/title/relevance all ignored in list/list-detail mode). The new relevance sort surfaced it (off-target cards have low sortOrder → floated to top). The comparator + the read/mapping were correct (DB + PostgREST both return the right scores; unit-tested DESC).

## Fix (commit 1)
`ListView.tsx`: `const sortedCards = cards` — render in the host-given order. This is the **same fix CardList (grid) already had** ("Re-sorting here would override publishedAt ranking … '5d ago in the middle'"); ListView was the one place it was missed. Not load-bearing for D&D (ListView doesn't receive `onCardsReorder`). Fixes **all 4 sorts** in list mode, not just relevance.

Regression test mocks the virtualizer and asserts a pre-sorted input (sortOrder reversed vs array order) renders **unchanged** — breaks if anyone re-adds an internal sort.

## Dropdown order (commit 2)
`ContextHeader.tsx`: move 관련도순 to **2nd** (after 최신순, above title sorts) — "core but explicit-choice" signal. Default selection unchanged (`sortMode` default stays `latest`).

## Verify
tsc clean + vitest 374/374 (+1 ListView guard) + build. Real-screen verification = re-run the `5ffb458f` browser smoke post-deploy: 젠레스/미식 to the bottom + 관련도순 at dropdown position 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)