### PR TITLE
feat(deck-button): '슬라이드 덱 생성' menu item — data-prep trigger (③)

### DIFF
--- a/frontend/src/features/mandala/index.ts
+++ b/frontend/src/features/mandala/index.ts
@@ -4,6 +4,7 @@ export {
   useCreateMandala,
   useDeleteMandala,
   useRenameMandala,
+  useGenerateSlideDeck,
   useSwitchMandala,
   useMandalaQuota,
   useToggleMandalaShare,

--- a/frontend/src/features/mandala/model/useMandalaQuery.ts
+++ b/frontend/src/features/mandala/model/useMandalaQuery.ts
@@ -263,6 +263,17 @@ export function useRenameMandala() {
   });
 }
 
+/**
+ * Trigger slide-deck DATA PREP (③) — enqueues book-index + segment-relevance
+ * fills for a mandala. Fire-and-forget (the jobs run async on the server); the
+ * caller shows a "준비중" progress state. Does NOT render a deck (slidegen).
+ */
+export function useGenerateSlideDeck() {
+  return useMutation({
+    mutationFn: (mandalaId: string) => apiClient.generateSlideDeck(mandalaId),
+  });
+}
+
 export function useSwitchMandala() {
   const queryClient = useQueryClient();
 

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1352,6 +1352,10 @@
     "upgrade": "Upgrade",
     "mandalaActions": {
       "openMenu": "Open menu",
+      "generateDeck": "Generate slide deck",
+      "generatingDeck": "Preparing",
+      "deckPrepStarted": "Started preparing the book index",
+      "deckPrepError": "Couldn't start preparation. Please try again in a moment.",
       "share": "Share",
       "archive": "Archive",
       "delete": "Delete",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1360,6 +1360,10 @@
     "upgrade": "Upgrade",
     "mandalaActions": {
       "openMenu": "메뉴 열기",
+      "generateDeck": "슬라이드 덱 생성",
+      "generatingDeck": "준비중",
+      "deckPrepStarted": "북인덱스 생성을 시작했어요",
+      "deckPrepError": "생성을 시작하지 못했어요. 잠시 후 다시 시도해주세요.",
       "share": "공유",
       "archive": "아카이브에 보관",
       "delete": "삭제",

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1479,6 +1479,17 @@ class ApiClient {
   }
 
   /**
+   * Trigger slide-deck DATA PREP for a mandala (③). Enqueues book-index +
+   * segment-relevance fills (the verified #932/#933 contracts). Does NOT render
+   * a deck — that is slidegen's job; this only readies the data.
+   */
+  async generateSlideDeck(mandalaId: string): Promise<{ success: boolean }> {
+    return this.request<{ success: boolean }>(`/mandalas/${mandalaId}/generate-deck`, {
+      method: 'POST',
+    });
+  }
+
+  /**
    * Toggle pin/bookmark state on a grid view card (CP457+).
    *
    * `source` must match `InsightCard.sourceTable` — the FE-only discriminator

--- a/frontend/src/widgets/app-shell/ui/MandalaRowMenu.tsx
+++ b/frontend/src/widgets/app-shell/ui/MandalaRowMenu.tsx
@@ -14,7 +14,7 @@
  */
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MoreHorizontal, Share2, Archive, Trash2 } from 'lucide-react';
+import { MoreHorizontal, Share2, Archive, Trash2, Presentation } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import {
   DropdownMenu,
@@ -41,9 +41,19 @@ interface MandalaRowMenuProps {
   /** Parent-hosted delete handler. Called on AlertDialog confirm with the
    * mandala id. The parent runs the mutation + toast + optimistic mask. */
   onConfirmDelete: (mandalaId: string) => void;
+  /** Slide-deck data-prep trigger (③). Parent fires the enqueue + toast. */
+  onGenerateDeck: (mandalaId: string) => void;
+  /** True while this mandala's deck data-prep is in flight (shows "준비중"). */
+  isGeneratingDeck: boolean;
 }
 
-export function MandalaRowMenu({ mandalaId, isLastMandala, onConfirmDelete }: MandalaRowMenuProps) {
+export function MandalaRowMenu({
+  mandalaId,
+  isLastMandala,
+  onConfirmDelete,
+  onGenerateDeck,
+  isGeneratingDeck,
+}: MandalaRowMenuProps) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -66,7 +76,25 @@ export function MandalaRowMenu({ mandalaId, isLastMandala, onConfirmDelete }: Ma
             <MoreHorizontal className="h-3.5 w-3.5" strokeWidth={2.5} />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-44" onClick={(e) => e.stopPropagation()}>
+        <DropdownMenuContent align="end" className="w-48" onClick={(e) => e.stopPropagation()}>
+          <DropdownMenuItem
+            disabled={isGeneratingDeck}
+            onSelect={(e) => {
+              e.preventDefault();
+              onGenerateDeck(mandalaId);
+              setMenuOpen(false);
+            }}
+            className="focus:bg-foreground/[0.04] focus:text-foreground"
+          >
+            <Presentation className="mr-2 h-4 w-4" />
+            <span>{t('sidebar.mandalaActions.generateDeck')}</span>
+            {isGeneratingDeck && (
+              <span className="ml-auto text-[10px] text-muted-foreground/70">
+                {t('sidebar.mandalaActions.generatingDeck')}
+              </span>
+            )}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem
             disabled
             className="opacity-60 focus:bg-foreground/[0.04] focus:text-foreground"

--- a/frontend/src/widgets/app-shell/ui/SidebarMandalaSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarMandalaSection.tsx
@@ -4,7 +4,12 @@ import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChevronDown, RefreshCw } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
-import { useMandalaList, useSwitchMandala, useDeleteMandala } from '@/features/mandala';
+import {
+  useMandalaList,
+  useSwitchMandala,
+  useDeleteMandala,
+  useGenerateSlideDeck,
+} from '@/features/mandala';
 import { useMandalaStore } from '@/stores/mandalaStore';
 import { queryKeys } from '@/shared/config/query-client';
 import type { InsightCard } from '@/entities/card/model/types';
@@ -59,6 +64,38 @@ export function SidebarMandalaSection({
   // the inline { onSuccess } callback can fire, swallowing the toast.
   const queryClient = useQueryClient();
   const deleteMandala = useDeleteMandala();
+  const generateDeck = useGenerateSlideDeck();
+  // Mandalas whose deck data-prep is in flight (drives the menu "준비중" label).
+  const [generatingIds, setGeneratingIds] = useState<Set<string>>(new Set());
+
+  // Slide-deck data prep (③): fire the verified book + segment-relevance fills.
+  // HONEST: this readies data; the deck render (slidegen) is not wired here yet.
+  const handleGenerateDeck = useCallback(
+    (mandalaId: string) => {
+      setGeneratingIds((prev) => new Set(prev).add(mandalaId));
+      generateDeck.mutate(mandalaId, {
+        onSuccess: () => {
+          toast.success(t('sidebar.mandalaActions.deckPrepStarted', '북인덱스 생성을 시작했어요'));
+        },
+        onError: () => {
+          toast.error(
+            t(
+              'sidebar.mandalaActions.deckPrepError',
+              '생성을 시작하지 못했어요. 잠시 후 다시 시도해주세요.'
+            )
+          );
+        },
+        onSettled: () => {
+          setGeneratingIds((prev) => {
+            const next = new Set(prev);
+            next.delete(mandalaId);
+            return next;
+          });
+        },
+      });
+    },
+    [generateDeck, t]
+  );
 
   const switchMandala = useSwitchMandala();
 
@@ -303,6 +340,8 @@ export function SidebarMandalaSection({
                   mandalaId={mandala.id}
                   isLastMandala={sortedMandalas.length <= 1}
                   onConfirmDelete={handleConfirmDelete}
+                  onGenerateDeck={handleGenerateDeck}
+                  isGeneratingDeck={generatingIds.has(mandala.id)}
                 />
               </div>
             );

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -1,5 +1,7 @@
 import { FastifyPluginCallback } from 'fastify';
 import { getMandalaManager } from '../../modules/mandala';
+import { enqueueMandalaBookFill } from '../../modules/queue/handlers/mandala-book-fill';
+import { enqueueSegmentRelevanceForMandala } from '../../modules/relevance/segment-relevance-trigger';
 import { getMood } from '../../modules/mandala/mood';
 import { triggerMandalaPostCreationAsync } from '../../modules/mandala/mandala-post-creation';
 import { getPrismaClient } from '../../modules/database/client';
@@ -390,6 +392,35 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       } catch {
         return reply.code(404).send({ error: 'Mandala not found' });
       }
+    }
+  );
+
+  /**
+   * POST /api/v1/mandalas/:id/generate-deck — slide-deck data prep (③).
+   *
+   * HONEST scope: this triggers the DATA-PREP for a slide deck, NOT the deck
+   * render (deck render ④⑥ is slidegen's job). It enqueues:
+   *   - book-index fill (#932): mandala_books from v2 summaries;
+   *   - segment-relevance fill (#933): video_mandala_segment_relevance.
+   * Ownership-checked (own mandala only); reuses the already-verified enqueue
+   * contracts (no new generation logic).
+   */
+  fastify.post<{ Params: { id: string } }>(
+    '/:id/generate-deck',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const userId = getUserId(request, reply);
+      if (!userId) return;
+      const mandalaId = request.params.id;
+
+      // Ownership: getMandalaById is scoped to (userId, mandalaId) → null if not owned.
+      const mandala = await getMandalaManager().getMandalaById(userId, mandalaId);
+      if (!mandala) return reply.code(404).send({ error: 'Mandala not found' });
+
+      const bookJobId = await enqueueMandalaBookFill({ userId, mandalaId, trigger: 'deck-button' });
+      const segmentResult = await enqueueSegmentRelevanceForMandala({ userId, mandalaId });
+
+      return reply.send({ success: true, data: { bookJobId, segmentResult } });
     }
   );
 

--- a/tests/unit/api/mandala-routes.test.ts
+++ b/tests/unit/api/mandala-routes.test.ts
@@ -64,6 +64,16 @@ jest.mock('../../../src/modules/mandala', () => ({
   }),
 }));
 
+// ③ slide-deck data-prep enqueues (verified contracts #932/#933).
+const mockEnqueueBookFill = jest.fn().mockResolvedValue('book-job-1');
+jest.mock('../../../src/modules/queue/handlers/mandala-book-fill', () => ({
+  enqueueMandalaBookFill: (...a: unknown[]) => mockEnqueueBookFill(...a),
+}));
+const mockEnqueueSegments = jest.fn().mockResolvedValue({ enqueued: 5, segments: 5 });
+jest.mock('../../../src/modules/relevance/segment-relevance-trigger', () => ({
+  enqueueSegmentRelevanceForMandala: (...a: unknown[]) => mockEnqueueSegments(...a),
+}));
+
 import { mandalaRoutes } from '../../../src/api/routes/mandalas';
 
 // ─── Test Fixtures ───
@@ -890,6 +900,50 @@ describe('Mandala API Routes', () => {
       });
 
       expect(res.statusCode).toBe(404);
+    });
+  });
+
+  // ─── POST /:id/generate-deck (③ slide-deck data prep) ───
+
+  describe('POST /:id/generate-deck', () => {
+    test('owned mandala → 200 + enqueues book-fill AND segment-relevance', async () => {
+      mockGetMandalaById.mockResolvedValue({
+        id: 'm1',
+        levels: [{ centerGoal: 'g', subjects: [] }],
+      });
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `${PREFIX}/m1/generate-deck`,
+        headers: authHeaders(),
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(mockEnqueueBookFill).toHaveBeenCalledWith({
+        userId: 'test-user-id',
+        mandalaId: 'm1',
+        trigger: 'deck-button',
+      });
+      expect(mockEnqueueSegments).toHaveBeenCalledWith({ userId: 'test-user-id', mandalaId: 'm1' });
+    });
+
+    test('not-owned mandala → 404 + NO enqueue', async () => {
+      mockGetMandalaById.mockResolvedValue(null);
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `${PREFIX}/m1/generate-deck`,
+        headers: authHeaders(),
+      });
+
+      expect(res.statusCode).toBe(404);
+      expect(mockEnqueueBookFill).not.toHaveBeenCalled();
+      expect(mockEnqueueSegments).not.toHaveBeenCalled();
+    });
+
+    test('no auth → 401', async () => {
+      const res = await app.inject({ method: 'POST', url: `${PREFIX}/m1/generate-deck` });
+      expect(res.statusCode).toBe(401);
     });
   });
 });


