### PR TITLE
fix(notes): route rich-note by sourceTable so ulc notes persist (CP501 ①a)

### DIFF
--- a/frontend/src/pages/learning/ui/RightPanel.tsx
+++ b/frontend/src/pages/learning/ui/RightPanel.tsx
@@ -53,12 +53,12 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
     setNoteLoaded(false);
     setRichNote(null);
     apiClient
-      .getRichNote(currentCard.id)
+      .getRichNote(currentCard.id, currentCard.sourceTable)
       .then((res) => {
         if (res?.note) setRichNote(res.note as TiptapDoc);
       })
       .finally(() => setNoteLoaded(true));
-  }, [currentCard?.id]);
+  }, [currentCard?.id, currentCard?.sourceTable]);
 
   const noteContent = richNote ?? currentCard?.userNote ?? '';
 
@@ -66,12 +66,20 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
   const handleDocChange = useCallback(
     (doc: unknown) => {
       if (!currentCard?.id) return;
+      const cardId = currentCard.id;
+      const sourceTable = currentCard.sourceTable;
       clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(() => {
-        apiClient.saveRichNote(currentCard.id, doc).catch(() => {});
+        // CP501 — route by sourceTable so ulc notes persist; surface failures
+        // instead of swallowing them (previously `.catch(() => {})` hid the
+        // ulc 404 → silent data loss).
+        apiClient.saveRichNote(cardId, doc, sourceTable).catch((err) => {
+          console.error('saveRichNote failed', err);
+          toast.error(t('learning.noteSaveFailed', '노트 저장에 실패했어요. 다시 시도해 주세요.'));
+        });
       }, 1500);
     },
-    [currentCard?.id]
+    [currentCard?.id, currentCard?.sourceTable, t]
   );
 
   const handleSeek = useCallback(

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1217,18 +1217,29 @@ class ApiClient {
     });
   }
 
