### PR TITLE
feat(wizard): template search is non-blocking decoration — silent fail + late-arrival discard (PR-C, CP499+)

### DIFF
--- a/frontend/src/features/mandala-wizard/model/useWizard.ts
+++ b/frontend/src/features/mandala-wizard/model/useWizard.ts
@@ -247,6 +247,15 @@ export function useWizard() {
   const precomputeSessionIdRef = useRef<string | null>(null);
 
   // ─── Tier 1: Embedding search (instant) ───
+  //
+  // PR-C (CP499+) — the template search is DECORATION for the generation wait:
+  // its failure must never surface to the user (no error card, no retry), and
+  // a batch that resolves AFTER the custom result is already on screen is
+  // DISCARDED — late templates popping in would shift the user's choice
+  // mid-decision. generateSettledRef marks "the main result landed";
+  // discardLateSearchRef freezes that verdict for this goal's lifecycle.
+  const generateSettledRef = useRef(false);
+  const discardLateSearchRef = useRef(false);
   const searchMutation = useMutation({
     mutationFn: (goal: string) =>
       apiClient.searchMandalasByGoal(goal, {
@@ -254,6 +263,9 @@ export function useWizard() {
         language: detectGoalLanguage(goal),
         signal: goalAbortRef.current?.signal,
       }),
+    onSuccess: () => {
+      if (generateSettledRef.current) discardLateSearchRef.current = true;
+    },
   });
 
   // ─── Tier 2: AI generation ───
@@ -307,6 +319,11 @@ export function useWizard() {
           signal: goalAbortRef.current?.signal,
         });
       }
+    },
+    // PR-C — the main result is on screen from here: any template batch that
+    // resolves after this point is discarded (see searchMutation.onSuccess).
+    onSuccess: () => {
+      generateSettledRef.current = true;
     },
   });
 
@@ -907,6 +924,9 @@ export function useWizard() {
       goalAbortRef.current = new AbortController();
       searchMutation.reset();
       generateMutation.reset();
+      // PR-C — fresh goal: re-arm the late-arrival discard window.
+      generateSettledRef.current = false;
+      discardLateSearchRef.current = false;
       setState((prev) => ({ ...prev, goalInput: trimmed }));
       searchMutation.mutate(trimmed);
       generateMutation.mutate(trimmed);
@@ -930,18 +950,17 @@ export function useWizard() {
     setState((prev) => ({ ...prev, goalInput: '' }));
   }, [cancelGoal]);
 
-  /** Retry template search only (leaves in-flight AI generation untouched). */
-  const retrySearch = useCallback(() => {
-    const goal = state.goalInput.trim();
-    if (!goal) return;
-    searchMutation.reset();
-    searchMutation.mutate(goal);
-  }, [state.goalInput, searchMutation]);
+  // PR-C — retrySearch removed: the template section is decoration and its
+  // failure is silent (no retry affordance). A new goal submit re-fires both.
 
   /** Retry AI generation only (leaves in-flight template search untouched). */
   const retryGenerate = useCallback(() => {
     const goal = state.goalInput.trim();
     if (!goal) return;
+    // PR-C — main result leaves the screen for a re-run: re-open the window
+    // so a template batch landing during the retry can still show.
+    generateSettledRef.current = false;
+    discardLateSearchRef.current = false;
     generateMutation.reset();
     generateMutation.mutate(goal);
   }, [state.goalInput, generateMutation]);
