### PR TITLE
Revert stage-1 inflow-gate canary — placement regression (CP500++ PR-3)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -254,14 +254,6 @@ services:
       # off-topic cards demoted (gc<65) WITHOUT deletion. PASS → flip BATCH_GATE_PRUNE
       # (separate [GO]). Rollback: delete this line + redeploy → code default false.
       - RELEVANCE_RUBRIC_ENABLED=true
-      # CP500++ PR-3 (2026-06-18, James [GO] stage1) — wizard inflow-gate canary.
-      # The wizard v5 path (cell_binning) has NO relevance judge (v3=cosine,
-      # pool-serve=Haiku already gated). INFLOW_GATE_ENABLED runs the Layer-2
-      # Haiku judge at startPrecompute and TRACES `inflow_gate.would_cut` WITHOUT
-      # dropping (score/log-only). INFLOW_GATE_CUT stays UNSET → ZERO card cut.
-      # Canary: James inspects would_cut traces (only garbage flagged?). PASS →
-      # flip INFLOW_GATE_CUT (separate [GO]). Rollback: delete this line + redeploy.
-      - INFLOW_GATE_ENABLED=true
       # CP437 (2026-04-29) — Operator flip: enable YouTube metadata backfill cron.
       # Default in code is `false` — cron stays dormant unless this env is
       # explicitly true. With this set, `startYouTubeMetadataCron()` schedules


### PR DESCRIPTION
Reverts #926 (`INFLOW_GATE_ENABLED=true`). **Live regression rollback.**

**Root cause (trace-measured):** the judge ran at `startPrecompute` and scored 60 slots via Haiku (~30s), delaying precompute `status='done'`. `consumePrecompute`'s sub-1s done-poll then MISSED the precompute → fell back to a degraded path: **8 cards (vs usual), ~30s (vs 3-5s)**.

- `scored=60, would_cut=3` (NCS자료해석 correctly flagged) → **judge LOGIC is sound**; only the **PLACEMENT** on the precompute→consume timing path is wrong.
- `INFLOW_GATE_CUT` was unset → **zero cards dropped** (the 2-stage canary contained data loss to latency-only).

Gate code (`#925`) stays in prod, flag OFF = inert. Judge logic reused; placement to be redesigned so it does not block precompute's time-to-done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)