### PR TITLE
fix(discover): EN search is EN-ONLY — replace-mode, mixing removed (James final re-correction, CP499+)

### DIFF
--- a/src/skills/plugins/video-discover/v2/keyword-builder.ts
+++ b/src/skills/plugins/video-discover/v2/keyword-builder.ts
@@ -71,7 +71,7 @@ export interface KeywordBuilderOpts {
   maxQueries?: number;
 }
 
-export type QuerySource = 'core' | 'llm' | 'focus' | 'level' | 'subgoal' | 'merged';
+export type QuerySource = 'core' | 'llm' | 'focus' | 'level' | 'subgoal' | 'merged' | 'en_only';
 
 export interface SearchQuery {
   query: string;

--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -73,12 +73,6 @@ const v5EnvSchema = z.object({
   // CP494 ④-1 — per-cell "full" threshold. ≥ this many grid cards → skip.
   // 12 favors "user may want to see more" (cells with 7-11 still searched).
   V5_CELL_SKIP_THRESHOLD: z.coerce.number().int().min(1).max(60).default(12),
-  // CP499+ EN pass ASSIGNMENT floor — when the toggle fired, reserve up to
-  // this many slots of each cell's candidate slice for EN candidates, so
-  // KO-rich cells (raw 23-40 >> perCell ~12) still surface SOME English
-  // ("toggle ON = English visible" — James verification criterion ③).
-  // 0 disables the floor (pre-floor binning, bit-identical).
-  V5_EN_FLOOR_PER_CELL: z.coerce.number().int().min(0).max(10).default(2),
   // CP494 안 A — pool match strategy. 'global' (default, current) runs ONE
   // centerGoal-OR tsquery with a global LIMIT (vocabulary-rich cells starve the
   // others = displacement). 'per_cell' runs each cell's own query with its own
@@ -120,8 +114,6 @@ export interface V5Config {
   cellSkip: boolean;
   /** CP494 ④-1 — per-cell card count threshold for skip. */
   cellSkipThreshold: number;
-  /** CP499+ EN pass — per-cell candidate slots reserved for EN when fired. */
-  enFloorPerCell: number;
   /** CP494 안 A — pool match strategy ('global' | 'per_cell'). */
   poolMatch: 'global' | 'per_cell';
 }
@@ -157,7 +149,6 @@ export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
     reuseLoop: p.V5_REUSE_LOOP,
     cellSkip: p.V5_CELL_SKIP,
     cellSkipThreshold: p.V5_CELL_SKIP_THRESHOLD,
-    enFloorPerCell: p.V5_EN_FLOOR_PER_CELL,
     poolMatch: p.V5_POOL_MATCH,
   };
   return cached;

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -203,12 +203,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
   let pickerModelStr = 'cell_binning';
 
   if (cfg.pickerMode === 'cell_binning') {
-    picksMerged = binByCells(
-      survivors,
-      cfg.targetPicks,
-      cfg.shortOverpickFactor,
-      fanout.enPass.fired ? cfg.enFloorPerCell : 0
-    );
+    picksMerged = binByCells(survivors, cfg.targetPicks, cfg.shortOverpickFactor);
     picksRawCount = picksMerged.length;
     stage.llmMs = Date.now() - tLlm0; // ~0 — no network call
   } else {
@@ -461,8 +456,7 @@ function chunk<T>(arr: T[], size: number): T[][] {
 export function binByCells(
   survivors: FanoutCandidate[],
   targetPicks: number,
-  overpickFactor: number,
-  enFloorPerCell = 0
+  overpickFactor: number
 ): PickResult[] {
   const byCell = new Map<number, FanoutCandidate[]>();
   for (const c of survivors) {
@@ -473,28 +467,6 @@ export function binByCells(
   }
   const cells = Array.from(byCell.keys()).sort((a, b) => a - b);
   const perCell = Math.ceil((targetPicks * overpickFactor) / Math.max(cells.length, 1));
-
-  // CP499+ EN floor (toggle ON only; 0 = pre-floor behaviour bit-identical).
-  // KO-rich buckets carry 23-40 KO before any EN, so a plain rank slice
-  // (perCell ~12) would NEVER surface EN there — defeating "toggle ON =
-  // English visible" (verification criterion ③). Reserve up to enFloorPerCell
-  // tail slots of each cell's slice for its first EN candidates: KO keeps the
-  // front (never displaced by more than the reserved tail), EN is guaranteed
-  // presence. Cells with fewer EN than the floor give the slots back to KO.
-  if (enFloorPerCell > 0) {
-    for (const [key, bucket] of byCell) {
-      const ens = bucket.filter((c) => c.fromEnPass);
-      if (ens.length === 0) continue;
-      const kos = bucket.filter((c) => !c.fromEnPass);
-      const reserved = Math.min(enFloorPerCell, ens.length, perCell);
-      byCell.set(key, [
-        ...kos.slice(0, Math.max(perCell - reserved, 0)),
-        ...ens.slice(0, reserved),
-        ...kos.slice(Math.max(perCell - reserved, 0)),
-        ...ens.slice(reserved),
-      ]);
-    }
-  }
 
   const out: PickResult[] = [];
   for (let r = 0; r < perCell; r += 1) {

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -90,8 +90,6 @@ export interface FanoutCandidate {
   publishedAt: string;
   thumbnailUrl: string;
   cellIndex: number | null;
-  /** CP499+ — candidate came from the EN query pass (assignment floor input). */
-  fromEnPass?: boolean;
 }
 
 /** CP491 F5c — per-query observability (raw count + q_ok), independent of dedup/hardcap. */
@@ -526,6 +524,55 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
     }
   }
 
+  // ── CP499+ EN-only search ('영문 카드 포함' re-corrected to EN-ONLY) ─────
+  // James final intent: the English action fetches ENGLISH CARDS ONLY — not a
+  // ko+en mix (mixing measured: KO crowds EN out). ON ⇒ the ko cell queries
+  // are translated (one fail-open LLM call) and REPLACE the live query set,
+  // so the run searches English only: no KO pass, no competition, and the
+  // quota cost is NEUTRAL (same N search.list calls as a normal run).
+  // Translation failure ⇒ fall back to the normal ko run (user gets results
+  // rather than nothing); meta records translated=false for the verdict.
+  // Empty/low-cell-first assignment is unchanged (binByCells round-robin).
+  const enOnly = Boolean(input.includeEnCards) && input.language === 'ko';
+  const enPass: EnPassMeta = {
+    fired: false,
+    cellsFired: [],
+    translated: false,
+    queriesFired: 0,
+    rawItems: 0,
+    candidatesAdded: 0,
+  };
+  if (enOnly && liveQueries.length > 0) {
+    const targetByCell = new Map<number, string>();
+    for (const q of liveQueries) {
+      if (typeof q.cellIndex === 'number' && !targetByCell.has(q.cellIndex)) {
+        targetByCell.set(q.cellIndex, q.query);
+      }
+    }
+    const targets = [...targetByCell.entries()].map(([cellIndex, query]) => ({
+      cellIndex,
+      query,
+    }));
+    const translated = targets.length
+      ? await translateQueriesToEn(targets, { apiKey: input.env['OPENROUTER_API_KEY'] })
+      : null;
+    if (translated) {
+      enPass.translated = true;
+      enPass.fired = true;
+      enPass.cellsFired = [...translated.keys()].sort((a, b) => a - b);
+      liveQueries = [...translated.entries()].map(([cellIndex, query]) => ({
+        query,
+        source: 'en_only',
+        cellIndex,
+      }));
+      enPass.queriesFired = liveQueries.length;
+      log.info(`v5 en-only: cells=[${enPass.cellsFired.join(',')}] queries=${liveQueries.length}`);
+    } else {
+      log.info('v5 en-only: translation unavailable — falling back to the ko run (fail-open)');
+    }
+  }
+  const enOnlyActive = enPass.fired;
+
   const results = await Promise.allSettled(
     liveQueries.map((q, i) =>
       searchVideos({
@@ -540,11 +587,9 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
         // keeping the rest as failover.
         apiKey: rotateKeys(apiKeys, i),
         maxResults: cfg.searchMaxResults,
-        // CP499+ toggle — ON drops the ko bias so EN candidates can actually
-        // enter live results (the pool is 5.9% EN; live is the supply body).
-        // searchVideos omits the param when undefined (youtube-client :223).
-        relevanceLanguage:
-          input.includeEnCards && input.language === 'ko' ? undefined : input.language,
+        // CP499+ EN-only — the run searches English: bias to 'en'. regionCode
+        // stays KR ("EN content consumed in Korea" slant, James-approved).
+        relevanceLanguage: enOnlyActive ? 'en' : input.language,
         // CP492 — region bias (ko→KR, en→US). relevanceLanguage alone is a soft
         // hint YouTube ignores for sparse queries (it backfilled "드리블 핸들링"
         // with a high-view Chinese drama). regionCode nudges toward the locale;
@@ -559,6 +604,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
   let rawItemCount = 0;
   let queriesSucceeded = 0;
   let offLangDropped = 0;
+  let liveAdded = 0;
   const seen = new Map<string, FanoutCandidate>();
 
   // CP494 — seed pool candidates first (already gate-filtered above) so they get
@@ -585,117 +631,29 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       // high-view global content (Chinese dramas on a Korean basketball query).
       // Conservative: only drop titles dominated by a non-target script (see
       // isOffLanguageTitle) so English-titled or Hanja-mixed Korean content is kept.
-      if (isOffLanguageTitleToggled(cand.title, input.language, input.includeEnCards)) {
+      // EN-only: the result set must be English — drop hangul titles outright
+      // (the en script-gate alone only blocks CJK Han and would pass Korean).
+      if (
+        enOnlyActive
+          ? /[가-힣]/.test(cand.title)
+          : isOffLanguageTitleToggled(cand.title, input.language, input.includeEnCards)
+      ) {
         offLangDropped += 1;
         continue;
       }
       seen.set(cand.videoId, cand);
+      liveAdded += 1;
       if (seen.size >= cfg.dedupHardCap) break;
     }
     if (seen.size >= cfg.dedupHardCap) break;
   }
 
-  // ── CP499+ EN query pass ('영문 카드 포함') — fire/assign separation ─────
-  // James re-correction (2026-06-10): FIRE is unconditional — the toggle is
-  // an explicit user request for English, so every searched cell gets its EN
-  // query (+100u each, ON-only). The earlier weak-cell cut belonged to
-  // ASSIGNMENT, not firing (it silenced the pass on KO-rich domains).
-  // Assignment priority lives downstream in binByCells: per-cell buckets keep
-  // insertion order (KO first, EN appended) + rank round-robin → KO-poor
-  // cells reach their EN entries at shallow ranks while KO-rich cells keep KO
-  // in front — EN supplements, never displaces. Per-cell ceiling stays with
-  // the cellSkip(12) gate.
-  const enPass: EnPassMeta = {
-    fired: false,
-    cellsFired: [],
-    translated: false,
-    queriesFired: 0,
-    rawItems: 0,
-    candidatesAdded: 0,
-  };
-  const enPerQuery: FanoutPerQuery[] = [];
-  if (input.includeEnCards && input.language === 'ko' && liveQueries.length > 0) {
-    const targetByCell = new Map<number, string>();
-    for (const q of liveQueries) {
-      if (typeof q.cellIndex === 'number' && !targetByCell.has(q.cellIndex)) {
-        targetByCell.set(q.cellIndex, q.query);
-      }
-    }
-    enPass.cellsFired = [...targetByCell.keys()].sort((a, b) => a - b);
-
-    if (targetByCell.size > 0) {
-      const targets = [...targetByCell.entries()].map(([cellIndex, query]) => ({
-        cellIndex,
-        query,
-      }));
-      const translated = await translateQueriesToEn(targets, {
-        apiKey: input.env['OPENROUTER_API_KEY'],
-      });
-
-      if (translated) {
-        enPass.translated = true;
-        enPass.fired = true;
-        const enResults = await Promise.allSettled(
-          [...translated.entries()].map(([cellIndex, query], i) =>
-            searchVideos({
-              query,
-              apiKey: rotateKeys(apiKeys, liveQueries.length + i),
-              maxResults: cfg.searchMaxResults,
-              // No language bias on purpose; regionCode KR keeps the
-              // "EN content consumed in Korea" slant (James-approved).
-              regionCode: 'KR',
-              timeoutMs: cfg.searchTimeoutMs,
-              publishedAfter: input.publishedAfter,
-            }).then((items) => ({ items, cellIndex, query }))
-          )
-        );
-        enPass.queriesFired = targets.length;
-
-        for (const r of enResults) {
-          if (r.status !== 'fulfilled') {
-            enPerQuery.push({
-              query: '(en-pass)',
-              source: 'en_pass',
-              cellIndex: null,
-              rawCount: 0,
-              fulfilled: false,
-            });
-            continue;
-          }
-          const { items, cellIndex, query } = r.value;
-          enPerQuery.push({
-            query,
-            source: 'en_pass',
-            cellIndex,
-            rawCount: items.length,
-            fulfilled: true,
-          });
-          for (const it of items) {
-            enPass.rawItems += 1;
-            rawItemCount += 1;
-            const cand = toFanoutCandidate(it, cellIndex);
-            if (!cand) continue;
-            if (seen.has(cand.videoId)) continue;
-            if (titleHitsBlocklist(cand.title) || titleIndicatesShorts(cand.title)) continue;
-            if (isOffLanguageTitleToggled(cand.title, input.language, input.includeEnCards)) {
-              offLangDropped += 1;
-              continue;
-            }
-            seen.set(cand.videoId, { ...cand, fromEnPass: true });
-            enPass.candidatesAdded += 1;
-            if (seen.size >= cfg.dedupHardCap) break;
-          }
-          if (seen.size >= cfg.dedupHardCap) break;
-        }
-        log.info(
-          `v5 en-pass: cells=[${enPass.cellsFired.join(',')}] fired=${enPass.queriesFired} raw=${enPass.rawItems} added=${enPass.candidatesAdded}`
-        );
-      } else {
-        log.info(
-          `v5 en-pass: ON for cells [${enPass.cellsFired.join(',')}] but translation unavailable — skipped (fail-open)`
-        );
-      }
-    }
+  // EN-only observability: in replace-mode the main loop IS the EN pass.
+  // (Pool seeds are not hangul-purged here — V5_POOL_* is OFF in prod; the
+  // pool×en-only interplay is a TODO for the pool re-enable track.)
+  if (enOnlyActive) {
+    enPass.rawItems = rawItemCount;
+    enPass.candidatesAdded = liveAdded;
   }
 
   // CP491 F5c — per-query raw count + q_ok, computed independently of the
@@ -717,12 +675,13 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
     candidates: Array.from(seen.values()),
     // CP494 — attempted/quota now reflect ONLY the live queries actually fired
     // (pool-satisfied cells dropped theirs). poolBackfill carries the delta.
-    // CP499+ — the EN pass adds its fired queries to quota (100u each).
+    // CP499+ EN-only is REPLACE-mode: liveQueries already is the fired set
+    // (EN when ON+translated, ko otherwise) — quota is N×100 either way.
     queriesAttempted: liveQueries.length,
     queriesSucceeded,
     rawItemCount,
-    quotaUnitsApprox: (liveQueries.length + enPass.queriesFired) * 100,
-    perQuery: [...perQuery, ...enPerQuery],
+    quotaUnitsApprox: liveQueries.length * 100,
+    perQuery,
     queryGenMs,
     queryGen,
     offLangDropped,

--- a/tests/unit/skills/video-discover/v5-en-pass.test.ts
+++ b/tests/unit/skills/video-discover/v5-en-pass.test.ts
@@ -1,15 +1,16 @@
 /**
- * CP499+ EN query pass — fire/assign separation (James re-correction).
+ * CP499+ EN-ONLY search ('영문 카드 포함' — James final re-correction).
  *
- * FIRE: toggle ON ⇒ EVERY searched cell gets its EN query (unconditional —
- * the toggle is an explicit user request for English). No weak-cell gate.
- * ASSIGN: EN supplements, never displaces — per-cell buckets keep insertion
- * order (KO first, EN appended) and binByCells round-robins by rank, so
- * KO-poor cells reach EN at shallow ranks while KO-rich cells keep KO ahead.
+ * Intent: the English action fetches ENGLISH CARDS ONLY — not a ko+en mix
+ * (mixing measured: KO crowds EN out; floor/mix binning removed). ON ⇒ the
+ * ko cell queries are translated and REPLACE the live set: no KO pass, no
+ * competition, quota-NEUTRAL (same N search.list calls). Translation failure
+ * ⇒ fall back to the normal ko run (results over nothing). Empty/low-cell
+ * priority is unchanged (binByCells round-robin over per-cell buckets).
  *
- * Pins: fire-all / EN params (KR + no relevanceLanguage) / cell-preserved
- * merge / OFF bit-identical / translate fail-open skip / binByCells
- * assignment invariants (KO-before-EN in a rich cell; EN early in a poor cell).
+ * Pins: replace-mode fire (ko queries NOT searched) / EN params (rl=en,
+ * KR region) / hangul titles dropped from results / cellIndex preserved /
+ * OFF bit-identical / translation-null ko fallback.
  */
 
 jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
@@ -45,9 +46,7 @@ const { translateQueriesToEn } = jest.requireMock(
 );
 
 import { runYouTubeFanout } from '@/skills/plugins/video-discover/v5/youtube-fanout';
-import { binByCells } from '@/skills/plugins/video-discover/v5/executor';
 import { parseEnTranslateResponse } from '@/skills/plugins/video-discover/v5/en-query-translate';
-import type { FanoutCandidate } from '@/skills/plugins/video-discover/v5/youtube-fanout';
 
 const { translateQueriesToEn: realTranslate } = jest.requireActual(
   '@/skills/plugins/video-discover/v5/en-query-translate'
@@ -64,8 +63,6 @@ const item = (id: string, title: string) => ({
     thumbnails: { high: { url: 'u' } },
   },
 });
-const koItems = (n: number, p: string) =>
-  Array.from({ length: n }, (_, i) => item(`${p}-${i}`, `한국어 영상 ${p} ${i}`));
 
 const baseInput = {
   centerGoal: '바이브 코딩',
@@ -101,39 +98,44 @@ describe('translate fail-open (real impl)', () => {
   });
 });
 
-describe('fanout EN pass — FIRE is unconditional on the toggle', () => {
-  it('ko+ON: EVERY cell is translated + fired, even KO-rich ones (no weak gate)', async () => {
-    // BOTH cells rich (30 raw each) — pre-correction code would fire nothing.
-    searchVideos.mockImplementation(({ query }: { query: string }) =>
-      Promise.resolve(
-        query === 'vibe coding basics'
-          ? [item('en-0', 'Vibe Coding Basics in English')]
-          : query === 'vibe coding advanced'
-            ? [item('en-1', 'Advanced Vibe Coding Guide')]
-            : koItems(30, query.includes('기초') ? 'rich0' : 'rich1')
-      )
-    );
+describe('EN-only replace mode', () => {
+  it('ON: ko queries are NOT searched — EN queries replace them (quota-neutral), rl=en + KR region', async () => {
     translateQueriesToEn.mockResolvedValue(
       new Map([
         [0, 'vibe coding basics'],
         [1, 'vibe coding advanced'],
       ])
     );
+    searchVideos.mockImplementation(({ query }: { query: string }) =>
+      Promise.resolve(
+        query === 'vibe coding basics'
+          ? [item('en-0', 'Vibe Coding Basics'), item('ko-x', '한국어 섞임 영상')]
+          : [item('en-1', 'Advanced Vibe Coding')]
+      )
+    );
 
     const res = await runYouTubeFanout({ ...baseInput, includeEnCards: true });
 
-    expect(translateQueriesToEn).toHaveBeenCalledTimes(1);
-    expect(translateQueriesToEn.mock.calls[0][0]).toEqual([
-      { cellIndex: 0, query: '바이브 코딩 기초' },
-      { cellIndex: 1, query: '바이브 코딩 심화' },
-    ]);
-
-    // 2 ko + 2 EN calls; EN calls carry KR region and NO relevanceLanguage
-    expect(searchVideos).toHaveBeenCalledTimes(4);
-    for (const call of searchVideos.mock.calls.slice(2)) {
-      expect(call[0].regionCode).toBe('KR');
-      expect(call[0].relevanceLanguage).toBeUndefined();
+    // exactly 2 searches — the EN ones; quota neutral
+    expect(searchVideos).toHaveBeenCalledTimes(2);
+    const queries = searchVideos.mock.calls.map(
+      (c: unknown[]) => (c[0] as { query: string }).query
+    );
+    expect(queries.sort()).toEqual(['vibe coding advanced', 'vibe coding basics']);
+    for (const c of searchVideos.mock.calls) {
+      expect(c[0].relevanceLanguage).toBe('en');
+      expect(c[0].regionCode).toBe('KR');
     }
+    expect(res.quotaUnitsApprox).toBe(200);
+
+    // English-only result set: the hangul title is dropped
+    const ids = res.candidates.map((c) => c.videoId).sort();
+    expect(ids).toEqual(['en-0', 'en-1']);
+    expect(res.offLangDropped).toBe(1);
+
+    // cellIndex preserved through translation
+    expect(res.candidates.find((c) => c.videoId === 'en-0')?.cellIndex).toBe(0);
+    expect(res.candidates.find((c) => c.videoId === 'en-1')?.cellIndex).toBe(1);
 
     expect(res.enPass).toMatchObject({
       fired: true,
@@ -142,71 +144,36 @@ describe('fanout EN pass — FIRE is unconditional on the toggle', () => {
       queriesFired: 2,
       candidatesAdded: 2,
     });
-    expect(res.candidates.find((c) => c.videoId === 'en-0')?.cellIndex).toBe(0);
-    expect(res.candidates.find((c) => c.videoId === 'en-1')?.cellIndex).toBe(1);
-    expect(res.quotaUnitsApprox).toBe((2 + 2) * 100);
+    expect(res.perQuery.every((q) => q.source === 'en_only')).toBe(true);
   });
 
-  it('ko+OFF: single pass bit-identical — no translate, no extra search', async () => {
-    searchVideos.mockResolvedValue(koItems(2, 'q'));
+  it('OFF: bit-identical normal ko run — no translate call', async () => {
+    searchVideos.mockResolvedValue([item('ko-1', '한국어 영상')]);
     const res = await runYouTubeFanout({ ...baseInput, includeEnCards: false });
     expect(translateQueriesToEn).not.toHaveBeenCalled();
     expect(searchVideos).toHaveBeenCalledTimes(2);
+    expect(searchVideos.mock.calls[0][0].relevanceLanguage).toBe('ko');
     expect(res.enPass.fired).toBe(false);
-    expect(res.quotaUnitsApprox).toBe(200);
+    expect(res.candidates.map((c) => c.videoId)).toContain('ko-1');
   });
 
-  it('translation null (fail-open): EN pass skipped, ko results untouched', async () => {
-    searchVideos.mockResolvedValue(koItems(3, 'q'));
+  it('translation null: falls back to the normal ko run (results over nothing)', async () => {
     translateQueriesToEn.mockResolvedValue(null);
+    searchVideos.mockResolvedValue([item('ko-1', '한국어 영상')]);
     const res = await runYouTubeFanout({ ...baseInput, includeEnCards: true });
-    expect(res.enPass).toMatchObject({ fired: false, translated: false, cellsFired: [0, 1] });
-    expect(searchVideos).toHaveBeenCalledTimes(2);
-  });
-});
-
-describe('binByCells ASSIGN — EN supplements, never displaces (James spec 2)', () => {
-  const cand = (videoId: string, cellIndex: number): FanoutCandidate => ({
-    videoId,
-    title: videoId,
-    description: '',
-    channelTitle: '',
-    channelId: '',
-    publishedAt: '',
-    thumbnailUrl: '',
-    cellIndex,
-    fromEnPass: videoId.startsWith('en'),
+    const queries = searchVideos.mock.calls.map(
+      (c: unknown[]) => (c[0] as { query: string }).query
+    );
+    expect(queries).toEqual(['바이브 코딩 기초', '바이브 코딩 심화']); // ko queries ran
+    expect(res.enPass).toMatchObject({ fired: false, translated: false });
+    expect(res.candidates.map((c) => c.videoId)).toContain('ko-1'); // user still gets cards
   });
 
-  it('KO-rich cell keeps KO ahead of EN; KO-poor cell receives EN at shallow rank', () => {
-    // cell 0: 4 KO then 1 EN appended; cell 1: 1 KO then 1 EN appended.
-    const survivors = [
-      cand('ko0-a', 0),
-      cand('ko0-b', 0),
-      cand('ko0-c', 0),
-      cand('ko0-d', 0),
-      cand('ko1-a', 1),
-      cand('en0-x', 0),
-      cand('en1-x', 1),
-    ];
-    // floor=0 (OFF / pre-floor): tight budget drops the rich cell's EN.
-    const noFloor = binByCells(survivors, 8, 1, 0).map((p) => p.videoId);
-    expect(noFloor).not.toContain('en0-x');
-    expect(noFloor).toContain('en1-x');
-
-    // ★ floor=2 (toggle fired): the rich cell now SURFACES its EN inside the
-    // slice (criterion ③ — "toggle ON = English visible" even in KO-rich
-    // cells) while KO keeps the slice front (only the reserved tail yields).
-    const floored = binByCells(survivors, 8, 1, 2).map((p) => p.videoId);
-    expect(floored).toContain('en0-x');
-    expect(floored.indexOf('en0-x')).toBeGreaterThan(floored.indexOf('ko0-c')); // KO front intact
-    expect(floored).toContain('en1-x');
-    expect(floored.indexOf('en1-x')).toBeGreaterThan(floored.indexOf('ko1-a'));
-  });
-
-  it('floor gives unused EN slots back to KO (cell with no EN unchanged)', () => {
-    const survivors = [cand('ko-a', 0), cand('ko-b', 0), cand('ko-c', 0), cand('ko-d', 0)];
-    const out = binByCells(survivors, 4, 1, 2).map((p) => p.videoId);
-    expect(out).toEqual(['ko-a', 'ko-b', 'ko-c', 'ko-d']);
+  it('en mandala: toggle is a no-op (en path unchanged)', async () => {
+    searchVideos.mockResolvedValue([item('en-a', 'English Video')]);
+    const res = await runYouTubeFanout({ ...baseInput, language: 'en', includeEnCards: true });
+    expect(translateQueriesToEn).not.toHaveBeenCalled();
+    expect(searchVideos.mock.calls[0][0].relevanceLanguage).toBe('en');
+    expect(res.enPass.fired).toBe(false);
   });
 });

--- a/tests/unit/skills/video-discover/v5-fanout.test.ts
+++ b/tests/unit/skills/video-discover/v5-fanout.test.ts
@@ -88,7 +88,11 @@ describe('runYouTubeFanout — F5c perQuery', () => {
     expect(res.candidates).toHaveLength(8); // 5 + 3, all unique
   });
 
-  test("CP499+ '영문 카드 포함': ko+ON drops relevanceLanguage; ko+OFF keeps 'ko' (the toggle's effective lever)", async () => {
+  test("CP499+ '영문 카드 포함' EN-only: ON without translation (no key) falls back to the ko run; OFF keeps 'ko'", async () => {
+    // No OPENROUTER_API_KEY in env → translateQueriesToEn fail-opens to null
+    // → the run falls back to the normal ko pass (relevanceLanguage 'ko').
+    // The EN-only success path (rl='en', replace-mode) is pinned in
+    // v5-en-pass.test.ts.
     buildRuleBasedQueriesSync.mockReturnValue([{ query: 'q0', source: 'core', cellIndex: null }]);
     searchVideos.mockResolvedValue(items(2, 'q'));
     const base = {
@@ -102,7 +106,7 @@ describe('runYouTubeFanout — F5c perQuery', () => {
 
     await runYouTubeFanout({ ...base, includeEnCards: true });
     for (const call of searchVideos.mock.calls) {
-      expect(call[0].relevanceLanguage).toBeUndefined(); // ko bias dropped -> EN can enter
+      expect(call[0].relevanceLanguage).toBe('ko'); // fail-open ko fallback
     }
 
     searchVideos.mockClear();


### PR DESCRIPTION
## Final intent (James)

영문 검색 = **영어 카드만** 가져오는 별도 액션. ko+en 섞기는 자기-패배적 (KO 가 EN 을 밀어냄 — floor 는 틀린 전제의 보상 장치였음).

## Changes vs #894 (already merged — this PR amends on top)

- **Replace-mode**: ON(ko 만다라) → 생성된 ko 셀 쿼리를 번역해 **live 쿼리 세트를 대체**. KO 패스 자체가 안 돎 → 경쟁 0, **쿼터 중립** (일반 런과 동일 N콜). 번역 실패 → 정상 ko 런 폴백 (빈손 방지, meta `translated=false`).
- **EN 순도**: `relevanceLanguage='en'` (+regionCode KR 슬랜트 유지) + 병합 게이트에서 **한글 제목 drop** (en 스크립트 게이트만으론 한국어가 통과).
- **과잉설계 제거**: `V5_EN_FLOOR_PER_CELL`·binByCells floor·`fromEnPass` 마커 전부 삭제 (binByCells 원형 복원). 빈/적은 셀 우선 배정은 per-cell 버킷 round-robin 의 고유 성질.
- `QuerySource` += `'en_only'` (perQuery 관측).
- 코드 명기된 한계: pool seed 는 EN-only 에서 한글-purge 안 함 (prod V5_POOL_* OFF; pool 재가동 트랙 TODO).

## Tests

5 재작성 + v5-fanout 1 갱신: replace-mode (ko 쿼리 미발사) / rl=en+KR / 한글 결과 drop / cellIndex 보존 / OFF bit-identical / 번역-실패 ko 폴백 / en 만다라 no-op. **v5 전 스위트 82 green**, tsc clean.

## Verification (post-deploy)

바이브 코딩 만다라 (토글 ON 유지됨) add-cards 1회 → 후보 전부 영어 + `cellsFired=[0..7]` + 빈/적은 셀 우선 배치. **영어만 나오면 끝** (floor/섞기 검증 불요 — James). PASS → T2.

## Rollback

Revert — toggle default OFF ⇒ path never taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)