### PR TITLE
fix(wizard): single-flight goal embeds + body-read timeout + search error logging (CP499+)

### DIFF
--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -1512,6 +1512,13 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         if (err instanceof MandalaSearchError) {
           const statusCode =
             err.code === 'SERVICE_UNAVAILABLE' || err.code === 'TIMEOUT' ? 503 : 422;
+          // CP499+ — embed failures (TIMEOUT/RATE_LIMITED/...) previously left
+          // ZERO log trace: the 2026-06-10 86s-stall diagnosis had to be
+          // reconstructed from absence-of-completion lines. Keep this warn.
+          request.log.warn(
+            { code: err.code, statusCode, userId, goal: goal.trim().slice(0, 80) },
+            `Mandala search error: ${err.message}`
+          );
           return reply.code(statusCode).send({
             status: statusCode,
             code: err.code,

--- a/src/modules/mandala/search.ts
+++ b/src/modules/mandala/search.ts
@@ -112,6 +112,17 @@ const SYSTEM_TEMPLATES_USER_ID = '00000000-0000-0000-0000-000000000001';
  *
  * Both return a same-dim vector matching mandala_embeddings.
  */
+/**
+ * CP499+ single-flight — cold-key concurrent callers (FE /search-by-goal +
+ * wizard-stream template search + merged-gen fire in the same instant) share
+ * ONE in-flight embed instead of racing N identical provider calls. In the
+ * 2026-06-10 prod repro, one of two simultaneous identical embeds stalled
+ * ~85s while the other returned in 2.5s — the stalled one pushed the FE past
+ * its 15s abort. Entries live only for the call duration; failures are NOT
+ * cached (`finally` removes the entry, so the next caller retries fresh).
+ */
+const inflightEmbeds = new Map<string, Promise<number[]>>();
+
 export async function embedGoalForMandala(goalText: string): Promise<number[]> {
   const provider = config.mandalaEmbed.provider;
   // CP499 — cache by provider+goal: the embed is goal-deterministic, so the FE
@@ -120,10 +131,21 @@ export async function embedGoalForMandala(goalText: string): Promise<number[]> {
   const cached = goalEmbedCache.get(cacheKey);
   if (cached) return cached;
 
-  const vector =
-    provider === 'openrouter' ? await embedViaOpenRouter(goalText) : await embedViaOllama(goalText);
-  goalEmbedCache.set(cacheKey, vector);
-  return vector;
+  const inflight = inflightEmbeds.get(cacheKey);
+  if (inflight) return inflight;
+
+  const pending = (
+    provider === 'openrouter' ? embedViaOpenRouter(goalText) : embedViaOllama(goalText)
+  )
+    .then((vector) => {
+      goalEmbedCache.set(cacheKey, vector);
+      return vector;
+    })
+    .finally(() => {
+      inflightEmbeds.delete(cacheKey);
+    });
+  inflightEmbeds.set(cacheKey, pending);
+  return pending;
 }
 
 async function embedViaOllama(goalText: string): Promise<number[]> {
@@ -136,6 +158,10 @@ async function embedViaOllama(goalText: string): Promise<number[]> {
   }
 
   const controller = new AbortController();
+  // CP499+ — the timer must cover the BODY read too: fetch() resolves on
+  // response HEADERS, so clearing the timer there left response.json()
+  // unguarded — a stalled body stream ran ~86s past the 30s cap in the
+  // 2026-06-10 prod repro. clearTimeout now lives in `finally`.
   const timeout = setTimeout(() => controller.abort(), EMBED_TIMEOUT_MS);
 
   try {
@@ -145,8 +171,6 @@ async function embedViaOllama(goalText: string): Promise<number[]> {
       body: JSON.stringify({ model, input: goalText }),
       signal: controller.signal,
     });
-
-    clearTimeout(timeout);
 
     if (!response.ok) {
       const body = await response.text();
@@ -172,7 +196,6 @@ async function embedViaOllama(goalText: string): Promise<number[]> {
 
     return vector;
   } catch (err) {
-    clearTimeout(timeout);
     if (err instanceof MandalaSearchError) throw err;
     if (err instanceof Error && err.name === 'AbortError') {
       throw new MandalaSearchError('Embedding request timed out', 'TIMEOUT');
@@ -185,6 +208,8 @@ async function embedViaOllama(goalText: string): Promise<number[]> {
       );
     }
     throw new MandalaSearchError(message, 'EMBED_FAILED');
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -211,6 +236,8 @@ async function embedViaOpenRouter(goalText: string): Promise<number[]> {
   }
 
   const controller = new AbortController();
+  // CP499+ — same body-read coverage as the Ollama path: the 30s cap must
+  // span response.json(), not just the headers. See embedViaOllama.
   const timeout = setTimeout(() => controller.abort(), EMBED_TIMEOUT_MS);
 
   try {
@@ -223,8 +250,6 @@ async function embedViaOpenRouter(goalText: string): Promise<number[]> {
       body: JSON.stringify({ model, input: goalText, encoding_format: 'float' }),
       signal: controller.signal,
     });
-
-    clearTimeout(timeout);
 
     if (!response.ok) {
       const body = await response.text();
@@ -258,13 +283,14 @@ async function embedViaOpenRouter(goalText: string): Promise<number[]> {
 
     return vector;
   } catch (err) {
-    clearTimeout(timeout);
     if (err instanceof MandalaSearchError) throw err;
     if (err instanceof Error && err.name === 'AbortError') {
       throw new MandalaSearchError('OpenRouter embed request timed out', 'TIMEOUT');
     }
     const message = err instanceof Error ? err.message : String(err);
     throw new MandalaSearchError(`OpenRouter embed failed: ${message}`, 'EMBED_FAILED');
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/tests/unit/modules/mandala-embed-singleflight.test.ts
+++ b/tests/unit/modules/mandala-embed-singleflight.test.ts
@@ -1,0 +1,187 @@
+/**
+ * CP499+ — goal-embed single-flight + body-read timeout regression tests.
+ *
+ * Prod repro 2026-06-10: FE /search-by-goal + wizard-stream fired the same
+ * goal in the same instant; both missed the goal-embed cache and raced two
+ * identical OpenRouter embeds. One returned in 2.5s, the other stalled ~85s —
+ * past the FE 15s abort AND past the 30s EMBED_TIMEOUT_MS, because
+ * clearTimeout ran when fetch() resolved (headers) leaving response.json()
+ * (body download) unguarded.
+ *
+ * Pins three behaviours:
+ *   1. concurrent cold-key callers share ONE underlying fetch (single-flight)
+ *   2. a failed embed is NOT cached — the next call fires a fresh fetch
+ *   3. the 30s abort covers the body read (stalled json() → TIMEOUT)
+ *
+ * Per CLAUDE.md Hard Rule on LLM API usage, this test must NEVER make a real
+ * OpenRouter call — config is statically mocked and global fetch is spied in
+ * every case. Each test uses a UNIQUE goal string: the module-level
+ * goalEmbedCache + inflight map are intentionally not reset between cases.
+ */
+
+interface TestConfig {
+  mandalaEmbed: {
+    provider: 'ollama' | 'openrouter';
+    openRouterBaseUrl: string;
+    openRouterModel: string;
+    openRouterDimension: number;
+  };
+  mandalaGen: {
+    url: string;
+    model: string;
+    embedModel: string;
+    embedDimension: number;
+  };
+  openrouter: {
+    apiKey: string | undefined;
+    model: string;
+  };
+}
+
+const mockConfig: TestConfig = {
+  mandalaEmbed: {
+    provider: 'openrouter',
+    openRouterBaseUrl: 'https://openrouter.test/api/v1',
+    openRouterModel: 'qwen/qwen3-embedding-8b',
+    openRouterDimension: 4096,
+  },
+  mandalaGen: {
+    url: 'http://ollama.local:11434',
+    model: 'mandala-gen',
+    embedModel: 'qwen3-embedding:8b',
+    embedDimension: 4096,
+  },
+  openrouter: {
+    apiKey: 'test-key',
+    model: 'qwen/qwen3-30b-a3b',
+  },
+};
+
+jest.mock('../../../src/config', () => {
+  return {
+    config: new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (prop === 'mandalaEmbed') return mockConfig.mandalaEmbed;
+          if (prop === 'mandalaGen') return mockConfig.mandalaGen;
+          if (prop === 'openrouter') return mockConfig.openrouter;
+          if (prop === 'database')
+            return { url: 'postgresql://test:test@localhost:5432/test', directUrl: undefined };
+          if (prop === 'app')
+            return {
+              env: 'test',
+              isDevelopment: false,
+              isProduction: false,
+              isTest: true,
+              logLevel: 'silent',
+            };
+          if (prop === 'supabase')
+            return { url: '', anonKey: '', serviceRoleKey: '', jwtSecret: '' };
+          return undefined;
+        },
+      }
+    ),
+  };
+});
+
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({}),
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import { embedGoalForMandala } from '../../../src/modules/mandala/search';
+
+const VEC = Array(4096).fill(0.001);
+
+function okEmbedResponse(): Response {
+  return new Response(JSON.stringify({ data: [{ embedding: VEC }] }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.useRealTimers();
+});
+
+describe('embedGoalForMandala single-flight (CP499+)', () => {
+  it('concurrent cold-key callers share ONE underlying fetch', async () => {
+    let resolveFetch: (r: Response) => void = () => {};
+    const fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    // Fire the FE-search + merged-gen pair: same goal, same instant, no await.
+    const p1 = embedGoalForMandala('singleflight concurrent goal');
+    const p2 = embedGoalForMandala('singleflight concurrent goal');
+
+    // Both callers are queued before the provider responds.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    resolveFetch(okEmbedResponse());
+    const [v1, v2] = await Promise.all([p1, p2]);
+    expect(v1).toHaveLength(4096);
+    expect(v2).toHaveLength(4096);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Post-resolve caller hits the value cache — still no second fetch.
+    const v3 = await embedGoalForMandala('singleflight concurrent goal');
+    expect(v3).toHaveLength(4096);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('a failed embed is NOT cached — the next call fires a fresh fetch', async () => {
+    const fetchSpy = jest
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValueOnce(new Error('socket hang up'))
+      .mockResolvedValueOnce(okEmbedResponse());
+
+    await expect(embedGoalForMandala('singleflight retry goal')).rejects.toMatchObject({
+      code: 'EMBED_FAILED',
+    });
+
+    // The inflight entry must be gone — retry reaches the provider again.
+    const vec = await embedGoalForMandala('singleflight retry goal');
+    expect(vec).toHaveLength(4096);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('the 30s abort covers the body read — stalled json() rejects with TIMEOUT', async () => {
+    jest.useFakeTimers();
+
+    // Headers arrive instantly; the BODY never does. Pre-fix, clearTimeout
+    // ran on fetch-resolve and this json() hung unbounded (~86s prod repro).
+    jest.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      const signal = (init as RequestInit | undefined)?.signal;
+      return {
+        ok: true,
+        status: 200,
+        json: () =>
+          new Promise((_resolve, reject) => {
+            signal?.addEventListener('abort', () =>
+              reject(Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }))
+            );
+          }),
+      } as unknown as Response;
+    });
+
+    const pending = embedGoalForMandala('singleflight body stall goal');
+    const assertion = expect(pending).rejects.toMatchObject({ code: 'TIMEOUT' });
+
+    await jest.advanceTimersByTimeAsync(30_000);
+    await assertion;
+  });
+});


### PR DESCRIPTION
## Problem (log-traced prod repro, 2026-06-10 03:54 UTC)

Wizard step-3 "similar templates" hit the FE retry card despite #878's goal-embed cache being deployed and working (retry = 81ms cache hit). Trace:

| UTC | request | result |
|---|---|---|
| 03:54:21.297 | `req-1tf` POST /wizard-stream (same goal) | 200 in 9.4s (`[TIMING] merged-gen: search=4982ms gen=4411ms`) |
| 03:54:21.305 | `req-1tg` POST /search-by-goal (1st) | no completion — FE aborted at its 15s hard timeout |
| 03:54:52.4 | `req-1tj` retry | 200 in **81ms** (cache hit) |
| 03:55:47 | `req-1tg` finally completed server-side | **86s** after start |

Root cause: cold-key concurrent callers (FE search + wizard-stream template search + merged-gen) each fired their **own** identical OpenRouter embed — no in-flight sharing. One of the duplicates stalled ~85s. It survived `EMBED_TIMEOUT_MS=30s` because `clearTimeout` ran when `fetch()` resolved (**headers**), leaving `response.json()` (body download) unguarded. The failure also left **zero log trace** (`MandalaSearchError` branch replied without logging).

## Fix (one PR, three single-concern changes)

1. **Single-flight** (`search.ts`): module-level `inflightEmbeds: Map<key, Promise<number[]>>` in front of the `TtlLruCache` (value-cache class untouched). Cold-key concurrent callers await one shared embed. Failures are never cached — `finally` deletes the entry so the next call retries fresh. Accepted tradeoff: the shared fetch failing fails all waiters of that instant; a retry fires a new fetch.
2. **Body-read timeout** (`search.ts`, both providers): `clearTimeout` moved to `finally` so the 30s abort covers the body read. Kills 86s zombie calls.
3. **Observability** (`mandalas.ts` /search-by-goal): `MandalaSearchError` branch now logs `warn` with `code/statusCode/userId/goal` before replying.

## Tests (3 new, regression-pinned)

- concurrent 2 calls on a cold key → exactly 1 underlying fetch, both resolve, post-resolve call hits value cache
- failed embed is NOT cached → next call fires a fresh fetch
- stalled `json()` (headers OK, body never arrives) → aborts with `TIMEOUT` at 30s (fails on pre-fix code)

`npx jest mandala`: my touched suites all PASS (embed-singleflight 3/3, embed-openrouter 8/8, merged-gen, mandala-quota smoke). Pre-existing local failures in `mandala-routes`/`manager`/`post-creation` reproduce **identically without this change** (verified via stash) — unrelated.

## Rollback

`git revert` of the single commit — behavioral only, no schema/env/flag changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)