### PR TITLE
fix(wizard): timeout-bound merged-gen reference search — wizard latency cap (CP500++)

### DIFF
--- a/src/config/wizard-merged-gen.ts
+++ b/src/config/wizard-merged-gen.ts
@@ -28,10 +28,19 @@ const boolFlag = z.preprocess((v) => {
 
 export const wizardMergedGenEnvSchema = z.object({
   WIZARD_MERGED_GEN: boolFlag.default(false as unknown as string),
+  // CP500+ — timeout (ms) for the OPTIONAL few-shot reference search inside
+  // merged-gen. searchMandalasByGoal does a qwen3-embedding-8b embed on the
+  // wizard critical path; when the embed provider degrades it can take ~5s and
+  // block the wizard, but the reference is optional (the prompt builds without
+  // it). Cap it so an embed-latency spike never blocks generation. Measured
+  // healthy embed p50 ~530-800ms → 1500 keeps the reference when fast, skips it
+  // when degraded. 0 = no timeout (legacy blocking behavior).
+  MERGED_GEN_REF_TIMEOUT_MS: z.coerce.number().int().min(0).default(1500),
 });
 
 export interface WizardMergedGenConfig {
   enabled: boolean;
+  refTimeoutMs: number;
 }
 
 export function loadWizardMergedGenConfig(
@@ -39,9 +48,13 @@ export function loadWizardMergedGenConfig(
 ): WizardMergedGenConfig {
   const parsed = wizardMergedGenEnvSchema.safeParse({
     WIZARD_MERGED_GEN: env['WIZARD_MERGED_GEN'],
+    MERGED_GEN_REF_TIMEOUT_MS: env['MERGED_GEN_REF_TIMEOUT_MS'],
   });
   if (!parsed.success) {
-    return { enabled: false };
+    return { enabled: false, refTimeoutMs: 1500 };
   }
-  return { enabled: parsed.data.WIZARD_MERGED_GEN };
+  return {
+    enabled: parsed.data.WIZARD_MERGED_GEN,
+    refTimeoutMs: parsed.data.MERGED_GEN_REF_TIMEOUT_MS,
+  };
 }

--- a/src/modules/mandala/generator.ts
+++ b/src/modules/mandala/generator.ts
@@ -12,7 +12,8 @@ import { config } from '../../config';
 import { logger } from '../../utils/logger';
 import { MemoryCache } from '../../utils/memory-cache';
 import { getPrismaClient } from '../database/client';
-import { searchMandalasByGoal, formatMandalasForFewShot } from './search';
+import { searchMandalasByGoal, formatMandalasForFewShot, type MandalaSearchResult } from './search';
+import { loadWizardMergedGenConfig } from '@/config/wizard-merged-gen';
 import { OpenRouterGenerationProvider } from '../llm/openrouter';
 import {
   buildStructurePrompt,
@@ -747,11 +748,42 @@ export async function generateMandalaWithQueries(
   // (embed + cosine) and the generate() LLM call. Splitting them in the [TIMING]
   // log decomposes the merged-gen total (66s reproductions) into its real parts.
   const tSearch = Date.now();
-  const similar = await searchMandalasByGoal(input.goal, {
+  // CP500+ — the few-shot reference is OPTIONAL (the prompt builds without it,
+  // see buildMandalaWithQueriesPrompt: example = reference ? ... : ''). The
+  // search does a qwen3-embedding-8b embed that, when the embed provider
+  // degrades, takes ~5s on the wizard critical path. Cap it so a slow embed
+  // never blocks generation: on timeout/error we proceed with no reference.
+  // MERGED_GEN_REF_TIMEOUT_MS=0 disables the cap (legacy blocking behavior).
+  const refTimeoutMs = loadWizardMergedGenConfig().refTimeoutMs;
+  const searchPromise = searchMandalasByGoal(input.goal, {
     limit: 1,
     threshold: 0.4,
     language: input.language,
+  }).catch((err) => {
+    logger.warn(
+      `merged-gen reference search failed (proceeding without reference): ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return [] as MandalaSearchResult[];
   });
+  let refTimer: ReturnType<typeof setTimeout> | undefined;
+  const similar =
+    refTimeoutMs > 0
+      ? await Promise.race([
+          searchPromise.finally(() => {
+            if (refTimer) clearTimeout(refTimer);
+          }),
+          new Promise<MandalaSearchResult[]>((resolve) => {
+            refTimer = setTimeout(() => {
+              logger.warn(
+                `merged-gen reference search exceeded ${refTimeoutMs}ms — proceeding without reference`
+              );
+              resolve([]);
+            }, refTimeoutMs);
+          }),
+        ])
+      : await searchPromise;
   const searchMs = Date.now() - tSearch;
 
   const lang = input.language ?? 'ko';

--- a/tests/unit/modules/mandala-merged-gen.test.ts
+++ b/tests/unit/modules/mandala-merged-gen.test.ts
@@ -17,6 +17,9 @@ import {
   generateMandalaWithQueries,
   MandalaGenError,
 } from '@/modules/mandala/generator';
+import { searchMandalasByGoal } from '@/modules/mandala/search';
+
+const mockSearch = searchMandalasByGoal as jest.Mock;
 
 const SUB_GOALS = Array.from({ length: 8 }, (_, i) => `sub goal ${i}`);
 const SUB_LABELS = Array.from({ length: 8 }, (_, i) => `label ${i}`);
@@ -131,5 +134,61 @@ describe('generateMandalaWithQueries', () => {
     await expect(
       generateMandalaWithQueries(baseInput, { generateImpl: async () => 'garbage' })
     ).rejects.toThrow(MandalaGenError);
+  });
+});
+
+describe('generateMandalaWithQueries — reference search timeout (CP500+)', () => {
+  const baseInput = { goal: '한국어 목표', language: 'ko' as const };
+  const orig = process.env['MERGED_GEN_REF_TIMEOUT_MS'];
+  const REF = [
+    { center_goal: '비슷한 목표', center_label: '짧은', sub_goals: ['a'], sub_labels: ['b'] },
+  ];
+
+  afterEach(() => {
+    if (orig === undefined) delete process.env['MERGED_GEN_REF_TIMEOUT_MS'];
+    else process.env['MERGED_GEN_REF_TIMEOUT_MS'] = orig;
+    mockSearch.mockReset();
+    mockSearch.mockResolvedValue([]);
+  });
+
+  test('slow reference search → timeout → gen proceeds WITHOUT reference', async () => {
+    process.env['MERGED_GEN_REF_TIMEOUT_MS'] = '50';
+    // resolves AFTER the timeout — race returns [] first
+    mockSearch.mockReturnValue(new Promise((r) => setTimeout(() => r(REF), 400)));
+    let seenPrompt = '';
+    const res = await generateMandalaWithQueries(baseInput, {
+      generateImpl: async (p: string) => {
+        seenPrompt = p;
+        return mergedJson(FULL_CQ);
+      },
+    });
+    expect(res.structure.sub_goals).toHaveLength(8); // valid gen despite slow search
+    expect(seenPrompt).not.toContain('Reference:'); // reference skipped
+  });
+
+  test('fast reference search → reference injected into prompt', async () => {
+    process.env['MERGED_GEN_REF_TIMEOUT_MS'] = '2000';
+    mockSearch.mockResolvedValue(REF);
+    let seenPrompt = '';
+    await generateMandalaWithQueries(baseInput, {
+      generateImpl: async (p: string) => {
+        seenPrompt = p;
+        return mergedJson(FULL_CQ);
+      },
+    });
+    expect(seenPrompt).toContain('Reference:'); // fast search → reference used
+  });
+
+  test('MERGED_GEN_REF_TIMEOUT_MS=0 → no cap, search fully awaited (reference used)', async () => {
+    process.env['MERGED_GEN_REF_TIMEOUT_MS'] = '0';
+    mockSearch.mockResolvedValue(REF);
+    let seenPrompt = '';
+    await generateMandalaWithQueries(baseInput, {
+      generateImpl: async (p: string) => {
+        seenPrompt = p;
+        return mergedJson(FULL_CQ);
+      },
+    });
+    expect(seenPrompt).toContain('Reference:');
   });
 });


### PR DESCRIPTION
## Problem (James-measured + server-confirmed)
Wizard create browser-felt **2-4s → 10-13s (3-5x regression)**. Decomposed server-side: `/wizard-stream` = 9.9s, dominated by `searchMandalasByGoal` embed (`/search-by-goal` standalone measured **4,920ms** = pure embed). The embed is `qwen3-embedding-8b` (4096-dim) which takes ~5s on **both** OpenRouter and Mac Mini (Mac Mini probe = 5.2s) — provider-independent; OpenRouter qwen3-embedding-8b latency is unstable (measured p50 530ms healthy → 4,165ms degraded), and `generateMandalaWithQueries` **awaited it on the critical path**.

The reference it fetches is **OPTIONAL** (`buildMandalaWithQueriesPrompt`: `example = reference ? ... : ''`) — gen produces valid structure without it.

## Fix
Cap the reference search at `MERGED_GEN_REF_TIMEOUT_MS` (default **1500ms**; healthy embed p50 530-800ms so the reference is kept when fast, skipped when degraded). On timeout OR error → proceed with no reference (valid gen). `0` = no cap (legacy blocking). → wizard caps at ~Haiku(3s) + ≤1.5s ≈ **baseline restored**, robust to embed-latency spikes.

**Scope honesty**: this is a robust symptom cap — it does NOT fix the embed degradation root (OpenRouter qwen3-embedding-8b). Acceptable because the reference is optional and healthy embed preserves quality. If the embed chronically degrades, the reference is always lost → embed itself (lighter model / cache) needs a separate fix. CC will monitor embed p50 post-deploy.

## Changes
- `src/config/wizard-merged-gen.ts`: + `MERGED_GEN_REF_TIMEOUT_MS` (zod, default 1500, env-configurable).
- `generator.ts:749`: `Promise.race(searchPromise, timeout) → []`; search error → `[]` (graceful, was an uncaught throw → legacy fallback).
- tests: slow→timeout→no-reference (gen valid) / fast→reference used / `0`→no-cap.

## Verification
- `tsc --noEmit`: 0 errors · jest mandala-merged-gen: **12/12** (9 existing + 3 new).
- Reversible: `MERGED_GEN_REF_TIMEOUT_MS=0` (or large) → legacy blocking. No code revert.
- Done = CC re-measures prod wizard wall-clock (`/wizard-stream` responseTime) → ~4s cap even when embed slow = 2-4s baseline restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)