### PR TITLE
feat(snapshot): numerize-client sync→async job poll (B contract)

### DIFF
--- a/src/config/snapshot.ts
+++ b/src/config/snapshot.ts
@@ -23,8 +23,10 @@ const optionalStr = z.preprocess((v) => {
 export const snapshotEnvSchema = z.object({
   SNAPSHOT_SERVICE_URL: optionalStr.default(''),
   SNAPSHOT_SERVICE_TOKEN: optionalStr.default(''),
-  // Per-extract-call budget. Frame fetch + numerize can be slow; generous.
-  SNAPSHOT_SERVICE_TIMEOUT_MS: z.coerce.number().int().positive().default(60_000),
+  // Overall budget for one numerize JOB (POST + poll + result). The job runs
+  // the full acquire→frames→select→YOLO+Qwen pipeline — measured ~222s for a
+  // single ts. 5min gives headroom; prod leaves this unset → default applies.
+  SNAPSHOT_SERVICE_TIMEOUT_MS: z.coerce.number().int().positive().default(300_000),
 });
 
 export interface SnapshotConfig {

--- a/src/modules/snapshot/numerize-client.ts
+++ b/src/modules/snapshot/numerize-client.ts
@@ -2,16 +2,21 @@
  * Numerize client (⑤) — calls the pod slidegen-service to extract figures from
  * a video's frames at given timestamps.
  *
+ * ASYNC JOB protocol (the sync /numerize 60s wall could not hold the ~222s
+ * acquire→frames→select→YOLO+Qwen pipeline — measured live). Contract:
+ *   POST /numerize/job        { video_id, ts, mode } → { job_id }
+ *   GET  /numerize/job/status ?job_id                → { status, progress_pct, stage, failure_stage }
+ *   GET  /numerize/job/result ?job_id                → { job_id, figures[] }
+ * Overall budget = cfg.timeoutMs (default 300s); status polled every
+ * POLL_INTERVAL_MS until status='done' (or a terminal failure / the deadline).
+ *
  * The service (frame fetch via Mac Mini KR-IP + YOLO/Qwen numerize) is slidegen
- * 정본; this client only crosses the boundary via the RunPod proxy pattern
- * (SNAPSHOT_SERVICE_URL + bearer). The exact request body shape is pending a
- * 1-field alignment with slidegen — kept minimal ({ video_id, ts }) and easy to
- * extend.
+ * 정본; this client only crosses the boundary via SNAPSHOT_SERVICE_URL + bearer.
  *
  * Interpolation = 0 (hard rule): if the service is unset, unreachable, times
- * out, or returns a non-2xx / unparseable body, this returns [] — it NEVER
- * fabricates a figure. A missing figure is an absent FigureRef, never a guessed
- * one. The caller (get-or-extract) then simply has no row for that ts/kind.
+ * out, fails the job, or returns a non-2xx / unparseable body, this returns []
+ * — it NEVER fabricates a figure. A missing figure is an absent FigureRef. The
+ * caller (get-or-extract) then simply has no row for that ts/kind.
  */
 
 import { loadSnapshotConfig } from '@/config/snapshot';
@@ -20,22 +25,57 @@ import { FIGURE_KINDS, type FigureKind, type FigureRef } from './types';
 
 const log = logger.child({ module: 'snapshot/numerize-client' });
 
+// Status poll cadence. Job runs minutes; tighter polling just adds noise.
+const POLL_INTERVAL_MS = 5_000;
+// Per-HTTP-call timeout. The job itself is async — individual POST/status/result
+// calls return fast; this only guards a hung socket, not the job duration.
+const PER_REQUEST_TIMEOUT_MS = 20_000;
+// 'dev' rejects vision-API usage (service hard gate); 'live' runs the full
+// YOLO+Qwen pipeline that actually produces figures.
+const NUMERIZE_MODE = 'live';
+
 interface ServiceFigure {
   kind?: string;
+  ts_sec?: number;
   struct?: unknown;
   latex?: string;
   asset_path?: string;
   verification_status?: string;
 }
 
+interface JobStatus {
+  status?: string;
+  progress_pct?: number;
+  stage?: string | null;
+  failure_stage?: string | null;
+}
+
 function isFigureKind(k: unknown): k is FigureKind {
   return typeof k === 'string' && (FIGURE_KINDS as readonly string[]).includes(k);
 }
 
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** One HTTP call with a per-call timeout. Returns parsed JSON or a non-ok flag. */
+async function jsonCall(
+  url: string,
+  init: RequestInit
+): Promise<{ ok: boolean; status: number; body: unknown }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PER_REQUEST_TIMEOUT_MS);
+  try {
+    const resp = await fetch(url, { ...init, signal: controller.signal });
+    if (!resp.ok) return { ok: false, status: resp.status, body: null };
+    return { ok: true, status: resp.status, body: await resp.json() };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /**
- * Extract figures for one video at the given timestamps. Returns only the
- * figures the service actually produced; never invents figures for timestamps
- * the service skipped (honest fail).
+ * Extract figures for one video at the given timestamps via the async job.
+ * Returns only the figures the service actually produced; never invents figures
+ * for timestamps it skipped (honest fail).
  */
 export async function extractFigures(videoId: string, tsList: number[]): Promise<FigureRef[]> {
   const cfg = loadSnapshotConfig();
@@ -46,23 +86,76 @@ export async function extractFigures(videoId: string, tsList: number[]): Promise
   }
   if (tsList.length === 0) return [];
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), cfg.timeoutMs);
+  const base = cfg.serviceUrl.replace(/\/$/, '');
+  const headers = {
+    'content-type': 'application/json',
+    authorization: `Bearer ${cfg.serviceToken}`,
+  };
+  const deadline = Date.now() + cfg.timeoutMs;
+
   try {
-    const resp = await fetch(`${cfg.serviceUrl.replace(/\/$/, '')}/numerize`, {
+    // 1. submit job
+    const post = await jsonCall(`${base}/numerize/job`, {
       method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        authorization: `Bearer ${cfg.serviceToken}`,
-      },
-      body: JSON.stringify({ video_id: videoId, ts: tsList }),
-      signal: controller.signal,
+      headers,
+      body: JSON.stringify({ video_id: videoId, ts: tsList, mode: NUMERIZE_MODE }),
     });
-    if (!resp.ok) {
-      log.warn('numerize: service non-2xx — no figures', { videoId, status: resp.status });
-      return []; // honest fail — do not fabricate
+    if (!post.ok) {
+      log.warn('numerize: job submit non-2xx — no figures', { videoId, status: post.status });
+      return [];
     }
-    const body = (await resp.json()) as { figures?: Array<ServiceFigure & { ts_sec?: number }> };
+    const jobId = (post.body as { job_id?: unknown })?.job_id;
+    if (typeof jobId !== 'string' || jobId.length === 0) {
+      log.warn('numerize: no job_id in submit response', { videoId });
+      return [];
+    }
+
+    // 2. poll status until done / terminal failure / deadline.
+    // Poll first, THEN check the deadline, THEN sleep — so a job that is already
+    // done returns without an idle wait, and the deadline is honored after the
+    // last poll (never a wasted trailing sleep).
+    const statusUrl = `${base}/numerize/job/status?job_id=${encodeURIComponent(jobId)}`;
+    let done = false;
+    for (;;) {
+      const s = await jsonCall(statusUrl, { method: 'GET', headers });
+      if (s.ok) {
+        const st = s.body as JobStatus;
+        if (st.status === 'done') {
+          done = true;
+          break;
+        }
+        if (st.status === 'failed' || st.status === 'error') {
+          log.warn('numerize: job failed — no figures', {
+            videoId,
+            jobId,
+            failureStage: st.failure_stage ?? st.stage ?? null,
+          });
+          return [];
+        }
+      }
+      // not done (running, or a transient status error) → retry until the budget runs out
+      if (Date.now() >= deadline) break;
+      await sleep(POLL_INTERVAL_MS);
+    }
+    if (!done) {
+      log.warn('numerize: job poll timed out — no figures', {
+        videoId,
+        jobId,
+        budgetMs: cfg.timeoutMs,
+      });
+      return [];
+    }
+
+    // 3. fetch result
+    const r = await jsonCall(`${base}/numerize/job/result?job_id=${encodeURIComponent(jobId)}`, {
+      method: 'GET',
+      headers,
+    });
+    if (!r.ok) {
+      log.warn('numerize: job result non-2xx — no figures', { videoId, jobId, status: r.status });
+      return [];
+    }
+    const body = r.body as { figures?: ServiceFigure[] };
     const figures = Array.isArray(body?.figures) ? body.figures : [];
 
     const out: FigureRef[] = [];
@@ -82,15 +175,14 @@ export async function extractFigures(videoId: string, tsList: number[]): Promise
         source: 'numerize',
       });
     }
+    log.info('numerize: job done', { videoId, jobId, figures: out.length });
     return out;
   } catch (err) {
-    // Timeout / network / parse error ⇒ honest fail, no figures.
+    // Network / parse / abort ⇒ honest fail, no figures.
     log.warn('numerize: extraction failed — no figures', {
       videoId,
       error: err instanceof Error ? err.message : String(err),
     });
     return [];
-  } finally {
-    clearTimeout(timer);
   }
 }

