### PR TITLE
feat(book): §1⑤ 토픽 종합 파이프라인 연결 (flag-gated, default off)

### DIFF
--- a/src/config/book-gate.ts
+++ b/src/config/book-gate.ts
@@ -62,3 +62,16 @@ export function passesBookGate(relevance: number | null, cfg: BookGateConfig): b
   if (relevance == null) return cfg.passNull;
   return relevance >= cfg.minRelevance;
 }
+
+/**
+ * §1⑤ topic synthesis on/off. Default FALSE (unset = legacy one-section-per-video,
+ * no LLM cost, byte-identical books) per the "new env default = prior behavior"
+ * rule. Flip to 'true' to make fill-book synthesize content topics (adds one
+ * Haiku call per non-empty cell). Code-revert-free rollback = flag off.
+ */
+export function isBookTopicSynthesisEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['BOOK_TOPIC_SYNTHESIS_ENABLED'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes';
+}

--- a/src/modules/mandala-book/build-book.ts
+++ b/src/modules/mandala-book/build-book.ts
@@ -13,6 +13,7 @@
 // atom without a timestamp yields no book atom (book atom.ts is required).
 
 import type { BookJsonInput } from './book-schema';
+import type { TopicSection } from './topic-synthesis';
 import type {
   RichSummaryAnalysis,
   RichSummarySegments,
@@ -33,6 +34,10 @@ export interface CellInput {
   cellIndex: number; // 0..N-1, becomes chapter.ch
   title: string; // subject label / sub-goal, becomes chapter.title
   videos: CellVideoV2[];
+  // §1⑤ topic synthesis output (set by fill-book when enabled). Present ⇒
+  // sections are built per-topic (content), resolving atom_refs against `videos`.
+  // Absent ⇒ legacy one-section-per-video. build-book stays pure either way.
+  topics?: TopicSection[];
 }
 
 export interface BuildBookInput {
@@ -87,50 +92,78 @@ function assembleNarrative(video: CellVideoV2): string {
 }
 
 /**
+ * v2 atoms (with a real timestamp) → book atoms. NO interpolation: atoms without
+ * a timestamp are skipped (book atom.ts is required). Shared by both assembly
+ * modes so a book atom is built identically whether grouped by video or topic.
+ */
+function bookAtomsForVideo(video: CellVideoV2) {
+  const segments = video.segments;
+  return (segments?.atoms ?? [])
+    .filter((a) => typeof a.timestamp_sec === 'number')
+    .map((a) => {
+      const ts = a.timestamp_sec as number;
+      const seg_ref = segments ? segRefForTimestamp(segments, ts) : undefined;
+      return {
+        vid: video.videoId,
+        ts,
+        text: a.text,
+        ...(a.type ? { type: a.type } : {}),
+        ...(seg_ref ? { seg_ref } : {}),
+      };
+    });
+}
+
+/**
  * Assemble book_json from mandala cells + their v2 summaries. Pure: same input
- * → same output. Returns the book plus the two source counters.
+ * → same output (NO LLM here — topic synthesis runs upstream in fill-book and
+ * arrives as cell.topics). Returns the book plus the two source counters.
  */
 export function buildBookJson(input: BuildBookInput): BuildBookResult {
   let sourceVideos = 0;
   let sourceAtoms = 0;
 
   const chapters = input.cells.map((cell) => {
-    const sections = cell.videos.map((video) => {
+    // Source counters (both modes draw from the same videos/atoms pool).
+    for (const v of cell.videos) {
       sourceVideos += 1;
+      sourceAtoms += v.segments?.atoms?.length ?? 0; // input pool: every harvested atom
+    }
 
-      const segments = video.segments;
-      const rawAtoms = segments?.atoms ?? [];
-      sourceAtoms += rawAtoms.length; // input pool: every harvested atom counts
-
-      // Book atoms = v2 atoms that have a real timestamp. Atoms without one are
-      // skipped (book atom.ts is required; no interpolation of fake timestamps).
-      const atoms = rawAtoms
-        .filter((a) => typeof a.timestamp_sec === 'number')
-        .map((a) => {
-          const ts = a.timestamp_sec as number;
-          const seg_ref = segments ? segRefForTimestamp(segments, ts) : undefined;
-          return {
-            vid: video.videoId,
-            ts,
-            text: a.text,
-            ...(a.type ? { type: a.type } : {}),
-            ...(seg_ref ? { seg_ref } : {}),
-          };
-        });
-
-      // qa: v2 lora.qa_pairs are all context='video' (rich-summary-v2-prompt.ts
-      // :268); map them as-is to the book's {q, a} shape. No context filter
-      // (the handoff's 'mandala_cell' filter would drop every row — corrected
-      // against code).
-      const qa = (video.lora?.qa_pairs ?? []).map((p) => ({ q: p.q, a: p.a }));
-
-      return {
+    let sections;
+    if (cell.topics && cell.topics.length > 0) {
+      // TOPIC mode (§1⑤): one section per CONTENT topic (not per video). Resolve
+      // synthesis atom_refs {vid,ts} → full book atoms from this cell's videos —
+      // provenance preserved, so figure/relevance (keyed on {vid,ts}) travel with
+      // the topic. narrative = the topic summary (light synthesis, no fabrication);
+      // qa = gathered from the topic's source videos.
+      const atomByKey = new Map<string, ReturnType<typeof bookAtomsForVideo>[number]>();
+      const qaByVid = new Map<string, Array<{ q: string; a: string }>>();
+      for (const v of cell.videos) {
+        for (const a of bookAtomsForVideo(v)) atomByKey.set(`${a.vid}:${a.ts}`, a);
+        qaByVid.set(
+          v.videoId,
+          (v.lora?.qa_pairs ?? []).map((p) => ({ q: p.q, a: p.a }))
+        );
+      }
+      sections = cell.topics.map((topic) => {
+        const atoms = topic.atom_refs
+          .map((r) => atomByKey.get(`${r.vid}:${r.ts}`))
+          .filter((a): a is NonNullable<typeof a> => a != null);
+        const vids = Array.from(new Set(topic.atom_refs.map((r) => r.vid)));
+        const qa = vids.flatMap((v) => qaByVid.get(v) ?? []);
+        return { title: topic.topic_title, narrative: topic.summary, atoms, qa };
+      });
+    } else {
+      // LEGACY mode: one section per video (synthesis off/failed → safe fallback;
+      // byte-identical to pre-§1⑤ output).
+      sections = cell.videos.map((video) => ({
         title: video.title,
         narrative: assembleNarrative(video),
-        atoms,
-        qa,
-      };
-    });
+        atoms: bookAtomsForVideo(video),
+        // qa: v2 lora.qa_pairs are all context='video'; map as-is to {q,a}.
+        qa: (video.lora?.qa_pairs ?? []).map((p) => ({ q: p.q, a: p.a })),
+      }));
+    }
 
     return {
       ch: cell.cellIndex,

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -13,7 +13,12 @@ import { getMandalaManager } from '@/modules/mandala/manager';
 import { logger } from '@/utils/logger';
 import { buildBookJson, type CellInput, type CellVideoV2 } from './build-book';
 import { parseBookJson } from './book-schema';
-import { loadBookGateConfig, passesBookGate } from '@/config/book-gate';
+import {
+  loadBookGateConfig,
+  passesBookGate,
+  isBookTopicSynthesisEnabled,
+} from '@/config/book-gate';
+import { synthesizeCellTopics } from './topic-synthesis';
 import type {
   RichSummaryAnalysis,
   RichSummarySegments,
@@ -171,6 +176,33 @@ export async function fillMandalaBook(params: {
       });
     }
     cells.push({ cellIndex: i, title, videos });
+  }
+
+  // 3b. §1⑤ topic synthesis (flag-gated; off = legacy per-video). For each
+  // non-empty cell, pool its videos' atoms → synthesizeCellTopics → attach
+  // topics. build-book then builds sections per TOPIC (not per video), removing
+  // defect-1 (section title = video title). A cell whose synthesis fails keeps
+  // topics undefined → build-book falls back to per-video for THAT cell (safe).
+  // This is the only non-deterministic step; build-book stays pure.
+  if (isBookTopicSynthesisEnabled()) {
+    let synthOk = 0;
+    let synthFail = 0;
+    for (const cell of cells) {
+      const atoms = cell.videos.flatMap((v) =>
+        (v.segments?.atoms ?? [])
+          .filter((a) => typeof a.timestamp_sec === 'number')
+          .map((a) => ({ vid: v.videoId, ts: a.timestamp_sec as number, text: a.text }))
+      );
+      if (atoms.length === 0) continue; // empty cell → no synthesis, no topics
+      const r = await synthesizeCellTopics(cell.title, atoms);
+      if (r.ok) {
+        cell.topics = r.topics;
+        synthOk += 1;
+      } else {
+        synthFail += 1; // leave topics undefined → legacy per-video for this cell
+      }
+    }
+    log.info('topic synthesis', { mandalaId, cellsSynthesized: synthOk, cellsFallback: synthFail });
   }
 
   // 4. Assemble (pure, LLM-free) + validate (hard gate).

--- a/src/modules/mandala-book/topic-synthesis.ts
+++ b/src/modules/mandala-book/topic-synthesis.ts
@@ -64,6 +64,7 @@ export function buildTopicSynthesisPrompt(cellTitle: string, atoms: TopicAtom[])
     `3. 토픽 수는 내용에 맞게 자연스럽게 정하되 최대 ${MAX_TOPICS_PER_CELL}개를 넘지 않는다.`,
     `4. summary는 토픽의 1-2문장 요약. 조각에 없는 사실을 지어내지 마라(라벨링·요약만, 창작 금지).`,
     `5. 각 토픽은 atom_idx 배열로 자신이 묶은 조각 번호들을 가리킨다(출처 보존). 한 조각은 한 토픽에만.`,
+    `6. 명백한 중복·완전 무관 조각만 제외하고, 나머지 조각은 반드시 어느 토픽엔가 배치하라. 임의로 빠뜨리지 마라 — 누락된 조각은 책 내용 손실이다(절삭 금지).`,
     ``,
     `JSON만 출력(코드펜스 금지):`,
     `{"topics":[{"topic_title":"...","summary":"...","atom_idx":[0,3,5]}]}`,

--- a/tests/unit/modules/build-book-topics.test.ts
+++ b/tests/unit/modules/build-book-topics.test.ts
@@ -1,0 +1,99 @@
+/**
+ * build-book §1⑤ topic mode — sections per TOPIC (not video) when cell.topics
+ * present; atom_refs {vid,ts} resolved against the cell's videos (provenance);
+ * legacy per-video fallback when topics absent. build-book stays pure.
+ */
+
+import {
+  buildBookJson,
+  type CellInput,
+  type CellVideoV2,
+} from '../../../src/modules/mandala-book/build-book';
+
+const vid = (id: string, atomTs: number[]): CellVideoV2 => ({
+  videoId: id,
+  title: `VIDEO TITLE ${id}`, // legacy section title = this (the defect-1 string)
+  analysis: { core_argument: `core ${id}` } as never,
+  segments: {
+    atoms: atomTs.map((ts) => ({ timestamp_sec: ts, text: `atom ${id}@${ts}` })),
+    sections: [],
+  } as never,
+  lora: { qa_pairs: [{ q: `q ${id}`, a: `a ${id}` }] } as never,
+});
+
+const base = (cells: CellInput[]) => ({
+  mandalaId: 'm',
+  mandalaTitle: 'T',
+  generatedAt: '2026',
+  cells,
+});
+
+type Sec = {
+  title: string;
+  narrative: string;
+  atoms: Array<{ vid: string; ts: number }>;
+  qa: unknown[];
+};
+const sectionsOf = (book: { chapters: Array<{ sections: unknown[] }> }): Sec[] =>
+  book.chapters[0]!.sections as Sec[];
+
+describe('buildBookJson — topic mode (§1⑤)', () => {
+  it('builds one section per topic; title=topic_title, atoms resolved cross-video', () => {
+    const cell: CellInput = {
+      cellIndex: 0,
+      title: '백엔드',
+      videos: [vid('vidA', [10, 50]), vid('vidB', [30])],
+      topics: [
+        {
+          topic_title: 'API 라우팅 구조', // CONTENT name, not video title
+          summary: '라우터→컨트롤러 흐름',
+          atom_refs: [
+            { vid: 'vidA', ts: 10 },
+            { vid: 'vidB', ts: 30 }, // cross-video topic
+          ],
+        },
+        {
+          topic_title: '컨트롤러 처리',
+          summary: '로직 처리',
+          atom_refs: [{ vid: 'vidA', ts: 50 }],
+        },
+      ],
+    };
+    const { book } = buildBookJson(base([cell]));
+    const secs = sectionsOf(book);
+    expect(secs).toHaveLength(2);
+    // section title = topic name (NOT "VIDEO TITLE ...") → defect-1 removed
+    expect(secs[0]!.title).toBe('API 라우팅 구조');
+    expect(secs[0]!.narrative).toBe('라우터→컨트롤러 흐름');
+    // atoms resolved from refs, preserving vid/ts provenance (cross-video)
+    expect(secs[0]!.atoms.map((a) => `${a.vid}:${a.ts}`)).toEqual(['vidA:10', 'vidB:30']);
+    expect(secs[1]!.atoms.map((a) => a.ts)).toEqual([50]);
+    // qa gathered from the topic's source videos
+    expect(secs[0]!.qa.length).toBe(2); // vidA + vidB qa
+  });
+
+  it('legacy mode (no topics): one section per video, title=video.title (byte-identical)', () => {
+    const cell: CellInput = { cellIndex: 0, title: 'c', videos: [vid('vidA', [10])] };
+    const { book } = buildBookJson(base([cell]));
+    const secs = sectionsOf(book);
+    expect(secs).toHaveLength(1);
+    expect(secs[0]!.title).toBe('VIDEO TITLE vidA');
+  });
+
+  it('source counters identical regardless of mode', () => {
+    const videos = [vid('vidA', [10, 50]), vid('vidB', [30])];
+    const legacy = buildBookJson(base([{ cellIndex: 0, title: 'c', videos }]));
+    const topic = buildBookJson(
+      base([
+        {
+          cellIndex: 0,
+          title: 'c',
+          videos,
+          topics: [{ topic_title: 't', summary: '', atom_refs: [{ vid: 'vidA', ts: 10 }] }],
+        },
+      ])
+    );
+    expect(topic.sourceVideos).toBe(legacy.sourceVideos); // 2
+    expect(topic.sourceAtoms).toBe(legacy.sourceAtoms); // 3
+  });
+});


### PR DESCRIPTION
## What

ARCHITECTURE-bookindex.md **§1⑤ 내용차원 재배치 파이프라인 연결**. `fill-book(게이트 통과 atoms) → synthesizeCellTopics(셀별) → build-book(토픽=섹션)`. **결함1 뿌리 제거**: section.title = 영상 원제목 → 내용 토픽명.

## 변경
- **build-book**: `cell.topics` 있으면 **토픽=섹션** (atom_refs `{vid,ts}` → cell videos서 full atom 복원 = 출처/figure/relevance 자동 동행, narrative=topic.summary, qa=토픽 출처영상서 수집). 없으면 **레거시 영상=섹션 (byte-identical fallback)**. 순수 유지(LLM은 앞단). `bookAtomsForVideo` 헬퍼 추출.
- **fill-book**: `BOOK_TOPIC_SYNTHESIS_ENABLED` 시 셀별 `synthesizeCellTopics` 호출 → topics 부착. 실패 셀 = topics undefined → 레거시(안전 fallback). source 카운터 모드 무관 동일.
- **config**: `isBookTopicSynthesisEnabled` **default false** — unset=레거시=**배포 시 동작 무변**, flag-off 롤백(CLAUDE.md "신규 env=기존 동작" 준수). 켜면 셀당 Haiku 1콜.
- **8-drop 보정**: 종합 프롬프트에 절삭 금지(중복·무관만 제외, 나머지 전부 배치) 1줄.

## 검증
- jest **22/22**: 토픽모드(출처해석·cross-video), 레거시 byte-identical, source 카운터 모드무관 동일, gate/synthesis 단위. tsc clean, lint 0.
- 스키마 무변경(섹션 multi-video 합법). 게이트(§1③) 불변. BE-only.

## ⚠️ 배포 ≠ 활성
flag default **off** → 배포해도 기존 레거시 동작. **942 flag-on 재-fill 실물검증 = James [GO]** (OpenRouter 종합 + mandala_books write). book_json 실물(섹션 제목 전부 내용명, 영상경계 해체, drop율 개선)이 Done.