### PR TITLE
feat(inflow-gate): Layer-2 relevance judge on wizard v5 path (CP500++ PR-3)

### DIFF
--- a/src/config/inflow-gate.ts
+++ b/src/config/inflow-gate.ts
@@ -1,0 +1,56 @@
+/**
+ * Inflow-gate config (CP500++ PR-3 — wizard relevance judge).
+ *
+ * The wizard v5 path (V5_PICKER_MODE=cell_binning) places cards with NO
+ * relevance judge, unlike v3 (cosine center gate) and pool-serve (Haiku gate).
+ * This flag pair gates a Layer-2 relevance judge on the wizard path only.
+ *
+ * 2-stage canary (mirrors the RELEVANCE_RUBRIC_ENABLED → BATCH_GATE_PRUNE split):
+ *   INFLOW_GATE_ENABLED — run the judge and TRACE would-cut, but DO NOT drop
+ *     (score/log-only; zero behavior change). Observe traces first.
+ *   INFLOW_GATE_CUT — actually drop slots below the threshold. Separate flag,
+ *     separate [GO], flipped only after would-cut traces look clean.
+ *
+ * Default: both OFF (unset = legacy, no judge, no cut). Rollback = flip env,
+ * no code revert. Single-sourced in docker-compose.prod.yml environment per
+ * CONFIG-SSOT (PR-1); never written to .env by deploy.yml.
+ */
+
+import { z } from 'zod';
+
+// Treat only "true"/"1"/"yes" as true (avoids z.coerce.boolean making "false"
+// truthy) — same idiom as src/config/relevance-rubric.ts.
+const boolFlag = z.preprocess((v) => {
+  if (v == null || v === '') return false;
+  const s = String(v).trim().toLowerCase();
+  return s === 'true' || s === '1' || s === 'yes';
+}, z.boolean());
+
+export const inflowGateEnvSchema = z.object({
+  INFLOW_GATE_ENABLED: boolFlag.default(false as unknown as string),
+  INFLOW_GATE_CUT: boolFlag.default(false as unknown as string),
+  /** Slots scoring below this gate pct are would-cut (stage 1) / dropped (stage 2). */
+  INFLOW_GATE_RELEVANCE_MIN: z.coerce.number().int().min(0).max(100).default(60),
+});
+
+export interface InflowGateConfig {
+  enabled: boolean;
+  cut: boolean;
+  relevanceMin: number;
+}
+
+export function loadInflowGateConfig(env: NodeJS.ProcessEnv = process.env): InflowGateConfig {
+  const parsed = inflowGateEnvSchema.safeParse({
+    INFLOW_GATE_ENABLED: env['INFLOW_GATE_ENABLED'],
+    INFLOW_GATE_CUT: env['INFLOW_GATE_CUT'],
+    INFLOW_GATE_RELEVANCE_MIN: env['INFLOW_GATE_RELEVANCE_MIN'],
+  });
+  if (!parsed.success) {
+    return { enabled: false, cut: false, relevanceMin: 60 };
+  }
+  return {
+    enabled: parsed.data.INFLOW_GATE_ENABLED,
+    cut: parsed.data.INFLOW_GATE_CUT,
+    relevanceMin: parsed.data.INFLOW_GATE_RELEVANCE_MIN,
+  };
+}

