### PR TITLE
feat(bookindex): mandala_books v2 contract + segment-relevance sidecar schema

### DIFF
--- a/prisma/migrations/bookindex/001_video_mandala_segment_relevance.sql
+++ b/prisma/migrations/bookindex/001_video_mandala_segment_relevance.sql
@@ -1,0 +1,47 @@
+-- Book-index track (feat/bookindex-schema): segment-level relevance sidecar.
+--
+-- Finer-grain SIBLING of the existing `video_mandala_relevance` table
+-- (PK (video_id, mandala_id), whole-video score). This table stores the
+-- per-time-segment relevance that slidegen's relevance gate consumes to
+-- narrow a video to its on-goal time ranges before rendering snapshots.
+--
+-- Keyed by (video_id, mandala_id, segment_idx): mandala-scoped, so it is
+-- leak-safe by the same invariant as video_mandala_relevance — a mandala is
+-- single-user-owned, and each mandala carries its own centerGoal, so the
+-- same video segment legitimately scores differently per mandala without one
+-- user's score bleeding onto another (contrast video_rich_summaries.segments[]
+-- .relevance_pct, which is keyed by video_id alone = cross-user shared).
+--
+-- segment_idx mirrors rich_summary segments.sections[] index, BUT that index
+-- is NOT stable across rich-summary regeneration: sections are LLM-emitted and
+-- the section count/boundaries adapt per run (rich-summary-v2-prompt.ts:270).
+-- from_sec/to_sec are transcript-anchored ground truth (prompt:278) and travel
+-- as the stable anchor for re-matching after regeneration. computed_at lets a
+-- consumer detect staleness vs video_rich_summaries.updated_at (invalidation
+-- policy lives in the fill job track, not this schema).
+--
+-- Apply order (mirrors prisma/migrations/book-poc/001_add_table.sql):
+--   1. Local: psql "$DATABASE_URL" -f prisma/migrations/bookindex/001_video_mandala_segment_relevance.sql
+--   2. Local: prisma db push --skip-generate (sync Prisma)
+--   3. Local: psql "$DATABASE_URL" -c "NOTIFY pgrst, 'reload schema'"
+--   4. Prod: deploy.yml CI runs prisma db push (LEVEL-3 silent-fail risk)
+--   5. Prod: apply-custom-sql.sh re-applies this raw DDL (defensive; allowlisted)
+--   6. Prod: Supabase Dashboard -> Settings -> API -> "Reload schema"
+
+CREATE TABLE IF NOT EXISTS video_mandala_segment_relevance (
+  video_id      VARCHAR(11) NOT NULL,
+  mandala_id    UUID        NOT NULL REFERENCES user_mandalas(id) ON DELETE CASCADE,
+  segment_idx   INTEGER     NOT NULL,
+  from_sec      INTEGER     NOT NULL,
+  to_sec        INTEGER     NOT NULL,
+  relevance_pct INTEGER     NOT NULL,
+  computed_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (video_id, mandala_id, segment_idx),
+  CONSTRAINT chk_vmsr_relevance_pct CHECK (relevance_pct BETWEEN 0 AND 100),
+  CONSTRAINT chk_vmsr_sec_order CHECK (to_sec >= from_sec)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vmsr_mandala
+  ON video_mandala_segment_relevance(mandala_id, video_id);
+
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -448,6 +448,7 @@ model user_mandalas {
   users           users                     @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
   levels          user_mandala_levels[]
   videoRelevance  video_mandala_relevance[]
+  segmentRelevance video_mandala_segment_relevance[]
   videoStates     UserVideoState[]
   localCards      user_local_cards[]
   subscriptions   mandala_subscriptions[]
@@ -2292,5 +2293,28 @@ model video_mandala_relevance {
 
   @@id([video_id, mandala_id])
   @@index([mandala_id], map: "idx_vmr_mandala")
+  @@schema("public")
+}
+
+/// Segment-level relevance (book-index track). Finer-grain sibling of
+/// video_mandala_relevance: one row per (video_id, mandala_id, segment_idx)
+/// where segment_idx mirrors rich_summary segments.sections[]. mandala-keyed
+/// = leak-safe (a mandala is single-user-owned; same segment scores per its
+/// own centerGoal). slidegen's relevance gate reads this to narrow a video to
+/// its on-goal time ranges. from_sec/to_sec are the stable transcript-anchored
+/// re-match anchor (sections[] index drifts across rich-summary regeneration);
+/// computed_at flags staleness vs video_rich_summaries.updated_at.
+model video_mandala_segment_relevance {
+  video_id      String        @db.VarChar(11)
+  mandala_id    String        @db.Uuid
+  segment_idx   Int
+  from_sec      Int
+  to_sec        Int
+  relevance_pct Int
+  computed_at   DateTime      @default(now()) @db.Timestamptz(6)
+  mandala       user_mandalas @relation(fields: [mandala_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@id([video_id, mandala_id, segment_idx])
+  @@index([mandala_id, video_id], map: "idx_vmsr_mandala")
   @@schema("public")
 }

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -91,6 +91,10 @@ APPLY_FILES=(
   # Both ADD COLUMN/CREATE TABLE IF NOT EXISTS — idempotent.
   "prisma/migrations/score-pipeline/001_add_user_mandalas_volatility.sql"
   "prisma/migrations/score-pipeline/002_video_mandala_relevance.sql"
+  # Book-index track — segment-level relevance sidecar of video_mandala_relevance
+  # (PK video_id+mandala_id+segment_idx). CREATE TABLE IF NOT EXISTS + CHECK
+  # constraints — idempotent. Inert until the slidegen gate / fill job consume it.
+  "prisma/migrations/bookindex/001_video_mandala_segment_relevance.sql"
   # CP466 — Add Cards Phase 1 (surfacing). `surfaced_at` column + partial
   # index on user_video_states for Layer 1 Coverage dedup. ADD COLUMN IF
   # NOT EXISTS / CREATE INDEX IF NOT EXISTS — idempotent.

--- a/src/modules/mandala-book/book-schema.ts
+++ b/src/modules/mandala-book/book-schema.ts
@@ -1,0 +1,100 @@
+// Book-index (mandala_books.book_json) v2 contract.
+//
+// SSOT for the per-mandala distilled book index. The book stays a JSONB blob
+// on mandala_books.book_json (normalization deferred — prod legacy is 1 row,
+// 4 consumers read the blob whole). This zod schema is the shape the auto-fill
+// (살붙임) job MUST emit and the validator a write path SHOULD run before upsert.
+//
+// Granularity note: book sections are THEMATIC (chapter -> section -> atoms),
+// distinct from video_rich_summaries.segments.sections which are time-ranges.
+// Book atoms carry {vid, ts} back-links to video timestamps; an optional
+// seg_ref ties an atom to the rich-summary time-segment it was distilled from.
+
+import { z } from 'zod';
+
+const YT_ID = z.string().min(1).max(11);
+
+/** Atom = one standalone insight, linked to a source video timestamp. */
+export const bookAtomSchema = z.object({
+  vid: YT_ID,
+  ts: z.number().int().min(0),
+  text: z.string(),
+  // Optional — unused in current prod data (0/98 rows); kept for generator freedom.
+  type: z.string().optional(),
+  // Optional back-link to the rich_summary time-segment this atom came from.
+  // Travels by time coords because rich_summary sections[] index is unstable
+  // across regeneration (see video_mandala_segment_relevance migration).
+  seg_ref: z
+    .object({ from_sec: z.number().int().min(0), to_sec: z.number().int().min(0) })
+    .optional(),
+});
+
+const bookQaSchema = z.object({ q: z.string(), a: z.string() });
+
+/** Fork D placeholders — reserved fields, fill job not implemented (v1 scope = skeleton + body only). */
+const provenanceSchema = z
+  .object({
+    video_ids: z.array(YT_ID).default([]),
+    rich_summary_versions: z.array(z.string()).default([]),
+  })
+  .nullish();
+
+const verificationSchema = z
+  .object({
+    status: z.enum(['unverified', 'verified', 'flagged']).default('unverified'),
+    notes: z.string().optional(),
+  })
+  .nullish();
+
+export const bookSectionSchema = z.object({
+  title: z.string(),
+  narrative: z.string(), // 살붙임 body assembled from v2 analysis + segments
+  atoms: z.array(bookAtomSchema).default([]),
+  qa: z.array(bookQaSchema).default([]),
+  provenance: provenanceSchema, // Fork D placeholder
+  verification: verificationSchema, // Fork D placeholder
+});
+
+export const bookChapterSchema = z.object({
+  ch: z.number().int(),
+  title: z.string(),
+  intro: z.string(),
+  sections: z.array(bookSectionSchema),
+});
+
+export const bookJsonSchema = z.object({
+  // NEW in v2 — drives validation + future migration. Existing PoC rows (no
+  // schema_version) are treated as legacy v1 by callers before this validator.
+  schema_version: z.literal(2),
+  mandala_id: z.string().uuid(),
+  mandala_title: z.string(),
+  generated_at: z.string(),
+  // source_videos = count of source videos distilled into this book.
+  source_videos: z.number().int().min(0),
+  // source_atoms = total INPUT atom pool harvested from those videos' v2
+  // summaries — NOT the count of atoms included in the book (curated subset
+  // is smaller; observed prod row: 213 input vs 98 included).
+  source_atoms: z.number().int().min(0),
+  estimated_pages: z.number().int().min(0).optional(),
+  stats: z.record(z.unknown()).optional(),
+  // Fork D placeholder — book-level completeness, fill job not implemented.
+  completeness: z.object({ status: z.string(), checked_at: z.string() }).nullish(),
+  chapters: z.array(bookChapterSchema),
+});
+
+/** Pre-parse input shape (defaults + Fork-D placeholders optional) — for fixtures/generators. */
+export type BookJsonInput = z.input<typeof bookJsonSchema>;
+export type BookAtom = z.infer<typeof bookAtomSchema>;
+export type BookSection = z.infer<typeof bookSectionSchema>;
+export type BookChapter = z.infer<typeof bookChapterSchema>;
+export type BookJson = z.infer<typeof bookJsonSchema>;
+
+/** Throws ZodError on shape violation — call before upserting a generated book. */
+export function parseBookJson(input: unknown): BookJson {
+  return bookJsonSchema.parse(input);
+}
+
+/** Non-throwing variant for read paths that must tolerate legacy/partial rows. */
+export function safeParseBookJson(input: unknown): z.SafeParseReturnType<unknown, BookJson> {
+  return bookJsonSchema.safeParse(input);
+}

--- a/tests/unit/modules/book-schema.test.ts
+++ b/tests/unit/modules/book-schema.test.ts
@@ -1,0 +1,163 @@
+/**
+ * book-schema — mandala_books.book_json v2 contract validation.
+ *
+ * Pins the shape the 살붙임 (auto-fill) job must emit, grounded in the observed
+ * prod row (mandala 72d5…173ef: 8 chapters / 23 sections / 98 atoms, every
+ * section has {title, narrative, atoms, qa}, every atom {vid, ts, text}):
+ *   - well-formed v2 book parses
+ *   - schema_version must be literal 2
+ *   - relevance/Fork-D fields are optional (current data omits them)
+ *   - atom.type optional (prod 0/98), seg_ref optional time anchor
+ *   - source_atoms (input pool) may exceed atoms actually in the book
+ *   - structural violations throw
+ */
+
+import {
+  parseBookJson,
+  safeParseBookJson,
+  bookJsonSchema,
+  type BookJson,
+  type BookJsonInput,
+  type BookSection,
+} from '../../../src/modules/mandala-book/book-schema';
+
+const validBook = (): BookJsonInput => ({
+  schema_version: 2 as const,
+  mandala_id: '72d5fe52-2f35-4a9e-8ef6-cd21629173ef',
+  mandala_title: '영어 회화',
+  generated_at: '2026-06-21T00:00:00.000Z',
+  source_videos: 26,
+  source_atoms: 213, // input pool — larger than atoms included below
+  chapters: [
+    {
+      ch: 1,
+      title: 'Chapter 1',
+      intro: 'intro text',
+      sections: [
+        {
+          title: 'Section 1',
+          narrative: '영어 회화의 80%는 고정된 슬롯에…',
+          atoms: [
+            { vid: 'dQw4w9WgXcQ', ts: 120, text: 'atom text' },
+            { vid: 'dQw4w9WgXcQ', ts: 240, text: 'atom 2', type: 'tip' },
+          ],
+          qa: [{ q: 'q?', a: 'a.' }],
+        },
+      ],
+    },
+  ],
+});
+
+/** First section of the first chapter — keeps assertions readable under strict indexing. */
+const firstSection = (b: BookJson): BookSection => b.chapters[0]!.sections[0]!;
+
+describe('book-schema v2 contract', () => {
+  it('parses a well-formed v2 book', () => {
+    const book = parseBookJson(validBook());
+    expect(book.chapters).toHaveLength(1);
+    expect(firstSection(book).atoms).toHaveLength(2);
+  });
+
+  it('defaults optional section arrays (atoms/qa) to empty', () => {
+    const b = validBook();
+    delete (b.chapters[0]!.sections[0] as { qa?: unknown }).qa;
+    const parsed = parseBookJson(b);
+    expect(firstSection(parsed).qa).toEqual([]);
+  });
+
+  it('rejects a non-2 schema_version', () => {
+    const b = { ...validBook(), schema_version: 1 };
+    expect(() => parseBookJson(b)).toThrow();
+    expect(safeParseBookJson(b).success).toBe(false);
+  });
+
+  it('accepts source_atoms (input pool) larger than included atoms', () => {
+    const b = validBook();
+    b.source_atoms = 213; // pool
+    expect(parseBookJson(b).source_atoms).toBe(213);
+  });
+
+  it('keeps atom.type and seg_ref optional', () => {
+    const base = validBook();
+    const book = {
+      ...base,
+      chapters: [
+        {
+          ...base.chapters[0]!,
+          sections: [
+            {
+              ...base.chapters[0]!.sections[0]!,
+              atoms: [
+                {
+                  vid: 'dQw4w9WgXcQ',
+                  ts: 30,
+                  text: 'no type',
+                  seg_ref: { from_sec: 0, to_sec: 120 },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const parsed = parseBookJson(book);
+    const atom = firstSection(parsed).atoms[0]!;
+    expect(atom.seg_ref).toEqual({ from_sec: 0, to_sec: 120 });
+    expect(atom.type).toBeUndefined();
+  });
+
+  it('accepts Fork-D placeholders as null/absent (fill job not implemented)', () => {
+    const base = validBook();
+    const book = {
+      ...base,
+      completeness: null,
+      chapters: [
+        {
+          ...base.chapters[0]!,
+          sections: [{ ...base.chapters[0]!.sections[0]!, provenance: null, verification: null }],
+        },
+      ],
+    };
+    expect(safeParseBookJson(book).success).toBe(true);
+  });
+
+  it('parses a populated Fork-D verification block when present', () => {
+    const base = validBook();
+    const book = {
+      ...base,
+      chapters: [
+        {
+          ...base.chapters[0]!,
+          sections: [
+            {
+              ...base.chapters[0]!.sections[0]!,
+              verification: { status: 'unverified', notes: 'pending' },
+            },
+          ],
+        },
+      ],
+    };
+    const parsed = parseBookJson(book);
+    expect(firstSection(parsed).verification?.status).toBe('unverified');
+  });
+
+  it('rejects a missing required field (mandala_id)', () => {
+    const { mandala_id, ...withoutMandalaId } = validBook();
+    void mandala_id;
+    expect(() => parseBookJson(withoutMandalaId)).toThrow();
+  });
+
+  it('rejects an atom without a video id', () => {
+    const base = validBook();
+    const book = {
+      ...base,
+      chapters: [
+        {
+          ...base.chapters[0]!,
+          sections: [{ ...base.chapters[0]!.sections[0]!, atoms: [{ ts: 1, text: 'x' } as never] }],
+        },
+      ],
+    };
+    expect(bookJsonSchema.safeParse(book).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Schema-only foundation for the **book-index (북인덱스)** track — the per-mandala distilled SSOT that slidegen/docx/newsletter fan out from. **No consumers yet; both artifacts are inert** until the fill (살붙임) job and slidegen relevance gate land.

Decision: **extend `mandala_books`** (per-mandala book index already exists as a PoC blob), not a new book table — confirmed with James.

## Changes

1. **`video_mandala_segment_relevance`** (new table + Prisma model) — finer-grain **sibling** of the existing `video_mandala_relevance` (whole-video, PK `(video_id, mandala_id)`). Keyed `(video_id, mandala_id, segment_idx)`.
   - **mandala-keyed = leak-safe**: a mandala is single-user-owned and carries its own `centerGoal`, so the same video segment legitimately scores differently per mandala — unlike the video-global `video_rich_summaries.segments[].relevance_pct` (same leak class as `mandala_relevance_pct`). This mirrors how A-stage card relevance avoided cross-user leak, but keyed by mandala (not user) because the book is per-mandala.
   - `from_sec/to_sec` travel as the **stable transcript-anchored re-match anchor**: verified in `rich-summary-v2-prompt.ts:270/278` + `-v2-generator.ts:275` that `segments.sections[]` is LLM-emitted and its array index/boundaries drift across regeneration, while `from_sec/to_sec` are transcript ground-truth. `computed_at` flags staleness vs `video_rich_summaries.updated_at`.
2. **`src/modules/mandala-book/book-schema.ts`** — zod v2 contract for `mandala_books.book_json`. Blob kept (normalization deferred: prod legacy = **1 row**, 4 consumers read the blob whole). `schema_version=2` + **Fork-D nullable placeholders** (`completeness` / `provenance` / `verification`) reserved — fill job NOT built (v1 scope = skeleton + body only). `source_atoms` documented as input pool (observed prod **213**) vs atoms actually included in the book (**98**).
3. **`apply-custom-sql.sh` allowlist** — DDL force-tracked + registered (CP499+ LEVEL-3 rule: a `schema.prisma` model addition ships its idempotent `CREATE TABLE IF NOT EXISTS` DDL in the **same PR** so deploy can't silent-fail the table while the Prisma client gains the model).

## Safety

- New model has **no query consumer** → no findMany 500 risk (CP499+ incident pattern N/A). Back-relation on `user_mandalas` is a virtual Prisma field (not a default-selected column).
- DDL idempotent (`IF NOT EXISTS` + CHECK constraints). Applies local+prod via the allowlist on deploy.

## Verification

`prisma validate` ✓ · eslint clean ✓ · **jest 9/9** (`book-schema.test.ts` contract cases) ✓. BE-only (no `frontend/` changes).

## Grounding

All field names verified against current code (handoff was web-authored, not code-grounded): `note_documents` is per-(user,mandala); v2 payload keys (`from_sec/to_sec`, `atoms[].timestamp_sec`) confirmed in `rich-summary-v2-prompt.ts`; `video_mandala_relevance` discovered as the existing mandala-keyed sibling.