### PR TITLE
fix(discover): poorest-cell-wins dedup — tail-cell starvation (B7, CP499+)

### DIFF
--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -614,6 +614,23 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
     if (!seen.has(cand.videoId)) seen.set(cand.videoId, cand);
   }
 
+  // CP499+ B7 — poorest-cell-wins dedup. first-cell-wins starved tail cells:
+  // overlapping query families (measured: "Claude Code…" mandala, raw 40/40 on
+  // every cell but rec_cache cells 6·7 = 0) return the same videos for many
+  // cells, and the EARLIER cell swallowed every duplicate, hollowing later
+  // buckets before binning. A duplicate now YIELDS to the strictly poorer
+  // cell (fewer assigned candidates at that moment) — same candidate set,
+  // balanced buckets. Null-cell (core) candidates never reassign.
+  const cellAssignCounts = new Map<number, number>();
+  for (const c of seen.values()) {
+    if (typeof c.cellIndex === 'number') {
+      cellAssignCounts.set(c.cellIndex, (cellAssignCounts.get(c.cellIndex) ?? 0) + 1);
+    }
+  }
+  const countAssigned = (ci: number | null) => {
+    if (typeof ci === 'number') cellAssignCounts.set(ci, (cellAssignCounts.get(ci) ?? 0) + 1);
+  };
+
   for (const r of results) {
     if (r.status !== 'fulfilled') {
       log.debug(`v5 fanout query rejected: ${String(r.reason)}`);
@@ -625,7 +642,20 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       rawItemCount += 1;
       const cand = toFanoutCandidate(it, cellIndex);
       if (!cand) continue;
-      if (seen.has(cand.videoId)) continue;
+      const dup = seen.get(cand.videoId);
+      if (dup) {
+        if (
+          typeof cand.cellIndex === 'number' &&
+          typeof dup.cellIndex === 'number' &&
+          cand.cellIndex !== dup.cellIndex &&
+          (cellAssignCounts.get(cand.cellIndex) ?? 0) < (cellAssignCounts.get(dup.cellIndex) ?? 0)
+        ) {
+          cellAssignCounts.set(dup.cellIndex, (cellAssignCounts.get(dup.cellIndex) ?? 1) - 1);
+          countAssigned(cand.cellIndex);
+          seen.set(cand.videoId, { ...dup, cellIndex: cand.cellIndex });
+        }
+        continue;
+      }
       if (titleHitsBlocklist(cand.title) || titleIndicatesShorts(cand.title)) continue;
       // CP492 — off-language hard drop. YouTube backfills sparse queries with
       // high-view global content (Chinese dramas on a Korean basketball query).
@@ -642,6 +672,7 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
         continue;
       }
       seen.set(cand.videoId, cand);
+      countAssigned(cand.cellIndex);
       liveAdded += 1;
       if (seen.size >= cfg.dedupHardCap) break;
     }

