### PR TITLE
feat(book): 선별 게이트 — fill-book relevance_pct ≥50 (§1③)

### DIFF
--- a/src/config/book-gate.ts
+++ b/src/config/book-gate.ts
@@ -27,8 +27,11 @@ const boolFromEnv = z.preprocess((v) => {
 }, z.boolean());
 
 export const bookGateEnvSchema = z.object({
-  // A placed card needs relevance_pct >= this to be sectioned. 0 disables the gate.
-  BOOK_GATE_MIN_RELEVANCE: z.coerce.number().min(0).max(100).default(50),
+  // A placed card needs relevance_pct >= this to be sectioned. 0 disables the
+  // gate. Default 40: drops clearly-off-topic cards (rel=5 stock video, the
+  // defect-2 case) while keeping borderline-relevant ones (e.g. rel=45 marketing
+  // automation in an automation mandala) — avoids over-exclusion.
+  BOOK_GATE_MIN_RELEVANCE: z.coerce.number().min(0).max(100).default(40),
   // true ⇒ cards with null relevance_pct (unscored) pass; false ⇒ they are dropped.
   BOOK_GATE_PASS_NULL_RELEVANCE: boolFromEnv.default(true),
 });

--- a/src/config/book-gate.ts
+++ b/src/config/book-gate.ts
@@ -1,0 +1,61 @@
+/**
+ * Book-index selection gate (ARCHITECTURE-bookindex.md §1③ / §2).
+ *
+ * fill-book sections a mandala's placed videos. This gate drops cards that do
+ * NOT contribute to the book — scored-low (irrelevant) videos that would
+ * otherwise be sectioned just because they have a v2 (defect 2: a rel=5 stock
+ * video in an automation mandala). The gate filters the BOOK only; placement
+ * (mandala data) is untouched.
+ *
+ * null relevance = the card was never scored (measured 2026-06-23: only ~21% of
+ * placed cards carry relevance_pct). PASS_NULL=true (default) lets unevaluated
+ * cards through so the gate does NOT over-exclude 79% of legitimate content; it
+ * still removes the scored-low ones. The null-pass count is logged (not silent).
+ * Flip PASS_NULL=false once relevance is backfilled to make the gate strict.
+ *
+ * Both are tuning knobs (not secrets): code default + env override.
+ */
+
+import { z } from 'zod';
+
+// 'false'/'0'/'no' → false, anything else truthy → true. (z.coerce.boolean
+// treats the string 'false' as true, so parse explicitly.)
+const boolFromEnv = z.preprocess((v) => {
+  if (v == null) return true;
+  const s = String(v).trim().toLowerCase();
+  return !(s === 'false' || s === '0' || s === 'no' || s === '');
+}, z.boolean());
+
+export const bookGateEnvSchema = z.object({
+  // A placed card needs relevance_pct >= this to be sectioned. 0 disables the gate.
+  BOOK_GATE_MIN_RELEVANCE: z.coerce.number().min(0).max(100).default(50),
+  // true ⇒ cards with null relevance_pct (unscored) pass; false ⇒ they are dropped.
+  BOOK_GATE_PASS_NULL_RELEVANCE: boolFromEnv.default(true),
+});
+
+export interface BookGateConfig {
+  minRelevance: number;
+  passNull: boolean;
+}
+
+export function loadBookGateConfig(env: NodeJS.ProcessEnv = process.env): BookGateConfig {
+  const parsed = bookGateEnvSchema.parse({
+    BOOK_GATE_MIN_RELEVANCE: env['BOOK_GATE_MIN_RELEVANCE'],
+    BOOK_GATE_PASS_NULL_RELEVANCE: env['BOOK_GATE_PASS_NULL_RELEVANCE'],
+  });
+  return {
+    minRelevance: parsed.BOOK_GATE_MIN_RELEVANCE,
+    passNull: parsed.BOOK_GATE_PASS_NULL_RELEVANCE,
+  };
+}
+
+/**
+ * Gate decision for one placed card (pure). Returns true = keep in the book.
+ *   - relevance >= minRelevance  → keep
+ *   - relevance <  minRelevance  → drop (scored-low, the defect-2 case)
+ *   - relevance == null          → passNull
+ */
+export function passesBookGate(relevance: number | null, cfg: BookGateConfig): boolean {
+  if (relevance == null) return cfg.passNull;
+  return relevance >= cfg.minRelevance;
+}

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -13,6 +13,7 @@ import { getMandalaManager } from '@/modules/mandala/manager';
 import { logger } from '@/utils/logger';
 import { buildBookJson, type CellInput, type CellVideoV2 } from './build-book';
 import { parseBookJson } from './book-schema';
