### PR TITLE
feat(book): 토픽 종합 모듈 — 셀 atoms→내용 토픽 (§1⑤, standalone/inert)

### DIFF
--- a/src/modules/mandala-book/topic-synthesis.ts
+++ b/src/modules/mandala-book/topic-synthesis.ts
@@ -1,0 +1,148 @@
+// Topic synthesis (ARCHITECTURE-bookindex.md §1⑤ 내용차원 재배치).
+//
+// Takes one cell's atom pool (atoms from MANY videos, each carrying {vid, ts,
+// text}) and regroups them into content TOPICS — dissolving the video boundary
+// so a section is a topic, not a video (removes defect-1: section title = video
+// title). The LLM ONLY clusters + labels; it references atoms by index and code
+// resolves those indices back to {vid, ts}, so provenance (and the figure /
+// relevance links that travel on {vid, ts}) is preserved without fabrication.
+//
+// Deliberately ISOLATED from build-book (which stays a PURE function). This is
+// the ONLY non-deterministic step; build-book consumes its output.
+//
+// Service module — OpenRouter Haiku is a production LLM call (the deployed
+// pipeline / a James-run prototype invokes it; CC must not call it for tests).
+
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'mandala-book/topic-synthesis' });
+
+const HAIKU_MODEL = 'anthropic/claude-haiku-4.5';
+const MAX_TOKENS = 2000;
+const TEMPERATURE = 0.2;
+// Cap topics per cell so the LLM can't explode a cell into dozens of fragments.
+const MAX_TOPICS_PER_CELL = 6;
+
+/** One source atom (from the cell's pooled v2 atoms). */
+export interface TopicAtom {
+  vid: string;
+  ts: number;
+  text: string;
+}
+
+/** A synthesized topic-section: a content theme grouping atoms across videos. */
+export interface TopicSection {
+  topic_title: string; // CONTENT name (e.g. "REST API 라우팅 구조"), NOT a video title
+  summary: string; // 1-2 line topic framing (light synthesis, no invented facts)
+  atom_refs: Array<{ vid: string; ts: number }>; // provenance — resolved from LLM indices
+}
+
+export type TopicSynthesisResult =
+  | { ok: true; topics: TopicSection[]; droppedAtomIdx: number[] }
+  | { ok: false; reason: string };
+
+interface LlmTopic {
+  topic_title?: unknown;
+  summary?: unknown;
+  atom_idx?: unknown;
+}
+
+/** Build the clustering prompt. Atoms are indexed so the model references them. */
+export function buildTopicSynthesisPrompt(cellTitle: string, atoms: TopicAtom[]): string {
+  const indexed = atoms.map((a, i) => `[${i}] ${a.text}`).join('\n');
+  return [
+    `당신은 한 주제군의 학습 조각(atom)들을 "내용 토픽"으로 재구성하는 편집자다.`,
+    `주제군(셀): "${cellTitle}"`,
+    ``,
+    `아래는 이 주제군에 속한 여러 영상에서 추출한 핵심 조각들이다. 각 줄 앞 [n]은 조각 번호다.`,
+    indexed,
+    ``,
+    `작업:`,
+    `1. 조각들을 "내용 흐름"으로 묶어 자연스러운 토픽으로 재구성하라. 영상 경계는 무시한다 — 같은 내용이면 다른 영상의 조각이라도 한 토픽으로 묶는다.`,
+    `2. 토픽 제목(topic_title)은 반드시 "내용을 설명하는 이름"이어야 한다. 영상 제목·채널명·클릭베이트 금지. (예: O "REST API 라우터 구조", X "이 영상 하나면 끝!")`,
+    `3. 토픽 수는 내용에 맞게 자연스럽게 정하되 최대 ${MAX_TOPICS_PER_CELL}개를 넘지 않는다.`,
+    `4. summary는 토픽의 1-2문장 요약. 조각에 없는 사실을 지어내지 마라(라벨링·요약만, 창작 금지).`,
+    `5. 각 토픽은 atom_idx 배열로 자신이 묶은 조각 번호들을 가리킨다(출처 보존). 한 조각은 한 토픽에만.`,
+    ``,
+    `JSON만 출력(코드펜스 금지):`,
+    `{"topics":[{"topic_title":"...","summary":"...","atom_idx":[0,3,5]}]}`,
+  ].join('\n');
+}
+
+/**
+ * Synthesize a cell's atom pool into content topics. Returns topics with
+ * provenance (atom_refs resolved from LLM indices); never fabricates a vid/ts.
+ * Honest fail → ok:false (caller keeps the prior per-video sections).
+ */
+export async function synthesizeCellTopics(
+  cellTitle: string,
+  atoms: TopicAtom[]
+): Promise<TopicSynthesisResult> {
+  if (atoms.length === 0) return { ok: false, reason: 'no_atoms' };
+
+  const prompt = buildTopicSynthesisPrompt(cellTitle, atoms);
+
+  let raw: string;
+  try {
+    raw = await new OpenRouterGenerationProvider(HAIKU_MODEL).generate(prompt, {
+      format: 'json',
+      temperature: TEMPERATURE,
+      maxTokens: MAX_TOKENS,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `provider_error: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const stripped = raw
+    .trim()
+    .replace(/^\s*```(?:json)?\s*\n?/i, '')
+    .replace(/\n?\s*```\s*$/i, '')
+    .trim();
+
+  let json: { topics?: unknown };
+  try {
+    json = JSON.parse(stripped) as { topics?: unknown };
+  } catch (err) {
+    return { ok: false, reason: `json_parse: ${err instanceof Error ? err.message : String(err)}` };
+  }
+  if (!Array.isArray(json.topics)) return { ok: false, reason: 'no_topics_array' };
+
+  // Resolve LLM atom indices → real {vid, ts}. Drop out-of-range / duplicate
+  // indices (no fabrication). Track which atoms the model placed somewhere.
+  const used = new Set<number>();
+  const topics: TopicSection[] = [];
+  for (const t of (json.topics as LlmTopic[]).slice(0, MAX_TOPICS_PER_CELL)) {
+    const title = typeof t.topic_title === 'string' ? t.topic_title.trim() : '';
+    if (!title) continue;
+    const idxs = Array.isArray(t.atom_idx) ? t.atom_idx : [];
+    const refs: Array<{ vid: string; ts: number }> = [];
+    for (const raw of idxs) {
+      const i = typeof raw === 'number' ? raw : Number(raw);
+      if (!Number.isInteger(i) || i < 0 || i >= atoms.length || used.has(i)) continue;
+      used.add(i);
+      refs.push({ vid: atoms[i]!.vid, ts: atoms[i]!.ts });
+    }
+    if (refs.length === 0) continue; // a topic with no real atoms is dropped
+    topics.push({
+      topic_title: title,
+      summary: typeof t.summary === 'string' ? t.summary.trim() : '',
+      atom_refs: refs,
+    });
+  }
+
+  if (topics.length === 0) return { ok: false, reason: 'no_valid_topics' };
+
+  const droppedAtomIdx = atoms.map((_, i) => i).filter((i) => !used.has(i));
+  log.info('topic-synthesis done', {
+    cellTitle,
+    atomsIn: atoms.length,
+    topics: topics.length,
+    atomsPlaced: used.size,
+    atomsDropped: droppedAtomIdx.length,
+  });
+  return { ok: true, topics, droppedAtomIdx };
+}

--- a/tests/unit/modules/topic-synthesis.test.ts
+++ b/tests/unit/modules/topic-synthesis.test.ts
@@ -1,0 +1,97 @@
+/**
+ * topic-synthesis (§1⑤) — provenance-preserving clustering. The OpenRouter
+ * provider is MOCKED (no live LLM — unit test only). Locks: atom_idx → {vid,ts}
+ * resolution, no-fabrication (out-of-range/dup indices dropped), topic cap,
+ * honest fail.
+ */
+
+const mockGenerate = jest.fn();
+jest.mock('@/modules/llm/openrouter', () => ({
+  OpenRouterGenerationProvider: jest.fn().mockImplementation(() => ({ generate: mockGenerate })),
+}));
+jest.mock('@/config/index', () => ({
+  config: { paths: { logs: '/tmp' }, app: { isTest: true } },
+}));
+
+import {
+  synthesizeCellTopics,
+  buildTopicSynthesisPrompt,
+  type TopicAtom,
+} from '../../../src/modules/mandala-book/topic-synthesis';
+
+const atoms: TopicAtom[] = [
+  { vid: 'vidA', ts: 10, text: 'REST 라우터로 요청을 분기한다' },
+  { vid: 'vidA', ts: 50, text: '컨트롤러가 비즈니스 로직을 처리한다' },
+  { vid: 'vidB', ts: 30, text: '스키마로 데이터 형태를 정의한다' },
+];
+
+beforeEach(() => mockGenerate.mockReset());
+
+describe('buildTopicSynthesisPrompt', () => {
+  it('indexes atoms and forbids video-title labels', () => {
+    const p = buildTopicSynthesisPrompt('백엔드', atoms);
+    expect(p).toContain('[0] REST 라우터');
+    expect(p).toContain('[2] 스키마로');
+    expect(p).toContain('영상 제목·채널명·클릭베이트 금지');
+  });
+});
+
+describe('synthesizeCellTopics', () => {
+  it('resolves atom_idx → {vid,ts} provenance (cross-video topic)', async () => {
+    mockGenerate.mockResolvedValue(
+      JSON.stringify({
+        topics: [
+          { topic_title: 'API 라우팅 구조', summary: '라우터→컨트롤러', atom_idx: [0, 1] },
+          { topic_title: '데이터 스키마', summary: '형태 정의', atom_idx: [2] },
+        ],
+      })
+    );
+    const r = await synthesizeCellTopics('백엔드', atoms);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.topics).toHaveLength(2);
+    expect(r.topics[0]!.topic_title).toBe('API 라우팅 구조');
+    expect(r.topics[0]!.atom_refs).toEqual([
+      { vid: 'vidA', ts: 10 },
+      { vid: 'vidA', ts: 50 },
+    ]);
+    expect(r.topics[1]!.atom_refs).toEqual([{ vid: 'vidB', ts: 30 }]);
+    expect(r.droppedAtomIdx).toEqual([]);
+  });
+
+  it('drops out-of-range and duplicate indices (no fabrication)', async () => {
+    mockGenerate.mockResolvedValue(
+      JSON.stringify({
+        topics: [{ topic_title: 'T', summary: '', atom_idx: [0, 0, 9, -1] }],
+      })
+    );
+    const r = await synthesizeCellTopics('c', atoms);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // only idx 0 is valid+unique; 0(dup), 9(oob), -1(oob) dropped
+    expect(r.topics[0]!.atom_refs).toEqual([{ vid: 'vidA', ts: 10 }]);
+    expect(r.droppedAtomIdx).toEqual([1, 2]);
+  });
+
+  it('drops a topic with no valid atoms', async () => {
+    mockGenerate.mockResolvedValue(
+      JSON.stringify({ topics: [{ topic_title: 'Empty', atom_idx: [99] }] })
+    );
+    const r = await synthesizeCellTopics('c', atoms);
+    expect(r.ok).toBe(false); // no valid topic → honest fail
+  });
+
+  it('honest fail on unparseable LLM output', async () => {
+    mockGenerate.mockResolvedValue('not json');
+    const r = await synthesizeCellTopics('c', atoms);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toContain('json_parse');
+  });
+
+  it('honest fail when atoms empty (no LLM call)', async () => {
+    const r = await synthesizeCellTopics('c', []);
+    expect(r.ok).toBe(false);
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

ARCHITECTURE-bookindex.md **§1⑤ 내용차원 재배치** 1차. 한 셀의 atoms 풀(여러 영상 atoms)을 **내용 토픽**으로 재구성 — 영상 경계 해체, 섹션=토픽 (**결함1 뿌리 제거**: section.title=video.title). LLM은 **클러스터+라벨만**; `atom_idx` 참조 → 코드가 `{vid,ts}` 해석 → **출처/figure/relevance 자동 보존, 날조 0**.

## 구조
- **build-book(순수) 미연결 = INERT** (아무것도 import 안 함). 비결정은 이 모듈에만 격리 (build-book은 순수함수 유지).
- 출처 보존: `atom_idx → {vid,ts}`, out-of-range/dup 인덱스 드롭(날조 0), 토픽 ≤6 cap, honest fail.
- 모델 = OpenRouter Haiku (서비스 LLM).

## ⚠️ HARD RULE 준수 (CLAUDE.md LLM API 금지)
**CC는 OpenRouter를 실행하지 않음.** standalone 품질 실측 = (A) 배포 후 **James가** container one-off로 942 cell 호출, 또는 (B) 서비스 경로 배포. 이 PR은 코드만(inert).

## 검증
- jest **6/6 — provider MOCK (실 LLM 0)**: atom_idx→{vid,ts} 출처해석(cross-video), out-of-range/dup 드롭(날조 0), 빈토픽 드롭, json-parse honest-fail, empty=no-LLM-call, prompt indexing.
- tsc clean (신규), lint 0. BE-only.

## 다음 (배포 후, James 실행)
942 cell3 "보고서 작성"(4영상/46 atoms)에 종합 호출 → 토픽 분할·제목(내용명?)·출처보존·Haiku 품질 실측. PASS면 build-book 연결 설계.