### PR TITLE
feat(relevance): manual-add fires SSOT relevance on panel close (CP499 sub-PR #3)

### DIFF
--- a/frontend/src/__tests__/smoke/api-url-contract.test.ts
+++ b/frontend/src/__tests__/smoke/api-url-contract.test.ts
@@ -65,6 +65,12 @@ describe('API Client URL Contract', () => {
     expect(content).not.toMatch(/\/api\/v1\/mandalas\/templates\/typeahead/);
   });
 
+  // CP499 #3 — A-stage relevance trigger (user-facing twin of rich-summary-trigger).
+  it('triggerMandalaRelevance posts /mandalas/:id/relevance-trigger (no double prefix)', () => {
+    expect(content).toContain('/mandalas/${mandalaId}/relevance-trigger');
+    expect(content).not.toMatch(/\/api\/v1\/mandalas\/\$\{mandalaId\}\/relevance-trigger/);
+  });
+
   it('listPublicTemplates uses /mandalas/templates-public (no double prefix)', () => {
     expect(content).toContain('/mandalas/templates-public');
     expect(content).not.toMatch(/\/api\/v1\/mandalas\/templates-public/);

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1001,6 +1001,19 @@ class ApiClient {
     );
   }
 
+  /**
+   * CP499 #3 — A-stage relevance trigger. Fired fire-and-forget by the Add Cards
+   * panel on close (when ≥1 pick happened this session). Scores the mandala's
+   * unscored placed cards via the SSOT (cellGoal-aware), idempotent. Errors are
+   * swallowed by the caller's void pattern — never blocks the close UX.
+   */
+  async triggerMandalaRelevance(mandalaId: string): Promise<void> {
+    await this.request<{ status: 'ok'; data: unknown }>(
+      `/mandalas/${mandalaId}/relevance-trigger`,
+      { method: 'POST', body: JSON.stringify({}) }
+    );
+  }
+
   // ─── CP456 Billing (Lemon Squeezy, MoR subscription) ──────────────────────
 
   /**

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -6,6 +6,7 @@ import { useMandalaQuery } from '@/features/mandala';
 import { ChevronDown, ChevronUp, Loader2, Lock, RotateCcw, Search, Undo2, X } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/shared/lib/utils';
+import { apiClient } from '@/shared/lib/api-client';
 import { useLikeCard } from '@/features/card-management/model/useLikeCard';
 import { localCardsKeys } from '@/features/card-management/model/useLocalCards';
 import { useAllVideoStates, youtubeSyncKeys } from '@/features/youtube-sync/model/useYouTubeSync';
@@ -406,6 +407,17 @@ export function AddCardsPanel() {
 
   const handleClose = useCallback(() => {
     if (isClosingLocal) return;
+    // CP499 #3 — A-stage relevance trigger on close. Fire only when this mandala
+    // has picks (guard: idle open of a fresh mandala → localPicks empty → no
+    // fire). Fire-and-forget + idempotent (BE skip-if-null) → safe to re-fire;
+    // for a curated mandala it's a cheap no-op scan or a free catch-up if a
+    // prior close was missed. Scores the mandala's unscored placed cards
+    // (cellGoal-aware) off the hot path. Errors swallowed — never block close.
+    if (mandalaId && localPicks.size > 0) {
+      void apiClient.triggerMandalaRelevance(mandalaId).catch(() => {
+        /* never block close UX; idempotent trigger self-heals on the next close */
+      });
+    }
     setIsClosingLocal(true);
     if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
     closeTimerRef.current = setTimeout(() => {
@@ -413,7 +425,7 @@ export function AddCardsPanel() {
       setIsClosingLocal(false);
       closeTimerRef.current = null;
     }, CLOSE_ANIMATION_MS);
-  }, [closePanel, isClosingLocal]);
+  }, [closePanel, isClosingLocal, mandalaId, localPicks]);
 
   useEffect(() => {
     return () => {

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -2748,6 +2748,45 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
   );
 
   /**
+   * POST /api/v1/mandalas/:id/relevance-trigger — CP499 #3 (A-stage relevance).
+   *
+   * User-facing twin of /rich-summary-trigger. Called fire-and-forget by the FE
+   * when the Add Cards panel closes after ≥1 pick. Scores the mandala's unscored
+   * placed cards via the SSOT (computeCardRelevance), cellGoal-aware. Idempotent
+   * (skip-if-null) — re-firing only scores not-yet-scored rows. NOT flag-gated:
+   * the user is actively curating this mandala (BACKFILL_RELEVANCE_ENABLED gates
+   * only the fleet/bulk sweep). 'all-unscored' scope = a one-time lazy mini-
+   * backfill of the mandala being curated (bounded to one mandala).
+   */
+  fastify.post<{ Params: { id: string } }>(
+    '/:id/relevance-trigger',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const userId = getUserId(request, reply);
+      if (!userId) return;
+
+      const { id: mandalaId } = request.params;
+
+      const owned = await getPrismaClient().user_mandalas.findFirst({
+        where: { id: mandalaId, user_id: userId },
+        select: { id: true },
+      });
+      if (!owned) {
+        return reply.code(404).send({ status: 'error', error: 'Mandala not found' });
+      }
+
+      const { enqueueRelevanceBackfillForMandala } =
+        await import('../../modules/relevance/relevance-backfill-trigger');
+      const result = await enqueueRelevanceBackfillForMandala({
+        userId,
+        mandalaId,
+        applyCutoff: false,
+      });
+      return reply.code(202).send({ status: 'ok', data: result });
+    }
+  );
+
+  /**
    * GET /api/v1/mandalas/:id/book — CP438+1 PoC.
    *
    * Returns the generated book index (chapters + sections + atoms + qa)


### PR DESCRIPTION
Sub-PR #3 (design: docs/handoffs/relevance-idempotent-ssot-cp499.md). Manual card-add now scores via the SSOT — **trigger-reuse, no bespoke batch endpoint**.

- BE: `POST /mandalas/:id/relevance-trigger` (user-facing twin of rich-summary-trigger) → `enqueueRelevanceBackfillForMandala` (cellGoal-aware, async, off hot path).
- FE: Add Cards panel `handleClose` fires it **iff ≥1 pick this session** (guard: no idle-open fire); fire-and-forget, errors swallowed (never blocks close).
- **all-unscored scope** = one-time lazy mini-backfill of the curated mandala (NOT flag-gated; flag gates only fleet sweep). Idempotent (skip-if-null) → re-fire safe + free catch-up for missed closes.
- Picking flow unchanged (per-pick like). tsc clean (BE+FE), jest 13/13 core, vitest 376/376 (+url-contract), build ✓. No schema/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)