### PR TITLE
fix(lang): Hangul presence wins over Latin proper nouns in detectLanguage (diagnosis A-3, CP499+)

### DIFF
--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -9,21 +9,31 @@
  * Korean results. This helper recovers the input language from the text
  * itself so the YouTube search is issued in the right language/region.
  *
- * Zero-dependency, deterministic — pure character-class counting.
+ * CP499+ (diagnosis A-3): Hangul PRESENCE now wins outright. The previous
+ * count-comparison (`hangul >= latin`) let long Latin proper nouns outvote
+ * Korean particles — "Claude Code로 프로덕션 앱 개발" (latin 10 vs hangul 8)
+ * was judged 'en' although a Korean user typed it on a Korean keyboard.
+ * Proper nouns are NOT a language signal; particles are. Measured fleet
+ * impact (2026-06-11 prod, full scan): exactly 3 en-misjudged mandalas
+ * corrected, 0 reverse flips (no stored-ko mandala has a Latin-only goal).
+ *
+ * Zero-dependency, deterministic — pure character-class testing.
  */
 
 export type DetectedLanguage = 'ko' | 'en';
 
 /** Hangul Syllables block (U+AC00–U+D7A3) — Korean pre-composed syllables. */
-const HANGUL_RE = /[가-힣]/gu;
+const HANGUL_RE = /[가-힣]/u;
 /** Basic Latin letters — the English signal. */
