### PR TITLE
feat(relevance): SSOT computeCardRelevance + cellGoal (CP499 sub-PR #1)

### DIFF
--- a/src/modules/relevance/compute-card-relevance.ts
+++ b/src/modules/relevance/compute-card-relevance.ts
@@ -52,6 +52,15 @@ export interface CardRelevanceInput {
   description?: string;
   /** The card's mandala centerGoal. Empty ⇒ model returns 0 per the prompt. */
   centerGoal: string;
+  /**
+   * CP499 — the cell (sub-goal) this card is placed into. When present, the goal
+   * text passed to the scorer is a 2-label block (center + cell + criterion) so
+   * the score reflects cell-fit AND center contribution. When absent, the goal
+   * is `centerGoal` verbatim — byte-identical to the pre-CP499 string, so the
+   * SHARED v2 Heart path (rich-summary-v2-quick-generator, which never passes
+   * cellGoal) is unchanged. SSOT param, routed from wizard/manual/backfill.
+   */
+  cellGoal?: string;
   /** Optional transcript; '' ⇒ prompt uses title+description fallback. */
   transcript?: string;
 }
@@ -69,13 +78,23 @@ export async function computeCardRelevance(
   }
 
   const language = detectLanguage(input.title);
+  // CP499 — cell-aware goal. cellGoal present ⇒ labeled 2-line block + criterion
+  // (cell-fit AND center contribution). Absent ⇒ `centerGoal` verbatim, i.e. the
+  // exact same string passed to the SHARED buildV2QuickPrompt before CP499, so
+  // the v2 Heart path (no cellGoal) is byte-for-byte unchanged.
+  const goal =
+    input.cellGoal && input.cellGoal.trim().length > 0
+      ? `중심 목표: ${input.centerGoal}\n` +
+        `이 카드가 배치될 셀: ${input.cellGoal}\n` +
+        `→ 이 영상이 셀에 적합하면서 중심 목표에 기여하는 정도로 평가`
+      : input.centerGoal;
   const prompt = buildV2QuickPrompt({
     title: input.title,
     description: input.description ?? '',
     channel: '',
     language,
     transcript: input.transcript ?? '',
-    mandalaCenterGoal: input.centerGoal,
+    mandalaCenterGoal: goal,
   });
 
   let raw: string;

--- a/tests/smoke/compute-card-relevance.test.ts
+++ b/tests/smoke/compute-card-relevance.test.ts
@@ -79,4 +79,36 @@ describe('computeCardRelevance (CP498 PR3a)', () => {
     const out = await computeCardRelevance({ title: 'T', centerGoal: 'g' });
     expect(out).toEqual({ ok: true, relevancePct: 55 });
   });
+
+  // CP499 — cellGoal: SSOT cell-aware scoring + back-compat (v2-path-identical).
+  it('cellGoal present → prompt carries BOTH center goal and cell goal + criterion', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okResponse(haikuJson(70)));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await computeCardRelevance({
+      title: '집중력 높이는 법',
+      centerGoal: '목표 달성',
+      cellGoal: '집중 환경 만들기',
+    });
+
+    const body = (fetchMock.mock.calls[0][1] as RequestInit).body as string;
+    expect(body).toContain('목표 달성'); // centerGoal
+    expect(body).toContain('집중 환경 만들기'); // cellGoal
+    expect(body).toContain('이 카드가 배치될 셀'); // cell label injected
+    expect(body).toContain('셀에 적합하면서 중심 목표에 기여'); // explicit criterion
+  });
+
+  it('cellGoal absent → goal is centerGoal VERBATIM (no cell label) = v2-path-identical', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okResponse(haikuJson(60)));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await computeCardRelevance({ title: 'T', centerGoal: '운동 습관 만들기' });
+
+    const body = (fetchMock.mock.calls[0][1] as RequestInit).body as string;
+    // verbatim single-line goal — byte-identical to the pre-CP499 string the
+    // shared buildV2QuickPrompt received (so the v2 Heart path is unchanged).
+    expect(body).toContain('MANDALA CENTER GOAL: 운동 습관 만들기');
+    expect(body).not.toContain('이 카드가 배치될 셀'); // no cell injection
+    expect(body).not.toContain('셀에 적합하면서'); // no criterion line
+  });
 });


### PR DESCRIPTION
First of the idempotent-relevance sub-PRs (design: docs/handoffs/relevance-idempotent-ssot-cp499.md).

**Pure calculator change** — adds optional `cellGoal` to `computeCardRelevance`. Present → labeled 2-line goal (center + cell) + criterion (cell-fit AND center contribution); **absent → centerGoal verbatim** (byte-identical to pre-CP499 → the SHARED v2 Heart path is unchanged — option (a), template untouched).

No entrance wiring yet (#2 wizard inline, #3 manual batch, #4 decommission). No schema/migration. tsc clean + jest 6/6 (4 existing + 2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)