### PR TITLE
fix(kg-bridge): phantom column yv.video_id → youtube_video_id (42703 silent fail, CP499+)

### DIFF
--- a/src/modules/ontology/kg-bridge.ts
+++ b/src/modules/ontology/kg-bridge.ts
@@ -107,7 +107,7 @@ async function findResourceNode(
            SELECT 1 FROM user_video_states uvs
            JOIN youtube_videos yv ON yv.id = uvs.video_id
            WHERE uvs.id::text = source_ref->>'id'
-             AND yv.video_id = ${videoId}
+             AND yv.youtube_video_id = ${videoId}
          ))
       )
     LIMIT 1

--- a/tests/unit/modules/kg-bridge-column.test.ts
+++ b/tests/unit/modules/kg-bridge-column.test.ts
@@ -1,0 +1,26 @@
+/**
+ * KG Bridge — findResourceNode column regression (CP499+).
+ *
+ * The uvs branch joined youtube_videos on `yv.video_id` — a column that
+ * does not exist (the external YouTube id is `youtube_video_id`,
+ * schema @unique). Every uvs-branch lookup failed with Postgres 42703
+ * and was swallowed upstream → mentions edges for uvs-sourced resources
+ * were silently never created. Pin: the raw SQL references the real
+ * column and never the phantom one.
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('kg-bridge — youtube_videos column name', () => {
+  const src = readFileSync(join(process.cwd(), 'src/modules/ontology/kg-bridge.ts'), 'utf8');
+
+  it('uses yv.youtube_video_id (the real external-id column)', () => {
+    expect(src).toContain('yv.youtube_video_id');
+  });
+
+  it('never references the phantom yv.video_id (42703 source)', () => {
+    // `yv.video_id` must not appear except as part of yv.youtube_video_id
+    const phantom = src.match(/yv\.video_id\b/g) ?? [];
+    expect(phantom).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## 1줄 fix (기승인 트랙)

uvs 분기의 `JOIN youtube_videos yv … AND yv.video_id = ?` — **`yv.video_id` 는 존재하지 않는 컬럼** (외부 YouTube id = `youtube_video_id`, schema @unique) → 모든 uvs-분기 조회가 42703 으로 죽고 상류에서 swallow → **uvs-소스 resource 의 mentions 엣지가 ship 이후 전수 미생성** (40s+ 분해 중 에러 로그 스윕에서 발견).

## Backfill 판단 (1줄)

**지금 불요** — mentions 엣지는 부가적 graph enrichment 이고 KG 소비 기능 미출시 → KG UI 출시 시점에 일괄 re-bridge 1회가 더 싸고 전체 커버.

## Test

source-pin regression 2건 (실컬럼 존재 / phantom 부재). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)