### PR TITLE
feat(relevance): wizard fires SSOT relevance, async + cellGoal-aware (CP499 sub-PR #2)

### DIFF
--- a/docs/handoffs/relevance-idempotent-ssot-cp499.md
+++ b/docs/handoffs/relevance-idempotent-ssot-cp499.md
@@ -69,7 +69,7 @@ number ≠ the sorted-by number (dual-number confusion).
 ### 4. Compute location per entrance (all via the one SSOT).
 | entrance | when | context available | call site |
 |---|---|---|---|
-| **Wizard** | inline at placement | centerGoal + subGoals[cellIndex] already in scope, **0 DB round-trip** | `v5/executor.ts:295-299` (assemble) → compute → write `uvs.relevance_pct` |
+| **Wizard** | **async**, on creation (fire-and-forget) | cellGoal from the already-fetched mandala `levels[0].subjects[cell_index]` (0 extra query) | `pipeline-runner.ts` fires the relevance trigger after auto-add (next to rich-summary). ⚠️ NOT sync-inline at `executor.ts:295` — that only assembles in-memory; the DB write is `auto-add-recommendations.ts:305`, and ~64 sync Haiku calls would blow the wizard latency cap. The worker scores off the hot path; the badge appears once `relevance_pct` lands. NOT flag-gated. |
 | **Manual** | on panel **close** (batch) | centerGoal + the cell each pick targets | batch commit (decision 3) |
 | **Backfill** | existing worker | centerGoal (+ cellGoal from row's cell) | `enrich-relevance-quick.ts` (already routes to `computeCardRelevance`) |
 
@@ -123,7 +123,8 @@ that reads `relevance_pct` (NOT the old `mandala_relevance_pct`):
 
 ## Impacted files (no migration)
 - `compute-card-relevance.ts` — `+cellGoal` param + prompt.
-- `v5/executor.ts` — wizard inline compute + write at placement.
+- `pipeline-runner.ts` — fire the relevance trigger (async, fire-and-forget) on wizard creation, next to the rich-summary trigger. (`executor.ts` only assembles; no DB write there.)
+- `relevance-backfill-trigger.ts` — resolve `cellGoal` per row from the fetched mandala's `subjects[cell_index]` + pass to the worker; `RelevanceQuickPayload` + worker forward `cellGoal`.
 - `add-cards-panel/*` + `cards.ts` (or new batch endpoint) — manual batch-on-close.
 - `enrich-relevance-quick.ts` / trigger — pass cellGoal (backfill).
 - `rich-summary-v2-*generator.ts` — stop sourcing relevance from `mandala_relevance_pct`.

--- a/src/modules/mandala/pipeline-runner.ts
+++ b/src/modules/mandala/pipeline-runner.ts
@@ -263,6 +263,23 @@ export async function executePipelineRun(runId: string): Promise<void> {
                 log.warn(`[${runId}] rich-summary trigger failed (non-fatal): ${msg}`);
               });
           });