### PR DESCRIPTION
## What

Adds the **last missing end-to-end link (③)**: an active "슬라이드 덱 생성" item in the sidebar mandala "..." menu (currently only share/archive 준비중 + delete). The demo entry point.

**(B) decision (James-approved):** the click does **real server work** — it triggers the slide-deck DATA PREP via the already-verified contracts, not a fake toast.

**Honest scope:** this readies DATA (book index + segment relevance). The deck **render** (④⑥) is slidegen's job — not wired here. The progress copy says **"북인덱스 생성을 시작했어요"**, never "deck generated".

## Changes

- **BE**: `POST /api/v1/mandalas/:id/generate-deck` (user auth + **ownership check** via `getMandalaById(userId, id)` → 404 if not owned). Reuses `enqueueMandalaBookFill` (#932) + `enqueueSegmentRelevanceForMandala` (#933). Thin wrapper, **no new generation logic**.
- **FE**: `MandalaRowMenu` active item (Presentation icon) + `useGenerateSlideDeck` hook + `apiClient.generateSlideDeck` + `SidebarMandalaSection` wiring (per-mandala "준비중" state + success/error toast). i18n ko + en.

## Verification (/verify FULL)

| Check | Result |
|---|---|
| BE tsc | ✅ (0 in my files) |
| BE jest | ✅ **3/3 generate-deck** (owned→200+both enqueues / not-owned→404+no enqueue / no-auth→401) |
| FE tsc | ✅ 0 errors |
| FE vitest | ✅ 4/4 |
| FE build | ✅ dist OK |
| browser smoke | ✅ / · /mandalas · /login → 200; **'슬라이드 덱 생성' in built bundle** |

**Caveat**: curl-smoke confirms no-crash + label bundled; the literal authenticated click-through (open menu → click → toast) is best confirmed in the live demo browser. Button is additive (tsc+build+vitest verified) + BE route 3/3 tested → low runtime risk.

## End-to-end status (insighta-side)

① book-fill (#932) ✅ · ② segment-relevance (#933) ✅ · ⑤ get-or-extract (#934) ✅ · **③ button (this PR)**. ④⑥ render = slidegen (separate repo, §4).