### PR TITLE
fix(discover): EN translate parser — fence/brace strip + partial-lenient (prod-caught, CP499+)

### DIFF
--- a/src/skills/plugins/video-discover/v5/en-query-translate.ts
+++ b/src/skills/plugins/video-discover/v5/en-query-translate.ts
@@ -41,23 +41,39 @@ export function buildEnTranslatePrompt(targets: EnTranslateTarget[]): string {
   ].join('\n');
 }
 
-/** Strict parse: same keys back, non-empty string values. Anything else → null. */
+/**
+ * Lenient parse, mirroring the PROVEN parsePerCellResponse (llm-query-gen):
+ * strip a markdown fence, extract the first {...} block, then accept any
+ * subset of the requested keys (partial translation ⇒ only those cells are
+ * searched this run — EN-only purity over coverage). Empty set ⇒ null.
+ * The original strict all-keys naive-JSON.parse version died on Haiku's
+ * fenced output in prod (2026-06-10 15:38 — call 200, parser null).
+ */
 export function parseEnTranslateResponse(
   raw: string,
   targets: EnTranslateTarget[]
 ): Map<number, string> | null {
+  let text = (raw ?? '').trim();
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fence?.[1]) text = fence[1].trim();
+  const brace = text.match(/\{[\s\S]*\}/);
+  if (brace) text = brace[0];
+
+  let obj: unknown;
   try {
-    const obj = JSON.parse(raw) as Record<string, unknown>;
-    const out = new Map<number, string>();
-    for (const t of targets) {
-      const v = obj[String(t.cellIndex)];
-      if (typeof v !== 'string' || v.trim().length === 0) return null;
-      out.set(t.cellIndex, v.trim());
-    }
-    return out;
+    obj = JSON.parse(text);
   } catch {
     return null;
   }
+  if (typeof obj !== 'object' || obj === null) return null;
+  const rec = obj as Record<string, unknown>;
+
+  const out = new Map<number, string>();
+  for (const t of targets) {
+    const v = rec[String(t.cellIndex)];
+    if (typeof v === 'string' && v.trim().length > 0) out.set(t.cellIndex, v.trim());
+  }
+  return out.size > 0 ? out : null;
 }
 
 /**

--- a/tests/unit/skills/video-discover/v5-en-pass.test.ts
+++ b/tests/unit/skills/video-discover/v5-en-pass.test.ts
@@ -83,9 +83,32 @@ beforeEach(() => {
 });
 
 describe('translate fail-open (real impl)', () => {
+  it('REGRESSION: fenced/prefixed Haiku output parses (prod 2026-06-10 15:38 — call 200, old parser null)', () => {
+    const targets = [
+      { cellIndex: 0, query: 'q0' },
+      { cellIndex: 1, query: 'q1' },
+    ];
+    const fenced =
+      'Here are the translations:\n```json\n{"0":"vibe coding basics","1":"advanced vibe coding"}\n```';
+    const out = parseEnTranslateResponse(fenced, targets);
+    expect(out?.get(0)).toBe('vibe coding basics');
+    expect(out?.get(1)).toBe('advanced vibe coding');
+  });
+
+  it('partial translation is accepted (only translated cells get searched)', () => {
+    const targets = [
+      { cellIndex: 0, query: 'q0' },
+      { cellIndex: 1, query: 'q1' },
+    ];
+    const out = parseEnTranslateResponse('{"0":"vibe coding basics"}', targets);
+    expect(out?.size).toBe(1);
+    expect(out?.get(0)).toBe('vibe coding basics');
+  });
+
   it('parse mismatch / LLM throw / no key → null', async () => {
     const targets = [{ cellIndex: 1, query: 'q' }];
     expect(parseEnTranslateResponse('not-json', targets)).toBeNull();
+    expect(parseEnTranslateResponse('{"9":"wrong-key-only"}', targets)).toBeNull();
     expect(parseEnTranslateResponse('{"1":"vibe coding"}', targets)?.get(1)).toBe('vibe coding');
     expect(
       await realTranslate(targets, {


### PR DESCRIPTION
## Prod-caught (verification run, vibe-coding toggle ON, 15:38–39)

Translate call **succeeded** (Haiku 200, 248→124 tokens) but the parser returned null → "translation unavailable" → ko fallback. Root: naive `JSON.parse(raw)` + strict all-keys vs Haiku's **markdown-fenced** output. The proven `parsePerCellResponse` (same model+format, working in prod) strips the fence + extracts the first `{...}` — now mirrored exactly.

- fence strip + brace extract before parse
- **partial translation accepted**: only translated cells searched this run (EN-only purity over coverage); empty → null (ko fallback)

Tests +2 (fenced prod-repro / partial). All v5 suites green (84), tsc clean.

Verification after deploy: same 1-click on vibe-coding → 전부 영어 + 한글 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)