### PR TITLE
feat(book): §1⑤ flag default ON (토픽 종합 전체 활성)

### DIFF
--- a/src/config/book-gate.ts
+++ b/src/config/book-gate.ts
@@ -64,14 +64,14 @@ export function passesBookGate(relevance: number | null, cfg: BookGateConfig): b
 }
 
 /**
- * §1⑤ topic synthesis on/off. Default FALSE (unset = legacy one-section-per-video,
- * no LLM cost, byte-identical books) per the "new env default = prior behavior"
- * rule. Flip to 'true' to make fill-book synthesize content topics (adds one
- * Haiku call per non-empty cell). Code-revert-free rollback = flag off.
+ * §1⑤ topic synthesis on/off. Default TRUE (verified §1⑤ Done — 942 clickbait 0,
+ * drop 0, content-name topics). Every fill now synthesizes content topics (one
+ * Haiku call per non-empty cell). Code-revert-free rollback = set
+ * BOOK_TOPIC_SYNTHESIS_ENABLED=false (the only values that disable it).
  */
 export function isBookTopicSynthesisEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const v = String(env['BOOK_TOPIC_SYNTHESIS_ENABLED'] ?? '')
     .trim()
     .toLowerCase();
-  return v === 'true' || v === '1' || v === 'yes';
+  return !(v === 'false' || v === '0' || v === 'no'); // unset ⇒ true (default on)
 }

--- a/tests/unit/modules/book-gate.test.ts
+++ b/tests/unit/modules/book-gate.test.ts
@@ -6,6 +6,7 @@
 import {
   passesBookGate,
   loadBookGateConfig,
+  isBookTopicSynthesisEnabled,
   type BookGateConfig,
 } from '../../../src/config/book-gate';
 
@@ -51,5 +52,19 @@ describe('loadBookGateConfig', () => {
     });
     expect(c.minRelevance).toBe(70);
     expect(c.passNull).toBe(false);
+  });
+});
+
+describe('isBookTopicSynthesisEnabled — default ON', () => {
+  it('unset ⇒ true (default on)', () => {
+    expect(isBookTopicSynthesisEnabled({})).toBe(true);
+  });
+  it('only explicit false/0/no disables (rollback)', () => {
+    expect(isBookTopicSynthesisEnabled({ BOOK_TOPIC_SYNTHESIS_ENABLED: 'false' })).toBe(false);
+    expect(isBookTopicSynthesisEnabled({ BOOK_TOPIC_SYNTHESIS_ENABLED: '0' })).toBe(false);
+    expect(isBookTopicSynthesisEnabled({ BOOK_TOPIC_SYNTHESIS_ENABLED: 'no' })).toBe(false);
+  });
+  it('true/anything-else ⇒ enabled', () => {
+    expect(isBookTopicSynthesisEnabled({ BOOK_TOPIC_SYNTHESIS_ENABLED: 'true' })).toBe(true);
   });
 });


### PR DESCRIPTION
## What
§1⑤ Done(942 클릭베이트 0·drop 0·내용명 검증) → `BOOK_TOPIC_SYNTHESIS_ENABLED` **default off→on**. 신규/재빌드 fill이 토픽모드(셀당 Haiku 1콜). **unset⇒true, 명시 `false`/`0`/`no`만 비활성 = 롤백 안전망 유지**.

## 검증
book-gate 단위(unset→true / false→비활성 / true→enabled). tsc clean, lint 0. BE-only.

## backfill 산정 (별도 [GO])
기존 레거시 만다라(942 외) 토픽 재-fill: **10권 / 40 OpenRouter 콜 / ~$0.40 / ~9분**. **>600 atom 셀 0 = 보류분 없음**(max 434<600). 실행 = batch 분할 + 배치별 클릭베이트 0 확인, **단계별 James [GO]**.