### PR TITLE
feat(figure-chain): C' warm-select + D figure-build mapping/collect (inert)

### DIFF
--- a/scripts/warm-figure-snapshots.ts
+++ b/scripts/warm-figure-snapshots.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env npx tsx
+/**
+ * C' figure-snapshot warming (figure deck chain).
+ *
+ * Pre-extracts figures for a mandala's high-relevance segments into
+ * video_figure_snapshots, so the demo button chain only COLLECTS cached figures
+ * (D) + builds — no live numerize at click time (numerize is 10-60s/video, not
+ * one-take-able). Picks figure-worthy timestamps SPREAD across cells (theme
+ * groups) via selectWarmTargets (capped — no over-extraction).
+ *
+ * Calls the insighta-internal POST /api/v1/internal/snapshot/get-or-extract
+ * route (x-internal-token); that route's numerize-client does the actual
+ * extraction — but only when extract is ENABLED (A: SNAPSHOT_SERVICE_TOKEN set)
+ * AND the slidegen /numerize responds (B). Until A+B, --execute extracts nothing
+ * (returns []), so this is gated:
+ *
+ *   --dry-run (DEFAULT): build + print the warm plan (video/cell/ts). NO HTTP,
+ *                        NO writes. Verifies the selection up to the call.
+ *   --execute         : actually POST get-or-extract per target (prod write =
+ *                        snapshots upsert). Run ONLY after A+B land, per James.
+ *
+ * Run IN the prod container (DIRECT_URL + API both reachable). NOT auto-executed.
+ *
+ * Usage:
+ *   npx tsx scripts/warm-figure-snapshots.ts                       # dry-run, mandala 942
+ *   npx tsx scripts/warm-figure-snapshots.ts --mandala <uuid>      # dry-run other mandala
+ *   npx tsx scripts/warm-figure-snapshots.ts --execute             # real extraction (A+B required)
+ *   npx tsx scripts/warm-figure-snapshots.ts --min-rel 75 --per-cell 3 --per-video 4
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { getInternalBatchToken } from '@/config/internal-auth';
+import { selectWarmTargets, type RelSegment } from '@/modules/snapshot/warm-select';
+
+const DEMO_MANDALA = '942e2757-64fa-4759-afc5-56e2f33869f2';
+
+function arg(name: string, fallback?: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+async function main(): Promise<void> {
+  const mandalaId = arg('mandala', DEMO_MANDALA)!;
+  const execute = process.argv.includes('--execute');
+  const minRel = Number(arg('min-rel', '80'));
+  const perCellVideoCap = Number(arg('per-cell', '2'));
+  const perVideoTsCap = Number(arg('per-video', '3'));
+  const prisma = getPrismaClient();
+
+  // High-relevance segments + per-video cell (placements). Both user-scoped tables.
+  const segments = await prisma.$queryRawUnsafe<RelSegment[]>(
+    `SELECT video_id AS "videoId", from_sec AS "fromSec", relevance_pct AS "relevancePct"
+     FROM video_mandala_segment_relevance
+     WHERE mandala_id = $1::uuid AND relevance_pct >= $2
+     ORDER BY relevance_pct DESC`,
+    mandalaId,
+    minRel
+  );
+  const cells = await prisma.$queryRawUnsafe<{ vid: string; cell: number }[]>(
+    `SELECT yv.youtube_video_id AS vid, uvs.cell_index AS cell
+       FROM user_video_states uvs JOIN youtube_videos yv ON yv.id = uvs.video_id
+       WHERE uvs.mandala_id = $1::uuid AND uvs.cell_index >= 0
+     UNION
+     SELECT ulc.video_id AS vid, ulc.cell_index AS cell
+       FROM user_local_cards ulc
+       WHERE ulc.mandala_id = $1::uuid AND ulc.cell_index >= 0 AND ulc.video_id IS NOT NULL`,
+    mandalaId
+  );
+  const cellByVideo = new Map<string, number>();
+  for (const c of cells) if (!cellByVideo.has(c.vid)) cellByVideo.set(c.vid, c.cell);
+
+  const targets = selectWarmTargets(segments, cellByVideo, { minRel, perCellVideoCap, perVideoTsCap });
+  const tsCount = targets.reduce((n, t) => n + t.ts.length, 0);
+
+  console.log(`[warm] mandala ${mandalaId} | segments>=${minRel}: ${segments.length} | targets: ${targets.length} videos / ${tsCount} ts (cap ${perCellVideoCap}/cell, ${perVideoTsCap}/video)`);
+  for (const t of targets) console.log(`  cell${t.cellIndex} ${t.videoId} ts=${JSON.stringify(t.ts)}`);
+
+  if (!execute) {
+    console.log('[warm] DRY-RUN — no HTTP, no writes. Add --execute after extract is ENABLED (A) + slidegen /numerize responds (B).');
+    await prisma.$disconnect();
+    return;
+  }
+
+  // --execute: real extraction via the internal route (prod write = snapshots upsert).
+  const token = getInternalBatchToken();
+  if (!token) {
+    console.log('[warm] ABORT: INTERNAL_BATCH_TOKEN unset — cannot call internal route.');
+    await prisma.$disconnect();
+    return;
+  }
+  const base = process.env['API_INTERNAL_BASE'] ?? 'http://localhost:3000';
+  let ok = 0,
+    empty = 0,
+    fail = 0;
+  for (const t of targets) {
+    try {
+      const resp = await fetch(`${base}/api/v1/internal/snapshot/get-or-extract`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-internal-token': token },
+        body: JSON.stringify({ videoId: t.videoId, ts: t.ts }),
+      });
+      const body = (await resp.json()) as { figures?: unknown[] };
+      const n = Array.isArray(body.figures) ? body.figures.length : 0;
+      if (n > 0) ok += 1;
+      else empty += 1;
+      console.log(`  ${t.videoId}: ${resp.status} figures=${n}`);
+    } catch (e) {
+      fail += 1;
+      console.log(`  ${t.videoId}: ERR ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+  console.log(`[warm] execute done — videos with figures: ${ok}, empty: ${empty}, fail: ${fail}`);
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error('[warm] fatal:', e);
+  process.exit(1);
+});

--- a/src/modules/snapshot/collect-figures.ts
+++ b/src/modules/snapshot/collect-figures.ts
@@ -1,0 +1,63 @@
+// D (figure → /slides/build) — collect a mandala's cached figures.
+//
+// Reads video_figure_snapshots for the mandala's placed videos and maps them to
+// the build-service figures[] payload. INERT until the build-call site exists:
+// nothing calls this yet (the POST /slides/build endpoint is not deployed on the
+// slidegen service). When the deck-build step lands, it calls this to gather the
+// figures it forwards. Read-only — no writes, no extraction (warming = C').
+
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+import {
+  snapshotRowToBuildFigure,
+  type BuildFigure,
+  type SnapshotRow,
+} from './figure-build-mapping';
+
+const log = logger.child({ module: 'snapshot/collect-figures' });
+
+/**
+ * Gather build figures for a mandala: placed videos (uvs+ulc, cell_index>=0) →
+ * their non-expired video_figure_snapshots → BuildFigure[]. Empty when the
+ * warming (C') has not populated snapshots yet (no fabrication).
+ */
+export async function collectFiguresForMandala(mandalaId: string): Promise<BuildFigure[]> {
+  const prisma = getPrismaClient();
+
+  // Placed videos across both user-scoped tables (mirror fill-book enumeration).
+  const [videoStates, localCards] = await Promise.all([
+    prisma.userVideoState.findMany({
+      where: { mandala_id: mandalaId, cell_index: { gte: 0 } },
+      select: { video: { select: { youtube_video_id: true } } },
+    }),
+    prisma.user_local_cards.findMany({
+      where: { mandala_id: mandalaId, cell_index: { gte: 0 } },
+      select: { video_id: true },
+    }),
+  ]);
+
+  const videoIds = Array.from(
+    new Set([
+      ...videoStates.map((r) => r.video?.youtube_video_id).filter((v): v is string => !!v),
+      ...localCards.map((r) => r.video_id).filter((v): v is string => !!v),
+    ])
+  );
+  if (videoIds.length === 0) return [];
+
+  // Non-expired cached figures for those videos. Raw SQL (composite-key table).
+  const rows = await prisma.$queryRawUnsafe<SnapshotRow[]>(
+    `SELECT video_id, ts_sec, kind, struct, latex, asset_path
+     FROM video_figure_snapshots
+     WHERE video_id = ANY($1::text[]) AND expires_at > NOW()
+     ORDER BY video_id, ts_sec, kind`,
+    videoIds
+  );
+
+  const figures = rows.map(snapshotRowToBuildFigure);
+  log.info('collect-figures', {
+    mandalaId,
+    placedVideos: videoIds.length,
+    figures: figures.length,
+  });
+  return figures;
+}