--- a/tests/unit/skills/video-discover/v5-dedup-poorest-cell.test.ts
+++ b/tests/unit/skills/video-discover/v5-dedup-poorest-cell.test.ts
@@ -1,0 +1,123 @@
+/**
+ * CP499+ B7 — poorest-cell-wins dedup regression.
+ *
+ * Measured defect ("Claude Code…" mandala): every cell's search returned
+ * raw≈40 but rec_cache cells 6·7 = 0 — overlapping query families return
+ * the same videos for many cells and first-cell-wins dedup let the EARLIER
+ * cell swallow every duplicate, hollowing later buckets before binning.
+ *
+ * Pins: a duplicate yields to the strictly poorer cell / unique results
+ * keep their own cell / null-cell (core) candidates never reassign /
+ * fully-overlapping two-cell fixture ends balanced, not N:0.
+ */
+
+jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
+  searchVideos: jest.fn(),
+  resolveSearchApiKeys: jest.fn().mockReturnValue(['key1']),
+  titleIndicatesShorts: jest.fn().mockReturnValue(false),
+  titleHitsBlocklist: jest.fn().mockReturnValue(false),
+}));
+jest.mock('@/skills/plugins/video-discover/v2/keyword-builder', () => ({
+  buildRuleBasedQueriesSync: jest.fn(),
+}));
+jest.mock('@/utils/logger', () => {
+  const base: Record<string, unknown> = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  };
+  base['child'] = jest.fn(() => base);
+  return { logger: base };
+});
+
+const { searchVideos } = jest.requireMock('@/skills/plugins/video-discover/v2/youtube-client');
+const { buildRuleBasedQueriesSync } = jest.requireMock(
+  '@/skills/plugins/video-discover/v2/keyword-builder'
+);
+
+import { runYouTubeFanout } from '@/skills/plugins/video-discover/v5/youtube-fanout';
+import { resetV5ConfigForTest } from '@/skills/plugins/video-discover/v5/config';
+
+const item = (id: string) => ({
+  id: { videoId: id },
+  snippet: {
+    title: `한국어 영상 ${id}`,
+    channelTitle: 'ch',
+    channelId: 'cid',
+    publishedAt: '2026-01-01T00:00:00Z',
+    thumbnails: { high: { url: 'u' } },
+  },
+});
+
+const baseInput = {
+  centerGoal: '클로드 코드',
+  subGoals: ['모니터링', '스케일링'],
+  focusTags: [],
+  targetLevel: 'standard',
+  language: 'ko' as const,
+  env: {} as NodeJS.ProcessEnv,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetV5ConfigForTest();
+});
+
+describe('v5 fanout dedup — poorest-cell-wins (B7)', () => {
+  it('FULL overlap: buckets end balanced instead of N:0 (the measured starvation)', async () => {
+    buildRuleBasedQueriesSync.mockReturnValue([
+      { query: 'q-cell0', source: 'subgoal', cellIndex: 0 },
+      { query: 'q-cell1', source: 'subgoal', cellIndex: 1 },
+    ]);
+    // both cells return the SAME 4 videos — pre-fix: cell0 4, cell1 0.
+    const overlap = [item('v1'), item('v2'), item('v3'), item('v4')];
+    searchVideos.mockResolvedValue(overlap);
+
+    const res = await runYouTubeFanout(baseInput);
+
+    const byCell = new Map<number | null, number>();
+    for (const c of res.candidates) byCell.set(c.cellIndex, (byCell.get(c.cellIndex) ?? 0) + 1);
+    expect(res.candidates).toHaveLength(4); // dedup count unchanged
+    expect(byCell.get(0)).toBe(2);
+    expect(byCell.get(1)).toBe(2); // tail cell no longer starved
+  });
+
+  it('NO overlap: every result keeps its own cell (no spurious reassignment)', async () => {
+    buildRuleBasedQueriesSync.mockReturnValue([
+      { query: 'q-cell0', source: 'subgoal', cellIndex: 0 },
+      { query: 'q-cell1', source: 'subgoal', cellIndex: 1 },
+    ]);
+    searchVideos.mockImplementation(({ query }: { query: string }) =>
+      Promise.resolve(query === 'q-cell0' ? [item('a1'), item('a2')] : [item('b1'), item('b2')])
+    );
+    const res = await runYouTubeFanout(baseInput);
+    expect(
+      res.candidates
+        .filter((c) => c.cellIndex === 0)
+        .map((c) => c.videoId)
+        .sort()
+    ).toEqual(['a1', 'a2']);
+    expect(
+      res.candidates
+        .filter((c) => c.cellIndex === 1)
+        .map((c) => c.videoId)
+        .sort()
+    ).toEqual(['b1', 'b2']);
+  });
+
+  it('duplicate does NOT move to an equal-or-richer cell (strictly poorer only)', async () => {
+    buildRuleBasedQueriesSync.mockReturnValue([
+      { query: 'q-cell0', source: 'subgoal', cellIndex: 0 },
+      { query: 'q-cell1', source: 'subgoal', cellIndex: 1 },
+    ]);
+    // cell0: [v1]; cell1: [u1, v1] — when v1 re-arrives for cell1, counts are
+    // cell0=1 vs cell1=1 (u1 assigned first) → equal → v1 STAYS in cell0.
+    searchVideos.mockImplementation(({ query }: { query: string }) =>
+      Promise.resolve(query === 'q-cell0' ? [item('v1')] : [item('u1'), item('v1')])
+    );
+    const res = await runYouTubeFanout(baseInput);
+    expect(res.candidates.find((c) => c.videoId === 'v1')?.cellIndex).toBe(0);
+    expect(res.candidates.find((c) => c.videoId === 'u1')?.cellIndex).toBe(1);
+  });
+});


### PR DESCRIPTION
## B7 실측 (READ-ONLY 체인)

"Claude Code로 프로덕션 앱 개발" 51장 만다라: 위저드 perQuery **raw 40/40 (cells 6·7 포함)** 인데 rec_cache **cells 6·7 = 0** (cells 0-5 = 6~12) → 두 셀 영구 공백. picker 는 cell_binning (공평) — **버킷이 binning 전에 비어 있었음**.

## Root & Fix

**first-cell-wins dedup**: 겹치는 쿼리 패밀리에서 같은 영상이 여러 셀에 반환 → 앞 셀이 중복 전부 독식 → 뒷 셀 버킷 공동화. → **poorest-cell-wins**: 중복 도착 시 보유 셀보다 **strictly 빈약한** 셀이면 양보 (per-cell assigned-count, pool seed 포함 초기화). 후보 집합·dedup 수 불변 — 배분만 균형. null-cell(core) 비대상. live 루프 단일 적용 (live-live·live-vs-pool 중복 + EN-only 공유).

- #804 undershoot(count) 와 **별개 PR** (James 지시 준수).
- fix 후에도 빈 셀이면 = 진짜 공급 갭 → 공급 fallback 트랙 (순서 정합).

## Tests

3 fixture (전중복 → N:0 대신 균형 / 무중복 무간섭 / **동수면 비이동** — strictly-poorer 고정). v5 전 스위트 **13개 87 green**, tsc clean. 800u 재발사 대체 (메커니즘 = 코드 사실).

🤖 Generated with [Claude Code](https://claude.com/claude-code)