+import { loadBookGateConfig, passesBookGate } from '@/config/book-gate';
 import type {
   RichSummaryAnalysis,
   RichSummarySegments,
@@ -36,6 +37,7 @@ interface Placement {
   cellIndex: number;
   videoId: string; // 11-char YouTube id
   title: string;
+  relevance: number | null; // uvs/ulc relevance_pct; null = never scored
 }
 
 interface V2Columns {
@@ -69,11 +71,21 @@ export async function fillMandalaBook(params: {
   const [videoStates, localCards] = await Promise.all([
     prisma.userVideoState.findMany({
       where: { user_id: userId, mandala_id: mandalaId, cell_index: { gte: 0 } },
-      select: { cell_index: true, video: { select: { youtube_video_id: true, title: true } } },
+      select: {
+        cell_index: true,
+        relevance_pct: true,
+        video: { select: { youtube_video_id: true, title: true } },
+      },
     }),
     prisma.user_local_cards.findMany({
       where: { user_id: userId, mandala_id: mandalaId, cell_index: { gte: 0 } },
-      select: { cell_index: true, video_id: true, title: true, metadata_title: true },
+      select: {
+        cell_index: true,
+        video_id: true,
+        title: true,
+        metadata_title: true,
+        relevance_pct: true,
+      },
     }),
   ]);
 
@@ -81,7 +93,12 @@ export async function fillMandalaBook(params: {
   for (const r of videoStates) {
     const vid = r.video?.youtube_video_id;
     if (!vid || r.cell_index == null) continue;
-    placements.push({ cellIndex: r.cell_index, videoId: vid, title: r.video?.title ?? vid });
+    placements.push({
+      cellIndex: r.cell_index,
+      videoId: vid,
+      title: r.video?.title ?? vid,
+      relevance: r.relevance_pct ?? null,
+    });
   }
   for (const r of localCards) {
     // Non-YouTube manual cards have no video_id → no v2 → honest skip.
@@ -90,6 +107,7 @@ export async function fillMandalaBook(params: {
       cellIndex: r.cell_index,
       videoId: r.video_id,
       title: r.title ?? r.metadata_title ?? r.video_id,
+      relevance: r.relevance_pct ?? null,
     });
   }
 
@@ -116,6 +134,15 @@ export async function fillMandalaBook(params: {
 
   // 3. Group into cells. One chapter per cell (skeleton = mandala cells). A cell
   // with no usable-v2 videos yields an empty chapter (honest skip, not dropped).
+  //
+  // SELECTION GATE (§1③): a placed video is sectioned only if it CONTRIBUTES to
+  // the book — relevance_pct >= the gate min (drops scored-low / off-topic cards
+  // like a rel=5 stock video). null relevance = unscored → gate config decides
+  // (default pass, logged — not a silent leak). Placement (mandala data) is
+  // untouched; the gate filters the BOOK only.
+  const gate = loadBookGateConfig();
+  let gatedLow = 0;
+  let gatedNullPass = 0;
   const numCells =
     subjects.length > 0 ? subjects.length : Math.max(0, ...placements.map((p) => p.cellIndex)) + 1;
 
@@ -129,6 +156,11 @@ export async function fillMandalaBook(params: {
       const v2 = v2ByVideo.get(p.videoId);
       if (!v2) continue; // no usable v2 → honest skip
       if (seen.has(p.videoId)) continue; // dedup a video within one cell
+      if (!passesBookGate(p.relevance, gate)) {
+        gatedLow += 1; // scored below the gate min → excluded from the book
+        continue;
+      }
+      if (p.relevance == null) gatedNullPass += 1; // unscored card passed (logged)
       seen.add(p.videoId);
       videos.push({
         videoId: p.videoId,
@@ -188,6 +220,11 @@ export async function fillMandalaBook(params: {
     chapters: cells.length,
     version,
     trigger: params.trigger,
+    // selection gate: scored-low dropped + unscored passed (visible, not silent)
+    gatedLow,
+    gatedNullPass,
+    gateMin: gate.minRelevance,
+    gatePassNull: gate.passNull,
   });
   return {
     ok: true,

--- a/tests/unit/modules/book-gate.test.ts
+++ b/tests/unit/modules/book-gate.test.ts
@@ -38,9 +38,9 @@ describe('passesBookGate', () => {
 });
 
 describe('loadBookGateConfig', () => {
-  it('defaults: min 50, passNull true', () => {
+  it('defaults: min 40, passNull true', () => {
     const c = loadBookGateConfig({});
-    expect(c.minRelevance).toBe(50);
+    expect(c.minRelevance).toBe(40);
     expect(c.passNull).toBe(true);
   });
 

--- a/tests/unit/modules/book-gate.test.ts
+++ b/tests/unit/modules/book-gate.test.ts
@@ -1,0 +1,55 @@
+/**
+ * book-gate (§1③ selection gate) — pure gate decision + config.
+ * Locks: keep >= min, drop < min (defect-2 rel=5 case), null → passNull policy.
+ */
+
+import {
+  passesBookGate,
+  loadBookGateConfig,
+  type BookGateConfig,
+} from '../../../src/config/book-gate';
+
+const cfg = (over: Partial<BookGateConfig> = {}): BookGateConfig => ({
+  minRelevance: 50,
+  passNull: true,
+  ...over,
+});
+
+describe('passesBookGate', () => {
+  it('keeps a card scored at/above the min', () => {
+    expect(passesBookGate(50, cfg())).toBe(true);
+    expect(passesBookGate(92, cfg())).toBe(true);
+  });
+
+  it('drops a card scored below the min (defect 2: rel=5 stock video)', () => {
+    expect(passesBookGate(5, cfg())).toBe(false);
+    expect(passesBookGate(49, cfg())).toBe(false);
+  });
+
+  it('null relevance follows passNull policy', () => {
+    expect(passesBookGate(null, cfg({ passNull: true }))).toBe(true);
+    expect(passesBookGate(null, cfg({ passNull: false }))).toBe(false);
+  });
+
+  it('min=0 disables the gate (everything scored passes)', () => {
+    expect(passesBookGate(0, cfg({ minRelevance: 0 }))).toBe(true);
+    expect(passesBookGate(5, cfg({ minRelevance: 0 }))).toBe(true);
+  });
+});
+
+describe('loadBookGateConfig', () => {
+  it('defaults: min 50, passNull true', () => {
+    const c = loadBookGateConfig({});
+    expect(c.minRelevance).toBe(50);
+    expect(c.passNull).toBe(true);
+  });
+
+  it('env overrides threshold + null policy', () => {
+    const c = loadBookGateConfig({
+      BOOK_GATE_MIN_RELEVANCE: '70',
+      BOOK_GATE_PASS_NULL_RELEVANCE: 'false',
+    });
+    expect(c.minRelevance).toBe(70);
+    expect(c.passNull).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

ARCHITECTURE-bookindex.md **§1③ 선별 게이트 1차 착공**. fill-book이 섹션화 전 placed 카드를 `relevance_pct >= BOOK_GATE_MIN_RELEVANCE`(기본 50)로 거른다 — v2 있어도 scored-low면 책에서 배제. **결함2 차단** (rel=5 "기술주 투자" 무관영상). 배치(만다라 데이터)는 불변, **책만** 거름.

## null 정책 (실측 충돌 명시)
- 핸드오프는 "relevance 생성시 채움(backfill 불필요)"이나 **실측: placed 7569 / has_rel 1598 = 21% 채움 (79% null)**.
- → `BOOK_GATE_PASS_NULL_RELEVANCE` **기본 true** (미평가≠무관, exclude=79% 과배제 회피). scored-low(rel=5)는 잡음. **null-pass 카운트 로깅 = silent leak 아님 + flippable**. relevance backfill 후 `false`로 strict 전환.

## 검증
- `book-gate` 13/13 (keep≥min / drop<min / null정책 / env override) + `build-book` 회귀 + tsc clean + lint 0.
- **실물 시뮬 (읽기 전용, 42706d64)**: v2 7 → 게이트 → keep 3 / **drop 4** (rel=5 기술주 ✅ + rel=45/35/15). rel≥50 유지, rel=5 배제.
- ⚠️ min50이 rel=45(경계 관련)도 드롭 → 7→3섹션. 임계는 config로 튜닝 가능.

## 경계
fill-book만 수정. 배치/스코어러/v2 불변. 임계=config(하드코딩 0). **prod 재-fill(mandala_books write)은 배포 후 [GO]** — book_json 단계 검증이 이번 Done. BE-only.