### PR TITLE
fix(cards): scroll to top on card-set change — viewport no longer strands past the new set's window (CP499+)

### DIFF
--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -911,6 +911,7 @@ function AuthenticatedApp() {
           <ResizablePanel defaultSize={isSidePanelOpen ? 65 : 100} minSize={30}>
             <div className="flex h-full overflow-hidden">
               <div
+                data-scroll-container
                 className={`flex-1 h-full px-6 md:px-10 lg:px-[70px] py-6 ${modal.isModalOpen ? 'overflow-hidden' : 'overflow-y-auto scrollbar-pro'} ${
                   isSidePanelOpen
                     ? '[&_[data-card-item]]:opacity-40 [&_[data-card-item]]:grayscale [&_[data-card-item]]:transition-[opacity,filter] [&_[data-card-item]]:duration-300 [&_[data-card-item]:hover]:opacity-100 [&_[data-card-item]:hover]:grayscale-0 [&_[data-card-chrome]]:opacity-40 [&_[data-card-chrome]]:grayscale [&_[data-card-chrome]]:transition-[opacity,filter] [&_[data-card-chrome]]:duration-300'

--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -34,6 +34,19 @@ export function cardSetKey(cards: { id: string }[]): string {
     .join(',');
 }
 
+/**
+ * CP499+ — when the card SET changes, the scrollable ancestor must return to
+ * the top alongside the visibleCount reset. Without it, switching mandala
+ * A→B while scrolled deep left the viewport past B's first-page window —
+ * only skeletons visible until a scroll nudge re-fired the observer
+ * (prod 2026-06-10). `scrollTo?.` is optional-called: jsdom lacks
+ * Element.scrollTo, and a missing scroller must never throw.
+ */
+export function scrollCardSetContainerToTop(from: Element | null): void {
+  const scroller = from?.closest('[data-scroll-container]') as HTMLElement | null;
+  scroller?.scrollTo?.({ top: 0 });
+}
+
 function safeVideoId(videoUrl: string): string | null {
   try {
     return extractYouTubeVideoId(new URL(videoUrl));
@@ -253,6 +266,14 @@ export function CardList({
   const cardListKey = useMemo(() => cardSetKey(cards), [cards]);
   useEffect(() => {
     resetVisibleCount();
+    // CP499+ — also reset the SCROLL position: visibleCount collapses to the
+    // first page but the scrollable ancestor kept the previous set's offset
+    // (prod 2026-06-10: switch mandala A→B while scrolled deep → viewport sat
+    // past B's rendered window → only skeletons until a scroll nudge re-fired
+    // the observer). A new card set starts at the top — which also guarantees
+    // the sentinel begins below the viewport, so the observer's first real
+    // trigger is a clean user-scroll intersection change.
+    scrollCardSetContainerToTop(gridRef.current);
   }, [cardListKey, resetVisibleCount]);
 
   const visibleCards = useMemo(

--- a/frontend/src/widgets/card-list/ui/cardSetKey.test.ts
+++ b/frontend/src/widgets/card-list/ui/cardSetKey.test.ts
@@ -4,8 +4,8 @@
  * does NOT reset the lazy-pagination window (the infinite-skeleton bug), while a
  * SET change (cell switch / add / remove) still does.
  */
-import { describe, test, expect } from 'vitest';
-import { cardSetKey } from './CardList';
+import { describe, test, it, expect, vi } from 'vitest';
+import { cardSetKey, scrollCardSetContainerToTop } from './CardList';
 
 describe('cardSetKey — order-independent set identity', () => {
   test('same cards REORDERED → SAME key (no visibleCount reset on re-sort)', () => {
@@ -28,5 +28,37 @@ describe('cardSetKey — order-independent set identity', () => {
     const a = [{ id: '3' }, { id: '1' }, { id: '2' }];
     cardSetKey(a);
     expect(a.map((c) => c.id)).toEqual(['3', '1', '2']);
+  });
+});
+
+/**
+ * CP499+ — scroll-to-top on card-set change (prod 2026-06-10: mandala switch
+ * kept the previous set's deep scroll offset → viewport past the new set's
+ * first-page window → skeletons until a scroll nudge).
+ */
+describe('scrollCardSetContainerToTop (CP499+)', () => {
+  it('scrolls the nearest [data-scroll-container] ancestor to top', () => {
+    const scroller = document.createElement('div');
+    scroller.setAttribute('data-scroll-container', '');
+    const inner = document.createElement('div');
+    scroller.appendChild(inner);
+    const scrollTo = vi.fn();
+    (scroller as unknown as { scrollTo: typeof scrollTo }).scrollTo = scrollTo;
+
+    scrollCardSetContainerToTop(inner);
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0 });
+  });
+
+  it('is a no-op (no throw) without a scroll container or scrollTo (jsdom)', () => {
+    const orphan = document.createElement('div');
+    expect(() => scrollCardSetContainerToTop(orphan)).not.toThrow();
+    expect(() => scrollCardSetContainerToTop(null)).not.toThrow();
+
+    const scroller = document.createElement('div');
+    scroller.setAttribute('data-scroll-container', '');
+    const inner = document.createElement('div');
+    scroller.appendChild(inner);
+    // jsdom: Element.scrollTo undefined — optional call must not throw
+    expect(() => scrollCardSetContainerToTop(inner)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Problem (post-#883 residual, James repro)

Mandala A → scroll down → switch to mandala B: the scroll position is **kept** (the scroller is IndexPage's `overflow-y-auto` div, not window) while `visibleCount` collapses to the first page → the viewport sits **past B's rendered window** → only tail skeletons visible; a scroll nudge changes the sentinel's intersection and only then the observer fires.

## Code-confirmed (no guessing)

- The `cardListKey` effect reset **visibleCount only** — grep over the switch path shows **zero** scroll resets (`IndexPage.tsx:322 scrollIntoView` is cell-selection, unrelated). James's hypothesis ① confirmed.
- Observer initial evaluation (spec: one entry on `observe()`) can legitimately report `isIntersecting=false` in the post-switch geometry, after which only an intersection **change** re-fires — the "scroll nudge". The fix removes this geometry class entirely rather than depending on it.

## Fix

`scrollCardSetContainerToTop(gridRef)` runs alongside `resetVisibleCount()` in the `cardListKey` effect: a new card SET starts at the top. The scroller is marked with `data-scroll-container` (IndexPage). This also guarantees the sentinel starts below the viewport → the observer's first trigger is always a clean user-scroll intersection change.

- Re-sort / relevance freeze / archive do **NOT** jump (cardSetKey is set-identity; the hidden filter doesn't change the `cards` prop).
- Known behavior: a genuine set change while browsing (card added into the viewed cell) now lands at top — consistent with the pre-existing visibleCount collapse on the same trigger.
- Helper optional-calls `scrollTo` (jsdom lacks `Element.scrollTo`; missing scroller never throws).

## Tests + verification

2 unit tests (nearest-ancestor `scrollTo({top:0})` / no-throw without scroller or scrollTo). `/verify` PASS: FE tsc + vitest **388/388** + build + browser smoke (`/`, `/mandalas/new` → 200).

**selesai (James)**: mandala A scroll-down → switch B → B shows cards immediately at scroll 0, no nudge needed.

## Rollback

Revert single commit — FE-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)