### PR TITLE
feat(deck): slide_decks scaffold — table + serving + status SSE + FE state (③)

### DIFF
--- a/frontend/src/features/mandala/model/useMandalaQuery.ts
+++ b/frontend/src/features/mandala/model/useMandalaQuery.ts
@@ -274,6 +274,23 @@ export function useGenerateSlideDeck() {
   });
 }
 
+/**
+ * Deck lifecycle for a mandala (③ button state). `enabled` gates the query so
+ * it only runs while the row menu is open (avoids N background polls across the
+ * sidebar). Polls every 3s while pending/building so 생성중→완료 flips live.
+ */
+export function useDeckStatus(mandalaId: string, enabled: boolean) {
+  return useQuery({
+    queryKey: ['deck-status', mandalaId],
+    queryFn: () => apiClient.getDeckStatus(mandalaId),
+    enabled,
+    refetchInterval: (query) => {
+      const s = query.state.data?.status;
+      return s === 'pending' || s === 'building' ? 3000 : false;
+    },
+  });
+}
+
 export function useSwitchMandala() {
   const queryClient = useQueryClient();
 

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1353,9 +1353,11 @@
     "mandalaActions": {
       "openMenu": "Open menu",
       "generateDeck": "Generate slide deck",
+      "openDeck": "Open deck",
       "generatingDeck": "Preparing",
       "deckPrepStarted": "Started preparing the book index",
       "deckPrepError": "Couldn't start preparation. Please try again in a moment.",
+      "deckOpenError": "Couldn't open the deck.",
       "share": "Share",
       "archive": "Archive",
       "delete": "Delete",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1361,9 +1361,11 @@
     "mandalaActions": {
       "openMenu": "메뉴 열기",
       "generateDeck": "슬라이드 덱 생성",
+      "openDeck": "덱 열기",
       "generatingDeck": "준비중",
       "deckPrepStarted": "북인덱스 생성을 시작했어요",
       "deckPrepError": "생성을 시작하지 못했어요. 잠시 후 다시 시도해주세요.",
+      "deckOpenError": "덱을 열지 못했어요.",
       "share": "공유",
       "archive": "아카이브에 보관",
       "delete": "삭제",

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1492,6 +1492,43 @@ class ApiClient {
     });
   }
 
+  /** ③ deck lifecycle for the FE button (없음/생성중/완료+링크). */
+  async getDeckStatus(mandalaId: string): Promise<{
+    status: 'pending' | 'building' | 'done' | 'failed' | null;
+    pptxUrl: string | null;
+    generatedAt: string | null;
+    error: string | null;
+  }> {
+    const res = await this.request<{
+      success: boolean;
+      data: {
+        status: 'pending' | 'building' | 'done' | 'failed' | null;
+        pptxUrl: string | null;
+        generatedAt: string | null;
+        error: string | null;
+      };
+    }>(`/mandalas/${mandalaId}/deck-status`);
+    return res.data;
+  }
+
+  /**
+   * Open a finished deck's .pptx. The serving route is JWT-authenticated, so a
+   * plain `window.open` (browser nav, no auth header) would 401 — fetch it with
+   * the token, then open an object URL. Throws if the deck is not ready.
+   */
+  async openDeckPptx(mandalaId: string): Promise<void> {
+    const token = await this.getFreshToken();
+    const resp = await fetch(`${this.baseUrl}/api/v1/mandalas/${mandalaId}/deck.pptx`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!resp.ok) throw new Error(`deck not ready (${resp.status})`);
+    const blob = await resp.blob();
+    const url = URL.createObjectURL(blob);
+    window.open(url, '_blank');
+    // Revoke after a minute — long enough for the browser to load it.
+    setTimeout(() => URL.revokeObjectURL(url), 60_000);
+  }
+
   /**
    * Toggle pin/bookmark state on a grid view card (CP457+).
    *

--- a/frontend/src/widgets/app-shell/ui/MandalaRowMenu.tsx
+++ b/frontend/src/widgets/app-shell/ui/MandalaRowMenu.tsx
@@ -14,8 +14,11 @@
  */
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MoreHorizontal, Share2, Archive, Trash2, Presentation } from 'lucide-react';
+import { MoreHorizontal, Share2, Archive, Trash2, Presentation, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 import { cn } from '@/shared/lib/utils';
+import { useDeckStatus } from '@/features/mandala/model/useMandalaQuery';
+import { apiClient } from '@/shared/lib/api-client';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -58,6 +61,19 @@ export function MandalaRowMenu({
   const [menuOpen, setMenuOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
+  // Persistent deck lifecycle — only polled while the menu is open. Combined
+  // with the transient isGeneratingDeck for instant post-click feedback.
+  const { data: deck } = useDeckStatus(mandalaId, menuOpen);
+  const deckStatus = deck?.status ?? null;
+  const deckBuilding = isGeneratingDeck || deckStatus === 'pending' || deckStatus === 'building';
+  const deckDone = deckStatus === 'done';
+
+  const handleOpenDeck = (): void => {
+    apiClient.openDeckPptx(mandalaId).catch(() => {
+      toast.error(t('sidebar.mandalaActions.deckOpenError', '덱을 열지 못했어요.'));
+    });
+  };
+
   return (
     <>
       <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
@@ -78,17 +94,29 @@ export function MandalaRowMenu({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48" onClick={(e) => e.stopPropagation()}>
           <DropdownMenuItem
-            disabled={isGeneratingDeck}
+            disabled={deckBuilding}
             onSelect={(e) => {
               e.preventDefault();
-              onGenerateDeck(mandalaId);
+              if (deckDone) {
+                handleOpenDeck();
+              } else if (!deckBuilding) {
+                onGenerateDeck(mandalaId);
+              }
               setMenuOpen(false);
             }}
             className="focus:bg-foreground/[0.04] focus:text-foreground"
           >
-            <Presentation className="mr-2 h-4 w-4" />
-            <span>{t('sidebar.mandalaActions.generateDeck')}</span>
-            {isGeneratingDeck && (
+            {deckBuilding ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Presentation className="mr-2 h-4 w-4" />
+            )}
+            <span>
+              {deckDone
+                ? t('sidebar.mandalaActions.openDeck', '덱 열기')
+                : t('sidebar.mandalaActions.generateDeck')}
+            </span>
+            {deckBuilding && (
               <span className="ml-auto text-[10px] text-muted-foreground/70">
                 {t('sidebar.mandalaActions.generatingDeck')}
               </span>

--- a/prisma/migrations/slide-decks/001_create_table.sql
+++ b/prisma/migrations/slide-decks/001_create_table.sql
@@ -1,0 +1,13 @@
+-- slide_decks (③ deck UI scaffold) — one deck per mandala (PK = mandala_id).
+-- Tracks the deck-generation lifecycle so the FE button can show
+-- 없음 → 생성중 → 완료+링크 across reloads (replaces the transient toast).
+-- Idempotent (CP421 allowlist requirement).
+CREATE TABLE IF NOT EXISTS slide_decks (
+  mandala_id   UUID PRIMARY KEY REFERENCES user_mandalas(id) ON DELETE CASCADE,
+  status       TEXT NOT NULL DEFAULT 'pending',   -- pending | building | done | failed
+  pptx_url     TEXT,                               -- serving route path; NULL until done
+  error        TEXT,                               -- failure_stage / message when failed
+  generated_at TIMESTAMPTZ,                        -- set when status=done
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -464,6 +464,7 @@ model user_mandalas {
   pipeline_runs        mandala_pipeline_runs[]
   create_timings       mandala_create_timings[]
   book                 mandala_books?
+  slide_deck           slide_decks?
   note_documents       note_documents[]
   card_interactions    card_interactions[]
 
@@ -654,6 +655,25 @@ model mandala_books {
   generated_at  DateTime      @default(now()) @db.Timestamptz(6)
   updated_at    DateTime      @default(now()) @updatedAt @db.Timestamptz(6)
   mandala       user_mandalas @relation(fields: [mandala_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@schema("public")
+}
+
+/// ③ deck UI scaffold — one slide deck per mandala (PK = mandala_id).
+/// Lifecycle: pending (data-prep) → building (slidegen /slides/build) → done
+/// (pptx_url set) | failed. The FE button reads `status` to show 없음/생성중/
+/// 완료+링크 across reloads. `pptx_url` is the authenticated serving route path
+/// (deck.pptx); the file lives on EC2 disk (no Drive). DDL: prisma/migrations/
+/// slide-decks/001_create_table.sql.
+model slide_decks {
+  mandala_id   String        @id @db.Uuid
+  status       String        @default("pending")
+  pptx_url     String?
+  error        String?
+  generated_at DateTime?     @db.Timestamptz(6)
+  created_at   DateTime      @default(now()) @db.Timestamptz(6)
+  updated_at   DateTime      @default(now()) @updatedAt @db.Timestamptz(6)
+  mandala      user_mandalas @relation(fields: [mandala_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@schema("public")
 }

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -152,6 +152,9 @@ APPLY_FILES=(
   # TABLE IF NOT EXISTS + CHECK constraint — idempotent. Inert until the
   # get-or-extract endpoint / slidegen consume it.
   "prisma/migrations/snapshot/001_video_figure_snapshots.sql"
+  # ③ deck UI scaffold — one slide deck per mandala. CREATE TABLE IF NOT
+  # EXISTS — idempotent. Drives the FE 없음/생성중/완료+링크 button state.
+  "prisma/migrations/slide-decks/001_create_table.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -2,6 +2,9 @@ import { FastifyPluginCallback } from 'fastify';
 import { getMandalaManager } from '../../modules/mandala';
 import { enqueueMandalaBookFill } from '../../modules/queue/handlers/mandala-book-fill';
 import { enqueueSegmentRelevanceForMandala } from '../../modules/relevance/segment-relevance-trigger';
+import { markDeckPending, getDeckState, deckPptxDiskPath } from '../../modules/deck/deck-status';
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
 import { getMood } from '../../modules/mandala/mood';
 import { triggerMandalaPostCreationAsync } from '../../modules/mandala/mandala-post-creation';
 import { getPrismaClient } from '../../modules/database/client';
@@ -88,6 +91,11 @@ function getUserId(request: any, reply: any): string | null {
   }
   return request.user.userId;
 }
+
+// deck-stream SSE caps (mirror cards enrich-stream). Poll slide_decks every 2s;
+// give up after 10min (a deck-build job is minutes, not hours).
+const DECK_STREAM_POLL_MS = 2000;
+const DECK_STREAM_MAX_MS = 10 * 60 * 1000;
 
 /**
  * Build skill_config rows for a freshly created mandala. Always ensures
@@ -417,10 +425,154 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       const mandala = await getMandalaManager().getMandalaById(userId, mandalaId);
       if (!mandala) return reply.code(404).send({ error: 'Mandala not found' });
 
+      // Persist the deck lifecycle so the button shows 생성중 across reloads
+      // (replaces the transient toast). status='pending' until deck-build lands.
+      await markDeckPending(mandalaId);
+
       const bookJobId = await enqueueMandalaBookFill({ userId, mandalaId, trigger: 'deck-button' });
       const segmentResult = await enqueueSegmentRelevanceForMandala({ userId, mandalaId });
 
-      return reply.send({ success: true, data: { bookJobId, segmentResult } });
+      return reply.send({ success: true, data: { status: 'pending', bookJobId, segmentResult } });
+    }
+  );
+
+  /**
+   * GET /api/v1/mandalas/:id/deck-status — current deck lifecycle for the FE
+   * button (없음/생성중/완료+링크). Ownership-checked. Returns null status when
+   * the deck was never requested.
+   */
+  fastify.get<{ Params: { id: string } }>(
+    '/:id/deck-status',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const userId = getUserId(request, reply);
+      if (!userId) return;
+      const mandalaId = request.params.id;
+      const mandala = await getMandalaManager().getMandalaById(userId, mandalaId);
+      if (!mandala) return reply.code(404).send({ error: 'Mandala not found' });
+
+      const deck = await getDeckState(mandalaId);
+      return reply.send({
+        success: true,
+        data: deck
+          ? {
+              status: deck.status,
+              pptxUrl: deck.pptxUrl,
+              generatedAt: deck.generatedAt,
+              error: deck.error,
+            }
+          : { status: null, pptxUrl: null, generatedAt: null, error: null },
+      });
+    }
+  );
+
+  /**
+   * GET /api/v1/mandalas/:id/deck-stream — SSE of the deck lifecycle, mirroring
+   * the cards enrich-stream pattern (reply.hijack + 1s slide_decks poll). Emits
+   * a `status` event on each transition; closes on done/failed or the cap.
+   */
+  fastify.get<{ Params: { id: string } }>(
+    '/:id/deck-stream',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const userId = getUserId(request, reply);
+      if (!userId) return;
+      const mandalaId = request.params.id;
+      const mandala = await getMandalaManager().getMandalaById(userId, mandalaId);
+      if (!mandala) return reply.code(404).send({ error: 'Mandala not found' });
+
+      void reply.hijack();
+      const raw = reply.raw;
+      const reqOrigin = request.headers.origin;
+      const allowed = config.cors.allowedOrigins;
+      if (reqOrigin && (allowed.includes('*') || allowed.includes(reqOrigin))) {
+        raw.setHeader('Access-Control-Allow-Origin', reqOrigin);
+        raw.setHeader('Access-Control-Allow-Credentials', 'true');
+        raw.setHeader('Vary', 'Origin');
+      }
+      raw.setHeader('Content-Type', 'text/event-stream');
+      raw.setHeader('Cache-Control', 'no-cache');
+      raw.setHeader('Connection', 'keep-alive');
+      raw.setHeader('X-Accel-Buffering', 'no');
+      raw.statusCode = 200;
+      raw.write('retry: 5000\n\n');
+      raw.write(`: connected mandala=${mandalaId}\n\n`);
+
+      const startedAt = Date.now();
+      let lastStatus: string | null = null;
+      let closed = false;
+
+      const send = (status: string, extra?: Record<string, unknown>): void => {
+        if (closed || raw.destroyed) return;
+        raw.write(`event: status\ndata: ${JSON.stringify({ status, mandalaId, ...extra })}\n\n`);
+      };
+      const close = (): void => {
+        if (closed) return;
+        closed = true;
+        clearInterval(interval);
+        try {
+          raw.end();
+        } catch {
+          /* connection may already be closed */
+        }
+      };
+      const pollOnce = async (): Promise<void> => {
+        if (Date.now() - startedAt > DECK_STREAM_MAX_MS) {
+          send('timeout');
+          close();
+          return;
+        }
+        const deck = await getDeckState(mandalaId);
+        const status = deck?.status ?? 'none';
+        if (status !== lastStatus) {
+          send(status, { pptxUrl: deck?.pptxUrl ?? null });
+          lastStatus = status;
+          if (status === 'done' || status === 'failed') close();
+        }
+      };
+
+      const interval = setInterval(() => {
+        pollOnce().catch(() => {
+          /* single poll failure not fatal — retry until the cap */
+        });
+      }, DECK_STREAM_POLL_MS);
+      void pollOnce();
+      request.raw.on('close', close);
+    }
+  );
+
+  /**
+   * GET /api/v1/mandalas/:id/deck.pptx — serve the generated .pptx from EC2
+   * disk (authenticated + ownership-checked; no Drive). 404 until status=done
+   * with a file on disk. This is the URL stored in slide_decks.pptx_url.
+   */
+  fastify.get<{ Params: { id: string } }>(
+    '/:id/deck.pptx',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const userId = getUserId(request, reply);
+      if (!userId) return;
+      const mandalaId = request.params.id;
+      const mandala = await getMandalaManager().getMandalaById(userId, mandalaId);
+      if (!mandala) return reply.code(404).send({ error: 'Mandala not found' });
+
+      const deck = await getDeckState(mandalaId);
+      if (!deck || deck.status !== 'done' || !deck.pptxUrl) {
+        return reply.code(404).send({ error: 'Deck not ready' });
+      }
+      const diskPath = deckPptxDiskPath(mandalaId);
+      try {
+        await stat(diskPath); // 404 (not 500) if the file is missing
+      } catch {
+        return reply.code(404).send({ error: 'Deck file missing' });
+      }
+      return reply
+        .header(
+          'Content-Type',
+          'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+        )
+        .header('Content-Disposition', `inline; filename="deck-${mandalaId}.pptx"`)
+        .send(createReadStream(diskPath));
     }
   );
 

--- a/src/modules/deck/deck-status.ts
+++ b/src/modules/deck/deck-status.ts
@@ -1,0 +1,60 @@
+// ③ deck UI scaffold — slide_decks lifecycle helpers.
+//
+// The deck button reads `status` to render 없음 / 생성중 / 완료+링크 across
+// reloads. Lifecycle: pending (data-prep enqueued) → building (deck-build calls
+// slidegen /slides/build — wired when that endpoint deploys) → done (pptx_url
+// set) | failed. This module owns slide_decks read/write; the serving route and
+// SSE read through it. No fabrication — pptx_url is set only by a real build.
+
+import path from 'node:path';
+import { getPrismaClient } from '@/modules/database/client';
+import { config } from '@/config/index';
+
+export type DeckStatus = 'pending' | 'building' | 'done' | 'failed';
+
+export interface DeckState {
+  mandalaId: string;
+  status: DeckStatus;
+  pptxUrl: string | null;
+  error: string | null;
+  generatedAt: Date | null;
+}
+
+/** The authenticated serving-route path for a mandala's .pptx (stored in pptx_url). */
+export function deckPptxRoutePath(mandalaId: string): string {
+  return `/api/v1/mandalas/${mandalaId}/deck.pptx`;
+}
+
+/**
+ * On-disk path where the deck-build job writes the .pptx (EC2 local disk, served
+ * via the authenticated route — no Drive). Under config.paths.data/decks.
+ */
+export function deckPptxDiskPath(mandalaId: string): string {
+  return path.join(config.paths.data, 'decks', `${mandalaId}.pptx`);
+}
+
+/** Read the deck row, or null if the deck was never requested for this mandala. */
+export async function getDeckState(mandalaId: string): Promise<DeckState | null> {
+  const row = await getPrismaClient().slide_decks.findUnique({ where: { mandala_id: mandalaId } });
+  if (!row) return null;
+  return {
+    mandalaId: row.mandala_id,
+    status: row.status as DeckStatus,
+    pptxUrl: row.pptx_url,
+    error: row.error,
+    generatedAt: row.generated_at,
+  };
+}
+
+/**
+ * Mark a deck as requested: upsert the row to 'pending', clearing any prior
+ * pptx_url/error so a re-generate starts clean. Called by the generate-deck
+ * button before the data-prep jobs are enqueued.
+ */
+export async function markDeckPending(mandalaId: string): Promise<void> {
+  await getPrismaClient().slide_decks.upsert({
+    where: { mandala_id: mandalaId },
+    create: { mandala_id: mandalaId, status: 'pending' },
+    update: { status: 'pending', pptx_url: null, error: null, generated_at: null },
+  });
+}

--- a/tests/unit/api/mandala-routes.test.ts
+++ b/tests/unit/api/mandala-routes.test.ts
@@ -73,6 +73,14 @@ const mockEnqueueSegments = jest.fn().mockResolvedValue({ enqueued: 5, segments:
 jest.mock('../../../src/modules/relevance/segment-relevance-trigger', () => ({
   enqueueSegmentRelevanceForMandala: (...a: unknown[]) => mockEnqueueSegments(...a),
 }));
+// ③ deck UI scaffold — mock slide_decks read/write (no DB in route tests).
+const mockMarkDeckPending = jest.fn().mockResolvedValue(undefined);
+const mockGetDeckState = jest.fn().mockResolvedValue(null);
+jest.mock('../../../src/modules/deck/deck-status', () => ({
+  markDeckPending: (...a: unknown[]) => mockMarkDeckPending(...a),
+  getDeckState: (...a: unknown[]) => mockGetDeckState(...a),
+  deckPptxDiskPath: (id: string) => `/srv/data/decks/${id}.pptx`,
+}));
 
 import { mandalaRoutes } from '../../../src/api/routes/mandalas';
 
@@ -919,6 +927,7 @@ describe('Mandala API Routes', () => {
       });
 
       expect(res.statusCode).toBe(200);
+      expect(mockMarkDeckPending).toHaveBeenCalledWith('m1');
       expect(mockEnqueueBookFill).toHaveBeenCalledWith({
         userId: 'test-user-id',
         mandalaId: 'm1',
@@ -944,6 +953,51 @@ describe('Mandala API Routes', () => {
     test('no auth → 401', async () => {
       const res = await app.inject({ method: 'POST', url: `${PREFIX}/m1/generate-deck` });
       expect(res.statusCode).toBe(401);
+    });
+  });
+
+  // ─── GET /:id/deck-status (③ deck lifecycle for FE button) ───
+
+  describe('GET /:id/deck-status', () => {
+    test('owned mandala with a deck → 200 + status', async () => {
+      mockGetMandalaById.mockResolvedValue({ id: 'm1', levels: [{ centerGoal: 'g', subjects: [] }] });
+      mockGetDeckState.mockResolvedValue({
+        mandalaId: 'm1',
+        status: 'done',
+        pptxUrl: `${PREFIX}/m1/deck.pptx`,
+        error: null,
+        generatedAt: new Date('2026-06-22T00:00:00Z'),
+      });
+      const res = await app.inject({
+        method: 'GET',
+        url: `${PREFIX}/m1/deck-status`,
+        headers: authHeaders(),
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data.status).toBe('done');
+      expect(res.json().data.pptxUrl).toBe(`${PREFIX}/m1/deck.pptx`);
+    });
+
+    test('owned mandala, no deck → 200 + null status', async () => {
+      mockGetMandalaById.mockResolvedValue({ id: 'm1', levels: [{ centerGoal: 'g', subjects: [] }] });
+      mockGetDeckState.mockResolvedValue(null);
+      const res = await app.inject({
+        method: 'GET',
+        url: `${PREFIX}/m1/deck-status`,
+        headers: authHeaders(),
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data.status).toBeNull();
+    });
+
+    test('not-owned mandala → 404', async () => {
+      mockGetMandalaById.mockResolvedValue(null);
+      const res = await app.inject({
+        method: 'GET',
+        url: `${PREFIX}/m1/deck-status`,
+        headers: authHeaders(),
+      });
+      expect(res.statusCode).toBe(404);
     });
   });
 });

--- a/tests/unit/modules/deck-status.test.ts
+++ b/tests/unit/modules/deck-status.test.ts
@@ -1,0 +1,71 @@
+/**
+ * deck-status (③ scaffold) — slide_decks read/upsert + path helpers.
+ * Dry-verified with a mock prisma (no DB). Locks: route/disk path shape,
+ * pending upsert clears prior url/error, null when no row.
+ */
+
+const mockFindUnique = jest.fn();
+const mockUpsert = jest.fn();
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({ slide_decks: { findUnique: mockFindUnique, upsert: mockUpsert } }),
+}));
+jest.mock('@/config/index', () => ({
+  config: { paths: { data: '/srv/data' } },
+}));
+
+import {
+  deckPptxRoutePath,
+  deckPptxDiskPath,
+  getDeckState,
+  markDeckPending,
+} from '../../../src/modules/deck/deck-status';
+
+const M = '942e2757-64fa-4759-afc5-56e2f33869f2';
+
+beforeEach(() => {
+  mockFindUnique.mockReset();
+  mockUpsert.mockReset();
+});
+
+describe('deck-status helpers', () => {
+  it('builds the authenticated serving route path', () => {
+    expect(deckPptxRoutePath(M)).toBe(`/api/v1/mandalas/${M}/deck.pptx`);
+  });
+
+  it('builds the on-disk path under config.paths.data/decks', () => {
+    expect(deckPptxDiskPath(M)).toBe(`/srv/data/decks/${M}.pptx`);
+  });
+
+  it('getDeckState maps a row to DeckState', async () => {
+    const at = new Date('2026-06-22T00:00:00Z');
+    mockFindUnique.mockResolvedValue({
+      mandala_id: M,
+      status: 'done',
+      pptx_url: `/api/v1/mandalas/${M}/deck.pptx`,
+      error: null,
+      generated_at: at,
+    });
+    const s = await getDeckState(M);
+    expect(s).toEqual({
+      mandalaId: M,
+      status: 'done',
+      pptxUrl: `/api/v1/mandalas/${M}/deck.pptx`,
+      error: null,
+      generatedAt: at,
+    });
+  });
+
+  it('getDeckState returns null when no deck row exists', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    expect(await getDeckState(M)).toBeNull();
+  });
+
+  it('markDeckPending upserts pending and clears prior url/error/generated_at', async () => {
+    mockUpsert.mockResolvedValue({});
+    await markDeckPending(M);
+    const arg = mockUpsert.mock.calls[0]![0];
+    expect(arg.where).toEqual({ mandala_id: M });
+    expect(arg.create).toEqual({ mandala_id: M, status: 'pending' });
+    expect(arg.update).toEqual({ status: 'pending', pptx_url: null, error: null, generated_at: null });
+  });
+});


### PR DESCRIPTION
## What

The **버튼→스피너→완료→링크** scaffold for the deck button. Contract-stable, insighta-internal halves wired now; the D build-call (slidegen `/slides/build`) connects when that endpoint deploys (absent → not wired, no guessing).

## Built

- **slide_decks table** (PK `mandala_id`): `status` (pending|building|done|failed) + `pptx_url` + `generated_at` + `error`. DDL force-tracked (`prisma/migrations/slide-decks/001`, #931 convention) + apply-custom-sql allowlist. Prisma model + back-relation.
- **generate-deck route**: `markDeckPending` (status=pending) before the existing book-fill + segment enqueues → persists 생성중 across reloads (replaces transient toast).
- **GET /:id/deck-status** (JSON, FE button state) + **GET /:id/deck-stream** (SSE — mirrors cards `enrich-stream` hijack+1s poll) + **GET /:id/deck.pptx** (auth + ownership, `createReadStream` from `config.paths.data/decks` — **no Drive OAuth**).
- **FE**: MandalaRowMenu 3-state — 없음(생성 클릭) / 생성중(spinner, `isGeneratingDeck` ∪ pending|building) / done(openDeck). The serving route is JWT-gated, so `openDeckPptx` fetches with the token → blob → object URL (a plain `window.open` would 401). `useDeckStatus` polls every 3s while pending/building, gated on menu-open (no N background polls). i18n `openDeck`/`deckOpenError`.

## NOT wired (slidegen endpoint absent)

deck-build job + `collect-figures`→`/slides/build` call. slide_decks stays `pending` until that lands; then deck-build sets `building`→`done`+`pptx_url`.

## Verification

- BE: `deck-status` 5/5 + route 6/6 (generate-deck markDeckPending + deck-status 3) ; explore/quota failures in the suite are pre-existing env-dependent (no Supabase keys locally), unrelated.
- FE: url-contract 16/16, `tsc` 0, `npm run build` OK, **browser smoke** `/` + `/mandalas/new` → 200, no runtime errors.
- BE `tsc` clean (new files), lint **0 errors**.
- **PROD migration apply = James** (CI "Verify all tables exist" path, #931 pattern). Local schema verified via prisma generate.