### PR TITLE
fix(wizard): exclude owned videos at recruitment + pool-serve completed-grace (B-1/C diagnosis fixes, CP500+)

### DIFF
--- a/frontend/src/features/mandala/model/useMandalaQuery.ts
+++ b/frontend/src/features/mandala/model/useMandalaQuery.ts
@@ -31,6 +31,8 @@ export interface MandalaMeta {
   cardCount: number;
   /** CP499+ pool-serve — cells with an async deficit-fill in flight. */
   fillPendingCells: number[];
+  /** CP500+ — cells whose fill run completed <60s ago (grace: invalidate once). */
+  fillCompletedCells: number[];
 }
 
 interface MandalaQueryShape {
@@ -40,6 +42,7 @@ interface MandalaQueryShape {
 
 const EMPTY_META: MandalaMeta = {
   fillPendingCells: [],
+  fillCompletedCells: [],
   focusTags: [],
   targetLevel: 'standard',
   language: 'ko',
@@ -71,6 +74,7 @@ export function useMandalaQuery(mandalaId?: string | null) {
             title: apiResponse.mandala.title ?? '',
             cardCount: apiResponse.mandala.cardCount ?? 0,
             fillPendingCells: apiResponse.mandala.fillPendingCells ?? [],
+            fillCompletedCells: apiResponse.mandala.fillCompletedCells ?? [],
           },
         };
       } catch (err: unknown) {

--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -795,6 +795,23 @@ function AuthenticatedApp() {
     return () => clearInterval(timer);
   }, [fillPending, effectiveMandalaId, queryClient]);
 
+  // CP500+ C-fix (completed-grace) — a FAST fill run (measured 17s) can finish
+  // BEFORE this page ever fetches mandalaMeta: fillPendingCells is then already
+  // empty, the poll above never starts, and the card cache stays stale until a
+  // manual refresh. When the meta lands inside the 60s completed-grace window,
+  // invalidate the card sources ONCE (ref-guarded per mandala — the refetched
+  // meta may still carry the grace cells, which must not loop).
+  const fillCompletedCells = mandalaMeta?.fillCompletedCells ?? [];
+  const fillGraceInvalidatedFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!effectiveMandalaId || fillPending) return; // poll path already refreshes
+    if (fillCompletedCells.length === 0) return;
+    if (fillGraceInvalidatedFor.current === effectiveMandalaId) return;
+    fillGraceInvalidatedFor.current = effectiveMandalaId;
+    queryClient.invalidateQueries({ queryKey: queryKeys.youtube.allVideoStates() });
+    queryClient.invalidateQueries({ queryKey: queryKeys.localCards.all });
+  }, [fillCompletedCells.length, fillPending, effectiveMandalaId, queryClient]);
+
   // Shared MandalaGrid element
   const mandalaGridElement = () => (
     <MandalaGrid

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -433,6 +433,8 @@ interface MandalaResponse {
   cardCount?: number;
   // CP499+ pool-serve — cells with an async deficit-fill in flight (W1b pulse).
   fillPendingCells?: number[];
+  // CP500+ — cells whose fill run completed <60s ago (grace: invalidate once).
+  fillCompletedCells?: number[];
   createdAt: string;
   updatedAt: string;
   levels: Array<{

--- a/src/modules/mandala/manager.ts
+++ b/src/modules/mandala/manager.ts
@@ -69,6 +69,10 @@ export interface MandalaWithLevels {
   // 'pool-serve-fill', status=running, ≤3min old). FE shows the W1b
   // "filling" pulse on these cells and bounded-polls until they clear.
   fillPendingCells: number[];
+  // CP500+ C-fix — cells whose fill run COMPLETED within the last 60s
+  // (completed-grace). FE invalidates its card cache ONCE when it lands
+  // inside this window (fast runs finish before the first meta fetch).
+  fillCompletedCells: number[];
   createdAt: Date;
   updatedAt: Date;
   levels: {
@@ -165,7 +169,8 @@ export class MandalaManager {
       }[];
     },
     cardCount?: number,
-    fillPendingCells?: number[]
+    fillPendingCells?: number[],
+    fillCompletedCells?: number[]
   ): MandalaWithLevels {
     return {
       id: mandala.id,
@@ -180,6 +185,7 @@ export class MandalaManager {
       language: mandala.language ?? 'ko',
       cardCount: cardCount ?? 0,
       fillPendingCells: fillPendingCells ?? [],
+      fillCompletedCells: fillCompletedCells ?? [],
       createdAt: mandala.created_at,
       updatedAt: mandala.updated_at,
       levels: mandala.levels.map((l) => ({
@@ -362,31 +368,49 @@ export class MandalaManager {
     if (!mandala) return null;
 
     const cardCount = await this.computeCardCount(userId, mandalaId);
-    const fillPendingCells = await this.computeFillPendingCells(userId, mandalaId);
-    return this.mapMandala(mandala, cardCount, fillPendingCells);
+    const fill = await this.computeFillSignals(userId, mandalaId);
+    return this.mapMandala(mandala, cardCount, fill.pending, fill.recentlyCompleted);
   }
 
   /**
-   * CP499+ pool-serve — cells with an active fill run: input.cells minus
-   * reported output keys on running 'pool-serve-fill' skill_runs rows
-   * (≤3min TTL so a dead worker degrades to plain empty cells, mirroring
-   * the W1b actions-poll bound). Fail-open: any error ⇒ [].
+   * CP499+ pool-serve fill signals.
+   * - pending: cells with an ACTIVE fill run — input.cells minus reported
+   *   output keys on running rows (≤3min TTL so a dead worker degrades to
+   *   plain empty cells, mirroring the W1b actions-poll bound). FE pulses +
+   *   bounded-polls these.
+   * - recentlyCompleted (CP500+ C-fix, completed-grace 60s): cells whose fill
+   *   run COMPLETED within the last 60s. A fast run (measured 17s on the
+   *   2026-06-12 N잡 run) can finish BEFORE the FE ever fetches mandalaMeta —
+   *   pending is then already empty, no poll fires, and the card cache stays
+   *   stale until a manual refresh. The grace signal lets the FE invalidate
+   *   ONCE when it lands inside the window.
+   * Fail-open: any error ⇒ both empty.
    */
-  private async computeFillPendingCells(userId: string, mandalaId: string): Promise<number[]> {
+  private async computeFillSignals(
+    userId: string,
+    mandalaId: string
+  ): Promise<{ pending: number[]; recentlyCompleted: number[] }> {
     try {
-      const rows = await this.prisma.$queryRaw<{ cell: number }[]>`
-        SELECT DISTINCT (c.value)::int AS cell
+      const rows = await this.prisma.$queryRaw<{ cell: number; status: string }[]>`
+        SELECT DISTINCT (c.value)::int AS cell, sr.status
         FROM skill_runs sr,
              jsonb_array_elements_text(sr.input -> 'cells') AS c(value)
         WHERE sr.skill_id = 'pool-serve-fill'
-          AND sr.status = 'running'
           AND sr.user_id = ${userId}::uuid
           AND sr.input ->> 'mandalaId' = ${mandalaId}
-          AND sr.started_at > now() - interval '3 minutes'
-          AND NOT (COALESCE(sr.output, '{}'::jsonb) ? c.value)`;
-      return rows.map((r) => r.cell);
+          AND (
+            (sr.status = 'running'
+              AND sr.started_at > now() - interval '3 minutes'
+              AND NOT (COALESCE(sr.output, '{}'::jsonb) ? c.value))
+            OR (sr.status = 'completed'
+              AND sr.ended_at > now() - interval '60 seconds')
+          )`;
+      return {
+        pending: rows.filter((r) => r.status === 'running').map((r) => r.cell),
+        recentlyCompleted: rows.filter((r) => r.status === 'completed').map((r) => r.cell),
+      };
     } catch {
-      return [];
+      return { pending: [], recentlyCompleted: [] };
     }
   }
 

--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -127,6 +127,12 @@ export async function startPrecompute(input: StartPrecomputeInput): Promise<void
       focusTags: input.focusTags,
       targetLevel: input.targetLevel ?? 'standard',
       env: process.env,
+      // CP500+ B-1 — exclude ALREADY-OWNED videos at recruitment. uvs has a
+      // GLOBAL @@unique(user_id, videoId), so picks overlapping ANY existing
+      // mandala silently evaporate at auto-add insert (measured 24/39 = 62%
+      // lost, 2026-06-12 SaaS run). add-cards already excludes owned; the
+      // wizard path did not. Fail-open: lookup failure ⇒ empty set.
+      excludeVideoIds: await fetchOwnedYoutubeIds(input.userId),
       // CP493 — when WIZARD_MERGED_GEN produced full per-cell coverage.
       precomputedQueries: input.cellQueries,
     });
@@ -521,4 +527,29 @@ export async function consumePrecompute(
   }
 
   return { consumed: true, cardsInserted: inserted, slotsCount: slots.length };
+}
+
+/**
+ * CP500+ B-1 — the user's ALREADY-OWNED youtube video ids (all mandalas).
+ * Recruitment-stage exclude set for the wizard discover: uvs carries a GLOBAL
+ * @@unique(user_id, videoId), so any pick the user already owns can never be
+ * inserted — excluding it up front lets the picker spend the slot on a NEW
+ * video instead of silently evaporating at auto-add (measured 24/39 lost).
+ * Fail-open: any failure returns an empty set (= pre-CP500 behavior).
+ */
+export async function fetchOwnedYoutubeIds(userId: string): Promise<Set<string>> {
+  try {
+    const db = getPrismaClient();
+    const rows = await db.$queryRaw<{ youtube_video_id: string }[]>`
+      SELECT DISTINCT yv.youtube_video_id
+      FROM user_video_states uvs
+      JOIN youtube_videos yv ON yv.id = uvs.video_id
+      WHERE uvs.user_id = ${userId}::uuid`;
+    return new Set(rows.map((r) => r.youtube_video_id));
+  } catch (err) {
+    log.warn(
+      `fetchOwnedYoutubeIds failed (fail-open, empty exclude): ${err instanceof Error ? err.message : String(err)}`
+    );
+    return new Set();
+  }
 }

--- a/tests/unit/modules/wizard-precompute.test.ts
+++ b/tests/unit/modules/wizard-precompute.test.ts
@@ -19,6 +19,7 @@ const mockFindUnique = jest.fn();
 const mockCreate = jest.fn();
 const mockUpdate = jest.fn();
 const mockExecuteRaw = jest.fn();
+const mockQueryRaw = jest.fn();
 const mockRunDiscoverEphemeral = jest.fn();
 const mockNotifyCardAdded = jest.fn();
 const mockLoadConfig = jest.fn();
@@ -31,6 +32,7 @@ jest.mock('@/modules/database/client', () => ({
       update: mockUpdate,
     },
     $executeRaw: mockExecuteRaw,
+    $queryRaw: mockQueryRaw,
   }),
 }));
 
@@ -210,6 +212,51 @@ describe('wizard-precompute — startPrecompute', () => {
     expect(mockCreate).toHaveBeenCalledTimes(1);
     expect(mockUpdate).not.toHaveBeenCalled();
     expect(mockRunDiscoverEphemeral).not.toHaveBeenCalled();
+  });
+
+  test('CP500+ B-1 증발 regression — discover receives the OWNED youtube ids as excludeVideoIds', async () => {
+    mockCreate.mockResolvedValueOnce({});
+    mockUpdate.mockResolvedValue({});
+    mockQueryRaw.mockResolvedValueOnce([
+      { youtube_video_id: 'ownedA' },
+      { youtube_video_id: 'ownedB' },
+    ]);
+    mockRunDiscoverEphemeral.mockResolvedValueOnce({ slots: [], queriesUsed: 0, duration_ms: 1 });
+
+    await startPrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      goal: 'g',
+      language: 'ko',
+      focusTags: [],
+      subGoals: SUB_GOALS,
+    });
+
+    const arg = mockRunDiscoverEphemeral.mock.calls[0]![0];
+    expect(arg.excludeVideoIds).toBeInstanceOf(Set);
+    expect(arg.excludeVideoIds.has('ownedA')).toBe(true);
+    expect(arg.excludeVideoIds.has('ownedB')).toBe(true);
+    expect(arg.excludeVideoIds.size).toBe(2);
+  });
+
+  test('CP500+ B-1 fail-open — owned lookup failure ⇒ EMPTY exclude set, discover still runs', async () => {
+    mockCreate.mockResolvedValueOnce({});
+    mockUpdate.mockResolvedValue({});
+    mockQueryRaw.mockRejectedValueOnce(new Error('db down'));
+    mockRunDiscoverEphemeral.mockResolvedValueOnce({ slots: [], queriesUsed: 0, duration_ms: 1 });
+
+    await startPrecompute({
+      sessionId: SESSION,
+      userId: USER,
+      goal: 'g',
+      language: 'ko',
+      focusTags: [],
+      subGoals: SUB_GOALS,
+    });
+
+    const arg = mockRunDiscoverEphemeral.mock.calls[0]![0];
+    expect(arg.excludeVideoIds).toBeInstanceOf(Set);
+    expect(arg.excludeVideoIds.size).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

James-approved PR1 of the 2026-06-12 diagnosis batch — two measured fixes:

**① B-1 owned-video evaporation (dominant card-count cause).** `user_video_states` carries a GLOBAL `@@unique([user_id, videoId])` (schema:54): wizard picks overlapping ANY existing mandala silently evaporated at auto-add insert — measured **24/39 = 62% lost** on the "클로드 코드 SaaS" run (23 cards), 16/60 on "AI 에이전트", 11/55 on "Docker K8s". add-cards already excludes owned; the wizard path did not. Fix: `fetchOwnedYoutubeIds(userId)` (all-mandala uvs youtube ids, fail-open empty) → `runV5ForWizard({ excludeVideoIds })` — the picker now spends every slot on a NEW video.

**② C completed-grace (second-run no-refresh).** A fast pool-serve run (measured **17s** on the N잡 run — vmr cache hits) finishes BEFORE the FE ever fetches mandalaMeta: `fillPendingCells` is already empty, the W1b poll never starts, the card cache stays stale until manual refresh. Fix: `computeFillSignals` adds **`fillCompletedCells`** (runs completed <60s, one combined query) → FE invalidates card sources ONCE when meta lands inside the grace window (ref-guarded per mandala — refetched meta still carrying grace cells cannot loop; the pending-poll path is untouched and takes precedence).

**UX principle alignment**: Principle 2 — 빈 셀 불허 체인의 두 누수(증발·무갱신)를 막는 보수 작업; 신규 게이트 추가 없음.

## Tests

- NEW: B-1 증발 regression — discover receives the owned ids as `excludeVideoIds` (SaaS-pattern 24/39 evaporation → recruitment-stage exclusion); fail-open empty-set on lookup failure.
- BE/FE tsc 0. Note: 2 pre-existing `consumePrecompute` poll-timing failures reproduce on CLEAN main locally (CI green on main) — untouched, CI arbitrates.

## Rollback

①: revert (behavior-only, no flag — exclusion is strictly additive recall-safe: excluded picks could never insert anyway). ②: additive field; FE guard ignores it when absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)