### PR TITLE
feat(bookindex): segment-relevance fill job (§2-D #2)

### DIFF
--- a/src/api/routes/admin/index.ts
+++ b/src/api/routes/admin/index.ts
@@ -27,6 +27,7 @@ import { adminV4ArbiterRunsRoutes } from './v4-arbiter-runs';
 import { adminPoolHealthRoutes } from './pool-health';
 import { adminRelevanceBackfillRoutes } from './relevance-backfill';
 import { adminMandalaBookFillRoutes } from './mandala-book-fill';
+import { adminSegmentRelevanceFillRoutes } from './segment-relevance-fill';
 import { adminPoolServeRoutes } from './pool-serve';
 
 /**
@@ -75,6 +76,8 @@ export async function adminRoutes(fastify: FastifyInstance) {
   await fastify.register(adminRelevanceBackfillRoutes, { prefix: '/relevance-backfill' });
   // §2-D #1 — book-index fill (assemble mandala_books from v2 summaries).
   await fastify.register(adminMandalaBookFillRoutes, { prefix: '/mandala-book-fill' });
+  // §2-D #2 — segment-relevance fill (score v2 segments → video_mandala_segment_relevance).
+  await fastify.register(adminSegmentRelevanceFillRoutes, { prefix: '/segment-relevance-fill' });
   // CP499+ — pool-serve canary trigger (deficit-cell fill, flag bypassed).
   await fastify.register(adminPoolServeRoutes, { prefix: '/pool-serve' });
   // await fastify.register(stripeWebhookRoutes, { prefix: '/webhooks/stripe' });

--- a/src/api/routes/admin/segment-relevance-fill.ts
+++ b/src/api/routes/admin/segment-relevance-fill.ts
@@ -1,0 +1,42 @@
+/**
+ * Admin Segment-Relevance Fill route (§2-D #2).
+ *
+ * Manual entrypoint to score one mandala's rich-summary time-segments against
+ * its centerGoal and populate video_mandala_segment_relevance (the slidegen
+ * relevance-gate input). Mirrors relevance-backfill: admin-guarded, single
+ * mandala, fans out durable pg-boss jobs.
+ *
+ *   POST /api/v1/admin/segment-relevance-fill/run   body { userId, mandalaId }
+ */
+
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+import { createSuccessResponse } from '../../schemas/common.schema';
+import { enqueueSegmentRelevanceForMandala } from '@/modules/relevance/segment-relevance-trigger';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'AdminSegmentRelevanceFill' });
+
+const RunBodySchema = z.object({
+  userId: z.string().uuid(),
+  mandalaId: z.string().uuid(),
+});
+
+export async function adminSegmentRelevanceFillRoutes(fastify: FastifyInstance): Promise<void> {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  /**
+   * POST /api/v1/admin/segment-relevance-fill/run
+   * Fan out segment-relevance jobs for every placed video's v2 segments in the
+   * target mandala (stale rows cleared first). Returns enqueue/segment counts.
+   */
+  fastify.post('/run', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
+    const { userId, mandalaId } = RunBodySchema.parse(request.body ?? {});
+
+    const result = await enqueueSegmentRelevanceForMandala({ userId, mandalaId });
+
+    log.info('admin segment relevance fill run', { userId, mandalaId, ...result });
+    return reply.send(createSuccessResponse(result));
+  });
+}

