### PR TITLE
fix(enrich): ensure youtube_videos row before v2 generation — IdeaSpot D&D v2 dead-trigger (H fix, CP500+)

### DIFF
--- a/src/modules/queue/handlers/enrich-rich-summary.ts
+++ b/src/modules/queue/handlers/enrich-rich-summary.ts
@@ -42,6 +42,7 @@ import { generateRichSummaryV2Quick } from '../../skills/rich-summary-v2-quick-g
 import { generateRichSummaryV2 } from '../../skills/rich-summary-v2-generator';
 import { getMandalaManager } from '../../mandala/manager';
 import { getCaptionExtractor } from '../../caption/extractor';
+import { ensureYoutubeVideoRow } from '../../youtube/ensure-video-row';
 import { getPrismaClient } from '../../database/client';
 import { logger } from '../../../utils/logger';
 import { getJobQueue } from '../manager';
@@ -114,6 +115,13 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
       error: err instanceof Error ? err.message : String(err),
     });
   }
+
+  // CP500+ H fix — chokepoint: guarantee a youtube_videos row exists before the
+  // v2 generators re-read it for title/description. Inflow paths (notably
+  // IdeaSpot D&D via the local-cards Edge Function) can place a card without
+  // ingesting metadata; without the row the job completes writing no v2 row,
+  // leaving the FE bookmark spinner blinking forever. Fail-open / never throws.
+  await ensureYoutubeVideoRow(videoId);
 
   // Hard rule: NO v2 row without a transcript. Captions absent ⇒ throw
   // NO_TRANSCRIPT ⇒ SSE `failed` ⇒ grid renders the retry icon.

