### PR TITLE
feat(v2): long-video truncate (skip→first N min) + badge [PR-A] (CP500+)

### DIFF
--- a/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
@@ -59,6 +59,10 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
   const hasRich = hasNewV2 || hasLegacyRich;
   const hasShort = Boolean(short) || tags.length > 0;
 
+  // CP500+ — `truncation` rides in core for long-video summaries generated from
+  // the first N minutes (renders a "first N min of M min" badge).
+  const truncation = richSummary?.core?.truncation;
+
   // CP475+ — background enrich + SSE wiring. Fire `/enrich-bg` once per
   // (videoId, mandalaId) when the segments block is missing; subscribe
   // to /enrich-stream so the UI flips to the completed state without a
@@ -143,6 +147,9 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
   return (
     <div className="space-y-5">
       {isQualityWarning && <AIQualityImprovingBadge />}
+      {truncation?.truncated && (
+        <TruncatedBadge coveredSec={truncation.coveredSec} fullSec={truncation.fullSec} />
+      )}
       {hasNewV2 && richSummary && (
         <RichSummaryV2NewBlock
           core={richSummary.core ?? null}
@@ -733,6 +740,28 @@ function AIQualityImprovingBadge() {
         ●
       </span>
       <span>{t('learning.aiQualityImproving')}</span>
+    </div>
+  );
+}
+
+/**
+ * CP500+ — badge shown on a v2 summary generated from only the first N minutes
+ * of a video that exceeds the duration cap. Tells the user the summary covers a
+ * partial window so a "the conclusion is…" line isn't mistaken for the whole video.
+ */
+function TruncatedBadge({ coveredSec, fullSec }: { coveredSec: number; fullSec: number }) {
+  const { t } = useTranslation();
+  const coveredMin = Math.round(coveredSec / 60);
+  const fullMin = Math.round(fullSec / 60);
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-2 rounded-md border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-[12px] text-sky-300"
+    >
+      <span aria-hidden className="text-sky-400">
+        ⚠
+      </span>
+      <span>{t('learning.aiSummaryTruncated', { covered: coveredMin, full: fullMin })}</span>
     </div>
   );
 }

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1840,6 +1840,7 @@
     "reportPreparing": "Preparing report...",
     "contentCollecting": "Collecting content...",
     "aiSummaryNotReady": "No AI summary has been generated yet",
+    "aiSummaryTruncated": "Summary of the first {{covered}} min (of {{full}} min total)",
     "aiSummaryGenerating": "Generating AI summary",
     "richSummaryGenerating": "Generating detailed summary",
     "richSummaryQualityLowPendingRegen": "Improving the AI analysis for this video",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1848,6 +1848,7 @@
     "reportPreparing": "보고서 작성 준비중 ...",
     "contentCollecting": "콘텐츠 수집 중...",
     "aiSummaryNotReady": "아직 AI 요약이 생성되지 않았어요",
+    "aiSummaryTruncated": "앞 {{covered}}분 기준 요약 (전체 {{full}}분)",
     "aiSummaryGenerating": "AI 요약을 생성하고 있습니다",
     "richSummaryGenerating": "상세 요약을 생성하고 있습니다",
     "richSummaryQualityLowPendingRegen": "이 영상의 AI 분석을 개선하고 있습니다",

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -143,6 +143,12 @@ export interface VideoRichSummaryCore {
   depth_level?: string;
   content_type?: string;
   target_audience?: string;
+  /**
+   * CP500+ — present when the source video exceeded the v2 duration cap and
+   * the summary was generated from the first `coveredSec` of `fullSec`
+   * seconds. The FE renders a "first N min of M min" badge.
+   */
+  truncation?: { truncated: boolean; coveredSec: number; fullSec: number };
 }
 
 export interface VideoRichSummaryKeyConcept {

--- a/src/modules/caption/format-transcript.ts
+++ b/src/modules/caption/format-transcript.ts
@@ -32,6 +32,22 @@ function formatStamp(seconds: number): string {
   return `[${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}]`;
 }
 
+/**
+ * Truncate caption segments to those starting at or before `maxStartSec`
+ * (CP500+ long-video v2 support). Feeds the v2 generators the first N minutes
+ * of a video that exceeds RICH_SUMMARY_V2_MAX_DURATION_SECONDS instead of
+ * skipping it. Time-based (segment.start) so the cut lands on a clean caption
+ * boundary; the prompt builders' char-slice is a separate secondary bound
+ * applied after this. Empty/absent input ⇒ [].
+ */
+export function truncateSegmentsToDuration(
+  segments: ReadonlyArray<CaptionSegment> | undefined | null,
+  maxStartSec: number
+): CaptionSegment[] {
+  if (!segments || segments.length === 0) return [];
+  return segments.filter((seg) => seg && typeof seg.start === 'number' && seg.start <= maxStartSec);
+}
+
 export function formatAnnotatedTranscript(
   segments: ReadonlyArray<CaptionSegment> | undefined | null
 ): string {

--- a/src/modules/queue/handlers/enrich-rich-summary.ts
+++ b/src/modules/queue/handlers/enrich-rich-summary.ts
@@ -48,6 +48,7 @@ import { logger } from '../../../utils/logger';
 import { getJobQueue } from '../manager';
 import { JOB_NAMES, RICH_SUMMARY_RETRY_OPTIONS, type EnrichRichSummaryPayload } from '../types';
 import { config } from '@/config/index';
+import { loadRichSummaryConfig } from '@/config/rich-summary';
 import { richSummaryWorkOptions } from './rich-summary-work-options';
 
 /** Thrown when captions are unavailable so the worker fails fast and the
@@ -123,6 +124,27 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
   // leaving the FE bookmark spinner blinking forever. Fail-open / never throws.
   await ensureYoutubeVideoRow(videoId);
 
+  // CP500+ long-video v2 — videos over the duration cap are TRUNCATED to the
+  // first `maxDurationSeconds` of transcript (not skipped). Fetch duration AFTER
+  // ensureYoutubeVideoRow so a freshly-created row is seen. effectiveDurationSec
+  // (= cap when long) is passed to the generators' prompt + timeline validator
+  // so they treat the truncated transcript as a full short video (no "covered
+  // the whole 107min" hallucination).
+  const richCfg = loadRichSummaryConfig();
+  let ytDurationSec: number | null = null;
+  try {
+    const yt = await getPrismaClient().youtube_videos.findUnique({
+      where: { youtube_video_id: videoId },
+      select: { duration_seconds: true },
+    });
+    ytDurationSec = yt?.duration_seconds ?? null;
+  } catch {
+    /* non-fatal — unknown duration ⇒ no truncation */
+  }
+  const isLongVideo = ytDurationSec != null && ytDurationSec > richCfg.maxDurationSeconds;
+  const effectiveDurationSec = isLongVideo ? richCfg.maxDurationSeconds : ytDurationSec;
+  let truncation: { truncated: true; coveredSec: number; fullSec: number } | undefined;
+
   // Hard rule: NO v2 row without a transcript. Captions absent ⇒ throw
   // NO_TRANSCRIPT ⇒ SSE `failed` ⇒ grid renders the retry icon.
   let transcript: string | undefined;
@@ -134,15 +156,28 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
       // and forced Sonnet to guess timeline coverage → hallucination
       // pattern Phase 3 dogfooding surfaced). Falls back to fullText if
       // segments are absent.
-      const { formatAnnotatedTranscript } = await import('@/modules/caption/format-transcript');
-      const annotated = formatAnnotatedTranscript(result.caption.segments);
+      const { formatAnnotatedTranscript, truncateSegmentsToDuration } =
+        await import('@/modules/caption/format-transcript');
+      const segs = isLongVideo
+        ? truncateSegmentsToDuration(result.caption.segments, richCfg.maxDurationSeconds)
+        : result.caption.segments;
+      const annotated = formatAnnotatedTranscript(segs);
       transcript = annotated || result.caption.fullText;
+      if (isLongVideo && ytDurationSec != null) {
+        truncation = {
+          truncated: true,
+          coveredSec: richCfg.maxDurationSeconds,
+          fullSec: ytDurationSec,
+        };
+      }
       logger.info('enrich-rich-summary: transcript fetched', {
         jobId: job.id,
         videoId,
         chars: transcript.length,
         language: result.language,
         langHint: langHint ?? null,
+        truncatedToSec: truncation?.coveredSec ?? null,
+        fullDurationSec: ytDurationSec,
       });
     } else {
       logger.info('enrich-rich-summary: transcript unavailable — surfacing retry', {
@@ -205,6 +240,7 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
     userId,
     mandalaCenterGoal: centerGoal,
     transcript,
+    truncation,
   });
 
   // ── Step 2: Full path (Sonnet, ~30-60s) ──
@@ -217,6 +253,8 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
     mandalaCenterGoal: centerGoal,
     transcript,
     forceRegen: true,
+    effectiveDurationSec,
+    truncation,
   });
 
   logger.info('enrich-rich-summary: completed', {

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -89,6 +89,19 @@ export interface V2GenerationInput {
   /** CP474 — bypass the "complete v2" skip gate so a description-only row
    *  can be regenerated when a transcript becomes available. */
   forceRegen?: boolean;
+  /**
+   * CP500+ — effective (covered) duration in seconds. When the handler
+   * truncated a long video's transcript to the first N seconds, this is N
+   * (= the duration cap), NOT the full video length. Drives the prompt's
+   * `durationSeconds` + the timeline-range validator so the model scopes
+   * timestamps to the covered window. Falls back to the full duration.
+   */
+  effectiveDurationSec?: number | null;
+  /**
+   * CP500+ — truncation marker recorded into `core.truncation` for the FE
+   * "first N min of M min" badge. Absent ⇒ full video (no badge).
+   */
+  truncation?: { truncated: true; coveredSec: number; fullSec: number };
 }
 
 export async function generateRichSummaryV2(
@@ -139,24 +152,13 @@ export async function generateRichSummaryV2(
     return { kind: 'skip', videoId: input.videoId, reason: 'no_youtube_metadata' };
   }
 
-  // CP488+ — duration cap. Videos longer than the configured cap (default
-  // 90min) skip v2 generation. The generator code path stays in place
-  // (no behavioural change beyond this guard) so flipping the env opens
-  // it back up without a code change. Long-form chunked summarisation
-  // is the follow-up that would justify raising the cap.
+  // CP500+ — the duration cap no longer skips. The handler truncates long
+  // videos to the first `maxDurationSeconds` of transcript and passes
+  // `effectiveDurationSec` (= cap when truncated). The prompt + timeline
+  // validator below use it so the model treats the truncated text as a full
+  // short video instead of hallucinating coverage of the whole length.
   const richConfig = loadRichSummaryConfig();
-  if (ytRow.duration_seconds != null && ytRow.duration_seconds > richConfig.maxDurationSeconds) {
-    log.info('v2 skip: duration exceeds cap', {
-      videoId: input.videoId,
-      durationSec: ytRow.duration_seconds,
-      capSec: richConfig.maxDurationSeconds,
-    });
-    return {
-      kind: 'skip',
-      videoId: input.videoId,
-      reason: `duration_exceeds_cap_${richConfig.maxDurationSeconds}s`,
-    };
-  }
+  const effectiveDurationSec = input.effectiveDurationSec ?? ytRow.duration_seconds;
 
   // Title-based language override — `source_language` is stamped from the
   // transcript track YouTube returned, which is sometimes the wrong track
@@ -175,7 +177,9 @@ export async function generateRichSummaryV2(
     // CP488+ Phase 1.5 — duration is now a first-class prompt input so the
     // LLM can produce sections/atoms timestamps that fit the wall-clock
     // length. The validator below rejects outputs that still over-shoot.
-    durationSeconds: ytRow.duration_seconds,
+    // CP500+ — `effectiveDurationSec` (= cap when truncated) so the model
+    // scopes timestamps to the covered window, not the full video length.
+    durationSeconds: effectiveDurationSec,
   });
 
   // CP488+ — pinned Sonnet 4.6 (see SONNET_MODEL doc-comment above).
@@ -233,10 +237,10 @@ export async function generateRichSummaryV2(
       // hallucinated outputs (XrlKWAIFQUY pattern: sections.last.to_sec
       // overshooting wall-clock duration by 30-50%). No-op when duration
       // is unknown.
-      if (ytRow.duration_seconds != null) {
+      if (effectiveDurationSec != null) {
         try {
           validateV2TimelineRange({
-            durationSeconds: ytRow.duration_seconds,
+            durationSeconds: effectiveDurationSec,
             sections: summary.segments?.sections,
             atoms: summary.segments?.atoms,
           });
@@ -256,6 +260,12 @@ export async function generateRichSummaryV2(
         }
       }
 
+      // CP500+ — stamp truncation marker into core (post-validation merge) for
+      // the FE "first N min of M min" badge. Display-only jsonb sub-field.
+      const coreWithTruncation = input.truncation
+        ? { ...summary.core, truncation: input.truncation }
+        : summary.core;
+
       // UPSERT — the quick-path normally creates the row first, but
       // standalone callers (cron / scripts) may invoke this generator
       // without the quick step. INSERT branch covers that case.
@@ -263,7 +273,7 @@ export async function generateRichSummaryV2(
         where: { video_id: input.videoId },
         update: {
           template_version: 'v2',
-          core: summary.core as unknown as Prisma.InputJsonValue,
+          core: coreWithTruncation as unknown as Prisma.InputJsonValue,
           analysis: summary.analysis as unknown as Prisma.InputJsonValue,
           lora: summary.lora as unknown as Prisma.InputJsonValue,
           // CP474 — persist segments emitted by the same LLM call.
@@ -285,7 +295,7 @@ export async function generateRichSummaryV2(
         create: {
           video_id: input.videoId,
           template_version: 'v2',
-          core: summary.core as unknown as Prisma.InputJsonValue,
+          core: coreWithTruncation as unknown as Prisma.InputJsonValue,
           analysis: summary.analysis as unknown as Prisma.InputJsonValue,
           lora: summary.lora as unknown as Prisma.InputJsonValue,
           ...(summary.segments

--- a/src/modules/skills/rich-summary-v2-quick-generator.ts
+++ b/src/modules/skills/rich-summary-v2-quick-generator.ts
@@ -24,7 +24,6 @@ import { Prisma } from '@prisma/client';
 
 import { getPrismaClient } from '@/modules/database/client';
 import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
-import { loadRichSummaryConfig } from '@/config/rich-summary';
 import { logger } from '@/utils/logger';
 
 import { detectContentLanguageFromTitle as detectLanguageFromTitle } from '@/utils/detect-language';
@@ -53,6 +52,12 @@ export interface V2QuickInput {
   userId?: string | null;
   mandalaCenterGoal?: string;
   transcript: string;
+  /**
+   * CP500+ — set by the handler when the transcript was truncated to the first
+   * N seconds of a long video (duration > cap). Recorded into `core.truncation`
+   * so the FE renders the "first N min of M min" badge. Absent ⇒ full video.
+   */
+  truncation?: { truncated: true; coveredSec: number; fullSec: number };
 }
 
 export async function generateRichSummaryV2Quick(input: V2QuickInput): Promise<V2QuickOutcome> {
@@ -75,21 +80,9 @@ export async function generateRichSummaryV2Quick(input: V2QuickInput): Promise<V
     return { kind: 'skip', videoId: input.videoId, reason: 'no_transcript' };
   }
 
-  // CP488+ — same duration cap as the full generator. Skips Heart-click
-  // path for long videos until chunked summarisation lands.
-  const richConfig = loadRichSummaryConfig();
-  if (ytRow.duration_seconds != null && ytRow.duration_seconds > richConfig.maxDurationSeconds) {
-    log.info('v2-quick skip: duration exceeds cap', {
-      videoId: input.videoId,
-      durationSec: ytRow.duration_seconds,
-      capSec: richConfig.maxDurationSeconds,
-    });
-    return {
-      kind: 'skip',
-      videoId: input.videoId,
-      reason: `duration_exceeds_cap_${richConfig.maxDurationSeconds}s`,
-    };
-  }
+  // CP500+ — the duration cap no longer skips here. The handler truncates long
+  // videos to the first `maxDurationSeconds` of transcript and passes
+  // `input.truncation`; this generator proceeds on the (already-bounded) text.
 
   const language: 'ko' | 'en' =
     detectLanguageFromTitle(ytRow.title) ?? (ytRow.default_language === 'en' ? 'en' : 'ko');
@@ -157,7 +150,12 @@ export async function generateRichSummaryV2Quick(input: V2QuickInput): Promise<V
 
   // UPSERT minimal v2 row. core/analysis only contain the quick fields;
   // the full generator will merge in segments/atoms/entities/etc.
-  const minimalCore = parsed.core;
+  // CP500+ — stamp the truncation marker into core (post-validation merge) so
+  // the FE can render the "first N min of M min" badge. Display-only; no schema
+  // change (jsonb sub-field, not a column).
+  const minimalCore = input.truncation
+    ? { ...parsed.core, truncation: input.truncation }
+    : parsed.core;
   const minimalAnalysis = parsed.analysis;
 
   try {

--- a/tests/unit/caption/format-transcript.test.ts
+++ b/tests/unit/caption/format-transcript.test.ts
@@ -8,7 +8,46 @@
  * back to hallucinating coverage.
  */
 
-import { formatAnnotatedTranscript } from '@/modules/caption/format-transcript';
+import {
+  formatAnnotatedTranscript,
+  truncateSegmentsToDuration,
+} from '@/modules/caption/format-transcript';
+
+describe('truncateSegmentsToDuration (CP500+ long-video v2)', () => {
+  const segs = [
+    { start: 0, duration: 5, text: 'a' },
+    { start: 5400, duration: 4, text: 'b (exactly at cap)' },
+    { start: 5401, duration: 4, text: 'c (just over cap)' },
+    { start: 6440, duration: 4, text: 'd (way over)' },
+  ];
+
+  it('keeps segments starting at or before the cap (inclusive boundary)', () => {
+    const out = truncateSegmentsToDuration(segs, 5400);
+    expect(out.map((s) => s.text)).toEqual(['a', 'b (exactly at cap)']);
+  });
+
+  it('returns [] for empty / null / undefined input', () => {
+    expect(truncateSegmentsToDuration([], 5400)).toEqual([]);
+    expect(truncateSegmentsToDuration(null, 5400)).toEqual([]);
+    expect(truncateSegmentsToDuration(undefined, 5400)).toEqual([]);
+  });
+
+  it('returns all segments when none exceed the cap', () => {
+    const short = [
+      { start: 0, duration: 5, text: 'x' },
+      { start: 100, duration: 5, text: 'y' },
+    ];
+    expect(truncateSegmentsToDuration(short, 5400)).toHaveLength(2);
+  });
+
+  it('feeds a truncated transcript whose last stamp is within the cap', () => {
+    const out = formatAnnotatedTranscript(truncateSegmentsToDuration(segs, 5400));
+    expect(out).toContain('[00:00] a');
+    expect(out).toContain('[01:30:00] b (exactly at cap)');
+    expect(out).not.toContain('c (just over cap)');
+    expect(out).not.toContain('d (way over)');
+  });
+});
 
 describe('formatAnnotatedTranscript', () => {
   it('returns empty string for empty input', () => {


### PR DESCRIPTION
## PR-A (A/B split) — truncate + badge only
원래 번들에서 **A(truncate+배지)만** 분리. B(genuine-skip terminal + churn-0)는 **PR-B로 이관** — 핸들러 `NO_TRANSCRIPT` throw 경로의 skipped-행 GAP(자막부재=가장 흔함)을 포함해 증거 갖춰 별도 진행. **A에서 B를 떼도 genuine-skip 거동은 현행 유지 = regression 아님.**

## Root cause (측정)
xuUHWCT6gN4(107분) v2 미생성 → 로그 `skip reason=duration_exceeds_cap_5400s`. 90분 cap이 통째 skip.

## What (James: skip→truncate)
duration>cap = **앞 90분 truncate 후 v2 생성**.
- 신규 `truncateSegmentsToDuration(seg.start≤cap)` + 핸들러 단일 chokepoint truncate.
- 두 생성기: cap-skip 제거, **`effectiveDurationSec`(=cap)를 prompt `durationSeconds` + `validateV2TimelineRange`에 전달**(전체 duration 환각·오판 차단), `core.truncation` 병합(post-validation).
- FE `TruncatedBadge` "앞 N분(전체 M분)" (ko·en). 타입 = `core.truncation`(스키마 변경 0).

## 증거 (코드/측정)
- #1 quick: `grep NO_MATCH` — quick-prompt는 duration 미참조, timestamp 미산출 → 환각벡터 없음.
- #4 char-cap: prod 로그 chars=55523(full 107분) → 90분 ≈46.5k < 100k slice → 배지 정직. known-limit: 90분 transcript ≥100k(희귀) = coveredSec 보정 follow-up.

## Test
truncateSegmentsToDuration +4 + 기존 17 regression green. BE/FE tsc clean, JSON valid.

## 검증 = prod 동작
머지+배포 후: ① xuUHWCT6gN4(107분) → truncated v2 + 배지 화면 ③ 90분 미만 정상 v2. (② genuine-skip = PR-B.)
