### PR TITLE
fix(card): remove relevance % badge + stable sort tiebreak (CP498 PR3c finish)

### DIFF
--- a/frontend/src/widgets/card-list-view/ui/CardListView.tsx
+++ b/frontend/src/widgets/card-list-view/ui/CardListView.tsx
@@ -38,8 +38,13 @@ import { LabelFilterPillsV2 } from './LabelFilterPillsV2';
  * the ordering contract (highest-first, unscored-last) is unit-tested against a
  * sign-flip regression. NEVER reads the video-keyed v2MandalaRelevancePct.
  */
-export const compareByRelevanceDesc = (a: InsightCard, b: InsightCard): number =>
-  (b.relevancePct ?? -1) - (a.relevancePct ?? -1);
+export const compareByRelevanceDesc = (a: InsightCard, b: InsightCard): number => {
+  // DESC by relevancePct (NULLS LAST via ?? -1) + stable tiebreak by id so the
+  // large equal-score band (title-only "70s cluster") does NOT reshuffle on
+  // refetch — e.g. after a Heart/like invalidates the cards query. CP498 PR3c.
+  const d = (b.relevancePct ?? -1) - (a.relevancePct ?? -1);
+  return d !== 0 ? d : a.id.localeCompare(b.id);
+};
 
 const SORT_ICON_BY_VALUE: Record<SortMode, typeof ArrowDownWideNarrow> = {
   latest: ArrowDownWideNarrow,

--- a/frontend/src/widgets/card-list-view/ui/cardSort.relevance.test.ts
+++ b/frontend/src/widgets/card-list-view/ui/cardSort.relevance.test.ts
@@ -59,4 +59,15 @@ describe('compareByRelevanceDesc — DESC NULLS LAST', () => {
     const firstThree = new Set(sorted.slice(0, 3));
     expect(firstThree).toEqual(new Set(['rel-8가지', 'rel-결심', 'rel-성공이유']));
   });
+
+  it('ties (equal relevancePct) break by id ascending — stable, no reshuffle on refetch', () => {
+    // The title-only "70s cluster" produces many equal scores; without a
+    // tiebreak they reshuffled when a Heart/like invalidated + refetched the
+    // cards query (input order changed → tie order changed). id-asc pins it.
+    const a = [card('z-id', 72), card('a-id', 72), card('m-id', 72)];
+    const b = [card('m-id', 72), card('z-id', 72), card('a-id', 72)]; // different input order
+    expect([...a].sort(compareByRelevanceDesc).map((c) => c.id)).toEqual(['a-id', 'm-id', 'z-id']);
+    // same output regardless of input order = stable across refetch
+    expect([...b].sort(compareByRelevanceDesc).map((c) => c.id)).toEqual(['a-id', 'm-id', 'z-id']);
+  });
 });

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -23,39 +23,9 @@ import { decodeHtmlEntities } from '@/shared/lib/decode-html-entities';
 
 // ── Constants ──────────────────────────────────────────────
 
-const QUALITY_BADGE_THRESHOLD_HIGH = 90;
-const QUALITY_BADGE_THRESHOLD_MID = 80;
-const QUALITY_BADGE_THRESHOLD_LOW = 70;
-// CP463 — Heart'd cards always show the % badge regardless of score
-// (user directive 2026-05-17: "하트 선택된 내용은 관련도가 백분율로
-// 표기되어야해"). Color stays score-tiered (high/mid/low) but the
-// previous "hide below 70" cut-off is dropped — a 50 or 60 score still
-// renders, just in the lower-tier color.
-
 // ── Helpers ────────────────────────────────────────────────
 // formatDuration / formatViewCount live in shared/lib/format-number so
 // the Add Cards panel + future card surfaces share the same rules.