--- a/src/modules/youtube/ensure-video-row.ts
+++ b/src/modules/youtube/ensure-video-row.ts
@@ -1,0 +1,75 @@
+/**
+ * ensureYoutubeVideoRow — chokepoint guarantee that a youtube_videos row exists
+ * for a videoId (CP500+ H fix).
+ *
+ * Why: any card-inflow path (wizard / add-cards / pool-serve / IdeaSpot D&D)
+ * may place a card whose youtube_videos row was never ingested. The IdeaSpot
+ * D&D path (local-cards Edge Function) in particular never produced a row
+ * (source='user-d-and-d' rows = 0 ever). rich-summary generation re-reads
+ * youtube_videos for title/description, so an absent row silently yields no v2
+ * (the enrich job completes without writing). Rather than replicate metadata
+ * ingest on every inflow path, this single chokepoint — called from the
+ * enrich-rich-summary handler — fetches and creates the row on demand.
+ *
+ * Reuse: videosBatchFullMetadata (API-key path, background-safe) +
+ * VideoManager.upsertVideo (validated column mapping + ISO duration parse +
+ * create-or-update). No new mapping invented.
+ *
+ * Fail-open: returns false (never throws) when no API key is configured, the
+ * YouTube lookup fails, or the video is unavailable — the caller proceeds and
+ * the existing no-metadata behavior applies.
+ */
+
+import { youtube_v3 } from 'googleapis';
+import { logger } from '@/utils/logger';
+import { getPrismaClient } from '@/modules/database';
+import {
+  videosBatchFullMetadata,
+  resolveVideosApiKeys,
+} from '@/skills/plugins/video-discover/v2/youtube-client';
+import { VideoManager } from '@/modules/video/manager';
+
+const log = logger.child({ module: 'ensure-youtube-video-row' });
+
+/**
+ * Ensure a youtube_videos row exists for `videoId`. Returns true when the row
+ * exists (already present or freshly created), false when it could not be
+ * created. Never throws.
+ */
+export async function ensureYoutubeVideoRow(
+  videoId: string,
+  env: Readonly<Record<string, string | undefined>> = process.env
+): Promise<boolean> {
+  const prisma = getPrismaClient();
+  try {
+    const existing = await prisma.youtube_videos.findUnique({
+      where: { youtube_video_id: videoId },
+      select: { youtube_video_id: true },
+    });
+    if (existing) return true;
+
+    const apiKeys = resolveVideosApiKeys(env);
+    if (apiKeys.length === 0) {
+      log.warn('no YouTube API key — cannot create missing youtube_videos row', { videoId });
+      return false;
+    }
+
+    const [meta] = await videosBatchFullMetadata({ videoIds: [videoId], apiKey: apiKeys });
+    if (!meta?.id) {
+      log.warn('videos.list returned no item — youtube_videos row not created', { videoId });
+      return false;
+    }
+
+    // YouTubeVideoFullMetadata shares the snippet/contentDetails/statistics
+    // shape upsertVideo reads; the cast is structural, not a behavior change.
+    await new VideoManager().upsertVideo(meta as unknown as youtube_v3.Schema$Video);
+    log.info('created missing youtube_videos row (chokepoint)', { videoId });
+    return true;
+  } catch (err) {
+    log.warn('ensure youtube_videos row failed (non-fatal)', {
+      videoId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}

--- a/tests/unit/modules/youtube/ensure-video-row.test.ts
+++ b/tests/unit/modules/youtube/ensure-video-row.test.ts
@@ -1,0 +1,75 @@
+/**
+ * ensureYoutubeVideoRow — chokepoint that creates a missing youtube_videos row
+ * (CP500+ H fix). Validates: present row → no fetch; absent row → fetch+upsert;
+ * fail-open on no-key / empty lookup / errors.
+ */
+
+const findUnique = jest.fn();
+const upsertVideo = jest.fn();
+const videosBatchFullMetadata = jest.fn();
+const resolveVideosApiKeys = jest.fn();
+
+jest.mock('@/modules/database', () => ({
+  getPrismaClient: () => ({ youtube_videos: { findUnique } }),
+}));
+jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
+  videosBatchFullMetadata: (args: unknown) => videosBatchFullMetadata(args),
+  resolveVideosApiKeys: (env: unknown) => resolveVideosApiKeys(env),
+}));
+jest.mock('@/modules/video/manager', () => ({
+  VideoManager: jest.fn().mockImplementation(() => ({ upsertVideo })),
+}));
+
+import { ensureYoutubeVideoRow } from '@/modules/youtube/ensure-video-row';
+
+describe('ensureYoutubeVideoRow', () => {
+  beforeEach(() => {
+    findUnique.mockReset();
+    upsertVideo.mockReset();
+    videosBatchFullMetadata.mockReset();
+    resolveVideosApiKeys.mockReset();
+    resolveVideosApiKeys.mockReturnValue(['k']);
+  });
+
+  it('returns true and skips fetch when the row already exists', async () => {
+    findUnique.mockResolvedValue({ youtube_video_id: 'v1' });
+    const ok = await ensureYoutubeVideoRow('v1', {});
+    expect(ok).toBe(true);
+    expect(videosBatchFullMetadata).not.toHaveBeenCalled();
+    expect(upsertVideo).not.toHaveBeenCalled();
+  });
+
+  it('fetches and creates the row when absent', async () => {
+    findUnique.mockResolvedValue(null);
+    videosBatchFullMetadata.mockResolvedValue([
+      { id: 'v2', snippet: { title: 'T', channelTitle: 'C' }, contentDetails: { duration: 'PT5M' } },
+    ]);
+    const ok = await ensureYoutubeVideoRow('v2', {});
+    expect(ok).toBe(true);
+    expect(videosBatchFullMetadata).toHaveBeenCalledWith({ videoIds: ['v2'], apiKey: ['k'] });
+    expect(upsertVideo).toHaveBeenCalledTimes(1);
+    expect(upsertVideo.mock.calls[0][0].id).toBe('v2');
+  });
+
+  it('fails open (false) when no API key is configured', async () => {
+    findUnique.mockResolvedValue(null);
+    resolveVideosApiKeys.mockReturnValue([]);
+    const ok = await ensureYoutubeVideoRow('v3', {});
+    expect(ok).toBe(false);
+    expect(videosBatchFullMetadata).not.toHaveBeenCalled();
+  });
+
+  it('fails open (false) when videos.list returns no item', async () => {
+    findUnique.mockResolvedValue(null);
+    videosBatchFullMetadata.mockResolvedValue([]);
+    const ok = await ensureYoutubeVideoRow('v4', {});
+    expect(ok).toBe(false);
+    expect(upsertVideo).not.toHaveBeenCalled();
+  });
+
+  it('fails open (false) and never throws when the lookup errors', async () => {
+    findUnique.mockRejectedValue(new Error('db down'));
+    const ok = await ensureYoutubeVideoRow('v5', {});
+    expect(ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Root cause (measured)
IdeaSpot/수동 D&D 카드는 `local-cards` Edge Function 으로 추가되는데, 이 경로의 youtube_videos 메타 ingest 가 **역대 0건** (`source='user-d-and-d'` 행 0). 메타 행 부재 시:
- 하트클릭 → `/like` 가 enrich-rich-summary enqueue → 잡 **completed (retrycount=0)** 인데 **v2 행 미생성** (v2 생성기가 youtube_videos 를 재조회→부재→메타 없이 종료).
- FE 는 v2 행을 polling → 영원히 pending = "북마크 progress 점멸하나 완료 안 됨".

측정: 최근 수동 배치 7/7 v2 없음, 6/7 잡 completed+retrycount=0, `RICH_SUMMARY_ENABLED=true`, EF `YOUTUBE_API_KEY` 존재(키부재 반증).

## Fix (locus B — chokepoint, James 결정)
enrich 핸들러 단일 지점에서 v2 생성 직전 `ensureYoutubeVideoRow(videoId)` 호출 — 행 부재 시 `videosBatchFullMetadata`(API-key) fetch + `VideoManager.upsertVideo`(검증된 매핑) create. 어느 유입 경로(wizard/add-cards/pool-serve/IdeaSpot D&D)든 단일 길목에서 메타 보장. fail-open(never throws).

**원칙**: "유입 경로 가드는 복제보다 chokepoint 보장 우선" (LEVEL-2 recurrence=3 실물 해법 — A안 EF-side ingest 복제 폐기).

## 가드/부수효과 대조표 (LEVEL-2 의무)
| 항목 | /like (검증된 경로) | local-cards EF (IdeaSpot) | 본 PR chokepoint |
|---|---|---|---|
| youtube_videos 메타 | ✅ videoCacheHint+ingest | ❌ 0건 (silent skip) | ✅ enrich 핸들러가 보장 |
| rich-summary enqueue | ✅ (mandalaId 게이트) | ❌ 없음 (하트클릭 의존) | (별도 — 아래) |

## Test
`ensure-video-row.test.ts` +5: 행 존재→fetch 스킵 / 부재→fetch+upsert / no-key·empty·error 전부 fail-open. 로컬 5/5 green. tsc clean.

## 스코프 노트 (James 확인 요청)
James H fix 에 "+ local-cards add enqueue(점멸→완료 연결)" 포함이었으나, **본 chokepoint 만으로 보고된 증상(하트클릭→v2)은 해소**됩니다 (잡이 이제 행 생성). "add 시 자동 enqueue"(하트클릭 없이도 v2)는 EF→BE pg-boss enqueue 배선이 필요한 별도 변경이라 분리했습니다. 하트클릭이 이미 트리거이므로 자동-enqueue 가 지금 필요한지 = James 결정.