### PR TITLE
feat(discover): async pool-serve fill — deficit cells through the semantic relevance gate + live ko fallback (UX principle 2, CP499+)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -140,6 +140,12 @@ services:
       # injects no content. Canary: trace v5_skipped_full_cells + quota delta.
       # Revert: delete this line + redeploy → code default false (search all).
       - V5_CELL_SKIP=true
+      # CP499+ flag-pair simultaneity (James 2026-06-11): code default is ON,
+      # but deploy must keep EXISTING behavior — the EN-drop must activate in
+      # the SAME [GO] that turns pool-serve on (V5_POOL_SERVE=true), so users
+      # see "English becomes Korean", never "English becomes empty cells".
+      # [GO] = flip this to true + add V5_POOL_SERVE=true, one redeploy.
+      - V5_KO_EN_TITLE_DROP=false
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the

--- a/frontend/src/features/mandala/model/useMandalaQuery.ts
+++ b/frontend/src/features/mandala/model/useMandalaQuery.ts
@@ -29,6 +29,8 @@ export interface MandalaMeta {
   /** Server-truth card count (user_local_cards ∪ user_video_states dedup'd).
    *  Used by the grid as a layout commitment so unloaded cells render skeletons. */
   cardCount: number;
+  /** CP499+ pool-serve — cells with an async deficit-fill in flight. */
+  fillPendingCells: number[];
 }
 
 interface MandalaQueryShape {
@@ -37,6 +39,7 @@ interface MandalaQueryShape {
 }
 
 const EMPTY_META: MandalaMeta = {
+  fillPendingCells: [],
   focusTags: [],
   targetLevel: 'standard',
   language: 'ko',
@@ -67,6 +70,7 @@ export function useMandalaQuery(mandalaId?: string | null) {
             language: apiResponse.mandala.language ?? 'ko',
             title: apiResponse.mandala.title ?? '',
             cardCount: apiResponse.mandala.cardCount ?? 0,
+            fillPendingCells: apiResponse.mandala.fillPendingCells ?? [],
           },
         };
       } catch (err: unknown) {

--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -767,9 +767,38 @@ function AuthenticatedApp() {
     return () => clearInterval(timer);
   }, [actionsPending, effectiveMandalaId, queryClient]);
 
