### PR TITLE
feat(add-cards): T2 — language chip (한/영) + round TABS (CP499+)

### DIFF
--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -81,17 +81,10 @@
     "recentActivity": "Recent Activity",
     "noActivity": "No activity yet",
     "modal": {
-      "aiTemplate": "Insighta AI Template",
-      "copyLink": "Copy link",
-      "start": "Start with this template",
-      "starting": "Starting…",
-      "whatNextLabel": "When you start with this template",
-      "whatNext1": "9×9 structure cloned automatically",
-      "whatNext2": "AI places 3 videos per cell",
-      "whatNext3": "Land on the dashboard, ready to watch",
-      "startedCount": "{{count}} started",
-      "cloneCount": "{{count}} clones",
-      "updatedAt": "Updated {{date}}"
+      "clone": "Clone to My Mandalas",
+      "copyLink": "Copy Link",
+      "improve": "Improve with AI",
+      "loading": "Loading full mandala..."
     },
     "hero": {
       "badge": "Explore Mandalas",
@@ -152,12 +145,6 @@
       "dAgo": "d ago",
       "wAgo": "w ago",
       "moAgo": "mo ago"
-    },
-    "modal": {
-      "clone": "Clone to My Mandalas",
-      "copyLink": "Copy Link",
-      "improve": "Improve with AI",
-      "loading": "Loading full mandala..."
     },
     "sharePrompt": {
       "title": "Share yours too!",
@@ -1930,6 +1917,11 @@
         "30d": "Past month",
         "180d": "Past 6 months",
         "365d": "Past year"
+      },
+      "language": {
+        "label": "Language",
+        "ko": "Korean",
+        "en": "English"
       }
     },
     "targetLevel": {
@@ -1946,7 +1938,9 @@
     "round": {
       "first": "Round 1",
       "nth": "Round {{n}} (more)",
-      "foundCount": "{{count}} new"
+      "foundCount": "{{count}} new",
+      "tablist": "Search rounds",
+      "activePanel": "Active round results"
     }
   }
 }

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -81,17 +81,10 @@
     "recentActivity": "최근 활동",
     "noActivity": "아직 활동이 없습니다",
     "modal": {
-      "aiTemplate": "Insighta AI 템플릿",
+      "clone": "내 만다라로 복제",
       "copyLink": "링크 복사",
-      "start": "이 템플릿으로 시작",
-      "starting": "시작하는 중…",
-      "whatNextLabel": "이 템플릿으로 시작하면",
-      "whatNext1": "9×9 구조 자동 복제",
-      "whatNext2": "AI가 셀마다 영상 3개 배치",
-      "whatNext3": "대시보드 도착, 바로 시청",
-      "startedCount": "{{count}}명이 시작함",
-      "cloneCount": "{{count}}회 복제",
-      "updatedAt": "업데이트 {{date}}"
+      "improve": "AI로 개선하기",
+      "loading": "전체 만다라 로딩 중..."
     },
     "hero": {
       "badge": "만다라트 탐색",
@@ -152,12 +145,6 @@
       "dAgo": "일 전",
       "wAgo": "주 전",
       "moAgo": "개월 전"
-    },
-    "modal": {
-      "clone": "내 만다라로 복제",
-      "copyLink": "링크 복사",
-      "improve": "AI로 개선하기",
-      "loading": "전체 만다라 로딩 중..."
     },
     "sharePrompt": {
       "title": "나의 만다라트도 공유해보세요!",
@@ -1938,6 +1925,11 @@
         "30d": "지난 1개월",
         "180d": "지난 6개월",
         "365d": "지난 1년"
+      },
+      "language": {
+        "label": "언어",
+        "ko": "한국어",
+        "en": "English"
       }
     },
     "targetLevel": {
@@ -1954,7 +1946,9 @@
     "round": {
       "first": "1차 검색",
       "nth": "{{n}}차 추가 검색",
-      "foundCount": "{{count}}개 발견"
+      "foundCount": "{{count}}개 발견",
+      "tablist": "검색 라운드",
+      "activePanel": "선택한 라운드 결과"
     }
   }
 }

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1583,6 +1583,10 @@ class ApiClient {
     body: {
       extraKeywords: string[];
       excludeVideoIds: string[];
+      /** T2 (CP499+) — per-request language override for the EN-only search.
+       *  'en' = this search fetches English cards only (한/영 chip).
+       *  Absent = server falls back to the persisted config (DB-set mandalas). */
+      searchLanguage?: 'ko' | 'en';
       filters?: {
         minViewCount?: number;
         durationBucket?: 'short' | 'medium' | 'long' | 'xlong';

--- a/frontend/src/widgets/add-cards-panel/model/useAddCards.ts
+++ b/frontend/src/widgets/add-cards-panel/model/useAddCards.ts
@@ -36,6 +36,8 @@ export interface AddCardsFilters {
 
 interface AddCardsRequest {
   mandalaId: string;
+  /** T2 — 'en' = EN-only search for this request (한/영 chip). */
+  searchLanguage?: 'ko' | 'en';
   extraKeywords: string[];
   excludeVideoIds: string[];
   filters?: AddCardsFilters;
@@ -70,10 +72,11 @@ interface AddCardsResponseData {
 
 export function useAddCards() {
   return useMutation<AddCardsResponseData, Error, AddCardsRequest>({
-    mutationFn: async ({ mandalaId, extraKeywords, excludeVideoIds, filters }) => {
+    mutationFn: async ({ mandalaId, extraKeywords, excludeVideoIds, filters, searchLanguage }) => {
       const result = await apiClient.addCards(mandalaId, {
         extraKeywords,
         excludeVideoIds,
+        ...(searchLanguage && { searchLanguage }),
         ...(filters && { filters }),
       });
       return result.data;

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsFilters.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsFilters.tsx
@@ -98,7 +98,20 @@ function ChipRow<V extends string>({ label, presets, selectedValue, onSelect }: 
   );
 }
 
-export function AddCardsFilters() {
+interface AddCardsFiltersProps {
+  /** T2 (CP499+) — 한/영 search-language chip (ko mandalas only). Per-request
+   *  override semantics (option (a)): transient panel state, NOT persisted —
+   *  pressing 영 makes THIS search EN-only; reopening the panel resets to 한. */
+  searchLanguage?: 'ko' | 'en';
+  onSearchLanguageChange?: (v: 'ko' | 'en') => void;
+  showLanguageChips?: boolean;
+}
+
+export function AddCardsFilters({
+  searchLanguage = 'ko',
+  onSearchLanguageChange,
+  showLanguageChips = false,
+}: AddCardsFiltersProps = {}) {
   const { t } = useTranslation();
   const filters = useAddCardsPanelStore((s) => s.filters);
   const setFilters = useAddCardsPanelStore((s) => s.setFilters);
@@ -120,8 +133,29 @@ export function AddCardsFilters() {
   }));
   const publishedPresetsTr = PUBLISHED_PRESETS.map((p) => ({ ...p, defaultLabel: tr(p) }));
 
+  const languagePresets: ReadonlyArray<FacetPreset<'ko' | 'en'>> = [
+    {
+      value: 'ko',
+      labelKey: 'addCards.filters.language.ko',
+      defaultLabel: t('addCards.filters.language.ko', '한국어') as string,
+    },
+    {
+      value: 'en',
+      labelKey: 'addCards.filters.language.en',
+      defaultLabel: t('addCards.filters.language.en', 'English') as string,
+    },
+  ];
+
   return (
     <div className="py-1 space-y-0.5">
+      {showLanguageChips && onSearchLanguageChange && (
+        <ChipRow
+          label={t('addCards.filters.language.label', 'Language')}
+          presets={languagePresets}
+          selectedValue={searchLanguage}
+          onSelect={onSearchLanguageChange}
+        />
+      )}
       <ChipRow
         label={t('addCards.filters.viewCount.label', 'Views')}
         presets={viewPresetsTr}

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tabs.test.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tabs.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * T2 (CP499+, James 확정·드롭 금지) — rounds are TABS, not a scrolled stack.
+ * Pins: one tab per round (newest first) / only the ACTIVE round's cards
+ * render / newest round auto-activates on arrival / manual switch works.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { AddCardsList } from './AddCardsList';
+import type { AddCardsRound } from '../lib/persistence';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_k: string, d: string | object) => (typeof d === 'string' ? d : _k),
+  }),
+}));
+
+const card = (videoId: string) => ({
+  videoId,
+  title: videoId,
+  channel: 'ch',
+  thumbnail: null,
+  durationSec: 60,
+  viewCount: 10,
+  publishedAt: '2026-01-01T00:00:00Z',
+  score: 0.5,
+  cellIndex: 0,
+  source: 'realtime' as const,
+});
+
+const round = (id: string, at: string, ids: string[]): AddCardsRound => ({
+  id,
+  at,
+  cards: ids.map(card),
+});
+
+const baseProps = {
+  isLoading: false,
+  isError: false,
+  errorMessage: null,
+  hasSearched: true,
+  pickedSet: new Set<string>(),
+  isPickPending: false,
+  onPick: vi.fn(),
+};
+
+describe('AddCardsList — round tabs (T2)', () => {
+  const rounds = [
+    round('r2', '2026-06-10T12:30:00Z', ['new-a', 'new-b']), // newest first
+    round('r1', '2026-06-10T12:00:00Z', ['old-a']),
+  ];
+
+  it('renders one tab per round; ONLY the newest (active) round cards show', () => {
+    const { getAllByRole, queryByText, getByText } = render(
+      <AddCardsList {...baseProps} rounds={rounds} />
+    );
+    expect(getAllByRole('tab')).toHaveLength(2);
+    expect(getByText('new-a')).toBeTruthy(); // active round
+    expect(queryByText('old-a')).toBeNull(); // inactive round NOT rendered
+  });
+
+  it('clicking an older tab switches the visible round', () => {
+    const { getAllByRole, queryByText, getByText } = render(
+      <AddCardsList {...baseProps} rounds={rounds} />
+    );
+    fireEvent.click(getAllByRole('tab')[1]!); // "Round 1"
+    expect(getByText('old-a')).toBeTruthy();
+    expect(queryByText('new-a')).toBeNull();
+  });
+
+  it('a NEW round arriving auto-activates (user just searched)', () => {
+    const { rerender, getByText, queryByText } = render(
+      <AddCardsList {...baseProps} rounds={rounds} />
+    );
+    const withNew = [round('r3', '2026-06-10T13:00:00Z', ['fresh-a']), ...rounds];
+    rerender(<AddCardsList {...baseProps} rounds={withNew} />);
+    expect(getByText('fresh-a')).toBeTruthy();
+    expect(queryByText('new-a')).toBeNull();
+  });
+});

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
@@ -17,6 +17,7 @@
  * Spec: docs/design/add-cards-2026-05-18.md §6 + issue #785.
  */
 
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AlertCircle, Bookmark, Check, Loader2, RotateCw, X } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
@@ -57,6 +58,16 @@ export function AddCardsList({
 }: AddCardsListProps) {
   const { t } = useTranslation();
   const totalCards = rounds.reduce((n, r) => n + r.cards.length, 0);
+
+  // Active tab follows the NEWEST round: initial mount and every newly
+  // prepended round auto-activate rounds[0] (the user just searched — show
+  // them their result); manual tab clicks win until the next new round.
+  const newestRoundId = rounds[0]?.id ?? null;
+  const [activeRoundId, setActiveRoundId] = useState<string | null>(newestRoundId);
+  useEffect(() => {
+    setActiveRoundId(newestRoundId);
+  }, [newestRoundId]);
+  const activeRound = rounds.find((r) => r.id === activeRoundId) ?? rounds[0] ?? null;
 
   if (isLoading) {
     return (
@@ -106,63 +117,74 @@ export function AddCardsList({
     );
   }
 
-  // Total round count drives the per-round label. "1차 검색" is the
-  // OLDEST entry (last in newest-first array); each newer round above
-  // increments. With 3 rounds: rounds[0] = "3차 추가", rounds[1] =
-  // "2차 추가", rounds[2] = "1차 검색".
+  // T2 (CP499+, James 확정 — 드롭 금지) — rounds are TABS, not a vertical
+  // stack of separator sections: the cumulative model made users scroll past
+  // every earlier round to reach the newest. One tab per round (newest first,
+  // newest auto-active — including when a NEW round lands mid-session), only
+  // the active round's grid renders. Label semantics unchanged: "1차 검색" is
+  // the OLDEST entry (last in the newest-first array).
   const totalRounds = rounds.length;
 
   return (
     <div className="flex flex-col">
-      {rounds.map((round, idx) => {
-        const roundNumber = totalRounds - idx;
-        const isFirstRound = roundNumber === 1;
-        const label = isFirstRound
-          ? t('addCards.round.first', 'Round 1')
-          : t('addCards.round.nth', 'Round {{n}} (more)', { n: roundNumber });
-        return (
-          <section key={round.id} aria-label={label}>
-            <RoundSeparator label={label} foundCount={round.cards.length} roundAt={round.at} />
-            <ul className="grid grid-cols-3 gap-3 px-5 py-3 sm:px-6">
-              {round.cards.map((card) => (
-                <CardItem
-                  key={card.videoId}
-                  card={card}
-                  isPicked={pickedSet.has(card.videoId)}
-                  isPickPending={isPickPending}
-                  onPick={onPick}
-                />
-              ))}
-            </ul>
-          </section>
-        );
-      })}
-    </div>
-  );
-}
-
-function RoundSeparator({
-  label,
-  foundCount,
-  roundAt,
-}: {
-  label: string;
-  foundCount: number;
-  roundAt: string;
-}) {
-  const { t } = useTranslation();
-  const age = formatRelativeDate(roundAt);
-  return (
-    <div className="flex items-center gap-2 px-5 pt-3 pb-1 sm:px-6">
-      <span className="h-px flex-1 bg-border/50" aria-hidden="true" />
-      <span className="text-[11px] font-medium text-muted-foreground tracking-wide">
-        {label}{' '}
-        <span className="opacity-60">
-          ({t('addCards.round.foundCount', '{{count}} new', { count: foundCount })})
-        </span>
-        {age && <span className="ml-1 opacity-50">· {age}</span>}
-      </span>
-      <span className="h-px flex-1 bg-border/50" aria-hidden="true" />
+      <div
+        role="tablist"
+        aria-label={t('addCards.round.tablist', 'Search rounds')}
+        className="flex items-center gap-1.5 px-5 pt-3 pb-1 sm:px-6 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {rounds.map((round, idx) => {
+          const roundNumber = totalRounds - idx;
+          const label =
+            roundNumber === 1
+              ? t('addCards.round.first', 'Round 1')
+              : t('addCards.round.nth', 'Round {{n}} (more)', { n: roundNumber });
+          const isActive = round.id === activeRoundId;
+          return (
+            <button
+              key={round.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`add-cards-round-${round.id}`}
+              onClick={() => setActiveRoundId(round.id)}
+              className={cn(
+                'shrink-0 inline-flex items-center gap-1 h-7 rounded-full border px-3 text-[11.5px] font-medium transition-colors',
+                isActive
+                  ? 'bg-foreground text-background border-foreground'
+                  : 'bg-transparent text-foreground/80 border-border/50 hover:border-border hover:bg-foreground/[0.04]'
+              )}
+            >
+              {label}
+              <span className={cn('text-[10.5px]', isActive ? 'opacity-70' : 'opacity-50')}>
+                ({round.cards.length})
+              </span>
+            </button>
+          );
+        })}
+      </div>
+      {activeRound && (
+        <section
+          key={activeRound.id}
+          id={`add-cards-round-${activeRound.id}`}
+          role="tabpanel"
+          aria-label={t('addCards.round.activePanel', 'Active round results')}
+        >
+          <div className="px-5 pt-1 sm:px-6 text-[11px] text-muted-foreground">
+            {formatRelativeDate(activeRound.at)}
+          </div>
+          <ul className="grid grid-cols-3 gap-3 px-5 py-3 sm:px-6">
+            {activeRound.cards.map((card) => (
+              <CardItem
+                key={card.videoId}
+                card={card}
+                isPicked={pickedSet.has(card.videoId)}
+                isPickPending={isPickPending}
+                onPick={onPick}
+              />
+            ))}
+          </ul>
+        </section>
+      )}
     </div>
   );
 }

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -49,6 +49,16 @@ export function AddCardsPanel() {
 
   const mutation = useAddCards();
 
+  // T2 (CP499+) — 한/영 search-language chip, option (a) per James: transient
+  // per-panel-open state (NOT persisted). 영 = THIS search is EN-only;
+  // reopening the panel (or switching mandala) resets to 한. The persisted
+  // config (includeEnCards) stays as the server-side fallback when no
+  // explicit override is sent — the two coexist, request override wins.
+  const [searchLanguage, setSearchLanguage] = useState<'ko' | 'en'>('ko');
+  useEffect(() => {
+    setSearchLanguage('ko');
+  }, [open, mandalaId]);
+
   // CP489 Phase 4 — rounds[] (newest-first) replaces the flat restoredCards.
   // Each successful search PREPENDS a round so the cumulative result set
   // grows across "Search" clicks instead of replacing the prior batch (user
@@ -353,9 +363,12 @@ export function AddCardsPanel() {
       mandalaId,
       extraKeywords: keywords,
       excludeVideoIds: surfacedVideoIds,
+      // explicit override every time the chips are visible — 'ko' keeps a
+      // DB-toggled mandala deterministic from the UI (chip state wins).
+      searchLanguage,
       filters,
     });
-  }, [mandalaId, extraKeywords, filters, mutation, targetLevel, surfacedVideoIds]);
+  }, [mandalaId, extraKeywords, filters, mutation, targetLevel, surfacedVideoIds, searchLanguage]);
 
   // In-memory snapshot of the last cleared search — enables a quick "Show
   // previous results" undo when the user clicks 초기화 by mistake. Lost on
