### PR TITLE
chore(compose): fleet-ON flag pair — V5_KO_EN_TITLE_DROP + V5_POOL_SERVE together (James [GO], CP499+)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -140,12 +140,15 @@ services:
       # injects no content. Canary: trace v5_skipped_full_cells + quota delta.
       # Revert: delete this line + redeploy → code default false (search all).
       - V5_CELL_SKIP=true
-      # CP499+ flag-pair simultaneity (James 2026-06-11): code default is ON,
-      # but deploy must keep EXISTING behavior — the EN-drop must activate in
-      # the SAME [GO] that turns pool-serve on (V5_POOL_SERVE=true), so users
-      # see "English becomes Korean", never "English becomes empty cells".
-      # [GO] = flip this to true + add V5_POOL_SERVE=true, one redeploy.
-      - V5_KO_EN_TITLE_DROP=false
+      # CP499+ flag-pair fleet-ON (James [GO] 2026-06-11): EN-drop and
+      # pool-serve activate TOGETHER so users see "English becomes Korean",
+      # never "English becomes empty cells". Canary run 31a4017d on the K8s
+      # mandala: 0 residual empty cells, 7/7 inserts relevance>=60 + Korean
+      # (pool passed 0 — gate fail-closed as designed; live carried the fill).
+      # No retroactive cleanup: existing mandalas untouched, new wizards only.
+      # Rollback = flip BOTH back (false / delete line) + redeploy, no revert.
+      - V5_KO_EN_TITLE_DROP=true
+      - V5_POOL_SERVE=true
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the


### PR DESCRIPTION
## Summary

James [GO] fleet-ON (2026-06-11): activate the EN-drop (#905/#907) and pool-serve fill (#907) **in the same deploy** — users see "English becomes Korean", never "English becomes empty cells".

**UX principle alignment**: Principle 1 (ko mandala = ko-only auto-inflow) + Principle 2 (no empty cells AND no irrelevant videos) activate as one pair.

## Evidence (canary run `31a4017d`, K8s mandala)

- 0 residual empty cells (c2/c6/c7 → all 3/3), 7/7 inserts relevance ≥60 (62–82) + Korean titles, James visual PASS.
- Pool passed 0/34 — the semantic gate fail-closed as designed (CP494+1 incident class blocked); live fallback carried 100% of the fill within the per-cell 1-call cap.

## Scope

- compose 2 lines: `V5_KO_EN_TITLE_DROP=true` + `V5_POOL_SERVE=true`.
- No retroactive cleanup — existing mandalas untouched (James decision), new wizards only.
- Rollback: flip both back + redeploy, no code revert.

## Done gate (post-deploy, "on ≠ done")

① `printenv` both flags true ② James creates one new wizard → no English-dominant cards, no empty cells (pool-serve `skill_runs` recorded), existing mandalas unchanged (K8s baseline [9,7,3,10,10,10,3,3]) ③ 3-point report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)