### PR TITLE
fix(deck-button): generate-deck empty-body 400 + regression guard (#935 hotfix)

### DIFF
--- a/frontend/src/__tests__/api-client-generate-deck.test.ts
+++ b/frontend/src/__tests__/api-client-generate-deck.test.ts
@@ -1,0 +1,64 @@
+/**
+ * apiClient.generateSlideDeck — empty-body 400 regression guard.
+ *
+ * The bug (#935 prod): a body-less POST still gets Content-Type: application/json
+ * from request(), and Fastify rejects an empty JSON body with
+ * FST_ERR_CTP_EMPTY_JSON_BODY (400) BEFORE the route runs. The BE inject() test
+ * missed it (inject without a content-type never triggers the JSON body parser).
+ *
+ * This test exercises the REAL fetch shape: it asserts the request carries a
+ * non-empty JSON body. On the unfixed method (no body) `init.body` is undefined
+ * → this test FAILS. That failure is the point — it is a true guard.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/shared/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+      refreshSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+    },
+  },
+}));
+
+import { apiClient } from '@/shared/lib/api-client';
+
+describe('apiClient.generateSlideDeck — empty-body 400 guard', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true }),
+      text: async () => '{"success":true}',
+      headers: new Headers({ 'content-type': 'application/json' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('sends a non-empty JSON body (else FST_ERR_CTP_EMPTY_JSON_BODY 400)', async () => {
+    try {
+      await apiClient.generateSlideDeck('m1');
+    } catch {
+      // Response-parsing details are irrelevant — we assert on the request that
+      // was actually sent (the body is set before the response is read).
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/mandalas/m1/generate-deck');
+    expect(init.method).toBe('POST');
+
+    // request() always sets JSON content-type → an empty body 400s server-side.
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Content-Type']).toBe('application/json');
+
+    // THE GUARD: a body MUST be present and valid JSON.
+    expect(init.body).toBeDefined();
+    expect(init.body).not.toBe('');
+    expect(() => JSON.parse(init.body as string)).not.toThrow();
+  });
+});

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1486,6 +1486,9 @@ class ApiClient {
   async generateSlideDeck(mandalaId: string): Promise<{ success: boolean }> {
     return this.request<{ success: boolean }>(`/mandalas/${mandalaId}/generate-deck`, {
       method: 'POST',
+      // Empty `{}` body to satisfy the default `Content-Type: application/json`
+      // — a body-less POST 400s with FST_ERR_CTP_EMPTY_JSON_BODY (see #935 prod).
+      body: JSON.stringify({}),
     });
   }
 


### PR DESCRIPTION
## Bug (prod, #935)

Clicking '슬라이드 덱 생성' showed the **error** toast ("생성을 시작하지 못했어요"). Root cause (prod log fact-read): `POST /mandalas/:id/generate-deck` was sent with **no body** but `Content-Type: application/json` (`request()` always sets it) → Fastify rejected it with **`FST_ERR_CTP_EMPTY_JSON_BODY` (400) before the route ran**. Ownership + both enqueues never executed (verified: `mandala_books` NONE, `video_mandala_segment_relevance` 0 rows for the clicked mandala).

## Fix (1 line)

`generateSlideDeck` now sends `body: JSON.stringify({})` — the existing in-code pattern (`api-client.ts:1544`) for this exact class of body-less POST.

## Regression guard (the point)

New FE test exercises the **real fetch shape** (not `inject()`): it asserts the request carries a non-empty JSON body.
- **Verified it FAILS on the unfixed method** (`expected undefined to be defined`) → true guard.
- PASSES after the fix.
- The BE `inject()` test could NOT catch this — `inject` without a content-type never triggers the JSON body parser. That gap is why #935 shipped green.

## 전수 점검 — same zombie elsewhere (RECORDED, out of demo path)

Other body-less single-line POST api-client methods share this latent bug:
`/auth/logout`, `/mandalas/:id/like`, `/mandalas/:id/clone`, `/mandalas/:id/trigger-pipeline`, `/sharing/:code/clone`, admin clawbot/audit.

**Structural follow-up recommended**: `request()` should omit `Content-Type` when there is no body — fixes the whole class + prevents future zombies. Not done here (demo cut; this PR fixes only the demo path + adds the guard).

## Verification (/verify FE)

FE tsc 0 · eslint 0 · vitest (guard: fail-on-unfixed → pass-on-fixed) · build ✓ · browser smoke / · /mandalas · /login → 200.