### PR TITLE
fix(iks-embed): W3 — body-covering timeout + terminal external abort (#882 mirror, CP499+)

### DIFF
--- a/src/skills/plugins/iks-scorer/__tests__/embedding-body-timeout.test.ts
+++ b/src/skills/plugins/iks-scorer/__tests__/embedding-body-timeout.test.ts
@@ -1,0 +1,87 @@
+/**
+ * W3 (CP499+) — #882 mirror regression: the embed timeout must cover the
+ * BODY read (res.json()), not just headers, and an external pipeline abort
+ * must cancel an in-flight embed. Pre-fix, clearTimeout fired after headers
+ * → res.json() was untimed (the 86s/102.8s zombie measured on the
+ * goal-embed path before #882).
+ */
+
+const noopFn = jest.fn();
+const noopLogger = {
+  info: noopFn,
+  warn: noopFn,
+  error: noopFn,
+  debug: noopFn,
+  child: () => noopLogger,
+};
+jest.mock('@/utils/logger', () => ({ logger: noopLogger }));
+
+jest.mock('@/config/index', () => ({
+  config: {
+    iksEmbed: { provider: 'openrouter' },
+    openrouter: { apiKey: 'test-key' },
+    mandalaEmbed: {
+      openRouterBaseUrl: 'https://openrouter.ai/api/v1',
+      openRouterModel: 'qwen/qwen3-embedding-8b',
+      openRouterDimension: 4096,
+    },
+  },
+}));
+jest.mock('@/modules/llm/call-logger', () => ({ logLLMCall: jest.fn() }));
+jest.mock('@/modules/database', () => ({ getPrismaClient: () => ({}) }));
+jest.mock('@/modules/discover-tracing', () => ({ recordTrace: jest.fn() }));
+
+import { embedBatch } from '../embedding';
+
+/** A fetch whose RESPONSE BODY hangs until the request signal aborts. */
+function hangingBodyFetch(): typeof fetch {
+  return ((_url: string, init?: RequestInit) => {
+    const signal = init?.signal as AbortSignal | undefined;
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () =>
+        new Promise((_resolve, reject) => {
+          // never resolves on its own — only the abort signal ends it
+          signal?.addEventListener('abort', () =>
+            reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+          );
+        }),
+      text: () => Promise.resolve(''),
+    } as unknown as Response);
+  }) as unknown as typeof fetch;
+}
+
+describe('W3 — embed timeout covers the body read', () => {
+  jest.setTimeout(30000);
+
+  it('hanging res.json() is aborted by the per-call timer (no zombie); embedBatch null-fills', async () => {
+    // Pre-fix the timer was cleared after HEADERS, so a hanging body ran
+    // forever (the 86s/102.8s zombie class). Post-fix the timer covers the
+    // body read: every retry/fallback attempt aborts at timeoutMs and
+    // embedBatch settles with nulls instead of hanging.
+    const t0 = Date.now();
+    const out = await embedBatch(['text-a'], {
+      fetchImpl: hangingBodyFetch(),
+      timeoutMs: 200,
+    });
+    expect(out).toEqual([null]); // chunk failed, swallowed by design
+    expect(Date.now() - t0).toBeLessThan(15000); // retries+fallback, all timed
+  });
+
+  it('external pipeline abort is TERMINAL — no retries, no provider fallback', async () => {
+    const ac = new AbortController();
+    const t0 = Date.now();
+    const pending = embedBatch(['text-a'], {
+      fetchImpl: hangingBodyFetch(),
+      signal: ac.signal,
+      // generous per-call timer so ONLY the external abort can end it fast
+      timeoutMs: 20000,
+    });
+    setTimeout(() => ac.abort(), 50);
+    const out = await pending;
+    expect(out).toEqual([null]);
+    // well under timeoutMs and any retry chain — abort was terminal
+    expect(Date.now() - t0).toBeLessThan(5000);
+  });
+});