--- a/src/modules/snapshot/figure-build-mapping.ts
+++ b/src/modules/snapshot/figure-build-mapping.ts
@@ -1,0 +1,53 @@
+// D (figure → /slides/build) — pure mapping from a cached snapshot row to the
+// build-service figures[] contract. No I/O. The build-call site (POST
+// /slides/build) does not exist yet (slidegen endpoint pending); this module
+// only produces the payload it will carry, so it is unit-testable in isolation.
+//
+// Build contract (agreed with slidegen): figures[] = { figure_id, kind, struct?,
+// latex?, png_url?, ts }. Field gaps vs video_figure_snapshots:
+//   - figure_id: snapshots have no id column (PK = video_id+ts_sec+kind) →
+//     synthesized as `${video_id}:${ts_sec}:${kind}`.
+//   - png_url:   snapshots store keyframe binary pointer in asset_path (deferred,
+//     usually null) → passed through; struct/latex figures don't need it.
+
+import type { FigureKind } from './types';
+
+/** A single video_figure_snapshots row (the columns this mapping reads). */
+export interface SnapshotRow {
+  video_id: string;
+  ts_sec: number;
+  kind: string;
+  struct: unknown | null;
+  latex: string | null;
+  asset_path: string | null;
+}
+
+/** One figure in the /slides/build request payload. */
+export interface BuildFigure {
+  figure_id: string;
+  video_id: string;
+  ts: number;
+  kind: FigureKind;
+  struct?: unknown;
+  latex?: string;
+  png_url?: string | null;
+}
+
+/** Synthesize the build figure_id (snapshots have no id column). */
+export function snapshotFigureId(videoId: string, tsSec: number, kind: string): string {
+  return `${videoId}:${tsSec}:${kind}`;
+}
+
+/** Map one snapshot row to a BuildFigure (pure). Only payload that exists is set. */
+export function snapshotRowToBuildFigure(row: SnapshotRow): BuildFigure {
+  return {
+    figure_id: snapshotFigureId(row.video_id, row.ts_sec, row.kind),
+    video_id: row.video_id,
+    ts: row.ts_sec,
+    kind: row.kind as FigureKind,
+    ...(row.struct != null ? { struct: row.struct } : {}),
+    ...(row.latex != null ? { latex: row.latex } : {}),
+    // asset_path is the keyframe binary pointer (deferred, often null) → png_url.
+    ...(row.asset_path != null ? { png_url: row.asset_path } : {}),
+  };
+}