--- a/src/modules/queue/handlers/segment-relevance-fill.ts
+++ b/src/modules/queue/handlers/segment-relevance-fill.ts
@@ -1,0 +1,121 @@
+/**
+ * Segment-relevance fill worker (§2-D #2).
+ *
+ * Scores ONE rich-summary time-segment against the mandala centerGoal using the
+ * SSOT card scorer (computeCardRelevance, Haiku) and upserts the result into
+ * video_mandala_segment_relevance, keyed (video_id, mandala_id, segment_idx).
+ *
+ * Why re-score (not reuse video_rich_summaries.segments[].relevance_pct): that
+ * value lives on the video-keyed (shared) v2 row and was scored against whatever
+ * single mandala triggered generation — wrong for every other mandala holding
+ * the same video. Re-scoring per mandala is the whole reason this table is
+ * mandala-keyed (cross-mandala leak avoidance, §2-C).
+ *
+ * Interpolation = 0 (hard rule): relevance_pct is ONLY ever the scorer's output.
+ * A failed/empty score writes NOTHING — never a fabricated 0 or default.
+ *
+ * Concurrency: richSummaryWorkOptions(N) — teamSize:N + teamRefill so N is not
+ * inert (CP498 teamSize:1 serial trap). Reuses the relevance-backfill knob; the
+ * scorer shares the OpenRouter key, so concurrency is bounded the same way.
+ */
+
+import type PgBoss from 'pg-boss';
+
+import { computeCardRelevance } from '@/modules/relevance/compute-card-relevance';
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+import { getJobQueue } from '../manager';
+import {
+  JOB_NAMES,
+  SEGMENT_RELEVANCE_FILL_OPTIONS,
+  type SegmentRelevanceFillPayload,
+} from '../types';
+import { config } from '@/config/index';
+import { richSummaryWorkOptions } from './rich-summary-work-options';
+
+const log = logger.child({ module: 'queue/segment-relevance-fill' });
+
+export async function registerSegmentRelevanceFillWorker(): Promise<void> {
+  const boss = getJobQueue().getInstance();
+  const concurrency = config.queue.relevanceBackfillConcurrency;
+  await boss.work<SegmentRelevanceFillPayload>(
+    JOB_NAMES.SEGMENT_RELEVANCE_FILL,
+    richSummaryWorkOptions(concurrency),
+    handleSegmentRelevanceFill
+  );
+  log.info('segment-relevance-fill worker registered', { concurrency });
+}
+
+async function handleSegmentRelevanceFill(
+  job: PgBoss.Job<SegmentRelevanceFillPayload>
+): Promise<void> {
+  const { videoId, mandalaId, segmentIdx, fromSec, toSec, title, summary, centerGoal, cellGoal } =
+    job.data;
+
+  const result = await computeCardRelevance({
+    title,
+    description: summary,
+    centerGoal,
+    cellGoal,
+  });
+
+  if (!result.ok) {
+    // no_title = legitimate terminal skip (no usable text). NO row written —
+    // an unscored segment simply has no row (interpolation forbidden).
+    if (result.reason === 'no_title') {
+      log.info('segment-relevance-fill: skipped (no_title)', {
+        jobId: job.id,
+        videoId,
+        segmentIdx,
+      });
+      return;
+    }
+    // Transient (provider/validation) → throw → pg-boss retries once.
+    log.warn('segment-relevance-fill: compute failed', {
+      jobId: job.id,
+      videoId,
+      segmentIdx,
+      reason: result.reason,
+    });
+    throw new Error(`segment_relevance_compute_failed: ${result.reason}`);
+  }
+
+  // Upsert — relevance_pct is ONLY ever result.relevancePct (scorer output).
+  // Raw SQL: composite PK, and the model may lag client regen on some deploys.
+  const prisma = getPrismaClient();
+  await prisma.$executeRawUnsafe(
+    `INSERT INTO video_mandala_segment_relevance
+       (video_id, mandala_id, segment_idx, from_sec, to_sec, relevance_pct, computed_at)
+     VALUES ($1, $2::uuid, $3, $4, $5, $6, NOW())
+     ON CONFLICT (video_id, mandala_id, segment_idx) DO UPDATE SET
+       from_sec      = EXCLUDED.from_sec,
+       to_sec        = EXCLUDED.to_sec,
+       relevance_pct = EXCLUDED.relevance_pct,
+       computed_at   = NOW()`,
+    videoId,
+    mandalaId,
+    segmentIdx,
+    fromSec,
+    toSec,
+    result.relevancePct
+  );
+
+  log.info('segment-relevance-fill: scored', {
+    jobId: job.id,
+    videoId,
+    segmentIdx,
+    relevancePct: result.relevancePct,
+  });
+}
+
+/** Enqueue one segment-relevance job. Returns the pg-boss job id (or null). */
+export async function enqueueSegmentRelevanceFill(
+  payload: SegmentRelevanceFillPayload,
+  options?: PgBoss.SendOptions
+): Promise<string | null> {
+  const boss = getJobQueue().getInstance();
+  return boss.send(JOB_NAMES.SEGMENT_RELEVANCE_FILL, payload, {
+    ...SEGMENT_RELEVANCE_FILL_OPTIONS,
+    ...options,
+  });
+}

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -33,6 +33,7 @@ import { registerEnrichRelevanceQuickWorker } from './handlers/enrich-relevance-
 import { registerPoolServeFillWorker } from './handlers/pool-serve-fill';
 import { registerMandalaActionsFillWorker } from './handlers/mandala-actions-fill';
 import { registerMandalaBookFillWorker } from './handlers/mandala-book-fill';