-  async getRichNote(cardId: string): Promise<{ note: unknown; updatedAt: string } | null> {
+  async getRichNote(
+    cardId: string,
+    sourceTable?: 'user_video_states' | 'user_local_cards'
+  ): Promise<{ note: unknown; updatedAt: string } | null> {
     try {
-      return await this.request<{ note: unknown; updatedAt: string }>(`/rich-notes/${cardId}`);
+      // CP501 — route read to the card's origin table (uvs vs ulc).
+      const qs = sourceTable ? `?source=${sourceTable}` : '';
+      return await this.request<{ note: unknown; updatedAt: string }>(`/rich-notes/${cardId}${qs}`);
     } catch {
       return null;
     }
   }
 
-  async saveRichNote(cardId: string, note: unknown): Promise<{ updatedAt: string }> {
+  async saveRichNote(
+    cardId: string,
+    note: unknown,
+    sourceTable?: 'user_video_states' | 'user_local_cards'
+  ): Promise<{ updatedAt: string }> {
+    // CP501 — route write to the card's origin table so ulc notes persist
+    // (previously uvs-only → ulc saves 404'd and were silently dropped).
     return this.request<{ updatedAt: string }>(`/rich-notes/${cardId}`, {
       method: 'PATCH',
-      body: JSON.stringify({ note }),
+      body: JSON.stringify({ note, sourceTable }),
     });
   }
 

--- a/src/api/routes/video-rich-notes.ts
+++ b/src/api/routes/video-rich-notes.ts
@@ -22,8 +22,17 @@ const paramsSchema = z.object({
   cardId: z.string().uuid(),
 });
 
+// Origin table of the card id (CP501). Optional ⇒ defaults to user_video_states
+// in the service (back-compat with callers that don't pass it).
+const noteSourceSchema = z.enum(['user_video_states', 'user_local_cards']).optional();
+
+const getQuerySchema = z.object({
+  source: noteSourceSchema,
+});
+
 const patchBodySchema = z.object({
   note: tiptapDocSchema,
+  sourceTable: noteSourceSchema,
 });
 
 export const videoRichNotesRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
@@ -48,8 +57,12 @@ export const videoRichNotesRoutes: FastifyPluginCallback = (fastify, _opts, done
       }
       const { cardId } = parseResult.data;
 
+      // Source is optional; an invalid value falls back to the service default.
+      const queryResult = getQuerySchema.safeParse(request.query);
+      const source = queryResult.success ? queryResult.data.source : undefined;
+
       try {
-        const view = await service().getRichNote(request.user.userId, cardId);
+        const view = await service().getRichNote(request.user.userId, cardId, source);
         return reply.code(200).send({
           cardId,
           video: view.video,
@@ -105,7 +118,12 @@ export const videoRichNotesRoutes: FastifyPluginCallback = (fastify, _opts, done
       }
 
       try {
-        const result = await service().saveRichNote(request.user.userId, cardId, doc);
+        const result = await service().saveRichNote(
+          request.user.userId,
+          cardId,
+          doc,
+          bodyResult.data.sourceTable
+        );
         return reply.code(200).send({ updatedAt: result.updatedAt });
       } catch (err) {
         if (err instanceof RichNoteNotFoundError) {

--- a/src/modules/notes/rich-note-service.ts
+++ b/src/modules/notes/rich-note-service.ts
@@ -2,16 +2,25 @@
  * Rich Note Service
  *
  * Backs the Notion-style side editor (Phase 1-4 MVP).
- * Persists Tiptap JSON in `user_video_states.user_note_json` (source of truth)
- * AND a plain-text extract in `user_video_states.user_note` so that the
- * existing eviction rule (WHERE user_note IS NULL) continues to work unchanged.
+ *
+ * Source-aware routing (CP501 — ① note write-dead fix):
+ *   A card id is an opaque uuid that can belong to EITHER user_video_states
+ *   (uvs) OR user_local_cards (ulc). The caller passes the origin table via
+ *   `sourceTable` so this single service routes read/write to the right table
+ *   — no per-call-site branching (canonical-layer first application).
+ *   - uvs: dual-writes Tiptap JSON (`user_note_json`, source of truth) + a
+ *     plain-text extract (`user_note`) so the eviction rule (WHERE user_note
+ *     IS NULL) keeps working.
+ *   - ulc: has NO `user_note_json` column → stores the plain-text extract only
+ *     (`user_note`). Rich formatting is not persisted for ulc cards (full rich
+ *     parity would require a DDL column-add — tracked as (a)-B, out of scope).
  *
  * Contract:
- *   - getRichNote(): returns Tiptap JSON if available; if only legacy plain text exists,
- *     wraps it into a read-only paragraph doc (DB is NOT modified here — write-through
- *     migration happens on the first PATCH).
- *   - saveRichNote(): dual-writes both columns atomically in a single UPDATE.
- *     Empty docs clear both columns so the card returns to eviction eligibility.
+ *   - getRichNote(): returns Tiptap JSON if available; if only legacy/plain text
+ *     exists, wraps it into a read-only paragraph doc (DB is NOT modified here).
+ *   - saveRichNote(): persists the user-edited doc. Empty docs clear the note
+ *     column(s) so the card returns to eviction eligibility. Only the edited
+ *     doc is written — no legacy/bulk write-through migration.
  */
 import { Prisma, type PrismaClient } from '@prisma/client';
 import { getPrismaClient } from '../database';
@@ -19,12 +28,15 @@ import type { TiptapDoc, TiptapNode } from './tiptap-schema';
 import { extractPlainText, isEmptyDoc } from './tiptap-text-extract';
 import { logger } from '../../utils/logger';
 
+/** Origin table of a card id. Mirrors InsightCard.sourceTable on the FE. */
+export type NoteSourceTable = 'user_video_states' | 'user_local_cards';
+
 export interface RichNoteView {
   /** Tiptap JSON to render in the editor. Never null — legacy text is wrapped. */
   note: TiptapDoc | null;
-  /** True when returned note was synthesized from a legacy plain-text value. */
+  /** True when returned note was synthesized from a legacy/plain-text value. */
   isLegacy: boolean;
-  /** Last-updated timestamp (ISO string) from user_video_states.updatedAt. */
+  /** Last-updated timestamp (ISO string). */
   updatedAt: string | null;
   /** Video metadata for the editor header. */
   video: {
@@ -39,7 +51,7 @@ export interface RichNoteView {
 }
 
 export class RichNoteNotFoundError extends Error {
-  constructor(message = 'user_video_state row not found') {
+  constructor(message = 'card row not found') {
     super(message);
     this.name = 'RichNoteNotFoundError';
   }
@@ -67,10 +79,47 @@ function coerceTiptapDoc(value: Prisma.JsonValue | null): TiptapDoc | null {
   return value as unknown as TiptapDoc;
 }
 
+/** True when the Prisma error signals "row not found" for an update. */
+function isRowNotFound(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: string }).code === 'P2025'
+  );
+}
+
 export class RichNoteService {
   constructor(private readonly db: PrismaClient = getPrismaClient()) {}
 
-  async getRichNote(userId: string, cardId: string): Promise<RichNoteView> {
+  /** Route a read to the correct origin table. Defaults to uvs (back-compat). */
+  async getRichNote(
+    userId: string,
+    cardId: string,
+    sourceTable: NoteSourceTable = 'user_video_states'
+  ): Promise<RichNoteView> {
+    return sourceTable === 'user_local_cards'
+      ? this.getRichNoteFromLocalCard(userId, cardId)
+      : this.getRichNoteFromVideoState(userId, cardId);
+  }
+
+  /** Route a write to the correct origin table. Defaults to uvs (back-compat). */
+  async saveRichNote(
+    userId: string,
+    cardId: string,
+    doc: TiptapNode,
+    sourceTable: NoteSourceTable = 'user_video_states'
+  ): Promise<{ updatedAt: string }> {
+    return sourceTable === 'user_local_cards'
+      ? this.saveRichNoteToLocalCard(userId, cardId, doc)
+      : this.saveRichNoteToVideoState(userId, cardId, doc);
+  }
+
+  // ---------------------------------------------------------------------------
+  // user_video_states (uvs) — dual-write JSON + plain extract (unchanged)
+  // ---------------------------------------------------------------------------
+
+  private async getRichNoteFromVideoState(userId: string, cardId: string): Promise<RichNoteView> {
     const row = await this.db.userVideoState.findFirst({
       where: { id: cardId, user_id: userId },
       select: {
@@ -130,7 +179,7 @@ export class RichNoteService {
    * Ownership is enforced by checking user_id before the UPDATE so an attacker
    * cannot overwrite another user's note by guessing a card UUID.
    */
-  async saveRichNote(
+  private async saveRichNoteToVideoState(
     userId: string,
     cardId: string,
     doc: TiptapNode
@@ -158,15 +207,94 @@ export class RichNoteService {
       });
       return { updatedAt: updated.updatedAt.toISOString() };
     } catch (err) {
-      if (
-        typeof err === 'object' &&
-        err !== null &&
-        'code' in err &&
-        (err as { code?: string }).code === 'P2025'
-      ) {
+      if (isRowNotFound(err)) {
         throw new RichNoteNotFoundError(`No user_video_state for user=${userId} card=${cardId}`);
       }
-      logger.error('rich-note-service: save failed', { err, userId, cardId, empty });
+      logger.error('rich-note-service: uvs save failed', { err, userId, cardId, empty });
+      throw err;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // user_local_cards (ulc) — plain-text only (no user_note_json column)
+  // ---------------------------------------------------------------------------
+
+  private async getRichNoteFromLocalCard(userId: string, cardId: string): Promise<RichNoteView> {
+    const row = await this.db.user_local_cards.findFirst({
+      where: { id: cardId, user_id: userId },
+      select: {
+        user_note: true,
+        updated_at: true,
+        title: true,
+        metadata_title: true,
+        metadata_image: true,
+        video_id: true,
+        mandala_id: true,
+        cell_index: true,
+      },
+    });
+
+    if (!row) {
+      throw new RichNoteNotFoundError(`No user_local_card for user=${userId} card=${cardId}`);
+    }
+
+    // ulc stores plain text only → any existing note is wrapped (always legacy).
+    const note =
+      row.user_note && row.user_note.length > 0 ? wrapLegacyPlainText(row.user_note) : null;
+
+    return {
+      note,
+      isLegacy: note !== null,
+      updatedAt: row.updated_at ? row.updated_at.toISOString() : null,
+      video: {
+        id: row.video_id ?? cardId,
+        title: row.title ?? row.metadata_title ?? '',
+        channel: null,
+        durationSec: null,
+        thumbnail: row.metadata_image ?? null,
+      },
+      mandalaCell:
+        row.mandala_id && typeof row.cell_index === 'number' && row.cell_index >= 0
+          ? { mandalaId: row.mandala_id, cellIndex: row.cell_index }
+          : null,
+    };
+  }
+
+  /**
+   * Write the plain-text extract to user_local_cards.user_note. ulc has no
+   * user_note_json column, so rich formatting is not persisted (the editor
+   * round-trips as plain text). Empty docs clear the note. updated_at is set
+   * explicitly because ulc.updated_at is `@default(now())` without `@updatedAt`.
+   */
+  private async saveRichNoteToLocalCard(
+    userId: string,
+    cardId: string,
+    doc: TiptapNode
+  ): Promise<{ updatedAt: string }> {
+    const empty = isEmptyDoc(doc);
+    const plainText = empty ? null : extractPlainText(doc);
+
+    const existing = await this.db.user_local_cards.findUnique({
+      where: { id: cardId },
+      select: { user_id: true },
+    });
+    if (!existing || existing.user_id !== userId) {
+      throw new RichNoteNotFoundError(`No user_local_card for user=${userId} card=${cardId}`);
+    }
+
+    try {
+      const now = new Date();
+      const updated = await this.db.user_local_cards.update({
+        where: { id: cardId },
+        data: { user_note: plainText, updated_at: now },
+        select: { updated_at: true },
+      });
+      return { updatedAt: (updated.updated_at ?? now).toISOString() };
+    } catch (err) {
+      if (isRowNotFound(err)) {
+        throw new RichNoteNotFoundError(`No user_local_card for user=${userId} card=${cardId}`);
+      }
+      logger.error('rich-note-service: ulc save failed', { err, userId, cardId, empty });
       throw err;
     }
   }

--- a/tests/unit/modules/rich-note-service.test.ts
+++ b/tests/unit/modules/rich-note-service.test.ts
@@ -6,6 +6,9 @@ import { Prisma } from '@prisma/client';
 const mockFindFirst = jest.fn();
 const mockFindUnique = jest.fn();
 const mockUpdate = jest.fn();
+const mockUlcFindFirst = jest.fn();
+const mockUlcFindUnique = jest.fn();
+const mockUlcUpdate = jest.fn();
 
 jest.mock('../../../src/modules/database', () => ({
   getPrismaClient: () => ({
@@ -13,6 +16,11 @@ jest.mock('../../../src/modules/database', () => ({
       findFirst: mockFindFirst,
       findUnique: mockFindUnique,
       update: mockUpdate,
+    },
+    user_local_cards: {
+      findFirst: mockUlcFindFirst,
+      findUnique: mockUlcFindUnique,
+      update: mockUlcUpdate,
     },
   }),
 }));
@@ -41,6 +49,9 @@ beforeEach(() => {
   mockFindFirst.mockReset();
   mockFindUnique.mockReset();
   mockUpdate.mockReset();
+  mockUlcFindFirst.mockReset();
+  mockUlcFindUnique.mockReset();
+  mockUlcUpdate.mockReset();
 });
 
 describe('RichNoteService.getRichNote', () => {
@@ -157,5 +168,101 @@ describe('RichNoteService.saveRichNote', () => {
     await expect(svc.saveRichNote('u', 'card-x', doc)).rejects.toBeInstanceOf(
       RichNoteNotFoundError
     );
+  });
+});
+
+// CP501 — ulc note routing (the fix). ulc has NO user_note_json column → plain
+// text only; the single service routes by sourceTable.
+describe('RichNoteService — user_local_cards routing', () => {
+  it('getRichNote(ulc) wraps plain user_note + reads ulc-only (never touches uvs)', async () => {
+    mockUlcFindFirst.mockResolvedValue({
+      user_note: 'ulc memo',
+      updated_at: new Date('2026-04-09T02:00:00Z'),
+      title: 'Local Title',
+      metadata_title: null,
+      metadata_image: 'https://thumb',
+      video_id: 'abc12345678',
+      mandala_id: 'mid-9',
+      cell_index: 2,
+    });
+
+    const svc = new RichNoteService();
+    const view = await svc.getRichNote('user-1', 'card-ulc', 'user_local_cards');
+
+    expect(mockUlcFindFirst).toHaveBeenCalledTimes(1);
+    expect(mockFindFirst).not.toHaveBeenCalled(); // uvs path untouched
+    expect(view.isLegacy).toBe(true);
+    expect(view.note).toEqual(wrapLegacyPlainText('ulc memo'));
+    expect(view.updatedAt).toBe('2026-04-09T02:00:00.000Z');
+    expect(view.video.title).toBe('Local Title');
+    expect(view.mandalaCell).toEqual({ mandalaId: 'mid-9', cellIndex: 2 });
+  });
+
+  it('getRichNote(ulc) returns note=null when user_note is null', async () => {
+    mockUlcFindFirst.mockResolvedValue({
+      user_note: null,
+      updated_at: new Date(),
+      title: 'T',
+      metadata_title: null,
+      metadata_image: null,
+      video_id: null,
+      mandala_id: null,
+      cell_index: -1,
+    });
+    const svc = new RichNoteService();
+    const view = await svc.getRichNote('user-1', 'card-ulc', 'user_local_cards');
+    expect(view.note).toBeNull();
+    expect(view.isLegacy).toBe(false);
+  });
+
+  it('getRichNote(ulc) throws RichNoteNotFoundError when row missing', async () => {
+    mockUlcFindFirst.mockResolvedValue(null);
+    const svc = new RichNoteService();
+    await expect(svc.getRichNote('u', 'card-x', 'user_local_cards')).rejects.toBeInstanceOf(
+      RichNoteNotFoundError
+    );
+  });
+
+  it('saveRichNote(ulc) writes plain user_note only (no user_note_json) + sets updated_at', async () => {
+    mockUlcFindUnique.mockResolvedValue({ user_id: 'user-1' });
+    mockUlcUpdate.mockResolvedValue({ updated_at: new Date('2026-04-09T03:00:00Z') });
+    const svc = new RichNoteService();
+    const result = await svc.saveRichNote('user-1', 'card-ulc', doc, 'user_local_cards');
+
+    expect(mockUlcUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).not.toHaveBeenCalled(); // uvs path untouched
+    const call = mockUlcUpdate.mock.calls[0][0];
+    expect(call.where).toEqual({ id: 'card-ulc' });
+    expect(call.data.user_note).toBe('hello');
+    expect('user_note_json' in call.data).toBe(false); // ulc has no such column
+    expect(call.data.updated_at).toBeInstanceOf(Date);
+    expect(result.updatedAt).toBe('2026-04-09T03:00:00.000Z');
+  });
+
+  it('saveRichNote(ulc) clears user_note when doc is empty', async () => {
+    mockUlcFindUnique.mockResolvedValue({ user_id: 'user-1' });
+    mockUlcUpdate.mockResolvedValue({ updated_at: new Date() });
+    const svc = new RichNoteService();
+    const empty: TiptapDoc = { type: 'doc', content: [{ type: 'paragraph' }] };
+    await svc.saveRichNote('user-1', 'card-ulc', empty, 'user_local_cards');
+    expect(mockUlcUpdate.mock.calls[0][0].data.user_note).toBeNull();
+  });
+
+  it('saveRichNote(ulc) enforces ownership (wrong user) without updating', async () => {
+    mockUlcFindUnique.mockResolvedValue({ user_id: 'other' });
+    const svc = new RichNoteService();
+    await expect(svc.saveRichNote('u', 'card-x', doc, 'user_local_cards')).rejects.toBeInstanceOf(
+      RichNoteNotFoundError
+    );
+    expect(mockUlcUpdate).not.toHaveBeenCalled();
+  });
+
+  it('default sourceTable routes to uvs (back-compat)', async () => {
+    mockFindUnique.mockResolvedValue({ user_id: 'user-1' });
+    mockUpdate.mockResolvedValue({ updatedAt: new Date() });
+    const svc = new RichNoteService();
+    await svc.saveRichNote('user-1', 'card-1', doc); // no sourceTable
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUlcUpdate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem
Rich-note read/write (`RichNoteService` / `/rich-notes/:cardId`) were **user_video_states-only**. A `user_local_cards` (ulc) card id 404'd, and the FE swallowed it (`apiClient.saveRichNote(...).catch(() => {})`) → **ulc card notes silently lost** (including for new users — ongoing).

## Fix (code-only, scope = ① (a) only)
- **`rich-note-service.ts`** — single service routes by `sourceTable` (default uvs = back-compat):
  - uvs: dual-write `user_note_json` + `user_note` (unchanged).
  - ulc: write plain extract to `user_note` (ulc has **no** `user_note_json` column → plain only). Ownership-checked.
- **`video-rich-notes.ts`** — GET reads `?source=`, PATCH reads `sourceTable` (zod enum, optional).
- **`api-client.ts`** — `getRichNote`/`saveRichNote` thread `sourceTable`.
- **`RightPanel.tsx`** — pass `currentCard.sourceTable`; **remove the `.catch(() => {})` swallow** → surface save failure via toast.

## Out of scope (roadmap)
- (a)-B: add `ulc.user_note_json` for rich parity on ulc (DDL; realized loss ~13 rows → low priority).
- (b) #911 evaporation: uvs per-mandala re-model (DDL + like/ownership split, ⑦ persona key) — post-launch (overlap 0.12%).
- No DDL/migration. No legacy/bulk write-through (overloaded CLI-enrich `user_note` rows untouched).

## Verification (local, worktree off origin/main)
BE tsc ✅ · BE jest rich-note 16/16 ✅ (incl. 7 new ulc-routing + uvs-unchanged guards) · BE build ✅ · FE tsc ✅ · FE vitest 401/401 ✅ · FE build ✅. (route smoke = env-gated skip)

**Done = prod (James screen):** ulc card → write note → save → reload → persists; uvs no regression; save failure surfaces.

Rollback: revert (sourceTable-unset = uvs = today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)