+          // CP499 #2 — relevance trigger (fire-and-forget, async, OFF the hot
+          // path). Scores every newly-placed wizard card via the SSOT
+          // (computeCardRelevance) at worker concurrency. NOT flag-gated: new
+          // wizard cards always get relevance so the badge shows once the worker
+          // fills relevance_pct (display-revival "new = immediate"). cellGoal is
+          // resolved inside the trigger from the mandala's cell subjects.
+          setImmediate(() => {
+            void import('../relevance/relevance-backfill-trigger')
+              .then(({ enqueueRelevanceBackfillForMandala }) =>
+                enqueueRelevanceBackfillForMandala({ userId, mandalaId, applyCutoff: false })
+              )
+              .then((r) => log.info(`[${runId}] relevance trigger: enqueued=${r.enqueued}`))
+              .catch((err) => {
+                const msg = err instanceof Error ? err.message : String(err);
+                log.warn(`[${runId}] relevance trigger failed (non-fatal): ${msg}`);
+              });
+          });
         } else {
           await updateStep(runId, 3, 'completed', result); // not-applicable ≠ failed
           log.info(`[${runId}] step3 skipped: ${result.reason}`);

--- a/src/modules/queue/handlers/enrich-relevance-quick.ts
+++ b/src/modules/queue/handlers/enrich-relevance-quick.ts
@@ -49,9 +49,9 @@ export async function registerEnrichRelevanceQuickWorker(): Promise<void> {
  * so pg-boss retries once per RELEVANCE_QUICK_RETRY_OPTIONS.
  */
 async function handleEnrichRelevanceQuick(job: PgBoss.Job<RelevanceQuickPayload>): Promise<void> {
-  const { table, rowId, title, description, centerGoal } = job.data;
+  const { table, rowId, title, description, centerGoal, cellGoal } = job.data;
 
-  const result = await computeCardRelevance({ title, description, centerGoal });
+  const result = await computeCardRelevance({ title, description, centerGoal, cellGoal });
 
   if (!result.ok) {
     if (result.reason === 'no_title') {

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -115,6 +115,10 @@ export interface RelevanceQuickPayload {
   title: string;
   description?: string;
   centerGoal: string;
+  /** CP499 — the card's cell sub-goal (`mandala.levels[0].subjects[cell_index]`).
+   *  Forwarded to the SSOT `computeCardRelevance` so the score reflects cell-fit
+   *  AND center contribution. Absent ⇒ centerGoal-only (back-compat). */
+  cellGoal?: string;
 }
 
 // ============================================================================

--- a/src/modules/relevance/relevance-backfill-trigger.ts
+++ b/src/modules/relevance/relevance-backfill-trigger.ts
@@ -50,9 +50,13 @@ export async function enqueueRelevanceBackfillForMandala(params: {
   // Resolve the mandala centerGoal once (root level depth=0) — same source as
   // enrich-rich-summary.ts:174. Empty ⇒ compute returns 0 per the quick prompt.
   let centerGoal = '';
+  let cellGoals: string[] = [];
   try {
     const mandala = await getMandalaManager().getMandalaById(params.userId, params.mandalaId);
     centerGoal = mandala?.levels[0]?.centerGoal ?? '';
+    // CP499 — the 8 cell sub-goals from the SAME fetched mandala (0 extra query).
+    // cellGoals[cell_index] is the per-card cell goal forwarded to the SSOT scorer.
+    cellGoals = mandala?.levels[0]?.subjects ?? [];
   } catch (err) {
     log.warn('mandala lookup failed (continuing with empty centerGoal)', {
       userId: params.userId,
@@ -74,7 +78,7 @@ export async function enqueueRelevanceBackfillForMandala(params: {
         relevance_pct: null,
         ...(cutoffDate ? { createdAt: { gt: cutoffDate } } : {}),
       },
-      select: { id: true, video: { select: { title: true } } },
+      select: { id: true, cell_index: true, video: { select: { title: true } } },
     }),
     prisma.user_local_cards.findMany({
       where: {
@@ -84,7 +88,13 @@ export async function enqueueRelevanceBackfillForMandala(params: {
         relevance_pct: null,
         ...(cutoffDate ? { created_at: { gt: cutoffDate } } : {}),
       },
-      select: { id: true, title: true, metadata_title: true, metadata_description: true },
+      select: {
+        id: true,
+        cell_index: true,
+        title: true,
+        metadata_title: true,
+        metadata_description: true,
+      },
     }),
   ]);
 
@@ -99,6 +109,7 @@ export async function enqueueRelevanceBackfillForMandala(params: {
         rowId: row.id,
         title: row.video?.title ?? '',
         centerGoal,
+        cellGoal: row.cell_index != null ? cellGoals[row.cell_index] : undefined,
       });
       if (jobId) enqueued += 1;
       else skipped += 1;
@@ -120,6 +131,7 @@ export async function enqueueRelevanceBackfillForMandala(params: {
         title: row.title ?? row.metadata_title ?? '',
         description: row.metadata_description ?? undefined,
         centerGoal,
+        cellGoal: row.cell_index != null ? cellGoals[row.cell_index] : undefined,
       });
       if (jobId) enqueued += 1;
       else skipped += 1;

--- a/tests/unit/modules/relevance-backfill-trigger.test.ts
+++ b/tests/unit/modules/relevance-backfill-trigger.test.ts
@@ -104,6 +104,48 @@ describe('enqueueRelevanceBackfillForMandala — row-not-video fan-out (regressi
     expect(result).toMatchObject({ enqueued: 2, uvsRows: 1, ulcRows: 1 });
   });
 
+  // CP499 #2 — cellGoal resolved from the fetched mandala's subjects[cell_index].
+  test('cellGoal = mandala.subjects[cell_index] per row (uvs + ulc)', async () => {
+    mockGetMandalaById.mockResolvedValueOnce({
+      levels: [{ centerGoal: 'C', subjects: ['cell0 goal', 'cell1 goal', 'cell2 goal'] }],
+    });
+    mockUvsFindMany.mockResolvedValueOnce([
+      { id: 'uvs-c0', cell_index: 0, video: { title: 'T0' } },
+      { id: 'uvs-c2', cell_index: 2, video: { title: 'T2' } },
+    ]);
+    mockUlcFindMany.mockResolvedValueOnce([
+      {
+        id: 'ulc-c1',
+        cell_index: 1,
+        title: 'L1',
+        metadata_title: null,
+        metadata_description: null,
+      },
+    ]);
+
+    await enqueueRelevanceBackfillForMandala({ userId: 'u1', mandalaId: 'm1', applyCutoff: false });
+
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ rowId: 'uvs-c0', cellGoal: 'cell0 goal' })
+    );
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ rowId: 'uvs-c2', cellGoal: 'cell2 goal' })
+    );
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ rowId: 'ulc-c1', cellGoal: 'cell1 goal' })
+    );
+  });
+
+  test('cellGoal undefined when subjects absent / out-of-bounds (centerGoal-only fallback)', async () => {
+    mockGetMandalaById.mockResolvedValueOnce({ levels: [{ centerGoal: 'C' }] }); // no subjects
+    mockUvsFindMany.mockResolvedValueOnce([{ id: 'uvs-x', cell_index: 5, video: { title: 'T' } }]);
+
+    await enqueueRelevanceBackfillForMandala({ userId: 'u1', mandalaId: 'm1', applyCutoff: false });
+
+    const call = mockEnqueue.mock.calls.find((c) => (c[0] as { rowId: string }).rowId === 'uvs-x');
+    expect((call![0] as { cellGoal?: string }).cellGoal).toBeUndefined();
+  });
+
   test('ulc title falls back to metadata_title when title is null', async () => {
     mockUlcFindMany.mockResolvedValueOnce([
       { id: 'ulc-2', title: null, metadata_title: 'Meta Title', metadata_description: null },


### PR DESCRIPTION
Sub-PR #2 of idempotent-relevance (design: docs/handoffs/relevance-idempotent-ssot-cp499.md).

Wizard creation → **async fire-and-forget** relevance trigger (pipeline-runner, next to rich-summary; off the hot path — sync ×64 Haiku would blow the latency cap). `cellGoal` resolved from the **same already-fetched mandala** (`levels[0].subjects[cell_index]`, 0 extra query) → `RelevanceQuickPayload` → worker → SSOT `computeCardRelevance`. **Not flag-gated** (new wizard cards always scored). Corrects the diagnosis's 'inline at executor.ts:295' (assemble-only; write is auto-add). tsc clean + jest 30/30. No schema/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)