### PR TITLE
feat(auto-add): view-count gate + meta enrich at auto-add chokepoint (CP500+)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/jeonhokim/cursor/insighta/node_modules

--- a/src/config/recommendations.ts
+++ b/src/config/recommendations.ts
@@ -9,6 +9,8 @@
  * (Phase 3, see src/skills/plugins/video-discover/executor.ts).
  */
 
+import { z } from 'zod';
+
 /** Max items returned by GET /api/v1/mandalas/:id/recommendations. */
 export const RECOMMENDATION_FETCH_LIMIT = 200;
 
@@ -45,3 +47,81 @@ export const VIDEO_DISCOVER_DEFAULT_AUTO_ADD = true;
 
 /** skill_type string used in user_skill_config (matches mandala-post-creation.ts). */
 export const VIDEO_DISCOVER_SKILL_TYPE = 'video_discover';
+
+// ─── Auto-add chokepoint guards (CP500+, 2026-06-15) ───────────────────────
+//
+// Two guards applied at the single auto-add confluence
+// (src/modules/mandala/auto-add-recommendations.ts) that ALL automatic inflow
+// (live 'realtime' + pool-serve + wizard inline) passes through. Diagnosis
+// (mandala bdc5505f): the v5 live path bypasses the pool's view-count gate and
+// metadata ingest, so 13/43 recs were <1k views (a 2-view scribble scored 65%)
+// and 49/49 rows had metadata_fetched_at=NULL. /check [6w] chokepoint pattern.
+//
+// Both default to no-op (unset = prior behaviour) per CLAUDE.md config rule —
+// merging is inert; flip via env after measurement + a [GO].
+//
+//   AUTO_ADD_MIN_VIEW_COUNT  view floor for AUTO-added cards. 0 = off (default).
+//                            Recommended initial value: 1000 (= the batch
+//                            collector's existing BRONZE floor; lower later via
+//                            env). NULL view (enrich failed/absent) = fail-open.
+//   AUTO_ADD_META_ENRICH     when true, synchronously calls
+//                            collectAndUpsertMetadata() after youtube_videos
+//                            rows are created so the view gate decides on
+//                            authoritative counts. Sync is forced: the gate
+//                            depends on the freshly-filled view_count, and
+//                            metadata-collector is UPDATE-only (rows must exist).
+
+const boolFlag = z.preprocess((v) => {
+  if (v == null || v === '') return false;
+  const s = String(v).trim().toLowerCase();
+  return s === 'true' || s === '1' || s === 'yes';
+}, z.boolean());
+
+export const autoAddEnvSchema = z.object({
+  AUTO_ADD_MIN_VIEW_COUNT: z.coerce.number().int().min(0).default(0),
+  AUTO_ADD_META_ENRICH: boolFlag.default(false as unknown as string),
+});
+
+export interface AutoAddGuardConfig {
+  /** Minimum view_count for AUTO-added cards. 0 disables the gate. */
+  minViewCount: number;
+  /** When true, enrich youtube_videos metadata synchronously before gating. */
+  metaEnrich: boolean;
+}
+
+const AUTO_ADD_GUARD_FALLBACK: AutoAddGuardConfig = {
+  minViewCount: 0,
+  metaEnrich: false,
+};
+
+/**
+ * Load the auto-add guard config from env. Read per-invocation (not at module
+ * load) so a runtime env flip takes effect without a process restart and so
+ * tests can set process.env before calling.
+ */
+export function loadAutoAddGuardConfig(env: NodeJS.ProcessEnv = process.env): AutoAddGuardConfig {
+  const parsed = autoAddEnvSchema.safeParse({
+    AUTO_ADD_MIN_VIEW_COUNT: env['AUTO_ADD_MIN_VIEW_COUNT'],
+    AUTO_ADD_META_ENRICH: env['AUTO_ADD_META_ENRICH'],
+  });
+  if (!parsed.success) return AUTO_ADD_GUARD_FALLBACK;
+  return {
+    minViewCount: parsed.data.AUTO_ADD_MIN_VIEW_COUNT,
+    metaEnrich: parsed.data.AUTO_ADD_META_ENRICH,
+  };
+}
+
+/**
+ * Pure view-count gate predicate (chokepoint). Exported for unit testing.
+ *   - minViewCount <= 0      → no-op (everything passes; default)
+ *   - viewCount null/undef   → fail-open (enrich failed or absent → pass)
+ *   - else                   → pass iff viewCount >= minViewCount
+ */
+export function passesViewCountGate(
+  viewCount: number | bigint | null | undefined,
+  minViewCount: number
+): boolean {
+  if (minViewCount <= 0) return true;
+  if (viewCount == null) return true;
+  return Number(viewCount) >= minViewCount;
+}

