### PR TITLE
feat(bookindex): auto-fill job — assemble mandala_books from v2 summaries (§2-D #1)

### DIFF
--- a/src/api/routes/admin/index.ts
+++ b/src/api/routes/admin/index.ts
@@ -26,6 +26,7 @@ import { adminV2QualityAuditRoutes } from './v2-quality-audit';
 import { adminV4ArbiterRunsRoutes } from './v4-arbiter-runs';
 import { adminPoolHealthRoutes } from './pool-health';
 import { adminRelevanceBackfillRoutes } from './relevance-backfill';
+import { adminMandalaBookFillRoutes } from './mandala-book-fill';
 import { adminPoolServeRoutes } from './pool-serve';
 
 /**
@@ -72,6 +73,8 @@ export async function adminRoutes(fastify: FastifyInstance) {
   // CP498 PR3b — A-stage relevance backfill manual trigger (1-mandala
   // measurement surface; bypasses BACKFILL_RELEVANCE_ENABLED + cutoff).
   await fastify.register(adminRelevanceBackfillRoutes, { prefix: '/relevance-backfill' });
+  // §2-D #1 — book-index fill (assemble mandala_books from v2 summaries).
+  await fastify.register(adminMandalaBookFillRoutes, { prefix: '/mandala-book-fill' });
   // CP499+ — pool-serve canary trigger (deficit-cell fill, flag bypassed).
   await fastify.register(adminPoolServeRoutes, { prefix: '/pool-serve' });
   // await fastify.register(stripeWebhookRoutes, { prefix: '/webhooks/stripe' });

--- a/src/api/routes/admin/mandala-book-fill.ts
+++ b/src/api/routes/admin/mandala-book-fill.ts
@@ -1,0 +1,41 @@
+/**
+ * Admin Mandala Book Fill route (§2-D #1).
+ *
+ * Manual entrypoint to (re)generate one mandala's book_json from its placed
+ * videos' v2 summaries. Mirrors relevance-backfill: admin-guarded, single
+ * mandala, enqueues a durable pg-boss job (the '...' menu / async '준비중' UX
+ * button is wired separately in §2-D — this is the enqueue contract).
+ *
+ *   POST /api/v1/admin/mandala-book-fill/run   body { userId, mandalaId }
+ */
+
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+import { createSuccessResponse } from '../../schemas/common.schema';
+import { enqueueMandalaBookFill } from '@/modules/queue/handlers/mandala-book-fill';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'AdminMandalaBookFill' });
+
+const RunBodySchema = z.object({
+  userId: z.string().uuid(),
+  mandalaId: z.string().uuid(),
+});
+
+export async function adminMandalaBookFillRoutes(fastify: FastifyInstance) {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  /**
+   * POST /api/v1/admin/mandala-book-fill/run
+   * Enqueue a book-fill job for the target mandala. Returns the job id.
+   */
+  fastify.post('/run', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
+    const { userId, mandalaId } = RunBodySchema.parse(request.body ?? {});
+
+    const jobId = await enqueueMandalaBookFill({ userId, mandalaId, trigger: 'admin' });
+
+    log.info('admin mandala book fill enqueued', { userId, mandalaId, jobId });
+    return reply.send(createSuccessResponse({ enqueued: jobId != null, jobId }));
+  });
+}