--- a/src/modules/inflow-gate/judge.ts
+++ b/src/modules/inflow-gate/judge.ts
@@ -1,0 +1,127 @@
+/**
+ * Inflow-gate Layer-2 — wizard relevance judge (CP500++ PR-3, INV-INFLOW-GATE).
+ *
+ * The wizard v5 path (cell_binning) places cards with NO relevance judge,
+ * unlike v3 (cosine center gate) and pool-serve (Haiku gate). This partitions
+ * wizard-generated slots into kept / would-cut using the SHARED Haiku scorer
+ * (computeCardRelevance), so the caller can trace (stage 1) or drop (stage 2).
+ *
+ * FAIL-OPEN: any scorer failure (provider error / no title / parse) KEEPS the
+ * slot — a judge outage must never empty a cell. This differs from pool-serve,
+ * which is fail-CLOSED to guard the pool-first lexical path (CP494+1); the
+ * wizard path is live-generated, so supply-first wins = fail-open.
+ *
+ * Gate axis follows RELEVANCE_RUBRIC_ENABLED (same as pool-serve): rubric ON →
+ * goal_contribution_pct (the measured discriminator); OFF → composite score.
+ */
+
+import { computeCardRelevance } from '@/modules/relevance/compute-card-relevance';
+import { loadRelevanceRubricConfig } from '@/config/relevance-rubric';
+import type { InflowGateConfig } from '@/config/inflow-gate';
+
+// Bounded concurrency for the Haiku batch (mirrors pool-serve SCORE_BURST_SIZE).
+const SCORE_BURST = 8;
+
+/** Minimal slot shape the judge needs (AssembledSlot is a structural superset). */
+export interface JudgeSlot {
+  videoId: string;
+  title: string;
+  description: string | null;
+  cellIndex: number;
+}
+
+export interface WouldCutEntry {
+  videoId: string;
+  title: string;
+  cellIndex: number;
+  gatePct: number;
+  reason: string;
+}
+
+export interface JudgeResult<T> {
+  /** Slots that pass (≥ relevanceMin) OR fail-open (scorer error). */
+  kept: T[];
+  /** Slots below threshold — traced (stage 1) or dropped (stage 2 uses `kept`). */
+  wouldCut: WouldCutEntry[];
+  scored: number;
+  /** Slots kept because the scorer failed (fail-open), not because they passed. */
+  failedOpen: number;
+}
+
+export interface JudgeContext {
+  centerGoal: string;
+  /** Per-cell sub-goals; cellGoal = subGoals[slot.cellIndex]. */
+  subGoals: string[];
+  language?: 'ko' | 'en';
+  cfg: InflowGateConfig;
+}
+
+/**
+ * Score each slot and partition into kept / wouldCut. Never throws; a scorer
+ * error fails the slot OPEN (into `kept`). The caller applies the cut (stage 2)
+ * by using `kept`, or ignores it and only traces `wouldCut` (stage 1).
+ */
+export async function judgeWizardSlots<T extends JudgeSlot>(
+  slots: T[],
+  ctx: JudgeContext
+): Promise<JudgeResult<T>> {
+  const rubric = loadRelevanceRubricConfig().enabled;
+  const kept: T[] = [];
+  const wouldCut: WouldCutEntry[] = [];
+  let scored = 0;
+  let failedOpen = 0;
+
+  for (let i = 0; i < slots.length; i += SCORE_BURST) {
+    const burst = slots.slice(i, i + SCORE_BURST);
+    const verdicts = await Promise.all(
+      burst.map(async (slot) => {
+        const cellGoal = ctx.subGoals[slot.cellIndex];
+        const r = await computeCardRelevance({
+          title: slot.title,
+          description: slot.description ?? '',
+          centerGoal: ctx.centerGoal,
+          cellGoal,
+          language: ctx.language,
+          ...(rubric ? { rubric: true } : {}),
+        });
+        if (!r.ok) {
+          // FAIL-OPEN — keep the slot, do not cut on a scorer failure.
+          return {
+            slot,
+            keep: true,
+            failedOpen: true,
+            gatePct: null as number | null,
+            reason: `fail_open:${r.reason}`,
+          };
+        }
+        const gatePct = rubric && r.detail ? r.detail.goalContributionPct : r.relevancePct;
+        const keep = gatePct >= ctx.cfg.relevanceMin;
+        return {
+          slot,
+          keep,
+          failedOpen: false,
+          gatePct,
+          reason: keep ? 'pass' : `below_min:${gatePct}<${ctx.cfg.relevanceMin}`,
+        };
+      })
+    );
+
+    for (const v of verdicts) {
+      scored += 1;
+      if (v.failedOpen) failedOpen += 1;
+      if (v.keep) {
+        kept.push(v.slot);
+      } else {
+        wouldCut.push({
+          videoId: v.slot.videoId,
+          title: v.slot.title,
+          cellIndex: v.slot.cellIndex,
+          gatePct: v.gatePct as number,
+          reason: v.reason,
+        });
+      }
+    }
+  }
+
+  return { kept, wouldCut, scored, failedOpen };
+}

