### PR TITLE
feat(discover): ko mandala auto-inflow drops English-dominant titles (UX principle 1, CP499+)

### DIFF
--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -70,6 +70,10 @@ const v5EnvSchema = z.object({
   // candidate generation for "full enough" cells (pure quota/latency save; the
   // cell's cards are already excluded anyway). unset = false = no-op.
   V5_CELL_SKIP: booleanFlag.optional().default(false as unknown as string),
+  // CP499+ UX 원칙 1 (언어 일관성) — ko 만다라 자동유입에서 영어-우세 제목
+  // drop. DEFAULT ON (컨벤션 편차: 기존 동작 자체가 제품 결함 판정 — James
+  // 2026-06-11). env = 롤백 레버 (off = 기존 영어-통과 동작).
+  V5_KO_EN_TITLE_DROP: booleanFlag.optional().default(true as unknown as string),
   // CP494 ④-1 — per-cell "full" threshold. ≥ this many grid cards → skip.
   // 12 favors "user may want to see more" (cells with 7-11 still searched).
   V5_CELL_SKIP_THRESHOLD: z.coerce.number().int().min(1).max(60).default(12),
@@ -112,6 +116,8 @@ export interface V5Config {
   reuseLoop: boolean;
   /** CP494 ④-1 — full-cell skip enabled. */
   cellSkip: boolean;
+  /** CP499+ — ko 만다라 자동유입 영어-우세 제목 drop (UX 원칙 1). */
+  koEnTitleDrop: boolean;
   /** CP494 ④-1 — per-cell card count threshold for skip. */
   cellSkipThreshold: number;
   /** CP494 안 A — pool match strategy ('global' | 'per_cell'). */
@@ -148,6 +154,7 @@ export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
     poolTimeoutMs: p.V5_POOL_TIMEOUT_MS,
     reuseLoop: p.V5_REUSE_LOOP,
     cellSkip: p.V5_CELL_SKIP,
+    koEnTitleDrop: p.V5_KO_EN_TITLE_DROP,
     cellSkipThreshold: p.V5_CELL_SKIP_THRESHOLD,
     poolMatch: p.V5_POOL_MATCH,
   };

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -25,6 +25,7 @@ import { buildRuleBasedQueriesSync, type SearchQuery } from '../v2/keyword-build
 import { buildLLMQueriesPerCell, type QueryGenMeta } from './llm-query-gen';
 import { translateQueriesToEn } from './en-query-translate';
 import { getV5Config } from './config';
+import { detectLanguage } from '@/utils/detect-language';
 import { MERGED_GEN_MODEL } from '@/prompts/mandala-with-queries-generator';
 import {
   tsvectorKeywordCandidates,
@@ -262,21 +263,30 @@ export function rotateKeys(keys: string[], i: number): string[] {
 /**
  * CP499+ — toggle-aware off-language gate ('영문 카드 포함').
  *
- * DESIGN FINDING (test-caught): the ko-rules ALREADY pass pure-English titles
- * (hangul 0 + no dominant third script = kept), so the gate needs NO widening
- * for the toggle — and a ko∪en union would be actively WRONG: the en-rules
- * only block CJK, so Arabic/Thai/Cyrillic titles would re-enter through the
- * en side. The toggle's effective EN-inflow lever is therefore the
- * relevanceLanguage drop in the search call alone; this function keeps the
- * toggle branch explicit at both call sites and pins the EN-passes invariant.
- * Exported for tests.
+ * UX 원칙 1 (언어 일관성, James 2026-06-11): 입력 언어 = 경험 언어. ko 만다라의
+ * AUTO inflow (wizard / add-cards 기본) drops English-DOMINANT titles — the
+ * prior "English intentionally NEVER dropped" stance was re-judged a product
+ * defect on screen evidence (K8s mandala: "Kubernetes Monitoring with
+ * Prometheus & Grafana" etc. mixed into a ko grid). Signal = #902
+ * detectLanguage: ANY Hangul ⇒ ko ⇒ kept ("[용어]…쿠버네티스 보안",
+ * "Kubernetes란?"), zero Hangul + Latin ⇒ en ⇒ dropped.
+ *
+ * The explicit EN chip (includeEnCards=true) is opt-in and UNAFFECTED — that
+ * path wants English. Third-script rules (isOffLanguageTitle) still apply
+ * first in every mode. koEnTitleDrop = V5_KO_EN_TITLE_DROP rollback lever
+ * (off ⇒ legacy English-passes behavior). Exported for tests.
  */
 export function isOffLanguageTitleToggled(
   title: string,
   lang: 'ko' | 'en',
-  _includeEnCards: boolean | undefined
+  includeEnCards: boolean | undefined,
+  koEnTitleDrop = true
 ): boolean {
-  return isOffLanguageTitle(title, lang);
+  if (isOffLanguageTitle(title, lang)) return true;
+  if (lang === 'ko' && !includeEnCards && koEnTitleDrop) {
+    return detectLanguage(title) === 'en';
+  }
+  return false;
 }
 
 export function isOffLanguageTitle(title: string, lang: 'ko' | 'en'): boolean {
@@ -477,7 +487,15 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
         const cand = keywordCandidateToFanoutCandidate(kc);
         // Fork-1 caveat: pool candidates run the SAME gates as live items.
         if (titleHitsBlocklist(cand.title) || titleIndicatesShorts(cand.title)) continue;
-        if (isOffLanguageTitleToggled(cand.title, input.language, input.includeEnCards)) continue;
+        if (
+          isOffLanguageTitleToggled(
+            cand.title,
+            input.language,
+            input.includeEnCards,
+            cfg.koEnTitleDrop
+          )
+        )
+          continue;
         const ci = cand.cellIndex ?? -1;
         if (ci < 0) continue;
         const bucket = byCell.get(ci);
@@ -666,7 +684,12 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       if (
         enOnlyActive
           ? /[가-힣]/.test(cand.title)
-          : isOffLanguageTitleToggled(cand.title, input.language, input.includeEnCards)
+          : isOffLanguageTitleToggled(
+              cand.title,
+              input.language,
+              input.includeEnCards,
+              cfg.koEnTitleDrop
+            )
       ) {
         offLangDropped += 1;
         continue;

--- a/tests/unit/skills/video-discover/v5-include-en-toggle.test.ts
+++ b/tests/unit/skills/video-discover/v5-include-en-toggle.test.ts
@@ -1,14 +1,18 @@
 /**
- * CP499+ '영문 카드 포함' toggle — 3-way contract (James spec):
- *   ① ko + ON  → EN titles pass the gate; third-script stays blocked;
- *                the live search drops the relevanceLanguage=ko bias
- *   ② ko + OFF → current single-language gate, bit-identical
+ * CP499+ '영문 카드 포함' toggle — 3-way contract, UPDATED for UX 원칙 1
+ * (언어 일관성, James 2026-06-11):
+ *   ① ko + ON  → EN titles pass the gate (opt-in wants English);
+ *                third-script stays blocked
+ *   ② ko + OFF → English-DOMINANT titles are now DROPPED (spec change —
+ *                the prior "EN-passes invariant" was re-judged a product
+ *                defect on K8s-mandala screen evidence). Hangul-bearing
+ *                titles keep passing (Korean video with English terms).
  *   ③ en mandala → toggle is a no-op (en rules regardless of the flag)
+ *   ④ V5_KO_EN_TITLE_DROP=false → legacy English-passes behavior (rollback
+ *                lever, config-only).
  *
- * Honest note pinned in code: the ko-rules ALREADY pass pure-Latin titles —
- * the toggle's EN-inflow body is the relevanceLanguage drop (the pool is
- * 5.9% EN, live search is the supply body). The gate-widening keeps the
- * semantics explicit.
+ * Signal = #902 detectLanguage: ANY Hangul ⇒ ko ⇒ kept; zero Hangul +
+ * Latin ⇒ en ⇒ dropped.
  */
 import {
   isOffLanguageTitle,
@@ -20,23 +24,49 @@ const EN = 'Basketball Dribbling Fundamentals';
 const ZH = '篮球运球基础教程完整版'; // third-script: blocked in every mode
 const AR = 'أساسيات المراوغة في كرة السلة';
 
-describe("'영문 카드 포함' — off-language gate 3-way", () => {
-  it('① ko + ON: ko and EN pass; third-script (zh/ar) stays blocked', () => {
-    // Design finding pinned: the ko gate is already EN-permissive, and a
-    // ko∪en union would re-admit Arabic/Thai (the en-rules only block CJK).
-    // So ON keeps the ko gate; EN-inflow comes from the relevanceLanguage
-    // drop in the search call.
+// 2026-06-11 K8s-mandala screen regression set (the exact production cases).
+const SCREEN_EN_DOMINANT = [
+  'Kubernetes Monitoring with Prometheus & Grafana Using Helm | Complete Hands-On Demo',
+  'Container Security Explained Kubernetes, Docker & Cloud Native Threats',
+  'Kubernetes Security: Performance, Hardening, and Lifecycle Management | Uplatz',
+];
+const SCREEN_KO_WITH_TERMS = [
+  '[용어](Cybersecurity) Kubernetes Security - 쿠버네티스 보안',
+  'Kubernetes란? For Real Begginer',
+];
+
+describe("'영문 카드 포함' — off-language gate 3-way (UX 원칙 1)", () => {
+  it('① ko + ON: ko and EN pass (opt-in); third-script (zh/ar) stays blocked', () => {
     expect(isOffLanguageTitleToggled(KO, 'ko', true)).toBe(false);
     expect(isOffLanguageTitleToggled(EN, 'ko', true)).toBe(false);
     expect(isOffLanguageTitleToggled(ZH, 'ko', true)).toBe(true);
     expect(isOffLanguageTitleToggled(AR, 'ko', true)).toBe(true);
   });
 
-  it('② ko + OFF (and undefined): bit-identical to the current ko gate', () => {
-    for (const t of [KO, EN, ZH, AR]) {
-      expect(isOffLanguageTitleToggled(t, 'ko', false)).toBe(isOffLanguageTitle(t, 'ko'));
-      expect(isOffLanguageTitleToggled(t, 'ko', undefined)).toBe(isOffLanguageTitle(t, 'ko'));
+  it('② ko + OFF (and undefined): English-dominant DROPPED, Hangul-bearing kept (spec change)', () => {
+    for (const off of [false, undefined] as const) {
+      expect(isOffLanguageTitleToggled(KO, 'ko', off)).toBe(false);
+      expect(isOffLanguageTitleToggled(EN, 'ko', off)).toBe(true); // was false pre-UX원칙1
+      expect(isOffLanguageTitleToggled(ZH, 'ko', off)).toBe(true);
+      expect(isOffLanguageTitleToggled(AR, 'ko', off)).toBe(true);
     }
+  });
+
+  it('② regression — the 5 production K8s-screen cases (2026-06-11)', () => {
+    for (const t of SCREEN_EN_DOMINANT) {
+      expect(isOffLanguageTitleToggled(t, 'ko', false)).toBe(true);
+    }
+    for (const t of SCREEN_KO_WITH_TERMS) {
+      expect(isOffLanguageTitleToggled(t, 'ko', false)).toBe(false);
+    }
+    // and the EN chip keeps them (opt-in unaffected):
+    for (const t of SCREEN_EN_DOMINANT) {
+      expect(isOffLanguageTitleToggled(t, 'ko', true)).toBe(false);
+    }
+  });
+
+  it('② edge: digits/symbols-only title falls back ko → kept (conservative)', () => {
+    expect(isOffLanguageTitleToggled('2026 — 100%', 'ko', false)).toBe(false);
   });
 
   it('③ en mandala: the flag is a no-op — en rules apply regardless', () => {
@@ -44,5 +74,14 @@ describe("'영문 카드 포함' — off-language gate 3-way", () => {
       expect(isOffLanguageTitleToggled(t, 'en', true)).toBe(isOffLanguageTitle(t, 'en'));
       expect(isOffLanguageTitleToggled(t, 'en', false)).toBe(isOffLanguageTitle(t, 'en'));
     }
+  });
+
+  it('④ V5_KO_EN_TITLE_DROP=false (4th arg) → legacy English-passes behavior', () => {
+    expect(isOffLanguageTitleToggled(EN, 'ko', false, false)).toBe(false);
+    for (const t of SCREEN_EN_DOMINANT) {
+      expect(isOffLanguageTitleToggled(t, 'ko', false, false)).toBe(false);
+    }
+    // third-script rules unaffected by the lever
+    expect(isOffLanguageTitleToggled(ZH, 'ko', false, false)).toBe(true);
   });
 });


### PR DESCRIPTION
## What

ko mandala AUTO inflow (wizard auto-add / add-cards default) now drops **English-dominant** titles. Korean titles with English terms (any Hangul) are kept. The explicit English chip (opt-in) is unaffected.

## Evidence (production screen, K8s mandala 48 cards)

Dropped by new rule (regression-pinned):
- `Kubernetes Monitoring with Prometheus & Grafana Using Helm…`
- `Container Security Explained Kubernetes, Docker & Cloud Native Threats`
- `Kubernetes Security: Performance, Hardening, and Lifecycle Management`

Kept (Hangul-bearing = Korean videos with English terms):
- `[용어](Cybersecurity) Kubernetes Security - 쿠버네티스 보안`
- `Kubernetes란? For Real Begginer`

## Mechanism — zero new machinery
- Seam: `isOffLanguageTitleToggled`'s previously-unused `includeEnCards` param (`v5/youtube-fanout.ts:274`). New branch: `ko && !includeEnCards → detectLanguage(title)==='en' → drop` (#902 Hangul-presence rule reused).
- Third-script rules unchanged (applied first). en mandalas unchanged. Both call sites (`:480` pool, `:669` live) thread `cfg.koEnTitleDrop`.

## ⚠️ Convention deviation (approved)
`V5_KO_EN_TITLE_DROP` **default ON** — deviates from 'new env default = old behavior' because the old behavior itself was judged a product defect (James 2026-06-11). The env is a config-only rollback lever.

## Deploy-order judgement (recorded)
Removing irrelevant English (trust-breaking) outranks temporary empty cells (honest scarcity). Pool serving (A-2 gate) is the paired fix and follows immediately — long gap forbidden per `docs/UX_PRINCIPLES.md` (sibling PR).

## UX principle alignment
원칙 1 (언어 일관성) — first enforcement / 원칙 3 (명시 opt-in 무영향).

## Tests
`v5-include-en-toggle.test.ts` rewritten to the new spec (the old ② 'bit-identical EN-passes' pin was the defect): 5 production cases + EN-chip-ON + en-mandala no-op + third-script pins + rollback-lever case. 28/28 green across both gate suites, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)