### PR TITLE
fix(llm): prompt-level /no_think for Qwen — providers ignore the reasoning param (W2, CP499+)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -267,6 +267,12 @@ services:
       # Revert: delete this line and redeploy → code default off restores the
       # two-call path bit-identically (no code revert).
       - WIZARD_MERGED_GEN=true
+      # W2 (CP499+, 2026-06-10) — prompt-level `/no_think` for Qwen models on
+      # top of the existing reasoning:{enabled:false} param, which some
+      # OpenRouter providers ignore (prod: reasoning-only 1024-cap responses +
+      # 20-48s calls despite the param). Revert: delete this line + redeploy
+      # (code default off = param-only behaviour, no code revert).
+      - OPENROUTER_QWEN_NO_THINK=true
       # CP426 (2026-04-25) — Switch pipeline executor from v1 (3 recs/cell,
       # max 24 with channel diversity drop → ~5 actual) to v3 (12/cell target,
       # 96 max). v3 degrades gracefully to Tier 2 when video_pool is empty.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -267,12 +267,6 @@ services:
       # Revert: delete this line and redeploy → code default off restores the
       # two-call path bit-identically (no code revert).
       - WIZARD_MERGED_GEN=true
-      # W2 (CP499+, 2026-06-10) — prompt-level `/no_think` for Qwen models on
-      # top of the existing reasoning:{enabled:false} param, which some
-      # OpenRouter providers ignore (prod: reasoning-only 1024-cap responses +
-      # 20-48s calls despite the param). Revert: delete this line + redeploy
-      # (code default off = param-only behaviour, no code revert).
-      - OPENROUTER_QWEN_NO_THINK=true
       # CP426 (2026-04-25) — Switch pipeline executor from v1 (3 recs/cell,
       # max 24 with channel diversity drop → ~5 actual) to v3 (12/cell target,
       # 96 max). v3 degrades gracefully to Tier 2 when video_pool is empty.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -91,6 +91,16 @@ const envSchema = z.object({
   // OpenRouter
   OPENROUTER_API_KEY: z.string().optional(),
   OPENROUTER_MODEL: z.string().default('qwen/qwen3.5-9b'),
+  // W2 (CP499+) — belt-and-suspenders thinking suppression for Qwen models.
+  // generate() already sends `reasoning: {enabled:false}`, but some OpenRouter
+  // providers ignore it (prod 2026-06-10: reasoning-only 1024-token responses
+  // + 20-48s calls DESPITE the param). 'true' additionally appends the Qwen
+  // chat-template soft switch `/no_think` to the prompt — provider-agnostic.
+  // Default false = 기존 동작 (rollback = unset; CLAUDE.md env-default rule).
+  OPENROUTER_QWEN_NO_THINK: z
+    .string()
+    .optional()
+    .transform((v) => v === 'true'),
   // OpenRouter embedding endpoint (Phase 1). Same OPENROUTER_API_KEY is
   // reused for auth. Base URL is OpenAI-compatible; model id is exact
   // string as listed on the OpenRouter model catalogue. Dim must match
