### PR TITLE
feat(discover): EN query pass — weak-cell-only translation (toggle's effective lever, CP499+)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -428,6 +428,9 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               v5_stage_ms: v5Result.diagnostics.stageMs,
               v5_aborted_batches: v5Result.diagnostics.abortedBatches,
               v5_picker_timed_out: v5Result.diagnostics.pickerTimedOut,
+              // CP499+ EN query pass — prod verification surface for the
+              // includeEnCards toggle (weakCells/fired/added per run).
+              v5_en_pass: v5Result.diagnostics.enPass,
               // CP492 Track-1 — query-gen telemetry (mode/model/latency/llmCells/fellBack).
               // stageMs.queryGenMs already carries the latency via v5_stage_ms.
               v5_query_gen: v5Result.diagnostics.queryGen,

--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -73,6 +73,12 @@ const v5EnvSchema = z.object({
   // CP494 ④-1 — per-cell "full" threshold. ≥ this many grid cards → skip.
   // 12 favors "user may want to see more" (cells with 7-11 still searched).
   V5_CELL_SKIP_THRESHOLD: z.coerce.number().int().min(1).max(60).default(12),
+  // CP499+ EN query pass ('영문 카드 포함' toggle, weak-cell-only). A ko cell
+  // whose first-pass raw item total is BELOW this threshold gets its query
+  // translated to English and re-fired — auto-targets KO-absent domains
+  // without manual domain classification. Only consulted when the
+  // per-mandala includeEnCards toggle is ON; unset = 8.
+  V5_EN_PASS_RAW_THRESHOLD: z.coerce.number().int().min(1).max(40).default(8),
   // CP494 안 A — pool match strategy. 'global' (default, current) runs ONE
   // centerGoal-OR tsquery with a global LIMIT (vocabulary-rich cells starve the
   // others = displacement). 'per_cell' runs each cell's own query with its own
@@ -114,6 +120,8 @@ export interface V5Config {
   cellSkip: boolean;
   /** CP494 ④-1 — per-cell card count threshold for skip. */
   cellSkipThreshold: number;
+  /** CP499+ EN pass — first-pass raw floor below which a cell gets the EN query. */
+  enPassRawThreshold: number;
   /** CP494 안 A — pool match strategy ('global' | 'per_cell'). */
   poolMatch: 'global' | 'per_cell';
 }
@@ -149,6 +157,7 @@ export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
     reuseLoop: p.V5_REUSE_LOOP,
     cellSkip: p.V5_CELL_SKIP,
     cellSkipThreshold: p.V5_CELL_SKIP_THRESHOLD,
+    enPassRawThreshold: p.V5_EN_PASS_RAW_THRESHOLD,
     poolMatch: p.V5_POOL_MATCH,
   };
   return cached;

--- a/src/skills/plugins/video-discover/v5/en-query-translate.ts
+++ b/src/skills/plugins/video-discover/v5/en-query-translate.ts
@@ -1,0 +1,105 @@
+/**
+ * EN query pass — translation step (CP499+, '영문 카드 포함' toggle).
+ *
+ * One LLM call translates the weak cells' Korean search queries into natural
+ * English YouTube search queries. Chosen over prompt-doubling in the main
+ * query-gen (design (B), James-approved): the hot path stays untouched and a
+ * failure here silently drops ONLY the EN pass — the Korean results are never
+ * affected (fail-open ⇒ null).
+ *
+ * Cost: 1 Haiku-class call per toggle-ON add-cards run that HAS weak cells
+ * (~$0.002, ~1-2s) + 100 search.list units per weak cell (vs +800u for a
+ * full-mandala EN pass — the weak-cell cut auto-targets KO-absent domains).
+ */
+
+import { logger } from '@/utils/logger';
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import { SEARCH_QUERY_MODEL, SEARCH_QUERY_TEMPERATURE } from '@/prompts/search-query-generator';
+
+const log = logger.child({ module: 'v5/en-query-translate' });
+
+const TRANSLATE_MAX_TOKENS = 512;
+
+export interface EnTranslateTarget {
+  cellIndex: number;
+  query: string;
+}
+
+export type GenerateImpl = (
+  prompt: string,
+  opts?: { temperature?: number; maxTokens?: number; format?: 'json' }
+) => Promise<string>;
+
+export function buildEnTranslatePrompt(targets: EnTranslateTarget[]): string {
+  const lines = targets.map((t) => `"${t.cellIndex}": "${t.query.replace(/"/g, "'")}"`);
+  return [
+    'Translate each Korean YouTube search query into a natural English YouTube',
+    'search query an English-speaking learner would actually type. Keep proper',
+    'nouns / tool names as-is. Return ONLY a JSON object with the SAME keys:',
+    `{${lines.join(', ')}}`,
+  ].join('\n');
+}
+
+/** Strict parse: same keys back, non-empty string values. Anything else → null. */
+export function parseEnTranslateResponse(
+  raw: string,
+  targets: EnTranslateTarget[]
+): Map<number, string> | null {
+  try {
+    const obj = JSON.parse(raw) as Record<string, unknown>;
+    const out = new Map<number, string>();
+    for (const t of targets) {
+      const v = obj[String(t.cellIndex)];
+      if (typeof v !== 'string' || v.trim().length === 0) return null;
+      out.set(t.cellIndex, v.trim());
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Translate weak-cell queries to English. Fail-open: ANY failure (no key,
+ * LLM error, parse mismatch) returns null and the caller skips the EN pass.
+ */
+export async function translateQueriesToEn(
+  targets: EnTranslateTarget[],
+  opts: { apiKey?: string; generateImpl?: GenerateImpl } = {}
+): Promise<Map<number, string> | null> {
+  if (targets.length === 0) return null;
+  if (!opts.apiKey && !opts.generateImpl) return null;
+
+  const generate =
+    opts.generateImpl ??
+    ((p: string, o?: { temperature?: number; maxTokens?: number; format?: 'json' }) =>
+      new OpenRouterGenerationProvider(SEARCH_QUERY_MODEL).generate(p, o));
+
+  try {
+    const raw = await generate(buildEnTranslatePrompt(targets), {
+      temperature: SEARCH_QUERY_TEMPERATURE,
+      maxTokens: TRANSLATE_MAX_TOKENS,
+      format: 'json',
+    });
+    const parsed = parseEnTranslateResponse(raw, targets);
+    if (!parsed) log.warn('en-query-translate: parse failed — EN pass skipped (fail-open)');
+    return parsed;
+  } catch (err) {
+    log.warn(
+      `en-query-translate: LLM call failed — EN pass skipped (fail-open): ${err instanceof Error ? err.message : String(err)}`
+    );
+    return null;
+  }
+}
+
+/**
+ * Weak-cell selection: cells whose first-pass raw item total is below the
+ * threshold (cells with NO successful query count as 0). Pure, exported for
+ * tests — this cut is what auto-targets KO-absent domains.
+ */
+export function computeWeakCells(perCellRaw: Map<number, number>, threshold: number): number[] {
+  return [...perCellRaw.entries()]
+    .filter(([, raw]) => raw < threshold)
+    .map(([cell]) => cell)
+    .sort((a, b) => a - b);
+}

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -124,6 +124,8 @@ export interface V5ExecuteResult {
     poolBackfill: PoolBackfillMeta;
     /** CP494 ④-1 — # cell queries skipped (cell already full). */
     skippedFullCells: number;
+    /** CP499+ EN query pass observability. */
+    enPass: import('./youtube-fanout').EnPassMeta;
   };
 }
 
@@ -368,6 +370,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       offLangDropped: fanout.offLangDropped ?? 0,
       poolBackfill: fanout.poolBackfill,
       skippedFullCells: fanout.skippedFullCells,
+      enPass: fanout.enPass,
     },
   };
 }
@@ -383,6 +386,7 @@ function emptyResult(args: {
     offLangDropped?: number;
     poolBackfill: PoolBackfillMeta;
     skippedFullCells?: number;
+    enPass: import('./youtube-fanout').EnPassMeta;
   };
   afterTitleFilter: number;
   afterExcludeFilter: number;
@@ -415,6 +419,7 @@ function emptyResult(args: {
       offLangDropped: args.fanout.offLangDropped ?? 0,
       poolBackfill: args.fanout.poolBackfill,
       skippedFullCells: args.fanout.skippedFullCells ?? 0,
+      enPass: args.fanout.enPass,
     },
   };
 }

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -23,6 +23,7 @@ import {
 } from '../v2/youtube-client';
 import { buildRuleBasedQueriesSync, type SearchQuery } from '../v2/keyword-builder';
 import { buildLLMQueriesPerCell, type QueryGenMeta } from './llm-query-gen';
+import { translateQueriesToEn, computeWeakCells } from './en-query-translate';
 import { getV5Config } from './config';
 import { MERGED_GEN_MODEL } from '@/prompts/mandala-with-queries-generator';
 import {
@@ -100,6 +101,19 @@ export interface FanoutPerQuery {
   fulfilled: boolean;
 }
 
+/** CP499+ EN query pass observability (verification surface for the toggle). */
+export interface EnPassMeta {
+  /** Pass attempted (toggle ON + ko + weak cells existed + translation ok). */
+  fired: boolean;
+  /** Cells below the raw threshold after the ko first pass. */
+  weakCells: number[];
+  /** Translation call succeeded (false + weakCells>0 = fail-open skip). */
+  translated: boolean;
+  queriesFired: number;
+  rawItems: number;
+  candidatesAdded: number;
+}
+
 export interface FanoutResult {
   candidates: FanoutCandidate[];
   queriesAttempted: number;
@@ -118,6 +132,8 @@ export interface FanoutResult {
   poolBackfill: PoolBackfillMeta;
   /** CP494 ④-1 — # of cell queries skipped because the cell was already full. */
   skippedFullCells: number;
+  /** CP499+ EN query pass observability ('영문 카드 포함' toggle). */
+  enPass: EnPassMeta;
 }
 
 /**
@@ -324,6 +340,14 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       offLangDropped: 0,
       poolBackfill: POOL_BACKFILL_OFF(0),
       skippedFullCells: 0,
+      enPass: {
+        fired: false,
+        weakCells: [],
+        translated: false,
+        queriesFired: 0,
+        rawItems: 0,
+        candidatesAdded: 0,
+      },
     };
   }
 
@@ -386,6 +410,14 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       offLangDropped: 0,
       poolBackfill: POOL_BACKFILL_OFF(0),
       skippedFullCells: 0,
+      enPass: {
+        fired: false,
+        weakCells: [],
+        translated: false,
+        queriesFired: 0,
+        rawItems: 0,
+        candidatesAdded: 0,
+      },
     };
   }
 
@@ -559,6 +591,114 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
     if (seen.size >= cfg.dedupHardCap) break;
   }
 
+  // ── CP499+ EN query pass ('영문 카드 포함', weak-cell-only) ──────────────
+  // T1 measurement: dropping relevanceLanguage alone moved EN inflow 7%→5%
+  // (noise) — the dominant variable is the QUERY language. So when the toggle
+  // is ON, cells whose ko first-pass raw total is below the threshold get
+  // their query translated to English (1 fail-open LLM call) and re-fired
+  // (+100u per weak cell, vs +800u full-mandala). The weak-cell cut
+  // auto-targets KO-absent domains — no manual domain classification.
+  const enPass: EnPassMeta = {
+    fired: false,
+    weakCells: [],
+    translated: false,
+    queriesFired: 0,
+    rawItems: 0,
+    candidatesAdded: 0,
+  };
+  const enPerQuery: FanoutPerQuery[] = [];
+  if (input.includeEnCards && input.language === 'ko' && liveQueries.length > 0) {
+    const perCellRaw = new Map<number, number>();
+    results.forEach((r, i) => {
+      const ci = liveQueries[i]!.cellIndex;
+      if (typeof ci !== 'number') return;
+      const raw = r.status === 'fulfilled' ? r.value.items.length : 0;
+      perCellRaw.set(ci, (perCellRaw.get(ci) ?? 0) + raw);
+    });
+    enPass.weakCells = computeWeakCells(perCellRaw, cfg.enPassRawThreshold);
+
+    if (enPass.weakCells.length > 0) {
+      const weakSet = new Set(enPass.weakCells);
+      const targetByCell = new Map<number, string>();
+      for (const q of liveQueries) {
+        if (typeof q.cellIndex === 'number' && weakSet.has(q.cellIndex)) {
+          if (!targetByCell.has(q.cellIndex)) targetByCell.set(q.cellIndex, q.query);
+        }
+      }
+      const targets = [...targetByCell.entries()].map(([cellIndex, query]) => ({
+        cellIndex,
+        query,
+      }));
+      const translated = await translateQueriesToEn(targets, {
+        apiKey: input.env['OPENROUTER_API_KEY'],
+      });
+
+      if (translated) {
+        enPass.translated = true;
+        enPass.fired = true;
+        const enResults = await Promise.allSettled(
+          [...translated.entries()].map(([cellIndex, query], i) =>
+            searchVideos({
+              query,
+              apiKey: rotateKeys(apiKeys, liveQueries.length + i),
+              maxResults: cfg.searchMaxResults,
+              // No language bias on purpose; regionCode KR keeps the
+              // "EN content consumed in Korea" slant (James-approved).
+              regionCode: 'KR',
+              timeoutMs: cfg.searchTimeoutMs,
+              publishedAfter: input.publishedAfter,
+            }).then((items) => ({ items, cellIndex, query }))
+          )
+        );
+        enPass.queriesFired = targets.length;
+
+        for (const r of enResults) {
+          if (r.status !== 'fulfilled') {
+            enPerQuery.push({
+              query: '(en-pass)',
+              source: 'en_pass',
+              cellIndex: null,
+              rawCount: 0,
+              fulfilled: false,
+            });
+            continue;
+          }
+          const { items, cellIndex, query } = r.value;
+          enPerQuery.push({
+            query,
+            source: 'en_pass',
+            cellIndex,
+            rawCount: items.length,
+            fulfilled: true,
+          });
+          for (const it of items) {
+            enPass.rawItems += 1;
+            rawItemCount += 1;
+            const cand = toFanoutCandidate(it, cellIndex);
+            if (!cand) continue;
+            if (seen.has(cand.videoId)) continue;
+            if (titleHitsBlocklist(cand.title) || titleIndicatesShorts(cand.title)) continue;
+            if (isOffLanguageTitleToggled(cand.title, input.language, input.includeEnCards)) {
+              offLangDropped += 1;
+              continue;
+            }
+            seen.set(cand.videoId, cand);
+            enPass.candidatesAdded += 1;
+            if (seen.size >= cfg.dedupHardCap) break;
+          }
+          if (seen.size >= cfg.dedupHardCap) break;
+        }
+        log.info(
+          `v5 en-pass: cells=[${enPass.weakCells.join(',')}] fired=${enPass.queriesFired} raw=${enPass.rawItems} added=${enPass.candidatesAdded}`
+        );
+      } else {
+        log.info(
+          `v5 en-pass: weak cells [${enPass.weakCells.join(',')}] but translation unavailable — skipped (fail-open)`
+        );
+      }
+    }
+  }
+
   // CP491 F5c — per-query raw count + q_ok, computed independently of the
   // dedup/hardcap loop above so every attempted query is recorded even when
   // the cohort hits dedupHardCap early. `results` order == `queries` order
@@ -578,16 +718,18 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
     candidates: Array.from(seen.values()),
     // CP494 — attempted/quota now reflect ONLY the live queries actually fired
     // (pool-satisfied cells dropped theirs). poolBackfill carries the delta.
+    // CP499+ — the EN pass adds its fired queries to quota (100u each).
     queriesAttempted: liveQueries.length,
     queriesSucceeded,
     rawItemCount,
-    quotaUnitsApprox: liveQueries.length * 100,
-    perQuery,
+    quotaUnitsApprox: (liveQueries.length + enPass.queriesFired) * 100,
+    perQuery: [...perQuery, ...enPerQuery],
     queryGenMs,
     queryGen,
     offLangDropped,
     poolBackfill: poolMeta,
     skippedFullCells,
+    enPass,
   };
 }
 

--- a/tests/unit/skills/video-discover/v5-en-pass.test.ts
+++ b/tests/unit/skills/video-discover/v5-en-pass.test.ts
@@ -1,0 +1,189 @@
+/**
+ * CP499+ EN query pass — weak-cell-only (James-approved design (B)).
+ *
+ * Pins:
+ *   - weak-cell math (raw < threshold; failed queries count 0)
+ *   - translate fail-open (no key / LLM throw / parse mismatch → null)
+ *   - fanout integration: ONLY weak cells get translated+fired; EN calls
+ *     carry regionCode KR and NO relevanceLanguage; results merge with the
+ *     cell's index through the same gates; OFF = single pass bit-identical;
+ *     translation-null = EN pass skipped, ko results untouched.
+ */
+
+jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
+  searchVideos: jest.fn(),
+  resolveSearchApiKeys: jest.fn().mockReturnValue(['key1']),
+  titleIndicatesShorts: jest.fn().mockReturnValue(false),
+  titleHitsBlocklist: jest.fn().mockReturnValue(false),
+}));
+jest.mock('@/skills/plugins/video-discover/v2/keyword-builder', () => ({
+  buildRuleBasedQueriesSync: jest.fn(),
+}));
+jest.mock('@/skills/plugins/video-discover/v5/en-query-translate', () => {
+  const actual = jest.requireActual('@/skills/plugins/video-discover/v5/en-query-translate');
+  return { ...actual, translateQueriesToEn: jest.fn() };
+});
+jest.mock('@/utils/logger', () => {
+  const base: Record<string, unknown> = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  };
+  base['child'] = jest.fn(() => base);
+  return { logger: base };
+});
+
+const { searchVideos } = jest.requireMock('@/skills/plugins/video-discover/v2/youtube-client');
+const { buildRuleBasedQueriesSync } = jest.requireMock(
+  '@/skills/plugins/video-discover/v2/keyword-builder'
+);
+const { translateQueriesToEn } = jest.requireMock(
+  '@/skills/plugins/video-discover/v5/en-query-translate'
+);
+
+import { runYouTubeFanout } from '@/skills/plugins/video-discover/v5/youtube-fanout';
+import {
+  computeWeakCells,
+  parseEnTranslateResponse,
+} from '@/skills/plugins/video-discover/v5/en-query-translate';
+
+// The module is mocked above for the fanout integration; pull the REAL
+// translate impl for the fail-open unit tests.
+const { translateQueriesToEn: realTranslate } = jest.requireActual(
+  '@/skills/plugins/video-discover/v5/en-query-translate'
+);
+import { resetV5ConfigForTest } from '@/skills/plugins/video-discover/v5/config';
+
+const item = (id: string, title: string) => ({
+  id: { videoId: id },
+  snippet: {
+    title,
+    channelTitle: 'ch',
+    channelId: 'cid',
+    publishedAt: '2026-01-01T00:00:00Z',
+    thumbnails: { high: { url: 'u' } },
+  },
+});
+const koItems = (n: number, p: string) =>
+  Array.from({ length: n }, (_, i) => item(`${p}-${i}`, `한국어 영상 ${p} ${i}`));
+
+const baseInput = {
+  centerGoal: '바이브 코딩',
+  subGoals: ['기초', '심화'],
+  focusTags: [],
+  targetLevel: 'standard',
+  language: 'ko' as const,
+  env: { OPENROUTER_API_KEY: 'k' } as unknown as NodeJS.ProcessEnv,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetV5ConfigForTest();
+  buildRuleBasedQueriesSync.mockReturnValue([
+    { query: '바이브 코딩 기초', source: 'subgoal', cellIndex: 0 },
+    { query: '바이브 코딩 심화 희귀주제', source: 'subgoal', cellIndex: 1 },
+  ]);
+});
+
+describe('computeWeakCells (pure)', () => {
+  it('selects cells strictly below the threshold; failed/0-raw cells included', () => {
+    const m = new Map([
+      [0, 30],
+      [1, 7],
+      [2, 0],
+      [3, 8],
+    ]);
+    expect(computeWeakCells(m, 8)).toEqual([1, 2]); // 8 itself is NOT weak
+  });
+});
+
+describe('translate fail-open (real impl)', () => {
+  it('parse mismatch / missing key / empty value → null', () => {
+    const targets = [{ cellIndex: 1, query: 'q' }];
+    expect(parseEnTranslateResponse('not-json', targets)).toBeNull();
+    expect(parseEnTranslateResponse('{"9":"x"}', targets)).toBeNull();
+    expect(parseEnTranslateResponse('{"1":""}', targets)).toBeNull();
+    expect(parseEnTranslateResponse('{"1":"vibe coding basics"}', targets)?.get(1)).toBe(
+      'vibe coding basics'
+    );
+  });
+
+  it('LLM throw → null (caller skips EN pass)', async () => {
+    const out = await realTranslate([{ cellIndex: 1, query: 'q' }], {
+      generateImpl: async () => {
+        throw new Error('503');
+      },
+    });
+    expect(out).toBeNull();
+  });
+
+  it('no key and no impl → null', async () => {
+    expect(await realTranslate([{ cellIndex: 1, query: 'q' }], {})).toBeNull();
+  });
+});
+
+describe('fanout EN pass integration', () => {
+  it('ko+ON: only the weak cell is translated + fired (KR region, NO relevanceLanguage), results merge into its cell', async () => {
+    // cell0 rich (30 raw), cell1 weak (0 raw)
+    searchVideos.mockImplementation(({ query }: { query: string }) =>
+      Promise.resolve(
+        query.startsWith('바이브 코딩 기초')
+          ? koItems(30, 'rich')
+          : query === 'vibe coding advanced rare topic'
+            ? [item('en-1', 'Vibe Coding Advanced Rare Topic Guide')]
+            : []
+      )
+    );
+    translateQueriesToEn.mockResolvedValue(new Map([[1, 'vibe coding advanced rare topic']]));
+
+    const res = await runYouTubeFanout({ ...baseInput, includeEnCards: true });
+
+    // translate got ONLY the weak cell's query
+    expect(translateQueriesToEn).toHaveBeenCalledTimes(1);
+    expect(translateQueriesToEn.mock.calls[0][0]).toEqual([
+      { cellIndex: 1, query: '바이브 코딩 심화 희귀주제' },
+    ]);
+
+    // 2 ko calls + 1 EN call; the EN call = KR region, relevanceLanguage absent
+    expect(searchVideos).toHaveBeenCalledTimes(3);
+    const enCall = searchVideos.mock.calls[2][0];
+    expect(enCall.query).toBe('vibe coding advanced rare topic');
+    expect(enCall.regionCode).toBe('KR');
+    expect(enCall.relevanceLanguage).toBeUndefined();
+
+    // EN candidate merged with the weak cell's index
+    const en = res.candidates.find((c) => c.videoId === 'en-1');
+    expect(en?.cellIndex).toBe(1);
+
+    expect(res.enPass).toMatchObject({
+      fired: true,
+      translated: true,
+      weakCells: [1],
+      queriesFired: 1,
+      candidatesAdded: 1,
+    });
+    // quota counts the EN pass (+100u per fired query)
+    expect(res.quotaUnitsApprox).toBe((2 + 1) * 100);
+    // perQuery carries the EN entry
+    expect(res.perQuery.find((q) => q.source === 'en_pass')?.cellIndex).toBe(1);
+  });
+
+  it('ko+OFF: single pass — translate never called, no extra search', async () => {
+    searchVideos.mockResolvedValue(koItems(2, 'q'));
+    const res = await runYouTubeFanout({ ...baseInput, includeEnCards: false });
+    expect(translateQueriesToEn).not.toHaveBeenCalled();
+    expect(searchVideos).toHaveBeenCalledTimes(2);
+    expect(res.enPass.fired).toBe(false);
+    expect(res.quotaUnitsApprox).toBe(200);
+  });
+
+  it('translation null (fail-open): EN pass skipped, ko results untouched', async () => {
+    searchVideos.mockResolvedValue([]); // every cell weak
+    translateQueriesToEn.mockResolvedValue(null);
+    const res = await runYouTubeFanout({ ...baseInput, includeEnCards: true });
+    expect(res.enPass).toMatchObject({ fired: false, translated: false });
+    expect(res.enPass.weakCells).toEqual([0, 1]);
+    expect(searchVideos).toHaveBeenCalledTimes(2); // no second pass
+  });
+});


