### PR TITLE
fix(relevance): fire relevance trigger on wizard's real card-placement path (completes #873)

### DIFF
--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -459,6 +459,34 @@ export async function consumePrecompute(
           ? ` inserted=${autoAddResult.rowsInserted ?? 0} preserved=${autoAddResult.rowsPreserved ?? 0}`
           : ` reason=${autoAddResult.reason ?? 'unknown'}`)
     );
+
+    // CP499 — A-stage relevance trigger MUST fire on THIS path: the wizard
+    // places cards via this inline auto-add, NOT pipeline-runner step3. step3
+    // then sees 'no pending recommendation_cache rows' (auto-add flips them to
+    // 'shown') and no-ops, so its relevance trigger (gated on result.ok) never
+    // fires for wizard mandalas — #873 was mis-wired into that dead path, so
+    // new wizard cards were never scored (relevance_pct stayed NULL). Mirror
+    // the pipeline-runner block here: fire-and-forget, applyCutoff:false.
+    // Mutually exclusive with step3 (whichever consumes the 'pending' rows
+    // fires; the other gets ok:false); the trigger's relevance_pct IS NULL
+    // filter is an idempotent backstop against any double-enqueue edge.
+    if (autoAddResult.ok && (autoAddResult.rowsInserted ?? 0) > 0) {
+      setImmediate(() => {
+        void import('@/modules/relevance/relevance-backfill-trigger')
+          .then(({ enqueueRelevanceBackfillForMandala }) =>
+            enqueueRelevanceBackfillForMandala({
+              userId: input.userId,
+              mandalaId: input.mandalaId,
+              applyCutoff: false,
+            })
+          )
+          .then((r) => log.info(`relevance trigger (precompute path): enqueued=${r.enqueued}`))
+          .catch((err) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            log.warn(`relevance trigger (precompute path) failed (non-fatal): ${msg}`);
+          });
+      });
+    }
   } catch (err) {
     log.warn(
       `precompute consume → auto-add inline threw (non-fatal — pipeline-runner step3 will retry): ${

--- a/tests/unit/modules/wizard-precompute.test.ts
+++ b/tests/unit/modules/wizard-precompute.test.ts
@@ -55,6 +55,15 @@ jest.mock('@/modules/mandala/auto-add-recommendations', () => ({
   maybeAutoAddRecommendations: mockMaybeAutoAdd,
 }));
 
+// CP499 — the wizard's relevance trigger fires from THIS path (inline auto-add),
+// not pipeline-runner step3. Mock it to assert the wizard path reaches it.
+const mockEnqueueRelevanceBackfill = jest
+  .fn()
+  .mockResolvedValue({ enqueued: 0, skipped: 0, uvsRows: 0, ulcRows: 0 });
+jest.mock('@/modules/relevance/relevance-backfill-trigger', () => ({
+  enqueueRelevanceBackfillForMandala: mockEnqueueRelevanceBackfill,
+}));
+
 jest.mock('@/config/wizard-precompute', () => ({
   loadWizardPrecomputeConfig: mockLoadConfig,
 }));
@@ -327,6 +336,57 @@ describe('wizard-precompute — consumePrecompute', () => {
     expect(r.consumed).toBe(true);
     expect(r.cardsInserted).toBe(1);
     expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+  }, 15_000);
+
+  // CP499 regression — the wizard places cards via THIS inline auto-add, so the
+  // relevance trigger MUST fire here. #873 wired it into pipeline-runner step3,
+  // which is a no-op for wizard mandalas ('no pending recommendation_cache rows')
+  // → wizard cards were never scored (relevance_pct NULL). This locks the fix.
+  test('auto-add inserts >0 → relevance trigger fires on the precompute path', async () => {
+    mockMaybeAutoAdd.mockResolvedValueOnce({ ok: true, rowsInserted: 5, rowsPreserved: 0 });
+    mockFindUnique.mockResolvedValue({
+      session_id: SESSION,
+      user_id: USER,
+      goal: 'g',
+      status: 'done',
+      expires_at: FUTURE,
+      discover_result: { slots: [makeSlot(0, 'v1')] },
+    });
+    await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+    // trigger runs in setImmediate + a dynamic import → flush both ticks.
+    await new Promise((res) => setImmediate(res));
+    await new Promise((res) => setImmediate(res));
+    expect(mockEnqueueRelevanceBackfill).toHaveBeenCalledWith({
+      userId: USER,
+      mandalaId: MANDALA,
+      applyCutoff: false,
+    });
+  }, 15_000);
+
+  test('auto-add inserts 0 → relevance trigger does NOT fire (nothing new to score)', async () => {
+    mockMaybeAutoAdd.mockResolvedValueOnce({ ok: true, rowsInserted: 0, rowsPreserved: 0 });
+    mockFindUnique.mockResolvedValue({
+      session_id: SESSION,
+      user_id: USER,
+      goal: 'g',
+      status: 'done',
+      expires_at: FUTURE,
+      discover_result: { slots: [makeSlot(0, 'v1')] },
+    });
+    await consumePrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      mandalaId: MANDALA,
+      centerGoal: 'g',
+    });
+    await new Promise((res) => setImmediate(res));
+    await new Promise((res) => setImmediate(res));
+    expect(mockEnqueueRelevanceBackfill).not.toHaveBeenCalled();
   }, 15_000);
 
   test('status=failed → reason=not-done (no poll, immediate miss)', async () => {


### PR DESCRIPTION
#873 was mis-wired: the relevance trigger lived in pipeline-runner step3's if(result.ok), but the wizard places cards via consumePrecompute's inline auto-add → step3 = 'no pending' → ok:false → trigger never fired → new wizard mandalas had relevance_pct=NULL (no badge #875, no sort #869). Fix fires the trigger from the inline auto-add success (wizard's real path), guarded rowsInserted>0, mutually-exclusive with step3 + idempotent backstop. +2 regression tests (wizard path reaches trigger). tsc clean. Done-gate = prod repro: new wizard create → relevance_pct populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)