--- a/src/modules/mandala-book/build-book.ts
+++ b/src/modules/mandala-book/build-book.ts
@@ -1,0 +1,154 @@
+// Mandala book assembly — PURE, mechanical, NO LLM, NO DB.
+//
+// Distills already-generated v2 rich summaries into a mandala_books book_json.
+// Every value here is a copy or string-concat of existing v2 fields — there is
+// ZERO model inference in this module (no Anthropic/OpenRouter/Gemini import,
+// no generation). The LLM work already happened when the v2 summaries were
+// produced; this is assembly only. Interpolation is forbidden (hard rule):
+// missing inputs are SKIPPED, never synthesized.
+//
+// Skeleton = mandala cells (§2-B decision 1): one chapter per cell (subject),
+// one section per placed video that has a usable v2 summary. Honest skip:
+// a cell with no usable videos yields an empty chapter (sections: []), a video
+// atom without a timestamp yields no book atom (book atom.ts is required).
+
+import type { BookJsonInput } from './book-schema';
+import type {
+  RichSummaryAnalysis,
+  RichSummarySegments,
+  RichSummaryLora,
+} from '@/modules/skills/rich-summary-v2-prompt';
+
+/** One placed video's already-parsed v2 columns (DB-fetched upstream). */
+export interface CellVideoV2 {
+  videoId: string; // 11-char YouTube id
+  title: string;
+  analysis: RichSummaryAnalysis | null;
+  segments: RichSummarySegments | null;
+  lora: RichSummaryLora | null;
+}
+
+/** One mandala cell + its usable-v2 videos (videos already filtered upstream). */
+export interface CellInput {
+  cellIndex: number; // 0..N-1, becomes chapter.ch
+  title: string; // subject label / sub-goal, becomes chapter.title
+  videos: CellVideoV2[];
+}
+
+export interface BuildBookInput {
+  mandalaId: string;
+  mandalaTitle: string;
+  generatedAt: string; // ISO — passed in (pure fn stays deterministic/testable)
+  cells: CellInput[];
+}
+
+export interface BuildBookResult {
+  book: BookJsonInput;
+  /** Videos actually placed into the book (= sections produced). */
+  sourceVideos: number;
+  /**
+   * Total v2 atoms harvested from adopted videos BEFORE curation — the input
+   * pool. Asymmetric with atoms actually in the book: atoms lacking a
+   * timestamp_sec are counted here but skipped from the book (no interpolation),
+   * so source_atoms >= included atoms (matches the observed 213 input vs 98
+   * included). Kept distinct on purpose — see book-schema.ts source_atoms doc.
+   */
+  sourceAtoms: number;
+}
+
+/** Find the v2 segment window [from_sec, to_sec] that contains timestamp `t`. */
+function segRefForTimestamp(
+  segments: RichSummarySegments,
+  t: number
+): { from_sec: number; to_sec: number } | undefined {
+  const sections = segments.sections ?? [];
+  for (const s of sections) {
+    if (
+      typeof s.from_sec === 'number' &&
+      typeof s.to_sec === 'number' &&
+      t >= s.from_sec &&
+      t <= s.to_sec
+    ) {
+      return { from_sec: s.from_sec, to_sec: s.to_sec };
+    }
+  }
+  return undefined; // no containing window — omit seg_ref (optional), do not guess
+}
+
+/** Build a section's narrative by concatenating existing v2 text. NO generation. */
+function assembleNarrative(video: CellVideoV2): string {
+  const parts: string[] = [];
+  const core = video.analysis?.core_argument;
+  if (core && core.trim()) parts.push(core.trim());
+  for (const s of video.segments?.sections ?? []) {
+    if (s.summary && s.summary.trim()) parts.push(s.summary.trim());
+  }
+  return parts.join('\n\n'); // string join only — empty string is valid (schema allows "")
+}
+
+/**
+ * Assemble book_json from mandala cells + their v2 summaries. Pure: same input
+ * → same output. Returns the book plus the two source counters.
+ */
+export function buildBookJson(input: BuildBookInput): BuildBookResult {
+  let sourceVideos = 0;
+  let sourceAtoms = 0;
+
+  const chapters = input.cells.map((cell) => {
+    const sections = cell.videos.map((video) => {
+      sourceVideos += 1;
+
+      const segments = video.segments;
+      const rawAtoms = segments?.atoms ?? [];
+      sourceAtoms += rawAtoms.length; // input pool: every harvested atom counts
+
+      // Book atoms = v2 atoms that have a real timestamp. Atoms without one are
+      // skipped (book atom.ts is required; no interpolation of fake timestamps).
+      const atoms = rawAtoms
+        .filter((a) => typeof a.timestamp_sec === 'number')
+        .map((a) => {
+          const ts = a.timestamp_sec as number;
+          const seg_ref = segments ? segRefForTimestamp(segments, ts) : undefined;
+          return {
+            vid: video.videoId,
+            ts,
+            text: a.text,
+            ...(a.type ? { type: a.type } : {}),
+            ...(seg_ref ? { seg_ref } : {}),
+          };
+        });
+
+      // qa: v2 lora.qa_pairs are all context='video' (rich-summary-v2-prompt.ts
+      // :268); map them as-is to the book's {q, a} shape. No context filter
+      // (the handoff's 'mandala_cell' filter would drop every row — corrected
+      // against code).
+      const qa = (video.lora?.qa_pairs ?? []).map((p) => ({ q: p.q, a: p.a }));
+
+      return {
+        title: video.title,
+        narrative: assembleNarrative(video),
+        atoms,
+        qa,
+      };
+    });
+
+    return {
+      ch: cell.cellIndex,
+      title: cell.title,
+      intro: '', // skeleton intro reserved; not synthesized (no LLM)
+      sections, // empty array when the cell had no usable-v2 videos (honest skip)
+    };
+  });
+
+  const book: BookJsonInput = {
+    schema_version: 2,
+    mandala_id: input.mandalaId,
+    mandala_title: input.mandalaTitle,
+    generated_at: input.generatedAt,
+    source_videos: sourceVideos,
+    source_atoms: sourceAtoms,
+    chapters,
+  };
+
+  return { book, sourceVideos, sourceAtoms };
+}

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -1,0 +1,201 @@
+// Mandala book fill orchestrator (§2-D #1).
+//
+// Reads a mandala's placed videos + their v2 rich summaries from the DB, hands
+// them to the PURE buildBookJson assembler (no LLM there), validates the result
+// against the v2 contract, and upserts mandala_books with a version bump.
+//
+// This module does the DB I/O; build-book.ts does the (LLM-free) assembly. The
+// validator (parseBookJson) is a HARD gate: on any shape violation we log and
+// abort — never a partial upsert.
+
+import { getPrismaClient } from '@/modules/database/client';
+import { getMandalaManager } from '@/modules/mandala/manager';
+import { logger } from '@/utils/logger';
+import { buildBookJson, type CellInput, type CellVideoV2 } from './build-book';
+import { parseBookJson } from './book-schema';
+import type {
+  RichSummaryAnalysis,
+  RichSummarySegments,
+  RichSummaryLora,
+} from '@/modules/skills/rich-summary-v2-prompt';
+
+const log = logger.child({ module: 'mandala-book/fill-book' });
+
+export interface FillBookResult {
+  ok: boolean;
+  action: 'filled' | 'skipped-no-mandala' | 'skipped-no-videos' | 'failed';
+  mandalaId: string;
+  sourceVideos?: number;
+  sourceAtoms?: number;
+  chapters?: number;
+  version?: number;
+  reason?: string;
+}
+
+interface Placement {
+  cellIndex: number;
+  videoId: string; // 11-char YouTube id
+  title: string;
+}
+
+interface V2Columns {
+  analysis: RichSummaryAnalysis | null;
+  segments: RichSummarySegments | null;
+  lora: RichSummaryLora | null;
+}
+
+/**
+ * Build (or rebuild) a mandala's book from its placed videos' v2 summaries.
+ * Idempotent: a re-run overwrites book_json and bumps version.
+ */
+export async function fillMandalaBook(params: {
+  userId: string;
+  mandalaId: string;
+  trigger?: string;
+}): Promise<FillBookResult> {
+  const { userId, mandalaId } = params;
+  const prisma = getPrismaClient();
+
+  const mandala = await getMandalaManager().getMandalaById(userId, mandalaId);
+  if (!mandala) {
+    return { ok: false, action: 'skipped-no-mandala', mandalaId, reason: 'mandala not found' };
+  }
+
+  const root = mandala.levels[0];
+  const subjects = root?.subjects ?? [];
+  const subjectLabels = root?.subjectLabels ?? [];
+
+  // 1. Enumerate placed videos per cell across both user-scoped tables.
+  const [videoStates, localCards] = await Promise.all([
+    prisma.userVideoState.findMany({
+      where: { user_id: userId, mandala_id: mandalaId, cell_index: { gte: 0 } },
+      select: { cell_index: true, video: { select: { youtube_video_id: true, title: true } } },
+    }),
+    prisma.user_local_cards.findMany({
+      where: { user_id: userId, mandala_id: mandalaId, cell_index: { gte: 0 } },
+      select: { cell_index: true, video_id: true, title: true, metadata_title: true },
+    }),
+  ]);
+
+  const placements: Placement[] = [];
+  for (const r of videoStates) {
+    const vid = r.video?.youtube_video_id;
+    if (!vid || r.cell_index == null) continue;
+    placements.push({ cellIndex: r.cell_index, videoId: vid, title: r.video?.title ?? vid });
+  }
+  for (const r of localCards) {
+    // Non-YouTube manual cards have no video_id → no v2 → honest skip.
+    if (!r.video_id || r.cell_index == null) continue;
+    placements.push({
+      cellIndex: r.cell_index,
+      videoId: r.video_id,
+      title: r.title ?? r.metadata_title ?? r.video_id,
+    });
+  }
+
+  if (placements.length === 0) {
+    return { ok: false, action: 'skipped-no-videos', mandalaId, reason: 'no placed videos' };
+  }
+
+  // 2. Fetch v2 summaries; keep only rows with a usable (non-null) segments blob.
+  const videoIds = Array.from(new Set(placements.map((p) => p.videoId)));
+  const v2Rows = await prisma.video_rich_summaries.findMany({
+    where: { video_id: { in: videoIds }, template_version: 'v2' },
+    select: { video_id: true, analysis: true, segments: true, lora: true },
+  });
+
+  const v2ByVideo = new Map<string, V2Columns>();
+  for (const row of v2Rows) {
+    if (row.segments == null) continue; // no time-segments → not a usable 살붙임 source
+    v2ByVideo.set(row.video_id, {
+      analysis: (row.analysis ?? null) as RichSummaryAnalysis | null,
+      segments: (row.segments ?? null) as unknown as RichSummarySegments | null,
+      lora: (row.lora ?? null) as RichSummaryLora | null,
+    });
+  }
+
+  // 3. Group into cells. One chapter per cell (skeleton = mandala cells). A cell
+  // with no usable-v2 videos yields an empty chapter (honest skip, not dropped).
+  const numCells =
+    subjects.length > 0 ? subjects.length : Math.max(0, ...placements.map((p) => p.cellIndex)) + 1;
+
+  const cells: CellInput[] = [];
+  for (let i = 0; i < numCells; i++) {
+    const title = subjectLabels[i] || subjects[i] || `Cell ${i + 1}`;
+    const videos: CellVideoV2[] = [];
+    const seen = new Set<string>();
+    for (const p of placements) {
+      if (p.cellIndex !== i) continue;
+      const v2 = v2ByVideo.get(p.videoId);
+      if (!v2) continue; // no usable v2 → honest skip
+      if (seen.has(p.videoId)) continue; // dedup a video within one cell
+      seen.add(p.videoId);
+      videos.push({
+        videoId: p.videoId,
+        title: p.title,
+        analysis: v2.analysis,
+        segments: v2.segments,
+        lora: v2.lora,
+      });
+    }
+    cells.push({ cellIndex: i, title, videos });
+  }
+
+  // 4. Assemble (pure, LLM-free) + validate (hard gate).
+  const generatedAt = new Date().toISOString();
+  const { book, sourceVideos, sourceAtoms } = buildBookJson({
+    mandalaId,
+    mandalaTitle: mandala.title ?? '',
+    generatedAt,
+    cells,
+  });
+
+  let validated;
+  try {
+    validated = parseBookJson(book);
+  } catch (err) {
+    log.error('book failed schema validation — aborting upsert (no partial write)', {
+      mandalaId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { ok: false, action: 'failed', mandalaId, reason: 'schema validation failed' };
+  }
+
+  // 5. Upsert with version bump. Raw SQL — the mandala_books Prisma model may
+  // lag client regen on some deploys (same reason GET /:id/book uses raw SQL).
+  const rows = await prisma.$queryRawUnsafe<Array<{ version: number }>>(
+    `INSERT INTO mandala_books
+       (mandala_id, book_json, version, source_videos, source_atoms, generated_at, updated_at)
+     VALUES ($1::uuid, $2::jsonb, 1, $3, $4, NOW(), NOW())
+     ON CONFLICT (mandala_id) DO UPDATE SET
+       book_json     = EXCLUDED.book_json,
+       source_videos = EXCLUDED.source_videos,
+       source_atoms  = EXCLUDED.source_atoms,
+       version       = mandala_books.version + 1,
+       updated_at    = NOW()
+     RETURNING version`,
+    mandalaId,
+    JSON.stringify(validated),
+    sourceVideos,
+    sourceAtoms
+  );
+
+  const version = rows[0]?.version ?? 1;
+  log.info('mandala book filled', {
+    mandalaId,
+    sourceVideos,
+    sourceAtoms,
+    chapters: cells.length,
+    version,
+    trigger: params.trigger,
+  });
+  return {
+    ok: true,
+    action: 'filled',
+    mandalaId,
+    sourceVideos,
+    sourceAtoms,
+    chapters: cells.length,
+    version,
+  };
+}

--- a/src/modules/queue/handlers/mandala-book-fill.ts
+++ b/src/modules/queue/handlers/mandala-book-fill.ts
@@ -1,0 +1,69 @@
+/**
+ * Mandala book-fill worker (§2-D #1).
+ *
+ * Durable lane for assembling a mandala's book_json from its placed videos' v2
+ * rich summaries. The assembly is LLM-free (build-book.ts is pure string
+ * concat); this worker just provides persistence + retries so a triggered fill
+ * survives restarts and transient DB errors.
+ *
+ * Concurrency via richSummaryWorkOptions(N) — teamSize:N + teamRefill so the
+ * configured concurrency is NOT inert (CP498 teamSize:1 serial trap).
+ */
+
+import PgBoss from 'pg-boss';
+import { logger } from '@/utils/logger';
+import { getJobQueue } from '../manager';
+import { JOB_NAMES, MANDALA_BOOK_FILL_OPTIONS, type MandalaBookFillPayload } from '../types';
+import { richSummaryWorkOptions } from './rich-summary-work-options';
+
+const log = logger.child({ module: 'queue/mandala-book-fill' });
+
+// Low volume (one job per manual trigger), but use the trap-proof option shape
+// so raising this later actually parallelizes. Named constant — no magic number.
+const BOOK_FILL_CONCURRENCY = 2;
+
+export async function registerMandalaBookFillWorker(): Promise<void> {
+  const boss = getJobQueue().getInstance();
+  await boss.work<MandalaBookFillPayload>(
+    JOB_NAMES.MANDALA_BOOK_FILL,
+    richSummaryWorkOptions(BOOK_FILL_CONCURRENCY),
+    handleMandalaBookFill
+  );
+  log.info('mandala-book-fill worker registered', { concurrency: BOOK_FILL_CONCURRENCY });
+}
+
+export async function handleMandalaBookFill(
+  job: PgBoss.Job<MandalaBookFillPayload>
+): Promise<void> {
+  const { userId, mandalaId, trigger } = job.data ?? ({} as MandalaBookFillPayload);
+  if (!userId || !mandalaId) {
+    // Malformed payload — retrying cannot fix it; complete without throwing.
+    log.warn('mandala-book-fill: missing userId/mandalaId, dropping', { jobId: job.id });
+    return;
+  }
+
+  // Lazy import keeps the queue boot path free of the assembler import chain.
+  const { fillMandalaBook } = await import('@/modules/mandala-book/fill-book');
+  const result = await fillMandalaBook({ userId, mandalaId, trigger });
+
+  if (!result.ok && result.action === 'failed') {
+    // Throw → pg-boss retry (3× backoff). 'skipped-*' results are terminal (a
+    // mandala with no videos is not an error), so only 'failed' retries.
+    log.warn('mandala-book-fill: fill failed, will retry', { jobId: job.id, mandalaId });
+    throw new Error(`mandala-book-fill failed for ${mandalaId}: ${result.reason ?? 'unknown'}`);
+  }
+
+  log.info('mandala-book-fill done', { jobId: job.id, ...result });
+}
+
+/** Enqueue a book-fill job for one mandala. Returns the pg-boss job id (or null). */
+export async function enqueueMandalaBookFill(
+  payload: MandalaBookFillPayload,
+  options?: PgBoss.SendOptions
+): Promise<string | null> {
+  const boss = getJobQueue().getInstance();
+  return boss.send(JOB_NAMES.MANDALA_BOOK_FILL, payload, {
+    ...MANDALA_BOOK_FILL_OPTIONS,
+    ...options,
+  });
+}

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -32,6 +32,7 @@ import { registerPoolMaintenanceWorker } from './handlers/pool-maintenance';
 import { registerEnrichRelevanceQuickWorker } from './handlers/enrich-relevance-quick';
 import { registerPoolServeFillWorker } from './handlers/pool-serve-fill';
 import { registerMandalaActionsFillWorker } from './handlers/mandala-actions-fill';
+import { registerMandalaBookFillWorker } from './handlers/mandala-book-fill';
 import { logger } from '../../utils/logger';
 
 /**
@@ -54,6 +55,7 @@ export async function initJobQueue(): Promise<void> {
   await registerEnrichRelevanceQuickWorker();
   await registerPoolServeFillWorker();
   await registerMandalaActionsFillWorker();
+  await registerMandalaBookFillWorker();
 
-  logger.info('Job queue fully initialized (pg-boss + 8 workers)');
+  logger.info('Job queue fully initialized (pg-boss + 9 workers)');
 }

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -45,6 +45,12 @@ export const JOB_NAMES = {
    * 'skipped-full' on a no-op re-run).
    */
   MANDALA_ACTIONS_FILL: 'mandala-actions-fill',
+  /**
+   * Book-index fill (§2-D #1) — assemble a mandala's book_json from its placed
+   * videos' v2 rich summaries (LLM-free, mechanical). Idempotent: re-run
+   * overwrites book_json + bumps version. Worker = fillMandalaBook.
+   */
+  MANDALA_BOOK_FILL: 'mandala-book-fill',
 } as const;
 
 export type JobName = (typeof JOB_NAMES)[keyof typeof JOB_NAMES];
@@ -248,6 +254,23 @@ export const MANDALA_ACTIONS_FILL_OPTIONS = {
 export interface MandalaActionsFillPayload {
   mandalaId: string;
   userId?: string;
+  trigger?: string;
+}
+
+/**
+ * Book-index fill — pure DB+assembly, no LLM. Retry on transient DB errors so a
+ * triggered fill is not lost; the work is idempotent (version bump + overwrite).
+ */
+export const MANDALA_BOOK_FILL_OPTIONS = {
+  retryLimit: 3,
+  retryDelay: 30,
+  retryBackoff: true,
+  expireInMinutes: 10,
+} as const;
+
+export interface MandalaBookFillPayload {
+  userId: string;
+  mandalaId: string;
   trigger?: string;
 }
 

--- a/tests/unit/modules/build-book.test.ts
+++ b/tests/unit/modules/build-book.test.ts
@@ -1,0 +1,138 @@
+/**
+ * build-book — pure mandala-book assembler (§2-D #1).
+ *
+ * Locks the LLM-free assembly invariants:
+ *   - chapter per cell, section per video; output passes parseBookJson
+ *   - honest skip: a cell with no videos → empty chapter (kept, sections: [])
+ *   - atoms without timestamp_sec are skipped from the book but counted in
+ *     source_atoms (input-pool vs included asymmetry)
+ *   - seg_ref set only when an atom's timestamp falls inside a section window
+ *   - qa mapped from lora.qa_pairs as-is (no context filter)
+ *   - narrative = string concat of core_argument + section summaries (no gen)
+ */
+
+import { buildBookJson, type BuildBookInput } from '../../../src/modules/mandala-book/build-book';
+import { parseBookJson } from '../../../src/modules/mandala-book/book-schema';
+import type {
+  RichSummaryAnalysis,
+  RichSummarySegments,
+  RichSummaryLora,
+} from '../../../src/modules/skills/rich-summary-v2-prompt';
+
+const analysis = (core: string): RichSummaryAnalysis =>
+  ({ core_argument: core }) as unknown as RichSummaryAnalysis;
+
+const segments = (
+  sections: Array<{ from_sec: number; to_sec: number; summary?: string }>,
+  atoms: Array<{ text: string; type?: string; timestamp_sec?: number }>
+): RichSummarySegments =>
+  ({
+    sections: sections.map((s, i) => ({
+      idx: i,
+      from_sec: s.from_sec,
+      to_sec: s.to_sec,
+      title: `S${i}`,
+      summary: s.summary,
+      relevance_pct: 50,
+    })),
+    atoms: atoms.map((a, i) => ({
+      idx: i,
+      type: a.type ?? 'fact',
+      text: a.text,
+      timestamp_sec: a.timestamp_sec,
+    })),
+  }) as RichSummarySegments;
+
+const lora = (pairs: Array<{ q: string; a: string }>): RichSummaryLora => ({
+  qa_pairs: pairs.map((p) => ({ level: 1 as const, q: p.q, a: p.a, context: 'video' as const })),
+});
+
+const baseInput = (): BuildBookInput => ({
+  mandalaId: '72d5fe52-2f35-4a9e-8ef6-cd21629173ef',
+  mandalaTitle: '영어 회화',
+  generatedAt: '2026-06-21T00:00:00.000Z',
+  cells: [
+    {
+      cellIndex: 0,
+      title: 'Cell A',
+      videos: [
+        {
+          videoId: 'dQw4w9WgXcQ',
+          title: 'Video 1',
+          analysis: analysis('central thesis'),
+          segments: segments(
+            [{ from_sec: 0, to_sec: 120, summary: 'first part' }],
+            [
+              { text: 'atom with ts', timestamp_sec: 60 },
+              { text: 'atom no ts' }, // no timestamp → skipped from book, counted in pool
+            ]
+          ),
+          lora: lora([{ q: 'q1', a: 'a1' }]),
+        },
+      ],
+    },
+    { cellIndex: 1, title: 'Cell B (empty)', videos: [] }, // honest skip → empty chapter
+  ],
+});
+
+describe('build-book assembler', () => {
+  it('produces a chapter per cell and passes the v2 validator', () => {
+    const { book } = buildBookJson(baseInput());
+    expect(book.chapters).toHaveLength(2);
+    expect(() => parseBookJson(book)).not.toThrow();
+  });
+
+  it('keeps an empty chapter for a cell with no usable videos (honest skip)', () => {
+    const { book } = buildBookJson(baseInput());
+    const emptyChapter = book.chapters[1]!;
+    expect(emptyChapter.ch).toBe(1);
+    expect(emptyChapter.title).toBe('Cell B (empty)');
+    expect(emptyChapter.sections).toEqual([]);
+  });
+
+  it('skips atoms without timestamp from the book but counts them in source_atoms', () => {
+    const { book, sourceAtoms, sourceVideos } = buildBookJson(baseInput());
+    const section = book.chapters[0]!.sections[0]!;
+    expect(section.atoms).toHaveLength(1); // only the timestamped atom
+    expect(section.atoms![0]!.ts).toBe(60);
+    expect(sourceAtoms).toBe(2); // input pool counts BOTH atoms
+    expect(sourceVideos).toBe(1);
+  });
+
+  it('sets seg_ref only when timestamp falls inside a section window', () => {
+    const input = baseInput();
+    input.cells[0]!.videos[0]!.segments = segments(
+      [{ from_sec: 0, to_sec: 100 }],
+      [
+        { text: 'inside', timestamp_sec: 50 },
+        { text: 'outside', timestamp_sec: 999 },
+      ]
+    );
+    const { book } = buildBookJson(input);
+    const atoms = book.chapters[0]!.sections[0]!.atoms!;
+    expect(atoms[0]!.seg_ref).toEqual({ from_sec: 0, to_sec: 100 });
+    expect(atoms[1]!.seg_ref).toBeUndefined(); // outside any window → omitted, not guessed
+  });
+
+  it('maps qa from lora.qa_pairs as-is (no context filter)', () => {
+    const { book } = buildBookJson(baseInput());
+    expect(book.chapters[0]!.sections[0]!.qa).toEqual([{ q: 'q1', a: 'a1' }]);
+  });
+
+  it('assembles narrative as concat of core_argument + section summaries', () => {
+    const { book } = buildBookJson(baseInput());
+    expect(book.chapters[0]!.sections[0]!.narrative).toBe('central thesis\n\nfirst part');
+  });
+
+  it('yields empty narrative (valid) when no core_argument and no summaries', () => {
+    const input = baseInput();
+    input.cells[0]!.videos[0]!.analysis = null;
+    input.cells[0]!.videos[0]!.segments = segments(
+      [{ from_sec: 0, to_sec: 10 }],
+      [{ text: 'x', timestamp_sec: 1 }]
+    );
+    const { book } = buildBookJson(input);
+    expect(book.chapters[0]!.sections[0]!.narrative).toBe('');
+    expect(() => parseBookJson(book)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

Replaces manual/offline book authoring (1 hand-authored prod row) with an **automatic, LLM-free fill job** on top of the §2-C book-index schema (prod-verified, #931).

Built on James-approved §2-B decisions: skeleton = mandala cells, section = video, honest-skip / interpolation-0, LLM-0 assembly, admin-route trigger.

## Inspection points (per your pre-merge diff review)

**(a) LLM call count = 0 in assembly** — `build-book.ts` imports only types + `book-schema`. No Anthropic/OpenRouter/Gemini import, no generation. `narrative` = `[analysis.core_argument, ...segments.sections[].summary].join('\n\n')` (string concat, `assembleNarrative`). The LLM work already happened when v2 summaries were produced.

**(b) honest skip = omit, never synthesize** —
- cell with no usable-v2 videos → empty chapter `sections: []` (kept, not dropped; sidebar depends on ch/title).
- atom without `timestamp_sec` → omitted from book atoms (book `atom.ts` is required), but counted in `source_atoms` (input pool) → the 213-vs-98 asymmetry.
- `seg_ref` set only when timestamp falls inside a section window; outside → omitted (`segRefForTimestamp` returns undefined, "do not guess").
- empty `narrative` ("") when no core_argument and no summaries — valid, not filled.

**(c) parseBookJson hard gate** — `fill-book.ts` step 5: `parseBookJson(book)` in try/catch; on throw → `log.error` + `return {action:'failed'}` **before** any upsert. No partial write reaches `mandala_books`. (`failed` retries via pg-boss; `skipped-*` are terminal.)

## Pipeline

`enqueue(userId, mandalaId)` → getMandalaById (centerGoal, subjects[8]) → enumerate placed videos (uvs+ulc, cell_index≥0) → fetch v2 (`template_version='v2' AND segments NOT NULL`) → group by cell → `buildBookJson` (pure) → `parseBookJson` (gate) → raw-SQL upsert + `version = version + 1`.

## Two code-over-handoff corrections (code is authority)

1. **segments read directly from `video_rich_summaries`** — `rich-summary-reader.ts` drops segments for v2 (`:41` "always null per spec"), so it is not a 살붙임 source.
2. **qa mapped as-is from `lora.qa_pairs`** — v2 generator emits `context='video'` only (`rich-summary-v2-prompt.ts:268`); the handoff's `context='mandala_cell'` filter would drop every row.

## Trigger & concurrency

- `POST /api/v1/admin/mandala-book-fill/run {userId, mandalaId}` (mirrors relevance-backfill). The '...' menu / async '준비중' button UI is separate (§2-D).
- Worker uses `richSummaryWorkOptions(N)` (teamSize:N + teamRefill) → CP498 `teamSize:1` serial trap avoided.

## Safety / scope

- Job is **inert** until manually triggered (no auto call site). Fork-D fields untouched (null). note_documents re-baseline out of scope (§2-D #4).
- New worker (#9). No schema/DDL change (book_json is JSONB; schema_version is data-level).

## Verification

7/7 `build-book` unit tests (honest skip, counter asymmetry, seg_ref window, qa mapping, validator pass). `tsc --noEmit` clean for all new files. lint matches existing admin-route convention.