### PR TITLE
fix(cards): initial-load skeleton uses the SHARED card grid — columns always match gridColumns (CP499+)

### DIFF
--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
+import { useMemo, useState, useCallback, useEffect, useRef, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDroppable } from '@dnd-kit/core';
 import { toast } from 'sonner';
@@ -8,7 +8,7 @@ import { FileVideo, Check } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { useDragSelect } from '@/features/drag-select/model/useDragSelect';
 import { cardSlotDropId } from '@/shared/lib/dnd';
-import { CardSkeleton, CardSkeletonCell } from './CardSkeleton';
+import { CardSkeletonCell } from './CardSkeleton';
 import {
   useSummaryRatings,
   useRateSummary,
@@ -103,6 +103,23 @@ function CardSlot({ card, children }: { card: InsightCard; children: React.React
 }
 
 const PAGE_SIZE = 24;
+
+/**
+ * CP499+ — SINGLE SOURCE for the card-grid markup. The initial-load skeleton
+ * grid MUST stay identical to the real card grid (column count, gap, padding,
+ * minHeight): the two diverging is exactly the 4-col-skeleton vs 3-col-cards
+ * bug (CardSkeleton used to bring its own breakpoint grid). Both render sites
+ * below reference THESE — never inline a copy.
+ * The minHeight keeps the empty area a drag/drop target; do not remove.
+ */
+const CARD_GRID_CLASS =
+  'grid grid-cols-1 gap-4 p-3 min-h-full flex-1 pb-20 justify-items-center transition-all duration-200';
+function cardGridStyle(gridColumns: number): CSSProperties {
+  return {
+    minHeight: 'calc(100vh - 200px)',
+    gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))`,
+  };
+}
 
 export function CardList({
   cards,
@@ -403,7 +420,16 @@ export function CardList({
   );
 
   if (isLoading && cards.length === 0) {
-    return <CardSkeleton count={6} />;
+    // CP499+ — initial-load skeleton renders in the SAME grid as the cards
+    // (shared CARD_GRID_CLASS / cardGridStyle): same column count as the
+    // user's gridColumns, two full rows, no layout jump when cards land.
+    return (
+      <div className={CARD_GRID_CLASS} style={cardGridStyle(gridColumns)}>
+        {Array.from({ length: gridColumns * 2 }).map((_, i) => (
+          <CardSkeletonCell key={i} index={i} className="w-[95%]" />
+        ))}
+      </div>
+    );
   }
 
   if (cards.length === 0) {
@@ -426,17 +452,7 @@ export function CardList({
   return (
     <div className="animate-fade-in -mx-4 px-4 relative select-none" ref={containerRef}>
       {selectionStyle && <div style={selectionStyle} />}
-      <div
-        ref={gridRef}
-        className={cn(
-          'grid grid-cols-1 gap-4 p-3 min-h-full flex-1 pb-20 justify-items-center transition-all duration-200',
-          false
-        )}
-        style={{
-          minHeight: 'calc(100vh - 200px)',
-          gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))`,
-        }}
-      >
+      <div ref={gridRef} className={CARD_GRID_CLASS} style={cardGridStyle(gridColumns)}>
         {visibleCards.map((card, idx) => {
           const isSelected = selectedCardIds.has(card.id);
           return (

--- a/frontend/src/widgets/card-list/ui/CardSkeleton.test.tsx
+++ b/frontend/src/widgets/card-list/ui/CardSkeleton.test.tsx
@@ -1,14 +1,15 @@
 /**
- * CP499+ — skeleton tail moved inside CardList's grid. CardSkeletonCell must
- * stay grid-agnostic (no own grid wrapper) so it inherits the host grid's
- * gridColumns; the standalone CardSkeleton block keeps its own grid for the
- * no-cards isLoading state.
+ * CP499+ — skeleton cells are grid-agnostic BY DESIGN: CardSkeleton.tsx owns
+ * no grid. All render sites (initial-load + lazy-pagination tail) place the
+ * cells inside CardList's shared card grid (CARD_GRID_CLASS/cardGridStyle) so
+ * skeleton columns always match the user's gridColumns. The old standalone
+ * block with its own breakpoint grid was the 4-col vs 3-col mismatch defect.
  */
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
-import { CardSkeleton, CardSkeletonCell } from './CardSkeleton';
+import { CardSkeletonCell } from './CardSkeleton';
 
-describe('CardSkeletonCell (CP499+ grid-internal tail)', () => {
+describe('CardSkeletonCell (CP499+ grid-agnostic invariant)', () => {
   it('renders a single cell WITHOUT its own grid wrapper', () => {
     const { container } = render(<CardSkeletonCell />);
     const root = container.firstElementChild!;
@@ -20,13 +21,9 @@ describe('CardSkeletonCell (CP499+ grid-internal tail)', () => {
     const { container } = render(<CardSkeletonCell className="w-[95%]" />);
     expect(container.firstElementChild!.className).toContain('w-[95%]');
   });
-});
 
-describe('CardSkeleton (standalone block)', () => {
-  it('renders count cells inside its own grid', () => {
-    const { container } = render(<CardSkeleton count={3} />);
-    const root = container.firstElementChild!;
-    expect(root.className).toContain('grid');
-    expect(root.querySelectorAll('.aspect-video')).toHaveLength(3);
+  it('the module exports NO standalone grid block (regression guard)', async () => {
+    const mod = await import('./CardSkeleton');
+    expect(Object.keys(mod)).toEqual(['CardSkeletonCell']);
   });
 });

--- a/frontend/src/widgets/card-list/ui/CardSkeleton.tsx
+++ b/frontend/src/widgets/card-list/ui/CardSkeleton.tsx
@@ -1,11 +1,13 @@
 import { cn } from '@/shared/lib/utils';
 
 /**
- * CP499+ — single skeleton cell, grid-agnostic. CardList renders these INSIDE
- * its own grid (next cell after the last visible card) so the loading tail
- * sits flush under the cards instead of below the grid's stretched minHeight
- * (the "big gap before skeletons" defect, prod 2026-06-10) — and inherits the
- * user's gridColumns instead of this file's own breakpoint columns.
+ * CP499+ — single skeleton cell, grid-agnostic BY DESIGN: this file owns NO
+ * grid. Every render site (CardList initial-load skeleton AND the lazy-
+ * pagination tail) places these cells inside CardList's own card grid
+ * (shared CARD_GRID_CLASS / cardGridStyle), so skeletons always match the
+ * user's gridColumns. The old standalone <CardSkeleton> block with its own
+ * breakpoint grid (md:2/lg:3/xl:4) was the 4-col-skeleton vs 3-col-cards
+ * defect — do not reintroduce a grid wrapper here.
  */
 export function CardSkeletonCell({ index = 0, className }: { index?: number; className?: string }) {
   return (
@@ -24,18 +26,6 @@ export function CardSkeletonCell({ index = 0, className }: { index?: number; cla
           animation: `shimmer 1.5s ease-in-out infinite ${index * 100}ms`,
         }}
       />
-    </div>
-  );
-}
-
-/** Standalone block variant — used when there are no cards to align with
- *  (initial isLoading full-replace). Brings its own responsive grid. */
-export function CardSkeleton({ count = 6 }: { count?: number }) {
-  return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 p-3">
-      {Array.from({ length: count }).map((_, i) => (
-        <CardSkeletonCell key={i} index={i} />
-      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Problem (James repro)

Refresh → initial-load skeleton rendered **4 columns** while the user's grid is **3** (and count=6 made ragged 4+2 rows).

## Diagnosis (file:line, read-only first)

1. Initial-load path = `CardList.tsx` early return (`isLoading && cards.length===0`) → standalone `CardSkeleton` block with its **own breakpoint grid** (`md:2 lg:3 xl:4`) — a separate path from the #885 in-grid tail.
2. `gridColumns` **is synchronously available at first paint** — `useLayoutPreferences.ts:55` reads `localStorage('insighta-grid-columns')` in the `useState` initializer (server prefs sync later). No regression point.
3. `count={6}` was an arbitrary literal.
4. Loading-state header "0장"/cell-pill 0 → **backlogged only** (out of scope, recorded).

## Fix (approved plan + shared-markup directive)

- **Shared, not copied** (James invariant): `CARD_GRID_CLASS` + `cardGridStyle(gridColumns)` extracted as the single source of the card-grid markup — the real grid AND the initial skeleton both reference them. Chose **constant extraction** (not copy+cross-ref comment): the markup is a class string + a 2-field style object, so sharing costs nothing.
- Initial skeleton = `CardSkeletonCell × (gridColumns × 2)`, `w-[95%]` — two full rows in the user's exact column count; same `minHeight` → no layout jump when cards land.
- Standalone `CardSkeleton` block **removed** (sole consumer was this early return); module now exports only the grid-agnostic cell + a regression test guards that no grid wrapper is reintroduced (`Object.keys(mod) === ['CardSkeletonCell']`).

## Verification

`/verify` PASS: FE tsc + vitest **391/391** + build + browser smoke (`/`, `/mandalas/new` → 200).

**Done gate (James, post-deploy)**: refresh screen — skeleton columns match gridColumns + no load→loaded layout jump.

## Rollback

Revert single commit — FE-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)