### PR TITLE
feat(discover): includeEnCards toggle — BE plumbing + lang-gate branch (toggle T1, CP499+)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -286,12 +286,35 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               )
             : undefined;
 
+          // CP499+ '영문 카드 포함' toggle — per-mandala persistent state in
+          // user_skill_config(video_discover).config.includeEnCards. ko
+          // mandalas only; missing row / missing key / DB error = OFF
+          // (current behaviour preserved — the safe default).
+          let includeEnCards = false;
+          if (language === 'ko') {
+            const skillCfg = await prisma.user_skill_config
+              .findUnique({
+                where: {
+                  user_id_mandala_id_skill_type: {
+                    user_id: userId,
+                    mandala_id: mandalaId,
+                    skill_type: 'video_discover',
+                  },
+                },
+                select: { config: true },
+              })
+              .catch(() => null);
+            includeEnCards =
+              (skillCfg?.config as Record<string, unknown> | null)?.['includeEnCards'] === true;
+          }
+
           const v5Result = await runV5Executor({
             centerGoal,
             subGoals,
             focusTags,
             targetLevel,
             language,
+            includeEnCards,
             excludeVideoIds: excludeSet,
             env: process.env,
             fullCellIndices,

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -39,6 +39,8 @@ export interface V5ExecuteInput {
   focusTags: string[];
   targetLevel: string;
   language: 'ko' | 'en';
+  /** CP499+ '영문 카드 포함' toggle — forwarded to fanout. See FanoutInput. */
+  includeEnCards?: boolean;
   excludeVideoIds: Set<string>;
   env: NodeJS.ProcessEnv;
   /**
@@ -151,6 +153,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
     focusTags: input.focusTags,
     targetLevel: input.targetLevel,
     language: input.language,
+    includeEnCards: input.includeEnCards,
     env: input.env,
     publishedAfter: input.publishedAfter,
     precomputedQueries: input.precomputedQueries,

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -56,6 +56,13 @@ export interface FanoutInput {
   focusTags: string[];
   targetLevel: string;
   language: 'ko' | 'en';
+  /**
+   * CP499+ '영문 카드 포함' toggle (user_skill_config.config.includeEnCards).
+   * ko mandala + true → live search drops the relevanceLanguage=ko bias and
+   * the off-language gate widens to ko ∪ en (third-script content stays
+   * blocked). Undefined/false = current ko-only behaviour, bit-identical.
+   */
+  includeEnCards?: boolean;
   env: NodeJS.ProcessEnv;
   /** CP491 ROI1 — forwarded to search.list publishedAfter (ISO date). */
   publishedAfter?: string;
@@ -234,6 +241,26 @@ export function rotateKeys(keys: string[], i: number): string[] {
  *   - en: Latin-script. Zero Latin letters + ≥2 Han = CJK content → drop.
  * Exported for tests.
  */
+/**
+ * CP499+ — toggle-aware off-language gate ('영문 카드 포함').
+ *
+ * DESIGN FINDING (test-caught): the ko-rules ALREADY pass pure-English titles
+ * (hangul 0 + no dominant third script = kept), so the gate needs NO widening
+ * for the toggle — and a ko∪en union would be actively WRONG: the en-rules
+ * only block CJK, so Arabic/Thai/Cyrillic titles would re-enter through the
+ * en side. The toggle's effective EN-inflow lever is therefore the
+ * relevanceLanguage drop in the search call alone; this function keeps the
+ * toggle branch explicit at both call sites and pins the EN-passes invariant.
+ * Exported for tests.
+ */
+export function isOffLanguageTitleToggled(
+  title: string,
+  lang: 'ko' | 'en',
+  _includeEnCards: boolean | undefined
+): boolean {
+  return isOffLanguageTitle(title, lang);
+}
+
 export function isOffLanguageTitle(title: string, lang: 'ko' | 'en'): boolean {
   const t = title ?? '';
   const hangul = (t.match(/[가-힣]/g) ?? []).length;
@@ -416,7 +443,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
         const cand = keywordCandidateToFanoutCandidate(kc);
         // Fork-1 caveat: pool candidates run the SAME gates as live items.
         if (titleHitsBlocklist(cand.title) || titleIndicatesShorts(cand.title)) continue;
-        if (isOffLanguageTitle(cand.title, input.language)) continue;
+        if (isOffLanguageTitleToggled(cand.title, input.language, input.includeEnCards)) continue;
         const ci = cand.cellIndex ?? -1;
         if (ci < 0) continue;
         const bucket = byCell.get(ci);
@@ -477,7 +504,11 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
         // keeping the rest as failover.
         apiKey: rotateKeys(apiKeys, i),
         maxResults: cfg.searchMaxResults,
-        relevanceLanguage: input.language,
+        // CP499+ toggle — ON drops the ko bias so EN candidates can actually
+        // enter live results (the pool is 5.9% EN; live is the supply body).
+        // searchVideos omits the param when undefined (youtube-client :223).
+        relevanceLanguage:
+          input.includeEnCards && input.language === 'ko' ? undefined : input.language,
         // CP492 — region bias (ko→KR, en→US). relevanceLanguage alone is a soft
         // hint YouTube ignores for sparse queries (it backfilled "드리블 핸들링"
         // with a high-view Chinese drama). regionCode nudges toward the locale;
@@ -518,7 +549,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       // high-view global content (Chinese dramas on a Korean basketball query).
       // Conservative: only drop titles dominated by a non-target script (see
       // isOffLanguageTitle) so English-titled or Hanja-mixed Korean content is kept.
-      if (isOffLanguageTitle(cand.title, input.language)) {
+      if (isOffLanguageTitleToggled(cand.title, input.language, input.includeEnCards)) {
         offLangDropped += 1;
         continue;
       }

--- a/tests/unit/skills/video-discover/v5-fanout.test.ts
+++ b/tests/unit/skills/video-discover/v5-fanout.test.ts
@@ -88,6 +88,31 @@ describe('runYouTubeFanout — F5c perQuery', () => {
     expect(res.candidates).toHaveLength(8); // 5 + 3, all unique
   });
 
+  test("CP499+ '영문 카드 포함': ko+ON drops relevanceLanguage; ko+OFF keeps 'ko' (the toggle's effective lever)", async () => {
+    buildRuleBasedQueriesSync.mockReturnValue([{ query: 'q0', source: 'core', cellIndex: null }]);
+    searchVideos.mockResolvedValue(items(2, 'q'));
+    const base = {
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'ko' as const,
+      env: {} as NodeJS.ProcessEnv,
+    };
+
+    await runYouTubeFanout({ ...base, includeEnCards: true });
+    for (const call of searchVideos.mock.calls) {
+      expect(call[0].relevanceLanguage).toBeUndefined(); // ko bias dropped -> EN can enter
+    }
+
+    searchVideos.mockClear();
+    searchVideos.mockResolvedValue(items(2, 'q'));
+    await runYouTubeFanout({ ...base, includeEnCards: false });
+    for (const call of searchVideos.mock.calls) {
+      expect(call[0].relevanceLanguage).toBe('ko'); // OFF = current behaviour
+    }
+  });
+
   test('ROI1: forwards publishedAfter to every searchVideos call', async () => {
     buildRuleBasedQueriesSync.mockReturnValue([
       { query: 'q0', source: 'core', cellIndex: null },

--- a/tests/unit/skills/video-discover/v5-include-en-toggle.test.ts
+++ b/tests/unit/skills/video-discover/v5-include-en-toggle.test.ts
@@ -1,0 +1,48 @@
+/**
+ * CP499+ '영문 카드 포함' toggle — 3-way contract (James spec):
+ *   ① ko + ON  → EN titles pass the gate; third-script stays blocked;
+ *                the live search drops the relevanceLanguage=ko bias
+ *   ② ko + OFF → current single-language gate, bit-identical
+ *   ③ en mandala → toggle is a no-op (en rules regardless of the flag)
+ *
+ * Honest note pinned in code: the ko-rules ALREADY pass pure-Latin titles —
+ * the toggle's EN-inflow body is the relevanceLanguage drop (the pool is
+ * 5.9% EN, live search is the supply body). The gate-widening keeps the
+ * semantics explicit.
+ */
+import {
+  isOffLanguageTitle,
+  isOffLanguageTitleToggled,
+} from '../../../../src/skills/plugins/video-discover/v5/youtube-fanout';
+
+const KO = '농구 드리블 기본기 강좌';
+const EN = 'Basketball Dribbling Fundamentals';
+const ZH = '篮球运球基础教程完整版'; // third-script: blocked in every mode
+const AR = 'أساسيات المراوغة في كرة السلة';
+
+describe("'영문 카드 포함' — off-language gate 3-way", () => {
+  it('① ko + ON: ko and EN pass; third-script (zh/ar) stays blocked', () => {
+    // Design finding pinned: the ko gate is already EN-permissive, and a
+    // ko∪en union would re-admit Arabic/Thai (the en-rules only block CJK).
+    // So ON keeps the ko gate; EN-inflow comes from the relevanceLanguage
+    // drop in the search call.
+    expect(isOffLanguageTitleToggled(KO, 'ko', true)).toBe(false);
+    expect(isOffLanguageTitleToggled(EN, 'ko', true)).toBe(false);
+    expect(isOffLanguageTitleToggled(ZH, 'ko', true)).toBe(true);
+    expect(isOffLanguageTitleToggled(AR, 'ko', true)).toBe(true);
+  });
+
+  it('② ko + OFF (and undefined): bit-identical to the current ko gate', () => {
+    for (const t of [KO, EN, ZH, AR]) {
+      expect(isOffLanguageTitleToggled(t, 'ko', false)).toBe(isOffLanguageTitle(t, 'ko'));
+      expect(isOffLanguageTitleToggled(t, 'ko', undefined)).toBe(isOffLanguageTitle(t, 'ko'));
+    }
+  });
+
+  it('③ en mandala: the flag is a no-op — en rules apply regardless', () => {
+    for (const t of [KO, EN, ZH]) {
+      expect(isOffLanguageTitleToggled(t, 'en', true)).toBe(isOffLanguageTitle(t, 'en'));
+      expect(isOffLanguageTitleToggled(t, 'en', false)).toBe(isOffLanguageTitle(t, 'en'));
+    }
+  });
+});


### PR DESCRIPTION
## Scope (approved storage + requirements 2·3·4; requirement 1 FE = T2 follow-up)

Per-mandala toggle `'영문 카드 포함'` — storage as approved: **`user_skill_config(video_discover).config.includeEnCards`** (schema change 0, per-mandala persistent, existing row/pattern reuse). Default **OFF** for missing row/key/DB error (req 4 — current behaviour preserved, test-pinned).

## Flow

`add-cards` reads the config (ko mandalas only) → `V5ExecuteInput.includeEnCards` → `FanoutInput` → the two named branch points (req 2):

1. **`relevanceLanguage`** — ko+ON **omits the param** (youtube-client already skips unset) so EN candidates actually enter live results. **This is the effective lever** (pool is 5.9% EN; live search is the supply body — as flagged in the approval).
2. **off-language gate** — branch kept explicit via `isOffLanguageTitleToggled` at both call sites (`:419`-pool, `:521`-live). **Design finding (test-caught)**: the ko gate already passes pure-English titles, and a ko∪en union would be actively wrong — the en rules only block CJK, so Arabic/Thai/Cyrillic would re-enter through the en side. ON therefore keeps the ko gate; the invariant (EN passes, third-script blocked) is pinned.

## Tests (req 3 — 3-way + lever)

- ① ko+ON: EN passes, zh/ar blocked / ② ko+OFF & undefined: bit-identical to current gate / ③ en mandala: flag no-op
- fanout param: ko+ON → `relevanceLanguage` **undefined on every call**; ko+OFF → `'ko'`
- 25/25 with the existing fanout suite; tsc clean.

## T2 (next PR)

FE toggle UI (ko mandalas only, hidden on en) + `/:id/skills` route config-merge write + **live EN-inflow gate verification** (req 2 후단 — natural-traffic / 토글 ON 만다라에서 EN 후보 실유입 확인).

## Rollback

Revert commit — config key unread ⇒ no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)