### PR TITLE
feat(note): §2 구간 동기화 플레이어 — start/end 구간 재생 + 캡션 정제

### DIFF
--- a/frontend/src/__tests__/note-document-generator-segment.test.ts
+++ b/frontend/src/__tests__/note-document-generator-segment.test.ts
@@ -1,0 +1,51 @@
+/**
+ * note-document-generator §2 — videoBlock carries endSec from seg_ref.to_sec
+ * (segment playback bound), max across the vid group; falls back to last atom
+ * ts when seg_ref absent (older books). Pure generator → no mocks.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildInitialNoteDoc } from '@/pages/learning/lib/note-document-generator';
+import type { MandalaBookData } from '@/shared/lib/api-client';
+
+type VBlock = { type: string; attrs: { vid: string; fromSec: number; endSec: number } };
+const videoBlocks = (doc: { content?: unknown[] }): VBlock[] =>
+  (doc.content ?? []).filter((n): n is VBlock => (n as VBlock).type === 'videoBlock');
+
+const book = (atoms: MandalaBookData['chapters'][0]['sections'][0]['atoms']): MandalaBookData => ({
+  chapters: [{ ch: 0, title: '백엔드', sections: [{ title: 'API 라우팅', atoms }] }],
+});
+
+describe('note-document-generator — segment endSec', () => {
+  it('endSec = max seg_ref.to_sec across the vid group', () => {
+    const doc = buildInitialNoteDoc(
+      book([
+        { vid: 'vidA', ts: 10, text: 'a', seg_ref: { from_sec: 10, to_sec: 40 } },
+        { vid: 'vidA', ts: 50, text: 'b', seg_ref: { from_sec: 50, to_sec: 95 } },
+      ])
+    );
+    const vb = videoBlocks(doc).find((v) => v.attrs.vid === 'vidA')!;
+    expect(vb.attrs.fromSec).toBe(10);
+    expect(vb.attrs.endSec).toBe(95); // furthest segment boundary
+  });
+
+  it('falls back to last atom ts when seg_ref absent (older book)', () => {
+    const doc = buildInitialNoteDoc(book([
+      { vid: 'vidB', ts: 30, text: 'c' },
+      { vid: 'vidB', ts: 120, text: 'd' },
+    ]));
+    const vb = videoBlocks(doc).find((v) => v.attrs.vid === 'vidB')!;
+    expect(vb.attrs.endSec).toBe(120); // last atom ts (no seg_ref)
+  });
+
+  it('per-vid group → distinct videoBlocks with their own endSec', () => {
+    const doc = buildInitialNoteDoc(
+      book([
+        { vid: 'vidA', ts: 10, text: 'a', seg_ref: { from_sec: 10, to_sec: 40 } },
+        { vid: 'vidB', ts: 30, text: 'c', seg_ref: { from_sec: 30, to_sec: 200 } },
+      ])
+    );
+    const vbs = videoBlocks(doc);
+    expect(vbs.find((v) => v.attrs.vid === 'vidA')!.attrs.endSec).toBe(40);
+    expect(vbs.find((v) => v.attrs.vid === 'vidB')!.attrs.endSec).toBe(200);
+  });
+});

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -81,11 +81,30 @@ function horizontalRule(): TiptapNode {
   return { type: 'horizontalRule' };
 }
 
-function videoBlockNode(vid: string, fromSec: number, sectionTitle: string | null): TiptapNode {
+function videoBlockNode(
+  vid: string,
+  fromSec: number,
+  endSec: number,
+  sectionTitle: string | null
+): TiptapNode {
   return {
     type: 'videoBlock',
-    attrs: { vid, fromSec, sectionTitle },
+    attrs: { vid, fromSec, endSec, sectionTitle },
   };
+}
+
+/**
+ * Segment end for a vid group: the furthest segment boundary (max seg_ref.to_sec)
+ * so playback covers the group's whole span, not just up to the last atom START.
+ * Falls back to the last atom ts when seg_ref is absent (older books).
+ */
+function groupEndSec(atoms: MandalaBookAtom[]): number {
+  let end = 0;
+  for (const a of atoms) {
+    const segEnd = a.seg_ref?.to_sec;
+    end = Math.max(end, typeof segEnd === 'number' ? segEnd : (a.ts ?? 0));
+  }
+  return end;
 }
 
 /**
@@ -138,7 +157,8 @@ function renderSection(
   for (const g of groups) {
     if (g.atoms.length === 0) continue;
     const firstTs = g.atoms[0].ts ?? 0;
-    out.push(videoBlockNode(g.vid, firstTs, section.title ?? null));
+    const endSec = groupEndSec(g.atoms);
+    out.push(videoBlockNode(g.vid, firstTs, endSec, section.title ?? null));
     // Each atom → its own paragraph. Keeps editing granularity natural.
     for (const a of g.atoms) {
       if (a.text && a.text.trim()) out.push(paragraph(a.text));

--- a/frontend/src/pages/learning/lib/video-block.tsx
+++ b/frontend/src/pages/learning/lib/video-block.tsx
@@ -39,6 +39,7 @@ export interface VideoBlockOptions {
 export interface VideoBlockAttrs {
   vid: string;
   fromSec: number;
+  endSec: number; // segment end (YouTube `end` param); 0 ⇒ play to video end (older books)
   sectionTitle: string | null;
 }
 
@@ -155,9 +156,14 @@ function VideoBlockNodeView({ node, getPos, editor }: NodeViewProps) {
         <div className="video-block-frame video-block-frame--active">
           <iframe
             id={iframeIdRef.current}
+            // Segment playback: start..end bounds this topic-group's span so the
+            // player stops at the segment end (not the full video). rel=0 +
+            // modestbranding + iv_load_policy=3 suppress recommendations/branding/
+            // annotations as far as the YouTube iframe API allows (best-effort —
+            // "More videos" on pause + the logo cannot be fully removed).
             src={`https://www.youtube.com/embed/${attrs.vid}?autoplay=1&mute=0&start=${Math.floor(
               attrs.fromSec
-            )}&rel=0&modestbranding=1&enablejsapi=1`}
+            )}${attrs.endSec > attrs.fromSec ? `&end=${Math.ceil(attrs.endSec)}` : ''}&rel=0&modestbranding=1&iv_load_policy=3&enablejsapi=1`}
             title={attrs.sectionTitle ?? `Video ${attrs.vid}`}
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowFullScreen
@@ -199,7 +205,10 @@ function VideoBlockNodeView({ node, getPos, editor }: NodeViewProps) {
       )}
       {attrs.sectionTitle && (
         <div className="video-block-caption">
-          {ts} — {attrs.sectionTitle}
+          {/* Segment info only — NO "now playing" wording (state is shown by the
+              player chrome). "MM:SS–MM:SS · 구간명" when a segment end exists. */}
+          {attrs.endSec > attrs.fromSec ? `${ts}–${formatTs(attrs.endSec)}` : ts} ·{' '}
+          {attrs.sectionTitle}
         </div>
       )}
     </NodeViewWrapper>