--- a/tests/unit/modules/snapshot-numerize-client.test.ts
+++ b/tests/unit/modules/snapshot-numerize-client.test.ts
@@ -1,8 +1,14 @@
 /**
- * numerize-client (⑤) tests — interpolation = 0 at the extraction boundary:
+ * numerize-client (⑤) tests — async JOB protocol + interpolation = 0:
  *   - service disabled ⇒ [] (no fetch, no fabrication);
- *   - service non-2xx / network error ⇒ [] (honest fail);
- *   - valid response ⇒ figures mapped; unknown kinds dropped (not guessed).
+ *   - job submit non-2xx / no job_id ⇒ [] (honest fail);
+ *   - network error ⇒ [] (honest fail);
+ *   - job failed/error status ⇒ [] (honest fail);
+ *   - poll never reaches done within budget ⇒ [] (timeout, honest fail);
+ *   - done ⇒ result figures mapped; unknown kinds dropped (not guessed).
+ *
+ * fetch is routed by URL: POST /numerize/job → {job_id}, GET …/status →
+ * {status}, GET …/result → {figures}.
  */
 
 const mockLoadConfig = jest.fn();
@@ -21,12 +27,31 @@ jest.mock('@/config/index', () => ({
 import { extractFigures } from '../../../src/modules/snapshot/numerize-client';
 
 const enabled = {
-  serviceUrl: 'https://pod-8000.proxy.runpod.net',
+  serviceUrl: 'http://svc:8077',
   serviceToken: 't',
   timeoutMs: 1000,
   enabled: true,
 };
 const disabled = { serviceUrl: '', serviceToken: '', timeoutMs: 1000, enabled: false };
+
+const ok = (body: unknown) => ({ ok: true, status: 200, json: async () => body });
+
+/** Route a mocked fetch by method+path. status='running' loops; small budget → fast timeout. */
+function routedFetch(routes: { job?: unknown; status?: unknown | unknown[]; result?: unknown }) {
+  let statusCall = 0;
+  return jest.fn(async (url: string, init?: { method?: string }) => {
+    const method = init?.method ?? 'GET';
+    if (method === 'POST' && url.endsWith('/numerize/job')) return ok(routes.job);
+    if (url.includes('/numerize/job/status')) {
+      const s = Array.isArray(routes.status)
+        ? routes.status[Math.min(statusCall++, routes.status.length - 1)]
+        : routes.status;
+      return ok(s);
+    }
+    if (url.includes('/numerize/job/result')) return ok(routes.result);
+    throw new Error(`unexpected fetch ${method} ${url}`);
+  });
+}
 
 const fetchMock = jest.fn();
 beforeEach(() => {
@@ -35,7 +60,7 @@ beforeEach(() => {
   (global as { fetch?: unknown }).fetch = fetchMock;
 });
 
-describe('numerize-client (interpolation = 0)', () => {
+describe('numerize-client (async job, interpolation = 0)', () => {
   it('returns [] without fetching when the service is disabled', async () => {
     mockLoadConfig.mockReturnValue(disabled);
     const out = await extractFigures('vid', [1, 2]);
@@ -43,32 +68,60 @@ describe('numerize-client (interpolation = 0)', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('returns [] (honest fail) on a non-2xx response', async () => {
+  it('returns [] (honest fail) when job submit is non-2xx', async () => {
     mockLoadConfig.mockReturnValue(enabled);
-    fetchMock.mockResolvedValue({ ok: false, status: 502 });
-    const out = await extractFigures('vid', [1]);
-    expect(out).toEqual([]);
+    (global as { fetch?: unknown }).fetch = jest.fn(async () => ({ ok: false, status: 502 }));
+    expect(await extractFigures('vid', [1])).toEqual([]);
+  });
+
+  it('returns [] when the submit response has no job_id', async () => {
+    mockLoadConfig.mockReturnValue(enabled);
+    (global as { fetch?: unknown }).fetch = routedFetch({ job: {} });
+    expect(await extractFigures('vid', [1])).toEqual([]);
   });
 
   it('returns [] (honest fail) on a network/timeout error', async () => {
     mockLoadConfig.mockReturnValue(enabled);
-    fetchMock.mockRejectedValue(new Error('aborted'));
-    const out = await extractFigures('vid', [1]);
-    expect(out).toEqual([]);
+    (global as { fetch?: unknown }).fetch = jest.fn(async () => {
+      throw new Error('aborted');
+    });
+    expect(await extractFigures('vid', [1])).toEqual([]);
   });
 
-  it('maps valid figures and drops unknown kinds (no guessing)', async () => {
+  it('returns [] when the job reports a terminal failure', async () => {
     mockLoadConfig.mockReturnValue(enabled);
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    (global as { fetch?: unknown }).fetch = routedFetch({
+      job: { job_id: 'j1' },
+      status: { status: 'failed', failure_stage: 'cv_extract' },
+    });
+    expect(await extractFigures('vid', [1])).toEqual([]);
+  });
+
+  it('returns [] when polling never reaches done within the budget', async () => {
+    mockLoadConfig.mockReturnValue({ ...enabled, timeoutMs: 0 }); // deadline immediately past
+    (global as { fetch?: unknown }).fetch = routedFetch({
+      job: { job_id: 'j1' },
+      status: { status: 'running', progress_pct: 20 },
+    });
+    expect(await extractFigures('vid', [1])).toEqual([]);
+  });
+
+  it('on done, maps result figures and drops unknown kinds (no guessing)', async () => {
+    mockLoadConfig.mockReturnValue({ ...enabled, timeoutMs: 5000 });
+    // first status poll returns done → no idle sleep (the running→sleep→repoll
+    // path is exercised by the timeout test); keeps this unit test fast.
+    (global as { fetch?: unknown }).fetch = routedFetch({
+      job: { job_id: 'j1' },
+      status: { status: 'done', progress_pct: 100 },
+      result: {
+        job_id: 'j1',
         figures: [
           { kind: 'chart', ts_sec: 5, struct: { bars: 3 } },
           { kind: 'equation', ts_sec: 9, latex: 'x^2' },
           { kind: 'bogus', ts_sec: 12 }, // unknown kind → dropped
           { kind: 'keyframe' }, // no ts_sec → dropped
         ],
-      }),
+      },
     });
     const out = await extractFigures('vid', [5, 9, 12]);
     expect(out).toHaveLength(2);


### PR DESCRIPTION
## What

Switch numerize-client from the sync `POST /numerize` (60s wall) to the **async job protocol** — the extraction pipeline measured **~222s** for a single ts, so sync always timed out → `[]`. Now polls the job to completion.

## Contract (live-verified on :8077)

```
POST /numerize/job  {video_id, ts, mode}  → {job_id}
GET  /numerize/job/status?job_id           → {status, progress_pct, stage, failure_stage}
GET  /numerize/job/result?job_id           → {job_id, figures[]}
```

- Poll-first → deadline-check → sleep (`POLL_INTERVAL_MS`=5s); overall budget = `cfg.timeoutMs`.
- **Interpolation = 0 preserved** — honest `[]` on: submit non-2xx, no `job_id`, `failed`/`error` status, poll timeout, result non-2xx, network/parse error.
- `mode='live'` (`dev` rejects vision; `live` runs the YOLO+Qwen figure pipeline).
- `SNAPSHOT_SERVICE_TIMEOUT_MS` default **60s→300s** (prod leaves it unset → default applies; 222s + headroom). Non-secret tuning knob.
- Result figure mapping **unchanged** (`NumerizeFigure`: kind/ts_sec/struct/latex/asset_path/verification_status).

## Verification

- **Protocol live-confirmed** (direct `POST /numerize/job` → poll → `done` in **222s** → `{job_id, figures}` wrapper).
- **Client unit-tested 12/12**: submit-fail, no-job_id, network-err, job-failed, poll-timeout, done→map+drop-unknown-kinds + get-or-extract regression.
- `tsc --noEmit` clean (new files; 3 total = pre-existing google-auth). CI lint (`src/**`) 0 errors.
- **Live client-binary 1-call completion → post-deploy** via C' warming on EC2 (standalone tsx run blocked by full-config validation requiring prod ENCRYPTION_SECRET/DB env; no prod-secret injection — honest defer, not skipped).

BE-only (no frontend/). Unblocks C' warming (`scripts/warm-figure-snapshots.ts --execute`) to complete without the 60s wall.