--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -29,6 +29,7 @@ import { logger } from '@/utils/logger';
 import { loadWizardPrecomputeConfig } from '@/config/wizard-precompute';
 import type { EphemeralDiscoverResult } from '@/skills/plugins/video-discover/v3/executor';
 import { runV5ForWizard } from '@/skills/plugins/video-discover/v5/wizard-adapter';
+import { loadInflowGateConfig } from '@/config/inflow-gate';
 import { notifyCardAdded, type CardPayload } from '@/modules/recommendations/publisher';
 import { MS_PER_DAY } from '@/utils/time-constants';
 import { randomUUID } from 'crypto';
@@ -136,6 +137,59 @@ export async function startPrecompute(input: StartPrecomputeInput): Promise<void
       // CP493 — when WIZARD_MERGED_GEN produced full per-cell coverage.
       precomputedQueries: input.cellQueries,
     });
+
+    // CP500++ PR-3 (INV-INFLOW-GATE) — Layer-2 relevance judge for the wizard
+    // v5 path (cell_binning has no relevance judge, unlike v3 cosine / pool-serve
+    // Haiku). Runs HERE (off the consume/save SLO; fire-and-forget precompute).
+    // Stage 1 (INFLOW_GATE_ENABLED) traces would-cut WITHOUT dropping; stage 2
+    // (INFLOW_GATE_CUT) drops below-threshold slots. Fail-open at every level —
+    // a judge failure keeps slots. mandala_id does not exist yet (precompute is
+    // pre-save), so the trace is step-keyed by user_id, not mandala_id.
+    const gateCfg = loadInflowGateConfig(process.env);
+    if (gateCfg.enabled && result.slots.length > 0) {
+      try {
+        // Dynamic import — keeps the Haiku scorer / openrouter / config chain
+        // out of the static graph (load only when the gate is on; default off).
+        const { judgeWizardSlots } = await import('@/modules/inflow-gate/judge');
+        const verdict = await judgeWizardSlots(result.slots, {
+          centerGoal: input.goal,
+          subGoals: input.subGoals,
+          language: input.language,
+          cfg: gateCfg,
+        });
+        if (verdict.wouldCut.length > 0) {
+          const { withTraceContext, recordTrace } = await import('@/modules/discover-tracing');
+          await withTraceContext({ mandalaId: null, userId: input.userId }, async () => {
+            recordTrace({
+              step: gateCfg.cut ? 'inflow_gate.cut' : 'inflow_gate.would_cut',
+              status: 'ok',
+              response: {
+                session_id: input.sessionId,
+                scored: verdict.scored,
+                failed_open: verdict.failedOpen,
+                relevance_min: gateCfg.relevanceMin,
+                cut_count: verdict.wouldCut.length,
+                cut: verdict.wouldCut.slice(0, 50),
+              },
+            });
+          });
+        }
+        if (gateCfg.cut) {
+          result.slots = verdict.kept;
+        }
+        log.info(
+          `inflow-gate: scored=${verdict.scored} would_cut=${verdict.wouldCut.length} ` +
+            `cut=${gateCfg.cut} failed_open=${verdict.failedOpen} session=${input.sessionId}`,
+          { sessionId: input.sessionId }
+        );
+      } catch (err) {
+        // Orchestration-level fail-open: judge failure must not break precompute.
+        log.warn(
+          `inflow-gate judge threw (fail-open, slots kept): ${err instanceof Error ? err.message : String(err)}`,
+          { sessionId: input.sessionId }
+        );
+      }
+    }
 
     await db.mandala_wizard_precompute.update({
       where: { session_id: input.sessionId },

--- a/tests/unit/modules/inflow-gate-judge.test.ts
+++ b/tests/unit/modules/inflow-gate-judge.test.ts
@@ -1,0 +1,133 @@
+/**
+ * inflow-gate judge — wizard relevance judge partition tests (CP500++ PR-3).
+ *
+ * Pins the gate semantics:
+ *   - pass (gatePct ≥ relevanceMin)        → kept
+ *   - below min                            → wouldCut (NOT kept)
+ *   - boundary (gatePct === relevanceMin)  → kept (≥)
+ *   - scorer failure                       → FAIL-OPEN (kept, failedOpen++)
+ *   - rubric ON                            → gate axis = goal_contribution_pct
+ *   - title-only (description null)        → scorer called with description=''
+ *
+ * computeCardRelevance + loadRelevanceRubricConfig are mocked at module load.
+ */
+
+const mockCompute = jest.fn();
+const mockRubricCfg = jest.fn();
+
+jest.mock('@/modules/relevance/compute-card-relevance', () => ({
+  computeCardRelevance: (...args: unknown[]) => mockCompute(...args),
+}));
+jest.mock('@/config/relevance-rubric', () => ({
+  loadRelevanceRubricConfig: () => mockRubricCfg(),
+}));
+
+import { judgeWizardSlots, type JudgeSlot } from '@/modules/inflow-gate/judge';
+import type { InflowGateConfig } from '@/config/inflow-gate';
+
+const CFG: InflowGateConfig = { enabled: true, cut: true, relevanceMin: 60 };
+
+const slot = (
+  videoId: string,
+  title: string,
+  cellIndex = 0,
+  description: string | null = null
+): JudgeSlot => ({
+  videoId,
+  title,
+  description,
+  cellIndex,
+});
+
+const ctx = (over: Partial<Parameters<typeof judgeWizardSlots>[1]> = {}) => ({
+  centerGoal: 'become a better SaaS founder',
+  subGoals: ['pricing', 'growth', 'hiring'],
+  language: 'en' as const,
+  cfg: CFG,
+  ...over,
+});
+
+beforeEach(() => {
+  mockCompute.mockReset();
+  mockRubricCfg.mockReset();
+  mockRubricCfg.mockReturnValue({ enabled: false, prune: false, pruneGcMin: 65 });
+});
+
+describe('judgeWizardSlots — partition', () => {
+  it('keeps all slots that score ≥ relevanceMin', async () => {
+    mockCompute.mockResolvedValue({ ok: true, relevancePct: 80 });
+    const res = await judgeWizardSlots([slot('a', 'A'), slot('b', 'B')], ctx());
+    expect(res.kept.map((s) => s.videoId)).toEqual(['a', 'b']);
+    expect(res.wouldCut).toHaveLength(0);
+    expect(res.scored).toBe(2);
+    expect(res.failedOpen).toBe(0);
+  });
+
+  it('would-cuts slots below min, keeps the rest', async () => {
+    mockCompute
+      .mockResolvedValueOnce({ ok: true, relevancePct: 80 }) // a pass
+      .mockResolvedValueOnce({ ok: true, relevancePct: 30 }); // b cut
+    const res = await judgeWizardSlots([slot('a', 'A'), slot('b', 'B')], ctx());
+    expect(res.kept.map((s) => s.videoId)).toEqual(['a']);
+    expect(res.wouldCut).toHaveLength(1);
+    expect(res.wouldCut[0]).toMatchObject({ videoId: 'b', gatePct: 30 });
+    expect(res.wouldCut[0]!.reason).toContain('below_min');
+  });
+
+  it('treats gatePct === relevanceMin as PASS (≥)', async () => {
+    mockCompute.mockResolvedValue({ ok: true, relevancePct: 60 });
+    const res = await judgeWizardSlots([slot('a', 'A')], ctx());
+    expect(res.kept).toHaveLength(1);
+    expect(res.wouldCut).toHaveLength(0);
+  });
+});
+
+describe('judgeWizardSlots — fail-open', () => {
+  it('keeps a slot when the scorer returns ok:false (no cut on failure)', async () => {
+    mockCompute.mockResolvedValue({ ok: false, reason: 'provider_error: 500' });
+    const res = await judgeWizardSlots([slot('a', 'A'), slot('b', 'B')], ctx());
+    expect(res.kept.map((s) => s.videoId)).toEqual(['a', 'b']);
+    expect(res.wouldCut).toHaveLength(0);
+    expect(res.failedOpen).toBe(2);
+  });
+
+  it('mixes fail-open and real cuts correctly', async () => {
+    mockCompute
+      .mockResolvedValueOnce({ ok: false, reason: 'json_parse' }) // a fail-open → kept
+      .mockResolvedValueOnce({ ok: true, relevancePct: 10 }); // b real cut
+    const res = await judgeWizardSlots([slot('a', 'A'), slot('b', 'B')], ctx());
+    expect(res.kept.map((s) => s.videoId)).toEqual(['a']);
+    expect(res.wouldCut.map((w) => w.videoId)).toEqual(['b']);
+    expect(res.failedOpen).toBe(1);
+  });
+});
+
+describe('judgeWizardSlots — rubric axis + inputs', () => {
+  it('rubric ON → gate axis = goal_contribution_pct (not composite)', async () => {
+    mockRubricCfg.mockReturnValue({ enabled: true, prune: false, pruneGcMin: 65 });
+    // composite high (would pass) but goal_contribution low (must cut)
+    mockCompute.mockResolvedValue({
+      ok: true,
+      relevancePct: 90,
+      detail: { cellFitPct: 90, goalContributionPct: 20, actionabilityPct: 80 },
+    });
+    const res = await judgeWizardSlots([slot('a', 'A')], ctx());
+    expect(res.kept).toHaveLength(0);
+    expect(res.wouldCut[0]).toMatchObject({ videoId: 'a', gatePct: 20 });
+    // rubric:true forwarded to scorer
+    expect(mockCompute).toHaveBeenCalledWith(expect.objectContaining({ rubric: true }));
+  });
+
+  it('passes title-only (description null → empty string) + cellGoal from subGoals[cellIndex]', async () => {
+    mockCompute.mockResolvedValue({ ok: true, relevancePct: 75 });
+    await judgeWizardSlots([slot('a', 'A', 1, null)], ctx());
+    expect(mockCompute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'A',
+        description: '',
+        centerGoal: 'become a better SaaS founder',
+        cellGoal: 'growth',
+      })
+    );
+  });
+});