@@ -231,6 +240,11 @@ export const VideoBlock = Node.create<VideoBlockOptions>({
         default: 0,
         parseHTML: (el) => Number(el.getAttribute('data-from-sec') ?? 0),
         renderHTML: (attrs) => ({ 'data-from-sec': String(attrs['fromSec']) }),
+      },
+      endSec: {
+        default: 0,
+        parseHTML: (el) => Number(el.getAttribute('data-end-sec') ?? 0),
+        renderHTML: (attrs) => ({ 'data-end-sec': String(attrs['endSec'] ?? 0) }),
       },
       sectionTitle: {
         default: null,

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -283,6 +283,9 @@ export interface MandalaBookAtom {
   ts: number;
   text: string;
   type?: string;
+  // §1⑤/§2 — the rich-summary time-segment this atom came from. Used to bound
+  // segment playback (end = the segment's to_sec) in the note video player.
+  seg_ref?: { from_sec: number; to_sec: number };
 }
 
 export interface MandalaBookSection {


### PR DESCRIPTION
## What
노트 영상 임베드 정제(§2). 좌측 텍스트는 §1로 토픽명 됐으나 영상이 풀 유튜브 크롬(추천영상·로고)이라 §2가 영상 쪽 정제.

## 측정 결과 (이미 된 것 vs 갭)
- iframe: 이미 `start=fromSec & rel=0 & modestbranding=1`. 캡션: 이미 **"재생 중" 워딩 없음** ("MM:SS — title"). **유일 갭 = `end`(toSec) 부재.**

## 변경
- **endSec 배선**: book atom `seg_ref{from_sec,to_sec}`(이미 book에 존재, FE 타입엔 누락)를 `MandalaBookAtom`에 추가 → 생성기 `groupEndSec` = vid group의 **max to_sec**(없으면 last atom ts fallback) → videoBlock `endSec` attr.
- **iframe**: `&end=ceil(endSec)` (구간만 재생, 종료 시 정지) + `iv_load_policy=3`(주석 억제). start/rel=0/modestbranding 유지. **풀 제거 불가는 best-effort** (유튜브 iframe 한계 — More videos/로고 완전 제거 불가).
- **캡션**: "MM:SS — title" → **"MM:SS–MM:SS · 구간명"** (range). "재생 중" 0 (상태=플레이어 크롬).

## 검증
- vitest **3/3** (endSec=max to_sec / seg_ref-absent fallback / per-vid 독립). FE tsc 0, build OK, **브라우저 스모크 / + /mandalas/new 200**, lint 0.
- **스크롤 동기화·이어재생**(useNoteAutoFollow/YT.Player state) **무변 = 회귀 0**. §3 디자인 이후.

## 적용
신규/재빌드 노트(§1로 삭제된 5권 포함, aa3092ca)는 재생성 시 endSec 포함 → 구간 재생. 기존 편집 1권(72d5fe52)은 endSec 0(fallback, 풀 재생) until 재생성.