### PR TITLE
feat(relevance): R1 bundle — gc gate axis + batch-gate prune (auto-inflow only) + binByCells surplus backfill (CP500+)

### DIFF
--- a/src/config/relevance-rubric.ts
+++ b/src/config/relevance-rubric.ts
@@ -24,10 +24,18 @@ const boolFlag = z.preprocess((v) => {
 
 export const relevanceRubricEnvSchema = z.object({
   RELEVANCE_RUBRIC_ENABLED: boolFlag.default(false as unknown as string),
+  /** CP500+ R1 bundle — post-placement re-score prune (auto-inflow rows ONLY,
+   *  James rule: the system may delete only what it inserted). Default OFF →
+   *  canary → fleet. */
+  BATCH_GATE_PRUNE: boolFlag.default(false as unknown as string),
+  /** goal_contribution gate threshold (measured spec: 65). */
+  BATCH_GATE_GC_MIN: z.coerce.number().int().min(0).max(100).default(65),
 });
 
 export interface RelevanceRubricConfig {
   enabled: boolean;
+  prune: boolean;
+  pruneGcMin: number;
 }
 
 export function loadRelevanceRubricConfig(
@@ -35,9 +43,15 @@ export function loadRelevanceRubricConfig(
 ): RelevanceRubricConfig {
   const parsed = relevanceRubricEnvSchema.safeParse({
     RELEVANCE_RUBRIC_ENABLED: env['RELEVANCE_RUBRIC_ENABLED'],
+    BATCH_GATE_PRUNE: env['BATCH_GATE_PRUNE'],
+    BATCH_GATE_GC_MIN: env['BATCH_GATE_GC_MIN'],
   });
   if (!parsed.success) {
-    return { enabled: false };
+    return { enabled: false, prune: false, pruneGcMin: 65 };
   }
-  return { enabled: parsed.data.RELEVANCE_RUBRIC_ENABLED };
+  return {
+    enabled: parsed.data.RELEVANCE_RUBRIC_ENABLED,
+    prune: parsed.data.BATCH_GATE_PRUNE,
+    pruneGcMin: parsed.data.BATCH_GATE_GC_MIN,
+  };
 }

--- a/src/modules/queue/handlers/enrich-relevance-quick.ts
+++ b/src/modules/queue/handlers/enrich-relevance-quick.ts
@@ -93,6 +93,58 @@ async function handleEnrichRelevanceQuick(job: PgBoss.Job<RelevanceQuickPayload>
   }
 
   const prisma = getPrismaClient();
+
+  // CP500+ R1 bundle — batch gate prune (BATCH_GATE_PRUNE, default OFF).
+  // James rule: "the system may delete ONLY what it inserted" — DELETE is
+  // guarded by auto_added=true + the user-trace columns, so a MANUALLY added
+  // card is preserved regardless of its score (UX 원칙 3), and a traced auto
+  // card likewise. uvs only (user_local_cards are user-authored — never).
+  // Loop guard: pool-serve refills carry a copied relevance_pct, and the
+  // backfill trigger only enqueues relevance_pct IS NULL rows — a pruned
+  // cell's refill is never re-scored/re-pruned by this path.
+  const rubricCfg = loadRelevanceRubricConfig();
+  if (
+    table === 'uvs' &&
+    rubricCfg.prune &&
+    context &&
+    result.detail &&
+    result.detail.goalContributionPct < rubricCfg.pruneGcMin
+  ) {
+    const del = await prisma.$queryRaw<{ user_id: string; mandala_id: string | null }[]>`
+      DELETE FROM user_video_states
+      WHERE id = ${rowId}::uuid AND auto_added = true
+        AND pinned_at IS NULL AND user_note IS NULL AND is_watched = false
+        AND COALESCE(watch_position_seconds, 0) = 0 AND is_in_ideation = false
+      RETURNING user_id::text, mandala_id::text`;
+    if (del[0]) {
+      logger.info('enrich-relevance-quick: batch-gate pruned (gc below gate)', {
+        jobId: job.id,
+        rowId,
+        gc: result.detail.goalContributionPct,
+        gcMin: rubricCfg.pruneGcMin,
+      });
+      const { user_id, mandala_id } = del[0];
+      if (mandala_id) {
+        // Fire-and-forget refill — the W1b fill-pending/completed-grace
+        // signals cover the "정리되는 중" UX.
+        setImmediate(() => {
+          void import('./pool-serve-fill')
+            .then(({ dispatchPoolServeForMandala }) =>
+              dispatchPoolServeForMandala(user_id, mandala_id)
+            )
+            .catch((err) =>
+              logger.warn('batch-gate refill dispatch failed (non-fatal)', {
+                mandala_id,
+                error: err instanceof Error ? err.message : String(err),
+              })
+            );
+        });
+      }
+      return; // row deleted — nothing to persist
+    }
+    // Not eligible (manual card or user-traced) → keep the row AND its score.
+  }
+
   const data = { relevance_pct: result.relevancePct, relevance_at: new Date() };
 
   // Persist keyed by ROW PK — never by video_id (relation-not-attribute

--- a/src/modules/queue/handlers/pool-serve-fill.ts
+++ b/src/modules/queue/handlers/pool-serve-fill.ts
@@ -184,18 +184,36 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
       }
     };
 
-    /** Semantic gate: vmr cache first, score on miss, threshold; early-exit. */
+    /** Semantic gate: vmr cache first, score on miss, threshold; early-exit.
+     *  CP500+ R1 bundle — GATE AXIS depends on the rubric flag:
+     *    rubric ON  → gatePct = goal_contribution (detail.goalContributionPct,
+     *                 measured discriminator; threshold 65 spec). Cached rows
+     *                 WITHOUT detail (legacy composite scores) are treated as
+     *                 MISS and re-scored — legacy 62-72 mode scores must not
+     *                 leak through the gc gate.
+     *    rubric OFF → gatePct = composite (legacy behavior, byte-identical).
+     *  The COMPOSITE is always what gets copied to uvs.relevance_pct (sort/badge). */
     const gate = async (cands: GateCandidate[], passed: PassedCandidate[]): Promise<void> => {
       for (let i = 0; i < cands.length && passed.length < need; i += SCORE_BURST_SIZE) {
         const burst = cands.slice(i, i + SCORE_BURST_SIZE);
         const scores = await Promise.all(
           burst.map(async (c) => {
-            const cached = await prisma.$queryRaw<{ relevance_pct: number }[]>`
-              SELECT relevance_pct FROM video_mandala_relevance
+            const cached = await prisma.$queryRaw<
+              { relevance_pct: number; detail: { goalContributionPct?: number } | null }[]
+            >`
+              SELECT relevance_pct, detail FROM video_mandala_relevance
               WHERE video_id = ${c.youtubeVideoId} AND mandala_id = ${p.mandalaId}::uuid`;
             if (cached[0]) {
-              result.cacheHits += 1;
-              return { c, pct: cached[0].relevance_pct };
+              const cachedGc = cached[0].detail?.goalContributionPct;
+              if (!rubric) {
+                result.cacheHits += 1;
+                return { c, gatePct: cached[0].relevance_pct, displayPct: cached[0].relevance_pct };
+              }
+              if (typeof cachedGc === 'number') {
+                result.cacheHits += 1;
+                return { c, gatePct: cachedGc, displayPct: cached[0].relevance_pct };
+              }
+              // rubric ON + legacy cache row (no axes) → fall through to re-score.
             }
             const r = await computeCardRelevance({
               title: c.title,
@@ -208,19 +226,27 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
             result.scored += 1;
             if (!r.ok) {
               log.warn(`pool-serve gate score failed (skip): ${r.reason}`);
-              return { c, pct: null };
+              return { c, gatePct: null, displayPct: null };
             }
+            const detailJson = r.detail ? JSON.stringify(r.detail) : null;
             await prisma.$executeRaw`
-              INSERT INTO video_mandala_relevance (video_id, mandala_id, relevance_pct)
-              VALUES (${c.youtubeVideoId}, ${p.mandalaId}::uuid, ${r.relevancePct})
+              INSERT INTO video_mandala_relevance (video_id, mandala_id, relevance_pct, detail)
+              VALUES (${c.youtubeVideoId}, ${p.mandalaId}::uuid, ${r.relevancePct}, ${detailJson}::jsonb)
               ON CONFLICT (video_id, mandala_id)
-              DO UPDATE SET relevance_pct = EXCLUDED.relevance_pct, relevance_at = now()`;
-            return { c, pct: r.relevancePct };
+              DO UPDATE SET relevance_pct = EXCLUDED.relevance_pct,
+                            detail = EXCLUDED.detail, relevance_at = now()`;
+            const gatePct = rubric && r.detail ? r.detail.goalContributionPct : r.relevancePct;
+            return { c, gatePct, displayPct: r.relevancePct };
           })
         );
-        for (const { c, pct } of scores) {
-          if (pct !== null && pct >= cfg.relevanceMin && passed.length < need) {
-            passed.push({ ...c, relevancePct: pct });
+        for (const { c, gatePct, displayPct } of scores) {
+          if (
+            gatePct !== null &&
+            displayPct !== null &&
+            gatePct >= cfg.relevanceMin &&
+            passed.length < need
+          ) {
+            passed.push({ ...c, relevancePct: displayPct });
             seen.add(c.youtubeVideoId);
           }
         }

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -484,13 +484,31 @@ export function binByCells(
   const cells = Array.from(byCell.keys()).sort((a, b) => a - b);
   const perCell = Math.ceil((targetPicks * overpickFactor) / Math.max(cells.length, 1));
 
+  // CP500+ PR3 ("상한 → 최소 확보", James spec): the per-cell rank cut used to
+  // DISCARD surplus — a starved cell's unused budget was thrown away while a
+  // rich cell's rank-(perCell+1) candidate evaporated (the "12 limit" loss in
+  // the 2026-06-12 funnel diagnosis). Round-robin now CONTINUES past perCell
+  // while the total budget has room, so rich-cell surplus backfills the count.
+  // Per-cell MINIMUMS remain pool-serve's job (MIN_PER_CELL refill); the
+  // first perCell rounds are byte-identical to the previous output.
+  const budget = Math.ceil(targetPicks * overpickFactor);
   const out: PickResult[] = [];
-  for (let r = 0; r < perCell; r += 1) {
+  let r = 0;
+  let advanced = true;
+  while (out.length < budget && advanced) {
+    advanced = false;
     for (const cell of cells) {
+      if (out.length >= budget) break;
       const cand = byCell.get(cell)![r];
       if (!cand) continue;
-      out.push({ videoId: cand.videoId, score: 1 - r / (perCell + 1), reason: '' });
+      out.push({
+        videoId: cand.videoId,
+        score: Math.max(0.01, 1 - r / (perCell + 1)),
+        reason: '',
+      });
+      advanced = true;
     }
+    r += 1;
   }
   return out;
 }

--- a/tests/unit/modules/enrich-relevance-quick.test.ts
+++ b/tests/unit/modules/enrich-relevance-quick.test.ts
@@ -50,6 +50,12 @@ jest.mock('@/config/index', () => ({
   },
 }));
 
+// CP500+ batch-gate prune — refill dispatch is a fire-and-forget dynamic import.
+const mockDispatchRefill = jest.fn().mockResolvedValue({ runId: null, deficitCells: [] });
+jest.mock('@/modules/queue/handlers/pool-serve-fill', () => ({
+  dispatchPoolServeForMandala: (...a: unknown[]) => mockDispatchRefill(...a),
+}));
+
 jest.mock('@/utils/logger', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
 }));
@@ -244,5 +250,90 @@ describe('CP499+ rubric flag-on context fetch ($queryRaw, fail-open)', () => {
       data: { table: 'uvs', rowId: 'row-uvs-11', title: 'T', centerGoal: 'G' },
     });
     expect(mockQueryRaw).not.toHaveBeenCalled();
+  });
+});
+
+// ── CP500+ R1 bundle — batch-gate prune ("시스템은 자기가 넣은 것만 지울 수 있다") ──
+
+describe('CP500+ batch-gate prune', () => {
+  const RUBRIC_DETAIL = { cellFitPct: 60, goalContributionPct: 40, actionabilityPct: 70 };
+  beforeEach(() => {
+    process.env['RELEVANCE_RUBRIC_ENABLED'] = 'true';
+    process.env['BATCH_GATE_PRUNE'] = 'true';
+    mockDispatchRefill.mockClear();
+  });
+  afterEach(() => {
+    delete process.env['RELEVANCE_RUBRIC_ENABLED'];
+    delete process.env['BATCH_GATE_PRUNE'];
+  });
+  const flush = () => new Promise((r) => setImmediate(() => setImmediate(r)));
+
+  test('auto-added row with gc<65 is PRUNED (no persist) + refill dispatched', async () => {
+    mockQueryRaw
+      .mockResolvedValueOnce([{ language: 'ko' }]) // context fetch
+      .mockResolvedValueOnce([{ user_id: 'u-1', mandala_id: 'm-1' }]); // guarded DELETE hit
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 52, detail: RUBRIC_DETAIL });
+    const handler = await getHandler();
+
+    await handler({
+      id: 'jp1',
+      data: { table: 'uvs', rowId: 'row-prune-1', title: 'T', centerGoal: 'G' },
+    });
+    await flush();
+
+    expect(mockUvsUpdate).not.toHaveBeenCalled(); // row deleted — nothing persisted
+    expect(mockDispatchRefill).toHaveBeenCalledWith('u-1', 'm-1');
+  });
+
+  test('★REGRESSION — MANUAL card (guard rejects DELETE) keeps the row AND its score, gc<65 무관', async () => {
+    mockQueryRaw
+      .mockResolvedValueOnce([{ language: 'ko' }]) // context fetch
+      .mockResolvedValueOnce([]); // guarded DELETE: auto_added=false ⇒ 0 rows
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 52, detail: RUBRIC_DETAIL });
+    const handler = await getHandler();
+
+    await handler({
+      id: 'jp2',
+      data: { table: 'uvs', rowId: 'row-manual-1', title: 'T', centerGoal: 'G' },
+    });
+    await flush();
+
+    expect(mockUvsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'row-manual-1' } })
+    );
+    expect(mockDispatchRefill).not.toHaveBeenCalled();
+  });
+
+  test('gc≥65 ⇒ no DELETE attempted, normal persist', async () => {
+    mockQueryRaw.mockResolvedValueOnce([{ language: 'ko' }]);
+    mockCompute.mockResolvedValueOnce({
+      ok: true,
+      relevancePct: 78,
+      detail: { ...RUBRIC_DETAIL, goalContributionPct: 80 },
+    });
+    const handler = await getHandler();
+
+    await handler({
+      id: 'jp3',
+      data: { table: 'uvs', rowId: 'row-keep-1', title: 'T', centerGoal: 'G' },
+    });
+
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1); // context only — no DELETE
+    expect(mockUvsUpdate).toHaveBeenCalled();
+  });
+
+  test('BATCH_GATE_PRUNE off ⇒ scoring path unchanged (no DELETE)', async () => {
+    delete process.env['BATCH_GATE_PRUNE'];
+    mockQueryRaw.mockResolvedValueOnce([{ language: 'ko' }]);
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 52, detail: RUBRIC_DETAIL });
+    const handler = await getHandler();
+
+    await handler({
+      id: 'jp4',
+      data: { table: 'uvs', rowId: 'row-flagoff-1', title: 'T', centerGoal: 'G' },
+    });
+
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+    expect(mockUvsUpdate).toHaveBeenCalled();
   });
 });

