### PR TITLE
chore(llm): activate OPENROUTER_QWEN_NO_THINK in prod (W2 activation)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -267,6 +267,15 @@ services:
       # Revert: delete this line and redeploy → code default off restores the
       # two-call path bit-identically (no code revert).
       - WIZARD_MERGED_GEN=true
+      # W2 activation (CP499+, 2026-06-10, James marker) — prompt-level
+      # `/no_think` for Qwen models on top of reasoning:{enabled:false},
+      # which some OpenRouter providers ignore (prod: reasoning-only
+      # 1024-cap responses + 20-48s calls despite the param). Activation
+      # timestamp = the before/after measurement cut (judgment criteria
+      # fixed pre-measurement: success = 20-48s band collapse + leak 0 +
+      # success-rate non-degraded; hold verdict until dozens of calls).
+      # Revert: delete this line + redeploy (code default off, no revert).
+      - OPENROUTER_QWEN_NO_THINK=true
       # CP426 (2026-04-25) — Switch pipeline executor from v1 (3 recs/cell,
       # max 24 with channel diversity drop → ~5 actual) to v3 (12/cell target,
       # 96 max). v3 degrades gracefully to Tier 2 when video_pool is empty.


### PR DESCRIPTION
James marker (2026-06-10). One compose line — flips the dormant #888 code on. Activation timestamp = the before/after measurement cut (baseline = existing llm_call_logs, agreed sufficient).

**Judgment criteria (fixed pre-measurement)**: success = 20-48s band collapse + CoT-leak 0 + success-rate non-degraded / partial = latency improves, leaks persist → re-diagnose leak path / no-effect = unchanged → re-verify application point. **Verdict held until dozens of natural-traffic calls** (no early call on 5-10 samples).

Rollback: delete the line + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)