### PR TITLE
fix(v2): auto-refetch on failed/timeout so skipped terminal shows without reload [PR-B-followup] (CP500+)

### DIFF
--- a/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
@@ -101,11 +101,16 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
     })();
   }, [youtubeId, mandalaId, isRichLoading, hasSegments, isQualityWarning, openStream]);
 
-  // When the SSE stream terminates with `scored`, refetch the v2 row so
-  // the segments block lands without a manual reload.
+  // When the SSE stream reaches a TERMINAL phase, refetch the v2 row so the
+  // result lands without a manual reload. CP500+ PR-B-followup — `failed` /
+  // `timeout` were missing: a no_transcript job throws NO_TRANSCRIPT → SSE
+  // `failed`, and the PR-B skipped row written server-side was never fetched,
+  // so the panel stayed spinning until a manual refresh. Refetching here also
+  // makes isQualityWarning(≠'pass') true → the auto-enrich re-trigger guard
+  // engages → churn stops.
   useEffect(() => {
     if (!youtubeId) return;
-    if (streamPhase === 'scored') {
+    if (streamPhase === 'scored' || streamPhase === 'failed' || streamPhase === 'timeout') {
       void queryClient.invalidateQueries({ queryKey: queryKeys.video.richSummary(youtubeId) });
     }
   }, [streamPhase, youtubeId, queryClient]);


### PR DESCRIPTION
## PR-B-followup (1-line) — FE 자동전환 갭
#920(PR-B)이 서버측 `quality_flag='skipped'` 행을 썼고 "불가" 메시지도 렌더되나, James prod 보고: **"초반 무한스피닝 → 새로고침 후 정상"**.

## Root cause (코드 확정)
`PanelAISummary.tsx`의 terminal-refetch effect가 **`streamPhase==='scored'`일 때만** rich-summary refetch. no_transcript → 핸들러 throw → SSE **`'failed'`** → refetch 없음 → 방금 쓴 skipped 행 미fetch → 수동 새로고침 전까지 스피너.

## Fix (1줄)
refetch 조건에 `'failed'` / `'timeout'` 추가 → skipped 행 자동 fetch → "불가" **자동 전환**(새로고침 불요) + `isQualityWarning`(≠'pass') 발동 → 재enqueue churn0.

## 검증
- 서버측 확정: zP2mIsDH5s4 → `quality_flag='skipped'`, `reason='no_transcript'` (prod 측정).
- FE tsc clean. per-card SSOT 무관(vrs video-scoped, FE 폴링만).
- prod 동작: 무자막 카드 열기 → **새로고침 없이** "불가" 표시.