--- a/src/skills/plugins/iks-scorer/embedding.ts
+++ b/src/skills/plugins/iks-scorer/embedding.ts
@@ -86,6 +86,12 @@ export interface EmbeddingClientOptions {
   chunkSize?: number;
   /** Injectable fetch for testability. Defaults to global fetch. */
   fetchImpl?: typeof fetch;
+  /** Per-call timeout override (ms). Defaults to EMBED_TIMEOUT_MS. */
+  timeoutMs?: number;
+  /** W3 (CP499+) — external abort (e.g. the calling pipeline gave up).
+   *  Linked into the per-call controller so an abandoned pipeline doesn't
+   *  leave embeds running to completion. */
+  signal?: AbortSignal;
 }
 
 interface OllamaEmbedResponse {
@@ -204,6 +210,8 @@ async function embedOneChunk(texts: string[], opts: EmbeddingClientOptions): Pro
     try {
       return await embedOneChunkViaOpenRouterRetrying(texts, opts);
     } catch (err) {
+      // W3 — the pipeline gave up: do NOT fall back to the other provider.
+      if (opts.signal?.aborted) throw err;
       const reason = err instanceof Error ? err.message : String(err);
       log.warn(
         `OpenRouter embed failed after retries (chunk size=${texts.length}), falling back to Ollama: ${reason}`
@@ -216,6 +224,8 @@ async function embedOneChunk(texts: string[], opts: EmbeddingClientOptions): Pro
   try {
     return await embedOneChunkViaOllama(texts, opts);
   } catch (err) {
+    // W3 — the pipeline gave up: do NOT fall back to the other provider.
+    if (opts.signal?.aborted) throw err;
     const reason = err instanceof Error ? err.message : String(err);
     log.warn(
       `Ollama embed failed (chunk size=${texts.length}), falling back to OpenRouter: ${reason}`
@@ -233,35 +243,52 @@ async function embedOneChunkViaOllama(
   const fetchFn = opts.fetchImpl ?? fetch;
 
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), EMBED_TIMEOUT_MS);
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? EMBED_TIMEOUT_MS);
+  // W3 — external pipeline abort propagates into this call. An ALREADY
+  // aborted signal must abort immediately (listeners never fire post-abort
+  // — without this, the Ollama→OpenRouter fallback of an abandoned pipeline
+  // runs its full timeout).
+  const onExternalAbort = () => controller.abort();
+  if (opts.signal?.aborted) controller.abort();
+  else opts.signal?.addEventListener('abort', onExternalAbort, { once: true });
 
-  let res: Response;
+  // W3 (#882 mirror) — the timer must cover the BODY read too: clearing it
+  // after headers left res.text()/res.json() untimed, the exact zombie
+  // window measured at 86s/102.8s on the goal-embed path before #882.
+  let data: OllamaEmbedResponse;
   try {
-    res = await fetchFn(`${baseUrl}/api/embed`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model, input: texts }),
-      signal: controller.signal,
-    });
-  } catch (err) {
-    clearTimeout(timer);
-    throw new EmbeddingError(
-      `Ollama embed call failed: ${err instanceof Error ? err.message : String(err)}`
-    );
-  }
-  clearTimeout(timer);
-
-  if (!res.ok) {
-    let body = '';
+    let res: Response;
     try {
-      body = await res.text();
-    } catch {
-      // ignore
+      res = await fetchFn(`${baseUrl}/api/embed`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model, input: texts }),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      throw new EmbeddingError(
+        `Ollama embed call failed: ${err instanceof Error ? err.message : String(err)}`
+      );
     }
-    throw new EmbeddingError(`Ollama embed HTTP ${res.status}: ${body.slice(0, 200)}`, res.status);
-  }
 
-  const data = (await res.json()) as OllamaEmbedResponse;
+    if (!res.ok) {
+      let body = '';
+      try {
+        body = await res.text();
+      } catch {
+        // ignore
+      }
+      throw new EmbeddingError(
+        `Ollama embed HTTP ${res.status}: ${body.slice(0, 200)}`,
+        res.status
+      );
+    }
+
+    data = (await res.json()) as OllamaEmbedResponse;
+  } finally {
+    clearTimeout(timer);
+    opts.signal?.removeEventListener('abort', onExternalAbort);
+  }
   if (data.error) {
     throw new EmbeddingError(`Ollama embed error: ${data.error}`);
   }