### PR DESCRIPTION
## Why (hold withdrawn, James)

T1 measured `relevanceLanguage` omission = no effect (EN 7%→5%); the dominant variable is the **query language**. KO-absent domains exist → without an EN pass the toggle (and those mandalas) stay empty. Diagnosis B and this track fix different holes (KO-can't-scrape vs KO-doesn't-exist) — parallel, not competing.

## Design (approved spec, items 1–5)

1. **(B) translation call**: after the ko first pass, weak cells (`raw < V5_EN_PASS_RAW_THRESHOLD`, default 8, flag-tunable) get their queries translated in ONE fail-open Haiku-class call (`en-query-translate.ts`, strict same-keys JSON; any failure → null → EN pass silently skipped, **ko results never affected**).
2. **Weak-cell-only**: +100u per weak cell (vs +800u full-mandala) — the cut **auto-targets KO-absent domains**, no manual classification.
3. **Merge**: cellIndex-preserved append, identical gates + dedup + hardCap; cell binning unchanged. EN params: `regionCode KR`, **no relevanceLanguage**.
4. off-language gate: ko rules kept (EN passes, third-script blocked — T1 test-pinned).
5. Isolation: per-mandala toggle **default OFF**, ko-only; OFF = single pass bit-identical (test-pinned).

## Observability (prod verification surface)

`EnPassMeta {weakCells, translated, queriesFired, rawItems, candidatesAdded}` → FanoutResult → executor diagnostics → **`add_cards.end` trace `v5_en_pass`** + `tier2.search.list` trace rows show the EN queries/params.

## Tests

7 new (weak-cell math / 3× fail-open / weak-only fire with KR+no-relevanceLanguage + cell-preserved merge + quota / OFF single-pass / translation-null skip). **All 12 v5 suites green (84 tests)**, tsc clean.

## Verification plan (post-deploy, before T2)

KO-absent domain mandala (James picks) + toggle ON → expect `v5_en_pass.weakCells ≠ []`, EN candidates landing in those cells. Then **T2 (FE toggle)** — now non-deceptive.

## Rollback

Revert commit — toggle default OFF ⇒ path never taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)