### PR TITLE
chore(discover): restore min-view floor on wizard — AUTO_ADD_MIN_VIEW_COUNT=1000 (CP500++)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -164,6 +164,19 @@ services:
       # V5_SERIES_DEDUP_SIM (0.8) / V5_CHANNEL_SOFT_CAP (2 = demote from 3rd).
       # Revert: delete this line + redeploy → code default false (기존 동작).
       - V5_DIVERSITY_GUARD=true
+      # CP500++ (2026-06-18, James [GO]) — restore the min-view floor on the
+      # wizard/auto-add path. #804 (2026-05-30) switched the wizard v3→v5; the v3
+      # quality gate (filterByQualityGate, MIN_VIEW 1000) was NOT carried into v5,
+      # so live-search niche topics admit garbage (measured: a new "Claude Code"
+      # mandala had a 5-view card). The #922 view gate already exists at the
+      # placeAutoAddedCards chokepoint (auto-add passes applyViewGate:true) — this
+      # just sets its floor. Measured on the offending mandala: 1000 cuts 37% (the
+      # <1000 garbage), every cell keeps >=2 cards (no empty cell). rec_cache
+      # view_count null=0% (7d) so the gate input is reliable (no meta-enrich
+      # needed). NULL view = fail-open. Revert: set 0 (or delete) → no-op default.
+      # pool-serve does NOT yet pass applyViewGate (places ~0 now, fail-closed) —
+      # wire it when the pool is reactivated.
+      - AUTO_ADD_MIN_VIEW_COUNT=1000
       # Wizard redesign Phase 1 activation (2026-04-22).
       # Flips embedGoalForMandala from Mac-mini Ollama to OpenRouter's
       # hosted Qwen3-Embedding-8B. Same model family and 4096d so the


### PR DESCRIPTION
Restores the min-view floor lost when the wizard switched v3→v5 (#804, 2026-05-30): the v3 quality gate (MIN_VIEW 1000) was not carried into v5, so live-search niche topics admit low-view garbage (measured: a new "Claude Code" mandala had a **5-view** card — `config/recommendations.ts:56` documents this exact bypass).

**Pure config flip — no code.** The #922 view gate already exists at the `placeAutoAddedCards` chokepoint, and the auto-add path already passes `applyViewGate:true, minViewCount=AUTO_ADD_MIN_VIEW_COUNT`. This sets the floor (was `0` = no-op).

**Measured (the offending mandala, 60 cards):**
- 1000-floor cuts 37% (`<1000` = the garbage; `>=1000` = 38 kept).
- Per-cell after floor: **every cell keeps ≥2 cards (no empty cell)**.
- `recommendation_cache.view_count` null = **0%** (616 rows/7d) → gate input reliable, **meta-enrich not needed**.
- NULL view = fail-open (no wrong-cut). Reversible: `=0` → no-op default. CONFIG-SSOT (compose only, not `.env`).

**Scope**: auto-add (wizard/pipeline) only. pool-serve does NOT yet pass `applyViewGate` but places ~0 cards now (relevance gate fail-closed) — wire it on pool reactivation.

**vs PR-3 (relevance judge)**: floor cheaply/deterministically cuts low-view garbage; the judge handles high-view-but-irrelevant. Floor first.

Done = CC re-measures a new wizard: `<1000` cut + no empty cells + printenv=1000. Empty cells → tune to 500 (env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)