### PR TITLE
feat(snapshot): get-or-extract figure cache + endpoint (⑤)

### DIFF
--- a/prisma/migrations/snapshot/001_video_figure_snapshots.sql
+++ b/prisma/migrations/snapshot/001_video_figure_snapshots.sql
@@ -1,0 +1,39 @@
+-- Snapshot track (⑤ get-or-extract): figure snapshot cache.
+--
+-- Content-scoped cache (one row per video_id + timestamp + figure kind) for the
+-- slidegen get-or-extract boundary. A figure is a property of the VIDEO frame at
+-- a timestamp, shared across all mandalas/users — so the key is (video_id,
+-- ts_sec, kind), NOT user/mandala-scoped (contrast the relevance tables).
+--
+-- Payload by kind (⑤ contract): chart/diagram/table → struct (numerize JSON);
+-- equation → latex; keyframe → asset_path (binary pointer; Supabase Storage
+-- wiring is deferred — column is NULLable so struct/latex figures work without
+-- any object storage). verification_status carries the R6/verification slot.
+--
+-- Apply order (mirrors prisma/migrations/book-poc/001_add_table.sql):
+--   1. Local: psql "$DATABASE_URL" -f prisma/migrations/snapshot/001_video_figure_snapshots.sql
+--   2. Local: prisma db push --skip-generate
+--   3. Local: psql "$DATABASE_URL" -c "NOTIFY pgrst, 'reload schema'"
+--   4. Prod: deploy.yml CI runs prisma db push (LEVEL-3 silent-fail risk)
+--   5. Prod: apply-custom-sql.sh re-applies this raw DDL (defensive; allowlisted)
+--   6. Prod: Supabase Dashboard -> Settings -> API -> "Reload schema"
+
+CREATE TABLE IF NOT EXISTS video_figure_snapshots (
+  video_id            VARCHAR(11) NOT NULL,
+  ts_sec              INTEGER     NOT NULL,
+  kind                VARCHAR(16) NOT NULL, -- chart | diagram | table | equation | keyframe
+  struct              JSONB,                -- numerize structure (chart/diagram/table)
+  latex               TEXT,                 -- equation
+  asset_path          TEXT,                 -- keyframe binary pointer (deferred; NULL ok)
+  verification_status VARCHAR(16) NOT NULL DEFAULT 'unverified',
+  source              VARCHAR(16) NOT NULL DEFAULT 'numerize', -- numerize | manual-warm | cache
+  computed_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at          TIMESTAMPTZ NOT NULL DEFAULT (NOW() + interval '30 days'),
+  PRIMARY KEY (video_id, ts_sec, kind),
+  CONSTRAINT chk_vfs_kind CHECK (kind IN ('chart', 'diagram', 'table', 'equation', 'keyframe'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_vfs_video ON video_figure_snapshots(video_id);
+CREATE INDEX IF NOT EXISTS idx_vfs_expires ON video_figure_snapshots(expires_at);
+
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2318,3 +2318,26 @@ model video_mandala_segment_relevance {
   @@index([mandala_id, video_id], map: "idx_vmsr_mandala")
   @@schema("public")
 }
+
+/// Figure snapshot cache (⑤ get-or-extract). Content-scoped — one row per
+/// (video_id, ts_sec, kind); a figure is a property of the video frame, shared
+/// across mandalas/users (no user/mandala key). chart/diagram/table → struct
+/// (numerize JSON); equation → latex; keyframe → asset_path (binary deferred,
+/// NULLable). No FK on video_id (content cache, mirrors video_pool).
+model video_figure_snapshots {
+  video_id            String   @db.VarChar(11)
+  ts_sec              Int
+  kind                String   @db.VarChar(16)
+  struct              Json?    @db.JsonB
+  latex               String?
+  asset_path          String?
+  verification_status String   @default("unverified") @db.VarChar(16)
+  source              String   @default("numerize") @db.VarChar(16)
+  computed_at         DateTime @default(now()) @db.Timestamptz(6)
+  expires_at          DateTime @default(dbgenerated("(now() + '30 days'::interval)")) @db.Timestamptz(6)
+
+  @@id([video_id, ts_sec, kind])
+  @@index([video_id], map: "idx_vfs_video")
+  @@index([expires_at], map: "idx_vfs_expires")
+  @@schema("public")
+}

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -148,6 +148,10 @@ APPLY_FILES=(
   # (WHERE title/channel_title LIKE '%&%'). The backfill is idempotent
   # because the decode function is a no-op on already-decoded text.
   "prisma/migrations/youtube-videos-decode-entities/001_decode_entities.sql"
+  # ⑤ snapshot track — figure snapshot cache (video_id, ts_sec, kind). CREATE
+  # TABLE IF NOT EXISTS + CHECK constraint — idempotent. Inert until the
+  # get-or-extract endpoint / slidegen consume it.
+  "prisma/migrations/snapshot/001_video_figure_snapshots.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "

--- a/src/api/routes/internal/snapshot.ts
+++ b/src/api/routes/internal/snapshot.ts
@@ -1,0 +1,53 @@
+/**
+ * Snapshot get-or-extract endpoint (⑤).
+ *
+ * The slidegen consumer (④) sends a video_id + the high-relevance timestamps it
+ * wants figures for; this returns FigureRef[] from cache, extracting the misses.
+ *
+ * Auth: x-internal-token (shared INTERNAL_BATCH_TOKEN), same as the other
+ * internal routes. Serve-from-cache works even when the extractor is disabled.
+ *
+ *   POST /api/v1/internal/snapshot/get-or-extract
+ *   body { videoId: string, ts: number[] }  →  { figures: FigureRef[] }
+ */
+
+import type { FastifyPluginAsync } from 'fastify';
+
+import { getInternalBatchToken } from '@/config/internal-auth';
+import { getOrExtractSnapshots } from '@/modules/snapshot/get-or-extract';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'api/internal/snapshot' });
+
+interface GetOrExtractBody {
+  videoId?: string;
+  ts?: unknown;
+}
+
+export const internalSnapshotRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post<{ Body: GetOrExtractBody }>('/snapshot/get-or-extract', async (request, reply) => {
+    const expected = getInternalBatchToken();
+    if (!expected) return reply.code(503).send({ error: 'internal trigger not configured' });
+    const got = request.headers['x-internal-token'];
+    if (typeof got !== 'string' || got !== expected) {
+      return reply.code(401).send({ error: 'invalid internal token' });
+    }
+
+    const body = request.body ?? {};
+    const videoId = typeof body.videoId === 'string' ? body.videoId.trim() : '';
+    if (!videoId) return reply.code(400).send({ error: 'videoId required' });
+
+    const ts = Array.isArray(body.ts)
+      ? body.ts.filter((t): t is number => typeof t === 'number' && Number.isFinite(t))
+      : [];
+    if (ts.length === 0) return reply.code(400).send({ error: 'ts (number[]) required' });
+
+    const figures = await getOrExtractSnapshots(videoId, ts);
+    log.info('snapshot get-or-extract', {
+      videoId,
+      requested: ts.length,
+      returned: figures.length,
+    });
+    return reply.code(200).send({ figures });
+  });
+};

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -42,6 +42,7 @@ import { internalVideoPoolPromoteRoutes } from './routes/internal/video-pool-pro
 import { internalGoogleCseRoutes } from './routes/internal/google-cse';
 import { internalPlaylistImportRoutes } from './routes/internal/playlist-import';
 import { internalPromptBuildRoutes } from './routes/internal/prompt-build';
+import { internalSnapshotRoutes } from './routes/internal/snapshot';
 import { createErrorResponse, ErrorCode } from './schemas/common.schema';
 import { registerBotWriteGuard } from './plugins/bot-write-guard';
 import { registerBotUsageLogger } from './plugins/bot-usage-logger';
@@ -392,6 +393,9 @@ export async function buildServer() {
       // CP488+ — Mac Mini SSOT prompt builder. Returns the same prompt the
       // prod cron generator uses (no fork drift).
       await instance.register(internalPromptBuildRoutes, {
+        prefix: '/internal',
+      });
+      await instance.register(internalSnapshotRoutes, {
         prefix: '/internal',
       });
     },

--- a/src/config/snapshot.ts
+++ b/src/config/snapshot.ts
@@ -1,0 +1,54 @@
+/**
+ * Snapshot (figure get-or-extract) service configuration.
+ *
+ * The numerize step (frame → struct/latex/keyframe) runs on the pod
+ * slidegen-service, called via the RunPod proxy pattern (same as the chatbot's
+ * qwen-runpod path: a proxy URL + bearer token). Both values optional — unset
+ * ⇒ extraction is DISABLED and get-or-extract serves from cache only (the demo
+ * path: manual-warm rows are served without any live extraction).
+ *
+ * CP392 secret-vs-config: SNAPSHOT_SERVICE_URL is a proxy URL (not a credential,
+ * visible in logs/docker inspect) ⇒ GitHub Variable. SNAPSHOT_SERVICE_TOKEN is a
+ * bearer secret ⇒ GitHub Secret. (Mirror QWEN_LORA_API_URL var + RUNPOD_API_KEY
+ * secret split.)
+ */
+
+import { z } from 'zod';
+
+const optionalStr = z.preprocess((v) => {
+  if (v == null) return '';
+  return String(v).trim();
+}, z.string());
+
+export const snapshotEnvSchema = z.object({
+  SNAPSHOT_SERVICE_URL: optionalStr.default(''),
+  SNAPSHOT_SERVICE_TOKEN: optionalStr.default(''),
+  // Per-extract-call budget. Frame fetch + numerize can be slow; generous.
+  SNAPSHOT_SERVICE_TIMEOUT_MS: z.coerce.number().int().positive().default(60_000),
+});
+
+export interface SnapshotConfig {
+  /** Pod slidegen-service base URL. Empty ⇒ extraction disabled (cache-only). */
+  serviceUrl: string;
+  /** Bearer token for the service. */
+  serviceToken: string;
+  timeoutMs: number;
+  /** True only when BOTH url + token are set. */
+  enabled: boolean;
+}
+
+export function loadSnapshotConfig(env: NodeJS.ProcessEnv = process.env): SnapshotConfig {
+  const parsed = snapshotEnvSchema.parse({
+    SNAPSHOT_SERVICE_URL: env['SNAPSHOT_SERVICE_URL'],
+    SNAPSHOT_SERVICE_TOKEN: env['SNAPSHOT_SERVICE_TOKEN'],
+    SNAPSHOT_SERVICE_TIMEOUT_MS: env['SNAPSHOT_SERVICE_TIMEOUT_MS'],
+  });
+  const serviceUrl = parsed.SNAPSHOT_SERVICE_URL;
+  const serviceToken = parsed.SNAPSHOT_SERVICE_TOKEN;
+  return {
+    serviceUrl,
+    serviceToken,
+    timeoutMs: parsed.SNAPSHOT_SERVICE_TIMEOUT_MS,
+    enabled: serviceUrl.length > 0 && serviceToken.length > 0,
+  };
+}

--- a/src/modules/snapshot/get-or-extract.ts
+++ b/src/modules/snapshot/get-or-extract.ts
@@ -1,0 +1,116 @@
+/**
+ * get-or-extract (⑤) — serve cached figure snapshots, extracting on miss.
+ *
+ * Two independent halves:
+ *   GET (serve-from-cache): reads video_figure_snapshots for the requested
+ *     (video_id, ts). This works on its own — manual-warm rows are served with
+ *     NO call to the extractor (demo safety net: warm the cache, serve from it).
+ *   EXTRACT (on miss): only the timestamps with no cache row are sent to the
+ *     numerize-client; whatever it returns is cached and appended.
+ *
+ * Interpolation = 0: a timestamp that is neither cached NOR produced by the
+ * extractor contributes NOTHING to the result (no fabricated figure). The
+ * extractor itself returns [] on any failure, so a cache-miss + extract-fail
+ * simply yields no FigureRef for that ts.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+import { extractFigures } from './numerize-client';
+import type { FigureKind, FigureRef } from './types';
+
+const log = logger.child({ module: 'snapshot/get-or-extract' });
+
+interface CacheRow {
+  video_id: string;
+  ts_sec: number;
+  kind: string;
+  struct: unknown;
+  latex: string | null;
+  asset_path: string | null;
+  verification_status: string;
+  source: string;
+}
+
+function rowToFigure(r: CacheRow): FigureRef {
+  return {
+    videoId: r.video_id,
+    tsSec: r.ts_sec,
+    kind: r.kind as FigureKind,
+    ...(r.struct != null ? { struct: r.struct } : {}),
+    ...(r.latex != null ? { latex: r.latex } : {}),
+    ...(r.asset_path != null ? { assetPath: r.asset_path } : {}),
+    verificationStatus: r.verification_status,
+    source: r.source,
+  };
+}
+
+type PrismaLike = {
+  $queryRawUnsafe: <T>(sql: string, ...args: unknown[]) => Promise<T>;
+  $executeRawUnsafe: (sql: string, ...args: unknown[]) => Promise<number>;
+};
+
+async function upsertFigure(prisma: PrismaLike, f: FigureRef): Promise<void> {
+  await prisma.$executeRawUnsafe(
+    `INSERT INTO video_figure_snapshots
+       (video_id, ts_sec, kind, struct, latex, asset_path, verification_status, source, computed_at)
+     VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, NOW())
+     ON CONFLICT (video_id, ts_sec, kind) DO UPDATE SET
+       struct              = EXCLUDED.struct,
+       latex               = EXCLUDED.latex,
+       asset_path          = EXCLUDED.asset_path,
+       verification_status = EXCLUDED.verification_status,
+       source              = EXCLUDED.source,
+       computed_at         = NOW()`,
+    f.videoId,
+    f.tsSec,
+    f.kind,
+    f.struct !== undefined ? JSON.stringify(f.struct) : null,
+    f.latex ?? null,
+    f.assetPath ?? null,
+    f.verificationStatus,
+    f.source
+  );
+}
+
+/**
+ * Return cached figures for the given timestamps, extracting (and caching) only
+ * the timestamps that have no live cache row.
+ */
+export async function getOrExtractSnapshots(
+  videoId: string,
+  tsList: number[]
+): Promise<FigureRef[]> {
+  const prisma = getPrismaClient() as unknown as PrismaLike;
+  const uniqueTs = Array.from(new Set(tsList.filter((t) => Number.isFinite(t))));
+  if (uniqueTs.length === 0) return [];
+
+  // GET — serve from cache (non-expired). Independent of the extractor.
+  const cached = await prisma.$queryRawUnsafe<CacheRow[]>(
+    `SELECT video_id, ts_sec, kind, struct, latex, asset_path, verification_status, source
+     FROM video_figure_snapshots
+     WHERE video_id = $1 AND ts_sec = ANY($2::int[]) AND expires_at > NOW()`,
+    videoId,
+    uniqueTs
+  );
+  const cachedTs = new Set(cached.map((r) => r.ts_sec));
+  const result: FigureRef[] = cached.map(rowToFigure);
+
+  // EXTRACT — only the missing timestamps. Empty result ⇒ those ts stay absent.
+  const missingTs = uniqueTs.filter((t) => !cachedTs.has(t));
+  if (missingTs.length > 0) {
+    const extracted = await extractFigures(videoId, missingTs);
+    for (const fig of extracted) {
+      await upsertFigure(prisma, fig);
+      result.push(fig);
+    }
+    log.info('get-or-extract', {
+      videoId,
+      requested: uniqueTs.length,
+      cacheHit: cachedTs.size,
+      extracted: extracted.length,
+    });
+  }
+
+  return result;
+}

--- a/src/modules/snapshot/numerize-client.ts
+++ b/src/modules/snapshot/numerize-client.ts
@@ -1,0 +1,96 @@
+/**
+ * Numerize client (⑤) — calls the pod slidegen-service to extract figures from
+ * a video's frames at given timestamps.
+ *
+ * The service (frame fetch via Mac Mini KR-IP + YOLO/Qwen numerize) is slidegen
+ * 정본; this client only crosses the boundary via the RunPod proxy pattern
+ * (SNAPSHOT_SERVICE_URL + bearer). The exact request body shape is pending a
+ * 1-field alignment with slidegen — kept minimal ({ video_id, ts }) and easy to
+ * extend.
+ *
+ * Interpolation = 0 (hard rule): if the service is unset, unreachable, times
+ * out, or returns a non-2xx / unparseable body, this returns [] — it NEVER
+ * fabricates a figure. A missing figure is an absent FigureRef, never a guessed
+ * one. The caller (get-or-extract) then simply has no row for that ts/kind.
+ */
+
+import { loadSnapshotConfig } from '@/config/snapshot';
+import { logger } from '@/utils/logger';
+import { FIGURE_KINDS, type FigureKind, type FigureRef } from './types';
+
+const log = logger.child({ module: 'snapshot/numerize-client' });
+
+interface ServiceFigure {
+  kind?: string;
+  struct?: unknown;
+  latex?: string;
+  asset_path?: string;
+  verification_status?: string;
+}
+
+function isFigureKind(k: unknown): k is FigureKind {
+  return typeof k === 'string' && (FIGURE_KINDS as readonly string[]).includes(k);
+}
+
+/**
+ * Extract figures for one video at the given timestamps. Returns only the
+ * figures the service actually produced; never invents figures for timestamps
+ * the service skipped (honest fail).
+ */
+export async function extractFigures(videoId: string, tsList: number[]): Promise<FigureRef[]> {
+  const cfg = loadSnapshotConfig();
+  if (!cfg.enabled) {
+    // Service not configured ⇒ no live extraction. Cache-only mode (demo).
+    log.info('numerize: service disabled, no extraction', { videoId, tsCount: tsList.length });
+    return [];
+  }
+  if (tsList.length === 0) return [];
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), cfg.timeoutMs);
+  try {
+    const resp = await fetch(`${cfg.serviceUrl.replace(/\/$/, '')}/numerize`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${cfg.serviceToken}`,
+      },
+      body: JSON.stringify({ video_id: videoId, ts: tsList }),
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      log.warn('numerize: service non-2xx — no figures', { videoId, status: resp.status });
+      return []; // honest fail — do not fabricate
+    }
+    const body = (await resp.json()) as { figures?: Array<ServiceFigure & { ts_sec?: number }> };
+    const figures = Array.isArray(body?.figures) ? body.figures : [];
+
+    const out: FigureRef[] = [];
+    for (const f of figures) {
+      if (!isFigureKind(f.kind)) continue; // unknown kind → drop, don't guess
+      const tsSec = typeof f.ts_sec === 'number' ? f.ts_sec : NaN;
+      if (!Number.isFinite(tsSec)) continue;
+      out.push({
+        videoId,
+        tsSec,
+        kind: f.kind,
+        ...(f.struct !== undefined ? { struct: f.struct } : {}),
+        ...(typeof f.latex === 'string' ? { latex: f.latex } : {}),
+        ...(typeof f.asset_path === 'string' ? { assetPath: f.asset_path } : {}),
+        verificationStatus:
+          typeof f.verification_status === 'string' ? f.verification_status : 'unverified',
+        source: 'numerize',
+      });
+    }
+    return out;
+  } catch (err) {
+    // Timeout / network / parse error ⇒ honest fail, no figures.
+    log.warn('numerize: extraction failed — no figures', {
+      videoId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/modules/snapshot/types.ts
+++ b/src/modules/snapshot/types.ts
@@ -1,0 +1,21 @@
+// ⑤ get-or-extract — shared figure types.
+
+export const FIGURE_KINDS = ['chart', 'diagram', 'table', 'equation', 'keyframe'] as const;
+export type FigureKind = (typeof FIGURE_KINDS)[number];
+
+/**
+ * One extracted figure at a video timestamp (⑤ contract). Payload by kind:
+ *   chart | diagram | table → struct (numerize JSON, what slidegen renders)
+ *   equation               → latex
+ *   keyframe               → assetPath (binary pointer; deferred, may be null)
+ */
+export interface FigureRef {
+  videoId: string;
+  tsSec: number;
+  kind: FigureKind;
+  struct?: unknown;
+  latex?: string;
+  assetPath?: string;
+  verificationStatus: string;
+  source: string;
+}

--- a/tests/unit/modules/snapshot-get-or-extract.test.ts
+++ b/tests/unit/modules/snapshot-get-or-extract.test.ts
@@ -1,0 +1,127 @@
+/**
+ * get-or-extract (⑤) tests — the invariants James reviews before merge:
+ *   (b) interpolation = 0 — a cache-miss whose extraction yields nothing
+ *       contributes NO figure (no fabrication), and nothing is upserted;
+ *   (c) serve-from-cache is independent of extract — when every requested ts is
+ *       cached, the extractor is NEVER called (manual-warm rows serve alone).
+ *   plus: cache miss → extract → upsert → return; partial hit only extracts the
+ *   missing timestamps; query is content-scoped (video_id + ts, no user/mandala).
+ */
+
+const mockQuery = jest.fn();
+const mockExec = jest.fn().mockResolvedValue(1);
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    $queryRawUnsafe: (...args: unknown[]) => mockQuery(...args),
+    $executeRawUnsafe: (...args: unknown[]) => mockExec(...args),
+  }),
+}));
+
+const mockExtract = jest.fn();
+jest.mock('@/modules/snapshot/numerize-client', () => ({
+  extractFigures: (...args: unknown[]) => mockExtract(...args),
+}));
+
+jest.mock('@/config/index', () => ({
+  config: {
+    database: { url: 'postgresql://postgres:pass@127.0.0.1:5432/postgres', directUrl: undefined },
+    app: { isDevelopment: true, isProduction: false, isTest: true },
+    paths: { logs: '/tmp' },
+  },
+}));
+
+import { getOrExtractSnapshots } from '../../../src/modules/snapshot/get-or-extract';
+
+const VID = 'dQw4w9WgXcQ';
+
+const cacheRow = (ts: number, kind: string, extra: Record<string, unknown> = {}) => ({
+  video_id: VID,
+  ts_sec: ts,
+  kind,
+  struct: null,
+  latex: null,
+  asset_path: null,
+  verification_status: 'unverified',
+  source: 'manual-warm',
+  ...extra,
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockExec.mockClear();
+  mockExtract.mockReset();
+});
+
+describe('get-or-extract', () => {
+  it('serves from cache WITHOUT calling the extractor when all ts are cached', async () => {
+    mockQuery.mockResolvedValue([
+      cacheRow(10, 'diagram', { struct: { nodes: 3 } }),
+      cacheRow(20, 'equation', { latex: 'x^2' }),
+    ]);
+
+    const figs = await getOrExtractSnapshots(VID, [10, 20]);
+
+    expect(mockExtract).not.toHaveBeenCalled(); // independence
+    expect(mockExec).not.toHaveBeenCalled(); // no upsert on pure hit
+    expect(figs).toHaveLength(2);
+    expect(figs.find((f) => f.tsSec === 10)?.struct).toEqual({ nodes: 3 });
+    expect(figs.find((f) => f.tsSec === 20)?.latex).toBe('x^2');
+  });
+
+  it('queries the cache content-scoped by (video_id, ts) — no user/mandala key', async () => {
+    mockQuery.mockResolvedValue([]);
+    mockExtract.mockResolvedValue([]);
+    await getOrExtractSnapshots(VID, [42]);
+    const [sql, vid, tsArr] = mockQuery.mock.calls[0]!;
+    expect(sql).toContain('FROM video_figure_snapshots');
+    expect(sql).toContain('WHERE video_id = $1 AND ts_sec = ANY($2::int[])');
+    expect(sql).not.toMatch(/user_id|mandala_id/);
+    expect(vid).toBe(VID);
+    expect(tsArr).toEqual([42]);
+  });
+
+  it('writes NOTHING and returns no figure when a miss yields no extraction (interpolation = 0)', async () => {
+    mockQuery.mockResolvedValue([]); // nothing cached
+    mockExtract.mockResolvedValue([]); // extractor honest-fails
+
+    const figs = await getOrExtractSnapshots(VID, [5, 6]);
+
+    expect(mockExtract).toHaveBeenCalledWith(VID, [5, 6]);
+    expect(figs).toEqual([]); // no fabricated figures
+    expect(mockExec).not.toHaveBeenCalled(); // nothing cached
+  });
+
+  it('extracts misses, upserts, and returns them', async () => {
+    mockQuery.mockResolvedValue([]);
+    mockExtract.mockResolvedValue([
+      {
+        videoId: VID,
+        tsSec: 7,
+        kind: 'chart',
+        struct: { bars: 4 },
+        verificationStatus: 'unverified',
+        source: 'numerize',
+      },
+    ]);
+
+    const figs = await getOrExtractSnapshots(VID, [7]);
+
+    expect(mockExec).toHaveBeenCalledTimes(1);
+    const upsertSql = mockExec.mock.calls[0]![0] as string;
+    expect(upsertSql).toContain('INSERT INTO video_figure_snapshots');
+    expect(upsertSql).toContain('ON CONFLICT (video_id, ts_sec, kind)');
+    expect(figs).toHaveLength(1);
+    expect(figs[0]!.struct).toEqual({ bars: 4 });
+  });
+
+  it('only extracts the MISSING timestamps on a partial cache hit', async () => {
+    mockQuery.mockResolvedValue([cacheRow(10, 'table', { struct: { rows: 2 } })]);
+    mockExtract.mockResolvedValue([]); // 20 missing → extractor returns nothing
+
+    const figs = await getOrExtractSnapshots(VID, [10, 20]);
+
+    expect(mockExtract).toHaveBeenCalledWith(VID, [20]); // only the miss
+    expect(figs).toHaveLength(1); // the cached one only (20 honest-absent)
+    expect(figs[0]!.tsSec).toBe(10);
+  });
+});

--- a/tests/unit/modules/snapshot-numerize-client.test.ts
+++ b/tests/unit/modules/snapshot-numerize-client.test.ts
@@ -1,0 +1,78 @@
+/**
+ * numerize-client (⑤) tests — interpolation = 0 at the extraction boundary:
+ *   - service disabled ⇒ [] (no fetch, no fabrication);
+ *   - service non-2xx / network error ⇒ [] (honest fail);
+ *   - valid response ⇒ figures mapped; unknown kinds dropped (not guessed).
+ */
+
+const mockLoadConfig = jest.fn();
+jest.mock('@/config/snapshot', () => ({
+  loadSnapshotConfig: () => mockLoadConfig(),
+}));
+
+jest.mock('@/config/index', () => ({
+  config: {
+    database: { url: 'postgresql://postgres:pass@127.0.0.1:5432/postgres', directUrl: undefined },
+    app: { isDevelopment: true, isProduction: false, isTest: true },
+    paths: { logs: '/tmp' },
+  },
+}));
+
+import { extractFigures } from '../../../src/modules/snapshot/numerize-client';
+
+const enabled = {
+  serviceUrl: 'https://pod-8000.proxy.runpod.net',
+  serviceToken: 't',
+  timeoutMs: 1000,
+  enabled: true,
+};
+const disabled = { serviceUrl: '', serviceToken: '', timeoutMs: 1000, enabled: false };
+
+const fetchMock = jest.fn();
+beforeEach(() => {
+  mockLoadConfig.mockReset();
+  fetchMock.mockReset();
+  (global as { fetch?: unknown }).fetch = fetchMock;
+});
+
+describe('numerize-client (interpolation = 0)', () => {
+  it('returns [] without fetching when the service is disabled', async () => {
+    mockLoadConfig.mockReturnValue(disabled);
+    const out = await extractFigures('vid', [1, 2]);
+    expect(out).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns [] (honest fail) on a non-2xx response', async () => {
+    mockLoadConfig.mockReturnValue(enabled);
+    fetchMock.mockResolvedValue({ ok: false, status: 502 });
+    const out = await extractFigures('vid', [1]);
+    expect(out).toEqual([]);
+  });
+
+  it('returns [] (honest fail) on a network/timeout error', async () => {
+    mockLoadConfig.mockReturnValue(enabled);
+    fetchMock.mockRejectedValue(new Error('aborted'));
+    const out = await extractFigures('vid', [1]);
+    expect(out).toEqual([]);
+  });
+
+  it('maps valid figures and drops unknown kinds (no guessing)', async () => {
+    mockLoadConfig.mockReturnValue(enabled);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        figures: [
+          { kind: 'chart', ts_sec: 5, struct: { bars: 3 } },
+          { kind: 'equation', ts_sec: 9, latex: 'x^2' },
+          { kind: 'bogus', ts_sec: 12 }, // unknown kind → dropped
+          { kind: 'keyframe' }, // no ts_sec → dropped
+        ],
+      }),
+    });
+    const out = await extractFigures('vid', [5, 9, 12]);
+    expect(out).toHaveLength(2);
+    expect(out.map((f) => f.kind)).toEqual(['chart', 'equation']);
+    expect(out[0]!.source).toBe('numerize');
+  });
+});


### PR DESCRIPTION
## What

The slidegen **relevance-gate boundary** (⑤): given a `video_id` + the high-relevance timestamps (② output), return `FigureRef[]` from a content-scoped cache, extracting misses via the pod slidegen-service.

James-approved §2-B decisions: **(b) no object storage** (keyframe `asset_path` reserved/deferred; demo figures are struct/latex), numerize runs on the **pod service** (not insighta), and the storage module (James's v2-translations WIP) is **untouched**.

## Inspection points (per your pre-merge diff review)

**(a) DDL** — `prisma/migrations/snapshot/001_video_figure_snapshots.sql`: PK `(video_id, ts_sec, kind)`; `struct JSONB` nullable; `asset_path TEXT` nullable (keyframe deferred); `CREATE TABLE IF NOT EXISTS` + CHECK(kind) = idempotent; force-tracked + registered in `apply-custom-sql.sh` allowlist (CP499+).

**(b) interpolation = 0** — `get-or-extract.ts`: a cache-miss whose extraction yields nothing contributes **no figure** (not appended) and **nothing is upserted**. `numerize-client.ts` returns `[]` on unset/non-2xx/timeout/unknown-kind — never fabricates. Locked by tests `writes NOTHING ... when a miss yields no extraction` + numerize honest-fail cases.

**(c) serve-from-cache independent of extract** — `get-or-extract.ts` runs the cache SELECT first; when every requested ts is cached, `extractFigures` is **never called** (manual-warm rows serve alone). Locked by test `serves from cache WITHOUT calling the extractor`. This is the demo safety net: warm the cache, serve from it, even with the extractor disabled.

## Pipeline

`POST /api/v1/internal/snapshot/get-or-extract {videoId, ts[]}` (x-internal-token) → cache lookup (non-expired) → misses → `numerize-client` (pod service, RunPod proxy pattern) → upsert → `{figures: FigureRef[]}`.

FigureRef by kind: chart/diagram/table → `struct` · equation → `latex` · keyframe → `assetPath` (deferred).

## Cross-session contract note

The numerize-client request body (`{video_id, ts}`) is **pending a 1-field alignment with slidegen** (the service is slidegen-owned). The `FigureRef` **output** contract is set (James-delivered). Frame fetch (Mac Mini KR-IP) + numerize live behind the service per §4.

## Safety

- Inert until `SNAPSHOT_SERVICE_URL`+token configured (extractor disabled ⇒ cache-only). New table, no consumer ⇒ no findMany 500 risk. No FK on video_id (content cache, mirrors video_pool).
- `SNAPSHOT_SERVICE_URL` = GitHub Variable (URL, CP392) / `SNAPSHOT_SERVICE_TOKEN` = Secret.

## Verification

9/9 unit tests (serve-from-cache independence, interpolation-0, content-scoped query, miss→extract→upsert, partial-hit, numerize honest-fail). `prisma validate` 🚀. tsc clean for new files. Schema diff is exactly the new model (no format churn).