--- a/src/modules/mandala/auto-add-recommendations.ts
+++ b/src/modules/mandala/auto-add-recommendations.ts
@@ -53,9 +53,14 @@
 
 import { getPrismaClient } from '@/modules/database';
 import { logger } from '@/utils/logger';
-import { VIDEO_DISCOVER_SKILL_TYPE } from '@/config/recommendations';
+import {
+  VIDEO_DISCOVER_SKILL_TYPE,
+  loadAutoAddGuardConfig,
+  passesViewCountGate,
+} from '@/config/recommendations';
 import { notifyCardAdded, type CardPayload } from '@/modules/recommendations/publisher';
 import { recordTrace } from '@/modules/discover-tracing';
+import { collectAndUpsertMetadata } from '@/modules/youtube/metadata-collector';
 
 const log = logger.child({ module: 'auto-add-recommendations' });
 
@@ -125,6 +130,11 @@ export async function maybeAutoAddRecommendations(
   if (recs.length === 0) {
     return { ok: false, reason: 'no pending recommendation_cache rows' };
   }
+
+  // Chokepoint guards (CP500+): view-count floor + metadata enrich. Both
+  // default no-op (env unset). This is the single confluence ALL automatic
+  // inflow passes through (live/pool/wizard) — see loadAutoAddGuardConfig.
+  const guard = loadAutoAddGuardConfig();
 
   // Group by cell_index. No per-cell cap (2026-04-18): the upstream
   // pipeline already sets V3_TARGET_PER_CELL / V3_TARGET_TOTAL, so every
@@ -229,12 +239,16 @@ export async function maybeAutoAddRecommendations(
     // ─────────────────────────────────────────────────────────────────────────
     const cellVideoIds = cellRecs.map((r) => r.video_id);
 
-    // (a) Look up existing youtube_videos for this cell's recs.
+    // (a) Look up existing youtube_videos for this cell's recs. metadata_fetched_at
+    //     drives enrich-scoping below (only enrich rows that lack authoritative meta).
     const existingYt = await db.youtube_videos.findMany({
       where: { youtube_video_id: { in: cellVideoIds } },
-      select: { id: true, youtube_video_id: true },
+      select: { id: true, youtube_video_id: true, metadata_fetched_at: true },
     });
     const existingYtMap = new Map(existingYt.map((y) => [y.youtube_video_id, y.id]));
+    const existingMetaNull = new Set(
+      existingYt.filter((y) => y.metadata_fetched_at == null).map((y) => y.youtube_video_id)
+    );
 
     // (b) createMany for new youtube_videos only (skipDuplicates handles races).
     const newYtRows = cellRecs
@@ -274,16 +288,51 @@ export async function maybeAutoAddRecommendations(
       }
     }
 
-    // (c) Re-fetch full id map so we can build userVideoState rows.
+    // Meta enrich (chokepoint guard ②): now that the youtube_videos rows exist
+    // (createMany above), fill authoritative view_count/published_at/
+    // metadata_fetched_at so the view gate decides on real counts, not sparse
+    // search-snippet data. UPDATE-only (metadata-collector:73) → must run AFTER
+    // row creation. Idempotent + fail-open: a failure leaves view_count null
+    // and the gate passes the card (re-evaluated on the next refresh once
+    // enrichment succeeds, or by the nightly metadata cron backstop).
+    if (guard.metaEnrich) {
+      const idsToEnrich = cellVideoIds.filter(
+        (vid) => !existingYtMap.has(vid) || existingMetaNull.has(vid)
+      );
+      if (idsToEnrich.length > 0) {
+        try {
+          await collectAndUpsertMetadata(idsToEnrich);
+        } catch (err) {
+          log.warn(
+            `auto-add meta-enrich failed (cell=${cellIndex}, n=${idsToEnrich.length}): ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    }
+
+    // (c) Re-fetch full id map so we can build userVideoState rows. view_count
+    //     is the authoritative value (post-enrich) the gate below reads.
     const allYt = await db.youtube_videos.findMany({
       where: { youtube_video_id: { in: cellVideoIds } },
-      select: { id: true, youtube_video_id: true },
+      select: { id: true, youtube_video_id: true, view_count: true },
     });
     const ytIdByVideoId = new Map(allYt.map((y) => [y.youtube_video_id, y.id]));
+    const viewByVideoId = new Map(allYt.map((y) => [y.youtube_video_id, y.view_count]));
+
+    // View gate (chokepoint guard ①): drop ultra-low-view garbage from the
+    // AUTO path. Pure filter on insert candidates — issues NO delete and
+    // operates on cellRecs, which already excludes videos linked to this user
+    // (dedup at existingVideoIdSet above). So user-touched cards are never seen
+    // by the gate → immutable. fail-open on null view; min<=0 = no-op (default).
+    const survivingRecs = cellRecs.filter((r) =>
+      passesViewCountGate(viewByVideoId.get(r.video_id), guard.minViewCount)
+    );
+    if (survivingRecs.length === 0) continue;
 
     // (d) createMany userVideoState. skipDuplicates handles concurrent re-runs
-    //     hitting unique(user_id, videoId).
-    const uvsRows = cellRecs
+    //     hitting unique(user_id, videoId). Built from survivingRecs so gated
+    //     (ultra-low-view) candidates never materialize a card.
+    const uvsRows = survivingRecs
       .map((r, i) => {
         const videoId = ytIdByVideoId.get(r.video_id);
         if (!videoId) return null;
@@ -314,12 +363,12 @@ export async function maybeAutoAddRecommendations(
       }
     }
 
-    // SSE: fire notifyCardAdded for each rec the batch touched. Pre-existing
-    // user_video_states rows (filtered out at line 184) are not in cellRecs,
-    // so iterating cellRecs only emits events for actually-inserted-or-tried
-    // cards. notifyCardAdded is in-process EventEmitter — non-blocking.
-    for (let i = 0; i < cellRecs.length; i++) {
-      const rec = cellRecs[i];
+    // SSE: fire notifyCardAdded for each rec the batch touched. Iterate
+    // survivingRecs only — gated candidates have no uvs row, so emitting an
+    // event for them would surface a phantom card. notifyCardAdded is an
+    // in-process EventEmitter — non-blocking.
+    for (let i = 0; i < survivingRecs.length; i++) {
+      const rec = survivingRecs[i];
       if (!rec) continue;
       try {
         const payload: CardPayload = {

--- a/tests/unit/modules/auto-add-recommendations.test.ts
+++ b/tests/unit/modules/auto-add-recommendations.test.ts
@@ -67,7 +67,13 @@ jest.mock('@/modules/discover-tracing', () => ({
   recordTrace: jest.fn(),
 }));
 
+const mockCollectAndUpsertMetadata = jest.fn();
+jest.mock('@/modules/youtube/metadata-collector', () => ({
+  collectAndUpsertMetadata: (...args: unknown[]) => mockCollectAndUpsertMetadata(...args),
+}));
+
 import { maybeAutoAddRecommendations } from '../../../src/modules/mandala/auto-add-recommendations';
+import { passesViewCountGate } from '../../../src/config/recommendations';
 
 const USER = '00000000-0000-0000-0000-000000000001';
 const MANDALA = '00000000-0000-0000-0000-000000000002';
@@ -130,6 +136,14 @@ beforeEach(() => {
   mockRecCacheUpdateMany.mockResolvedValue({ count: 0 });
   // Default: no existing youtube_videos for dedup / existing checks
   mockYoutubeVideosFindMany.mockResolvedValue([]);
+  // Meta enrich defaults to a successful no-op; only called when
+  // AUTO_ADD_META_ENRICH=true (default off → never invoked).
+  mockCollectAndUpsertMetadata.mockResolvedValue({
+    videoIds: [],
+    fetched: 0,
+    upserted: 0,
+    errors: 0,
+  });
 });
 
 describe('maybeAutoAddRecommendations — opt-in gates', () => {
@@ -321,5 +335,120 @@ describe('maybeAutoAddRecommendations — bookkeeping', () => {
     await maybeAutoAddRecommendations(USER, MANDALA);
 
     expect(mockRecCacheUpdateMany).not.toHaveBeenCalled();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// CP500+ chokepoint guards: view-count gate + meta enrich.
+// Diagnosis: v5 live 'realtime' auto-add bypassed the pool's view floor + meta
+// ingest (mandala bdc5505f: 13/43 recs <1k views, a 2-view scribble scored 65%;
+// 49/49 metadata_fetched_at NULL). Gate sits at the single auto-add confluence.
+// ───────────────────────────────────────────────────────────────────────────
+describe('passesViewCountGate — pure predicate', () => {
+  it('blocks a 2-view video at floor 1000', () => {
+    expect(passesViewCountGate(2, 1000)).toBe(false);
+    expect(passesViewCountGate(2n, 1000)).toBe(false);
+  });
+  it('passes a video at/above floor 1000', () => {
+    expect(passesViewCountGate(1000, 1000)).toBe(true);
+    expect(passesViewCountGate(1001, 1000)).toBe(true);
+  });
+  it('fail-open: null/undefined view passes (enrich failed or absent)', () => {
+    expect(passesViewCountGate(null, 1000)).toBe(true);
+    expect(passesViewCountGate(undefined, 1000)).toBe(true);
+  });
+  it('no-op when floor <= 0 (default disabled)', () => {
+    expect(passesViewCountGate(2, 0)).toBe(true);
+  });
+});
+
+describe('maybeAutoAddRecommendations — view-count gate (CP500+)', () => {
+  const OLD_ENV = process.env;
+  beforeEach(() => {
+    process.env = { ...OLD_ENV };
+  });
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  // (1) 2뷰 차단 + (2) 1001뷰 통과
+  it('blocks the 2-view rec and materializes only the 1001-view rec at floor 1000', async () => {
+    process.env['AUTO_ADD_MIN_VIEW_COUNT'] = '1000';
+    mockRecCacheFindMany.mockResolvedValue([makeRec(0, 0.9, 'low'), makeRec(0, 0.8, 'high')]);
+    mockYoutubeVideosFindMany
+      .mockResolvedValueOnce([]) // dedup
+      .mockResolvedValueOnce([]) // (a) existing — all new
+      .mockResolvedValueOnce([
+        { id: 'yt-low', youtube_video_id: 'low', view_count: 2n },
+        { id: 'yt-high', youtube_video_id: 'high', view_count: 1001n },
+      ]); // (c) refetch with authoritative view_count
+    mockYoutubeVideosCreateMany.mockResolvedValue({ count: 2 });
+    mockUserVideoStateCreateMany.mockResolvedValue({ count: 1 });
+
+    const result = await maybeAutoAddRecommendations(USER, MANDALA);
+
+    const createCall = mockUserVideoStateCreateMany.mock.calls.find(
+      (c) => (c[0]?.data as Array<{ cell_index: number }>)?.[0]?.cell_index === 0
+    );
+    const rows = (createCall?.[0].data as Array<{ videoId: string }>) ?? [];
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.videoId).toBe('yt-high');
+    expect(result.ok).toBe(true);
+  });
+
+  // (3) 유저-터치(이미 링크된) 2뷰 카드 보존 — dedup 선제외로 게이트가 못 봄
+  it('a 2-view card already linked to the user is deduped out before the gate — never re-evaluated/dropped by it', async () => {
+    process.env['AUTO_ADD_MIN_VIEW_COUNT'] = '1000';
+    mockRecCacheFindMany.mockResolvedValue([makeRec(0, 0.9, 'touched')]);
+    // dedup (call 1) reports it already linked → cellRecs empty → loop continues
+    // before the gate ever runs. The existing uvs row is untouched by this module.
+    mockYoutubeVideosFindMany.mockResolvedValueOnce([{ youtube_video_id: 'touched' }]);
+
+    const result = await maybeAutoAddRecommendations(USER, MANDALA);
+
+    expect(mockUserVideoStateCreateMany).not.toHaveBeenCalled();
+    expect(mockCollectAndUpsertMetadata).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+  });
+
+  // (4) wizard inline reach — 동일 공유 함수라 caller 무관하게 게이트 상속
+  it('gate lives inside the shared function — wizard inline auto-add inherits it', async () => {
+    // wizard-precompute.consumePrecompute calls maybeAutoAddRecommendations
+    // inline (#879), so a floor set here applies to the wizard path identically.
+    process.env['AUTO_ADD_MIN_VIEW_COUNT'] = '1000';
+    mockRecCacheFindMany.mockResolvedValue([makeRec(0, 0.9, 'low')]);
+    mockYoutubeVideosFindMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'yt-low', youtube_video_id: 'low', view_count: 2n }]);
+
+    const result = await maybeAutoAddRecommendations(USER, MANDALA);
+
+    // 2-view filtered → cell yields no survivors → no card materialized.
+    expect(mockUserVideoStateCreateMany).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+  });
+
+  // (5) fail-open 재실행 무중복 — enrich 실패 시 카드 생성 + skipDuplicates
+  it('meta-enrich failure is fail-open (card created) and createMany stays skipDuplicates (re-run safe)', async () => {
+    process.env['AUTO_ADD_MIN_VIEW_COUNT'] = '1000';
+    process.env['AUTO_ADD_META_ENRICH'] = 'true';
+    mockCollectAndUpsertMetadata.mockRejectedValue(new Error('quota exceeded'));
+    mockRecCacheFindMany.mockResolvedValue([makeRec(0, 0.9, 'v1')]);
+    mockYoutubeVideosFindMany
+      .mockResolvedValueOnce([]) // dedup
+      .mockResolvedValueOnce([]) // (a) existing — all new (so enrich attempted)
+      .mockResolvedValueOnce([{ id: 'yt-v1', youtube_video_id: 'v1', view_count: null }]); // post-enrich still null (failed)
+    mockYoutubeVideosCreateMany.mockResolvedValue({ count: 1 });
+    mockUserVideoStateCreateMany.mockResolvedValue({ count: 1 });
+
+    const result = await maybeAutoAddRecommendations(USER, MANDALA);
+
+    expect(mockCollectAndUpsertMetadata).toHaveBeenCalledWith(['v1']);
+    const createCall = mockUserVideoStateCreateMany.mock.calls[0];
+    expect(createCall?.[0].skipDuplicates).toBe(true);
+    // null view → fail-open → the card is still created.
+    expect((createCall?.[0].data as unknown[]).length).toBe(1);
+    expect(result.ok).toBe(true);
   });
 });


### PR DESCRIPTION
## What
Apply two guards at `maybeAutoAddRecommendations` — the single confluence ALL automatic inflow (v5 live `realtime` + pool-serve + wizard inline) funnels through to materialize cards:
1. **view-count gate** — drop ultra-low-view garbage from the AUTO path.
2. **metadata enrich** — fill authoritative `view_count`/`published_at`/`metadata_fetched_at` so the gate decides on real counts (and cards show view/date).

Both **default no-op** (env unset = prior behaviour) → merging is inert.

## Why (prod diagnosis, mandala `bdc5505f`, 49 cards all `auto_added`)
The v5 live `realtime` path bypasses the `video_pool`'s view gate AND meta ingest:
- **13/43 recs <1000 views** — a 2-view children's-scribble video (`-p_cVis1GEY`) scored 65% and surfaced as a recommended card.
- **49/49 `metadata_fetched_at` NULL** — FE correctly hid view/date on the 6 rows missing snippet view_count ("counts shown inconsistently").

One hole, two symptoms = a new inflow path replicating neither guard. `/check [6w]` chokepoint-over-duplication pattern (4th/5th instance).

## Design (direction B — chokepoint, not per-path duplication)
- **Sync enrich is forced**: gate needs the freshly-filled `view_count`; `metadata-collector` is UPDATE-only (rows must pre-exist) → enrich runs after `youtube_videos.createMany`.
- **Gate is a pure filter** on insert candidates (`cellRecs`), which already excludes videos linked to this user (dedup) → user-touched cards are never seen by the gate → **immutable**.
- **fail-open**: enrich failure leaves `view_count` null → card passes; re-evaluated next refresh (or nightly metadata cron backstop).

## Idempotency (code-verified)
- (a) `collectAndUpsertMetadata` = `youtube_videos.update()` by unique id → idempotent.
- (b) gate issues **no delete**; operates post-dedup → existing/user-touched cards unaffected.
- (c) `createMany` keeps `skipDuplicates: true` → re-run safe, no dupes.

## Config (flip after measurement + GO)
| env | default | recommended-on |
|---|---|---|
| `AUTO_ADD_MIN_VIEW_COUNT` | `0` (off) | `1000` (= BRONZE floor; lower later via env) |
| `AUTO_ADD_META_ENRICH` | `false` | `true` |
| `YOUTUBE_METADATA_BACKFILL_ENABLED` (existing) | `false` | `true` (nightly backstop for non-auto paths) |

## Tests
21/21 pass, tsc clean. 5 regression specs: 2-view blocked / 1001 passes / user-touched deduped-out-before-gate / wizard inline reach / fail-open re-run keeps `skipDuplicates`; + pure `passesViewCountGate`.

## Verification plan (verified = James screen, code-live ≠ verified)
After merge + env GO: rerun `/tmp/insighta-diag-pool*.js` → `rec_cache <1k 30%→0%`, `metafetch 49/49→0`, scribble card not created; James runs a new wizard and confirms no 2-view garbage enters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)