### PR TITLE
fix(cards): render the skeleton tail inside the card grid — kill the gap before skeletons (CP499+)

### DIFF
--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -8,7 +8,7 @@ import { FileVideo, Check } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { useDragSelect } from '@/features/drag-select/model/useDragSelect';
 import { cardSlotDropId } from '@/shared/lib/dnd';
-import { CardSkeleton } from './CardSkeleton';
+import { CardSkeleton, CardSkeletonCell } from './CardSkeleton';
 import {
   useSummaryRatings,
   useRateSummary,
@@ -504,14 +504,21 @@ export function CardList({
             </CardSlot>
           );
         })}
-      </div>
 
-      {hasMore && (
-        <>
-          <CardSkeleton count={Math.min(sortedCards.length - visibleCount, 6)} />
-          <div ref={sentinelRef} aria-hidden className="h-1" />
-        </>
-      )}
+        {/* CP499+ — the loading tail lives INSIDE the grid: skeleton cells fill
+            the next cells right after the last card (flush, same gridColumns)
+            instead of a sibling block pushed below the grid's stretched
+            minHeight (the "big gap before skeletons" defect). The minHeight
+            itself is untouched — it keeps the empty area a drag/drop target. */}
+        {hasMore && (
+          <>
+            {Array.from({ length: Math.min(sortedCards.length - visibleCount, 6) }).map((_, i) => (
+              <CardSkeletonCell key={`skeleton-${i}`} index={i} className="w-[95%]" />
+            ))}
+            <div ref={sentinelRef} aria-hidden className="col-span-full h-1" />
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/widgets/card-list/ui/CardSkeleton.test.tsx
+++ b/frontend/src/widgets/card-list/ui/CardSkeleton.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * CP499+ — skeleton tail moved inside CardList's grid. CardSkeletonCell must
+ * stay grid-agnostic (no own grid wrapper) so it inherits the host grid's
+ * gridColumns; the standalone CardSkeleton block keeps its own grid for the
+ * no-cards isLoading state.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { CardSkeleton, CardSkeletonCell } from './CardSkeleton';
+
+describe('CardSkeletonCell (CP499+ grid-internal tail)', () => {
+  it('renders a single cell WITHOUT its own grid wrapper', () => {
+    const { container } = render(<CardSkeletonCell />);
+    const root = container.firstElementChild!;
+    expect(root.className).not.toContain('grid');
+    expect(root.querySelectorAll('.aspect-video')).toHaveLength(1);
+  });
+
+  it('applies the host-passed className (width match with cards)', () => {
+    const { container } = render(<CardSkeletonCell className="w-[95%]" />);
+    expect(container.firstElementChild!.className).toContain('w-[95%]');
+  });
+});
+
+describe('CardSkeleton (standalone block)', () => {
+  it('renders count cells inside its own grid', () => {
+    const { container } = render(<CardSkeleton count={3} />);
+    const root = container.firstElementChild!;
+    expect(root.className).toContain('grid');
+    expect(root.querySelectorAll('.aspect-video')).toHaveLength(3);
+  });
+});

--- a/frontend/src/widgets/card-list/ui/CardSkeleton.tsx
+++ b/frontend/src/widgets/card-list/ui/CardSkeleton.tsx
@@ -1,23 +1,40 @@
+import { cn } from '@/shared/lib/utils';
+
+/**
+ * CP499+ — single skeleton cell, grid-agnostic. CardList renders these INSIDE
+ * its own grid (next cell after the last visible card) so the loading tail
+ * sits flush under the cards instead of below the grid's stretched minHeight
+ * (the "big gap before skeletons" defect, prod 2026-06-10) — and inherits the
+ * user's gridColumns instead of this file's own breakpoint columns.
+ */
+export function CardSkeletonCell({ index = 0, className }: { index?: number; className?: string }) {
+  return (
+    <div className={cn('rounded-2xl overflow-hidden relative', className)}>
+      <div className="aspect-video bg-muted" />
+      <div className="p-3 space-y-2">
+        <div className="h-4 bg-muted rounded w-3/4" />
+        <div className="h-3 bg-muted rounded w-1/2" />
+      </div>
+      {/* Shimmer sweep overlay */}
+      <div
+        className="absolute inset-0 -translate-x-full"
+        style={{
+          background:
+            'linear-gradient(90deg, transparent, hsl(var(--foreground) / 0.04), transparent)',
+          animation: `shimmer 1.5s ease-in-out infinite ${index * 100}ms`,
+        }}
+      />
+    </div>
+  );
+}
+
+/** Standalone block variant — used when there are no cards to align with
+ *  (initial isLoading full-replace). Brings its own responsive grid. */
 export function CardSkeleton({ count = 6 }: { count?: number }) {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 p-3">
       {Array.from({ length: count }).map((_, i) => (
-        <div key={i} className="rounded-2xl overflow-hidden relative">
-          <div className="aspect-video bg-muted" />
-          <div className="p-3 space-y-2">
-            <div className="h-4 bg-muted rounded w-3/4" />
-            <div className="h-3 bg-muted rounded w-1/2" />
-          </div>
-          {/* Shimmer sweep overlay */}
-          <div
-            className="absolute inset-0 -translate-x-full"
-            style={{
-              background:
-                'linear-gradient(90deg, transparent, hsl(var(--foreground) / 0.04), transparent)',
-              animation: `shimmer 1.5s ease-in-out infinite ${i * 100}ms`,
-            }}
-          />
-        </div>
+        <CardSkeletonCell key={i} index={i} />
       ))}
     </div>
   );


### PR DESCRIPTION
## Problem (James repro, post-#884)

Last card row → ~viewport-sized empty gap → skeleton block. Users read it as "broken".

## Code-confirmed cause (3 questions closed)

1. **Main culprit**: the card grid carries inline `minHeight: calc(100vh - 200px)` (`CardList.tsx`, empty-area drag/drop target) and the skeleton tail + sentinel were **siblings below the grid** → they rendered under the stretched grid bottom + `pb-20`, not flush after the last card.
2. **Skeleton count innocent** — already `min(remaining, 6)`.
3. Side defect: `CardSkeleton` brought its **own breakpoint grid** (`md:2 lg:3 xl:4`), which can disagree with the user's `gridColumns`.

## Fix (approved design)

- New grid-agnostic `CardSkeletonCell`; CardList renders the tail **inside its own grid**, in the next cells right after the last visible card (`w-[95%]` matches card width), sentinel as a `col-span-full` cell.
- Grid `minHeight` **untouched** — empty-area drop target preserved (DnD intact).
- Column mismatch gone (cells inherit the host grid's `gridTemplateColumns`).
- Standalone `CardSkeleton` block kept for the no-cards `isLoading` state, recomposed from the same cells (visual unchanged).

## Tests + verification

3 render tests (cell has no grid wrapper / className pass-through / standalone block grid + count). `/verify` PASS: FE tsc + vitest **391/391** + build + browser smoke (`/`, `/mandalas/new` → 200).

**selesai (James)**: on the repro screen the skeletons sit flush in the cells right after the last card — no gap.

## Rollback

Revert single commit — FE-only, markup-level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)