### PR TITLE
feat(relevance): video_mandala_relevance gate-cache table (A-2 unified schema, inert) — merge = prod DDL go

### DIFF
--- a/prisma/migrations/score-pipeline/002_video_mandala_relevance.sql
+++ b/prisma/migrations/score-pipeline/002_video_mandala_relevance.sql
@@ -1,0 +1,13 @@
+-- CP499+ A-2 — pre-placement relevance gate cache (video x mandala).
+-- Lazy-filled by the pool-serving / auto-add gate; consumers ship in later PRs.
+-- First-serve scoring is ASYNC by design (W1b "filling" state; no sync block).
+-- Idempotent: IF NOT EXISTS throughout (apply-custom-sql.sh contract).
+CREATE TABLE IF NOT EXISTS public.video_mandala_relevance (
+  video_id      varchar(11) NOT NULL,
+  mandala_id    uuid        NOT NULL REFERENCES public.user_mandalas(id) ON DELETE CASCADE,
+  relevance_pct int         NOT NULL,
+  relevance_at  timestamptz NOT NULL DEFAULT now(),
+  detail        jsonb,
+  PRIMARY KEY (video_id, mandala_id)
+);
+CREATE INDEX IF NOT EXISTS idx_vmr_mandala ON public.video_mandala_relevance (mandala_id);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -447,6 +447,7 @@ model user_mandalas {
   updated_at      DateTime                  @default(now()) @db.Timestamptz(6)
   users           users                     @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   levels          user_mandala_levels[]
+  videoRelevance  video_mandala_relevance[]
   videoStates     UserVideoState[]
   localCards      user_local_cards[]
   subscriptions   mandala_subscriptions[]
@@ -2268,5 +2269,28 @@ model chatbot_settings {
   updated_at        DateTime @default(now()) @db.Timestamptz(6)
   updated_by        String?  @db.Uuid
 
+  @@schema("public")
+}
+
+/// CP499+ A-2 — PRE-PLACEMENT relevance gate cache, keyed (video, mandala).
+/// Stage-separated from uvs/ulc.relevance_pct (placed-card scores, row-keyed)
+/// and video_rich_summaries.mandala_relevance_pct (v2 signal, #876 KEEP).
+/// Filled LAZILY when the pool-serving / auto-add gate scores a candidate —
+/// no fleet pre-backfill. Consumers ship in later PRs; this table is inert.
+/// DESIGN CONSTRAINT (James 2026-06-11, user-perceived priority): first-serve
+/// scoring MUST be async — the screen renders immediately, filling cells show
+/// the W1b "filling" state and auto-update on completion. Sync blocking 금지.
+model video_mandala_relevance {
+  video_id      String        @db.VarChar(11)
+  mandala_id    String        @db.Uuid
+  relevance_pct Int
+  relevance_at  DateTime      @default(now()) @db.Timestamptz(6)
+  /// R1 rubric raw axes (cell_fit / goal_contribution / actionability /
+  /// recency) — NULL until the gate measurement justifies persisting detail.
+  detail        Json?         @db.JsonB
+  mandala       user_mandalas @relation(fields: [mandala_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@id([video_id, mandala_id])
+  @@index([mandala_id], map: "idx_vmr_mandala")
   @@schema("public")
 }

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -85,6 +85,12 @@ APPLY_FILES=(
   # CP474 — v2 regen gate based on transcript_used (boolean). ADD COLUMN
   # IF NOT EXISTS + idempotent backfill (WHERE transcript_used = false).
   "prisma/migrations/rich-summary-v2/006_add_transcript_used.sql"
+  # CP499+ score pipeline (A-2 통합 스키마). 001 = user_mandalas.volatility
+  # (merged-gen 1-line judgement, flag-gated writes). 002 = pre-placement
+  # relevance gate cache (video x mandala), inert until consumer PRs.
+  # Both ADD COLUMN/CREATE TABLE IF NOT EXISTS — idempotent.
+  "prisma/migrations/score-pipeline/001_add_user_mandalas_volatility.sql"
+  "prisma/migrations/score-pipeline/002_video_mandala_relevance.sql"
   # CP466 — Add Cards Phase 1 (surfacing). `surfaced_at` column + partial
   # index on user_video_states for Layer 1 Coverage dedup. ADD COLUMN IF
   # NOT EXISTS / CREATE INDEX IF NOT EXISTS — idempotent.


### PR DESCRIPTION
## What (PR #1 of the A-2 track — TABLE ONLY, zero consumers)

`video_mandala_relevance` — pre-placement relevance gate cache keyed `(video_id, mandala_id)`. The shared base for the three immediate user-visible fixes: pool-serving relevance gate, auto-add threshold, deleted-video prune.

### Stage separation (no dual-source)
| store | stage | key | role |
|---|---|---|---|
| **video_mandala_relevance (NEW)** | pre-placement | (video, mandala) | gate cache |
| uvs/ulc.relevance_pct | post-placement | row PK | sort/badge (unchanged) |
| video_rich_summaries.mandala_relevance_pct | v2 signal | video | SSE dot, KEEP per #876 (unchanged) |

- **Lazy fill only** — scored when a gate first evaluates a candidate; no fleet pre-backfill.
- `detail jsonb` included now as NULL (avoids a future ALTER; engineering call per James).
- **Recorded design constraint for consumer PRs**: first-serve scoring is ASYNC — screen renders immediately, filling cells reuse the W1b "filling" state and auto-update on completion. Sync blocking forbidden.

## ⚠️ Merge semantics — THIS MERGE EXECUTES THE PROD DDL

`scripts/verify-db-tables.js` derives expected tables from `schema.prisma`, so the model cannot merge without the table being created in the same deploy. This PR therefore registers BOTH score-pipeline DDLs in the `apply-custom-sql.sh` strict allowlist (the LEVEL-3 automation built for exactly this):
- `001_add_user_mandalas_volatility.sql` (shipped inert in #903, prod column currently ABSENT — measured)
- `002_video_mandala_relevance.sql` (this PR)

Both are idempotent (`IF NOT EXISTS`). On merge, deploy applies them via `DIRECT_URL` and the verify step confirms. **The [MERGE] tag on this PR is the prod-DDL go** — there is no separate manual DDL step afterward (post-deploy I will verify both objects exist on prod and report).

## Verification
- `prisma validate` clean. Local DB: 002 applied + `\d` verified (PK, idx_vmr_mandala, FK CASCADE) + pgrst reloaded. 001 was applied locally earlier.
- No code consumers — tsc/test surface unchanged.

## Next (approved order)
prod DDL verify → R1 `RELEVANCE_RUBRIC_ENABLED` ON + gate (2-3 abstract + 2-3 concrete, sd≥12 ∧ Spearman≥0.8) → consumer PRs: auto-add gate → pool-serving + prune (async first-serve) → C-1b invalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)