### PR TITLE
feat(relevance): unified score pipeline — 3-axis rubric + volatile-only recency + mandala-language alignment (diagnosis A, CP499+)

### DIFF
--- a/prisma/migrations/score-pipeline/001_add_user_mandalas_volatility.sql
+++ b/prisma/migrations/score-pipeline/001_add_user_mandalas_volatility.sql
@@ -1,0 +1,6 @@
+-- CP499+ score pipeline — mandala volatility ('volatile' | 'evergreen').
+-- Written by merged-gen wizard path when RELEVANCE_RUBRIC_ENABLED; NULL = recency bonus off.
+-- prisma db push silent-fail companion DDL (CLAUDE.md hard rule): apply manually
+-- local first, then prod (prod execution = separate per-step approval).
+ALTER TABLE public.user_mandalas
+  ADD COLUMN IF NOT EXISTS volatility varchar(10);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -436,6 +436,9 @@ model user_mandalas {
   is_template     Boolean                   @default(false)
   domain          String?
   language        String?                   @db.VarChar(10)
+  /// CP499+ score pipeline — merged-gen 1-line judgement ('volatile' | 'evergreen').
+  /// NULL (pre-existing / non-wizard mandalas) ⇒ recency bonus never applies.
+  volatility      String?                   @db.VarChar(10)
   like_count      Int                       @default(0)
   clone_count     Int                       @default(0)
   share_slug      String?                   @unique

--- a/src/api/routes/internal/prompt-build.ts
+++ b/src/api/routes/internal/prompt-build.ts
@@ -31,24 +31,11 @@ import { getInternalBatchToken } from '@/config/internal-auth';
 import { getPrismaClient } from '@/modules/database/client';
 import { buildV2Prompt } from '@/modules/skills/rich-summary-v2-prompt';
 import { logger } from '@/utils/logger';
+import { detectContentLanguageFromTitle as detectLanguageFromTitle } from '@/utils/detect-language';
 
 const log = logger.child({ module: 'api/internal/prompt-build' });
 
-const HANGUL_RANGE = /[가-힯]/g;
-const LATIN_RANGE = /[A-Za-z]/g;
-
-function detectLanguageFromTitle(title: string): 'ko' | 'en' | null {
-  if (!title) return null;
-  const stripped = title.replace(/\s+/g, '');
-  if (stripped.length === 0) return null;
-  const hangulCount = (stripped.match(HANGUL_RANGE) ?? []).length;
-  const latinCount = (stripped.match(LATIN_RANGE) ?? []).length;
-  const hangulRatio = hangulCount / stripped.length;
-  const latinRatio = latinCount / stripped.length;
-  if (hangulRatio >= 0.2) return 'ko';
-  if (latinRatio >= 0.5 && hangulRatio < 0.05) return 'en';
-  return null;
-}
+// CP499+ 전수 통일 — detectLanguageFromTitle now lives in @/utils/detect-language.
 
 interface BuildV2Body {
   videoId?: string;

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -986,7 +986,13 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           const tSaveStart = Date.now();
           try {
             const manager = getMandalaManager();
-            const saved = await manager.createMandala(userId, structure.center_goal, levels);
+            // CP499+ — volatility from merged-gen [3단계] (undefined on the
+            // legacy structure path / non-enum output). Persist is flag-gated
+            // inside createMandala (column exists only after the score-pipeline
+            // DDL — separate per-step approval).
+            const saved = await manager.createMandala(userId, structure.center_goal, levels, {
+              volatility: structure.volatility,
+            });
             mandalaId = saved.id;
             write('mandala_saved', {
               mandalaId: saved.id,

--- a/src/config/relevance-rubric.ts
+++ b/src/config/relevance-rubric.ts
@@ -1,0 +1,46 @@
+/**
+ * Relevance rubric config (CP499+ diagnosis A score pipeline).
+ *
+ * Single feature flag gates the WHOLE new score pipeline as one unit:
+ * - 3-axis rubric scoring (cell_fit / goal_contribution / actionability,
+ *   composed in code — see src/modules/relevance/relevance-composition.ts)
+ * - volatile-only recency bonus (needs user_mandalas.volatility)
+ * - volatility persistence from merged-gen output
+ *
+ * Default: OFF (unset = legacy single-axis scoring, byte-identical prompt).
+ * Rollback = flip env; no code revert.
+ *
+ * ⚠️ Deploy-order precondition: the `user_mandalas.volatility` column DDL
+ * (prisma/migrations/score-pipeline/001) must be applied to an environment
+ * BEFORE this flag is turned on there — the worker/persist paths select the
+ * column only when enabled. Prod DDL execution is a separate per-step
+ * approval (NOT automatic with the PR merge).
+ */
+
+import { z } from 'zod';
+
+const boolFlag = z.preprocess((v) => {
+  if (v == null || v === '') return false;
+  const s = String(v).trim().toLowerCase();
+  return s === 'true' || s === '1' || s === 'yes';
+}, z.boolean());
+
+export const relevanceRubricEnvSchema = z.object({
+  RELEVANCE_RUBRIC_ENABLED: boolFlag.default(false as unknown as string),
+});
+
+export interface RelevanceRubricConfig {
+  enabled: boolean;
+}
+
+export function loadRelevanceRubricConfig(
+  env: NodeJS.ProcessEnv = process.env
+): RelevanceRubricConfig {
+  const parsed = relevanceRubricEnvSchema.safeParse({
+    RELEVANCE_RUBRIC_ENABLED: env['RELEVANCE_RUBRIC_ENABLED'],
+  });
+  if (!parsed.success) {
+    return { enabled: false };
+  }
+  return { enabled: parsed.data.RELEVANCE_RUBRIC_ENABLED };
+}

--- a/src/modules/mandala/generator.ts
+++ b/src/modules/mandala/generator.ts
@@ -49,6 +49,9 @@ export interface GeneratedMandala {
   center_label: string;
   language: string;
   domain: string;
+  /** CP499+ score pipeline — merged-gen 1-line judgement. Sanitized to
+   *  'volatile' | 'evergreen' | undefined (anything else dropped). */
+  volatility?: 'volatile' | 'evergreen';
   sub_goals: string[];
   sub_labels?: string[];
   actions: Record<string, string[]>;
@@ -799,6 +802,11 @@ export async function generateMandalaWithQueries(
   if (!parsed.actions) parsed.actions = {};
   if (!parsed.language) parsed.language = lang;
   if (!parsed.domain) parsed.domain = domain;
+  // CP499+ — sanitize the volatility judgement (merged-gen [3단계]); anything
+  // other than the two enum values is dropped (NULL ⇒ recency bonus off).
+  if (parsed.volatility !== 'volatile' && parsed.volatility !== 'evergreen') {
+    delete (parsed as unknown as Record<string, unknown>)['volatility'];
+  }
   // Strip the merged-only key so the persisted structure shape is unchanged.
   delete (parsed as unknown as Record<string, unknown>)['cell_queries'];
 

--- a/src/modules/mandala/manager.ts
+++ b/src/modules/mandala/manager.ts
@@ -5,6 +5,7 @@ import { user_mandalas, Prisma } from '@prisma/client';
 import { nanoid } from 'nanoid';
 import { DEFAULT_TIER, getMandalaLimit, type Tier } from '@/config/quota';
 import { detectLanguage } from '@/utils/detect-language';
+import { loadRelevanceRubricConfig } from '@/config/relevance-rubric';
 import {
   EXPLORE_PAGE_LIMIT,
   EXPLORE_DEFAULT_PAGE_SIZE,
@@ -443,7 +444,7 @@ export class MandalaManager {
     userId: string,
     title: string,
     levels: MandalaLevelData[],
-    options: { promoteToDefault?: boolean } = {}
+    options: { promoteToDefault?: boolean; volatility?: 'volatile' | 'evergreen' } = {}
   ): Promise<MandalaWithLevels> {
     // Per-step wall-clock timing so P2028 incidents have a data-driven
     // root cause trail. Emitted via console.info at function exit so the
@@ -531,6 +532,12 @@ export class MandalaManager {
               language: detectLanguage(title),
               is_default: isDefault,
               position,
+              // CP499+ — flag-gated: the volatility column exists only after
+              // the score-pipeline DDL (per-step approval). Flag off ⇒ field
+              // omitted ⇒ INSERT identical to pre-CP499+.
+              ...(options.volatility && loadRelevanceRubricConfig().enabled
+                ? { volatility: options.volatility }
+                : {}),
             },
           });
           timings['tx_mandala_create'] = Date.now() - tMandalaCreate;

--- a/src/modules/queue/handlers/enrich-relevance-quick.ts
+++ b/src/modules/queue/handlers/enrich-relevance-quick.ts
@@ -19,6 +19,8 @@ import type PgBoss from 'pg-boss';
 
 import { computeCardRelevance } from '@/modules/relevance/compute-card-relevance';
 import { getPrismaClient } from '@/modules/database/client';
+import { loadRelevanceRubricConfig } from '@/config/relevance-rubric';
+import { resolveLanguage } from '@/utils/detect-language';
 import { logger } from '@/utils/logger';
 import { getJobQueue } from '../manager';
 import { JOB_NAMES, RELEVANCE_QUICK_RETRY_OPTIONS, type RelevanceQuickPayload } from '../types';
@@ -51,7 +53,28 @@ export async function registerEnrichRelevanceQuickWorker(): Promise<void> {
 async function handleEnrichRelevanceQuick(job: PgBoss.Job<RelevanceQuickPayload>): Promise<void> {
   const { table, rowId, title, description, centerGoal, cellGoal } = job.data;
 
-  const result = await computeCardRelevance({ title, description, centerGoal, cellGoal });
+  // CP499+ score pipeline (RELEVANCE_RUBRIC_ENABLED): fetch the row's mandala
+  // language/volatility + video published_at and run the 3-axis rubric.
+  // Fail-open: a context-fetch failure falls back to the legacy single-axis
+  // call. Flag off ⇒ legacy call with NO new selects (volatility column may
+  // not exist yet — prod DDL is a separate per-step approval).
+  const rubricEnabled = loadRelevanceRubricConfig().enabled;
+  const context = rubricEnabled ? await fetchRelevanceContext(table, rowId, centerGoal) : null;
+
+  const result = await computeCardRelevance({
+    title,
+    description,
+    centerGoal,
+    cellGoal,
+    ...(context
+      ? {
+          rubric: true,
+          language: context.language,
+          publishedAt: context.publishedAt,
+          volatility: context.volatility,
+        }
+      : {}),
+  });
 
   if (!result.ok) {
     if (result.reason === 'no_title') {
@@ -87,7 +110,69 @@ async function handleEnrichRelevanceQuick(job: PgBoss.Job<RelevanceQuickPayload>
     table,
     rowId,
     relevancePct: result.relevancePct,
+    // relevance_detail = LOG-ONLY for now (James decision 2026-06-11: no
+    // speculative column; persist axes only if gate measurement justifies it).
+    ...(result.detail ? { detail: result.detail } : {}),
   });
+}
+
+export interface RelevanceContext {
+  language: 'ko' | 'en';
+  publishedAt: Date | null;
+  volatility: string | null;
+}
+
+/**
+ * CP499+ — per-row scoring context: mandala language (#902 정합) + volatility
+ * (recency gate) + video published_at (recency input). Called ONLY when the
+ * rubric flag is on (the volatility column must exist by then — DDL is a
+ * deploy precondition for the flag). Returns null on any failure so the
+ * caller falls back to legacy single-axis scoring (fail-open).
+ */
+export async function fetchRelevanceContext(
+  table: 'uvs' | 'ulc',
+  rowId: string,
+  goalText?: string
+): Promise<RelevanceContext | null> {
+  const prisma = getPrismaClient();
+  // $queryRaw (not the typed client): the volatility column ships in this PR's
+  // schema but the shared generated client may predate it, and prod gets the
+  // column via the manual DDL step — raw SQL keeps this path decoupled from
+  // client-generation state. Read-only single-row lookup, tagged template.
+  try {
+    const rows =
+      table === 'uvs'
+        ? await prisma.$queryRaw<
+            { language: string | null; volatility: string | null; published_at: Date | null }[]
+          >`
+            SELECT m.language, m.volatility, yv.published_at
+            FROM user_video_states uvs
+            LEFT JOIN user_mandalas m ON m.id = uvs.mandala_id
+            LEFT JOIN youtube_videos yv ON yv.id = uvs.video_id
+            WHERE uvs.id = ${rowId}::uuid`
+        : await prisma.$queryRaw<
+            { language: string | null; volatility: string | null; published_at: Date | null }[]
+          >`
+            SELECT m.language, m.volatility, NULL::timestamptz AS published_at
+            FROM user_local_cards ulc
+            LEFT JOIN user_mandalas m ON m.id = ulc.mandala_id
+            WHERE ulc.id = ${rowId}::uuid`;
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      language: resolveLanguage(row.language, goalText ?? null),
+      // ulc rows have no clean youtube_videos FK — recency skipped (0 bonus).
+      publishedAt: row.published_at ?? null,
+      volatility: row.volatility ?? null,
+    };
+  } catch (err) {
+    logger.warn('enrich-relevance-quick: context fetch failed — legacy fallback', {
+      table,
+      rowId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
 }
 
 /**

--- a/src/modules/relevance/compute-card-relevance.ts
+++ b/src/modules/relevance/compute-card-relevance.ts
@@ -26,24 +26,16 @@ import {
   validateV2Quick,
   V2QuickValidationError,
 } from '@/modules/skills/rich-summary-v2-quick-prompt';
+import { applyRecency, recencyBonus } from '@/modules/relevance/relevance-composition';
+// CP499+ lang 정합 (#902): the prompt language follows the MANDALA language
+// (caller passes it). The previous LOCAL ratio-based detector (a 3rd variant of
+// detectLanguage in the codebase) is removed — fallback when the caller has no
+// mandala language is the single utils detector (Hangul-presence rule).
+import { detectLanguage } from '@/utils/detect-language';
 
 const HAIKU_MODEL = 'anthropic/claude-haiku-4.5';
 const MAX_TOKENS = 800;
 const TEMPERATURE = 0.2;
-
-const HANGUL_RANGE = /[가-힣]/g;
-const LATIN_RANGE = /[A-Za-z]/g;
-
-/** Best-effort ko/en hint from the card title (default ko). */
-function detectLanguage(title: string): 'ko' | 'en' {
-  const stripped = title.replace(/\s+/g, '');
-  if (stripped.length === 0) return 'ko';
-  const hangul = (stripped.match(HANGUL_RANGE) ?? []).length / stripped.length;
-  const latin = (stripped.match(LATIN_RANGE) ?? []).length / stripped.length;
-  if (hangul >= 0.2) return 'ko';
-  if (latin >= 0.5 && hangul < 0.05) return 'en';
-  return 'ko';
-}
 
 export interface CardRelevanceInput {
   /** Card title (required — the minimal signal). */
@@ -63,10 +55,35 @@ export interface CardRelevanceInput {
   cellGoal?: string;
   /** Optional transcript; '' ⇒ prompt uses title+description fallback. */
   transcript?: string;
+  /**
+   * CP499+ lang 정합 (#902) — the MANDALA's language (judging/display language).
+   * Absent ⇒ utils detectLanguage(title) fallback (Hangul-presence rule). The
+   * card-title language is a content attribute, not the judging language.
+   */
+  language?: 'ko' | 'en';
+  /**
+   * CP499+ rubric mode (RELEVANCE_RUBRIC_ENABLED — caller reads config; this
+   * module stays config-free). 3-axis LLM scoring + code composition + recency.
+   * Absent/false ⇒ legacy single-axis behavior, byte-identical prompt.
+   */
+  rubric?: boolean;
+  /** Video published_at — recency-bonus input (rubric mode, volatile only). */
+  publishedAt?: Date | null;
+  /** Mandala volatility ('volatile' | 'evergreen' | null) — recency gate. */
+  volatility?: string | null;
+}
+
+/** Rubric-mode raw axes + bonus, returned for logging (relevance_detail = log-only for now). */
+export interface CardRelevanceDetail {
+  cellFitPct: number | null;
+  goalContributionPct: number;
+  actionabilityPct: number;
+  basePct: number;
+  recencyBonus: number;
 }
 
 export type CardRelevanceResult =
-  | { ok: true; relevancePct: number }
+  | { ok: true; relevancePct: number; detail?: CardRelevanceDetail }
   | { ok: false; reason: string };
 
 /** Compute a 0-100 relevance score. No persistence — caller writes the result. */
@@ -77,13 +94,17 @@ export async function computeCardRelevance(
     return { ok: false, reason: 'no_title' };
   }
 
-  const language = detectLanguage(input.title);
-  // CP499 — cell-aware goal. cellGoal present ⇒ labeled 2-line block + criterion
-  // (cell-fit AND center contribution). Absent ⇒ `centerGoal` verbatim, i.e. the
+  // CP499+ lang 정합 (#902): mandala language wins; title detection is fallback.
+  const language = input.language ?? detectLanguage(input.title);
+  const hasCell = Boolean(input.cellGoal && input.cellGoal.trim().length > 0);
+  // CP499 — cell-aware goal (legacy single-axis path). cellGoal present ⇒
+  // labeled 2-line block + criterion. Absent ⇒ `centerGoal` verbatim, i.e. the
   // exact same string passed to the SHARED buildV2QuickPrompt before CP499, so
   // the v2 Heart path (no cellGoal) is byte-for-byte unchanged.
+  // Rubric mode passes centerGoal + cellGoal SEPARATELY (the prompt has a
+  // dedicated CELL GOAL line and per-axis rules).
   const goal =
-    input.cellGoal && input.cellGoal.trim().length > 0
+    !input.rubric && hasCell
       ? `중심 목표: ${input.centerGoal}\n` +
         `이 카드가 배치될 셀: ${input.cellGoal}\n` +
         `→ 이 영상이 셀에 적합하면서 중심 목표에 기여하는 정도로 평가`
@@ -95,6 +116,8 @@ export async function computeCardRelevance(
     language,
     transcript: input.transcript ?? '',
     mandalaCenterGoal: goal,
+    rubric: input.rubric,
+    cellGoal: input.rubric ? input.cellGoal : undefined,
   });
 
   let raw: string;
@@ -127,8 +150,26 @@ export async function computeCardRelevance(
   }
 
   try {
-    const parsed = validateV2Quick(json);
-    return { ok: true, relevancePct: parsed.analysis.mandala_fit.mandala_relevance_pct };
+    const parsed = validateV2Quick(json, { rubric: input.rubric });
+    const fit = parsed.analysis.mandala_fit;
+    if (input.rubric && fit.rubric) {
+      // Composite came from composeRubricScore (in the validator). Recency:
+      // volatile-only additive bonus, capped at 100 — evergreen / NULL
+      // volatility / NULL published_at are all 0 = unchanged.
+      const bonus = recencyBonus(input.publishedAt, input.volatility);
+      return {
+        ok: true,
+        relevancePct: applyRecency(fit.mandala_relevance_pct, bonus),
+        detail: {
+          cellFitPct: fit.rubric.cell_fit_pct,
+          goalContributionPct: fit.rubric.goal_contribution_pct,
+          actionabilityPct: fit.rubric.actionability_pct,
+          basePct: fit.mandala_relevance_pct,
+          recencyBonus: bonus,
+        },
+      };
+    }
+    return { ok: true, relevancePct: fit.mandala_relevance_pct };
   } catch (err) {
     const reason =
       err instanceof V2QuickValidationError

--- a/src/modules/relevance/relevance-composition.ts
+++ b/src/modules/relevance/relevance-composition.ts
@@ -17,6 +17,8 @@
  * convention). Callers read flags and pass data in.
  */
 
+import { MS_PER_MONTH_AVG } from '@/utils/time-constants';
+
 /** Rubric weights when a cell goal is present (cell-fit AND center contribution). */
 export const RUBRIC_WEIGHTS = {
   cellFit: 0.4,
@@ -35,8 +37,6 @@ export const RECENCY_FRESH_MONTHS = 6;
 export const RECENCY_MID_MONTHS = 12;
 export const RECENCY_FRESH_BONUS = 5;
 export const RECENCY_MID_BONUS = 2;
-
-const MS_PER_MONTH = 30.44 * 24 * 60 * 60 * 1000; // mean Gregorian month
 
 export interface RubricAxes {
   /** null ⇒ no cell goal was given (weights fall back to NO_CELL). */
@@ -72,7 +72,7 @@ export function recencyBonus(
   if (volatility !== 'volatile' || !publishedAt) return 0;
   const ageMs = now.getTime() - publishedAt.getTime();
   if (ageMs < 0) return RECENCY_FRESH_BONUS; // future-dated (premiere) = fresh
-  const months = ageMs / MS_PER_MONTH;
+  const months = ageMs / MS_PER_MONTH_AVG;
   if (months < RECENCY_FRESH_MONTHS) return RECENCY_FRESH_BONUS;
   if (months < RECENCY_MID_MONTHS) return RECENCY_MID_BONUS;
   return 0;

--- a/src/modules/relevance/relevance-composition.ts
+++ b/src/modules/relevance/relevance-composition.ts
@@ -1,0 +1,84 @@
+/**
+ * Relevance composition — code-side synthesis of the 3-axis rubric + the
+ * volatile-only recency bonus (CP499+ diagnosis A score pipeline).
+ *
+ * Why code composes (not the LLM): a single LLM-emitted composite collapses
+ * into round-number modes (72/78/85/92 measured fleet-wide 2026-06-11) and
+ * compresses on abstract goals (sd 6.8). Axis-wise scores have independent
+ * modes, so a weighted code-side sum spreads — that spread is the mechanism
+ * the gate validates (abstract-goal sd ≥ 12, concrete-goal Spearman ≥ 0.8).
+ *
+ * ⚠️ PROVISIONAL VALUES — gate-validation targets, NOT law. The weights
+ * (0.4/0.4/0.2, 0.7/0.3) and recency table (+5 <6m, +2 6-12m) are starting
+ * points; the multi-mandala gate (2-3 abstract + 2-3 concrete) re-tunes them
+ * on miss. Keep them HERE (single home) so re-tuning is a 1-file change.
+ *
+ * Pure module — no config, no Prisma, no provider (config-free pure-helper
+ * convention). Callers read flags and pass data in.
+ */
+
+/** Rubric weights when a cell goal is present (cell-fit AND center contribution). */
+export const RUBRIC_WEIGHTS = {
+  cellFit: 0.4,
+  goalContribution: 0.4,
+  actionability: 0.2,
+} as const;
+
+/** Rubric weights without a cell goal (Heart path / scratchpad rows). */
+export const RUBRIC_WEIGHTS_NO_CELL = {
+  goalContribution: 0.7,
+  actionability: 0.3,
+} as const;
+
+/** Recency bonus table — applies ONLY to volatile-domain mandalas. */
+export const RECENCY_FRESH_MONTHS = 6;
+export const RECENCY_MID_MONTHS = 12;
+export const RECENCY_FRESH_BONUS = 5;
+export const RECENCY_MID_BONUS = 2;
+
+const MS_PER_MONTH = 30.44 * 24 * 60 * 60 * 1000; // mean Gregorian month
+
+export interface RubricAxes {
+  /** null ⇒ no cell goal was given (weights fall back to NO_CELL). */
+  cellFitPct: number | null;
+  goalContributionPct: number;
+  actionabilityPct: number;
+}
+
+/** Weighted composite, rounded and clamped to [0, 100]. */
+export function composeRubricScore(axes: RubricAxes): number {
+  const raw =
+    axes.cellFitPct === null
+      ? RUBRIC_WEIGHTS_NO_CELL.goalContribution * axes.goalContributionPct +
+        RUBRIC_WEIGHTS_NO_CELL.actionability * axes.actionabilityPct
+      : RUBRIC_WEIGHTS.cellFit * axes.cellFitPct +
+        RUBRIC_WEIGHTS.goalContribution * axes.goalContributionPct +
+        RUBRIC_WEIGHTS.actionability * axes.actionabilityPct;
+  return Math.min(100, Math.max(0, Math.round(raw)));
+}
+
+/**
+ * Recency bonus for a card. Non-zero ONLY when the mandala is volatile AND
+ * published_at is known — evergreen, NULL volatility (pre-existing mandalas)
+ * and NULL published_at (3.7% of placed cards) are all 0 = unchanged behavior.
+ * Additive (never a penalty): a misclassified evergreen mandala can never be
+ * demoted, only a fresh-volatile card rewarded (James decision 2026-06-11).
+ */
+export function recencyBonus(
+  publishedAt: Date | null | undefined,
+  volatility: string | null | undefined,
+  now: Date = new Date()
+): number {
+  if (volatility !== 'volatile' || !publishedAt) return 0;
+  const ageMs = now.getTime() - publishedAt.getTime();
+  if (ageMs < 0) return RECENCY_FRESH_BONUS; // future-dated (premiere) = fresh
+  const months = ageMs / MS_PER_MONTH;
+  if (months < RECENCY_FRESH_MONTHS) return RECENCY_FRESH_BONUS;
+  if (months < RECENCY_MID_MONTHS) return RECENCY_MID_BONUS;
+  return 0;
+}
+
+/** Final score = base + bonus, capped at 100. */
+export function applyRecency(basePct: number, bonus: number): number {
+  return Math.min(100, basePct + bonus);
+}

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -31,6 +31,7 @@ import { validateV2TimelineRange, V2TimelineRangeError } from './rich-summary-v2
 // the next tier up. Search-replace point for future model swaps.
 const SONNET_MODEL = 'anthropic/claude-sonnet-4-6';
 
+import { detectContentLanguageFromTitle as detectLanguageFromTitle } from '@/utils/detect-language';
 import {
   buildV2Prompt,
   scoreCompleteness,
@@ -39,21 +40,7 @@ import {
   type RichSummaryV2Layered,
 } from './rich-summary-v2-prompt';
 
-const HANGUL_RANGE = /[가-힯]/g;
-const LATIN_RANGE = /[A-Za-z]/g;
-
-function detectLanguageFromTitle(title: string): 'ko' | 'en' | null {
-  if (!title) return null;
-  const stripped = title.replace(/\s+/g, '');
-  if (stripped.length === 0) return null;
-  const hangulCount = (stripped.match(HANGUL_RANGE) ?? []).length;
-  const latinCount = (stripped.match(LATIN_RANGE) ?? []).length;
-  const hangulRatio = hangulCount / stripped.length;
-  const latinRatio = latinCount / stripped.length;
-  if (hangulRatio >= 0.2) return 'ko';
-  if (latinRatio >= 0.5 && hangulRatio < 0.05) return 'en';
-  return null;
-}
+// CP499+ 전수 통일 — detectLanguageFromTitle now lives in @/utils/detect-language.
 
 const log = logger.child({ module: 'RichSummaryV2Generator' });
 

--- a/src/modules/skills/rich-summary-v2-quick-generator.ts
+++ b/src/modules/skills/rich-summary-v2-quick-generator.ts
@@ -27,6 +27,7 @@ import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
 import { loadRichSummaryConfig } from '@/config/rich-summary';
 import { logger } from '@/utils/logger';
 
+import { detectContentLanguageFromTitle as detectLanguageFromTitle } from '@/utils/detect-language';
 import {
   buildV2QuickPrompt,
   validateV2Quick,
@@ -40,21 +41,7 @@ const HAIKU_MODEL = 'anthropic/claude-haiku-4.5';
 const MAX_TOKENS = 800;
 const TEMPERATURE = 0.2;
 
-const HANGUL_RANGE = /[가-힯]/g;
-const LATIN_RANGE = /[A-Za-z]/g;
-
-function detectLanguageFromTitle(title: string): 'ko' | 'en' | null {
-  if (!title) return null;
-  const stripped = title.replace(/\s+/g, '');
-  if (stripped.length === 0) return null;
-  const hangulCount = (stripped.match(HANGUL_RANGE) ?? []).length;
-  const latinCount = (stripped.match(LATIN_RANGE) ?? []).length;
-  const hangulRatio = hangulCount / stripped.length;
-  const latinRatio = latinCount / stripped.length;
-  if (hangulRatio >= 0.2) return 'ko';
-  if (latinRatio >= 0.5 && hangulRatio < 0.05) return 'en';
-  return null;
-}
+// CP499+ 전수 통일 — detectLanguageFromTitle now lives in @/utils/detect-language.
 
 export type V2QuickOutcome =
   | { kind: 'pass'; videoId: string; mandalaRelevancePct: number }

--- a/src/modules/skills/rich-summary-v2-quick-prompt.ts
+++ b/src/modules/skills/rich-summary-v2-quick-prompt.ts
@@ -18,6 +18,8 @@
  *   - JSON output only — caller validates with `validateV2Quick` below.
  */
 
+import { composeRubricScore } from '@/modules/relevance/relevance-composition';
+
 export interface V2QuickResult {
   core: {
     one_liner: string;
@@ -26,6 +28,12 @@ export interface V2QuickResult {
     core_argument: string;
     mandala_fit: {
       mandala_relevance_pct: number;
+      /** Present ONLY in rubric mode — raw axes (logged, not persisted yet). */
+      rubric?: {
+        cell_fit_pct: number | null;
+        goal_contribution_pct: number;
+        actionability_pct: number;
+      };
     };
   };
 }
@@ -37,6 +45,17 @@ export interface QuickPromptInput {
   language: 'ko' | 'en';
   transcript: string;
   mandalaCenterGoal: string;
+  /**
+   * CP499+ rubric mode (RELEVANCE_RUBRIC_ENABLED) — the LLM scores 3 axes
+   * (cell_fit / goal_contribution / actionability) and the COMPOSITE is
+   * computed in code (relevance-composition.ts). Why: a single LLM composite
+   * collapses into round-number modes and compresses on abstract goals
+   * (sd 6.8 measured). Absent/false ⇒ the legacy single-axis prompt,
+   * byte-identical to pre-CP499+ output.
+   */
+  rubric?: boolean;
+  /** Rubric mode only — the cell sub-goal, printed as a separate CELL GOAL line. */
+  cellGoal?: string;
 }
 
 const RICH_SUMMARY_V2_QUICK_PROMPT = `You are a learning content analyst. Output ONLY valid JSON matching this exact shape — no markdown fences, no commentary, no chain-of-thought.
@@ -75,6 +94,28 @@ TRANSCRIPT (truncated 4000 chars):
 {transcript}
 `;
 
+/**
+ * CP499+ rubric variant — same prompt body, but mandala_fit asks for 3 raw
+ * axes instead of one composite. The composite is computed in code
+ * (relevance-composition.ts), which is the score-compression fix. Weights and
+ * axis definitions are PROVISIONAL gate-validation targets, not law.
+ */
+const RUBRIC_MANDALA_FIT_SCHEMA = `"mandala_fit": {
+      "cell_fit_pct": <integer 0..100, or null when CELL GOAL is "(none)">,
+      "goal_contribution_pct": <integer 0..100>,
+      "actionability_pct": <integer 0..100>
+    }`;
+
+const RUBRIC_MANDALA_FIT_RULES = `- analysis.mandala_fit.cell_fit_pct: integer 0-100 — how well the video fits the CELL GOAL below. Output null when CELL GOAL is "(none)".
+- analysis.mandala_fit.goal_contribution_pct: integer 0-100 — how much watching this video contributes to the MANDALA CENTER GOAL below. Score 0 when the goal is empty or genuinely unrelated; reserve 90+ for videos that clearly address the exact goal. Be conservative.
+- analysis.mandala_fit.actionability_pct: integer 0-100 — how directly a viewer can ACT on this video toward the goal. Concrete methods/steps/tools score high; abstract motivation/general talk scores low. Judge this axis independently from the other two.`;
+
+const SINGLE_AXIS_SCHEMA = `"mandala_fit": {
+      "mandala_relevance_pct": <integer 0..100>
+    }`;
+
+const SINGLE_AXIS_RULE = `- analysis.mandala_fit.mandala_relevance_pct: integer 0-100 measuring how well the video fits the user's mandala center goal below. Score 0 when the goal is empty or genuinely unrelated; reserve 90+ for videos that clearly address the exact goal. Be conservative.`;
+
 const MAX_DESC_CHARS = 400;
 const MAX_TRANSCRIPT_CHARS = 4000;
 
@@ -90,12 +131,25 @@ export function buildV2QuickPrompt(input: QuickPromptInput): string {
       ? `${transcriptText.slice(0, MAX_TRANSCRIPT_CHARS)}…`
       : transcriptText || '(no transcript)';
 
-  return RICH_SUMMARY_V2_QUICK_PROMPT.replace(/\{language\}/g, input.language)
+  let template = RICH_SUMMARY_V2_QUICK_PROMPT;
+  if (input.rubric) {
+    template = template
+      .replace(SINGLE_AXIS_SCHEMA, RUBRIC_MANDALA_FIT_SCHEMA)
+      .replace(SINGLE_AXIS_RULE, RUBRIC_MANDALA_FIT_RULES)
+      .replace(
+        'MANDALA CENTER GOAL: {mandala_center_goal}',
+        'MANDALA CENTER GOAL: {mandala_center_goal}\nCELL GOAL: {cell_goal}'
+      );
+  }
+
+  return template
+    .replace(/\{language\}/g, input.language)
     .replace(/\{language_label\}/g, languageLabel)
     .replace(/\{title\}/g, input.title)
     .replace(/\{channel\}/g, input.channel)
     .replace(/\{description\}/g, descTrim)
     .replace(/\{mandala_center_goal\}/g, input.mandalaCenterGoal || '(empty)')
+    .replace(/\{cell_goal\}/g, input.cellGoal?.trim() || '(none)')
     .replace(/\{transcript\}/g, transcriptTrim);
 }
 
@@ -151,7 +205,13 @@ export function trimOneLinerLabel(raw: string): string {
   return s;
 }
 
-export function validateV2Quick(raw: unknown): V2QuickResult {
+/**
+ * CP499+ — rubric-mode validation. The LLM emits 3 raw axes; the composite
+ * `mandala_relevance_pct` is computed HERE (composeRubricScore) so every
+ * consumer keeps reading the same field. opts.rubric MUST match the
+ * buildV2QuickPrompt rubric flag of the call that produced `raw`.
+ */
+export function validateV2Quick(raw: unknown, opts: { rubric?: boolean } = {}): V2QuickResult {
   if (typeof raw !== 'object' || raw === null) {
     throw new V2QuickValidationError('root must be an object', '$');
   }
@@ -172,6 +232,41 @@ export function validateV2Quick(raw: unknown): V2QuickResult {
   }
   const mff = mf as Record<string, unknown>;
 
+  let mandalaFit: V2QuickResult['analysis']['mandala_fit'];
+  if (opts.rubric) {
+    const cellFit =
+      mff['cell_fit_pct'] === null || mff['cell_fit_pct'] === undefined
+        ? null
+        : requireInteger(mff['cell_fit_pct'], 'analysis.mandala_fit.cell_fit_pct');
+    const goalContribution = requireInteger(
+      mff['goal_contribution_pct'],
+      'analysis.mandala_fit.goal_contribution_pct'
+    );
+    const actionability = requireInteger(
+      mff['actionability_pct'],
+      'analysis.mandala_fit.actionability_pct'
+    );
+    mandalaFit = {
+      mandala_relevance_pct: composeRubricScore({
+        cellFitPct: cellFit,
+        goalContributionPct: goalContribution,
+        actionabilityPct: actionability,
+      }),
+      rubric: {
+        cell_fit_pct: cellFit,
+        goal_contribution_pct: goalContribution,
+        actionability_pct: actionability,
+      },
+    };
+  } else {
+    mandalaFit = {
+      mandala_relevance_pct: requireInteger(
+        mff['mandala_relevance_pct'],
+        'analysis.mandala_fit.mandala_relevance_pct'
+      ),
+    };
+  }
+
   return {
     core: {
       // CP476+ — soft truncate at 20 chars. LLM occasionally ignores the
@@ -187,12 +282,7 @@ export function validateV2Quick(raw: unknown): V2QuickResult {
     },
     analysis: {
       core_argument: requireString(aa['core_argument'], 'analysis.core_argument', 500),
-      mandala_fit: {
-        mandala_relevance_pct: requireInteger(
-          mff['mandala_relevance_pct'],
-          'analysis.mandala_fit.mandala_relevance_pct'
-        ),
-      },
+      mandala_fit: mandalaFit,
     },
   };
 }

--- a/src/prompts/mandala-with-queries-generator.ts
+++ b/src/prompts/mandala-with-queries-generator.ts
@@ -58,8 +58,10 @@ ${koFocusLine ? '  - ' + koFocusLine.slice(2) + '을 자연스럽게 반영\n' :
 - 너무 길거나 문장형(예: "매일 학습할 수 있는 시간 블록 설정하는 방법")이면 YouTube 매칭 실패 → 금지.
 - 8개 검색어는 서로 다른 각도(방법론/경험담/도구/실수방지/루틴 등)로 분산 — 같은 표현 반복 금지 (한 셀이 동일 브랜드/채널로 뭉치는 노이즈 방지).
 
+[3단계 — 도메인 휘발성] volatility: 이 목표의 콘텐츠가 시간이 지나면 낡는가? 기술/도구/트렌드(예: AI 도구, 코딩, 투자 트렌드)면 "volatile", 시간 무관(예: 운동, 요가, 어학, 마음수련)이면 "evergreen". 한 단어만.
+
 ${example}JSON만 출력 (cell_queries 키는 sub_goals 순서 "0"~"7"):
-{"center_goal":"...","center_label":"...","language":"ko","domain":"${domain}","sub_goals":["8개"],"sub_labels":["8개"],"cell_queries":{"0":"검색어",...,"7":"검색어"}}
+{"center_goal":"...","center_label":"...","language":"ko","domain":"${domain}","volatility":"volatile|evergreen","sub_goals":["8개"],"sub_labels":["8개"],"cell_queries":{"0":"검색어",...,"7":"검색어"}}
 
 목표: ${goal}`;
   }
@@ -79,8 +81,10 @@ ${focusLine ? '  - Incorporate focus areas naturally: ' + (focusTags ?? []).join
 - Too long / sentence-like → no YouTube match → forbidden.
 - Spread the 8 queries across different angles (how-to / stories / tools / mistakes / routine) — never repeat a phrase (prevents a cell clustering on one brand/channel).
 
+[Step 3 — domain volatility] volatility: does content for this goal go stale over time? Tech/tools/trends (AI tools, coding, investing trends) = "volatile"; timeless (fitness, yoga, language learning, mindfulness) = "evergreen". One word only.
+
 ${example}JSON only (cell_queries keys are sub_goals order "0".."7"):
-{"center_goal":"...","center_label":"...","language":"en","domain":"${domain}","sub_goals":["8 items"],"sub_labels":["8 items"],"cell_queries":{"0":"query",...,"7":"query"}}
+{"center_goal":"...","center_label":"...","language":"en","domain":"${domain}","volatility":"volatile|evergreen","sub_goals":["8 items"],"sub_labels":["8 items"],"cell_queries":{"0":"query",...,"7":"query"}}
 
 Goal: ${goal}`;
 }

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -9,21 +9,31 @@
  * Korean results. This helper recovers the input language from the text
  * itself so the YouTube search is issued in the right language/region.
  *
- * Zero-dependency, deterministic — pure character-class counting.
+ * CP499+ (diagnosis A-3): Hangul PRESENCE now wins outright. The previous
+ * count-comparison (`hangul >= latin`) let long Latin proper nouns outvote
+ * Korean particles — "Claude Code로 프로덕션 앱 개발" (latin 10 vs hangul 8)
+ * was judged 'en' although a Korean user typed it on a Korean keyboard.
+ * Proper nouns are NOT a language signal; particles are. Measured fleet
+ * impact (2026-06-11 prod, full scan): exactly 3 en-misjudged mandalas
+ * corrected, 0 reverse flips (no stored-ko mandala has a Latin-only goal).
+ *
+ * Zero-dependency, deterministic — pure character-class testing.
  */
 
 export type DetectedLanguage = 'ko' | 'en';
 
 /** Hangul Syllables block (U+AC00–U+D7A3) — Korean pre-composed syllables. */
-const HANGUL_RE = /[가-힣]/gu;
+const HANGUL_RE = /[가-힣]/u;
 /** Basic Latin letters — the English signal. */
-const LATIN_RE = /[A-Za-z]/g;
+const LATIN_RE = /[A-Za-z]/;
 
 /**
- * Detect the dominant script of `text`.
+ * Detect the input language of `text`.
  *
- *   - Any Hangul that is at least as frequent as Latin letters → 'ko'.
- *   - Latin letters present, little/no Hangul → 'en'.
+ *   - ANY Hangul → 'ko'. Typing even one Hangul syllable means a Korean
+ *     keyboard/user; Latin tokens around it are proper nouns (tool names,
+ *     brands) and are excluded from the judgement.
+ *   - No Hangul, Latin letters present → 'en'.
  *   - No script signal at all (digits/symbols only, or empty) → 'ko',
  *     preserving the pre-CP458 default so this is never *more* surprising
  *     than the behavior it replaces.
@@ -34,10 +44,9 @@ const LATIN_RE = /[A-Za-z]/g;
  */
 export function detectLanguage(text: string | null | undefined): DetectedLanguage {
   if (!text) return 'ko';
-  const hangulCount = (text.match(HANGUL_RE) ?? []).length;
-  const latinCount = (text.match(LATIN_RE) ?? []).length;
-  if (hangulCount === 0 && latinCount === 0) return 'ko';
-  return hangulCount >= latinCount ? 'ko' : 'en';
+  if (HANGUL_RE.test(text)) return 'ko';
+  if (LATIN_RE.test(text)) return 'en';
+  return 'ko';
 }
 
 /**

--- a/src/utils/detect-language.ts
+++ b/src/utils/detect-language.ts
@@ -62,3 +62,34 @@ export function resolveLanguage(
   if (stored === 'ko' || stored === 'en') return stored;
   return detectLanguage(goalText);
 }
+
+/**
+ * CP499+ 전수 통일 — CONTENT-language detection from a VIDEO TITLE.
+ *
+ * Distinct from detectLanguage (INPUT language of user-typed goal text, where
+ * Hangul presence wins): this asks "what language is the video itself in?" so
+ * the v2 summary is GENERATED in the source language (accuracy; display-side
+ * translation handles the user's language — the v2-translations design).
+ * Tri-state: null = no confident signal; callers fall back to
+ * youtube default_language or their own default.
+ *
+ * Extracted from 3 byte-identical local copies (rich-summary-v2-quick-generator,
+ * rich-summary-v2-generator, internal/prompt-build). The original copies used
+ * the range 가-힯 (U+D7AF); normalized to 가-힣 (U+D7A3) — U+D7A4..D7AF are
+ * unassigned code points, so behavior on real text is identical.
+ */
+const TITLE_HANGUL_RE = /[가-힣]/g;
+const TITLE_LATIN_RE = /[A-Za-z]/g;
+
+export function detectContentLanguageFromTitle(title: string): 'ko' | 'en' | null {
+  if (!title) return null;
+  const stripped = title.replace(/\s+/g, '');
+  if (stripped.length === 0) return null;
+  const hangulCount = (stripped.match(TITLE_HANGUL_RE) ?? []).length;
+  const latinCount = (stripped.match(TITLE_LATIN_RE) ?? []).length;
+  const hangulRatio = hangulCount / stripped.length;
+  const latinRatio = latinCount / stripped.length;
+  if (hangulRatio >= 0.2) return 'ko';
+  if (latinRatio >= 0.5 && hangulRatio < 0.05) return 'en';
+  return null;
+}

--- a/tests/unit/modules/enrich-relevance-quick.test.ts
+++ b/tests/unit/modules/enrich-relevance-quick.test.ts
@@ -28,10 +28,12 @@ jest.mock('pg-boss', () => jest.fn().mockImplementation(() => mockBossInstance))
 
 const mockUvsUpdate = jest.fn().mockResolvedValue({});
 const mockUlcUpdate = jest.fn().mockResolvedValue({});
+const mockQueryRaw = jest.fn().mockResolvedValue([]);
 jest.mock('@/modules/database/client', () => ({
   getPrismaClient: () => ({
     userVideoState: { update: mockUvsUpdate },
     user_local_cards: { update: mockUlcUpdate },
+    $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
   }),
 }));
 
@@ -188,5 +190,64 @@ describe('enqueueRelevanceQuick', () => {
       centerGoal: 'G',
     });
     expect(result).toBeNull();
+  });
+});
+
+describe('CP499+ rubric flag-on context fetch ($queryRaw, fail-open)', () => {
+  afterEach(() => {
+    delete process.env['RELEVANCE_RUBRIC_ENABLED'];
+  });
+
+  test('flag on: context row -> compute called with rubric + language/volatility/publishedAt', async () => {
+    process.env['RELEVANCE_RUBRIC_ENABLED'] = 'true';
+    const published = new Date('2026-06-01T00:00:00Z');
+    mockQueryRaw.mockResolvedValueOnce([
+      { language: 'ko', volatility: 'volatile', published_at: published },
+    ]);
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 81 });
+    const handler = await getHandler();
+
+    await handler({
+      id: 'j-rubric',
+      data: { table: 'uvs', rowId: 'row-uvs-9', title: 'T', centerGoal: 'G' },
+    });
+
+    expect(mockCompute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rubric: true,
+        language: 'ko',
+        volatility: 'volatile',
+        publishedAt: published,
+      })
+    );
+    expect(mockUvsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'row-uvs-9' } })
+    );
+  });
+
+  test('flag on + context fetch throws -> fail-open legacy call (no rubric key)', async () => {
+    process.env['RELEVANCE_RUBRIC_ENABLED'] = 'true';
+    mockQueryRaw.mockRejectedValueOnce(new Error('column volatility does not exist'));
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 55 });
+    const handler = await getHandler();
+
+    await handler({
+      id: 'j-failopen',
+      data: { table: 'uvs', rowId: 'row-uvs-10', title: 'T', centerGoal: 'G' },
+    });
+
+    const arg = mockCompute.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg['rubric']).toBeUndefined();
+    expect(mockUvsUpdate).toHaveBeenCalled();
+  });
+
+  test('flag off (default): no $queryRaw at all — zero new selects', async () => {
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 60 });
+    const handler = await getHandler();
+    await handler({
+      id: 'j-off',
+      data: { table: 'uvs', rowId: 'row-uvs-11', title: 'T', centerGoal: 'G' },
+    });
+    expect(mockQueryRaw).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/modules/mandala-merged-gen.test.ts
+++ b/tests/unit/modules/mandala-merged-gen.test.ts
@@ -77,6 +77,26 @@ describe('parseMergedResponse', () => {
 describe('generateMandalaWithQueries', () => {
   const baseInput = { goal: '한국어 목표', language: 'ko' as const };
 
+  test('CP499+ volatility: enum value survives, garbage is dropped', async () => {
+    const withVol = (v: unknown) => {
+      const obj = JSON.parse(mergedJson(FULL_CQ)) as Record<string, unknown>;
+      obj['volatility'] = v;
+      return JSON.stringify(obj);
+    };
+    const ok = await generateMandalaWithQueries(baseInput, {
+      generateImpl: async () => withVol('volatile'),
+    });
+    expect(ok.structure.volatility).toBe('volatile');
+    const bad = await generateMandalaWithQueries(baseInput, {
+      generateImpl: async () => withVol('sometimes'),
+    });
+    expect(bad.structure.volatility).toBeUndefined();
+    const absent = await generateMandalaWithQueries(baseInput, {
+      generateImpl: async () => mergedJson(FULL_CQ),
+    });
+    expect(absent.structure.volatility).toBeUndefined();
+  });
+
   test('full coverage → 8 cellQueries, not degraded, center_goal overridden', async () => {
     const res = await generateMandalaWithQueries(baseInput, {
       generateImpl: async () => mergedJson(FULL_CQ),

--- a/tests/unit/modules/relevance-rubric-pipeline.test.ts
+++ b/tests/unit/modules/relevance-rubric-pipeline.test.ts
@@ -26,6 +26,7 @@ import {
 } from '@/modules/skills/rich-summary-v2-quick-prompt';
 import { buildMandalaWithQueriesPrompt } from '@/prompts/mandala-with-queries-generator';
 import { loadRelevanceRubricConfig } from '@/config/relevance-rubric';
+import { MS_PER_MONTH_AVG } from '@/utils/time-constants';
 
 describe('composeRubricScore (PROVISIONAL weights — gate-validation targets)', () => {
   it('weights 0.4/0.4/0.2 with a cell goal', () => {
@@ -61,7 +62,7 @@ describe('composeRubricScore (PROVISIONAL weights — gate-validation targets)',
 
 describe('recencyBonus (volatile-only, additive)', () => {
   const now = new Date('2026-06-11T00:00:00Z');
-  const monthsAgo = (m: number) => new Date(now.getTime() - m * 30.44 * 24 * 3600 * 1000);
+  const monthsAgo = (m: number) => new Date(now.getTime() - m * MS_PER_MONTH_AVG);
 
   it('volatile + fresh (<6m) → +5', () => {
     expect(recencyBonus(monthsAgo(5), 'volatile', now)).toBe(RECENCY_FRESH_BONUS);

--- a/tests/unit/modules/relevance-rubric-pipeline.test.ts
+++ b/tests/unit/modules/relevance-rubric-pipeline.test.ts
@@ -1,0 +1,193 @@
+/**
+ * CP499+ score pipeline — R1 rubric + volatile-only recency + lang 정합.
+ *
+ * Locks the pipeline invariants:
+ *   - composition is CODE-side (weights are PROVISIONAL gate targets);
+ *   - recency bonus fires ONLY for volatile + known published_at (additive,
+ *     never a penalty; evergreen / NULL volatility / NULL date = 0);
+ *   - rubric prompt actually swaps the mandala_fit block (guards against a
+ *     silent .replace no-op on template drift) and the legacy prompt is
+ *     byte-identical to pre-CP499+ output;
+ *   - validator parses both shapes and composes in rubric mode;
+ *   - merged-gen prompt asks the volatility judgement in BOTH languages.
+ */
+
+import {
+  composeRubricScore,
+  recencyBonus,
+  applyRecency,
+  RECENCY_FRESH_BONUS,
+  RECENCY_MID_BONUS,
+} from '@/modules/relevance/relevance-composition';
+import {
+  buildV2QuickPrompt,
+  validateV2Quick,
+  V2QuickValidationError,
+} from '@/modules/skills/rich-summary-v2-quick-prompt';
+import { buildMandalaWithQueriesPrompt } from '@/prompts/mandala-with-queries-generator';
+import { loadRelevanceRubricConfig } from '@/config/relevance-rubric';
+
+describe('composeRubricScore (PROVISIONAL weights — gate-validation targets)', () => {
+  it('weights 0.4/0.4/0.2 with a cell goal', () => {
+    expect(
+      composeRubricScore({ cellFitPct: 100, goalContributionPct: 100, actionabilityPct: 100 })
+    ).toBe(100);
+    expect(
+      composeRubricScore({ cellFitPct: 50, goalContributionPct: 100, actionabilityPct: 0 })
+    ).toBe(60);
+    expect(
+      composeRubricScore({ cellFitPct: 80, goalContributionPct: 70, actionabilityPct: 30 })
+    ).toBe(66);
+  });
+
+  it('weights 0.7/0.3 without a cell goal', () => {
+    expect(
+      composeRubricScore({ cellFitPct: null, goalContributionPct: 100, actionabilityPct: 0 })
+    ).toBe(70);
+    expect(
+      composeRubricScore({ cellFitPct: null, goalContributionPct: 80, actionabilityPct: 40 })
+    ).toBe(68);
+  });
+
+  it('rounds and clamps to [0, 100]', () => {
+    expect(composeRubricScore({ cellFitPct: 0, goalContributionPct: 0, actionabilityPct: 0 })).toBe(
+      0
+    );
+    expect(
+      composeRubricScore({ cellFitPct: 33, goalContributionPct: 33, actionabilityPct: 33 })
+    ).toBe(33);
+  });
+});
+
+describe('recencyBonus (volatile-only, additive)', () => {
+  const now = new Date('2026-06-11T00:00:00Z');
+  const monthsAgo = (m: number) => new Date(now.getTime() - m * 30.44 * 24 * 3600 * 1000);
+
+  it('volatile + fresh (<6m) → +5', () => {
+    expect(recencyBonus(monthsAgo(5), 'volatile', now)).toBe(RECENCY_FRESH_BONUS);
+  });
+  it('volatile + mid (6-12m) → +2', () => {
+    expect(recencyBonus(monthsAgo(11), 'volatile', now)).toBe(RECENCY_MID_BONUS);
+  });
+  it('volatile + old (>12m) → 0', () => {
+    expect(recencyBonus(monthsAgo(13), 'volatile', now)).toBe(0);
+  });
+  it('evergreen / NULL volatility / NULL published_at → 0 (unchanged behavior)', () => {
+    expect(recencyBonus(monthsAgo(1), 'evergreen', now)).toBe(0);
+    expect(recencyBonus(monthsAgo(1), null, now)).toBe(0);
+    expect(recencyBonus(null, 'volatile', now)).toBe(0);
+  });
+  it('future-dated (premiere) counts as fresh', () => {
+    expect(recencyBonus(monthsAgo(-1), 'volatile', now)).toBe(RECENCY_FRESH_BONUS);
+  });
+  it('applyRecency caps at 100', () => {
+    expect(applyRecency(98, 5)).toBe(100);
+    expect(applyRecency(60, 2)).toBe(62);
+  });
+});
+
+describe('buildV2QuickPrompt rubric variant', () => {
+  const base = {
+    title: '테스트 영상',
+    description: 'desc',
+    channel: 'ch',
+    language: 'ko' as const,
+    transcript: '',
+    mandalaCenterGoal: '바이브 코딩 마스터하기',
+  };
+
+  it('rubric prompt swaps the mandala_fit block (guard vs silent replace no-op)', () => {
+    const p = buildV2QuickPrompt({ ...base, rubric: true, cellGoal: '환경 구축' });
+    expect(p).toContain('cell_fit_pct');
+    expect(p).toContain('goal_contribution_pct');
+    expect(p).toContain('actionability_pct');
+    expect(p).not.toContain('mandala_relevance_pct');
+    expect(p).toContain('CELL GOAL: 환경 구축');
+  });
+
+  it('rubric without cellGoal prints "(none)"', () => {
+    const p = buildV2QuickPrompt({ ...base, rubric: true });
+    expect(p).toContain('CELL GOAL: (none)');
+  });
+
+  it('legacy prompt (rubric absent) is byte-identical to pre-CP499+ (no rubric tokens)', () => {
+    const p = buildV2QuickPrompt(base);
+    expect(p).toContain('mandala_relevance_pct');
+    expect(p).not.toContain('cell_fit_pct');
+    expect(p).not.toContain('CELL GOAL');
+  });
+});
+
+describe('validateV2Quick rubric mode', () => {
+  const body = (fit: Record<string, unknown>) => ({
+    core: { one_liner: '바이브 코딩 핵심' },
+    analysis: { core_argument: '핵심 주장이다.', mandala_fit: fit },
+  });
+
+  it('composes mandala_relevance_pct from the 3 axes', () => {
+    const r = validateV2Quick(
+      body({ cell_fit_pct: 80, goal_contribution_pct: 70, actionability_pct: 30 }),
+      { rubric: true }
+    );
+    expect(r.analysis.mandala_fit.mandala_relevance_pct).toBe(66);
+    expect(r.analysis.mandala_fit.rubric).toEqual({
+      cell_fit_pct: 80,
+      goal_contribution_pct: 70,
+      actionability_pct: 30,
+    });
+  });
+
+  it('null cell_fit_pct → NO_CELL weights', () => {
+    const r = validateV2Quick(
+      body({ cell_fit_pct: null, goal_contribution_pct: 100, actionability_pct: 0 }),
+      { rubric: true }
+    );
+    expect(r.analysis.mandala_fit.mandala_relevance_pct).toBe(70);
+  });
+
+  it('rubric mode rejects a missing axis', () => {
+    expect(() =>
+      validateV2Quick(body({ cell_fit_pct: 80, goal_contribution_pct: 70 }), { rubric: true })
+    ).toThrow(V2QuickValidationError);
+  });
+
+  it('legacy mode is unchanged (single axis, no rubric field)', () => {
+    const r = validateV2Quick(body({ mandala_relevance_pct: 85 }));
+    expect(r.analysis.mandala_fit.mandala_relevance_pct).toBe(85);
+    expect(r.analysis.mandala_fit.rubric).toBeUndefined();
+  });
+});
+
+describe('merged-gen prompt volatility judgement', () => {
+  it('ko prompt asks volatility and the JSON schema carries the key', () => {
+    const p = buildMandalaWithQueriesPrompt({ goal: '목표', domain: 'general', language: 'ko' });
+    expect(p).toContain('"volatility":"volatile|evergreen"');
+    expect(p).toContain('도메인 휘발성');
+  });
+  it('en prompt asks volatility and the JSON schema carries the key', () => {
+    const p = buildMandalaWithQueriesPrompt({ goal: 'goal', domain: 'general', language: 'en' });
+    expect(p).toContain('"volatility":"volatile|evergreen"');
+    expect(p).toContain('domain volatility');
+  });
+});
+
+describe('loadRelevanceRubricConfig', () => {
+  it('default OFF (unset = legacy pipeline)', () => {
+    expect(loadRelevanceRubricConfig({} as NodeJS.ProcessEnv).enabled).toBe(false);
+  });
+  it('true/1/yes enable; anything else off', () => {
+    expect(
+      loadRelevanceRubricConfig({ RELEVANCE_RUBRIC_ENABLED: 'true' } as NodeJS.ProcessEnv).enabled
+    ).toBe(true);
+    expect(
+      loadRelevanceRubricConfig({ RELEVANCE_RUBRIC_ENABLED: '1' } as NodeJS.ProcessEnv).enabled
+    ).toBe(true);
+    expect(
+      loadRelevanceRubricConfig({ RELEVANCE_RUBRIC_ENABLED: 'false' } as NodeJS.ProcessEnv).enabled
+    ).toBe(false);
+    expect(
+      loadRelevanceRubricConfig({ RELEVANCE_RUBRIC_ENABLED: 'garbage' } as NodeJS.ProcessEnv)
+        .enabled
+    ).toBe(false);
+  });
+});

--- a/tests/unit/utils/detect-language.test.ts
+++ b/tests/unit/utils/detect-language.test.ts
@@ -10,7 +10,11 @@
  *   3 en-misjudged corrected, 0 reverse flips).
  */
 
-import { detectLanguage, resolveLanguage } from '@/utils/detect-language';
+import {
+  detectLanguage,
+  resolveLanguage,
+  detectContentLanguageFromTitle,
+} from '@/utils/detect-language';
 
 describe('detectLanguage', () => {
   it('detects an English goal as en (the CP458 bug case)', () => {
@@ -68,5 +72,20 @@ describe('resolveLanguage', () => {
 
   it('CP499+ — NULL stored + mixed proper-noun goal resolves ko via detection', () => {
     expect(resolveLanguage(null, 'Claude Code로 프로덕션 앱 개발')).toBe('ko');
+  });
+});
+
+describe('detectContentLanguageFromTitle (CP499+ 전수 통일 — content language, tri-state)', () => {
+  it('matches the prior local-copy behavior (ratio-based)', () => {
+    expect(detectContentLanguageFromTitle('ETF 투자로 노후 자산 만들기')).toBe('ko');
+    expect(detectContentLanguageFromTitle('Build retirement assets via ETF investing')).toBe('en');
+  });
+  it('tri-state: no confident signal → null (caller falls back)', () => {
+    expect(detectContentLanguageFromTitle('')).toBeNull();
+    expect(detectContentLanguageFromTitle('2026 — 100%')).toBeNull();
+  });
+  it('mixed title below thresholds → null (NOT the input-language rule)', () => {
+    // hangul ratio < 0.2 AND >= 0.05 → neither branch fires
+    expect(detectContentLanguageFromTitle('AAAAAAAAAAAAAAAAAA 한')).toBeNull();
   });
 });

--- a/tests/unit/utils/detect-language.test.ts
+++ b/tests/unit/utils/detect-language.test.ts
@@ -1,15 +1,19 @@
 /**
- * detect-language — script detection for goal/title text (CP458).
+ * detect-language — script detection for goal/title text (CP458, CP499+).
  *
- * Pins the fix for the English-mandala-searched-as-Korean bug: an English
- * goal must resolve to 'en' so YouTube search uses regionCode=US +
- * relevanceLanguage=en instead of the NULL→'ko' default.
+ * Pins two fixes:
+ * - CP458: an English goal must resolve to 'en' so YouTube search uses
+ *   regionCode=US + relevanceLanguage=en instead of the NULL→'ko' default.
+ * - CP499+ (diagnosis A-3): Hangul PRESENCE wins outright — Latin proper
+ *   nouns must not outvote Korean particles. Regression cases below are the
+ *   exact 3 misjudged production goals (full-fleet scan 2026-06-11:
+ *   3 en-misjudged corrected, 0 reverse flips).
  */
 
 import { detectLanguage, resolveLanguage } from '@/utils/detect-language';
 
 describe('detectLanguage', () => {
-  it('detects an English goal as en (the reported bug case)', () => {
+  it('detects an English goal as en (the CP458 bug case)', () => {
     expect(detectLanguage('Build retirement assets via ETF investing')).toBe('en');
   });
 
@@ -18,12 +22,23 @@ describe('detectLanguage', () => {
   });
 
   it('treats Korean-dominant mixed text as ko', () => {
-    // "AI" is Latin but Hangul dominates → ko
     expect(detectLanguage('AI 마케팅으로 비즈니스 성장 시키기')).toBe('ko');
   });
 
-  it('treats English-dominant mixed text as en', () => {
-    expect(detectLanguage('Complete an AI/ML project portfolio 만들기')).toBe('en');
+  it('CP499+ — ANY Hangul wins even when Latin letters dominate (proper nouns excluded)', () => {
+    // Spec change vs CP458: previously latin-count > hangul-count → 'en'.
+    expect(detectLanguage('Complete an AI/ML project portfolio 만들기')).toBe('ko');
+  });
+
+  it('CP499+ regression — the 3 real misjudged production goals are ko', () => {
+    expect(detectLanguage('Claude Code로 프로덕션 앱 개발')).toBe('ko');
+    expect(detectLanguage('Ultra Learning 으로 AI 전문가 되기')).toBe('ko');
+    expect(detectLanguage('gitthub 공부')).toBe('ko');
+  });
+
+  it('pure-Latin text still detects as en (no reverse flip)', () => {
+    expect(detectLanguage('Master Kubernetes in 30 days')).toBe('en');
+    expect(detectLanguage('Claude Code')).toBe('en');
   });
 
   it('defaults to ko for empty / null / no-script input (preserves pre-CP458 default)', () => {
@@ -49,5 +64,9 @@ describe('resolveLanguage', () => {
     expect(resolveLanguage('', 'English text')).toBe('en');
     expect(resolveLanguage('EN', '한국어')).toBe('ko'); // case-sensitive — 'EN' is not 'en'
     expect(resolveLanguage('garbage', 'English text')).toBe('en');
+  });
+
+  it('CP499+ — NULL stored + mixed proper-noun goal resolves ko via detection', () => {
+    expect(resolveLanguage(null, 'Claude Code로 프로덕션 앱 개발')).toBe('ko');
   });
 });


### PR DESCRIPTION
## What (single PR = single pipeline, per agreement)

ONE flag (`RELEVANCE_RUBRIC_ENABLED`, **default OFF = byte-identical legacy behavior**) gates the whole new score pipeline:

### A. 3-axis rubric — LLM scores axes, CODE composes
- `cell_fit_pct` / `goal_contribution_pct` / `actionability_pct` in the (shared) quick prompt's `mandala_fit` block; composite computed in `relevance-composition.ts` (validator-level, so every consumer keeps reading `mandala_relevance_pct`).
- Why: fleet scan 2026-06-11 — a single LLM composite collapses into round-number modes (72/78/85/92) and compresses on abstract goals (sd 6.8). Axis modes are independent → code-side weighted sum spreads. `actionability` is the axis built to separate motivational vs method content on abstract goals.
- Scope: A-stage scorer (`compute-card-relevance`) only. The Heart v2 path writes the video-keyed v2 signal (`video_rich_summaries`), not the user-scoped sort column — left single-axis, no regime mixing in sort.

### B. Volatile-only recency bonus (additive, never a penalty)
- `+5` (<6m) / `+2` (6-12m) / 0 otherwise, cap 100. Evergreen / NULL volatility (all pre-existing mandalas) / NULL published_at (3.7%) ⇒ 0 = unchanged.
- Volatility judged by merged-gen in 1 extra line (`"volatility":"volatile|evergreen"`), sanitized to the 2-value enum, persisted **flag-gated** to new `user_mandalas.volatility`.

### C. Mandala-language alignment (#902 정합)
- Scorer prompt language = `mandala.language` via `resolveLanguage` (worker passes it; NULL-language mandalas — 56% of real-usage fleet — fall through to the #902 Hangul-presence rule on the goal text). Removed the scorer's local ratio-based detector (3rd variant).
- Unified the 3 byte-identical `detectLanguageFromTitle` copies (v2 quick/full generators, internal prompt-build) into `utils detectContentLanguageFromTitle` — documented as CONTENT-language (tri-state), distinct from INPUT-language detection. `qwen-prompt-middleware`'s detector judges chatbot system content (different domain) — left as is, noted here.

## ⚠️ PROVISIONAL VALUES — gate-validation targets, NOT law
Weights `0.4/0.4/0.2` (`0.7/0.3` no-cell), recency `+5/+2`, boundaries `6m/12m` are starting points. The gate re-tunes on miss. All live in ONE file (`relevance-composition.ts`).

## Gate (before fleet)
2-3 **abstract** + 2-3 **concrete** mandalas; PASS = abstract sd ≥ 12 AND concrete Spearman ≥ 0.8 vs current ranking AND fixed-sample order. Measured via the existing admin relevance-backfill 1-mandala trigger. Venue decision pending (see PR discussion).

## DDL — per-step approval (NOT automatic with merge)
- `prisma/migrations/score-pipeline/001_add_user_mandalas_volatility.sql` (force-tracked per manual-DDL convention; `ADD COLUMN IF NOT EXISTS`, inert).
- **Local: applied + \d verified + pgrst reloaded.** Prod: deploy's `prisma db push` may add it automatically OR silent-fail (known Supabase ownership issue) — authoritative application = manual DDL + \d verification, **separate go**, before the flag ever turns on.
- Worker context fetch uses `$queryRaw` (not the typed client) so this path is decoupled from client-generation state; flag off ⇒ zero new selects; context-fetch failure ⇒ fail-open to legacy scoring.

## Verification
- `tsc --noEmit` clean.
- 93 tests green across 8 affected suites incl. NEW `relevance-rubric-pipeline.test.ts` (composition math, recency boundaries, rubric prompt swap guard, validator both shapes, merged-gen volatility key ko+en, flag default-off) + worker flag-on/$queryRaw fail-open/flag-off-zero-selects cases + volatility sanitize cases.
- 2 pre-existing failures in `wizard-precompute.test.ts` reproduce identically on the origin/main baseline worktree (timing-sensitive poll test) — not introduced here; CI arbitrates.

## Dependency
Built on top of #902 (merged into this branch). After #902 lands on main, this PR shows only the pipeline delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)