--- a/tests/unit/skills/video-discover/v5-cell-binning.test.ts
+++ b/tests/unit/skills/video-discover/v5-cell-binning.test.ts
@@ -63,14 +63,20 @@ describe('binByCells', () => {
     expect(picks.map((p) => p.videoId)).toEqual(['c0_v0', 'c0_v1', 'c0_v2', 'c0_v3', 'c0_v4']);
   });
 
-  test('under-filled cell contributes what it has, others still fill', () => {
-    // cell 0 has 1 candidate, cell 1 has 5
+  test('CP500+ PR3 — under-filled cell contributes what it has; rich-cell SURPLUS backfills the budget (상한→최소확보)', () => {
+    // cell 0 has 1 candidate, cell 1 has 5. Budget = 6×1 = 6. Pre-PR3 the
+    // perCell cut (3) DISCARDED cell 1's rank-4/5 while the total ran short
+    // (4 picks for a 6 budget) — the "12 limit" loss. Now the round-robin
+    // continues past perCell while the budget has room.
     const survivors = [cand('c0_v0', 0), ...survivorsFor([1], 5)];
-    const picks = binByCells(survivors, 6, 1); // perCell = ceil(6/2) = 3
+    const picks = binByCells(survivors, 6, 1); // perCell = ceil(6/2) = 3, budget = 6
     const byCell = new Map<number, number>();
     for (const p of picks) byCell.set(cellOf(p.videoId), (byCell.get(cellOf(p.videoId)) ?? 0) + 1);
     expect(byCell.get(0)).toBe(1); // only had 1
-    expect(byCell.get(1)).toBe(3); // perCell
+    expect(byCell.get(1)).toBe(5); // 3 (perCell) + 2 surplus — budget filled
+    expect(picks).toHaveLength(6);
+    // surplus picks clamp to a small positive score (FE sort stays sane)
+    expect(picks.every((x) => x.score > 0)).toBe(true);
   });
 
   test('null cellIndex grouped as a single center bucket', () => {


### PR DESCRIPTION
## Summary

James-approved R1 bundle (design reviewed 2026-06-12, modification #1 applied). Three components, all flag-gated — **prod behavior unchanged at deploy** (`RELEVANCE_RUBRIC_ENABLED` and `BATCH_GATE_PRUNE` both OFF until the canary [GO]).

**UX principle alignment**: Principle 2 (관련 관문 = measured gc≥65 gate) + Principle 3 (수동 추가 절대 보존 — see rule below).

## ① Gate axis switch (pool-serve)

rubric ON → gate on `detail.goalContributionPct` (the measured discriminator; composite stays the sort/badge value copied to uvs). vmr cache now stores the axes (`detail` jsonb, #904 column); **legacy cache rows without axes = MISS → re-scored** (the 62/72-mode legacy scores cannot leak through the gc gate). rubric OFF → byte-identical legacy behavior.

## ② BATCH_GATE_PRUNE (James rule: "시스템은 자기가 넣은 것만 지울 수 있다")

After the post-placement re-score (existing enrich-relevance-quick chain), gc < `BATCH_GATE_GC_MIN`(65) ⇒ guarded DELETE — **`auto_added=true` AND no user trace** (pinned/note/watched/position/ideation). A MANUAL card is never pruned regardless of score (원칙 3); a traced auto card likewise — the guard rejects the DELETE and the score persists. Refill via `dispatchPoolServeForMandala` (fire-and-forget; W1b fill signals = "정리되는 중" UX). Loop-safe: refilled rows carry a copied score and the backfill trigger only enqueues `relevance_pct IS NULL` rows.

## ③ PR3 — binByCells surplus backfill (상한→최소확보)

The per-cell rank cut no longer DISCARDS surplus: round-robin continues past perCell while the pick budget has room, so rich-cell surplus backfills the count (the measured "12 limit" loss — 23-card wizards). First perCell rounds byte-identical; per-cell minimums remain pool-serve's job.

## Tests (45 across 4 suites)

★ MANUAL card gc<65 PRESERVED regression / auto pruned + refill dispatched / gc≥65 no delete / flag-off unchanged / legacy-cache-miss re-score path / surplus backfill + budget cap + score positivity (1 pre-PR3 assertion updated to the approved spec — not skipped).

## Rollout (approved sequence)

Deploy with both flags OFF → James new-wizard canary closes 3 tracks (R1 chain + #909 diversity + #911 card-count) → fleet ON + retroactive C-scope [GO].

🤖 Generated with [Claude Code](https://claude.com/claude-code)