### PR TITLE
fix(book): §1⑤ drop 0 — maxTokens + 비례 토픽 cap + 근접 fallback

### DIFF
--- a/src/modules/mandala-book/topic-synthesis.ts
+++ b/src/modules/mandala-book/topic-synthesis.ts
@@ -19,10 +19,23 @@ import { logger } from '@/utils/logger';
 const log = logger.child({ module: 'mandala-book/topic-synthesis' });
 
 const HAIKU_MODEL = 'anthropic/claude-haiku-4.5';
-const MAX_TOKENS = 2000;
+// Large cells (e.g. 434 atoms) need a long completion to list every atom_idx;
+// 2000 truncated the index lists → atoms went unplaced (34% drop). 4000 + the
+// proportional topic cap + the proximity fallback below together guarantee 0 drop.
+const MAX_TOKENS = 4000;
 const TEMPERATURE = 0.2;
-// Cap topics per cell so the LLM can't explode a cell into dozens of fragments.
-const MAX_TOPICS_PER_CELL = 6;
+// Topics scale with atom count (~12 atoms/topic) so a big cell isn't forced into
+// 6 over-stuffed topics; clamped so it neither collapses (min 2) nor fragments
+// (max 15). Replaces the old fixed 6.
+const ATOMS_PER_TOPIC = 12;
+const MIN_TOPICS_PER_CELL = 2;
+const MAX_TOPICS_CAP = 15;
+function topicCapFor(atomCount: number): number {
+  return Math.min(
+    MAX_TOPICS_CAP,
+    Math.max(MIN_TOPICS_PER_CELL, Math.ceil(atomCount / ATOMS_PER_TOPIC))
+  );
+}
 
 /** One source atom (from the cell's pooled v2 atoms). */
 export interface TopicAtom {
@@ -49,7 +62,11 @@ interface LlmTopic {
 }
 
 /** Build the clustering prompt. Atoms are indexed so the model references them. */
-export function buildTopicSynthesisPrompt(cellTitle: string, atoms: TopicAtom[]): string {
+export function buildTopicSynthesisPrompt(
+  cellTitle: string,
+  atoms: TopicAtom[],
+  maxTopics: number
+): string {
   const indexed = atoms.map((a, i) => `[${i}] ${a.text}`).join('\n');
   return [
     `당신은 한 주제군의 학습 조각(atom)들을 "내용 토픽"으로 재구성하는 편집자다.`,
@@ -61,7 +78,7 @@ export function buildTopicSynthesisPrompt(cellTitle: string, atoms: TopicAtom[])
     `작업:`,
     `1. 조각들을 "내용 흐름"으로 묶어 자연스러운 토픽으로 재구성하라. 영상 경계는 무시한다 — 같은 내용이면 다른 영상의 조각이라도 한 토픽으로 묶는다.`,
     `2. 토픽 제목(topic_title)은 반드시 "내용을 설명하는 이름"이어야 한다. 영상 제목·채널명·클릭베이트 금지. (예: O "REST API 라우터 구조", X "이 영상 하나면 끝!")`,
-    `3. 토픽 수는 내용에 맞게 자연스럽게 정하되 최대 ${MAX_TOPICS_PER_CELL}개를 넘지 않는다.`,
+    `3. 토픽 수는 내용에 맞게 자연스럽게 정하되 최대 ${maxTopics}개를 넘지 않는다.`,
     `4. summary는 토픽의 1-2문장 요약. 조각에 없는 사실을 지어내지 마라(라벨링·요약만, 창작 금지).`,
     `5. 각 토픽은 atom_idx 배열로 자신이 묶은 조각 번호들을 가리킨다(출처 보존). 한 조각은 한 토픽에만.`,
     `6. 명백한 중복·완전 무관 조각만 제외하고, 나머지 조각은 반드시 어느 토픽엔가 배치하라. 임의로 빠뜨리지 마라 — 누락된 조각은 책 내용 손실이다(절삭 금지).`,
@@ -82,7 +99,8 @@ export async function synthesizeCellTopics(
 ): Promise<TopicSynthesisResult> {
   if (atoms.length === 0) return { ok: false, reason: 'no_atoms' };
 
-  const prompt = buildTopicSynthesisPrompt(cellTitle, atoms);
+  const maxTopics = topicCapFor(atoms.length);
+  const prompt = buildTopicSynthesisPrompt(cellTitle, atoms, maxTopics);
 
   let raw: string;
   try {
@@ -116,7 +134,7 @@ export async function synthesizeCellTopics(
   // indices (no fabrication). Track which atoms the model placed somewhere.
   const used = new Set<number>();
   const topics: TopicSection[] = [];
-  for (const t of (json.topics as LlmTopic[]).slice(0, MAX_TOPICS_PER_CELL)) {
+  for (const t of (json.topics as LlmTopic[]).slice(0, maxTopics)) {
     const title = typeof t.topic_title === 'string' ? t.topic_title.trim() : '';
     if (!title) continue;
     const idxs = Array.isArray(t.atom_idx) ? t.atom_idx : [];
@@ -137,13 +155,51 @@ export async function synthesizeCellTopics(
 
   if (topics.length === 0) return { ok: false, reason: 'no_valid_topics' };
 
-  const droppedAtomIdx = atoms.map((_, i) => i).filter((i) => !used.has(i));
+  // FALLBACK (drop 0 보장): any atom the LLM left unplaced is assigned to the
+  // NEAREST topic by proximity — same video first, then closest timestamp among
+  // that topic's atoms (not "the last topic"). Content손실 0 without breaking
+  // topic cohesion. The fallback count is logged so silent over-stuffing shows.
+  const fallbackAssigned = atoms
+    .map((_, i) => i)
+    .filter((i) => !used.has(i))
+    .map((i) => {
+      const atom = atoms[i]!;
+      const topic = nearestTopic(atom, topics);
+      topic.atom_refs.push({ vid: atom.vid, ts: atom.ts });
+      used.add(i);
+      return i;
+    });
+
   log.info('topic-synthesis done', {
     cellTitle,
     atomsIn: atoms.length,
     topics: topics.length,
-    atomsPlaced: used.size,
-    atomsDropped: droppedAtomIdx.length,
+    atomsPlacedByLlm: used.size - fallbackAssigned.length,
+    atomsByFallback: fallbackAssigned.length,
+    atomsDropped: atoms.length - used.size, // 0 by construction (fallback covers all)
   });
-  return { ok: true, topics, droppedAtomIdx };
+  return { ok: true, topics, droppedAtomIdx: [] };
+}
+
+/**
+ * Nearest topic for an unplaced atom: prefer a topic that already holds an atom
+ * from the SAME video (closest ts wins); fall back to the globally closest ts.
+ * A large same-video penalty keeps cross-video matches as the last resort, so an
+ * orphan lands with related content, never just appended to the last topic.
+ */
+function nearestTopic(atom: TopicAtom, topics: TopicSection[]): TopicSection {
+  const SAME_VID_BONUS = 1_000_000;
+  let best = topics[0]!;
+  let bestScore = Infinity;
+  for (const t of topics) {
+    for (const ref of t.atom_refs) {
+      const vidPenalty = ref.vid === atom.vid ? 0 : SAME_VID_BONUS;
+      const score = vidPenalty + Math.abs(ref.ts - atom.ts);
+      if (score < bestScore) {
+        bestScore = score;
+        best = t;
+      }
+    }
+  }
+  return best;
 }

--- a/tests/unit/modules/topic-synthesis.test.ts
+++ b/tests/unit/modules/topic-synthesis.test.ts
@@ -29,10 +29,11 @@ beforeEach(() => mockGenerate.mockReset());
 
 describe('buildTopicSynthesisPrompt', () => {
   it('indexes atoms and forbids video-title labels', () => {
-    const p = buildTopicSynthesisPrompt('백엔드', atoms);
+    const p = buildTopicSynthesisPrompt('백엔드', atoms, 6);
     expect(p).toContain('[0] REST 라우터');
     expect(p).toContain('[2] 스키마로');
     expect(p).toContain('영상 제목·채널명·클릭베이트 금지');
+    expect(p).toContain('최대 6개');
   });
 });
 
@@ -59,7 +60,7 @@ describe('synthesizeCellTopics', () => {
     expect(r.droppedAtomIdx).toEqual([]);
   });
 
-  it('drops out-of-range and duplicate indices (no fabrication)', async () => {
+  it('ignores out-of-range/dup indices, then fallback-assigns the unplaced (no fabrication, drop 0)', async () => {
     mockGenerate.mockResolvedValue(
       JSON.stringify({
         topics: [{ topic_title: 'T', summary: '', atom_idx: [0, 0, 9, -1] }],
@@ -68,9 +69,40 @@ describe('synthesizeCellTopics', () => {
     const r = await synthesizeCellTopics('c', atoms);
     expect(r.ok).toBe(true);
     if (!r.ok) return;
-    // only idx 0 is valid+unique; 0(dup), 9(oob), -1(oob) dropped
-    expect(r.topics[0]!.atom_refs).toEqual([{ vid: 'vidA', ts: 10 }]);
-    expect(r.droppedAtomIdx).toEqual([1, 2]);
+    // idx 0 valid; 0(dup)/9(oob)/-1(oob) ignored. atoms 1,2 were unplaced →
+    // fallback assigns them to the nearest topic (only one) → drop 0.
+    expect(r.droppedAtomIdx).toEqual([]);
+    const refs = r.topics[0]!.atom_refs;
+    expect(refs).toContainEqual({ vid: 'vidA', ts: 10 });
+    expect(refs).toContainEqual({ vid: 'vidA', ts: 50 }); // atom 1, fallback
+    expect(refs).toContainEqual({ vid: 'vidB', ts: 30 }); // atom 2, fallback
+    expect(refs).toHaveLength(3);
+  });
+
+  it('fallback assigns an orphan to the SAME-video topic (proximity, not last topic)', async () => {
+    // 4 atoms: vidA@10, vidA@50, vidB@30, vidB@200. LLM places 0,1 (vidA) in T1
+    // and 2 (vidB) in T2, leaving 3 (vidB@200) unplaced. Fallback → T2 (same vid).
+    const four = [
+      { vid: 'vidA', ts: 10, text: 'a' },
+      { vid: 'vidA', ts: 50, text: 'b' },
+      { vid: 'vidB', ts: 30, text: 'c' },
+      { vid: 'vidB', ts: 200, text: 'd' },
+    ];
+    mockGenerate.mockResolvedValue(
+      JSON.stringify({
+        topics: [
+          { topic_title: 'T1', summary: '', atom_idx: [0, 1] },
+          { topic_title: 'T2', summary: '', atom_idx: [2] },
+        ],
+      })
+    );
+    const r = await synthesizeCellTopics('c', four);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.droppedAtomIdx).toEqual([]);
+    // orphan vidB@200 → T2 (holds vidB@30), NOT T1 (vidA)
+    expect(r.topics[1]!.atom_refs).toContainEqual({ vid: 'vidB', ts: 200 });
+    expect(r.topics[0]!.atom_refs).not.toContainEqual({ vid: 'vidB', ts: 200 });
   });
 
   it('drops a topic with no valid atoms', async () => {


### PR DESCRIPTION
## What

942 검증서 **drop 34% (282 atoms 순수 손실, 전부 timestamped=내용) FAIL**. 3개 보정 — drop 0 **구조 보장**:

1. **maxTokens 2000→4000**: 대형셀(ch0 434 atoms, prompt 26.9k/completion 1.6k) atom_idx 나열이 절단됐던 손실 직접 원인 제거.
2. **MAX_TOPICS 고정6 → `topicCapFor` = clamp(ceil(atoms/12), 2, 15)**: 대형셀이 6 과적 토픽 대신 더 많은 토픽으로 atoms 수용(토픽당 ~12).
3. **근접 fallback**: LLM 미배치 atom → `nearestTopic`(같은 영상 우선 → ts 근접) 자동 귀속. **"마지막 토픽에" 금지** — 관련 콘텐츠와 묶임. `droppedAtomIdx=[]` 구조 보장(drop 숨김 아니라 올바른 배치).

## 검증
- jest **10/10**: fallback 같은-영상 귀속(proximity not last), drop 0, cross-video, oob/dup ignore, honest-fail. 5/6 PASS 로직(제목 내용명·영상경계·출처) 불변. tsc clean, lint 0.
- build-book 순수성·게이트(§1③)·스키마 불변. BE-only.

## 다음 (재인증)
942 재-fill(OpenRouter + prod write) = **James [GO]/이번만 CC 재승인**. book_json 실측: **drop 0**(824 전부 배치, cell3 46 & ch0 434 모두) + 5/6 회귀 0 + fallback 귀속 품질 샘플. drop 0 + 5기준 유지 = **§1⑤ Done**.