@@ -355,6 +365,7 @@ export const config = {
   openrouter: {
     apiKey: env.OPENROUTER_API_KEY,
     model: env.OPENROUTER_MODEL,
+    qwenNoThink: env.OPENROUTER_QWEN_NO_THINK,
   },
 
   // Cohere Rerank (cross-encoder reranking, hybrid-retrieval spec 2026-05-12)

--- a/src/modules/llm/openrouter.ts
+++ b/src/modules/llm/openrouter.ts
@@ -62,9 +62,21 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
 
     const activeModel = this.modelOverride ?? config.openrouter.model;
 
+    // W2 (CP499+) — prompt-level thinking suppression for Qwen models.
+    // The `reasoning: {enabled:false}` param below is IGNORED by some
+    // OpenRouter providers (prod 2026-06-10: reasoning-only 1024-cap
+    // responses + 20-48s latencies DESPITE the param). `/no_think` is the
+    // Qwen chat-template soft switch — applied at the template layer, so it
+    // holds regardless of which provider serves the call. Idempotent: skipped
+    // when the caller (e.g. chatbot qwen-prompt-middleware) already added it.
+    const effectivePrompt =
+      config.openrouter.qwenNoThink && activeModel.includes('qwen') && !prompt.includes('/no_think')
+        ? `${prompt}\n/no_think`
+        : prompt;
+
     const body: Record<string, unknown> = {
       model: activeModel,
-      messages: [{ role: 'user', content: prompt }],
+      messages: [{ role: 'user', content: effectivePrompt }],
       temperature: options?.temperature ?? 0.3,
       max_tokens: options?.maxTokens ?? DEFAULT_MAX_TOKENS,
     };

--- a/tests/unit/modules/openrouter-qwen-no-think.test.ts
+++ b/tests/unit/modules/openrouter-qwen-no-think.test.ts
@@ -1,0 +1,87 @@
+/**
+ * W2 (CP499+) — prompt-level `/no_think` for Qwen models.
+ *
+ * generate() already sends `reasoning: {enabled:false}` for qwen models, but
+ * some OpenRouter providers IGNORE the param (prod 2026-06-10: reasoning-only
+ * 1024-token-cap responses + 20-48s latencies despite it). The Qwen
+ * chat-template soft switch `/no_think` holds at the template layer,
+ * provider-agnostic. Flag-gated: OPENROUTER_QWEN_NO_THINK unset = exactly the
+ * pre-W2 request body (CLAUDE.md env-default rule).
+ */
+
+const mockConfig = {
+  openrouter: {
+    apiKey: 'test-key',
+    model: 'qwen/qwen3-30b-a3b',
+    qwenNoThink: false as boolean | undefined,
+  },
+};
+
+jest.mock('@/config/index', () => ({ config: mockConfig }));
+jest.mock('@/modules/llm/call-logger', () => ({ logLLMCall: jest.fn(() => Promise.resolve()) }));
+
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+
+interface CapturedBody {
+  messages: Array<{ content: string }>;
+  reasoning?: { enabled: boolean };
+}
+
+function fetchCapturingPrompt(): { sentPrompt: () => string; sentBody: () => CapturedBody } {
+  const calls: CapturedBody[] = [];
+  global.fetch = jest.fn().mockImplementation(async (_url: unknown, init: { body: string }) => {
+    calls.push(JSON.parse(init.body) as CapturedBody);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }], usage: {} }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  const body = (): CapturedBody => {
+    if (!calls[0]) throw new Error('fetch was never called');
+    return calls[0];
+  };
+  return {
+    sentPrompt: () => body().messages[0]!.content,
+    sentBody: body,
+  };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  mockConfig.openrouter.qwenNoThink = false;
+});
+
+describe('OpenRouterGenerationProvider — qwen /no_think suppression (W2)', () => {
+  it('flag ON + qwen model → prompt gets the /no_think suffix', async () => {
+    mockConfig.openrouter.qwenNoThink = true;
+    const cap = fetchCapturingPrompt();
+    await new OpenRouterGenerationProvider('qwen/qwen3-30b-a3b').generate('summarize this');
+    expect(cap.sentPrompt()).toBe('summarize this\n/no_think');
+    // the param-level suppression stays alongside
+    expect(cap.sentBody().reasoning).toEqual({ enabled: false });
+  });
+
+  it('flag ON + non-qwen model → prompt untouched (and no reasoning param)', async () => {
+    mockConfig.openrouter.qwenNoThink = true;
+    const cap = fetchCapturingPrompt();
+    await new OpenRouterGenerationProvider('anthropic/claude-haiku-4.5').generate('summarize this');
+    expect(cap.sentPrompt()).toBe('summarize this');
+    expect(cap.sentBody().reasoning).toBeUndefined();
+  });
+
+  it('flag ON + prompt already carrying /no_think (chatbot middleware) → no duplicate', async () => {
+    mockConfig.openrouter.qwenNoThink = true;
+    const cap = fetchCapturingPrompt();
+    await new OpenRouterGenerationProvider('qwen/qwen3-30b-a3b').generate('chat turn\n/no_think');
+    expect(cap.sentPrompt()).toBe('chat turn\n/no_think');
+  });
+
+  it('flag OFF (default/unset) → request body is exactly pre-W2', async () => {
+    mockConfig.openrouter.qwenNoThink = undefined;
+    const cap = fetchCapturingPrompt();
+    await new OpenRouterGenerationProvider('qwen/qwen3-30b-a3b').generate('summarize this');
+    expect(cap.sentPrompt()).toBe('summarize this');
+    expect(cap.sentBody().reasoning).toEqual({ enabled: false });
+  });
+});


### PR DESCRIPTION
## Diagnosis correction (honest record)

The earlier finding "no thinking suppression applied" was an **incomplete scan** — `openrouter.ts:84-86` already sends `reasoning: {enabled: false}` for qwen models. The real defect: **some OpenRouter providers ignore the param**. Prod 2026-06-10 07:29–07:43 (qwen3-30b): 4× "CoT leakage blocked" errors (reasoning-only, 1024-token cap, 12–48s wasted each) + routine 20–48s latencies **despite the param**.

## Fix (W2, approved track)

Belt-and-suspenders: with `OPENROUTER_QWEN_NO_THINK=true` and a qwen-family model, `generate()` appends the Qwen **chat-template soft switch `/no_think`** to the prompt — template-layer, so it holds regardless of which provider serves the call. Idempotent (chatbot middleware's existing `/no_think` not duplicated). The `reasoning` param stays alongside.

- Env-default rule: **unset = byte-identical pre-W2 body** (test-pinned). Activation = compose line in this PR; rollback = delete line + redeploy.
- Blast radius: all qwen `generate()` callers (enrich-video bilingual/tags, merged-gen, structure-gen) — exactly the paths bleeding 20–48s/leak errors.

## Tests

4 new (11/11 with existing backoff suite): suffix+param coexist / non-qwen untouched / no duplicate / flag-off exact pre-W2.

## Post-deploy measurement (CC)

`llm_call_logs` qwen3-30b: latency distribution + "CoT leakage blocked" count, before/after deploy timestamp — expect 20–48s band collapse and leak → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)