--- a/src/modules/snapshot/warm-select.ts
+++ b/src/modules/snapshot/warm-select.ts
@@ -1,0 +1,84 @@
+// C' (figure warming) — pure selection of which (video, ts) to extract.
+//
+// Picks high-relevance segment timestamps to pre-extract into
+// video_figure_snapshots, SPREAD across the mandala's cells (theme groups) so
+// figures cover the book's chapters rather than concentrating in one crowded
+// cell (e.g. 942 ch0 holds 33 videos). Caps per cell + per video to avoid
+// over-extraction (numerize is expensive). Pure — no I/O; the script wrapper
+// feeds it DB rows and turns the result into get-or-extract calls.
+
+/** A high-relevance segment row (from video_mandala_segment_relevance). */
+export interface RelSegment {
+  videoId: string;
+  fromSec: number;
+  relevancePct: number;
+}
+
+export interface WarmSelectOpts {
+  /** Minimum relevance to consider (default 80 — the figure-worthy band). */
+  minRel?: number;
+  /** Max videos to warm per cell (theme spread). Default 2. */
+  perCellVideoCap?: number;
+  /** Max timestamps to warm per video. Default 3. */
+  perVideoTsCap?: number;
+}
+
+export interface WarmTarget {
+  videoId: string;
+  cellIndex: number;
+  ts: number[];
+}
+
+/**
+ * Select warm targets, spread across cells. cellByVideo maps a placed video to
+ * its cell_index; segments without a known cell are dropped (can't place them
+ * in a chapter). Returns at most perCellVideoCap videos per cell, each with up
+ * to perVideoTsCap highest-relevance timestamps.
+ */
+export function selectWarmTargets(
+  segments: RelSegment[],
+  cellByVideo: Map<string, number>,
+  opts: WarmSelectOpts = {}
+): WarmTarget[] {
+  const minRel = opts.minRel ?? 80;
+  const perCellVideoCap = opts.perCellVideoCap ?? 2;
+  const perVideoTsCap = opts.perVideoTsCap ?? 3;
+
+  // 1. keep figure-worthy segments that belong to a known cell.
+  const eligible = segments.filter((s) => s.relevancePct >= minRel && cellByVideo.has(s.videoId));
+
+  // 2. group ts by video; track each video's best relevance + its cell.
+  const perVideo = new Map<string, { cell: number; best: number; ts: number[] }>();
+  for (const s of eligible) {
+    const cell = cellByVideo.get(s.videoId)!;
+    const v = perVideo.get(s.videoId) ?? { cell, best: 0, ts: [] };
+    v.best = Math.max(v.best, s.relevancePct);
+    if (!v.ts.includes(s.fromSec)) v.ts.push(s.fromSec);
+    perVideo.set(s.videoId, v);
+  }
+  // cap + sort ts ascending per video.
+  for (const v of perVideo.values()) {
+    v.ts.sort((a, b) => a - b);
+    v.ts = v.ts.slice(0, perVideoTsCap);
+  }
+
+  // 3. per cell, take the top perCellVideoCap videos by best relevance.
+  const byCell = new Map<
+    number,
+    Array<{ videoId: string; cell: number; best: number; ts: number[] }>
+  >();
+  for (const [videoId, v] of perVideo) {
+    const arr = byCell.get(v.cell) ?? [];
+    arr.push({ videoId, ...v });
+    byCell.set(v.cell, arr);
+  }
+
+  const out: WarmTarget[] = [];
+  for (const [cell, vids] of Array.from(byCell.entries()).sort((a, b) => a[0] - b[0])) {
+    vids.sort((a, b) => b.best - a.best);
+    for (const v of vids.slice(0, perCellVideoCap)) {
+      out.push({ videoId: v.videoId, cellIndex: cell, ts: v.ts });
+    }
+  }
+  return out;
+}

