### PR TITLE
fix(cards): re-attach infinite-scroll observer on sentinel remount (CP499+)

### DIFF
--- a/frontend/src/__tests__/useSentinelPagination.test.ts
+++ b/frontend/src/__tests__/useSentinelPagination.test.ts
@@ -1,0 +1,107 @@
+/**
+ * CP499+ — sentinel observer re-attachment regression (prod 2026-06-10).
+ *
+ * The old CardList effect attached the IntersectionObserver keyed on
+ * [sortedCards.length]; when the sentinel node unmounted and later REMOUNTED
+ * on a same-length list, the effect never re-ran → the observer stayed bound
+ * to the detached node → infinite scroll dead, tail skeletons forever
+ * (25 rendered vs 34 placed). The hook attaches via callback ref so the
+ * observation follows the node lifecycle exactly.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSentinelPagination } from '@/widgets/card-list/model/useSentinelPagination';
+
+type IOCallback = (entries: Array<{ isIntersecting: boolean }>) => void;
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+  observed: Element[] = [];
+  disconnected = false;
+  constructor(public callback: IOCallback) {
+    MockIntersectionObserver.instances.push(this);
+  }
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+  disconnect() {
+    this.disconnected = true;
+  }
+  unobserve() {}
+  takeRecords() {
+    return [];
+  }
+  /** Simulate the sentinel entering the viewport on the LIVE observer. */
+  fire(isIntersecting = true) {
+    this.callback([{ isIntersecting }]);
+  }
+}
+
+beforeEach(() => {
+  MockIntersectionObserver.instances = [];
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+});
+
+const PAGE_SIZE = 24;
+const node = () => document.createElement('div');
+
+describe('useSentinelPagination (CP499+ observer re-attachment)', () => {
+  it('grows visibleCount by pageSize, capped at the CURRENT total (no stale clamp)', () => {
+    const { result, rerender } = renderHook(
+      ({ total }) => useSentinelPagination(total, PAGE_SIZE),
+      { initialProps: { total: 34 } }
+    );
+    expect(result.current.visibleCount).toBe(24);
+
+    const sentinel = node();
+    act(() => result.current.sentinelRef(sentinel));
+    const obs = MockIntersectionObserver.instances.at(-1)!;
+    expect(obs.observed).toContain(sentinel);
+
+    act(() => obs.fire());
+    expect(result.current.visibleCount).toBe(34); // min(24+24, 34)
+
+    // Total grows AFTER attachment — the cap must follow the fresh value,
+    // not the closure captured at observe-time.
+    rerender({ total: 60 });
+    act(() => obs.fire());
+    expect(result.current.visibleCount).toBe(58); // min(34+24, 60)
+  });
+
+  it('REGRESSION: re-attaches to a remounted sentinel on a same-length list', () => {
+    const { result } = renderHook(() => useSentinelPagination(34, PAGE_SIZE));
+
+    // Mount → grow to end → sentinel unmounts (hasMore false).
+    const first = node();
+    act(() => result.current.sentinelRef(first));
+    const obs1 = MockIntersectionObserver.instances.at(-1)!;
+    act(() => obs1.fire());
+    expect(result.current.visibleCount).toBe(34);
+    act(() => result.current.sentinelRef(null));
+    expect(obs1.disconnected).toBe(true);
+
+    // Window reset (cell/mandala switch, SAME length) → sentinel remounts.
+    act(() => result.current.resetVisibleCount());
+    expect(result.current.visibleCount).toBe(24);
+    const second = node();
+    act(() => result.current.sentinelRef(second));
+
+    // The pre-fix code skipped re-attachment here (deps length unchanged) —
+    // scroll was dead. The hook must observe the NEW node with a LIVE observer.
+    const obs2 = MockIntersectionObserver.instances.at(-1)!;
+    expect(obs2).not.toBe(obs1);
+    expect(obs2.observed).toContain(second);
+    expect(obs2.disconnected).toBe(false);
+
+    act(() => obs2.fire());
+    expect(result.current.visibleCount).toBe(34); // scroll alive again
+  });
+
+  it('disconnects the live observer when the hook unmounts', () => {
+    const { result, unmount } = renderHook(() => useSentinelPagination(34, PAGE_SIZE));
+    act(() => result.current.sentinelRef(node()));
+    const obs = MockIntersectionObserver.instances.at(-1)!;
+    unmount();
+    expect(obs.disconnected).toBe(true);
+  });
+});

--- a/frontend/src/widgets/card-list/model/useSentinelPagination.ts
+++ b/frontend/src/widgets/card-list/model/useSentinelPagination.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * CP499+ — infinite-scroll pagination whose IntersectionObserver attachment
+ * follows the sentinel NODE lifecycle, not a data dependency.
+ *
+ * The previous CardList implementation attached the observer in a
+ * `useEffect(..., [sortedCards.length])`. That effect never re-ran when the
+ * sentinel unmounted (visibleCount reached the end → hasMore false) and later
+ * REMOUNTED on a same-length list (visibleCount reset on cell/mandala switch)
+ * — the observer stayed bound to the detached old node, so infinite scroll
+ * died and the tail skeletons never resolved (2026-06-10 prod repro:
+ * 25 cards rendered vs 34 placed, stuck across refresh).
+ *
+ * A callback ref attaches/detaches exactly on mount/unmount of the sentinel.
+ * `totalCountRef` keeps the grow-cap fresh inside the observer callback
+ * without re-creating the observer on every data change (also kills the
+ * stale-closure cap: the old callback could clamp to an outdated length).
+ */
+export function useSentinelPagination(totalCount: number, pageSize: number) {
+  const [visibleCount, setVisibleCount] = useState(pageSize);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const totalCountRef = useRef(totalCount);
+  totalCountRef.current = totalCount;
+
+  const sentinelRef = useCallback(
+    (node: Element | null) => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      if (!node) return;
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries[0]?.isIntersecting) {
+            setVisibleCount((prev) => Math.min(prev + pageSize, totalCountRef.current));
+          }
+        },
+        { rootMargin: '200px' }
+      );
+      observer.observe(node);
+      observerRef.current = observer;
+    },
+    [pageSize]
+  );
+
+  // Component unmount: the callback ref already fired with null for the
+  // sentinel itself; this is a safety net for unmounts that skip it
+  // (e.g. an early-return branch replacing the whole grid).
+  useEffect(() => () => observerRef.current?.disconnect(), []);
+
+  /** Collapse the window back to the first page (card-set change). */
+  const resetVisibleCount = useCallback(() => setVisibleCount(pageSize), [pageSize]);
+
+  return { visibleCount, sentinelRef, resetVisibleCount };
+}

