### PR TITLE
fix(shorts): hard-drop known sub-180s on inflow at v5 executor chokepoint (E-final, CP500+)

### DIFF
--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -334,6 +334,9 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       const shortFlags = await Promise.all(
         cards.map(async (c) => {
           if (c.durationSec != null && c.durationSec >= SHORT_MAX_DURATION_SEC) return false;
+          // E-final (CP500+) — known sub-180s dropped on inflow without probing;
+          // learning content under 3 min lacks depth. Only unknown duration probes.
+          if (c.durationSec != null && c.durationSec < SHORT_MAX_DURATION_SEC) return true;
           const { isShort } = await isShortCached(c.videoId, c.durationSec, {
             signal: shortCtl.signal,
           });

--- a/tests/unit/skills/video-discover/v5-executor.test.ts
+++ b/tests/unit/skills/video-discover/v5-executor.test.ts
@@ -31,6 +31,9 @@ jest.mock('@/modules/video-pool/is-short', () => ({
 
 const { runYouTubeFanout } = jest.requireMock('@/skills/plugins/video-discover/v5/youtube-fanout');
 const { isShortCached } = jest.requireMock('@/modules/video-pool/is-short');
+const { videosBatchFullMetadata, resolveVideosApiKeys } = jest.requireMock(
+  '@/skills/plugins/video-discover/v2/youtube-client'
+);
 
 function makeFanoutCandidate(id: string, title = `Title ${id}`) {
   return {
@@ -62,6 +65,10 @@ describe('runV5Executor (orchestration smoke)', () => {
     runYouTubeFanout.mockReset();
     isShortCached.mockReset();
     isShortCached.mockResolvedValue({ isShort: false, signal: 'shorts_url_redirect' });
+    resolveVideosApiKeys.mockReset();
+    resolveVideosApiKeys.mockReturnValue([]);
+    videosBatchFullMetadata.mockReset();
+    videosBatchFullMetadata.mockResolvedValue([]);
   });
 
   afterAll(() => {
@@ -327,6 +334,56 @@ describe('runV5Executor (orchestration smoke)', () => {
     expect(ids).not.toContain('v1');
     expect(ids).not.toContain('v2');
     expect(typeof result.diagnostics.stageMs.shortMs).toBe('number');
+  });
+
+  // E-final (CP500+) — known sub-180s hard-dropped on inflow without probing;
+  // only unknown duration falls through to the URL probe.
+  test('short gate hard-drops known sub-180s without probing; null duration still probes', async () => {
+    runYouTubeFanout.mockResolvedValue({
+      candidates: [
+        makeFanoutCandidate('shortDur'),
+        makeFanoutCandidate('longDur'),
+        makeFanoutCandidate('nullDur'),
+      ],
+      queriesAttempted: 1,
+      queriesSucceeded: 1,
+      rawItemCount: 3,
+      quotaUnitsApprox: 100,
+      perQuery: [],
+    });
+    setVideoPickerForTest(
+      new FakePicker((input) =>
+        input.candidates.map((c, i) => ({ videoId: c.videoId, score: 0.9 - i * 0.01, reason: 'p' }))
+      )
+    );
+    // videos.list returns known durations for shortDur (60s) + longDur (10m);
+    // nullDur is absent → durationSec null → must fall through to the probe.
+    resolveVideosApiKeys.mockReturnValue(['k']);
+    videosBatchFullMetadata.mockResolvedValue([
+      { id: 'shortDur', contentDetails: { duration: 'PT60S' } },
+      { id: 'longDur', contentDetails: { duration: 'PT10M' } },
+    ]);
+    isShortCached.mockResolvedValue({ isShort: false, signal: 'shorts_url_redirect' });
+
+    const result = await runV5Executor({
+      centerGoal: 'goal',
+      subGoals: [],
+      focusTags: [],
+      targetLevel: 'standard',
+      language: 'en',
+      excludeVideoIds: new Set(),
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    const ids = result.cards.map((c) => c.videoId);
+    expect(ids).not.toContain('shortDur'); // <180 hard-dropped
+    expect(ids).toContain('longDur'); // >=180 kept (short-circuit, no probe)
+    expect(ids).toContain('nullDur'); // null duration probed → non-short → kept
+
+    const probed = isShortCached.mock.calls.map((c: unknown[]) => c[0]);
+    expect(probed).toContain('nullDur'); // only unknown duration is probed
+    expect(probed).not.toContain('shortDur'); // hard-drop path skips probe
+    expect(probed).not.toContain('longDur'); // >=180 short-circuit skips probe
   });
 
   test('short gate disabled via V5_SHORT_PROBE_DEADLINE_MS=0 → no probe, no drop', async () => {


### PR DESCRIPTION
## What
신규 유입에서 **known duration < 180s 카드를 probe 없이 hard-drop** (James 결정, 절충안). `>=180s`는 기존대로 단락 keep, **duration null만 기존 URL probe 잔류**.

## Where (chokepoint — LEVEL-2 룰 정합)
단일 지점 `src/skills/plugins/video-discover/v5/executor.ts` short-gate. 모든 유입 경로가 여기서 `durationSec`와 함께 수렴:
- wizard → `runV5ForWizard` → v5 executor
- add-cards → `runV5Executor` (`add-cards.ts:322`)
- pool-serve / live → v5 executor 내부

→ James 명문 **"유입 경로 가드는 복제보다 chokepoint 보장 우선"** 적용. fanout(479/659)엔 `durationSec`가 없어(live는 videos.list로 executor 시점 확보) duration 게이트 복제 불가·불필요.

## 가드 대조표 (LEVEL-2 의무 첨부)
| 가드 | executor:336-340 (chokepoint) | fanout:479/659 | 비고 |
|---|---|---|---|
| duration ≥180 keep | ✅ 기존 | — | duration 없음 |
| **duration <180 hard drop** | ✅ **본 PR** | — (불가) | known duration only |
| duration null → URL probe | ✅ 기존 | — | isShortCached |
| titleIndicatesShorts | (executor 후단) | ✅ 기존 | title 기반 선필터 |
| titleHitsBlocklist | — | ✅ 기존 | |
| off-language drop | — | ✅ 기존 | |

## 보존
- 기존 pool(probe-normal 행)은 **소급 삭제 없음** — 본 게이트는 신규 유입에만 적용.
- 행복 만다라 잔존 4장 개별 제거는 별도 `[GO]` 트랙.

## Test
`v5-executor.test.ts` +1: known sub-180 hard-drop(probe 미호출) + null-duration probe 잔류 검증. 로컬 10/10 green.

## 스펙 편차 (명시)
James 스펙은 "executor + fanout:479,659 + add-cards 전 경로"였으나, fanout엔 duration 부재 + add-cards는 executor 경유라 **executor 단일 chokepoint = 전 경로 커버**로 구현. 편차 사유 = chokepoint 원칙 + duration 가용성.