### PR TITLE
fix(pool-serve): replicate the v5 shorts gate onto pool + live paths (guard-replication fix, CP500+)

### DIFF
--- a/src/modules/queue/handlers/pool-serve-fill.ts
+++ b/src/modules/queue/handlers/pool-serve-fill.ts
@@ -36,10 +36,15 @@ import { loadRelevanceRubricConfig } from '@/config/relevance-rubric';
 import { tsvectorKeywordCandidatesPerCell } from '@/skills/plugins/video-discover/v3/hybrid-rerank';
 import {
   resolveSearchApiKeys,
+  resolveVideosApiKeys,
   searchVideos,
   titleHitsBlocklist,
   titleIndicatesShorts,
+  videosBatch,
 } from '@/skills/plugins/video-discover/v2/youtube-client';
+import { isShortCached, SHORT_MAX_DURATION_SEC } from '@/modules/video-pool/is-short';
+import { getV5Config } from '@/skills/plugins/video-discover/v5/config';
+import { parseIsoDurationSeconds } from '@/skills/plugins/video-discover/v5/executor';
 import { isOffLanguageTitleToggled } from '@/skills/plugins/video-discover/v5/youtube-fanout';
 import { dedupeSeries, softChannelCap } from '@/skills/plugins/video-discover/diversity-guard';
 import { loadDiversityGuardConfig } from '@/config/diversity-guard';
@@ -76,6 +81,8 @@ export interface GateCandidate {
   channelTitle: string | null;
   thumbnail: string | null;
   publishedAt: Date | null;
+  /** CP500+ shorts gate — pool rows carry it; live rows get it via videos.list. */
+  durationSec?: number | null;
 }
 
 interface PassedCandidate extends GateCandidate {
@@ -91,6 +98,8 @@ export interface PoolServeCellResult {
   liveRecruited: number;
   livePassed: number;
   inserted: number;
+  /** CP500+ — dropped by the replicated v5 shorts gate (duration<180 + URL probe). */
+  shortsDropped: number;
 }
 
 /** One deficit cell: 1차 pool → 2차 live fallback → 3차 honest-empty. */
@@ -107,6 +116,7 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
     liveRecruited: 0,
     livePassed: 0,
     inserted: 0,
+    shortsDropped: 0,
   };
 
   try {
@@ -142,6 +152,36 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
       if (!diversity.enabled) return cands;
       const d = dedupeSeries(cands, { simThreshold: diversity.seriesSim, against });
       return softChannelCap(d.kept, diversity.channelSoftCap);
+    };
+
+    // CP500+ shorts gate — EXACT replica of the v5 placement gate
+    // (v5/executor.ts step 6): duration>=180 short-circuits with no HTTP;
+    // <180 (or unknown) probes the /shorts/ URL via isShortCached; probes
+    // still in-flight at the shared deadline fail OPEN (kept) — identical
+    // semantics, same knob (V5_SHORT_PROBE_DEADLINE_MS). This path shipped
+    // (#907) with only the title heuristic — the guard-replication gap
+    // (troubleshooting LEVEL-2, recurrence=2 with the channel-cap loss).
+    const shortDeadlineMs = getV5Config(process.env).shortProbeDeadlineMs;
+    const dropShorts = async (cands: GateCandidate[]): Promise<GateCandidate[]> => {
+      if (cands.length === 0 || shortDeadlineMs <= 0) return cands;
+      const ctl = new AbortController();
+      const timer = setTimeout(() => ctl.abort(), shortDeadlineMs);
+      try {
+        const flags = await Promise.all(
+          cands.map(async (c) => {
+            if (c.durationSec != null && c.durationSec >= SHORT_MAX_DURATION_SEC) return false;
+            const { isShort } = await isShortCached(c.youtubeVideoId, c.durationSec ?? null, {
+              signal: ctl.signal,
+            });
+            return isShort;
+          })
+        );
+        const kept = cands.filter((_, i) => !flags[i]);
+        result.shortsDropped += cands.length - kept.length;
+        return kept;
+      } finally {
+        clearTimeout(timer);
+      }
     };
 
     /** Semantic gate: vmr cache first, score on miss, threshold; early-exit. */