@@ -540,7 +553,11 @@ export function AddCardsPanel() {
           </div>
 
           <KeywordChipInput />
-          <AddCardsFilters />
+          <AddCardsFilters
+            searchLanguage={searchLanguage}
+            onSearchLanguageChange={setSearchLanguage}
+            showLanguageChips={mandalaMetaFromQuery?.language === 'ko'}
+          />
           <TargetLevelChips />
 
           <div className="flex items-center justify-end gap-2 px-5 py-2.5 sm:px-6">

--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -95,6 +95,10 @@ interface AddCardsFilters {
 }
 
 interface AddCardsBody {
+  /** T2 (CP499+) — per-request language override for the EN-only search.
+   *  'en' ⇒ this search is EN-only; 'ko' ⇒ force normal ko run; absent ⇒
+   *  fall back to the persisted config (DB-toggled mandalas keep working). */
+  searchLanguage?: 'ko' | 'en';
   extraKeywords?: string[];
   excludeVideoIds?: string[];
   filters?: AddCardsFilters;
@@ -292,20 +296,27 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           // (current behaviour preserved — the safe default).
           let includeEnCards = false;
           if (language === 'ko') {
-            const skillCfg = await prisma.user_skill_config
-              .findUnique({
-                where: {
-                  user_id_mandala_id_skill_type: {
-                    user_id: userId,
-                    mandala_id: mandalaId,
-                    skill_type: 'video_discover',
+            // T2 — explicit request override (한/영 chip) wins over the
+            // persisted config; absent = config fallback (option (a)).
+            const requested = request.body?.searchLanguage;
+            if (requested === 'en' || requested === 'ko') {
+              includeEnCards = requested === 'en';
+            } else {
+              const skillCfg = await prisma.user_skill_config
+                .findUnique({
+                  where: {
+                    user_id_mandala_id_skill_type: {
+                      user_id: userId,
+                      mandala_id: mandalaId,
+                      skill_type: 'video_discover',
+                    },
                   },
-                },
-                select: { config: true },
-              })
-              .catch(() => null);
-            includeEnCards =
-              (skillCfg?.config as Record<string, unknown> | null)?.['includeEnCards'] === true;
+                  select: { config: true },
+                })
+                .catch(() => null);
+              includeEnCards =
+                (skillCfg?.config as Record<string, unknown> | null)?.['includeEnCards'] === true;
+            }
           }
 
           const v5Result = await runV5Executor({


### PR DESCRIPTION
## T2 bundle (James-approved order) — **탭 포함 ✓ (드롭 금지 작업)**

### 1) 한/영 검색 언어 칩 — EN-only 의 FE 레버
- `AddCardsFilters` 에 Language ChipRow (기존 Views/Duration ChipRow 패턴 재사용), **ko 만다라에만 노출** (`mandalaMeta.language==='ko'`, pre-search 가용 — CP467 경로).
- **기본 상태 = 옵션 (a) 채택**: 패널-오픈 단위 transient, 기본 '한' — '영' 선택 시 그 패널 세션 동안 EN-only 검색, 패널 재오픈 시 '한' 리셋. **영속 안 함**. 검색-단위 리셋은 연속 영어 검색에 과한 마찰이라 패널-단위로 — PR 명시 요청 사항.
- **영속 구조와 무충돌**: 요청에 `searchLanguage` 명시 시 그것이 승리, 부재 시 `config.includeEnCards` fallback (DB-토글 만다라 동작 유지).
- 배선: 패널 state → `useAddCards` → api-client body → BE `add-cards` override (4파일).

### 2) 라운드 구분선 → 탭
- 라운드당 탭 1개 (최신 우선), **활성 라운드 그리드만 렌더** — 세로 누적 스크롤 제거.
- 새 라운드 도착 시 자동 활성 (방금 검색한 결과 즉시 표시), 수동 탭 클릭 존중. 라벨 의미 불변 (1차 = 최고(最古)). `RoundSeparator` 삭제. `role=tablist/tab/tabpanel`.

## Gates
- vitest **398 green** (+3 탭 regression: 렌더/전환/자동활성), FE tsc + build + **browser smoke** (/, /mandalas/new → 200) PASS, /verify marker ✓
- BE tsc clean, v5 suites green. ⚠️ `v3-upsert-slots` 로컬 실패는 **main 에서 stash 재현된 pre-existing** (로컬 env 의존; #893–896 CI 전부 green).

## Verification (post-deploy)
ko 만다라: 칩 노출 + '영' 선택 검색 → 영어 결과 / en 만다라: 칩 숨김. 탭: 2회 검색 → 탭 2개 + 전환.

## Rollback
Revert — en 만다라엔 칩 자체가 없고 schema 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)