### PR TITLE
chore(compose): RELEVANCE_RUBRIC_ENABLED=true — R1 rubric canary ON (BATCH_GATE_PRUNE OFF) [James GO]

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -234,6 +234,13 @@ services:
       # set 4 (or delete → code default 4) + redeploy. Raise to 12-16 only after
       # measuring 429=0 (for 64+ card mandalas).
       - RELEVANCE_BACKFILL_CONCURRENCY=8
+      # CP500+ (2026-06-13, James [GO]) — R1 rubric scoring canary ON. Scoring
+      # switches to the R4 3-axis rubric (goal_contribution gate @ BATCH_GATE_GC_MIN
+      # default 65). BATCH_GATE_PRUNE stays UNSET (default false) → score/badge only,
+      # ZERO card pruning. Canary: James new wizard observes R4 scores render +
+      # off-topic cards demoted (gc<65) WITHOUT deletion. PASS → flip BATCH_GATE_PRUNE
+      # (separate [GO]). Rollback: delete this line + redeploy → code default false.
+      - RELEVANCE_RUBRIC_ENABLED=true
       # CP437 (2026-04-29) — Operator flip: enable YouTube metadata backfill cron.
       # Default in code is `false` — cron stays dormant unless this env is
       # explicitly true. With this set, `startYouTubeMetadataCron()` schedules


### PR DESCRIPTION
## What
`docker-compose.prod.yml` env에 **`RELEVANCE_RUBRIC_ENABLED=true`** 1줄 추가 (James `[GO]`). 채점이 R4 3축 루브릭으로 전환 (goal_contribution 게이트 @ `BATCH_GATE_GC_MIN` 기본 65).

## 안전성 (단독 flip)
- **`BATCH_GATE_PRUNE` 미설정 = 기본 false** → **카드 prune 0, 삭제 없음**. 점수·배지만 R4로 전환.
- 무관 카드는 gc<65로 **강등**되나 화면에서 제거 안 됨.

## 캐너리 (deploy 후 James)
신규 위저드 1개로: R4 점수 화면 정상 표기 ∧ 무관 카드 gc<65 강등(삭제 아님) 관측. PASS → `BATCH_GATE_PRUNE` fleet-ON (별도 `[GO]`).

## Rollback
라인 삭제 + redeploy → 코드 기본값 false (롤백제로).

## 무코드 변경
compose 1줄만. CI/검증 후 `[MERGE]`.