### PR TITLE
fix(book): §1⑤ ch0 절단 회귀 — maxTokens 8000 + 절단-레거시 무음 가드

### DIFF
--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -186,7 +186,7 @@ export async function fillMandalaBook(params: {
   // This is the only non-deterministic step; build-book stays pure.
   if (isBookTopicSynthesisEnabled()) {
     let synthOk = 0;
-    let synthFail = 0;
+    const failedCells: string[] = [];
     for (const cell of cells) {
       const atoms = cell.videos.flatMap((v) =>
         (v.segments?.atoms ?? [])
@@ -194,15 +194,27 @@ export async function fillMandalaBook(params: {
           .map((a) => ({ vid: v.videoId, ts: a.timestamp_sec as number, text: a.text }))
       );
       if (atoms.length === 0) continue; // empty cell → no synthesis, no topics
-      const r = await synthesizeCellTopics(cell.title, atoms);
+      const r = await synthesizeCellTopics(cell.title, atoms); // retries internally
       if (r.ok) {
         cell.topics = r.topics;
         synthOk += 1;
       } else {
-        synthFail += 1; // leave topics undefined → legacy per-video for this cell
+        // HARD fail after retries. This cell falls to legacy per-video (defect-1
+        // clickbait titles) — surfaced LOUDLY here so it is NOT a silent revert.
+        // (8000 tokens makes 942's cells fit; a hard fail signals a too-large
+        // cell that needs chunking — see backlog.)
+        failedCells.push(cell.title);
       }
     }
-    log.info('topic synthesis', { mandalaId, cellsSynthesized: synthOk, cellsFallback: synthFail });
+    if (failedCells.length > 0) {
+      log.error('topic synthesis HARD-FAILED cells → legacy/clickbait fallback (NOT silent)', {
+        mandalaId,
+        cellsSynthesized: synthOk,
+        failedCells,
+      });
+    } else {
+      log.info('topic synthesis', { mandalaId, cellsSynthesized: synthOk, failedCells: 0 });
+    }
   }
 
   // 4. Assemble (pure, LLM-free) + validate (hard gate).

--- a/src/modules/mandala-book/topic-synthesis.ts
+++ b/src/modules/mandala-book/topic-synthesis.ts
@@ -19,10 +19,16 @@ import { logger } from '@/utils/logger';
 const log = logger.child({ module: 'mandala-book/topic-synthesis' });
 
 const HAIKU_MODEL = 'anthropic/claude-haiku-4.5';
-// Large cells (e.g. 434 atoms) need a long completion to list every atom_idx;
-// 2000 truncated the index lists → atoms went unplaced (34% drop). 4000 + the
-// proportional topic cap + the proximity fallback below together guarantee 0 drop.
-const MAX_TOKENS = 4000;
+// Large cells need a long completion to list every atom_idx. 4000 still
+// truncated ch0 (434 atoms, completion hit the 4000 ceiling exactly → invalid
+// JSON → synthesis failed → cell fell to legacy per-video = clickbait titles
+// resurfaced). 8000 holds 942's largest cell (~434). >~600-atom cells need
+// chunking (backlog). With the truncation guard below, a still-truncated cell
+// is RETRIED then surfaced loudly — never a silent legacy/clickbait revert.
+const MAX_TOKENS = 8000;
+// Synthesis is retried once on a parse/provider failure (transient or a one-off
+// truncation) before the cell is reported as a hard failure.
+const SYNTHESIS_ATTEMPTS = 2;
 const TEMPERATURE = 0.2;
 // Topics scale with atom count (~12 atoms/topic) so a big cell isn't forced into
 // 6 over-stuffed topics; clamped so it neither collapses (min 2) nor fragments
@@ -99,6 +105,40 @@ export async function synthesizeCellTopics(
 ): Promise<TopicSynthesisResult> {
   if (atoms.length === 0) return { ok: false, reason: 'no_atoms' };
 
+  // Truncation guard: retry on a parse/provider failure (truncated JSON, transient
+  // error) before reporting a HARD failure. A hard failure is surfaced LOUDLY —
+  // the caller must NOT silently revert the cell to legacy per-video (which would
+  // resurrect defect-1 clickbait titles). The retry is the primary guard; 8000
+  // tokens makes 942's largest cell fit so it should not be reached for 942.
+  let lastReason = 'unknown';
+  for (let attempt = 1; attempt <= SYNTHESIS_ATTEMPTS; attempt++) {
+    const r = await attemptSynthesis(cellTitle, atoms);
+    if (r.ok) {
+      if (attempt > 1) log.info('topic-synthesis recovered on retry', { cellTitle, attempt });
+      return r;
+    }
+    lastReason = r.reason;
+    if (attempt < SYNTHESIS_ATTEMPTS) {
+      log.warn('topic-synthesis attempt failed — retrying', {
+        cellTitle,
+        attempt,
+        reason: r.reason,
+      });
+    }
+  }
+  log.error('topic-synthesis HARD FAIL after retries (NOT a silent legacy revert)', {
+    cellTitle,
+    atoms: atoms.length,
+    reason: lastReason,
+  });
+  return { ok: false, reason: `hard_fail: ${lastReason}` };
+}
+
+/** One synthesis attempt: generate → parse → resolve + fallback. Pure-ish (LLM call). */
+async function attemptSynthesis(
+  cellTitle: string,
+  atoms: TopicAtom[]
+): Promise<TopicSynthesisResult> {
   const maxTopics = topicCapFor(atoms.length);
   const prompt = buildTopicSynthesisPrompt(cellTitle, atoms, maxTopics);
 

--- a/tests/unit/modules/topic-synthesis.test.ts
+++ b/tests/unit/modules/topic-synthesis.test.ts
@@ -126,4 +126,26 @@ describe('synthesizeCellTopics', () => {
     expect(r.ok).toBe(false);
     expect(mockGenerate).not.toHaveBeenCalled();
   });
+
+  it('retries once on a truncated/parse failure, then succeeds (no silent revert)', async () => {
+    mockGenerate
+      .mockResolvedValueOnce('{"topics":[{"topic_title":"T","atom_idx":[0,1') // truncated
+      .mockResolvedValueOnce(
+        JSON.stringify({ topics: [{ topic_title: 'API', summary: '', atom_idx: [0, 1, 2] }] })
+      );
+    const r = await synthesizeCellTopics('c', atoms);
+    expect(mockGenerate).toHaveBeenCalledTimes(2); // retried
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.topics[0]!.topic_title).toBe('API');
+  });
+
+  it('hard-fails (loud) after all retries exhausted', async () => {
+    mockGenerate.mockResolvedValue('not json'); // both attempts fail
+    const r = await synthesizeCellTopics('c', atoms);
+    expect(mockGenerate).toHaveBeenCalledTimes(2);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toContain('hard_fail'); // surfaced as hard fail, not silent
+  });
 });


### PR DESCRIPTION
## What

942 재-fill서 **drop 0이나 ch0(434 atoms) completion=4000 천장 절단 → 종합 실패 → 레거시 per-video 무음 fallback → 클릭베이트 18 부활**(대부분 ch0). 'drop 0'이 사실 ch0=레거시인 **가짜 0**. 결함1 **백도어**(절단 시 클릭베이트 언제든 부활) 확인.

## 두 겹 보정
1. **MAX_TOKENS 4000→8000**: ch0 434-atom atom_idx 출력 수용 (942 max 충분).
2. **절단-레거시 무음 가드** (구조적, 더 중요): `synthesizeCellTopics`가 `attemptSynthesis`를 **2회 재시도**(파싱/provider 실패=절단·transient) → 그래도 실패면 **`log.error` LOUD 표면화** + `reason='hard_fail:'`. fill-book도 hard-fail 셀을 `log.error(failedCells)`로 surface — **조용히 레거시 클릭베이트로 안 떨어짐.**

## 검증
- jest **12/12**: 재시도-복구(truncated→retry→success), hard-fail-loud(2회 실패→hard_fail surfaced), 같은영상 fallback, drop0, cross-video. tsc clean, lint 0.
- build-book 순수성·게이트(§1③)·스키마 불변. BE-only.

## 다음 (재인증)
942 재-fill(OpenRouter+prod write) = **James [GO]/이번만 CC**: ch0 종합 성공(절단 0) + **클릭베이트 0**(18→0) + 전셀 토픽모드(레거시 0) + 진짜 drop 0. = §1⑤ Done.

## 백로그
>~600 atom 셀 청킹 (8000도 부족 가능 — atom_idx 전부 echo가 토큰 과중). 942(434)는 8000 충분.