@@ -1159,7 +1178,9 @@ export function useWizard() {
     selectSearchResult,
     selectGeneratedMandala,
     selectGeneratedAndComplete,
-    searchResults: searchMutation.data ?? [],
+    // PR-C — late-arrival discard: templates that resolved after the custom
+    // result settled never surface (decoration must not shift a decision).
+    searchResults: discardLateSearchRef.current ? [] : (searchMutation.data ?? []),
     isSearching: searchMutation.isPending,
     // CP358: isSuccess gates the empty-state UI to eliminate the 1-frame
     // race where reset() flips isPending to false before mutate() runs.
@@ -1169,7 +1190,6 @@ export function useWizard() {
     // CP361 Issue #375 — split soft-slow vs failed states
     isSearchSoftSlow,
     isSearchFailed,
-    retrySearch,
     aiGenerated: generateMutation.data?.mandala ?? null,
     aiSource: generateMutation.data?.source ?? null,
     isGenerating: generateMutation.isPending,

--- a/frontend/src/features/mandala-wizard/ui/WizardStepGoal.tsx
+++ b/frontend/src/features/mandala-wizard/ui/WizardStepGoal.tsx
@@ -51,6 +51,24 @@ const AI_PROGRESS_POLL_MS = 1_000;
 
 // ─── Component ───
 
+/**
+ * PR-C (CP499+) — template slot render decision, pure for testability.
+ * INVARIANT: a FAILED search is 'hidden' (indistinguishable from "no
+ * result"), never an error/retry surface — the template strip is decoration
+ * for the generation wait and its failure must not be user-visible.
+ */
+export type TemplateSlotKind = 'result' | 'loading' | 'hidden';
+export function templateSlotKind(
+  hasResult: boolean,
+  isSearchFailed: boolean,
+  isSearching: boolean
+): TemplateSlotKind {
+  if (hasResult) return 'result';
+  if (isSearchFailed) return 'hidden';
+  if (isSearching) return 'loading';
+  return 'hidden';
+}
+
 interface WizardStepGoalProps {
   goalInput: string;
   searchResults: MandalaSearchResult[];
@@ -62,10 +80,10 @@ interface WizardStepGoalProps {
   /** CP361 Issue #375 — search has crossed the soft-slow threshold but is
    *  still in flight (no error). Caller should show inline hint, NOT amber. */
   isSearchSoftSlow: boolean;
-  /** CP361 Issue #375 — search mutation has actually errored. Show amber
-   *  DelayedCard with Retry button. */
+  /** CP361 Issue #375 → PR-C (CP499+) — search mutation errored. The template
+   *  strip is DECORATION for the generation wait: failure renders NOTHING
+   *  (silent hide), never an error card or retry affordance. */
   isSearchFailed: boolean;
-  onRetrySearch: () => void;
   aiGenerated: GeneratedMandala | null;
   aiSource: 'lora' | 'llm-fallback' | null;
   isGenerating: boolean;
@@ -103,7 +121,6 @@ export default function WizardStepGoal({
   searchSucceeded,
   isSearchSoftSlow,
   isSearchFailed,
-  onRetrySearch,
   aiGenerated,
   isGenerating,
   isGenerateSoftSlow,
@@ -390,20 +407,15 @@ export default function WizardStepGoal({
                     />
                   );
                 }
-                if (isSearchFailed) {
-                  // Real error — amber card with Retry in slot 0 only
-                  if (slotIdx === 0) {
-                    return (
-                      <MandalaCard
-                        key="tpl-delayed"
-                        variant="template-delayed"
-                        onRetry={onRetrySearch}
-                      />
-                    );
-                  }
+                const slotKind = templateSlotKind(false, isSearchFailed, isSearching);
+                if (slotKind === 'hidden') {
+                  // PR-C (CP499+) — silent hide (covers FAILED too). The
+                  // template strip is decoration for the generation wait;
+                  // surfacing its failure (amber card + Retry) defeated that
+                  // purpose. The user must not be able to tell it failed.
                   return <div key={`tpl-empty-${slotIdx}`} aria-hidden="true" />;
                 }
-                if (isSearching) {
+                if (slotKind === 'loading') {
                   // Soft-slow shows inline hint, otherwise plain skeleton.
                   // Hint rendered ONLY on slot 0 so it doesn't repeat 3x.
                   return (

--- a/frontend/src/features/mandala-wizard/ui/templateSlotKind.test.ts
+++ b/frontend/src/features/mandala-wizard/ui/templateSlotKind.test.ts
@@ -1,0 +1,35 @@
+/**
+ * PR-C (CP499+) — template strip is DECORATION for the generation wait.
+ * Invariant under test: a FAILED search renders 'hidden' — byte-identical to
+ * "no result" — never an error card or retry affordance. (Prod 2026-06-10:
+ * the amber "다시 시도" card surfaced a decoration failure to the user.)
+ */
+import { describe, it, expect } from 'vitest';
+import { templateSlotKind } from './WizardStepGoal';
+
+describe('templateSlotKind (PR-C silent-fail invariant)', () => {
+  it('FAILED search → hidden (silent), regardless of pending flag', () => {
+    expect(templateSlotKind(false, true, false)).toBe('hidden');
+    // failed wins over a stale isSearching=true frame
+    expect(templateSlotKind(false, true, true)).toBe('hidden');
+  });
+
+  it('result present → result (failure of OTHER slots irrelevant)', () => {
+    expect(templateSlotKind(true, false, false)).toBe('result');
+    expect(templateSlotKind(true, true, false)).toBe('result');
+  });
+
+  it('in flight → loading skeleton; idle empty → hidden', () => {
+    expect(templateSlotKind(false, false, true)).toBe('loading');
+    expect(templateSlotKind(false, false, false)).toBe('hidden');
+  });
+
+  it('there is NO error/retry kind — the type space itself forbids it', () => {
+    const kinds: ReturnType<typeof templateSlotKind>[] = [
+      templateSlotKind(false, true, false),
+      templateSlotKind(false, false, true),
+      templateSlotKind(true, false, false),
+    ];
+    for (const k of kinds) expect(['result', 'loading', 'hidden']).toContain(k);
+  });
+});

--- a/frontend/src/pages/mandala-wizard/ui/MandalaWizardPage.tsx
+++ b/frontend/src/pages/mandala-wizard/ui/MandalaWizardPage.tsx
@@ -207,7 +207,6 @@ export default function MandalaWizardPage() {
               searchSucceeded={false}
               isSearchSoftSlow={false}
               isSearchFailed={false}
-              onRetrySearch={() => {}}
               aiGenerated={null}
               aiSource={null}
               isGenerating={false}
@@ -249,7 +248,6 @@ export default function MandalaWizardPage() {
               searchSucceeded={wizard.searchSucceeded}
               isSearchSoftSlow={wizard.isSearchSoftSlow}
               isSearchFailed={wizard.isSearchFailed}
-              onRetrySearch={wizard.retrySearch}
               aiGenerated={wizard.aiGenerated}
               aiSource={wizard.aiSource}
               isGenerating={wizard.isGenerating}


### PR DESCRIPTION
## Intent (James, launch-grade track)

The template strip is **decoration** for the custom-generation wait. A visible failure ("다시 시도" amber card — prod repro 2026-06-10) defeats its purpose. The custom generation is the main path.

## Changes

1. **Silent fail**: a FAILED template search renders byte-identical to "no result" — no error card, no retry. `retrySearch` removed from `useWizard` + prop chain.
2. **Late-arrival discard**: template batch resolving **after** the custom result settled is discarded (refs re-armed on new submit / `retryGenerate`). Before settle → shown as usual.
3. **Main-path coupling = 0 (verified, file:line)**: submit fires search ∥ generate (`useWizard.ts:911-912`); only UI coupling is the SearchBar `isBusy` label (≤15s api-client cap; selection/proceed flows through the cards, not the bar).
4. `templateSlotKind()` extracted pure — `result | loading | hidden`, **no error kind in the type space** + 4 invariant tests.

## Verification

`/verify` PASS: FE tsc + vitest **395/395** + build + browser smoke (`/`, `/mandalas/new` 200).

**Done gate (James)**: on a failure/timeout repro, the template area shows nothing unusual (skeleton → quiet empty), custom generation proceeds normally; no retry card anywhere.

## Rollback

Revert single commit — FE-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)