+import { registerSegmentRelevanceFillWorker } from './handlers/segment-relevance-fill';
 import { logger } from '../../utils/logger';
 
 /**
@@ -56,6 +57,7 @@ export async function initJobQueue(): Promise<void> {
   await registerPoolServeFillWorker();
   await registerMandalaActionsFillWorker();
   await registerMandalaBookFillWorker();
+  await registerSegmentRelevanceFillWorker();
 
-  logger.info('Job queue fully initialized (pg-boss + 9 workers)');
+  logger.info('Job queue fully initialized (pg-boss + 10 workers)');
 }

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -51,6 +51,13 @@ export const JOB_NAMES = {
    * overwrites book_json + bumps version. Worker = fillMandalaBook.
    */
   MANDALA_BOOK_FILL: 'mandala-book-fill',
+  /**
+   * Segment-level relevance fill (§2-D #2) — score each rich-summary time
+   * segment of a placed video against the mandala centerGoal (computeCardRelevance
+   * reuse, mandala-keyed) and upsert video_mandala_segment_relevance. One job
+   * per segment. relevance_pct comes ONLY from the scorer (no interpolation).
+   */
+  SEGMENT_RELEVANCE_FILL: 'segment-relevance-fill',
 } as const;
 
 export type JobName = (typeof JOB_NAMES)[keyof typeof JOB_NAMES];
@@ -139,6 +146,25 @@ export interface RelevanceQuickPayload {
   cellGoal?: string;
 }
 
+/**
+ * Segment-relevance fill (§2-D #2). Carries all scoring inputs + the table key
+ * so the worker does one scorer call + one upsert, ZERO extra DB reads. Keyed
+ * by (videoId, mandalaId, segmentIdx) → video_mandala_segment_relevance.
+ * mandala-keyed = leak-safe (a mandala is single-user-owned, scored vs its own
+ * centerGoal — the video-global segments[].relevance_pct cannot serve N mandalas).
+ */
+export interface SegmentRelevanceFillPayload {
+  videoId: string;
+  mandalaId: string;
+  segmentIdx: number;
+  fromSec: number;
+  toSec: number;
+  title: string;
+  summary?: string;
+  centerGoal: string;
+  cellGoal?: string;
+}
+
 // ============================================================================
 // Job Options
 // ============================================================================