-const LATIN_RE = /[A-Za-z]/g;
+const LATIN_RE = /[A-Za-z]/;
 
 /**
- * Detect the dominant script of `text`.
+ * Detect the input language of `text`.
  *
- *   - Any Hangul that is at least as frequent as Latin letters → 'ko'.
- *   - Latin letters present, little/no Hangul → 'en'.
+ *   - ANY Hangul → 'ko'. Typing even one Hangul syllable means a Korean
+ *     keyboard/user; Latin tokens around it are proper nouns (tool names,
+ *     brands) and are excluded from the judgement.
+ *   - No Hangul, Latin letters present → 'en'.
  *   - No script signal at all (digits/symbols only, or empty) → 'ko',
  *     preserving the pre-CP458 default so this is never *more* surprising
  *     than the behavior it replaces.
@@ -34,10 +44,9 @@ const LATIN_RE = /[A-Za-z]/g;
  */
 export function detectLanguage(text: string | null | undefined): DetectedLanguage {
   if (!text) return 'ko';
-  const hangulCount = (text.match(HANGUL_RE) ?? []).length;
-  const latinCount = (text.match(LATIN_RE) ?? []).length;
-  if (hangulCount === 0 && latinCount === 0) return 'ko';
-  return hangulCount >= latinCount ? 'ko' : 'en';
+  if (HANGUL_RE.test(text)) return 'ko';
+  if (LATIN_RE.test(text)) return 'en';
+  return 'ko';
 }
 
 /**

--- a/tests/unit/utils/detect-language.test.ts
+++ b/tests/unit/utils/detect-language.test.ts
@@ -1,15 +1,19 @@
 /**
- * detect-language — script detection for goal/title text (CP458).
+ * detect-language — script detection for goal/title text (CP458, CP499+).
  *
- * Pins the fix for the English-mandala-searched-as-Korean bug: an English
- * goal must resolve to 'en' so YouTube search uses regionCode=US +
- * relevanceLanguage=en instead of the NULL→'ko' default.
+ * Pins two fixes:
+ * - CP458: an English goal must resolve to 'en' so YouTube search uses
+ *   regionCode=US + relevanceLanguage=en instead of the NULL→'ko' default.
+ * - CP499+ (diagnosis A-3): Hangul PRESENCE wins outright — Latin proper
+ *   nouns must not outvote Korean particles. Regression cases below are the
+ *   exact 3 misjudged production goals (full-fleet scan 2026-06-11:
+ *   3 en-misjudged corrected, 0 reverse flips).
  */
 
 import { detectLanguage, resolveLanguage } from '@/utils/detect-language';
 
 describe('detectLanguage', () => {
-  it('detects an English goal as en (the reported bug case)', () => {
+  it('detects an English goal as en (the CP458 bug case)', () => {
     expect(detectLanguage('Build retirement assets via ETF investing')).toBe('en');
   });
 
@@ -18,12 +22,23 @@ describe('detectLanguage', () => {
   });
 
   it('treats Korean-dominant mixed text as ko', () => {
-    // "AI" is Latin but Hangul dominates → ko
     expect(detectLanguage('AI 마케팅으로 비즈니스 성장 시키기')).toBe('ko');
   });
 
-  it('treats English-dominant mixed text as en', () => {
-    expect(detectLanguage('Complete an AI/ML project portfolio 만들기')).toBe('en');
+  it('CP499+ — ANY Hangul wins even when Latin letters dominate (proper nouns excluded)', () => {
+    // Spec change vs CP458: previously latin-count > hangul-count → 'en'.
+    expect(detectLanguage('Complete an AI/ML project portfolio 만들기')).toBe('ko');
+  });
+
+  it('CP499+ regression — the 3 real misjudged production goals are ko', () => {
+    expect(detectLanguage('Claude Code로 프로덕션 앱 개발')).toBe('ko');
+    expect(detectLanguage('Ultra Learning 으로 AI 전문가 되기')).toBe('ko');
+    expect(detectLanguage('gitthub 공부')).toBe('ko');
+  });
+
+  it('pure-Latin text still detects as en (no reverse flip)', () => {
+    expect(detectLanguage('Master Kubernetes in 30 days')).toBe('en');
+    expect(detectLanguage('Claude Code')).toBe('en');
   });
 
   it('defaults to ko for empty / null / no-script input (preserves pre-CP458 default)', () => {
@@ -49,5 +64,9 @@ describe('resolveLanguage', () => {
     expect(resolveLanguage('', 'English text')).toBe('en');
     expect(resolveLanguage('EN', '한국어')).toBe('ko'); // case-sensitive — 'EN' is not 'en'
     expect(resolveLanguage('garbage', 'English text')).toBe('en');
+  });
+
+  it('CP499+ — NULL stored + mixed proper-noun goal resolves ko via detection', () => {
+    expect(resolveLanguage(null, 'Claude Code로 프로덕션 앱 개발')).toBe('ko');
   });
 });


### PR DESCRIPTION
## Problem

`detectLanguage` used a count comparison (`hangulCount >= latinCount → ko`). Long Latin proper nouns outvote Korean particles, so Korean-typed goals were judged `en` and searched/generated in English.

Full-fleet prod scan (2026-06-11, read-only): exactly **3 misjudged mandalas**, all the same pattern (Latin proper noun + Korean particles):
- `Claude Code로 프로덕션 앱 개발` (latin 10 vs hangul 8 → en)
- `Ultra Learning 으로 AI 전문가 되기`
- `gitthub 공부`

Reverse direction measured **0** (no stored-ko mandala has a Latin-only goal) — this change cannot flip any existing ko mandala.

## Fix

ANY Hangul → `ko` (proper nouns are not a language signal; particles are). No Hangul + Latin → `en`. No script → `ko` (default unchanged).

## Spec change note

One CP458-era test expectation flips by design: `'Complete an AI/ML project portfolio 만들기'` is now `ko` (it is itself the misjudge pattern — a Korean user typed 만들기). Replaced with the new-spec pin + 3 real production regression cases.

## Scope / rollout

- Pure function change, no schema/env. `resolveLanguage` stored-wins is untouched — existing rows keep their stored language; correcting the 3 existing rows is a separate decision (3-row UPDATE or recompute).
- Prerequisite for v2 translations (translation target = `mandala.language`) — **merge together with the v2 translations PR** per agreement.

## Verification

- `tsc --noEmit` clean
- detect-language suite 11/11 (3 production regression cases pinned)
- consumer suites green: enrich-relevance-quick, relevance-backfill-trigger, prompt-build-v2, openrouter-qwen-no-think (24 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)