-
-/**
- * Quality badge built from the CP462+ `mandala_relevance_pct` (0-100,
- * Heart'd cards only). The generic rec_score badge was retired per
- * handoff decision #8: only Heart'd cards earn a TL badge.
- */
-function getMandalaRelevanceBadge(
-  pct: number | null | undefined
-): { label: string; className: string } | null {
-  if (pct == null) return null;
-  const value = Math.max(0, Math.min(100, Math.round(pct)));
-  const label = `${value}%`;
-  // CP463 — user directive 2026-05-17: "관련도 는 배지가 아닌 텍스트
-  // (비율별 칼라 다르게 적용)". Drop the background/padding/rounded
-  // chrome; keep only the per-tier text color so the relevance reads
-  // as plain coloured text in the footer row.
-  if (value >= QUALITY_BADGE_THRESHOLD_HIGH) return { label, className: 'text-[#818cf8]' };
-  if (value >= QUALITY_BADGE_THRESHOLD_MID) return { label, className: 'text-[#34d399]' };
-  if (value >= QUALITY_BADGE_THRESHOLD_LOW) return { label, className: 'text-[#fbbf24]' };
-  return { label, className: 'text-[#94a3b8]' };
-}
 
 /** Extract YouTube metadata from InsightCard.metadata (runtime fields beyond UrlMetadata type) */
 function extractYouTubeMeta(card: InsightCard) {
@@ -329,7 +299,6 @@ export function InsightCardItemV2({
 
   // ── Data extraction ──
   const ytMeta = extractYouTubeMeta(card);
-  const relevanceBadge = getMandalaRelevanceBadge(mandalaRelevancePct);
   const duration = formatDuration(ytMeta.durationSec);
   const views = formatViewCount(ytMeta.viewCount);
   // CP475+ — when the BE has not yet caught up on this row's
@@ -598,12 +567,7 @@ export function InsightCardItemV2({
           {decodeHtmlEntities(card.title)}
         </h4>
 
-        {(footerLeft ||
-          footerRight ||
-          sectorLabel ||
-          relevanceBadge ||
-          isEnrichFailed ||
-          showFailedGlow) && (
+        {(footerLeft || footerRight || sectorLabel || isEnrichFailed || showFailedGlow) && (
           <div className="mt-2 flex items-center justify-between gap-2 text-[10.5px] text-muted-foreground/70">
             <span className="truncate flex items-center gap-1.5 min-w-0">
               {(() => {
@@ -640,30 +604,17 @@ export function InsightCardItemV2({
                 );
               })()}
             </span>
-            {/* Right slot priority:
-                  scored        → relevance % (color-tiered)
-                  liked && pending && !failed → spinner (Phase 2 fast-path
-                                                 ~3-4s window between bookmark
-                                                 click and quick-result arrival)
-                  else          → empty (retry signal redesign pending,
-                                  user directive 2026-05-20) */}
-            {relevanceBadge ? (
-              <span
-                className={cn(
-                  'text-[10.5px] font-semibold shrink-0 tabular-nums',
-                  relevanceBadge.className
-                )}
-              >
-                {relevanceBadge.label}
-              </span>
-            ) : v2EnrichmentPending && !showFailedGlow ? (
-              // CP475+ — subtle breathing dot replaces the previous 3-stage
-              // spinner per user directive 2026-05-20 ("품질이 안 좋아 —
-              // 직관적이되 과도하지 않게"). Minimal: a single 6px dot in
-              // the slot the relevance % will eventually occupy, breathing
-              // at 1.6s. Conveys "in progress" without competing with the
-              // surrounding type. Stops automatically — relevance % takes
-              // over the slot the moment it lands.
+            {/* Right slot — CP498 PR3c removed the per-card relevance % badge
+                (relevance is now the "관련도순" sort, not a card number — kills
+                the video-keyed leak + the dual-number confusion). The slot now
+                shows only the Heart-enrichment in-progress dot:
+                  liked && pending && !failed → breathing dot
+                  else                        → empty */}
+            {v2EnrichmentPending && !showFailedGlow ? (
+              // CP475+ — subtle breathing dot for the Heart-enrichment window
+              // (bookmark click → quick-result arrival). Single 6px dot
+              // breathing at 1.6s; stops when v2 lands. (CP498 PR3c: it no
+              // longer leads into a relevance % — that badge was removed.)
               <span
                 className="block w-1.5 h-1.5 rounded-full bg-foreground/40 shrink-0 animate-[breathe_1.6s_ease-in-out_infinite]"
                 aria-label={t('cards.enrichingAria')}


### PR DESCRIPTION
## PR3c finish — resolves the dual-"관련도" confusion + a visible leak

**Decision (ii)**: the card showed a per-card relevance **% badge** = video-keyed `mandala_relevance_pct` (Heart-triggered, cross-user-leaky) — a *different number* than the user-scoped `관련도순` **sort**. Two "관련도" values → confusion, and the badge was the visible leak. Resolution: **remove the % badge**; relevance lives only in the sort (its value = demoting off-target).

### Commit 1 — remove the % badge (`InsightCardItemV2.tsx`)
- Delete `getMandalaRelevanceBadge` + `QUALITY_BADGE_THRESHOLD_*` + the footer % slot.
- **Keep** `mandalaRelevancePct` prop — the Heart-enrichment breathing dot (`v2EnrichmentPending = liked && mandalaRelevancePct == null`) still uses it. Footer layout intact (right slot = dot / empty).
- Leak + dual-number confusion gone, **zero backfill dependency**.

### Commit 2 — stable sort tiebreak (`CardListView.tsx`)
- `compareByRelevanceDesc` had no tiebreak → the title-only "70s cluster" (many equal scores) reshuffled when a Heart/like invalidated + refetched the cards query. Add **id-asc tiebreak** → stable across refetch. Test asserts same output regardless of input order.

### Verify
tsc clean + vitest 375/375 (+1 tie test) + build. Display-only removal → post-deploy = quick glance (% gone, dot/footer normal); no scored-data dependency.

### Out of scope (separate backlog)
`/v2-summaries` user-aware leak fix (one-liner/core-argument still video-keyed), fleet backfill + (i) badge-unification to user-scoped, types.ts cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)