+  // CP499+ pool-serve — deficit cells being filled asynchronously (UX 원칙 2):
+  // pulse those cells (W1b pattern) and bounded-poll detail + cards until the
+  // fill run reports or the bound expires — a dead worker degrades to plain
+  // empty cells, never an infinite spinner.
+  const FILL_POLL_INTERVAL_MS = 5000;
+  const FILL_POLL_MAX_MS = 90_000;
+  const fillPendingCells = mandalaMeta?.fillPendingCells ?? [];
+  const fillPending = fillPendingCells.length > 0;
+  const fillPollStartedAt = useRef<number | null>(null);
+  useEffect(() => {
+    if (!fillPending || !effectiveMandalaId) {
+      fillPollStartedAt.current = null;
+      return;
+    }
+    fillPollStartedAt.current = fillPollStartedAt.current ?? Date.now();
+    const timer = setInterval(() => {
+      if (Date.now() - (fillPollStartedAt.current ?? 0) > FILL_POLL_MAX_MS) {
+        clearInterval(timer);
+        return;
+      }
+      queryClient.invalidateQueries({ queryKey: queryKeys.mandala.detail(effectiveMandalaId) });
+      // pool-serve inserts user_video_states rows — that is the cards source to refresh.
+      queryClient.invalidateQueries({ queryKey: queryKeys.youtube.allVideoStates() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.localCards.all });
+    }, FILL_POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [fillPending, effectiveMandalaId, queryClient]);
+
   // Shared MandalaGrid element
   const mandalaGridElement = () => (
     <MandalaGrid
+      fillPendingCells={fillPendingCells}
       mandalaId={effectiveMandalaId}
       level={navigation.currentLevel}
       actionsPending={actionsPending}

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -800,7 +800,8 @@
     "switchToFloating": "Switch to floating",
     "switchToDock": "Dock",
     "navigateToSub": "Navigate to {{subject}}",
-    "actionsFilling": "Filling…"
+    "actionsFilling": "Filling…",
+    "cardsFilling": "Filling…"
   },
   "scratchPad": {
     "title": "Scratch Pad",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -808,7 +808,8 @@
     "switchToFloating": "플로팅으로 전환",
     "switchToDock": "도킹하기",
     "navigateToSub": "{{subject}}로 이동",
-    "actionsFilling": "채워지는 중…"
+    "actionsFilling": "채워지는 중…",
+    "cardsFilling": "채워지는 중…"
   },
   "scratchPad": {
     "title": "스크래치패드",

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -431,6 +431,8 @@ interface MandalaResponse {
   language?: string;
   // CP467b — server-truth card count for grid layout commitment.
   cardCount?: number;
+  // CP499+ pool-serve — cells with an async deficit-fill in flight (W1b pulse).
+  fillPendingCells?: number[];
   createdAt: string;
   updatedAt: string;
   levels: Array<{

--- a/frontend/src/widgets/mandala-grid/ui/MandalaCell.tsx
+++ b/frontend/src/widgets/mandala-grid/ui/MandalaCell.tsx
@@ -23,6 +23,9 @@ export interface MandalaCellProps {
   /** W1b (CP499+) — actions-fill job still running for this sub-level:
    *  empty subject cells show a "filling" pulse instead of blank. */
   isActionsPending?: boolean;
+  /** Pool-serve (CP499+) — async deficit-fill job running for THIS cell:
+   *  show the same "filling" pulse on the empty-card state (display-only). */
+  isFillPending?: boolean;
   cards: InsightCard[];
   isDropTarget: boolean;
   isCellSwapTarget: boolean;
@@ -361,6 +364,7 @@ export const MandalaCell = memo(
     label,
     isCenter,
     isActionsPending = false,
+    isFillPending = false,
     cards,
     isDropTarget,
     isCellSwapTarget,
@@ -627,13 +631,22 @@ export const MandalaCell = memo(
           </div>
         )}
 
-        {/* Empty state — subtle + icon only */}
+        {/* Empty state — subtle + icon only. Pool-serve fill in flight ⇒
+            the cell is "filling" (W1b pattern), not permanently blank. */}
         {!isCenter && cardCount === 0 && (
-          <div className="flex-1 flex items-center justify-center w-full">
+          <div className="flex-1 flex flex-col items-center justify-center w-full gap-0.5">
             <Plus
               className="text-muted-foreground/20"
               style={{ width: 'clamp(12px, 4cqi, 24px)', height: 'clamp(12px, 4cqi, 24px)' }}
             />
+            {isFillPending && (
+              <span
+                className="animate-pulse text-muted-foreground/70 px-1 text-center"
+                style={{ fontSize: 'clamp(8px, 2.2cqi, 12px)' }}
+              >
+                {t('mandala.cardsFilling', 'Filling…')}
+              </span>
+            )}
           </div>
         )}
 

--- a/frontend/src/widgets/mandala-grid/ui/MandalaGrid.tsx
+++ b/frontend/src/widgets/mandala-grid/ui/MandalaGrid.tsx
@@ -9,6 +9,8 @@ import { useTranslation } from 'react-i18next';
 interface MandalaGridProps {
   /** W1b — current sub-level's actions-fill job still pending. */
   actionsPending?: boolean;
+  /** Pool-serve (CP499+) — cell indices with an async deficit-fill in flight. */
+  fillPendingCells?: number[];
   mandalaId?: string | null;
   level: MandalaLevel;
   cardsByCell: Record<number, InsightCard[]>;
@@ -46,6 +48,7 @@ export const MandalaGrid = memo(function MandalaGrid({
   mandalaId,
   level,
   actionsPending = false,
+  fillPendingCells,
   cardsByCell,
   selectedCellIndex,
   onCellClick,
@@ -359,6 +362,7 @@ export const MandalaGrid = memo(function MandalaGrid({
                   label={cellData.label}
                   isCenter={cellData.isCenter}
                   isActionsPending={actionsPending}
+                  isFillPending={fillPendingCells?.includes(index)}
                   cards={cellCards}
                   sizeMode={sizeMode}
                   totalCards={totalCards}

--- a/src/api/routes/admin/index.ts
+++ b/src/api/routes/admin/index.ts
@@ -26,6 +26,7 @@ import { adminV2QualityAuditRoutes } from './v2-quality-audit';
 import { adminV4ArbiterRunsRoutes } from './v4-arbiter-runs';
 import { adminPoolHealthRoutes } from './pool-health';
 import { adminRelevanceBackfillRoutes } from './relevance-backfill';
+import { adminPoolServeRoutes } from './pool-serve';
 
 /**
  * Admin routes plugin.
@@ -71,5 +72,7 @@ export async function adminRoutes(fastify: FastifyInstance) {
   // CP498 PR3b — A-stage relevance backfill manual trigger (1-mandala
   // measurement surface; bypasses BACKFILL_RELEVANCE_ENABLED + cutoff).
   await fastify.register(adminRelevanceBackfillRoutes, { prefix: '/relevance-backfill' });
+  // CP499+ — pool-serve canary trigger (deficit-cell fill, flag bypassed).
+  await fastify.register(adminPoolServeRoutes, { prefix: '/pool-serve' });
   // await fastify.register(stripeWebhookRoutes, { prefix: '/webhooks/stripe' });
 }

--- a/src/api/routes/admin/pool-serve.ts
+++ b/src/api/routes/admin/pool-serve.ts
@@ -1,0 +1,53 @@
+/**
+ * Admin pool-serve trigger — CP499+ canary measurement entry.
+ *
+ * POST /api/v1/admin/pool-serve/run   body { userId, mandalaId }
+ *   Detects deficit cells (placed < V5_POOL_SERVE_MIN_PER_CELL) and enqueues
+ *   one fill job per cell, BYPASSING the V5_POOL_SERVE flag — the canary
+ *   measures on one mandala while the fleet flag stays off.
+ *
+ * GET /api/v1/admin/pool-serve/runs/:runId
+ *   Returns the skill_runs row (per-cell outcomes: pool/live recruited,
+ *   scored, passed, inserted) — the canary 충당률 numbers come from here.
+ *
+ * Guarded by `fastify.authenticate + fastify.authenticateAdmin` per the admin
+ * route convention (mirrors admin/relevance-backfill.ts).
+ */
+
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+import { dispatchPoolServeForMandala } from '@/modules/queue/handlers/pool-serve-fill';
+import { getPrismaClient } from '@/modules/database/client';
+import { createSuccessResponse } from '../../schemas/common.schema';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'admin/pool-serve' });
+
+const RunBodySchema = z.object({
+  userId: z.string().uuid(),
+  mandalaId: z.string().uuid(),
+});
+
+const RunParamsSchema = z.object({
+  runId: z.string().uuid(),
+});
+
+export async function adminPoolServeRoutes(fastify: FastifyInstance) {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  fastify.post('/run', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
+    const { userId, mandalaId } = RunBodySchema.parse(request.body ?? {});
+
+    const result = await dispatchPoolServeForMandala(userId, mandalaId, { bypassFlag: true });
+
+    log.info('admin pool-serve run', { userId, mandalaId, ...result });
+    return reply.send(createSuccessResponse(result));
+  });
+
+  fastify.get('/runs/:runId', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
+    const { runId } = RunParamsSchema.parse(request.params ?? {});
+    const run = await getPrismaClient().skill_runs.findUnique({ where: { id: runId } });
+    return reply.send(createSuccessResponse(run));
+  });
+}

--- a/src/config/pool-serve.ts
+++ b/src/config/pool-serve.ts
@@ -1,0 +1,89 @@
+/**
+ * Pool-serve config (CP499+ — UX 원칙 2 "빈 셀 = 풀 서빙으로 충당").
+ *
+ * Gates the ASYNC pool-serving consumer of the A-2 relevance gate cache
+ * (`video_mandala_relevance`): empty/deficit cells are filled from the ko
+ * pool, every candidate passing the SEMANTIC relevance judge
+ * (computeCardRelevance) — this is the pool-side implementation of the
+ * "v5 공통 관련성 게이트" precondition (CP494+1 incident: pool serving
+ * without a judge is forbidden; lexical tsvector is candidate RECRUITMENT
+ * only, never the verdict). The legacy no-judge V5_POOL_BACKFILL stays OFF.
+ *
+ * ⚠️ PROVISIONAL VALUES — canary-validation targets, NOT law (threshold,
+ * floors, limits re-tuned on the K8s-mandala canary).
+ *
+ * Default: OFF. Rollback = flip env; no code revert.
+ *
+ * Zero-pass cells stay HONESTLY EMPTY (no irrelevant injection — 원칙 2).
+ * RESERVED follow-up (James 2026-06-11, NOT in this scope): un-filled cells
+ * → live ko re-search fallback (F3 family); canary measures 충당률 to judge
+ * its urgency.
+ */
+
+import { z } from 'zod';
+
+const boolFlag = z.preprocess((v) => {
+  if (v == null || v === '') return false;
+  const s = String(v).trim().toLowerCase();
+  return s === 'true' || s === '1' || s === 'yes';
+}, z.boolean());
+
+export const poolServeEnvSchema = z.object({
+  V5_POOL_SERVE: boolFlag.default(false as unknown as string),
+  /** Relevance gate threshold (0-100) a pool candidate must reach. */
+  V5_POOL_SERVE_RELEVANCE_MIN: z.coerce.number().int().min(0).max(100).default(60),
+  /** A cell with fewer placed cards than this is a deficit cell. */
+  V5_POOL_SERVE_MIN_PER_CELL: z.coerce.number().int().min(1).max(20).default(3),
+  /** Max cards a single fill job may add to one cell. */
+  V5_POOL_SERVE_MAX_FILL_PER_CELL: z.coerce.number().int().min(1).max(20).default(4),
+  /** Pool candidates recruited per cell (scored until MAX_FILL pass or exhausted). */
+  V5_POOL_SERVE_CANDIDATES_LIMIT: z.coerce.number().int().min(1).max(50).default(12),
+  /** pg-boss worker teamSize (scoring shares the OpenRouter key — keep low). */
+  V5_POOL_SERVE_CONCURRENCY: z.coerce.number().int().min(1).max(8).default(2),
+  /** 2차 live ko re-search fallback when the pool leaves a cell short.
+   *  Default ON — same-bundle lever (James 2026-06-11: no partial-state
+   *  exposure; per-cell ONE search.list call cap lives in the worker). */
+  V5_POOL_SERVE_LIVE_FALLBACK: boolFlag.default(true as unknown as string),
+});
+
+export interface PoolServeConfig {
+  enabled: boolean;
+  relevanceMin: number;
+  minPerCell: number;
+  maxFillPerCell: number;
+  candidatesLimit: number;
+  concurrency: number;
+  liveFallback: boolean;
+}
+
+const DEFAULTS: PoolServeConfig = {
+  enabled: false,
+  relevanceMin: 60,
+  minPerCell: 3,
+  maxFillPerCell: 4,
+  candidatesLimit: 12,
+  concurrency: 2,
+  liveFallback: true,
+};
+
+export function loadPoolServeConfig(env: NodeJS.ProcessEnv = process.env): PoolServeConfig {
+  const parsed = poolServeEnvSchema.safeParse({
+    V5_POOL_SERVE: env['V5_POOL_SERVE'],
+    V5_POOL_SERVE_RELEVANCE_MIN: env['V5_POOL_SERVE_RELEVANCE_MIN'],
+    V5_POOL_SERVE_MIN_PER_CELL: env['V5_POOL_SERVE_MIN_PER_CELL'],
+    V5_POOL_SERVE_MAX_FILL_PER_CELL: env['V5_POOL_SERVE_MAX_FILL_PER_CELL'],
+    V5_POOL_SERVE_CANDIDATES_LIMIT: env['V5_POOL_SERVE_CANDIDATES_LIMIT'],
+    V5_POOL_SERVE_CONCURRENCY: env['V5_POOL_SERVE_CONCURRENCY'],
+    V5_POOL_SERVE_LIVE_FALLBACK: env['V5_POOL_SERVE_LIVE_FALLBACK'],
+  });
+  if (!parsed.success) return DEFAULTS;
+  return {
+    enabled: parsed.data.V5_POOL_SERVE,
+    relevanceMin: parsed.data.V5_POOL_SERVE_RELEVANCE_MIN,
+    minPerCell: parsed.data.V5_POOL_SERVE_MIN_PER_CELL,
+    maxFillPerCell: parsed.data.V5_POOL_SERVE_MAX_FILL_PER_CELL,
+    candidatesLimit: parsed.data.V5_POOL_SERVE_CANDIDATES_LIMIT,
+    concurrency: parsed.data.V5_POOL_SERVE_CONCURRENCY,
+    liveFallback: parsed.data.V5_POOL_SERVE_LIVE_FALLBACK,
+  };
+}

--- a/src/modules/mandala/manager.ts
+++ b/src/modules/mandala/manager.ts
@@ -65,6 +65,10 @@ export interface MandalaWithLevels {
   // skeleton placeholders fill unloaded cells, eliminating the staggered
   // arrival jitter.
   cardCount: number;
+  // CP499+ pool-serve — cells with an ACTIVE fill run (skill_runs
+  // 'pool-serve-fill', status=running, ≤3min old). FE shows the W1b
+  // "filling" pulse on these cells and bounded-polls until they clear.
+  fillPendingCells: number[];
   createdAt: Date;
   updatedAt: Date;
   levels: {
@@ -160,7 +164,8 @@ export class MandalaManager {
         parent_level_id: string | null;
       }[];
     },
-    cardCount?: number
+    cardCount?: number,
+    fillPendingCells?: number[]
   ): MandalaWithLevels {
     return {
       id: mandala.id,
@@ -174,6 +179,7 @@ export class MandalaManager {
       targetLevel: mandala.target_level ?? 'standard',
       language: mandala.language ?? 'ko',
       cardCount: cardCount ?? 0,
+      fillPendingCells: fillPendingCells ?? [],
       createdAt: mandala.created_at,
       updatedAt: mandala.updated_at,
       levels: mandala.levels.map((l) => ({
@@ -356,7 +362,32 @@ export class MandalaManager {
     if (!mandala) return null;
 
     const cardCount = await this.computeCardCount(userId, mandalaId);
-    return this.mapMandala(mandala, cardCount);
+    const fillPendingCells = await this.computeFillPendingCells(userId, mandalaId);
+    return this.mapMandala(mandala, cardCount, fillPendingCells);
+  }
+
+  /**
+   * CP499+ pool-serve — cells with an active fill run: input.cells minus
+   * reported output keys on running 'pool-serve-fill' skill_runs rows
+   * (≤3min TTL so a dead worker degrades to plain empty cells, mirroring
+   * the W1b actions-poll bound). Fail-open: any error ⇒ [].
+   */
+  private async computeFillPendingCells(userId: string, mandalaId: string): Promise<number[]> {
+    try {
+      const rows = await this.prisma.$queryRaw<{ cell: number }[]>`
+        SELECT DISTINCT (c.value)::int AS cell
+        FROM skill_runs sr,
+             jsonb_array_elements_text(sr.input -> 'cells') AS c(value)
+        WHERE sr.skill_id = 'pool-serve-fill'
+          AND sr.status = 'running'
+          AND sr.user_id = ${userId}::uuid
+          AND sr.input ->> 'mandalaId' = ${mandalaId}
+          AND sr.started_at > now() - interval '3 minutes'
+          AND NOT (COALESCE(sr.output, '{}'::jsonb) ? c.value)`;
+      return rows.map((r) => r.cell);
+    } catch {
+      return [];
+    }
   }
 
   /**

--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -487,6 +487,31 @@ export async function consumePrecompute(
           });
       });
     }
+
+    // CP499+ pool-serve (UX 원칙 2): after wizard placement, fill DEFICIT
+    // cells from the ko pool through the semantic relevance gate. Fires on
+    // THIS path for the same reason as the relevance trigger above (#879
+    // flow-reach lesson) — the wizard never reaches pipeline-runner step3.
+    // Fire-and-forget; flag-gated inside (V5_POOL_SERVE, default off).
+    // Runs regardless of autoAddResult shape: a fully-failed auto-add IS the
+    // deficit case pool-serve exists for.
+    setImmediate(() => {
+      void import('@/modules/queue/handlers/pool-serve-fill')
+        .then(({ dispatchPoolServeForMandala }) =>
+          dispatchPoolServeForMandala(input.userId, input.mandalaId)
+        )
+        .then((r) => {
+          if (r.runId) {
+            log.info(
+              `pool-serve dispatched (precompute path): run=${r.runId} cells=[${r.deficitCells.join(',')}]`
+            );
+          }
+        })
+        .catch((err) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          log.warn(`pool-serve dispatch (precompute path) failed (non-fatal): ${msg}`);
+        });
+    });
   } catch (err) {
     log.warn(
       `precompute consume → auto-add inline threw (non-fatal — pipeline-runner step3 will retry): ${

--- a/src/modules/queue/handlers/pool-serve-fill.ts
+++ b/src/modules/queue/handlers/pool-serve-fill.ts
@@ -1,0 +1,452 @@
+/**
+ * Pool-serve fill — CP499+ (UX 원칙 2: 빈 셀 = 풀 서빙으로 충당).
+ *
+ * ASYNC consumer of the A-2 relevance gate cache: one job per DEFICIT CELL,
+ * three stages (James 2026-06-11 unified scope — no partial-state exposure):
+ *
+ *   1차 POOL  — recruit ko-pool candidates (lexical tsvector = recruitment
+ *               ONLY) → semantic judge (computeCardRelevance) ≥
+ *               V5_POOL_SERVE_RELEVANCE_MIN → top-K insert.
+ *   2차 LIVE  — still short of MIN_PER_CELL → ONE live ko re-search
+ *               (search.list, relevanceLanguage=ko, per-cell 1-call cap) →
+ *               SAME hygiene gates (#905 incl.) + SAME semantic judge
+ *               (live도 무심판 주입 금지 — displacement 방지 동일 원칙).
+ *               Lever: V5_POOL_SERVE_LIVE_FALLBACK (default ON).
+ *   3차 EMPTY — still zero = HONESTLY EMPTY (no irrelevant injection).
+ *
+ * This is the pool-side implementation of the "v5 공통 관련성 게이트"
+ * (CP494+1 incident: pool serving without a judge destroyed quality).
+ *
+ * Invariants:
+ *  - NEVER blocks a user request — dispatched fire-and-forget after card
+ *    placement; deficit cells show the W1b "filling" state
+ *    (skill_runs row drives `fillPendingCells`).
+ *  - Gate scores are CACHED in video_mandala_relevance (lazy A-2 fill) and
+ *    COPIED to uvs.relevance_pct on insert (no re-scoring).
+ *  - R1-independent: computeCardRelevance runs legacy single-axis when
+ *    RELEVANCE_RUBRIC_ENABLED is off; same call upgrades under R1.
+ */
+
+import type PgBoss from 'pg-boss';
+
+import { computeCardRelevance } from '@/modules/relevance/compute-card-relevance';
+import { getPrismaClient } from '@/modules/database/client';
+import { loadPoolServeConfig } from '@/config/pool-serve';
+import { loadRelevanceRubricConfig } from '@/config/relevance-rubric';
+import { tsvectorKeywordCandidatesPerCell } from '@/skills/plugins/video-discover/v3/hybrid-rerank';
+import {
+  resolveSearchApiKeys,
+  searchVideos,
+  titleHitsBlocklist,
+  titleIndicatesShorts,
+} from '@/skills/plugins/video-discover/v2/youtube-client';
+import { isOffLanguageTitleToggled } from '@/skills/plugins/video-discover/v5/youtube-fanout';
+import { logger } from '@/utils/logger';
+import { getJobQueue } from '../manager';
+import { JOB_NAMES, POOL_SERVE_FILL_RETRY_OPTIONS, type PoolServeFillPayload } from '../types';
+import { richSummaryWorkOptions } from './rich-summary-work-options';
+
+const log = logger.child({ module: 'pool-serve-fill' });
+
+const ROOT_LEVEL_ID = 'root';
+/** Candidates scored concurrently (OpenRouter key shared — bursts of 4, CP499). */
+const SCORE_BURST_SIZE = 4;
+/** Live fallback fetch size — one search.list call, gated downstream. */
+const LIVE_FALLBACK_MAX_RESULTS = 10;
+export const POOL_SERVE_SKILL_ID = 'pool-serve-fill';
+
+export async function registerPoolServeFillWorker(): Promise<void> {
+  const boss = getJobQueue().getInstance();
+  const concurrency = loadPoolServeConfig().concurrency;
+  await boss.work<PoolServeFillPayload>(
+    JOB_NAMES.POOL_SERVE_FILL,
+    richSummaryWorkOptions(concurrency),
+    handlePoolServeFill
+  );
+  log.info(`pool-serve-fill worker registered (concurrency=${concurrency})`);
+}
+
+/** Normalized candidate entering the gate (pool or live). */
+export interface GateCandidate {
+  youtubeVideoId: string;
+  title: string;
+  description: string | null;
+  channelTitle: string | null;
+  thumbnail: string | null;
+  publishedAt: Date | null;
+}
+
+interface PassedCandidate extends GateCandidate {
+  relevancePct: number;
+}
+
+export interface PoolServeCellResult {
+  recruited: number;
+  scored: number;
+  cacheHits: number;
+  poolPassed: number;
+  liveAttempted: boolean;
+  liveRecruited: number;
+  livePassed: number;
+  inserted: number;
+}
+
+/** One deficit cell: 1차 pool → 2차 live fallback → 3차 honest-empty. */
+async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promise<void> {
+  const p = job.data;
+  const cfg = loadPoolServeConfig();
+  const prisma = getPrismaClient();
+  const result: PoolServeCellResult = {
+    recruited: 0,
+    scored: 0,
+    cacheHits: 0,
+    poolPassed: 0,
+    liveAttempted: false,
+    liveRecruited: 0,
+    livePassed: 0,
+    inserted: 0,
+  };
+
+  try {
+    const need = Math.min(p.deficit, cfg.maxFillPerCell);
+    const rubric = loadRelevanceRubricConfig().enabled;
+    const volatility = rubric ? await fetchVolatility(p.mandalaId) : null;
+
+    const owned = await prisma.$queryRaw<{ youtube_video_id: string }[]>`
+      SELECT yv.youtube_video_id
+      FROM user_video_states uvs JOIN youtube_videos yv ON yv.id = uvs.video_id
+      WHERE uvs.user_id = ${p.userId}::uuid`;
+    const seen = new Set(owned.map((r) => r.youtube_video_id));
+
+    const hygienic = (cands: GateCandidate[]): GateCandidate[] =>
+      cands.filter(
+        (c) =>
+          c.youtubeVideoId &&
+          !seen.has(c.youtubeVideoId) &&
+          !titleHitsBlocklist(c.title) &&
+          !titleIndicatesShorts(c.title) &&
+          // #905 posture: AUTO inflow on a ko mandala is ko-only.
+          !isOffLanguageTitleToggled(c.title, p.language, false)
+      );
+
+    /** Semantic gate: vmr cache first, score on miss, threshold; early-exit. */
+    const gate = async (cands: GateCandidate[], passed: PassedCandidate[]): Promise<void> => {
+      for (let i = 0; i < cands.length && passed.length < need; i += SCORE_BURST_SIZE) {
+        const burst = cands.slice(i, i + SCORE_BURST_SIZE);
+        const scores = await Promise.all(
+          burst.map(async (c) => {
+            const cached = await prisma.$queryRaw<{ relevance_pct: number }[]>`
+              SELECT relevance_pct FROM video_mandala_relevance
+              WHERE video_id = ${c.youtubeVideoId} AND mandala_id = ${p.mandalaId}::uuid`;
+            if (cached[0]) {
+              result.cacheHits += 1;
+              return { c, pct: cached[0].relevance_pct };
+            }
+            const r = await computeCardRelevance({
+              title: c.title,
+              description: c.description ?? '',
+              centerGoal: p.centerGoal,
+              cellGoal: p.cellGoal,
+              language: p.language,
+              ...(rubric ? { rubric: true, publishedAt: c.publishedAt, volatility } : {}),
+            });
+            result.scored += 1;
+            if (!r.ok) {
+              log.warn(`pool-serve gate score failed (skip): ${r.reason}`);
+              return { c, pct: null };
+            }
+            await prisma.$executeRaw`
+              INSERT INTO video_mandala_relevance (video_id, mandala_id, relevance_pct)
+              VALUES (${c.youtubeVideoId}, ${p.mandalaId}::uuid, ${r.relevancePct})
+              ON CONFLICT (video_id, mandala_id)
+              DO UPDATE SET relevance_pct = EXCLUDED.relevance_pct, relevance_at = now()`;
+            return { c, pct: r.relevancePct };
+          })
+        );
+        for (const { c, pct } of scores) {
+          if (pct !== null && pct >= cfg.relevanceMin && passed.length < need) {
+            passed.push({ ...c, relevancePct: pct });
+            seen.add(c.youtubeVideoId);
+          }
+        }
+      }
+    };
+
+    // ── 1차 POOL ──────────────────────────────────────────────────────────
+    const recruits = await tsvectorKeywordCandidatesPerCell(
+      [{ cellIndex: p.cellIndex, query: p.cellQuery }],
+      [...seen],
+      cfg.candidatesLimit,
+      ['v2_promoted']
+    );
+    result.recruited = recruits.length;
+    const passed: PassedCandidate[] = [];
+    await gate(
+      hygienic(
+        recruits.map((c) => ({
+          youtubeVideoId: c.videoId,
+          title: c.title,
+          description: c.description,
+          channelTitle: c.channelName,
+          thumbnail: c.thumbnail,
+          publishedAt: c.publishedAt,
+        }))
+      ),
+      passed
+    );
+    result.poolPassed = passed.length;
+
+    // ── 2차 LIVE fallback — pool로 부족할 때만, 셀당 search.list 1콜 cap ──
+    if (passed.length < need && cfg.liveFallback) {
+      result.liveAttempted = true;
+      try {
+        const keys = resolveSearchApiKeys(process.env);
+        const items = await searchVideos({
+          query: p.cellQuery,
+          apiKey: keys,
+          maxResults: LIVE_FALLBACK_MAX_RESULTS,
+          relevanceLanguage: p.language,
+          regionCode: p.language === 'ko' ? 'KR' : 'US',
+        });
+        const liveCands = hygienic(
+          items.map((it) => ({
+            youtubeVideoId: it.id?.videoId ?? '',
+            title: it.snippet?.title ?? '',
+            description: it.snippet?.description ?? null,
+            channelTitle: it.snippet?.channelTitle ?? null,
+            thumbnail: it.snippet?.thumbnails?.high?.url ?? null,
+            publishedAt: it.snippet?.publishedAt ? new Date(it.snippet.publishedAt) : null,
+          }))
+        );
+        result.liveRecruited = liveCands.length;
+        const before = passed.length;
+        await gate(liveCands, passed);
+        result.livePassed = passed.length - before;
+      } catch (err) {
+        // Live failure never fails the job — pool passes still insert.
+        log.warn(
+          `pool-serve live fallback failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+
+    // ── Insert (1차+2차 합산) — auto-add 파이프라인과 동일 shape; 게이트
+    //    점수를 행에 복사 (재채점 0콜). live 후보는 youtube_videos 행이 없을
+    //    수 있어 minimal upsert 로 보강 (정상 파이프라인의 cache-hint 동작).
+    for (const cand of passed) {
+      let yv = await prisma.youtube_videos.findUnique({
+        where: { youtube_video_id: cand.youtubeVideoId },
+        select: { id: true },
+      });
+      if (!yv) {
+        yv = await prisma.youtube_videos.create({
+          data: {
+            youtube_video_id: cand.youtubeVideoId,
+            title: cand.title,
+            description: cand.description,
+            thumbnail_url: cand.thumbnail,
+            channel_title: cand.channelTitle,
+            published_at: cand.publishedAt,
+          },
+          select: { id: true },
+        });
+      }
+      const created = await prisma.userVideoState.createMany({
+        data: [
+          {
+            user_id: p.userId,
+            videoId: yv.id,
+            mandala_id: p.mandalaId,
+            cell_index: p.cellIndex,
+            level_id: ROOT_LEVEL_ID,
+            is_in_ideation: false,
+            auto_added: true,
+            relevance_pct: cand.relevancePct,
+            relevance_at: new Date(),
+          },
+        ],
+        skipDuplicates: true,
+      });
+      result.inserted += created.count;
+    }
+    // 3차: passed가 비면 아무것도 넣지 않는다 — 정직한 빈 셀.
+
+    log.info(
+      `pool-serve fill cell=${p.cellIndex} mandala=${p.mandalaId}: ` +
+        `pool(recruited=${result.recruited} passed=${result.poolPassed}) ` +
+        `live(attempted=${result.liveAttempted} recruited=${result.liveRecruited} passed=${result.livePassed}) ` +
+        `scored=${result.scored} cacheHits=${result.cacheHits} inserted=${result.inserted} (need=${need})`
+    );
+  } finally {
+    // Record the cell outcome on the batch run row (atomic jsonb concat —
+    // concurrent cell jobs write disjoint keys). All cells reported ⇒
+    // completed ⇒ FE fill-pending state clears.
+    await recordCellOutcome(
+      p.runId,
+      p.cellIndex,
+      result as unknown as Record<string, unknown>
+    ).catch((err) =>
+      log.warn(
+        `pool-serve run record failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+      )
+    );
+  }
+}
+
+async function fetchVolatility(mandalaId: string): Promise<string | null> {
+  const prisma = getPrismaClient();
+  try {
+    const rows = await prisma.$queryRaw<{ volatility: string | null }[]>`
+      SELECT volatility FROM user_mandalas WHERE id = ${mandalaId}::uuid`;
+    return rows[0]?.volatility ?? null;
+  } catch {
+    return null; // fail-open — recency bonus simply stays 0
+  }
+}
+
+async function recordCellOutcome(
+  runId: string,
+  cellIndex: number,
+  outcome: Record<string, unknown>
+): Promise<void> {
+  const prisma = getPrismaClient();
+  await prisma.$executeRaw`
+    UPDATE skill_runs
+    SET output = COALESCE(output, '{}'::jsonb) ||
+        jsonb_build_object(${String(cellIndex)}::text, ${JSON.stringify(outcome)}::jsonb)
+    WHERE id = ${runId}::uuid`;
+  // Mark completed when every dispatched cell has reported.
+  await prisma.$executeRaw`
+    UPDATE skill_runs
+    SET status = 'completed', ended_at = now()
+    WHERE id = ${runId}::uuid AND status = 'running'
+      AND (SELECT count(*) FROM jsonb_object_keys(COALESCE(output, '{}'::jsonb))) >=
+          COALESCE(jsonb_array_length(input -> 'cells'), 0)`;
+}
+
+export interface DispatchPoolServeInput {
+  userId: string;
+  mandalaId: string;
+  centerGoal: string;
+  language: 'ko' | 'en';
+  /** Per-cell goal + recruitment query for DEFICIT cells only. */
+  cells: { cellIndex: number; cellGoal: string; cellQuery: string; deficit: number }[];
+}
+
+/**
+ * Create the skill_runs batch row (FE fill-pending signal) and enqueue one
+ * job per deficit cell. Fire-and-forget at the call site — never blocks.
+ * Returns the runId (null = disabled or nothing to do).
+ */
+export async function dispatchPoolServeFill(
+  input: DispatchPoolServeInput,
+  opts: { bypassFlag?: boolean } = {}
+): Promise<string | null> {
+  const cfg = loadPoolServeConfig();
+  if ((!cfg.enabled && !opts.bypassFlag) || input.cells.length === 0) return null;
+  const prisma = getPrismaClient();
+  const run = await prisma.skill_runs.create({
+    data: {
+      skill_id: POOL_SERVE_SKILL_ID,
+      user_id: input.userId,
+      status: 'running',
+      input: {
+        mandalaId: input.mandalaId,
+        cells: input.cells.map((c) => c.cellIndex),
+      },
+    },
+    select: { id: true },
+  });
+  const boss = getJobQueue().getInstance();
+  for (const cell of input.cells) {
+    await boss.send(
+      JOB_NAMES.POOL_SERVE_FILL,
+      {
+        userId: input.userId,
+        mandalaId: input.mandalaId,
+        cellIndex: cell.cellIndex,
+        cellGoal: cell.cellGoal,
+        centerGoal: input.centerGoal,
+        language: input.language,
+        cellQuery: cell.cellQuery,
+        deficit: cell.deficit,
+        runId: run.id,
+      } satisfies PoolServeFillPayload,
+      POOL_SERVE_FILL_RETRY_OPTIONS
+    );
+  }
+  log.info(
+    `pool-serve dispatched: mandala=${input.mandalaId} cells=[${input.cells
+      .map((c) => c.cellIndex)
+      .join(',')}] run=${run.id}`
+  );
+  return run.id;
+}
+
+/**
+ * Mandala-level dispatcher: detect deficit cells (placed < minPerCell) and
+ * enqueue one fill job per cell. Cell goals come from user_mandala_levels
+ * (authoritative — the mandala is saved before this runs); the recruitment
+ * query is the cell-goal text (tsvector tokens; the semantic judge owns
+ * quality, recruitment only needs recall). Returns runId or null.
+ */
+export async function dispatchPoolServeForMandala(
+  userId: string,
+  mandalaId: string,
+  opts: { bypassFlag?: boolean } = {}
+): Promise<{ runId: string | null; deficitCells: number[] }> {
+  const cfg = loadPoolServeConfig();
+  if (!cfg.enabled && !opts.bypassFlag) return { runId: null, deficitCells: [] };
+  const prisma = getPrismaClient();
+
+  const mandala = await prisma.user_mandalas.findFirst({
+    where: { id: mandalaId, user_id: userId },
+    select: { language: true },
+  });
+  if (!mandala) return { runId: null, deficitCells: [] };
+  const language: 'ko' | 'en' = mandala.language === 'en' ? 'en' : 'ko';
+
+  const levels = await prisma.user_mandala_levels.findMany({
+    where: { mandala_id: mandalaId, depth: 1 },
+    select: { position: true, center_goal: true },
+    orderBy: { position: 'asc' },
+  });
+  const root = await prisma.user_mandala_levels.findFirst({
+    where: { mandala_id: mandalaId, depth: 0 },
+    select: { center_goal: true },
+  });
+  if (!root || levels.length === 0) return { runId: null, deficitCells: [] };
+
+  const counts = await prisma.$queryRaw<{ cell_index: number; n: number }[]>`
+    SELECT cell_index, COUNT(*)::int AS n FROM user_video_states
+    WHERE mandala_id = ${mandalaId}::uuid AND user_id = ${userId}::uuid
+      AND cell_index >= 0
+    GROUP BY cell_index`;
+  const byCell = new Map(counts.map((c) => [c.cell_index, c.n]));
+
+  const cells = levels
+    .map((l) => {
+      const placed = byCell.get(l.position) ?? 0;
+      const deficit = cfg.minPerCell - placed;
+      if (deficit <= 0 || !l.center_goal.trim()) return null;
+      return {
+        cellIndex: l.position,
+        cellGoal: l.center_goal,
+        cellQuery: l.center_goal,
+        deficit,
+      };
+    })
+    .filter((c): c is NonNullable<typeof c> => c !== null);
+
+  const runId = await dispatchPoolServeFill(
+    {
+      userId,
+      mandalaId,
+      centerGoal: root.center_goal,
+      language,
+      cells,
+    },
+    opts
+  );
+  return { runId, deficitCells: cells.map((c) => c.cellIndex) };
+}

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -30,6 +30,7 @@ import { registerEnrichRichSummaryWorker } from './handlers/enrich-rich-summary'
 import { registerBatchVideoCollectorWorker } from './handlers/batch-video-collector';
 import { registerPoolMaintenanceWorker } from './handlers/pool-maintenance';
 import { registerEnrichRelevanceQuickWorker } from './handlers/enrich-relevance-quick';
+import { registerPoolServeFillWorker } from './handlers/pool-serve-fill';
 import { registerMandalaActionsFillWorker } from './handlers/mandala-actions-fill';
 import { logger } from '../../utils/logger';
 
@@ -51,6 +52,7 @@ export async function initJobQueue(): Promise<void> {
   await registerBatchVideoCollectorWorker();
   await registerPoolMaintenanceWorker();
   await registerEnrichRelevanceQuickWorker();
+  await registerPoolServeFillWorker();
   await registerMandalaActionsFillWorker();
 
   logger.info('Job queue fully initialized (pg-boss + 7 workers)');

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -55,5 +55,5 @@ export async function initJobQueue(): Promise<void> {
   await registerPoolServeFillWorker();
   await registerMandalaActionsFillWorker();
 
-  logger.info('Job queue fully initialized (pg-boss + 7 workers)');
+  logger.info('Job queue fully initialized (pg-boss + 8 workers)');
 }

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -13,6 +13,9 @@ export const JOB_NAMES = {
   BATCH_SCAN: 'batch-scan',
   /** CP462+ Issue #649 — Heart-click on-demand rich summary (direct enrichRichSummary). */
   ENRICH_RICH_SUMMARY: 'enrich-rich-summary',
+  /** CP499+ pool-serve — async deficit-cell fill from the ko pool through the
+   *  semantic relevance gate (video_mandala_relevance cache). One job per cell. */
+  POOL_SERVE_FILL: 'pool-serve-fill',
   /**
    * CP489+ — fire-and-forget GHA trigger for the batch-video-collector skill.
    * The route returns 202 immediately; this worker runs the actual skill in
@@ -199,6 +202,33 @@ export const POOL_MAINTENANCE_RUN_OPTIONS = {
 export const RELEVANCE_QUICK_RETRY_OPTIONS = {
   retryLimit: 1,
   expireInMinutes: 5,
+} as const;
+
+/** CP499+ pool-serve fill payload — one DEFICIT CELL per job. */
+export interface PoolServeFillPayload {
+  userId: string;
+  mandalaId: string;
+  cellIndex: number;
+  /** The cell sub-goal (relevance judged cell-fit AND center contribution). */
+  cellGoal: string;
+  centerGoal: string;
+  language: 'ko' | 'en';
+  /** Pool tsquery for candidate recruitment (cell query from merged-gen / fanout). */
+  cellQuery: string;
+  /** How many cards this cell still needs (placed < minPerCell). */
+  deficit: number;
+  /** skill_runs row id recording this fill batch (FE fill-pending signal). */
+  runId: string;
+}
+
+/**
+ * Pool-serve fill — per-cell batch of gate-scored pool candidates. Worst case
+ * ~12 Haiku calls in bursts; generous expiry, single retry (idempotent: the
+ * uvs upsert keys on (user_id, videoId) and vmr caching makes a retry cheap).
+ */
+export const POOL_SERVE_FILL_RETRY_OPTIONS = {
+  retryLimit: 1,
+  expireInMinutes: 10,
 } as const;
 
 /**

--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -70,6 +70,10 @@ const v5EnvSchema = z.object({
   // candidate generation for "full enough" cells (pure quota/latency save; the
   // cell's cards are already excluded anyway). unset = false = no-op.
   V5_CELL_SKIP: booleanFlag.optional().default(false as unknown as string),
+  // CP499+ UX 원칙 1 (언어 일관성) — ko 만다라 자동유입에서 영어-우세 제목
+  // drop. DEFAULT ON (컨벤션 편차: 기존 동작 자체가 제품 결함 판정 — James
+  // 2026-06-11). env = 롤백 레버 (off = 기존 영어-통과 동작).
+  V5_KO_EN_TITLE_DROP: booleanFlag.optional().default(true as unknown as string),
   // CP494 ④-1 — per-cell "full" threshold. ≥ this many grid cards → skip.
   // 12 favors "user may want to see more" (cells with 7-11 still searched).
   V5_CELL_SKIP_THRESHOLD: z.coerce.number().int().min(1).max(60).default(12),
@@ -112,6 +116,8 @@ export interface V5Config {
   reuseLoop: boolean;
   /** CP494 ④-1 — full-cell skip enabled. */
   cellSkip: boolean;
+  /** CP499+ — ko 만다라 자동유입 영어-우세 제목 drop (UX 원칙 1). */
+  koEnTitleDrop: boolean;
   /** CP494 ④-1 — per-cell card count threshold for skip. */
   cellSkipThreshold: number;
   /** CP494 안 A — pool match strategy ('global' | 'per_cell'). */
@@ -148,6 +154,7 @@ export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
     poolTimeoutMs: p.V5_POOL_TIMEOUT_MS,
     reuseLoop: p.V5_REUSE_LOOP,
     cellSkip: p.V5_CELL_SKIP,
+    koEnTitleDrop: p.V5_KO_EN_TITLE_DROP,
     cellSkipThreshold: p.V5_CELL_SKIP_THRESHOLD,
     poolMatch: p.V5_POOL_MATCH,
   };

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -25,6 +25,7 @@ import { buildRuleBasedQueriesSync, type SearchQuery } from '../v2/keyword-build
 import { buildLLMQueriesPerCell, type QueryGenMeta } from './llm-query-gen';
 import { translateQueriesToEn } from './en-query-translate';
 import { getV5Config } from './config';
+import { detectLanguage } from '@/utils/detect-language';
 import { MERGED_GEN_MODEL } from '@/prompts/mandala-with-queries-generator';
 import {
   tsvectorKeywordCandidates,
@@ -262,21 +263,30 @@ export function rotateKeys(keys: string[], i: number): string[] {
 /**
  * CP499+ — toggle-aware off-language gate ('영문 카드 포함').
  *
- * DESIGN FINDING (test-caught): the ko-rules ALREADY pass pure-English titles
- * (hangul 0 + no dominant third script = kept), so the gate needs NO widening
- * for the toggle — and a ko∪en union would be actively WRONG: the en-rules
- * only block CJK, so Arabic/Thai/Cyrillic titles would re-enter through the
- * en side. The toggle's effective EN-inflow lever is therefore the
- * relevanceLanguage drop in the search call alone; this function keeps the
- * toggle branch explicit at both call sites and pins the EN-passes invariant.
- * Exported for tests.
+ * UX 원칙 1 (언어 일관성, James 2026-06-11): 입력 언어 = 경험 언어. ko 만다라의
+ * AUTO inflow (wizard / add-cards 기본) drops English-DOMINANT titles — the
+ * prior "English intentionally NEVER dropped" stance was re-judged a product
+ * defect on screen evidence (K8s mandala: "Kubernetes Monitoring with
+ * Prometheus & Grafana" etc. mixed into a ko grid). Signal = #902
+ * detectLanguage: ANY Hangul ⇒ ko ⇒ kept ("[용어]…쿠버네티스 보안",
+ * "Kubernetes란?"), zero Hangul + Latin ⇒ en ⇒ dropped.
+ *
+ * The explicit EN chip (includeEnCards=true) is opt-in and UNAFFECTED — that
+ * path wants English. Third-script rules (isOffLanguageTitle) still apply
+ * first in every mode. koEnTitleDrop = V5_KO_EN_TITLE_DROP rollback lever
+ * (off ⇒ legacy English-passes behavior). Exported for tests.
  */
 export function isOffLanguageTitleToggled(
   title: string,
   lang: 'ko' | 'en',
-  _includeEnCards: boolean | undefined
+  includeEnCards: boolean | undefined,
+  koEnTitleDrop = true
 ): boolean {
-  return isOffLanguageTitle(title, lang);
+  if (isOffLanguageTitle(title, lang)) return true;
+  if (lang === 'ko' && !includeEnCards && koEnTitleDrop) {
+    return detectLanguage(title) === 'en';
+  }
+  return false;
 }
 
 export function isOffLanguageTitle(title: string, lang: 'ko' | 'en'): boolean {
@@ -477,7 +487,15 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
         const cand = keywordCandidateToFanoutCandidate(kc);
         // Fork-1 caveat: pool candidates run the SAME gates as live items.
         if (titleHitsBlocklist(cand.title) || titleIndicatesShorts(cand.title)) continue;
-        if (isOffLanguageTitleToggled(cand.title, input.language, input.includeEnCards)) continue;
+        if (
+          isOffLanguageTitleToggled(
+            cand.title,
+            input.language,
+            input.includeEnCards,
+            cfg.koEnTitleDrop
+          )
+        )
+          continue;
         const ci = cand.cellIndex ?? -1;
         if (ci < 0) continue;
         const bucket = byCell.get(ci);
@@ -666,7 +684,12 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
       if (
         enOnlyActive
           ? /[가-힣]/.test(cand.title)
-          : isOffLanguageTitleToggled(cand.title, input.language, input.includeEnCards)
+          : isOffLanguageTitleToggled(
+              cand.title,
+              input.language,
+              input.includeEnCards,
+              cfg.koEnTitleDrop
+            )
       ) {
         offLangDropped += 1;
         continue;

--- a/tests/unit/modules/pool-serve-fill.test.ts
+++ b/tests/unit/modules/pool-serve-fill.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Pool-serve fill worker — CP499+ (UX 원칙 2).
+ *
+ * Locks the unified 3-stage contract (James 2026-06-11):
+ *   - 1차 pool: semantic gate ≥ threshold → insert with the score COPIED;
+ *   - 2차 live fallback fires ONLY when the pool leaves the cell short
+ *     (1차 충족 ⇒ live NOT called = quota saved), ONE search.list per cell,
+ *     live candidates pass the SAME hygiene + semantic gates;
+ *   - 3차: zero passes ⇒ zero inserts (honest empty cell) + run recorded;
+ *   - dispatcher: deficit = minPerCell - placed, flag-gated, bypassFlag for
+ *     the admin canary.
+ */
+
+// ── Mocks (before imports) ──────────────────────────────────────────────────
+
+const mockBossInstance = {
+  start: jest.fn().mockResolvedValue(undefined),
+  stop: jest.fn().mockResolvedValue(undefined),
+  on: jest.fn(),
+  work: jest.fn().mockResolvedValue('worker-id'),
+  send: jest.fn().mockResolvedValue('job-1'),
+  schedule: jest.fn().mockResolvedValue(undefined),
+  getQueueSize: jest.fn().mockResolvedValue(0),
+};
+jest.mock('pg-boss', () => jest.fn().mockImplementation(() => mockBossInstance));
+
+const mockQueryRaw = jest.fn();
+const mockExecuteRaw = jest.fn().mockResolvedValue(1);
+const mockYvFindUnique = jest.fn();
+const mockYvCreate = jest.fn();
+const mockUvsCreateMany = jest.fn().mockResolvedValue({ count: 1 });
+const mockSkillRunsCreate = jest
+  .fn()
+  .mockResolvedValue({ id: '00000000-0000-4000-8000-00000000aaaa' });
+const mockMandalaFindFirst = jest.fn();
+const mockLevelsFindMany = jest.fn();
+const mockLevelsFindFirst = jest.fn();
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    $queryRaw: (...a: unknown[]) => mockQueryRaw(...a),
+    $executeRaw: (...a: unknown[]) => mockExecuteRaw(...a),
+    youtube_videos: { findUnique: mockYvFindUnique, create: mockYvCreate },
+    userVideoState: { createMany: mockUvsCreateMany },
+    skill_runs: { create: mockSkillRunsCreate },
+    user_mandalas: { findFirst: mockMandalaFindFirst },
+    user_mandala_levels: { findMany: mockLevelsFindMany, findFirst: mockLevelsFindFirst },
+  }),
+}));
+
+const mockCompute = jest.fn();
+jest.mock('@/modules/relevance/compute-card-relevance', () => ({
+  computeCardRelevance: (...a: unknown[]) => mockCompute(...a),
+}));
+
+const mockPoolCandidates = jest.fn();
+jest.mock('@/skills/plugins/video-discover/v3/hybrid-rerank', () => ({
+  tsvectorKeywordCandidatesPerCell: (...a: unknown[]) => mockPoolCandidates(...a),
+}));
+
+// Partial mock: stub the network fns, keep the REAL title gates so the test
+// exercises the actual hygiene posture (#905 included via the v5 gate below).
+const mockSearchVideos = jest.fn();
+jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => {
+  const actual = jest.requireActual('@/skills/plugins/video-discover/v2/youtube-client');
+  return {
+    ...actual,
+    searchVideos: (...a: unknown[]) => mockSearchVideos(...a),
+    resolveSearchApiKeys: () => ['key-1'],
+  };
+});
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// ── Imports (after mocks) ───────────────────────────────────────────────────
+
+import { getJobQueue } from '../../../src/modules/queue/manager';
+import {
+  registerPoolServeFillWorker,
+  dispatchPoolServeForMandala,
+} from '../../../src/modules/queue/handlers/pool-serve-fill';
+import { JOB_NAMES, type PoolServeFillPayload } from '../../../src/modules/queue/types';
+import { loadPoolServeConfig } from '../../../src/config/pool-serve';
+
+type Handler = (job: { id: string; data: PoolServeFillPayload }) => Promise<void>;
+
+const UUID_USER = '00000000-0000-4000-8000-000000000001';
+const UUID_MANDALA = '00000000-0000-4000-8000-000000000002';
+const UUID_RUN = '00000000-0000-4000-8000-00000000aaaa';
+
+const basePayload: PoolServeFillPayload = {
+  userId: UUID_USER,
+  mandalaId: UUID_MANDALA,
+  cellIndex: 3,
+  cellGoal: '쿠버네티스 모니터링',
+  centerGoal: 'K8s 이용한 상용 서비스 운영 전문가 되기',
+  language: 'ko',
+  cellQuery: '쿠버네티스 모니터링',
+  deficit: 2,
+  runId: UUID_RUN,
+};
+
+const poolCand = (id: string, title: string) => ({
+  videoId: id,
+  title,
+  description: 'desc',
+  channelName: 'ch',
+  channelId: 'chid',
+  thumbnail: null,
+  viewCount: 100,
+  likeCount: 1,
+  durationSec: 600,
+  publishedAt: new Date('2026-01-01'),
+});
+
+beforeAll(async () => {
+  await getJobQueue().start();
+});
+afterAll(async () => {
+  await getJobQueue().stop();
+});
+beforeEach(() => {
+  jest.clearAllMocks();
+  // default DB shims: owned=[] / vmr cache miss / skill_runs concat ok
+  mockQueryRaw.mockResolvedValue([]);
+  mockYvFindUnique.mockResolvedValue({ id: 'uuid-yv-1' });
+  mockUvsCreateMany.mockResolvedValue({ count: 1 });
+  delete process.env['RELEVANCE_RUBRIC_ENABLED'];
+});
+
+async function getHandler(): Promise<Handler> {
+  await registerPoolServeFillWorker();
+  const call = mockBossInstance.work.mock.calls.find((c) => c[0] === JOB_NAMES.POOL_SERVE_FILL);
+  if (!call) throw new Error('worker not registered');
+  return call[2] as Handler;
+}
+
+describe('config defaults', () => {
+  it('flag OFF by default; live fallback ON (same-bundle lever); provisional numbers', () => {
+    const cfg = loadPoolServeConfig({} as NodeJS.ProcessEnv);
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.liveFallback).toBe(true);
+    expect(cfg.relevanceMin).toBe(60);
+    expect(cfg.minPerCell).toBe(3);
+  });
+});
+
+describe('1차 pool gate', () => {
+  it('passes ≥ threshold are inserted with the score COPIED; live NOT called when pool fills the need', async () => {
+    mockPoolCandidates.mockResolvedValueOnce([
+      poolCand('vidA1234567', '쿠버네티스 모니터링 입문'),
+      poolCand('vidB1234567', '프로메테우스 실전 강의'),
+    ]);
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 82 });
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 71 });
+    const handler = await getHandler();
+
+    await handler({ id: 'j1', data: basePayload });
+
+    // both inserted with relevance copy
+    expect(mockUvsCreateMany).toHaveBeenCalledTimes(2);
+    const first = mockUvsCreateMany.mock.calls[0][0].data[0];
+    expect(first).toMatchObject({
+      user_id: UUID_USER,
+      mandala_id: UUID_MANDALA,
+      cell_index: 3,
+      auto_added: true,
+      relevance_pct: 82,
+    });
+    // 1차 충족 ⇒ 2차 미발동 (quota 절약)
+    expect(mockSearchVideos).not.toHaveBeenCalled();
+  });
+
+  it('below-threshold pool candidates are NOT inserted', async () => {
+    mockPoolCandidates.mockResolvedValueOnce([poolCand('vidC1234567', '쿠버네티스 잡담')]);
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 35 });
+    mockSearchVideos.mockResolvedValueOnce([]); // live finds nothing either
+    const handler = await getHandler();
+
+    await handler({ id: 'j2', data: basePayload });
+
+    expect(mockUvsCreateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('2차 live fallback', () => {
+  it('fires ONLY when pool leaves the cell short; live candidates pass the SAME gates; ONE search call', async () => {
+    mockPoolCandidates.mockResolvedValueOnce([]); // pool empty
+    mockSearchVideos.mockResolvedValueOnce([
+      {
+        id: { videoId: 'liveKo12345' },
+        snippet: { title: '쿠버네티스 모니터링 구축기', publishedAt: '2026-05-01T00:00:00Z' },
+      },
+      {
+        id: { videoId: 'liveEn12345' },
+        // English-dominant — must be dropped by the #905 hygiene gate BEFORE scoring
+        snippet: { title: 'Kubernetes Monitoring with Prometheus & Grafana' },
+      },
+      {
+        id: { videoId: 'liveLow1234' },
+        snippet: { title: '쿠버네티스 단순 뉴스' },
+      },
+    ]);
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 77 }); // 구축기
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 20 }); // 뉴스 — gate rejects
+    mockYvFindUnique.mockResolvedValue(null); // live videos not in youtube_videos yet
+    mockYvCreate.mockResolvedValue({ id: 'uuid-live-1' });
+    const handler = await getHandler();
+
+    await handler({ id: 'j3', data: basePayload });
+
+    expect(mockSearchVideos).toHaveBeenCalledTimes(1); // 셀당 1콜 cap
+    expect(mockSearchVideos.mock.calls[0][0]).toMatchObject({
+      relevanceLanguage: 'ko',
+      regionCode: 'KR',
+    });
+    // English-dominant live title never reached the scorer
+    expect(mockCompute).toHaveBeenCalledTimes(2);
+    // only the ≥60 Korean candidate inserted; youtube_videos upserted for it
+    expect(mockYvCreate).toHaveBeenCalledTimes(1);
+    expect(mockUvsCreateMany).toHaveBeenCalledTimes(1);
+    expect(mockUvsCreateMany.mock.calls[0][0].data[0].relevance_pct).toBe(77);
+  });
+
+  it('live failure is non-fatal — pool passes still insert', async () => {
+    mockPoolCandidates.mockResolvedValueOnce([poolCand('vidD1234567', '쿠버네티스 보안 기초')]);
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 65 });
+    mockSearchVideos.mockRejectedValueOnce(new Error('quotaExceeded'));
+    const handler = await getHandler();
+
+    await handler({ id: 'j4', data: { ...basePayload, deficit: 3 } });
+
+    expect(mockUvsCreateMany).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('3차 honest empty', () => {
+  it('zero passes ⇒ zero inserts, run outcome still recorded', async () => {
+    mockPoolCandidates.mockResolvedValueOnce([]);
+    mockSearchVideos.mockResolvedValueOnce([]);
+    const handler = await getHandler();
+
+    await handler({ id: 'j5', data: basePayload });
+
+    expect(mockUvsCreateMany).not.toHaveBeenCalled();
+    expect(mockCompute).not.toHaveBeenCalled();
+    // run record concat fired (finally block)
+    expect(mockExecuteRaw).toHaveBeenCalled();
+  });
+});
+
+describe('dispatchPoolServeForMandala', () => {
+  it('flag off + no bypass ⇒ null, zero DB work', async () => {
+    const r = await dispatchPoolServeForMandala(UUID_USER, UUID_MANDALA);
+    expect(r.runId).toBeNull();
+    expect(mockMandalaFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('bypassFlag: deficit = minPerCell - placed; full cells skipped; jobs enqueued per deficit cell', async () => {
+    mockMandalaFindFirst.mockResolvedValueOnce({ language: 'ko' });
+    mockLevelsFindMany.mockResolvedValueOnce([
+      { position: 0, center_goal: '클러스터 구축' }, // placed 5 → no deficit
+      { position: 1, center_goal: '모니터링' }, // placed 1 → deficit 2
+      { position: 2, center_goal: '장애 대응' }, // placed 0 → deficit 3
+    ]);
+    mockLevelsFindFirst.mockResolvedValueOnce({ center_goal: 'K8s 전문가' });
+    mockQueryRaw.mockResolvedValueOnce([
+      { cell_index: 0, n: 5 },
+      { cell_index: 1, n: 1 },
+    ]);
+
+    const r = await dispatchPoolServeForMandala(UUID_USER, UUID_MANDALA, { bypassFlag: true });
+
+    expect(r.runId).toBe(UUID_RUN);
+    expect(r.deficitCells).toEqual([1, 2]);
+    expect(mockSkillRunsCreate).toHaveBeenCalledTimes(1);
+    expect(mockBossInstance.send).toHaveBeenCalledTimes(2);
+    const job1 = mockBossInstance.send.mock.calls[0][1];
+    expect(job1).toMatchObject({ cellIndex: 1, deficit: 2, cellGoal: '모니터링' });
+  });
+});

--- a/tests/unit/skills/video-discover/v5-include-en-toggle.test.ts
+++ b/tests/unit/skills/video-discover/v5-include-en-toggle.test.ts
@@ -1,14 +1,18 @@
 /**
- * CP499+ '영문 카드 포함' toggle — 3-way contract (James spec):
- *   ① ko + ON  → EN titles pass the gate; third-script stays blocked;
- *                the live search drops the relevanceLanguage=ko bias
- *   ② ko + OFF → current single-language gate, bit-identical
+ * CP499+ '영문 카드 포함' toggle — 3-way contract, UPDATED for UX 원칙 1
+ * (언어 일관성, James 2026-06-11):
+ *   ① ko + ON  → EN titles pass the gate (opt-in wants English);
+ *                third-script stays blocked
+ *   ② ko + OFF → English-DOMINANT titles are now DROPPED (spec change —
+ *                the prior "EN-passes invariant" was re-judged a product
+ *                defect on K8s-mandala screen evidence). Hangul-bearing
+ *                titles keep passing (Korean video with English terms).
  *   ③ en mandala → toggle is a no-op (en rules regardless of the flag)
+ *   ④ V5_KO_EN_TITLE_DROP=false → legacy English-passes behavior (rollback
+ *                lever, config-only).
  *
- * Honest note pinned in code: the ko-rules ALREADY pass pure-Latin titles —
- * the toggle's EN-inflow body is the relevanceLanguage drop (the pool is
- * 5.9% EN, live search is the supply body). The gate-widening keeps the
- * semantics explicit.
+ * Signal = #902 detectLanguage: ANY Hangul ⇒ ko ⇒ kept; zero Hangul +
+ * Latin ⇒ en ⇒ dropped.
  */
 import {
   isOffLanguageTitle,
@@ -20,23 +24,49 @@ const EN = 'Basketball Dribbling Fundamentals';
 const ZH = '篮球运球基础教程完整版'; // third-script: blocked in every mode
 const AR = 'أساسيات المراوغة في كرة السلة';
 
-describe("'영문 카드 포함' — off-language gate 3-way", () => {
-  it('① ko + ON: ko and EN pass; third-script (zh/ar) stays blocked', () => {
-    // Design finding pinned: the ko gate is already EN-permissive, and a
-    // ko∪en union would re-admit Arabic/Thai (the en-rules only block CJK).
-    // So ON keeps the ko gate; EN-inflow comes from the relevanceLanguage
-    // drop in the search call.
+// 2026-06-11 K8s-mandala screen regression set (the exact production cases).
+const SCREEN_EN_DOMINANT = [
+  'Kubernetes Monitoring with Prometheus & Grafana Using Helm | Complete Hands-On Demo',
+  'Container Security Explained Kubernetes, Docker & Cloud Native Threats',
+  'Kubernetes Security: Performance, Hardening, and Lifecycle Management | Uplatz',
+];
+const SCREEN_KO_WITH_TERMS = [
+  '[용어](Cybersecurity) Kubernetes Security - 쿠버네티스 보안',
+  'Kubernetes란? For Real Begginer',
+];
+
+describe("'영문 카드 포함' — off-language gate 3-way (UX 원칙 1)", () => {
+  it('① ko + ON: ko and EN pass (opt-in); third-script (zh/ar) stays blocked', () => {
     expect(isOffLanguageTitleToggled(KO, 'ko', true)).toBe(false);
     expect(isOffLanguageTitleToggled(EN, 'ko', true)).toBe(false);
     expect(isOffLanguageTitleToggled(ZH, 'ko', true)).toBe(true);
     expect(isOffLanguageTitleToggled(AR, 'ko', true)).toBe(true);
   });
 
-  it('② ko + OFF (and undefined): bit-identical to the current ko gate', () => {
-    for (const t of [KO, EN, ZH, AR]) {
-      expect(isOffLanguageTitleToggled(t, 'ko', false)).toBe(isOffLanguageTitle(t, 'ko'));
-      expect(isOffLanguageTitleToggled(t, 'ko', undefined)).toBe(isOffLanguageTitle(t, 'ko'));
+  it('② ko + OFF (and undefined): English-dominant DROPPED, Hangul-bearing kept (spec change)', () => {
+    for (const off of [false, undefined] as const) {
+      expect(isOffLanguageTitleToggled(KO, 'ko', off)).toBe(false);
+      expect(isOffLanguageTitleToggled(EN, 'ko', off)).toBe(true); // was false pre-UX원칙1
+      expect(isOffLanguageTitleToggled(ZH, 'ko', off)).toBe(true);
+      expect(isOffLanguageTitleToggled(AR, 'ko', off)).toBe(true);
     }
+  });
+
+  it('② regression — the 5 production K8s-screen cases (2026-06-11)', () => {
+    for (const t of SCREEN_EN_DOMINANT) {
+      expect(isOffLanguageTitleToggled(t, 'ko', false)).toBe(true);
+    }
+    for (const t of SCREEN_KO_WITH_TERMS) {
+      expect(isOffLanguageTitleToggled(t, 'ko', false)).toBe(false);
+    }
+    // and the EN chip keeps them (opt-in unaffected):
+    for (const t of SCREEN_EN_DOMINANT) {
+      expect(isOffLanguageTitleToggled(t, 'ko', true)).toBe(false);
+    }
+  });
+
+  it('② edge: digits/symbols-only title falls back ko → kept (conservative)', () => {
+    expect(isOffLanguageTitleToggled('2026 — 100%', 'ko', false)).toBe(false);
   });
 
   it('③ en mandala: the flag is a no-op — en rules apply regardless', () => {
@@ -44,5 +74,14 @@ describe("'영문 카드 포함' — off-language gate 3-way", () => {
       expect(isOffLanguageTitleToggled(t, 'en', true)).toBe(isOffLanguageTitle(t, 'en'));
       expect(isOffLanguageTitleToggled(t, 'en', false)).toBe(isOffLanguageTitle(t, 'en'));
     }
+  });
+
+  it('④ V5_KO_EN_TITLE_DROP=false (4th arg) → legacy English-passes behavior', () => {
+    expect(isOffLanguageTitleToggled(EN, 'ko', false, false)).toBe(false);
+    for (const t of SCREEN_EN_DOMINANT) {
+      expect(isOffLanguageTitleToggled(t, 'ko', false, false)).toBe(false);
+    }
+    // third-script rules unaffected by the lever
+    expect(isOffLanguageTitleToggled(ZH, 'ko', false, false)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Single PR per James's unified scope (2026-06-11): empty/deficit cells after wizard placement are filled asynchronously from the ko pool **through the semantic relevance judge**, with a live ko re-search fallback — and an honestly-empty third stage. No irrelevant injection, no blocking.

**UX principle alignment**: Principle 2 — ★no empty cells AND no irrelevant videos — both defended: fill comes only through the gate (≥ `V5_POOL_SERVE_RELEVANCE_MIN`), zero-pass cells stay honestly empty. Principle 1 — `#905` ko-only hygiene gate applied to BOTH pool and live candidates.

## Three-stage worker (`pool-serve-fill`, one job per deficit cell)

1. **POOL**: `tsvectorKeywordCandidatesPerCell` (lexical = recruitment ONLY, `v2_promoted`, limit 12, exclude owned) → hygiene (#905 incl.) → `video_mandala_relevance` cache lookup → miss ⇒ `computeCardRelevance` → vmr upsert → pass ≥60 → top-K insert (`auto_added`, score COPIED to `uvs.relevance_pct`, zero re-scoring).
2. **LIVE** (`V5_POOL_SERVE_LIVE_FALLBACK`, default ON): only when pool leaves the cell short — ONE `search.list` call per cell (`relevanceLanguage=ko`) → SAME hygiene + SAME semantic gate. Live failure is non-fatal.
3. **EMPTY**: zero passes ⇒ zero inserts (principle 2).

- Trigger: wizard `consumePrecompute` (post-placement, fire-and-forget, #879 flow-reach lesson) + admin manual (`POST /api/v1/admin/pool-serve/run`, flag-bypass for the canary).
- "Filling" UX: W1b pattern replica — `skill_runs` row → `mandalaMeta.fillPendingCells` (3-min TTL, dead worker degrades to plain empty) → FE pulse + bounded poll (90s).
- R1-independent: gate runs legacy scoring while `RELEVANCE_RUBRIC_ENABLED` is off; auto-upgrades under R1.
- Distinct from the incident path: legacy no-judge `V5_POOL_BACKFILL` (#859) stays OFF — this is the pool-side implementation of the v5 common relevance gate precondition.

## Flags (all provisional, canary-tuned)

`V5_POOL_SERVE` (default **OFF** → canary → fleet) / `RELEVANCE_MIN=60` / `MIN_PER_CELL=3` / `MAX_FILL_PER_CELL=4` / `CANDIDATES_LIMIT=12` / `CONCURRENCY=2` / `LIVE_FALLBACK=ON`. Rollback = flip env, no code revert.

## Tests (14)

Gate pass/fail, honest-empty, live fires ONLY on pool shortfall, live candidates pass the SAME gates, per-cell ONE search call cap, live failure non-fatal, dispatch deficit math + full-cell skip, flag-off zero DB work, config defaults — plus extended `v5-include-en-toggle` coverage for the shared #905 gate.

## Canary plan (deploy bundled with #905 + #906)

K8s mandala flag ON: ① pool fill-rate ② live-triggered cells + live fill-rate ③ final residual empty cells ④ ALL inserted rows relevance ≥60 + Korean ⑤ James visual PASS → fleet.

Stacked on #905 (`feat/ko-mandala-en-title-drop`) — auto-retargets to main when #905 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)