@@ -315,93 +342,102 @@ async function embedOneChunkViaOpenRouter(
   const fetchFn = opts.fetchImpl ?? fetch;
 
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), EMBED_TIMEOUT_MS);
+  const timer = setTimeout(() => controller.abort(), opts.timeoutMs ?? EMBED_TIMEOUT_MS);
+  // W3 — external pipeline abort (pre-aborted handled; see Ollama twin).
+  const onExternalAbort = () => controller.abort();
+  if (opts.signal?.aborted) controller.abort();
+  else opts.signal?.addEventListener('abort', onExternalAbort, { once: true });
   const t0 = Date.now();
 
-  let res: Response;
+  // W3 (#882 mirror) — timer covers the BODY read (json/text), not just
+  // headers; see embedOneChunkViaOllama for the measured zombie rationale.
   try {
-    res = await fetchFn(`${baseUrl}/embeddings`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({ model, input: texts }),
-      signal: controller.signal,
-    });
-  } catch (err) {
-    clearTimeout(timer);
-    const reason = err instanceof Error ? err.message : String(err);
-    void logLLMCall({
-      module: OPENROUTER_FALLBACK_MODULE,
-      model: `openrouter/${model}`,
-      latencyMs: Date.now() - t0,
-      status: 'error',
-      errorMessage: reason,
-    });
-    // Network / timeout / abort — transient, safe to retry.
-    throw new EmbeddingError(`OpenRouter embed call failed: ${reason}`, undefined, true);
-  }
-  clearTimeout(timer);
-
-  if (!res.ok) {
-    let body = '';
+    let res: Response;
     try {
-      body = await res.text();
-    } catch {
-      // ignore
+      res = await fetchFn(`${baseUrl}/embeddings`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({ model, input: texts }),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      void logLLMCall({
+        module: OPENROUTER_FALLBACK_MODULE,
+        model: `openrouter/${model}`,
+        latencyMs: Date.now() - t0,
+        status: 'error',
+        errorMessage: reason,
+      });
+      // Network / timeout / abort — transient, safe to retry.
+      throw new EmbeddingError(`OpenRouter embed call failed: ${reason}`, undefined, true);
     }
-    const errMsg = `OpenRouter embed HTTP ${res.status}: ${body.slice(0, 200)}`;
-    void logLLMCall({
-      module: OPENROUTER_FALLBACK_MODULE,
-      model: `openrouter/${model}`,
-      latencyMs: Date.now() - t0,
-      status: 'error',
-      errorMessage: errMsg,
-    });
-    // 404 is intermittent on OpenRouter /embeddings (~11%, CP458); 5xx is
-    // standard-transient. Both are retryable. 4xx-other (auth/bad request)
-    // is deterministic — not retryable.
-    const retryable = res.status === 404 || res.status >= 500;
-    throw new EmbeddingError(errMsg, res.status, retryable);
-  }
 
-  const data = (await res.json()) as {
-    data?: Array<{ embedding?: number[] }>;
-    usage?: { prompt_tokens?: number; total_tokens?: number };
-    error?: { message?: string };
-  };
-  if (data.error) {
-    throw new EmbeddingError(`OpenRouter embed error: ${data.error.message ?? 'unknown'}`);
-  }
+    if (!res.ok) {
+      let body = '';
+      try {
+        body = await res.text();
+      } catch {
+        // ignore
+      }
+      const errMsg = `OpenRouter embed HTTP ${res.status}: ${body.slice(0, 200)}`;
+      void logLLMCall({
+        module: OPENROUTER_FALLBACK_MODULE,
+        model: `openrouter/${model}`,
+        latencyMs: Date.now() - t0,
+        status: 'error',
+        errorMessage: errMsg,
+      });
+      // 404 is intermittent on OpenRouter /embeddings (~11%, CP458); 5xx is
+      // standard-transient. Both are retryable. 4xx-other (auth/bad request)
+      // is deterministic — not retryable.
+      const retryable = res.status === 404 || res.status >= 500;
+      throw new EmbeddingError(errMsg, res.status, retryable);
+    }
 
-  const items = data.data ?? [];
-  if (items.length !== texts.length) {
-    throw new EmbeddingError(
-      `OpenRouter embed returned ${items.length} vectors, expected ${texts.length}`
-    );
-  }
+    const data = (await res.json()) as {
+      data?: Array<{ embedding?: number[] }>;
+      usage?: { prompt_tokens?: number; total_tokens?: number };
+      error?: { message?: string };
+    };
+    if (data.error) {
+      throw new EmbeddingError(`OpenRouter embed error: ${data.error.message ?? 'unknown'}`);
+    }
 
-  const vectors: number[][] = [];
-  for (const item of items) {
-    const vec = item.embedding;
-    if (!vec || vec.length !== expectedDim) {
+    const items = data.data ?? [];
+    if (items.length !== texts.length) {
       throw new EmbeddingError(
-        `OpenRouter embedding dimension mismatch: got ${vec?.length ?? 0}, expected ${expectedDim}`
+        `OpenRouter embed returned ${items.length} vectors, expected ${texts.length}`
       );
     }
-    vectors.push(vec);
+
+    const vectors: number[][] = [];
+    for (const item of items) {
+      const vec = item.embedding;
+      if (!vec || vec.length !== expectedDim) {
+        throw new EmbeddingError(
+          `OpenRouter embedding dimension mismatch: got ${vec?.length ?? 0}, expected ${expectedDim}`
+        );
+      }
+      vectors.push(vec);
+    }
+
+    void logLLMCall({
+      module: OPENROUTER_FALLBACK_MODULE,
+      model: `openrouter/${model}`,
+      inputTokens: data.usage?.prompt_tokens,
+      latencyMs: Date.now() - t0,
+      status: 'success',
+    });
+
+    return vectors;
+  } finally {
+    clearTimeout(timer);
+    opts.signal?.removeEventListener('abort', onExternalAbort);
   }
-
-  void logLLMCall({
-    module: OPENROUTER_FALLBACK_MODULE,
-    model: `openrouter/${model}`,
-    inputTokens: data.usage?.prompt_tokens,
-    latencyMs: Date.now() - t0,
-    status: 'success',
-  });
-
-  return vectors;
 }
 
 /** Promise-based sleep for retry backoff. */
@@ -433,7 +469,8 @@ async function embedOneChunkViaOpenRouterRetrying(
       return await embedOneChunkViaOpenRouter(texts, opts);
     } catch (err) {
       lastErr = err;
-      const retryable = err instanceof EmbeddingError && err.retryable;
+      // W3 — external abort is terminal: the pipeline gave up, never retry.
+      const retryable = err instanceof EmbeddingError && err.retryable && !opts.signal?.aborted;
       if (!retryable || attempt === OPENROUTER_EMBED_MAX_RETRIES) {
         throw err;
       }


### PR DESCRIPTION
## W3 — iks-embed 의 #882 클래스 좀비 차단 (검증된 패턴 미러링 원칙의 첫 적용)

40s+ 분해에서 잡힌 **iks-embed 30s 행** = #882 와 동일 결함: `clearTimeout` 이 **헤더 직후** → `res.text()/json()` body 읽기 무타이머 (goal-embed 쌍둥이에서 실측 86s/102.8s).

### Changes
- **Body-covering timeout**: 두 chunk 함수 (Ollama/OpenRouter) 모두 try/finally 로 타이머가 body 읽기까지 커버 — 무타이머 구간 0.
- **`signal` 옵션 (pipeline 포기 연동 계약)**: 외부 abort → per-call controller 전파. **pre-aborted signal 즉시 abort** (abort 후 리스너는 영원히 발화 안 함 — 없으면 포기된 pipeline 의 폴백이 풀 타임아웃 소진).
- **외부 abort = 터미널**: 재시도 금지 (retry 루프 가드) + 교차-provider 폴백 금지 — 포기된 pipeline 이 쿼터 소비 즉시 중단. 타이머 abort 는 기존대로 retryable (transient-slow 는 폴백 가치 있음).
- `timeoutMs` 옵션 (테스트/튜닝).

### 정직 명기
- **호출측 연결은 본 PR 범위 밖**: pipeline-runner 에 현재 "포기" deadline controller 자체가 없어 연결할 signal 소스가 없음 — 본 PR 은 계약 제공, pipeline deadline 은 별도.
- `executor.test.ts` 0-run = clean main 에서 stash 재현된 pre-existing.

### Tests
+2 (hanging-body 가 타이머에 잘림·embedBatch null-fill 빠른 settle / 외부 abort 터미널). 기존 embedding-fallback 6/6 무파손, iks 47 green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)