### PR TITLE
perf(embed): [TIMING] search decomposition + single-flight on the iks-embed batch path (A diagnosis PR2, CP500+)

### DIFF
--- a/src/modules/mandala/search.ts
+++ b/src/modules/mandala/search.ts
@@ -311,7 +311,13 @@ export async function searchMandalasByGoal(
   const limit = Math.min(options.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
   const threshold = options.threshold ?? DEFAULT_THRESHOLD;
 
+  // CP500+ PR2 — decompose the searchMs that [TIMING] merged-gen reports:
+  // embed (provider call, the volatile 3.0-5.8s component measured 6/11-12)
+  // vs match (pgvector cosine + meta SQL, warm ~24ms per CP499 EXPLAIN).
+  const tEmbed = Date.now();
   const queryVector = await embedGoalForMandala(goalText);
+  const embedMs = Date.now() - tEmbed;
+  const tMatch = Date.now();
   const embeddingStr = `[${queryVector.join(',')}]`;
 
   const prisma = getPrismaClient();
@@ -378,7 +384,8 @@ export async function searchMandalasByGoal(
   logger.info(
     `Mandala search: threshold=${threshold} floor=${HARD_SIMILARITY_FLOOR} ` +
       `goal="${goalText}" results=${topRows.length} ` +
-      `(soft_target=${SOFT_RESULTS_TARGET})`
+      `(soft_target=${SOFT_RESULTS_TARGET}) ` +
+      `[TIMING] embed=${embedMs}ms match=${Date.now() - tMatch}ms`
   );
 
   if (topRows.length === 0) {

--- a/src/skills/plugins/iks-scorer/__tests__/embedding-fallback.test.ts
+++ b/src/skills/plugins/iks-scorer/__tests__/embedding-fallback.test.ts
@@ -186,3 +186,71 @@ describe('embedBatch — IKS_EMBED_PROVIDER fallback (Issue #543)', () => {
     expect(out).toEqual([null]);
   });
 });
+
+// ─── CP500+ PR2 — single-flight over identical chunks (#882/#899 family) ────
+
+describe('embedBatch — single-flight (CP500+ PR2)', () => {
+  beforeEach(() => {
+    configMock.iksEmbed.provider = 'ollama';
+    logLLMCallMock.mockClear();
+  });
+
+  function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+    let resolve!: (v: T) => void;
+    const promise = new Promise<T>((r) => (resolve = r));
+    return { promise, resolve };
+  }
+
+  it('identical concurrent chunks share ONE provider call', async () => {
+    const gate = deferred<Response>();
+    const fetchImpl = jest.fn().mockReturnValue(gate.promise);
+
+    const a = embedBatch(['t1', 't2'], { fetchImpl });
+    const b = embedBatch(['t1', 't2'], { fetchImpl });
+    gate.resolve(makeOllamaResponse(2));
+
+    const [ra, rb] = await Promise.all([a, b]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(ra[0]).toEqual(FAKE_OLLAMA_VECTOR);
+    expect(rb[0]).toEqual(FAKE_OLLAMA_VECTOR);
+  });
+
+  it('different texts do NOT share', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(makeOllamaResponse(1))
+      .mockResolvedValueOnce(makeOllamaResponse(1));
+    await Promise.all([embedBatch(['x'], { fetchImpl }), embedBatch(['y'], { fetchImpl })]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("one caller's external abort rejects ONLY that caller — the joiner still gets vectors", async () => {
+    const gate = deferred<Response>();
+    const fetchImpl = jest.fn().mockReturnValue(gate.promise);
+    const ac = new AbortController();
+
+    const keeper = embedBatch(['s1'], { fetchImpl });
+    const aborter = embedBatch(['s1'], { fetchImpl, signal: ac.signal });
+    ac.abort();
+    gate.resolve(makeOllamaResponse(1));
+
+    const [kept, aborted] = await Promise.all([keeper, aborter]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(kept[0]).toEqual(FAKE_OLLAMA_VECTOR); // shared call survived the abort
+    expect(aborted[0]).toBeNull(); // aborter's chunk failed per-chunk-isolation
+  });
+
+  it('failures are NOT cached — the next call retries fresh', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed')) // ollama
+      .mockRejectedValueOnce(new TypeError('fetch failed')) // openrouter retry 1
+      .mockRejectedValueOnce(new TypeError('fetch failed')) // openrouter retry 2
+      .mockRejectedValueOnce(new TypeError('fetch failed')) // openrouter retry 3
+      .mockResolvedValueOnce(makeOllamaResponse(1)); // fresh second call succeeds
+    const first = await embedBatch(['f1'], { fetchImpl });
+    expect(first[0]).toBeNull();
+    const second = await embedBatch(['f1'], { fetchImpl });
+    expect(second[0]).toEqual(FAKE_OLLAMA_VECTOR);
+  });
+});

--- a/src/skills/plugins/iks-scorer/embedding.ts
+++ b/src/skills/plugins/iks-scorer/embedding.ts
@@ -19,6 +19,8 @@
  * is the goal_relevance signal at IKS scoring time.
  */
 
+import { createHash } from 'crypto';
+
 import { logger } from '@/utils/logger';
 import { getPrismaClient } from '@/modules/database';
 import { Prisma } from '@prisma/client';
@@ -201,7 +203,63 @@ export async function embedBatch(
  * step1 ensureMandalaEmbeddings threw → step2/3 skipped → 0 cards in
  * dashboard while recommendation_cache had 74 rows).
  */
+/**
+ * CP500+ PR2 (#882/#899 family) — single-flight over identical chunks.
+ *
+ * Identical concurrent chunks (e.g. racing pipeline runs re-embedding the
+ * same centerGoal+titles — CP499 measured the wizard multiple-fire 2-4×/goal)
+ * share ONE provider round-trip. The 2026-06-09/10 `iks-embed-fallback` tail
+ * (p95 12-14.7s, max 102.8-114.3s) is the same stall class the goal-embed
+ * single-flight in mandala/search.ts already removes — this extends the cover
+ * to the batch path. Failures are NOT cached (`finally` evicts).
+ *
+ * Signal semantics: the SHARED call runs WITHOUT any caller's external signal
+ * (internal per-attempt timeouts still bound it — W3); each signal-bearing
+ * caller instead races the shared promise against its own abort, so one
+ * caller's abort rejects ONLY that caller and never kills a joiner's result.
+ */
+const inflightChunks = new Map<string, Promise<number[][]>>();
+
 async function embedOneChunk(texts: string[], opts: EmbeddingClientOptions): Promise<number[][]> {
+  // Key = full route (provider + host + model), not just texts — the same
+  // texts against a different host/model must NOT share a result.
+  const key = createHash('sha1')
+    .update(`${config.iksEmbed.provider}|${opts.baseUrl ?? ''}|${opts.model ?? ''}|`)
+    .update(texts.join('\u001f'))
+    .digest('hex');
+  let shared = inflightChunks.get(key);
+  if (!shared) {
+    shared = embedOneChunkRouted(texts, { ...opts, signal: undefined }).finally(() => {
+      inflightChunks.delete(key);
+    });
+    inflightChunks.set(key, shared);
+  }
+  if (!opts.signal) return shared;
+  return raceExternalAbort(shared, opts.signal);
+}
+
+function raceExternalAbort(shared: Promise<number[][]>, signal: AbortSignal): Promise<number[][]> {
+  if (signal.aborted) return Promise.reject(new Error('embed cancelled by external signal'));
+  return new Promise<number[][]>((resolve, reject) => {
+    const onAbort = () => reject(new Error('embed cancelled by external signal'));
+    signal.addEventListener('abort', onAbort, { once: true });
+    shared.then(
+      (v) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(v);
+      },
+      (e) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(e);
+      }
+    );
+  });
+}
+
+async function embedOneChunkRouted(
+  texts: string[],
+  opts: EmbeddingClientOptions
+): Promise<number[][]> {
   const provider = config.iksEmbed.provider;
   if (provider === 'openrouter') {
     // OpenRouter primary (retry on transient errors) → Ollama fallback once


### PR DESCRIPTION
## Summary

James-approved PR2 of the 2026-06-12 performance diagnosis.

**① [TIMING] search decomposition (1 line).** `searchMandalasByGoal` now logs `[TIMING] embed=Xms match=Yms` inside its existing search log line — decomposes the `searchMs` component that `[TIMING] merged-gen` reports (measured 3.0–5.8s volatile across 6/11–12 runs) into the provider embed call vs pgvector cosine+meta SQL (warm ~24ms per CP499 EXPLAIN). Closes the A1 known-limit: the volatile component is now attributable per run.

**② Single-flight on the iks-embed batch path (#882/#899 family).** `iks-embed-fallback` tail measured p95 12–14.7s, **max 102.8–114.3s** on 6/9–6/10 (`llm_call_logs`) — the same stall class the goal-embed single-flight in `mandala/search.ts` already removes. Extension: identical concurrent chunks (racing pipeline runs re-embedding the same centerGoal+titles — CP499 measured wizard multiple-fire 2–4×/goal) now share ONE provider round-trip, keyed by full route (provider|baseUrl|model) + chunk texts (sha1).

**Signal semantics (W3-aware)**: the SHARED call runs without any caller's external signal (internal per-attempt timeouts still bound it); each signal-bearing caller races the shared promise against its own abort — one caller's abort rejects only that caller, never a joiner's result. Trade-off: after all callers abort, the shared call may run to its internal timeout (bounded).

**UX principle alignment**: 무동작 관측성(①) + 기존 게이트 무변경 지연 단축(②) — 원칙 영향 없음.

## Verification gate (James): 확장 후 24h `iks-embed-fallback` p95/max 추적 보고 — **p95 < 3s**.

## Tests (10 green = 6 existing fallback + 4 new)

- identical concurrent chunks → ONE fetch; different texts → two.
- abort isolation: aborter gets per-chunk null, joiner gets vectors, single fetch.
- failures NOT cached (next call retries fresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)