### PR TITLE
diag(wizard): merged-gen sub-step timing (search/gen/other) (CP499)

### DIFF
--- a/src/modules/mandala/generator.ts
+++ b/src/modules/mandala/generator.ts
@@ -740,11 +740,16 @@ export async function generateMandalaWithQueries(
   const t0 = Date.now();
   logger.info(`Mandala merged structure+queries generation started: goal="${input.goal}"`);
 
+  // CP499 — sub-step timing: the only two awaited steps are searchMandalasByGoal
+  // (embed + cosine) and the generate() LLM call. Splitting them in the [TIMING]
+  // log decomposes the merged-gen total (66s reproductions) into its real parts.
+  const tSearch = Date.now();
   const similar = await searchMandalasByGoal(input.goal, {
     limit: 1,
     threshold: 0.4,
     language: input.language,
   });
+  const searchMs = Date.now() - tSearch;
 
   const lang = input.language ?? 'ko';
   const domain = input.domain ?? 'general';
@@ -767,11 +772,13 @@ export async function generateMandalaWithQueries(
     ((p: string, o?: { temperature?: number; maxTokens?: number; format?: 'json' }) =>
       new OpenRouterGenerationProvider(MERGED_GEN_MODEL).generate(p, o));
 
+  const tGen = Date.now();
   const raw = await generate(prompt, {
     temperature: MERGED_GEN_TEMPERATURE,
     maxTokens: MERGED_GEN_MAX_TOKENS,
     format: 'json',
   });
+  const genMs = Date.now() - tGen;
   const latencyMs = Date.now() - t0;
 
   const merged = parseMergedResponse(raw);
@@ -813,8 +820,11 @@ export async function generateMandalaWithQueries(
   }
   const degraded = !cellQueries;
 
+  // CP499 — `other` = latency − search − gen = synchronous parse/validate +
+  // any gap. If `other` is large, the cost is NOT in the two awaits (surprise).
   logger.info(
-    `[TIMING] merged-gen: ${latencyMs}ms | cellQueries=${cellQueryCount}/${totalCells} ` +
+    `[TIMING] merged-gen: ${latencyMs}ms (search=${searchMs}ms gen=${genMs}ms ` +
+      `other=${latencyMs - searchMs - genMs}ms) | cellQueries=${cellQueryCount}/${totalCells} ` +
       `degraded=${degraded}`
   );
 


### PR DESCRIPTION
Diagnostic-only (no behavior change). Splits the `[TIMING] merged-gen` log into search / generate / other so the 66s custom-create reproductions decompose into their real parts. `generateMandalaWithQueries` has exactly two awaits (searchMandalasByGoal ~7.5s + qwen3-30b generate ≤27s in logs) — the ~30s gap to 66s is currently unexplained; this log pins it. No fix proposed until decomposed. tsc clean, generator test 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)