### PR TITLE
refactor(relevance): R1 score = pure 3-axis — freshness removed from the rubric (axis separation, CP500+)

### DIFF
--- a/src/config/relevance-rubric.ts
+++ b/src/config/relevance-rubric.ts
@@ -1,20 +1,17 @@
 /**
  * Relevance rubric config (CP499+ diagnosis A score pipeline).
  *
- * Single feature flag gates the WHOLE new score pipeline as one unit:
- * - 3-axis rubric scoring (cell_fit / goal_contribution / actionability,
- *   composed in code — see src/modules/relevance/relevance-composition.ts)
- * - volatile-only recency bonus (needs user_mandalas.volatility)
- * - volatility persistence from merged-gen output
+ * Single feature flag gates the new score pipeline as one unit:
+ * - PURE 3-axis rubric scoring (cell_fit / goal_contribution / actionability,
+ *   composed in code — see src/modules/relevance/relevance-composition.ts).
+ *   CP500+ 축 분리 (James 2026-06-12): NO freshness term in the score —
+ *   relevance ≠ recency; the volatile-only 70/30 recency QUOTA is a
+ *   placement-layer follow-up (score-independent).
+ * - volatility persistence from merged-gen output (STAYS — the placement-layer
+ *   quota is its consumer).
  *
  * Default: OFF (unset = legacy single-axis scoring, byte-identical prompt).
  * Rollback = flip env; no code revert.
- *
- * ⚠️ Deploy-order precondition: the `user_mandalas.volatility` column DDL
- * (prisma/migrations/score-pipeline/001) must be applied to an environment
- * BEFORE this flag is turned on there — the worker/persist paths select the
- * column only when enabled. Prod DDL execution is a separate per-step
- * approval (NOT automatic with the PR merge).
  */
 
 import { z } from 'zod';

--- a/src/modules/queue/handlers/enrich-relevance-quick.ts
+++ b/src/modules/queue/handlers/enrich-relevance-quick.ts
@@ -54,10 +54,10 @@ async function handleEnrichRelevanceQuick(job: PgBoss.Job<RelevanceQuickPayload>
   const { table, rowId, title, description, centerGoal, cellGoal } = job.data;
 
   // CP499+ score pipeline (RELEVANCE_RUBRIC_ENABLED): fetch the row's mandala
-  // language/volatility + video published_at and run the 3-axis rubric.
+  // language and run the PURE 3-axis rubric (CP500+ 축 분리: no freshness term
+  // — the volatile-only recency quota is a placement-layer follow-up).
   // Fail-open: a context-fetch failure falls back to the legacy single-axis
-  // call. Flag off ⇒ legacy call with NO new selects (volatility column may
-  // not exist yet — prod DDL is a separate per-step approval).
+  // call. Flag off ⇒ legacy call with NO new selects.
   const rubricEnabled = loadRelevanceRubricConfig().enabled;
   const context = rubricEnabled ? await fetchRelevanceContext(table, rowId, centerGoal) : null;
 
@@ -70,8 +70,6 @@ async function handleEnrichRelevanceQuick(job: PgBoss.Job<RelevanceQuickPayload>
       ? {
           rubric: true,
           language: context.language,
-          publishedAt: context.publishedAt,
-          volatility: context.volatility,
         }
       : {}),
   });