--- a/tests/unit/modules/collect-figures.test.ts
+++ b/tests/unit/modules/collect-figures.test.ts
@@ -1,0 +1,81 @@
+/**
+ * collect-figures (D) — mandala placed videos → cached snapshots → build figures[].
+ * Dry verification with MOCK snapshots (no real extract; figures are mock data).
+ * Locks: enumerate placed (uvs+ulc) → query snapshots → map; empty when none.
+ */
+
+const mockUvsFindMany = jest.fn();
+const mockUlcFindMany = jest.fn();
+const mockQueryRawUnsafe = jest.fn();
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    userVideoState: { findMany: mockUvsFindMany },
+    user_local_cards: { findMany: mockUlcFindMany },
+    $queryRawUnsafe: (...a: unknown[]) => mockQueryRawUnsafe(...a),
+  }),
+}));
+jest.mock('@/config/index', () => ({
+  config: {
+    database: { url: 'postgresql://x:x@127.0.0.1:5432/x', directUrl: undefined },
+    app: { isDevelopment: true, isProduction: false, isTest: true },
+    paths: { logs: '/tmp' },
+  },
+}));
+
+import { collectFiguresForMandala } from '../../../src/modules/snapshot/collect-figures';
+
+const M = '942e2757-64fa-4759-afc5-56e2f33869f2';
+
+beforeEach(() => {
+  mockUvsFindMany.mockReset();
+  mockUlcFindMany.mockReset();
+  mockQueryRawUnsafe.mockReset();
+});
+
+describe('collectFiguresForMandala', () => {
+  it('collects placed videos (uvs+ulc) → snapshots → mapped build figures (MOCK snapshots)', async () => {
+    mockUvsFindMany.mockResolvedValue([{ video: { youtube_video_id: 'vidA' } }]);
+    mockUlcFindMany.mockResolvedValue([{ video_id: 'vidB' }]);
+    // MOCK snapshots (no real extract — explicit mock data)
+    mockQueryRawUnsafe.mockResolvedValue([
+      {
+        video_id: 'vidA',
+        ts_sec: 760,
+        kind: 'table',
+        struct: { rows: 2 },
+        latex: null,
+        asset_path: null,
+      },
+      {
+        video_id: 'vidB',
+        ts_sec: 12,
+        kind: 'equation',
+        struct: null,
+        latex: 'x^2',
+        asset_path: null,
+      },
+    ]);
+
+    const figs = await collectFiguresForMandala(M);
+
+    // queried the union of placed video ids
+    const [, idsArg] = mockQueryRawUnsafe.mock.calls[0]!;
+    expect((idsArg as string[]).sort()).toEqual(['vidA', 'vidB']);
+    expect(figs).toHaveLength(2);
+    expect(figs[0]).toMatchObject({
+      figure_id: 'vidA:760:table',
+      kind: 'table',
+      struct: { rows: 2 },
+      ts: 760,
+    });
+    expect(figs[1]).toMatchObject({ figure_id: 'vidB:12:equation', latex: 'x^2' });
+  });
+
+  it('returns [] when no placed videos (no fabrication)', async () => {
+    mockUvsFindMany.mockResolvedValue([]);
+    mockUlcFindMany.mockResolvedValue([]);
+    const figs = await collectFiguresForMandala(M);
+    expect(figs).toEqual([]);
+    expect(mockQueryRawUnsafe).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/modules/figure-build-mapping.test.ts
+++ b/tests/unit/modules/figure-build-mapping.test.ts
@@ -1,0 +1,50 @@
+/**
+ * figure-build-mapping (D core) — snapshot row → build figures[] (pure).
+ * Locks the field gaps: synthesized figure_id, struct/latex passthrough,
+ * png_url from asset_path (omitted when null).
+ */
+
+import {
+  snapshotRowToBuildFigure,
+  snapshotFigureId,
+  type SnapshotRow,
+} from '../../../src/modules/snapshot/figure-build-mapping';
+
+const row = (over: Partial<SnapshotRow> = {}): SnapshotRow => ({
+  video_id: 'dQw4w9WgXcQ',
+  ts_sec: 760,
+  kind: 'table',
+  struct: null,
+  latex: null,
+  asset_path: null,
+  ...over,
+});
+
+describe('figure-build-mapping', () => {
+  it('synthesizes figure_id as videoId:ts:kind', () => {
+    expect(snapshotFigureId('vid', 12, 'chart')).toBe('vid:12:chart');
+    expect(snapshotRowToBuildFigure(row()).figure_id).toBe('dQw4w9WgXcQ:760:table');
+  });
+
+  it('passes struct through for table/chart/diagram', () => {
+    const f = snapshotRowToBuildFigure(
+      row({ kind: 'table', struct: { headers: ['a'], rows: [[1]] } })
+    );
+    expect(f.kind).toBe('table');
+    expect(f.struct).toEqual({ headers: ['a'], rows: [[1]] });
+    expect(f.ts).toBe(760);
+  });
+
+  it('passes latex for equation, no struct', () => {
+    const f = snapshotRowToBuildFigure(row({ kind: 'equation', latex: 'E=mc^2' }));
+    expect(f.latex).toBe('E=mc^2');
+    expect(f.struct).toBeUndefined();
+  });
+
+  it('maps asset_path → png_url; omits png_url when asset_path null (deferred keyframe)', () => {
+    expect(
+      snapshotRowToBuildFigure(row({ kind: 'keyframe', asset_path: '/p/x.png' })).png_url
+    ).toBe('/p/x.png');
+    expect('png_url' in snapshotRowToBuildFigure(row())).toBe(false);
+  });
+});

--- a/tests/unit/modules/warm-select.test.ts
+++ b/tests/unit/modules/warm-select.test.ts
@@ -1,0 +1,65 @@
+/**
+ * warm-select (C' core) — high-rel segments → warm targets spread across cells.
+ * Locks: minRel filter, per-cell video cap (theme spread), per-video ts cap,
+ * drop segments whose video has no known cell.
+ */
+
+import { selectWarmTargets, type RelSegment } from '../../../src/modules/snapshot/warm-select';
+
+describe('selectWarmTargets', () => {
+  it('spreads across cells with per-cell video cap (no single-cell domination)', () => {
+    // cell 0 has 3 high-rel videos; cell 1 has 1. cap 2/cell → cell0 keeps top 2.
+    const segs: RelSegment[] = [
+      { videoId: 'a', fromSec: 0, relevancePct: 92 },
+      { videoId: 'b', fromSec: 0, relevancePct: 88 },
+      { videoId: 'c', fromSec: 0, relevancePct: 85 },
+      { videoId: 'd', fromSec: 0, relevancePct: 90 },
+    ];
+    const cellByVideo = new Map([
+      ['a', 0],
+      ['b', 0],
+      ['c', 0],
+      ['d', 1],
+    ]);
+    const out = selectWarmTargets(segs, cellByVideo, {
+      minRel: 80,
+      perCellVideoCap: 2,
+      perVideoTsCap: 3,
+    });
+    const cell0 = out
+      .filter((t) => t.cellIndex === 0)
+      .map((t) => t.videoId)
+      .sort();
+    const cell1 = out.filter((t) => t.cellIndex === 1).map((t) => t.videoId);
+    expect(cell0).toEqual(['a', 'b']); // top 2 by relevance (92, 88) — c (85) dropped
+    expect(cell1).toEqual(['d']);
+  });
+
+  it('caps timestamps per video and sorts ascending', () => {
+    const segs: RelSegment[] = [
+      { videoId: 'a', fromSec: 300, relevancePct: 90 },
+      { videoId: 'a', fromSec: 100, relevancePct: 90 },
+      { videoId: 'a', fromSec: 500, relevancePct: 90 },
+      { videoId: 'a', fromSec: 200, relevancePct: 90 },
+    ];
+    const out = selectWarmTargets(segs, new Map([['a', 0]]), { perVideoTsCap: 3 });
+    expect(out[0]!.ts).toEqual([100, 200, 300]); // sorted asc, capped to 3
+  });
+
+  it('drops segments below minRel and videos with no known cell', () => {
+    const segs: RelSegment[] = [
+      { videoId: 'a', fromSec: 0, relevancePct: 70 }, // below minRel 80
+      { videoId: 'b', fromSec: 0, relevancePct: 95 }, // no cell mapping
+      { videoId: 'c', fromSec: 0, relevancePct: 95 }, // kept
+    ];
+    const out = selectWarmTargets(
+      segs,
+      new Map([
+        ['a', 0],
+        ['c', 2],
+      ]),
+      { minRel: 80 }
+    );
+    expect(out.map((t) => t.videoId)).toEqual(['c']);
+  });
+});


### PR DESCRIPTION
## What

The contract-stable, insighta-internal halves of the figure deck chain (C' warming + D figures→build). **INERT** — nothing wires them into a chain yet; the parts that need slidegen's not-yet-deployed endpoints are deliberately NOT wired (would be guessing).

## Built (contract-stable, dry-verified)

- **C' `warm-select.ts`** (pure) — high-rel segments + per-video cell → warm targets **spread across cells** (per-cell + per-video caps; no over-extraction so figures cover the book's chapters, not just the crowded cell).
- **C' `scripts/warm-figure-snapshots.ts`** — `--dry-run` DEFAULT (print the warm plan, NO HTTP/write); `--execute` calls the insighta-internal `/internal/snapshot/get-or-extract` per target. **prod 쓰기 0** until run with `--execute` after A(token)+B(slidegen /numerize) land — James-gated. (force-added; `scripts/*` is gitignored, tracked via force-add like `backfill-shorts.ts`.)
- **D `figure-build-mapping.ts`** (pure) — snapshot row → build `figures[]` `{figure_id (synthesized video:ts:kind), kind, struct?, latex?, png_url:asset_path?}`. Field gaps documented.
- **D `collect-figures.ts`** — mandala placed videos (uvs+ulc) → non-expired `video_figure_snapshots` → `BuildFigure[]`. Read-only.

## NOT wired (measured absent — wiring would be guessing)

- numerize-client job transition (slidegen `/numerize/job` NOT deployed — :8077 paths = health/slides·generate/status/result/numerize only).
- D build-call (`/slides/build` NOT deployed).
- `slide_decks` scaffold (0 models — never built).

These wait until slidegen deploys the job/build endpoints + exposes their OpenAPI schemas; then re-measure → wire precisely. (Recorded, per 추측 금지.)

## Verification

9/9 dry-verify unit tests (mapping field gaps, cell-spread selection, mock-snapshot collection — 가짜 figure 0, mocks explicit). `tsc --noEmit` clean for new files (3 total = pre-existing google-auth drift). CI lint (`src/**`) 0 errors. BE-only (no frontend/).