### PR DESCRIPTION
## What
Adds a Layer-2 relevance judge on the **wizard v5 path only** — the one automatic card-inflow path that currently has **no relevance judge**. Default OFF (merge is prod-inert).

## Why (measured, not assumed)
Cross-cutting audit (`docs/handoffs/crosscutting-audit-pr3-findings.md`) + prod `printenv` showed the judgment landscape is **inconsistent, not absent**:
- v3 (prod-live): `V3_CENTER_GATE_MODE=semantic` cosine ≥0.5 + quality gate — **already judged**
- pool-serve: Haiku rubric gate ≥60 — **already judged**
- **wizard v5: `V5_PICKER_MODE=cell_binning` → NO relevance judge** ← the real gap
- add-cards: user Pick (`auto_added=false`) — user is the judge, excluded

So this gates **only** the wizard path (adding Haiku to v3/pool would double-judge + blow cost/latency).

## How
- `src/config/inflow-gate.ts` — 2-stage canary flags: `INFLOW_GATE_ENABLED` (score/log-only, traces would-cut, **no drop**) → `INFLOW_GATE_CUT` (actual drop). `INFLOW_GATE_RELEVANCE_MIN` default 60. Both default OFF (unset = legacy). CONFIG-SSOT compatible (compose `environment:` single-source; not `.env`).
- `src/modules/inflow-gate/judge.ts` — `judgeWizardSlots`: shared Haiku scorer (`computeCardRelevance`, title-only), bounded concurrency, **FAIL-OPEN** (scorer error keeps the slot — differs from pool-serve fail-closed). Gate axis = `goal_contribution_pct` when `RELEVANCE_RUBRIC_ENABLED`.
- `wizard-precompute.ts` — judge at `startPrecompute` (off the consume/save SLO; mandala_id absent pre-save so the trace is step-keyed). Dynamic import keeps the scorer chain out of the static graph (zero load when flag off).
- tests: pass / cut / boundary / fail-open / rubric-axis / title-only (7/7).

## Verification
- `tsc --noEmit`: 0 errors
- new judge tests: 7/7 pass
- wizard-precompute regression: **0 new failures** (5 pre-existing consumePrecompute failures confirmed identical on pristine origin/main — unrelated to this PR, flagged separately)

## Canary / rollout (per-step [GO] gated)
1. merge (prod-inert, both flags off)
2. `INFLOW_GATE_ENABLED=true` → observe `inflow_gate.would_cut` traces (only garbage flagged?)
3. `INFLOW_GATE_CUT=true` → actual drop
Rollback = flip env, no code revert.

## Scope
PR-3 = Layer-2 judge (wizard). PR-3b (follow-up, pre-launch) = Layer-1 shared rule module at the chokepoint (anti-replication invariant) — separated to isolate blast on the sensitive placement chokepoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)