@@ -118,16 +116,14 @@ async function handleEnrichRelevanceQuick(job: PgBoss.Job<RelevanceQuickPayload>
 
 export interface RelevanceContext {
   language: 'ko' | 'en';
-  publishedAt: Date | null;
-  volatility: string | null;
 }
 
 /**
- * CP499+ — per-row scoring context: mandala language (#902 정합) + volatility
- * (recency gate) + video published_at (recency input). Called ONLY when the
- * rubric flag is on (the volatility column must exist by then — DDL is a
- * deploy precondition for the flag). Returns null on any failure so the
- * caller falls back to legacy single-axis scoring (fail-open).
+ * CP499+ — per-row scoring context: mandala language (#902 정합). CP500+ 축
+ * 분리 removed volatility/published_at from here (freshness is not a score
+ * axis; the placement-layer recency quota reads user_mandalas.volatility in
+ * its own follow-up). Returns null on any failure so the caller falls back
+ * to legacy single-axis scoring (fail-open).
  */
 export async function fetchRelevanceContext(
   table: 'uvs' | 'ulc',
@@ -135,25 +131,17 @@ export async function fetchRelevanceContext(
   goalText?: string
 ): Promise<RelevanceContext | null> {
   const prisma = getPrismaClient();
-  // $queryRaw (not the typed client): the volatility column ships in this PR's
-  // schema but the shared generated client may predate it, and prod gets the
-  // column via the manual DDL step — raw SQL keeps this path decoupled from
-  // client-generation state. Read-only single-row lookup, tagged template.
+  // Read-only single-row lookup, tagged template.
   try {
     const rows =
       table === 'uvs'
-        ? await prisma.$queryRaw<
-            { language: string | null; volatility: string | null; published_at: Date | null }[]
-          >`
-            SELECT m.language, m.volatility, yv.published_at
+        ? await prisma.$queryRaw<{ language: string | null }[]>`
+            SELECT m.language
             FROM user_video_states uvs
             LEFT JOIN user_mandalas m ON m.id = uvs.mandala_id
-            LEFT JOIN youtube_videos yv ON yv.id = uvs.video_id
             WHERE uvs.id = ${rowId}::uuid`
-        : await prisma.$queryRaw<
-            { language: string | null; volatility: string | null; published_at: Date | null }[]
-          >`
-            SELECT m.language, m.volatility, NULL::timestamptz AS published_at
+        : await prisma.$queryRaw<{ language: string | null }[]>`
+            SELECT m.language
             FROM user_local_cards ulc
             LEFT JOIN user_mandalas m ON m.id = ulc.mandala_id
             WHERE ulc.id = ${rowId}::uuid`;
@@ -161,9 +149,6 @@ export async function fetchRelevanceContext(
     if (!row) return null;
     return {
       language: resolveLanguage(row.language, goalText ?? null),
-      // ulc rows have no clean youtube_videos FK — recency skipped (0 bonus).
-      publishedAt: row.published_at ?? null,
-      volatility: row.volatility ?? null,
     };
   } catch (err) {
     logger.warn('enrich-relevance-quick: context fetch failed — legacy fallback', {

--- a/src/modules/queue/handlers/pool-serve-fill.ts
+++ b/src/modules/queue/handlers/pool-serve-fill.ts
@@ -111,8 +111,9 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
 
   try {
     const need = Math.min(p.deficit, cfg.maxFillPerCell);
+    // CP500+ 축 분리: rubric = PURE 3-axis score (no freshness term). The
+    // volatile-only recency quota is a PLACEMENT-layer follow-up, not here.
     const rubric = loadRelevanceRubricConfig().enabled;
-    const volatility = rubric ? await fetchVolatility(p.mandalaId) : null;
 
     const owned = await prisma.$queryRaw<{ youtube_video_id: string }[]>`
       SELECT yv.youtube_video_id
@@ -162,7 +163,7 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
               centerGoal: p.centerGoal,
               cellGoal: p.cellGoal,
               language: p.language,
-              ...(rubric ? { rubric: true, publishedAt: c.publishedAt, volatility } : {}),
+              ...(rubric ? { rubric: true } : {}),
             });
             result.scored += 1;
             if (!r.ok) {
@@ -307,17 +308,6 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
         `pool-serve run record failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
       )
     );
-  }
-}
-
-async function fetchVolatility(mandalaId: string): Promise<string | null> {
-  const prisma = getPrismaClient();
-  try {
-    const rows = await prisma.$queryRaw<{ volatility: string | null }[]>`
-      SELECT volatility FROM user_mandalas WHERE id = ${mandalaId}::uuid`;
-    return rows[0]?.volatility ?? null;
-  } catch {
-    return null; // fail-open — recency bonus simply stays 0
   }
 }
 

--- a/src/modules/relevance/compute-card-relevance.ts
+++ b/src/modules/relevance/compute-card-relevance.ts
@@ -26,7 +26,6 @@ import {
   validateV2Quick,
   V2QuickValidationError,
 } from '@/modules/skills/rich-summary-v2-quick-prompt';
-import { applyRecency, recencyBonus } from '@/modules/relevance/relevance-composition';
 // CP499+ lang 정합 (#902): the prompt language follows the MANDALA language
 // (caller passes it). The previous LOCAL ratio-based detector (a 3rd variant of
 // detectLanguage in the codebase) is removed — fallback when the caller has no
@@ -63,23 +62,20 @@ export interface CardRelevanceInput {
   language?: 'ko' | 'en';
   /**
    * CP499+ rubric mode (RELEVANCE_RUBRIC_ENABLED — caller reads config; this
-   * module stays config-free). 3-axis LLM scoring + code composition + recency.
+   * module stays config-free). PURE 3-axis LLM scoring + code composition.
    * Absent/false ⇒ legacy single-axis behavior, byte-identical prompt.
+   * CP500+ 축 분리 (James 2026-06-12): freshness is NOT a score axis —
+   * relevance ≠ recency. The volatile-only 70/30 recency QUOTA lives at the
+   * PLACEMENT layer (separate follow-up; uses user_mandalas.volatility there).
    */
   rubric?: boolean;
-  /** Video published_at — recency-bonus input (rubric mode, volatile only). */
-  publishedAt?: Date | null;
-  /** Mandala volatility ('volatile' | 'evergreen' | null) — recency gate. */
-  volatility?: string | null;
 }
 
-/** Rubric-mode raw axes + bonus, returned for logging (relevance_detail = log-only for now). */
+/** Rubric-mode raw axes, returned for logging (relevance_detail = log-only for now). */
 export interface CardRelevanceDetail {
   cellFitPct: number | null;
   goalContributionPct: number;
   actionabilityPct: number;
-  basePct: number;
-  recencyBonus: number;
 }
 
 export type CardRelevanceResult =
@@ -153,19 +149,16 @@ export async function computeCardRelevance(
     const parsed = validateV2Quick(json, { rubric: input.rubric });
     const fit = parsed.analysis.mandala_fit;
     if (input.rubric && fit.rubric) {
-      // Composite came from composeRubricScore (in the validator). Recency:
-      // volatile-only additive bonus, capped at 100 — evergreen / NULL
-      // volatility / NULL published_at are all 0 = unchanged.
-      const bonus = recencyBonus(input.publishedAt, input.volatility);
+      // Composite came from composeRubricScore (in the validator) — PURE
+      // 3-axis, no freshness term (CP500+ 축 분리: relevance ≠ recency; the
+      // volatile-only recency quota is a placement-layer follow-up).
       return {
         ok: true,
-        relevancePct: applyRecency(fit.mandala_relevance_pct, bonus),
+        relevancePct: fit.mandala_relevance_pct,
         detail: {
           cellFitPct: fit.rubric.cell_fit_pct,
           goalContributionPct: fit.rubric.goal_contribution_pct,
           actionabilityPct: fit.rubric.actionability_pct,
-          basePct: fit.mandala_relevance_pct,
-          recencyBonus: bonus,
         },
       };
     }

--- a/src/modules/relevance/relevance-composition.ts
+++ b/src/modules/relevance/relevance-composition.ts
@@ -1,6 +1,7 @@
 /**
- * Relevance composition — code-side synthesis of the 3-axis rubric + the
- * volatile-only recency bonus (CP499+ diagnosis A score pipeline).
+ * Relevance composition — code-side synthesis of the PURE 3-axis rubric
+ * (cell_fit / goal_contribution / actionability — CP499+ score pipeline,
+ * CP500+ 축 분리).
  *
  * Why code composes (not the LLM): a single LLM-emitted composite collapses
  * into round-number modes (72/78/85/92 measured fleet-wide 2026-06-11) and
@@ -8,16 +9,23 @@
  * modes, so a weighted code-side sum spreads — that spread is the mechanism
  * the gate validates (abstract-goal sd ≥ 12, concrete-goal Spearman ≥ 0.8).
  *
+ * 축 분리 (James 2026-06-12): freshness is NOT a score axis — relevance ≠
+ * recency, and a freshness term would contaminate the R1 gate measurement.
+ * The earlier volatile-only recency BONUS was removed from this module.
+ * RESERVED placement-layer follow-up (separate PR, score-independent): a
+ * volatile-only 70/30 recency QUOTA at card placement — volatility 분기
+ * (volatile만 적용, evergreen/미분류 NULL 무적용) reads
+ * user_mandalas.volatility, which the merged-gen path keeps persisting for
+ * exactly that consumer.
+ *
  * ⚠️ PROVISIONAL VALUES — gate-validation targets, NOT law. The weights
- * (0.4/0.4/0.2, 0.7/0.3) and recency table (+5 <6m, +2 6-12m) are starting
- * points; the multi-mandala gate (2-3 abstract + 2-3 concrete) re-tunes them
- * on miss. Keep them HERE (single home) so re-tuning is a 1-file change.
+ * (0.4/0.4/0.2, 0.7/0.3) are starting points; the multi-mandala gate
+ * (2-3 abstract + 2-3 concrete) re-tunes them on miss. Keep them HERE
+ * (single home) so re-tuning is a 1-file change.
  *
  * Pure module — no config, no Prisma, no provider (config-free pure-helper
  * convention). Callers read flags and pass data in.
  */
-
-import { MS_PER_MONTH_AVG } from '@/utils/time-constants';
 
 /** Rubric weights when a cell goal is present (cell-fit AND center contribution). */
 export const RUBRIC_WEIGHTS = {
@@ -31,12 +39,6 @@ export const RUBRIC_WEIGHTS_NO_CELL = {
   goalContribution: 0.7,
   actionability: 0.3,
 } as const;
-
-/** Recency bonus table — applies ONLY to volatile-domain mandalas. */
-export const RECENCY_FRESH_MONTHS = 6;
-export const RECENCY_MID_MONTHS = 12;
-export const RECENCY_FRESH_BONUS = 5;
-export const RECENCY_MID_BONUS = 2;
 
 export interface RubricAxes {
   /** null ⇒ no cell goal was given (weights fall back to NO_CELL). */
@@ -55,30 +57,4 @@ export function composeRubricScore(axes: RubricAxes): number {
         RUBRIC_WEIGHTS.goalContribution * axes.goalContributionPct +
         RUBRIC_WEIGHTS.actionability * axes.actionabilityPct;
   return Math.min(100, Math.max(0, Math.round(raw)));
-}
-
-/**
- * Recency bonus for a card. Non-zero ONLY when the mandala is volatile AND
- * published_at is known — evergreen, NULL volatility (pre-existing mandalas)
- * and NULL published_at (3.7% of placed cards) are all 0 = unchanged behavior.
- * Additive (never a penalty): a misclassified evergreen mandala can never be
- * demoted, only a fresh-volatile card rewarded (James decision 2026-06-11).
- */
-export function recencyBonus(
-  publishedAt: Date | null | undefined,
-  volatility: string | null | undefined,
-  now: Date = new Date()
-): number {
-  if (volatility !== 'volatile' || !publishedAt) return 0;
-  const ageMs = now.getTime() - publishedAt.getTime();
-  if (ageMs < 0) return RECENCY_FRESH_BONUS; // future-dated (premiere) = fresh
-  const months = ageMs / MS_PER_MONTH_AVG;
-  if (months < RECENCY_FRESH_MONTHS) return RECENCY_FRESH_BONUS;
-  if (months < RECENCY_MID_MONTHS) return RECENCY_MID_BONUS;
-  return 0;
-}
-
-/** Final score = base + bonus, capped at 100. */
-export function applyRecency(basePct: number, bonus: number): number {
-  return Math.min(100, basePct + bonus);
 }

--- a/tests/unit/modules/enrich-relevance-quick.test.ts
+++ b/tests/unit/modules/enrich-relevance-quick.test.ts
@@ -198,12 +198,9 @@ describe('CP499+ rubric flag-on context fetch ($queryRaw, fail-open)', () => {
     delete process.env['RELEVANCE_RUBRIC_ENABLED'];
   });
 
-  test('flag on: context row -> compute called with rubric + language/volatility/publishedAt', async () => {
+  test('flag on: context row -> compute called with rubric + language ONLY (CP500+ 축 분리 — no freshness inputs)', async () => {
     process.env['RELEVANCE_RUBRIC_ENABLED'] = 'true';
-    const published = new Date('2026-06-01T00:00:00Z');
-    mockQueryRaw.mockResolvedValueOnce([
-      { language: 'ko', volatility: 'volatile', published_at: published },
-    ]);
+    mockQueryRaw.mockResolvedValueOnce([{ language: 'ko' }]);
     mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 81 });
     const handler = await getHandler();
 
@@ -213,13 +210,11 @@ describe('CP499+ rubric flag-on context fetch ($queryRaw, fail-open)', () => {
     });
 
     expect(mockCompute).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rubric: true,
-        language: 'ko',
-        volatility: 'volatile',
-        publishedAt: published,
-      })
+      expect.objectContaining({ rubric: true, language: 'ko' })
     );
+    const rubricArg = mockCompute.mock.calls[0][0] as Record<string, unknown>;
+    expect(rubricArg['volatility']).toBeUndefined();
+    expect(rubricArg['publishedAt']).toBeUndefined();
     expect(mockUvsUpdate).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: 'row-uvs-9' } })
     );

--- a/tests/unit/modules/relevance-rubric-pipeline.test.ts
+++ b/tests/unit/modules/relevance-rubric-pipeline.test.ts
@@ -1,24 +1,21 @@
 /**
- * CP499+ score pipeline — R1 rubric + volatile-only recency + lang 정합.
+ * CP499+ score pipeline — R1 PURE 3-axis rubric + lang 정합 (CP500+ 축 분리).
  *
  * Locks the pipeline invariants:
  *   - composition is CODE-side (weights are PROVISIONAL gate targets);
- *   - recency bonus fires ONLY for volatile + known published_at (additive,
- *     never a penalty; evergreen / NULL volatility / NULL date = 0);
+ *   - the score is PURE 3-axis — NO freshness term (James 2026-06-12 축 분리:
+ *     relevance ≠ recency; the volatile-only 70/30 recency QUOTA is a
+ *     placement-layer follow-up, score-independent);
  *   - rubric prompt actually swaps the mandala_fit block (guards against a
  *     silent .replace no-op on template drift) and the legacy prompt is
  *     byte-identical to pre-CP499+ output;
  *   - validator parses both shapes and composes in rubric mode;
- *   - merged-gen prompt asks the volatility judgement in BOTH languages.
+ *   - merged-gen prompt asks the volatility judgement in BOTH languages
+ *     (volatility persistence STAYS — the placement-layer quota consumes it).
  */
 
-import {
-  composeRubricScore,
-  recencyBonus,
-  applyRecency,
-  RECENCY_FRESH_BONUS,
-  RECENCY_MID_BONUS,
-} from '@/modules/relevance/relevance-composition';
+import * as composition from '@/modules/relevance/relevance-composition';
+import { composeRubricScore } from '@/modules/relevance/relevance-composition';
 import {
   buildV2QuickPrompt,
   validateV2Quick,
@@ -26,7 +23,6 @@ import {
 } from '@/modules/skills/rich-summary-v2-quick-prompt';
 import { buildMandalaWithQueriesPrompt } from '@/prompts/mandala-with-queries-generator';
 import { loadRelevanceRubricConfig } from '@/config/relevance-rubric';
-import { MS_PER_MONTH_AVG } from '@/utils/time-constants';
 
 describe('composeRubricScore (PROVISIONAL weights — gate-validation targets)', () => {
   it('weights 0.4/0.4/0.2 with a cell goal', () => {
@@ -60,30 +56,11 @@ describe('composeRubricScore (PROVISIONAL weights — gate-validation targets)',
   });
 });
 
-describe('recencyBonus (volatile-only, additive)', () => {
-  const now = new Date('2026-06-11T00:00:00Z');
-  const monthsAgo = (m: number) => new Date(now.getTime() - m * MS_PER_MONTH_AVG);
-
-  it('volatile + fresh (<6m) → +5', () => {
-    expect(recencyBonus(monthsAgo(5), 'volatile', now)).toBe(RECENCY_FRESH_BONUS);
-  });
-  it('volatile + mid (6-12m) → +2', () => {
-    expect(recencyBonus(monthsAgo(11), 'volatile', now)).toBe(RECENCY_MID_BONUS);
-  });
-  it('volatile + old (>12m) → 0', () => {
-    expect(recencyBonus(monthsAgo(13), 'volatile', now)).toBe(0);
-  });
-  it('evergreen / NULL volatility / NULL published_at → 0 (unchanged behavior)', () => {
-    expect(recencyBonus(monthsAgo(1), 'evergreen', now)).toBe(0);
-    expect(recencyBonus(monthsAgo(1), null, now)).toBe(0);
-    expect(recencyBonus(null, 'volatile', now)).toBe(0);
-  });
-  it('future-dated (premiere) counts as fresh', () => {
-    expect(recencyBonus(monthsAgo(-1), 'volatile', now)).toBe(RECENCY_FRESH_BONUS);
-  });
-  it('applyRecency caps at 100', () => {
-    expect(applyRecency(98, 5)).toBe(100);
-    expect(applyRecency(60, 2)).toBe(62);
+describe('축 분리 — NO freshness term in the score module (CP500+ regression pin)', () => {
+  it('relevance-composition exports no recency surface', () => {
+    const exported = Object.keys(composition);
+    expect(exported).toContain('composeRubricScore');
+    expect(exported.filter((k) => /recency/i.test(k))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

James spec-final (2026-06-12): the R1 rubric score is **pure 3-axis** (cell_fit / goal_contribution / actionability) — the volatile-only recency BONUS is removed from the score. Rationale: **axis separation** (relevance ≠ recency, James decision) + the freshness term would contaminate the R1 gate measurement (sd ≥ 12 ∧ Spearman ≥ 0.8).

**UX principle alignment**: Principle 2 — the 시의성 axis stays, but moves layers: "volatile 도메인만 recency 우대 (70/30 쿼터)" is a **placement-layer follow-up (score-independent, NOT in this PR)** — volatility-branch design reserved in comments (`relevance-composition.ts` header). `user_mandalas.volatility` persistence from merged-gen STAYS (the placement quota is its consumer).

## Changes (small PR, −154/+67)

- `relevance-composition.ts`: `recencyBonus` / `applyRecency` / `RECENCY_*` deleted; module = `composeRubricScore` only. Header reserves the placement-layer 70/30 quota design.
- `compute-card-relevance.ts`: `publishedAt` / `volatility` inputs removed; rubric result = composite verbatim; `detail` = 3 axes only (no `basePct`/`recencyBonus`).
- `enrich-relevance-quick.ts`: `fetchRelevanceContext` slims to mandala `language` only (no volatility/published_at selects).
- `pool-serve-fill.ts`: `fetchVolatility` deleted; rubric call passes `rubric: true` only.
- `relevance-rubric.ts` config header updated (DDL deploy-order precondition obsolete — no flag-on path selects volatility anymore).

## Behavior

`RELEVANCE_RUBRIC_ENABLED` stays **OFF in prod** (unchanged) — this PR changes what the flag WILL do when [GO] R1-flag-ON lands: pure-3-axis scores, uncontaminated gate measurement. Legacy single-axis path byte-identical.

## Tests (40 green across 4 suites)

- NEW regression pin: `relevance-composition` exports no recency surface.
- enrich worker: rubric call = `rubric + language` ONLY (volatility/publishedAt asserted absent); fail-open + flag-off zero-selects cases intact.
- recency-bonus describe block removed with the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)