--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -17,6 +17,7 @@ import type { SummaryRating } from '@/features/card-management/model/useSummaryR
 import { useV2Summaries } from '@/features/card-management/model/useV2Summaries';
 import { useArchiveCard } from '@/features/card-management/model/useArchiveCard';
 import { extractYouTubeVideoId } from '@/shared/lib/url-normalize';
+import { useSentinelPagination } from '../model/useSentinelPagination';
 
 /**
  * CP499 #2 — order-INDEPENDENT set key for the visibleCount reset. The lazy
@@ -217,10 +218,8 @@ export function CardList({
   );
   const containerRef = useRef<HTMLDivElement | null>(null);
   const gridRef = useRef<HTMLDivElement | null>(null);
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
   const [selectedCardIds, setSelectedCardIds] = useState<Set<string>>(new Set());
   const [lastSelectedIndex, setLastSelectedIndex] = useState<number | null>(null);
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   // Cards arrive already sorted by the host (CardListView applies the user's
   // sortMode chip). Re-sorting here would override publishedAt ranking with
@@ -240,28 +239,21 @@ export function CardList({
     [cards, hiddenVideoIds]
   );
 
+  // Infinite scroll — CP499+: observer attachment follows the sentinel node
+  // lifecycle (callback ref in the hook). The previous effect keyed on
+  // [sortedCards.length] never re-attached when the sentinel remounted on a
+  // same-length list → infinite scroll died, tail skeletons stuck forever
+  // (prod 2026-06-10: 25 rendered vs 34 placed). See useSentinelPagination.
+  const { visibleCount, sentinelRef, resetVisibleCount } = useSentinelPagination(
+    sortedCards.length,
+    PAGE_SIZE
+  );
+
   // Reset visible count when card list changes (e.g., cell switch)
   const cardListKey = useMemo(() => cardSetKey(cards), [cards]);
   useEffect(() => {
-    setVisibleCount(PAGE_SIZE);
-  }, [cardListKey]);
-
-  // Infinite scroll: observe sentinel at bottom of grid
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) {
-          setVisibleCount((prev) => Math.min(prev + PAGE_SIZE, sortedCards.length));
-        }
-      },
-      { rootMargin: '200px' }
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [sortedCards.length]);
+    resetVisibleCount();
+  }, [cardListKey, resetVisibleCount]);
 
   const visibleCards = useMemo(
     () => sortedCards.slice(0, visibleCount),


### PR DESCRIPTION
## Problem (probe-confirmed prod repro, 2026-06-10)

Dashboard rendered **25 cards of 34 placed** ("혼자 살아가는 삶", `2c0fe667`) and the tail `CardSkeleton`s never resolved — across refresh and re-navigation. Probe: `data-card-item = 25`, DB `user_video_states` placed = 34 (unplaced 0). The 9 missing cards sat behind a dead infinite scroll.

## Root cause

`CardList.tsx` attached the IntersectionObserver in `useEffect(..., [sortedCards.length])`. When the sentinel unmounted (visibleCount reached the end → `hasMore` false) and later **remounted on a same-length list** (visibleCount reset on cell/mandala switch), the effect never re-ran — the observer stayed bound to the **detached old node**. Scroll events hit a sentinel nobody was watching.

## Fix

New `useSentinelPagination(totalCount, pageSize)` hook (`frontend/src/widgets/card-list/model/`):
- observer attach/detach via **callback ref** — observation follows the sentinel node lifecycle exactly (remount → new observer on the new node, always)
- `totalCountRef` keeps the grow-cap fresh inside the observer callback (also removes the old stale-closure clamp)
- reset-on-set-change behavior unchanged (same `cardSetKey` effect, `PAGE_SIZE=24`)
- safety-net disconnect on hook unmount

`CardList.tsx` swaps its local state/effect/ref for the hook; the sentinel JSX and all D&D surfaces (CardSlot/droppable/drag handles) are untouched.

## Tests (3, regression-pinned)

- grow capped at the **current** total (fresh ref, not observe-time closure)
- **REGRESSION**: same-length sentinel remount → new live observer observes the new node, scroll grows again (pre-fix code skipped re-attachment here)
- disconnect on unmount

## Verification

`/verify` PASS: FE tsc + vitest **386/386** + production build + browser smoke (`/`, `/mandalas/new` → 200, no vite runtime errors).

**Post-deploy selesai gate (James)**: on the repro screen, scrolling must grow `document.querySelectorAll('[data-card-item]').length` from 25 → 34.

Note: the 38 console `maxresdefault.jpg` 404s are a separate track — `image-utils.ts` already walks a maxres→sd→hq→mq→default→placeholder fallback chain, so those 404s are inherent try-then-fallback noise; fact-check vs the "hqdefault fallback 부재" memo to be reported separately.

## Rollback

Revert the single commit — FE-only, no schema/env/flag changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)