### PR TITLE
feat(actions): guaranteed actions fill via pg-boss — replace in-memory fire-and-forget (W1a, CP499+)

### DIFF
--- a/src/modules/mandala/mandala-post-creation.ts
+++ b/src/modules/mandala/mandala-post-creation.ts
@@ -54,17 +54,32 @@ export function triggerMandalaPostCreationAsync(
     });
 
     (async () => {
-      // Lazy require so that test-time module graphs that do not need the
-      // generator / OpenRouter imports (e.g. `mandala-post-creation.test.ts`
-      // which mocks only a narrow surface) are not forced to resolve them.
-      const { fillMissingActionsIfNeeded } = await import('./fill-missing-actions');
-      const result = await fillMissingActionsIfNeeded(mandalaId);
-      log.info(
-        `actions-fill result for mandala=${mandalaId}: ${JSON.stringify({
-          action: result.action,
-          cellsFilled: result.cellsFilled ?? 0,
-        })}`
-      );
+      // W1' (CP499+) — actions fill is now a pg-boss job, not an in-memory
+      // attempt: the old inline call died with the process (deploy restarts)
+      // and never retried, so a single LLM failure left the mandala
+      // permanently actions-less. The job gives persistence + 3 backoff
+      // retries (absolute rule: missing actions ⇒ generate and store).
+      // Lazy import keeps narrow test module graphs unchanged.
+      const { enqueueMandalaActionsFill } =
+        await import('@/modules/queue/handlers/mandala-actions-fill');
+      try {
+        const jobId = await enqueueMandalaActionsFill({ mandalaId, userId, trigger });
+        log.info(`actions-fill enqueued: job=${jobId} mandala=${mandalaId}`);
+      } catch (enqueueErr) {
+        // Queue down (pg-boss unavailable) — fall back to the old inline
+        // attempt so the rule still has SOME execution path right now.
+        log.warn(
+          `actions-fill enqueue failed (${enqueueErr instanceof Error ? enqueueErr.message : String(enqueueErr)}) — falling back to inline fill for mandala=${mandalaId}`
+        );
+        const { fillMissingActionsIfNeeded } = await import('./fill-missing-actions');
+        const result = await fillMissingActionsIfNeeded(mandalaId);
+        log.info(
+          `actions-fill inline-fallback result for mandala=${mandalaId}: ${JSON.stringify({
+            action: result.action,
+            cellsFilled: result.cellsFilled ?? 0,
+          })}`
+        );
+      }
     })().catch((err) => {
       log.warn(
         `fill-missing-actions crashed for user=${userId} mandala=${mandalaId}: ${err instanceof Error ? err.message : String(err)}`

--- a/src/modules/queue/handlers/mandala-actions-fill.ts
+++ b/src/modules/queue/handlers/mandala-actions-fill.ts
@@ -1,0 +1,88 @@
+/**
+ * Mandala actions fill — guaranteed worker (W1', CP499+).
+ *
+ * Replaces the in-memory fire-and-forget IIFE in mandala-post-creation: that
+ * attempt died with the process (deploy restarts!) and never retried after
+ * its single inline failure — a mandala could stay permanently actions-less,
+ * violating the absolute rule "missing actions ⇒ LLM-generate and store".
+ *
+ * pg-boss gives: persistence across restarts + 3 backoff retries
+ * (MANDALA_ACTIONS_FILL_OPTIONS). The worker delegates to
+ * fillMissingActionsIfNeeded, which is idempotent ('skipped-full' when a
+ * concurrent/SSE path already filled the cells) — re-runs are free.
+ *
+ * The wizard-stream SSE actions path (mandalas.ts wizard-stream) is NOT
+ * touched: it remains the fast UX lane; this job is the durability lane.
+ */
+
+import PgBoss from 'pg-boss';
+import { logger } from '@/utils/logger';
+import { getJobQueue } from '../manager';
+import { JOB_NAMES, MANDALA_ACTIONS_FILL_OPTIONS, type MandalaActionsFillPayload } from '../types';
+
+const log = logger.child({ module: 'queue/mandala-actions-fill' });
+
+// One mandala-create at a time produces one job; low volume, serial is fine.
+// Explicit teamSize per the CP498 pg-boss trap (teamConcurrency alone is inert).
+const WORKER_TEAM = { teamConcurrency: 1, teamSize: 1 } as const;
+
+export async function registerMandalaActionsFillWorker(): Promise<void> {
+  const boss = getJobQueue().getInstance();
+  await boss.work<MandalaActionsFillPayload>(
+    JOB_NAMES.MANDALA_ACTIONS_FILL,
+    WORKER_TEAM,
+    handleMandalaActionsFill
+  );
+  log.info('mandala-actions-fill worker registered');
+}
+
+export async function handleMandalaActionsFill(
+  job: PgBoss.Job<MandalaActionsFillPayload>
+): Promise<void> {
+  const startedAt = Date.now();
+  const { mandalaId, trigger } = job.data ?? {};
+  if (!mandalaId) {
+    // Malformed payload — retrying cannot fix it; complete without throwing.
+    log.warn('mandala-actions-fill: missing mandalaId, dropping', { jobId: job.id });
+    return;
+  }
+
+  // Lazy import keeps narrow test module graphs (and the queue boot path)
+  // free of the generator/OpenRouter imports — same convention as the old
+  // inline call site in mandala-post-creation.
+  const { fillMissingActionsIfNeeded } = await import('@/modules/mandala/fill-missing-actions');
+  const result = await fillMissingActionsIfNeeded(mandalaId);
+
+  if (!result.ok && result.action === 'failed') {
+    // Throw → pg-boss retry (3× backoff). This is the guarantee the old
+    // fire-and-forget lacked.
+    log.warn('mandala-actions-fill: fill failed, will retry', {
+      jobId: job.id,
+      mandalaId,
+      reason: result.reason,
+      durationMs: Date.now() - startedAt,
+    });
+    throw new Error(`actions fill failed for ${mandalaId}: ${result.reason ?? 'unknown'}`);
+  }
+
+  log.info('mandala-actions-fill: completed', {
+    jobId: job.id,
+    mandalaId,
+    trigger,
+    action: result.action,
+    cellsFilled: result.cellsFilled ?? 0,
+    durationMs: Date.now() - startedAt,
+  });
+}
+
+/** Enqueue a guaranteed actions fill. Returns the pg-boss job id or null. */
+export async function enqueueMandalaActionsFill(
+  payload: MandalaActionsFillPayload,
+  options?: PgBoss.SendOptions
+): Promise<string | null> {
+  const boss = getJobQueue().getInstance();
+  return boss.send(JOB_NAMES.MANDALA_ACTIONS_FILL, payload, {
+    ...MANDALA_ACTIONS_FILL_OPTIONS,
+    ...options,
+  });
+}

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -30,6 +30,7 @@ import { registerEnrichRichSummaryWorker } from './handlers/enrich-rich-summary'
 import { registerBatchVideoCollectorWorker } from './handlers/batch-video-collector';
 import { registerPoolMaintenanceWorker } from './handlers/pool-maintenance';
 import { registerEnrichRelevanceQuickWorker } from './handlers/enrich-relevance-quick';
+import { registerMandalaActionsFillWorker } from './handlers/mandala-actions-fill';
 import { logger } from '../../utils/logger';
 
 /**
@@ -50,6 +51,7 @@ export async function initJobQueue(): Promise<void> {
   await registerBatchVideoCollectorWorker();
   await registerPoolMaintenanceWorker();
   await registerEnrichRelevanceQuickWorker();
+  await registerMandalaActionsFillWorker();
 
-  logger.info('Job queue fully initialized (pg-boss + 6 workers)');
+  logger.info('Job queue fully initialized (pg-boss + 7 workers)');
 }

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -33,6 +33,15 @@ export const JOB_NAMES = {
    * docs/handoffs/pr3-relevance-backfill-cp498.md.
    */
   ENRICH_RELEVANCE_QUICK: 'enrich-relevance-quick',
+  /**
+   * W1' (CP499+) — guaranteed actions fill. Replaces the in-memory
+   * fire-and-forget IIFE in mandala-post-creation (lost on restart, gone
+   * after its single inline attempt). pg-boss persistence + retries keep the
+   * absolute rule "missing actions ⇒ LLM-generate and store in DB" alive
+   * across crashes/restarts. Worker = fillMissingActionsIfNeeded (idempotent:
+   * 'skipped-full' on a no-op re-run).
+   */
+  MANDALA_ACTIONS_FILL: 'mandala-actions-fill',
 } as const;
 
 export type JobName = (typeof JOB_NAMES)[keyof typeof JOB_NAMES];
@@ -191,6 +200,26 @@ export const RELEVANCE_QUICK_RETRY_OPTIONS = {
   retryLimit: 1,
   expireInMinutes: 5,
 } as const;
+
+/**
+ * Actions fill — one Haiku batch call (~20s observed worst case). 3 retries
+ * with backoff: the job is the GUARANTEE layer for the absolute rule
+ * "missing actions ⇒ generate and store", so transient LLM failures must not
+ * leave a mandala permanently actions-less (the old inline IIFE did exactly
+ * that after its single attempt).
+ */
+export const MANDALA_ACTIONS_FILL_OPTIONS = {
+  retryLimit: 3,
+  retryDelay: 30,
+  retryBackoff: true,
+  expireInMinutes: 10,
+} as const;
+
+export interface MandalaActionsFillPayload {
+  mandalaId: string;
+  userId?: string;
+  trigger?: string;
+}
 
 // ============================================================================
 // Queue Configuration

--- a/tests/unit/modules/mandala-actions-fill.test.ts
+++ b/tests/unit/modules/mandala-actions-fill.test.ts
@@ -1,0 +1,102 @@
+/**
+ * mandala-actions-fill worker tests — W1' (CP499+).
+ *
+ * Locks the guarantee invariants that the old in-memory fire-and-forget
+ * lacked:
+ *   - 'failed' fill result ⇒ THROW (pg-boss retry path engages);
+ *   - 'filled' / 'skipped-full' / 'skipped-not-found' ⇒ complete, no throw
+ *     (idempotent re-runs are free; not-found is non-retryable);
+ *   - malformed payload (no mandalaId) ⇒ drop without throw (retry can't fix);
+ *   - enqueue carries MANDALA_ACTIONS_FILL_OPTIONS (retryLimit 3 + backoff).
+ */
+
+const mockBossInstance = {
+  start: jest.fn().mockResolvedValue(undefined),
+  stop: jest.fn().mockResolvedValue(undefined),
+  on: jest.fn(),
+  work: jest.fn().mockResolvedValue('worker-id'),
+  send: jest.fn().mockResolvedValue('job-123'),
+  schedule: jest.fn().mockResolvedValue(undefined),
+  getQueueSize: jest.fn().mockResolvedValue(0),
+};
+jest.mock('pg-boss', () => jest.fn().mockImplementation(() => mockBossInstance));
+
+const mockFill = jest.fn();
+jest.mock('@/modules/mandala/fill-missing-actions', () => ({
+  fillMissingActionsIfNeeded: (...args: unknown[]) => mockFill(...args),
+}));
+
+jest.mock('@/config/index', () => ({
+  config: {
+    database: { url: 'postgresql://postgres:pass@127.0.0.1:5432/postgres', directUrl: undefined },
+    app: { isDevelopment: true, isProduction: false, isTest: true },
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import type PgBoss from 'pg-boss';
+import { getJobQueue } from '@/modules/queue/manager';
+import {
+  handleMandalaActionsFill,
+  enqueueMandalaActionsFill,
+} from '@/modules/queue/handlers/mandala-actions-fill';
+import { JOB_NAMES, MANDALA_ACTIONS_FILL_OPTIONS } from '@/modules/queue/types';
+import type { MandalaActionsFillPayload } from '@/modules/queue/types';
+
+beforeAll(async () => {
+  await getJobQueue().start();
+});
+afterAll(async () => {
+  await getJobQueue().stop();
+});
+
+const job = (data: Partial<MandalaActionsFillPayload>): PgBoss.Job<MandalaActionsFillPayload> =>
+  ({ id: 'job-1', data }) as PgBoss.Job<MandalaActionsFillPayload>;
+
+afterEach(() => jest.clearAllMocks());
+
+describe('handleMandalaActionsFill (W1′ guarantee invariants)', () => {
+  it("fill 'failed' → throws so pg-boss retries (the old IIFE just logged)", async () => {
+    mockFill.mockResolvedValue({ ok: false, action: 'failed', reason: 'LLM 503' });
+    await expect(handleMandalaActionsFill(job({ mandalaId: 'm-1' }))).rejects.toThrow(/LLM 503/);
+    expect(mockFill).toHaveBeenCalledWith('m-1');
+  });
+
+  it("'filled' and idempotent 'skipped-full' complete without throw", async () => {
+    mockFill.mockResolvedValue({ ok: true, action: 'filled', cellsFilled: 8 });
+    await expect(handleMandalaActionsFill(job({ mandalaId: 'm-2' }))).resolves.toBeUndefined();
+
+    mockFill.mockResolvedValue({ ok: true, action: 'skipped-full' });
+    await expect(handleMandalaActionsFill(job({ mandalaId: 'm-2' }))).resolves.toBeUndefined();
+  });
+
+  it("'skipped-not-found' does NOT retry (deleted mandala is permanent)", async () => {
+    mockFill.mockResolvedValue({ ok: false, action: 'skipped-not-found' });
+    await expect(handleMandalaActionsFill(job({ mandalaId: 'm-gone' }))).resolves.toBeUndefined();
+  });
+
+  it('malformed payload (no mandalaId) is dropped without throw or fill call', async () => {
+    await expect(handleMandalaActionsFill(job({}))).resolves.toBeUndefined();
+    expect(mockFill).not.toHaveBeenCalled();
+  });
+});
+
+describe('enqueueMandalaActionsFill', () => {
+  it('sends with the retry options (retryLimit 3 + backoff) on the right queue', async () => {
+    const id = await enqueueMandalaActionsFill({ mandalaId: 'm-3', trigger: 'wizard' });
+    expect(id).toBe('job-123');
+    expect(mockBossInstance.send).toHaveBeenCalledWith(
+      JOB_NAMES.MANDALA_ACTIONS_FILL,
+      { mandalaId: 'm-3', trigger: 'wizard' },
+      expect.objectContaining(MANDALA_ACTIONS_FILL_OPTIONS)
+    );
+  });
+});

--- a/tests/unit/modules/queue-handlers.test.ts
+++ b/tests/unit/modules/queue-handlers.test.ts
@@ -205,10 +205,10 @@ describe('initJobQueue integration', () => {
     const { initJobQueue } = require('../../../src/modules/queue');
     await initJobQueue();
 
-    // Should register all 6 workers: enrich-video, batch-scan,
+    // Should register all 7 workers: enrich-video, batch-scan,
     // enrich-rich-summary, batch-video-collector, pool-maintenance,
-    // enrich-relevance-quick (CP498 PR3b).
-    expect(mockBossInstance.work).toHaveBeenCalledTimes(6);
+    // enrich-relevance-quick (CP498 PR3b), mandala-actions-fill (W1' CP499+).
+    expect(mockBossInstance.work).toHaveBeenCalledTimes(7);
 
     // Should schedule batch-scan
     expect(mockBossInstance.schedule).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Revised W1 rationale (James-approved)

Measurement refuted the original premise: actions never blocked the user journey (`mandala-post-creation.ts` detached IIFE + wizard-stream async SSE `actions_ready`). The real defect: the IIFE is **exactly the forbidden pattern** — in-memory fire-and-forget that dies with the process (deploy restarts) and never retries after its single attempt → a transient LLM failure leaves a mandala **permanently actions-less**, violating the absolute rule "missing actions ⇒ LLM-generate and store in DB". W1 value moved from performance to **data integrity**; journey latency moved to W3 + (iii).

## Changes (W1-1 requirement: pg-boss, no in-memory fire-and-forget)

- NEW job `mandala-actions-fill`: `retryLimit 3 + backoff`, persistence across restarts. Worker → `fillMissingActionsIfNeeded` (idempotent). `failed` → throw (retry engages); `skipped-not-found` → complete (non-retryable).
- `mandala-post-creation`: enqueue replaces the inline call; **enqueue failure (queue down) falls back to the old inline attempt** — the rule always has an execution path.
- Explicit `teamSize:1` (CP498 pg-boss inert-`teamConcurrency` trap).
- wizard-stream SSE actions lane untouched (fast UX lane vs this durability lane).

## Tests

5 new invariant tests + queue-handlers worker count 6→7. Pre-existing `mandala-post-creation` suite failures (13) reproduce **identically on main** (stash-verified, duration-stripped name diff = 0 new) — stale pipeline expectations, separate cleanup candidate.

## Scope note

**W1b (FE "채워지는 중" cell state — W1-2 requirement) follows as its own PR** after the FE actions-surface fact-read; kept separate so this BE durability change stays reviewable.

## Rollback

Revert commit — job name becomes unused; no queue residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)