@@ -197,18 +237,21 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
     result.recruited = recruits.length;
     const passed: PassedCandidate[] = [];
     await gate(
-      applyDiversity(
-        hygienic(
-          recruits.map((c) => ({
-            youtubeVideoId: c.videoId,
-            title: c.title,
-            description: c.description,
-            channelTitle: c.channelName,
-            thumbnail: c.thumbnail,
-            publishedAt: c.publishedAt,
-          }))
-        ),
-        []
+      await dropShorts(
+        applyDiversity(
+          hygienic(
+            recruits.map((c) => ({
+              youtubeVideoId: c.videoId,
+              title: c.title,
+              description: c.description,
+              channelTitle: c.channelName,
+              thumbnail: c.thumbnail,
+              publishedAt: c.publishedAt,
+              durationSec: c.durationSec,
+            }))
+          ),
+          []
+        )
       ),
       passed
     );
@@ -237,8 +280,30 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
           }))
         );
         result.liveRecruited = liveCands.length;
+        // CP500+ — live candidates carry NO duration (search.list snippet
+        // only); fetch it with ONE videos.list call (quota 1 unit) so the
+        // replicated shorts gate can run the same duration<180 + probe
+        // semantics as the v5 placement path.
+        if (liveCands.length > 0) {
+          try {
+            const metas = await videosBatch({
+              videoIds: liveCands.map((c) => c.youtubeVideoId),
+              apiKey: resolveVideosApiKeys(process.env),
+            });
+            const durById = new Map(
+              metas.map((m) => [m.id, parseIsoDurationSeconds(m.contentDetails?.duration)])
+            );
+            for (const c of liveCands) c.durationSec = durById.get(c.youtubeVideoId) ?? null;
+          } catch (err) {
+            // Duration fetch failure ⇒ unknown durations ⇒ the gate probes
+            // each id (fail-open on probe timeout) — never fails the job.
+            log.warn(
+              `pool-serve live videos.list failed (gate falls back to probe-only): ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        }
         const before = passed.length;
-        await gate(applyDiversity(liveCands, passed), passed);
+        await gate(await dropShorts(applyDiversity(liveCands, passed)), passed);
         result.livePassed = passed.length - before;
       } catch (err) {
         // Live failure never fails the job — pool passes still insert.

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -541,7 +541,7 @@ function assembleCard(
   };
 }
 
-function parseIsoDurationSeconds(iso: string | null | undefined): number | null {
+export function parseIsoDurationSeconds(iso: string | null | undefined): number | null {
   if (!iso) return null;
   const m = iso.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/);
   if (!m) return null;

--- a/tests/unit/modules/pool-serve-fill.test.ts
+++ b/tests/unit/modules/pool-serve-fill.test.ts
@@ -66,8 +66,29 @@ jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => {
     ...actual,
     searchVideos: (...a: unknown[]) => mockSearchVideos(...a),
     resolveSearchApiKeys: () => ['key-1'],
+    resolveVideosApiKeys: () => ['vkey-1'],
+    videosBatch: (...a: unknown[]) => mockVideosBatch(...a),
   };
 });
+
+// CP500+ shorts gate replica deps — probe is stubbed (no HTTP in unit tests);
+// duration>=180 short-circuits in the handler itself so the stub is only hit
+// for <180/unknown candidates.
+const mockVideosBatch = jest.fn().mockResolvedValue([]);
+const mockIsShortCached = jest
+  .fn()
+  .mockResolvedValue({ isShort: false, signal: 'probe_2xx_watch' });
+jest.mock('@/modules/video-pool/is-short', () => ({
+  SHORT_MAX_DURATION_SEC: 180,
+  isShortCached: (...a: unknown[]) => mockIsShortCached(...a),
+}));
+jest.mock('@/skills/plugins/video-discover/v5/config', () => ({
+  getV5Config: () => ({ shortProbeDeadlineMs: 4000 }),
+}));
+jest.mock('@/skills/plugins/video-discover/v5/executor', () => ({
+  parseIsoDurationSeconds: (iso: string | null | undefined) =>
+    iso === 'PT45S' ? 45 : iso === 'PT10M' ? 600 : null,
+}));
 
 jest.mock('@/utils/logger', () => ({
   logger: {
@@ -284,5 +305,79 @@ describe('dispatchPoolServeForMandala', () => {
     expect(mockBossInstance.send).toHaveBeenCalledTimes(2);
     const job1 = mockBossInstance.send.mock.calls[0][1];
     expect(job1).toMatchObject({ cellIndex: 1, deficit: 2, cellGoal: '모니터링' });
+  });
+});
+
+// ── CP500+ shorts gate (v5 placement gate replica) ───────────────────────────
+
+describe('CP500+ shorts gate — guard-replication fix', () => {
+  it('pool candidate <180s flagged short by the probe is dropped BEFORE scoring', async () => {
+    mockPoolCandidates.mockResolvedValueOnce([
+      { ...poolCand('vidS1234567', '쿠버네티스 1분 요약'), durationSec: 45 },
+    ]);
+    mockIsShortCached.mockResolvedValueOnce({ isShort: true, signal: 'probe_redirect_shorts' });
+    mockSearchVideos.mockResolvedValueOnce([]); // live empty
+    const handler = await getHandler();
+
+    await handler({ id: 'js1', data: basePayload });
+
+    expect(mockIsShortCached).toHaveBeenCalledWith('vidS1234567', 45, expect.anything());
+    expect(mockCompute).not.toHaveBeenCalled(); // dropped pre-gate (no Haiku spend)
+    expect(mockUvsCreateMany).not.toHaveBeenCalled();
+  });
+
+  it('duration>=180 short-circuits — kept WITHOUT a probe call (v5 semantics)', async () => {
+    mockPoolCandidates.mockResolvedValueOnce([
+      { ...poolCand('vidL1234567', '쿠버네티스 풀강의'), durationSec: 600 },
+    ]);
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 80 });
+    const handler = await getHandler();
+
+    await handler({ id: 'js2', data: basePayload });
+
+    expect(mockIsShortCached).not.toHaveBeenCalled();
+    expect(mockUvsCreateMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('live candidates get durations via ONE videos.list call, then the SAME gate drops shorts', async () => {
+    mockPoolCandidates.mockResolvedValueOnce([]); // pool empty → live fires
+    mockSearchVideos.mockResolvedValueOnce([
+      { id: { videoId: 'liveShort01' }, snippet: { title: '도커 쇼츠 모음' } },
+      { id: { videoId: 'liveLong001' }, snippet: { title: '도커 운영 강의 풀버전' } },
+    ]);
+    mockVideosBatch.mockResolvedValueOnce([
+      { id: 'liveShort01', contentDetails: { duration: 'PT45S' } },
+      { id: 'liveLong001', contentDetails: { duration: 'PT10M' } },
+    ]);
+    mockIsShortCached.mockResolvedValueOnce({ isShort: true, signal: 'probe_redirect_shorts' });
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 75 });
+    const handler = await getHandler();
+
+    await handler({ id: 'js3', data: basePayload });
+
+    expect(mockVideosBatch).toHaveBeenCalledTimes(1);
+    expect(mockVideosBatch.mock.calls[0][0].videoIds).toEqual(['liveShort01', 'liveLong001']);
+    // short(45s) probed+dropped; long(600s) kept with NO probe → exactly 1 probe call
+    expect(mockIsShortCached).toHaveBeenCalledTimes(1);
+    expect(mockIsShortCached).toHaveBeenCalledWith('liveShort01', 45, expect.anything());
+    expect(mockUvsCreateMany).toHaveBeenCalledTimes(1);
+    const row = mockUvsCreateMany.mock.calls[0][0].data[0];
+    expect(row.relevance_pct).toBe(75);
+  });
+
+  it('videos.list failure is non-fatal — gate falls back to probe-only on unknown durations', async () => {
+    mockPoolCandidates.mockResolvedValueOnce([]);
+    mockSearchVideos.mockResolvedValueOnce([
+      { id: { videoId: 'liveUnknown' }, snippet: { title: '도커 강의' } },
+    ]);
+    mockVideosBatch.mockRejectedValueOnce(new Error('videos.list HTTP 403'));
+    mockIsShortCached.mockResolvedValueOnce({ isShort: false, signal: 'probe_2xx_watch' });
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 70 });
+    const handler = await getHandler();
+
+    await handler({ id: 'js4', data: basePayload });
+
+    expect(mockIsShortCached).toHaveBeenCalledWith('liveUnknown', null, expect.anything());
+    expect(mockUvsCreateMany).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

James-spec sealing PR (2026-06-12, E diagnosis): the v5 placement path has a COMPLETE shorts gate — duration<180 short-circuit + `isShortCached` /shorts/-URL probe with a shared fail-open deadline (`v5/executor.ts:323-349`) — but the NEW pool-serve/live paths (#907) replicated only the title heuristic. This PR **replicates the existing verified gate, inventing nothing**: same `isShortCached`, same `SHORT_MAX_DURATION_SEC`, same `V5_SHORT_PROBE_DEADLINE_MS` knob.

**UX principle alignment**: Principle 2 (콘텐츠 품질) — 자동 유입 가드 동등성 회복; 신규 게이트/임계 없음.

## Guard-replication table (per the new LEVEL-2 rule — first PR to comply)

| Guard | v5 placement | pool-serve (before) | pool-serve (THIS PR) |
|---|---|---|---|
| off-language drop (#905) | ✓ fanout loop | ✓ `isOffLanguageTitleToggled` | ✓ unchanged |
| titleHitsBlocklist | ✓ | ✓ | ✓ unchanged |
| titleIndicatesShorts | ✓ | ✓ | ✓ unchanged |
| **duration<180 + URL probe** | ✓ executor.ts:336-337 | **✗ MISSING** | **✓ replicated (`dropShorts`)** |
| diversity guard (#909) | ✓ | ✓ | ✓ unchanged |
| owned exclude | ✓ (#911 wizard / `seen` here) | ✓ | ✓ unchanged |
| relevance gate | picker+R1(OFF) | ✓ vmr ≥60 | ✓ unchanged |

## Changes

- `pool-serve-fill.ts`: `dropShorts()` = exact v5 step-6 replica (≥180 keeps with NO HTTP; <180/unknown probes; in-flight probes at deadline fail OPEN). Runs BEFORE the relevance gate (saves Haiku spend on shorts). Pool candidates now carry `durationSec` (tsvector rows already had it — was being dropped in mapping). Live candidates get durations via **ONE `videos.list` call (1 quota unit)**; fetch failure degrades to probe-only (non-fatal). New `shortsDropped` counter in the run outcome.
- `v5/executor.ts`: `parseIsoDurationSeconds` exported (reuse, no copy).

## Tests (12 = 8 existing + 4 new)

short-by-probe dropped pre-scoring (no Haiku spend) / ≥180 kept with zero probe calls / live: one videos.list + same gate (45s dropped, 600s kept) / videos.list failure → probe-only fallback, non-fatal.

## Note

Purge of EXISTING shorts (E-4 plan: <60s 즉시 + 60-180 probe 확정분) is a SEPARATE [GO]-gated operation — this PR only closes the inflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)