@@ -206,6 +232,16 @@ export const POOL_MAINTENANCE_RUN_OPTIONS = {
  * (PR1 #864). A second failure (or no_title) is handled in the worker.
  */
 export const RELEVANCE_QUICK_RETRY_OPTIONS = {
+  retryLimit: 1,
+  expireInMinutes: 5,
+} as const;
+
+/**
+ * Segment-relevance fill: one Haiku scorer call + one upsert per segment.
+ * Mirror the relevance-quick retry shape (transient provider errors retry once;
+ * a missing title is a terminal skip, not a retry).
+ */
+export const SEGMENT_RELEVANCE_FILL_OPTIONS = {
   retryLimit: 1,
   expireInMinutes: 5,
 } as const;

--- a/src/modules/relevance/segment-relevance-trigger.ts
+++ b/src/modules/relevance/segment-relevance-trigger.ts
@@ -1,0 +1,158 @@
+/**
+ * Segment-relevance fill trigger (§2-D #2).
+ *
+ * Fans out one SEGMENT_RELEVANCE_FILL job per rich-summary time-segment of each
+ * placed video in a mandala. Mirrors relevance-backfill-trigger (enumerate
+ * placed videos across uvs+ulc, fetch the mandala centerGoal + cell sub-goals),
+ * but the unit of work is a SEGMENT (video_id, mandala_id, segment_idx), not a
+ * card row.
+ *
+ * Stale handling (§2-B decision 3): before fan-out, DELETE all existing rows for
+ * the videos being re-scored, scoped to THIS mandala only. A rich-summary
+ * regeneration reorders/shrinks segments[].sections — deleting then re-inserting
+ * the current segments absorbs that drift (orphan segment_idx cannot survive).
+ * The DELETE never touches other mandalas (mandala_id filter).
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { getMandalaManager } from '@/modules/mandala/manager';
+import { logger } from '@/utils/logger';
+import { enqueueSegmentRelevanceFill } from '@/modules/queue/handlers/segment-relevance-fill';
+import type { RichSummarySegments } from '@/modules/skills/rich-summary-v2-prompt';
+
+const log = logger.child({ module: 'SegmentRelevanceTrigger' });
+
+export interface SegmentRelevanceResult {
+  enqueued: number;
+  skipped: number;
+  videos: number;
+  segments: number;
+  staleDeleted: number;
+}
+
+interface Placement {
+  cellIndex: number;
+  videoId: string; // 11-char YouTube id
+}
+
+/**
+ * Enqueue segment-relevance jobs for every placed video's v2 time-segments in
+ * the target mandala. Re-runnable: stale rows for the affected videos are
+ * cleared first (regeneration drift), then current segments are fanned out.
+ */
+export async function enqueueSegmentRelevanceForMandala(params: {
+  userId: string;
+  mandalaId: string;
+}): Promise<SegmentRelevanceResult> {
+  const { userId, mandalaId } = params;
+  const prisma = getPrismaClient();
+
+  let centerGoal = '';
+  let cellGoals: string[] = [];
+  try {
+    const mandala = await getMandalaManager().getMandalaById(userId, mandalaId);
+    centerGoal = mandala?.levels[0]?.centerGoal ?? '';
+    cellGoals = mandala?.levels[0]?.subjects ?? [];
+  } catch (err) {
+    log.warn('mandala lookup failed (continuing with empty centerGoal)', {
+      userId,
+      mandalaId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // 1. Enumerate placed videos (uvs + ulc, cell_index >= 0).
+  const [videoStates, localCards] = await Promise.all([
+    prisma.userVideoState.findMany({
+      where: { user_id: userId, mandala_id: mandalaId, cell_index: { gte: 0 } },
+      select: { cell_index: true, video: { select: { youtube_video_id: true } } },
+    }),
+    prisma.user_local_cards.findMany({
+      where: { user_id: userId, mandala_id: mandalaId, cell_index: { gte: 0 } },
+      select: { cell_index: true, video_id: true },
+    }),
+  ]);
+
+  const byVideo = new Map<string, Placement>(); // dedup: one cell per video for scoring
+  for (const r of videoStates) {
+    const vid = r.video?.youtube_video_id;
+    if (!vid || r.cell_index == null) continue;
+    if (!byVideo.has(vid)) byVideo.set(vid, { cellIndex: r.cell_index, videoId: vid });
+  }
+  for (const r of localCards) {
+    if (!r.video_id || r.cell_index == null) continue;
+    if (!byVideo.has(r.video_id))
+      byVideo.set(r.video_id, { cellIndex: r.cell_index, videoId: r.video_id });
+  }
+
+  if (byVideo.size === 0) {
+    return { enqueued: 0, skipped: 0, videos: 0, segments: 0, staleDeleted: 0 };
+  }
+
+  // 2. Fetch v2 segments for those videos.
+  const videoIds = Array.from(byVideo.keys());
+  const v2Rows = await prisma.video_rich_summaries.findMany({
+    where: { video_id: { in: videoIds }, template_version: 'v2' },
+    select: { video_id: true, segments: true },
+  });
+
+  // 3. Stale cleanup: remove existing rows for these videos in THIS mandala only.
+  const staleDeleted = await prisma.$executeRawUnsafe(
+    `DELETE FROM video_mandala_segment_relevance WHERE mandala_id = $1::uuid AND video_id = ANY($2::text[])`,
+    mandalaId,
+    videoIds
+  );
+
+  // 4. Fan out one job per current segment.
+  let enqueued = 0;
+  let skipped = 0;
+  let segments = 0;
+  let videos = 0;
+
+  for (const row of v2Rows) {
+    const placement = byVideo.get(row.video_id);
+    if (!placement) continue;
+    const segs = (row.segments ?? null) as unknown as RichSummarySegments | null;
+    const sections = segs?.sections ?? [];
+    if (sections.length === 0) continue;
+    videos += 1;
+
+    const cellGoal = cellGoals[placement.cellIndex];
+    for (let idx = 0; idx < sections.length; idx++) {
+      const s = sections[idx]!;
+      segments += 1;
+      try {
+        const jobId = await enqueueSegmentRelevanceFill({
+          videoId: row.video_id,
+          mandalaId,
+          segmentIdx: idx,
+          fromSec: s.from_sec,
+          toSec: s.to_sec,
+          title: s.title,
+          summary: s.summary,
+          centerGoal,
+          cellGoal,
+        });
+        if (jobId) enqueued += 1;
+        else skipped += 1;
+      } catch (err) {
+        skipped += 1;
+        log.warn('enqueue failed (segment, non-fatal)', {
+          videoId: row.video_id,
+          segmentIdx: idx,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  log.info('segment relevance fan-out', {
+    mandalaId,
+    videos,
+    segments,
+    enqueued,
+    skipped,
+    staleDeleted,
+  });
+  return { enqueued, skipped, videos, segments, staleDeleted: Number(staleDeleted) };
+}

--- a/tests/unit/modules/segment-relevance-fill.test.ts
+++ b/tests/unit/modules/segment-relevance-fill.test.ts
@@ -1,0 +1,131 @@
+/**
+ * segment-relevance-fill — worker + trigger tests (§2-D #2).
+ *
+ * Locks the invariants James reviews before merge:
+ *   (a) interpolation = 0 — relevance_pct is ONLY the scorer's output; a failed
+ *       score writes NOTHING (no fabricated 0/default);
+ *   (b) upsert targets video_mandala_segment_relevance keyed by
+ *       (video_id, mandala_id, segment_idx);
+ *   (c) stale DELETE is scoped to (mandala_id, the affected videos) — never
+ *       other mandalas;
+ *   plus: one job per segment fan-out; no scoring in the trigger.
+ */
+
+// ============================================================================
+// Mocks (before imports)
+// ============================================================================
+
+const mockBossInstance = {
+  start: jest.fn().mockResolvedValue(undefined),
+  stop: jest.fn().mockResolvedValue(undefined),
+  on: jest.fn(),
+  work: jest.fn().mockResolvedValue('worker-id'),
+  send: jest.fn().mockResolvedValue('job-123'),
+};
+jest.mock('@/modules/queue/manager', () => ({
+  getJobQueue: () => ({ getInstance: () => mockBossInstance }),
+}));
+
+const mockExec = jest.fn().mockResolvedValue(0);
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    $executeRawUnsafe: (...args: unknown[]) => mockExec(...args),
+  }),
+}));
+
+const mockCompute = jest.fn();
+jest.mock('@/modules/relevance/compute-card-relevance', () => ({
+  computeCardRelevance: (...args: unknown[]) => mockCompute(...args),
+}));
+
+jest.mock('@/config/index', () => ({
+  config: {
+    database: { url: 'postgresql://postgres:pass@127.0.0.1:5432/postgres', directUrl: undefined },
+    app: { isDevelopment: true, isProduction: false, isTest: true },
+    queue: { relevanceBackfillConcurrency: 4 },
+    paths: { logs: '/tmp' },
+  },
+}));
+
+import {
+  registerSegmentRelevanceFillWorker,
+  enqueueSegmentRelevanceFill,
+} from '../../../src/modules/queue/handlers/segment-relevance-fill';
+
+type JobHandler = (job: { id: string; data: Record<string, unknown> }) => Promise<void>;
+
+const basePayload = {
+  videoId: 'dQw4w9WgXcQ',
+  mandalaId: '72d5fe52-2f35-4a9e-8ef6-cd21629173ef',
+  segmentIdx: 2,
+  fromSec: 0,
+  toSec: 120,
+  title: 'Section title',
+  summary: 'Section summary',
+  centerGoal: '요가 마스터하기',
+  cellGoal: '아침 루틴',
+};
+
+async function getHandler(): Promise<JobHandler> {
+  await registerSegmentRelevanceFillWorker();
+  const call = mockBossInstance.work.mock.calls.at(-1)!;
+  return call[2] as JobHandler;
+}
+
+beforeEach(() => {
+  mockExec.mockClear();
+  mockCompute.mockReset();
+  mockBossInstance.work.mockClear();
+  mockBossInstance.send.mockClear();
+});
+
+describe('segment-relevance-fill worker (interpolation = 0)', () => {
+  it('upserts ONLY the scorer value, keyed by (video_id, mandala_id, segment_idx)', async () => {
+    mockCompute.mockResolvedValue({ ok: true, relevancePct: 73 });
+    const handler = await getHandler();
+    await handler({ id: 'j1', data: { ...basePayload } });
+
+    expect(mockExec).toHaveBeenCalledTimes(1);
+    const args = mockExec.mock.calls[0]!;
+    const sql = args[0] as string;
+    expect(sql).toContain('INSERT INTO video_mandala_segment_relevance');
+    expect(sql).toContain('ON CONFLICT (video_id, mandala_id, segment_idx)');
+    // positional params: sql, videoId, mandalaId, segmentIdx, fromSec, toSec, relevancePct
+    expect(args.slice(1)).toEqual(['dQw4w9WgXcQ', basePayload.mandalaId, 2, 0, 120, 73]);
+  });
+
+  it('writes NOTHING on no_title (no fabricated 0/default)', async () => {
+    mockCompute.mockResolvedValue({ ok: false, reason: 'no_title' });
+    const handler = await getHandler();
+    await handler({ id: 'j2', data: { ...basePayload } });
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('throws (retry) and writes NOTHING on other compute failure', async () => {
+    mockCompute.mockResolvedValue({ ok: false, reason: 'provider_error' });
+    const handler = await getHandler();
+    await expect(handler({ id: 'j3', data: { ...basePayload } })).rejects.toThrow(
+      /segment_relevance_compute_failed/
+    );
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('forwards title+summary+centerGoal+cellGoal to the scorer (no rubric)', async () => {
+    mockCompute.mockResolvedValue({ ok: true, relevancePct: 50 });
+    const handler = await getHandler();
+    await handler({ id: 'j4', data: { ...basePayload } });
+    expect(mockCompute).toHaveBeenCalledWith({
+      title: 'Section title',
+      description: 'Section summary',
+      centerGoal: '요가 마스터하기',
+      cellGoal: '아침 루틴',
+    });
+  });
+
+  it('enqueue carries SEGMENT_RELEVANCE_FILL_OPTIONS retry shape', async () => {
+    await enqueueSegmentRelevanceFill(basePayload);
+    expect(mockBossInstance.send).toHaveBeenCalledTimes(1);
+    const opts = mockBossInstance.send.mock.calls[0]![2] as { retryLimit: number };
+    expect(opts.retryLimit).toBe(1);
+  });
+});

--- a/tests/unit/modules/segment-relevance-trigger.test.ts
+++ b/tests/unit/modules/segment-relevance-trigger.test.ts
@@ -1,0 +1,130 @@
+/**
+ * segment-relevance-trigger — fan-out + stale-scope tests (§2-D #2).
+ *
+ * Locks:
+ *   - one job per current segment (per placed video's v2 sections[]);
+ *   - stale DELETE scoped to (mandala_id, the affected videos) — never other
+ *     mandalas (James review check c);
+ *   - the trigger does NO scoring (computeCardRelevance is never imported here).
+ */
+
+const mockGetMandalaById = jest.fn();
+jest.mock('@/modules/mandala/manager', () => ({
+  getMandalaManager: () => ({ getMandalaById: mockGetMandalaById }),
+}));
+
+const mockUvsFindMany = jest.fn();
+const mockUlcFindMany = jest.fn();
+const mockVrsFindMany = jest.fn();
+const mockExec = jest.fn().mockResolvedValue(3);
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    userVideoState: { findMany: mockUvsFindMany },
+    user_local_cards: { findMany: mockUlcFindMany },
+    video_rich_summaries: { findMany: mockVrsFindMany },
+    $executeRawUnsafe: (...args: unknown[]) => mockExec(...args),
+  }),
+}));
+
+const mockEnqueue = jest.fn().mockResolvedValue('job-x');
+jest.mock('@/modules/queue/handlers/segment-relevance-fill', () => ({
+  enqueueSegmentRelevanceFill: (...args: unknown[]) => mockEnqueue(...args),
+}));
+
+jest.mock('@/config/index', () => ({
+  config: {
+    database: { url: 'postgresql://postgres:pass@127.0.0.1:5432/postgres', directUrl: undefined },
+    app: { isDevelopment: true, isProduction: false, isTest: true },
+    queue: { relevanceBackfillConcurrency: 4 },
+    paths: { logs: '/tmp' },
+  },
+}));
+
+import { enqueueSegmentRelevanceForMandala } from '../../../src/modules/relevance/segment-relevance-trigger';
+
+const MANDALA = '72d5fe52-2f35-4a9e-8ef6-cd21629173ef';
+const USER = '0192fedf-85f4-47ab-a652-7fdd116e2b39';
+
+beforeEach(() => {
+  mockGetMandalaById.mockReset();
+  mockUvsFindMany.mockReset();
+  mockUlcFindMany.mockReset();
+  mockVrsFindMany.mockReset();
+  mockExec.mockClear();
+  mockEnqueue.mockClear();
+  mockGetMandalaById.mockResolvedValue({
+    levels: [{ centerGoal: '요가', subjects: ['아침', '호흡'] }],
+  });
+});
+
+describe('segment-relevance-trigger fan-out + stale scope', () => {
+  it('enqueues one job per segment and scopes the stale DELETE to (mandala, videos)', async () => {
+    mockUvsFindMany.mockResolvedValue([
+      { cell_index: 0, video: { youtube_video_id: 'vidAAAAAAAA' } },
+    ]);
+    mockUlcFindMany.mockResolvedValue([]);
+    mockVrsFindMany.mockResolvedValue([
+      {
+        video_id: 'vidAAAAAAAA',
+        segments: {
+          sections: [
+            { from_sec: 0, to_sec: 60, title: 'S0', summary: 'a' },
+            { from_sec: 60, to_sec: 120, title: 'S1', summary: 'b' },
+          ],
+        },
+      },
+    ]);
+
+    const res = await enqueueSegmentRelevanceForMandala({ userId: USER, mandalaId: MANDALA });
+
+    // 2 segments → 2 enqueues, no scoring done here
+    expect(mockEnqueue).toHaveBeenCalledTimes(2);
+    expect(res.segments).toBe(2);
+    expect(res.enqueued).toBe(2);
+
+    // stale DELETE scoped to this mandala + only the affected videos
+    expect(mockExec).toHaveBeenCalledTimes(1);
+    const [sql, mandalaArg, videosArg] = mockExec.mock.calls[0]!;
+    expect(sql).toContain('DELETE FROM video_mandala_segment_relevance');
+    expect(sql).toContain('mandala_id = $1::uuid');
+    expect(sql).toContain('video_id = ANY($2::text[])');
+    expect(mandalaArg).toBe(MANDALA);
+    expect(videosArg).toEqual(['vidAAAAAAAA']);
+
+    // each enqueue carries the cell's sub-goal + segment idx + time window
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        videoId: 'vidAAAAAAAA',
+        mandalaId: MANDALA,
+        segmentIdx: 0,
+        fromSec: 0,
+        toSec: 60,
+        centerGoal: '요가',
+        cellGoal: '아침',
+      })
+    );
+  });
+
+  it('returns early (no DELETE, no enqueue) when no placed videos', async () => {
+    mockUvsFindMany.mockResolvedValue([]);
+    mockUlcFindMany.mockResolvedValue([]);
+
+    const res = await enqueueSegmentRelevanceForMandala({ userId: USER, mandalaId: MANDALA });
+
+    expect(res).toEqual({ enqueued: 0, skipped: 0, videos: 0, segments: 0, staleDeleted: 0 });
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+
+  it('skips a video whose v2 row has no segments (honest skip)', async () => {
+    mockUvsFindMany.mockResolvedValue([
+      { cell_index: 1, video: { youtube_video_id: 'vidBBBBBBBB' } },
+    ]);
+    mockUlcFindMany.mockResolvedValue([]);
+    mockVrsFindMany.mockResolvedValue([{ video_id: 'vidBBBBBBBB', segments: null }]);
+
+    const res = await enqueueSegmentRelevanceForMandala({ userId: USER, mandalaId: MANDALA });
+    expect(res.segments).toBe(0);
+    expect(mockEnqueue).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Scores each placed video's v2 time-segments against the **mandala centerGoal** and populates `video_mandala_segment_relevance` (#931 schema) — the **slidegen relevance-gate input**. Reuses the shipped A-stage card scorer (`computeCardRelevance`).

## Inspection points (per your pre-merge diff review)

**(a) interpolation = 0** — `segment-relevance-fill.ts` handler: `relevance_pct` is ONLY ever `result.relevancePct` (scorer output). On `!ok`: `no_title` → log + **return (no write)**; other → **throw (retry), no write**. There is no code path that writes a fabricated 0/default. Locked by tests `writes NOTHING on no_title` + `throws ... and writes NOTHING on other compute failure`.

**(b) mandala-keyed upsert ↔ #931 PK/FK** — upsert `ON CONFLICT (video_id, mandala_id, segment_idx)` matches the table PK exactly; mandala_id is the FK to user_mandalas (owner-scoped = leak-safe). Locked by test asserting the SQL + positional params `[videoId, mandalaId, segmentIdx, fromSec, toSec, relevancePct]`.

**(c) stale DELETE scope** — `segment-relevance-trigger.ts`: `DELETE FROM video_mandala_segment_relevance WHERE mandala_id = $1::uuid AND video_id = ANY($2::text[])` — scoped to THIS mandala + only the videos being re-scored. Other mandalas untouched. Locked by test asserting the SQL contains `mandala_id = $1::uuid` + the video list arg.

## Pipeline

`POST /admin/segment-relevance-fill/run {userId, mandalaId}` → getMandalaById (centerGoal + subjects[]) → enumerate placed videos (uvs+ulc, cell_index≥0) → fetch v2 segments → **stale DELETE (this mandala only)** → fan out one `SEGMENT_RELEVANCE_FILL` job per current segment → worker `computeCardRelevance` → upsert.

## Why re-score (not reuse `segments[].relevance_pct`)

The existing per-section value lives on the **video-keyed (shared)** v2 row, scored against the single mandala that triggered generation — wrong for every other mandala holding the same video (same cross-mandala leak class as `mandala_relevance_pct`). Mandala-keyed re-scoring is the reason the #931 table is mandala-keyed.

## Concurrency / safety

- `richSummaryWorkOptions(N)` → teamSize:N + teamRefill (CP498 `teamSize:1` serial trap avoided). Reuses `RELEVANCE_BACKFILL_CONCURRENCY` knob (shared OpenRouter key).
- Job is **inert** until manually triggered (no auto call site). 10th worker. No schema/DDL change.
- LLM scorer = **prod service path** → verification runs in prod (not a local script, per the LLM hard rule), on demo mandala.

## Verification

8/8 unit tests (interpolation-0, upsert keying, stale-scope, fan-out, honest skip, no-scoring-in-trigger). `tsc --noEmit` clean for new files. lint warnings match the admin-route + sibling-test convention.