### PR TITLE
feat(note): §3 시안 에디토리얼 디자인 — 토픽 노트 뷰 토큰화

### DIFF
--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&family=Source+Serif+Pro:wght@400;600;700&family=Source+Code+Pro:wght@400;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&family=Source+Serif+Pro:wght@400;600;700&family=Source+Code+Pro:wght@400;700&family=Noto+Serif+KR:wght@500;700&family=JetBrains+Mono:wght@400;500&display=swap");
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -445,53 +445,74 @@ export function ViewModeToggle({
 // ---------------------------------------------------------------------------
 
 const NOTE_PROSE_STYLE = `
+/* §3 editorial design tokens (시안 spec). Defined ONCE here; all rules below
+   reference these vars (no scattered color literals). Scoped to .note-prose-root
+   so the global theme is untouched (regression 0). */
+.note-prose-root {
+  --note-gold: #c9a36a;
+  --note-gold-text: #e7c79a;
+  --note-title: #f5f3ee;
+  --note-body: #e8e6e1;
+  --note-sub: #9a9893;
+  --note-meta: #6f6d68;
+  --note-serif: 'Noto Serif KR', 'Source Serif 4', Georgia, serif;
+  --note-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Noto Sans KR', sans-serif;
+  --note-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  /* Top-light editorial backdrop (not flat black). */
+  background: radial-gradient(120% 80% at 50% -10%, #121319 0%, #0a0b0d 60%);
+}
 .note-prose-root .ProseMirror {
-  font-family: 'Source Serif 4', 'Noto Serif KR', Georgia, serif;
+  /* 시안: body = system sans (serif is reserved for titles). */
+  font-family: var(--note-sans);
   font-size: 18px;
   line-height: 1.78;
   letter-spacing: -0.003em;
-  color: hsl(var(--foreground));
-  /* CP445.x v3(1) — max-width 제거 (중앙 column 가용 폭 전체). padding
-     48px 48px 140px (mockup spec). */
-  padding: 48px 48px 140px;
+  color: var(--note-body);
+  /* 시안: centered 680px reading column. */
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 48px 24px 140px;
   outline: none;
   word-break: keep-all;
 }
 .note-prose-root .ProseMirror h2 {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  font-size: 28px;
-  font-weight: 600;
-  line-height: 1.22;
+  /* 시안: 대제목 = Noto Serif KR 700 (editorial serif). */
+  font-family: var(--note-serif);
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 1.25;
   letter-spacing: -0.015em;
-  margin: 0 0 16px;
-  color: hsl(var(--foreground));
+  margin: 0 0 18px;
+  color: var(--note-title);
 }
 .note-prose-root .ProseMirror h3 {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  font-size: 21px;
-  font-weight: 500;
+  font-family: var(--note-serif);
+  font-size: 22px;
+  font-weight: 700;
   line-height: 1.3;
   letter-spacing: -0.01em;
   margin: 0 0 24px;
-  color: hsl(var(--foreground));
+  color: var(--note-title);
 }
 .note-prose-root .ProseMirror p {
   margin: 0 0 1.6em;
-  color: hsl(var(--foreground) / 0.92);
+  color: var(--note-body);
 }
 .note-prose-root .ProseMirror p strong {
   font-weight: 600;
-  color: hsl(var(--foreground));
+  color: var(--note-title);
 }
 .note-prose-root .ProseMirror p em:only-child {
   /* Eyebrow paragraph (italic-only by generator convention) — sans, 11px,
      uppercase, tertiary color. */
   font-style: normal;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--note-sans);
   font-size: 11px;
+  font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: hsl(var(--muted-foreground));
+  /* 시안: kicker/eyebrow = gold accent. */
+  color: var(--note-gold);
 }
 /* CP445.x v3(2) — eyebrow paragraphs hidden in read mode; visible only
    when the editor wrapper has class "editing" (toggled from isEditing). */
@@ -504,26 +525,32 @@ const NOTE_PROSE_STYLE = `
   margin: 3.2em 0;
 }
 .note-prose-root .ProseMirror blockquote {
-  border-left: 2.5px solid rgba(129, 140, 248, 0.4);
+  /* 시안: pull-quote = gold left rule + larger serif. */
+  border-left: 2px solid var(--note-gold);
   padding: 2px 0 2px 24px;
-  color: hsl(var(--foreground) / 0.75);
+  color: var(--note-title);
   margin: 2em 0 2.2em;
-  font-style: italic;
-  font-family: 'Source Serif 4', 'Noto Serif KR', Georgia, serif;
-  font-size: 18px;
-  line-height: 1.78;
-  letter-spacing: -0.003em;
+  font-style: normal;
+  font-family: var(--note-serif);
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 1.6;
+  letter-spacing: -0.005em;
 }
 .note-prose-root .ProseMirror code {
-  font-family: ui-monospace, SFMono-Regular, monospace;
-  font-size: 14px;
-  background: hsl(var(--secondary));
-  padding: 1px 5px;
-  border-radius: 3px;
+  /* 시안: code chip = JetBrains Mono, gold tint. */
+  font-family: var(--note-mono);
+  font-size: 0.86em;
+  color: var(--note-gold-text);
+  background: rgba(201, 163, 106, 0.10);
+  border: 1px solid rgba(201, 163, 106, 0.16);
+  padding: 1px 6px;
+  border-radius: 5px;
 }
 .note-prose-root .ProseMirror a {
-  color: #818cf8;
+  color: var(--note-gold);
   text-decoration: underline;
+  text-decoration-color: rgba(201, 163, 106, 0.4);
 }
 .note-prose-root .ProseMirror[contenteditable='false'] p:hover,
 .note-prose-root .ProseMirror[contenteditable='false'] h2:hover,
@@ -533,7 +560,7 @@ const NOTE_PROSE_STYLE = `
 .note-prose-root .ProseMirror[contenteditable='true'] p:focus,
 .note-prose-root .ProseMirror[contenteditable='true'] h2:focus,
 .note-prose-root .ProseMirror[contenteditable='true'] h3:focus {
-  outline: 1.5px solid #818cf8;
+  outline: 1.5px solid var(--note-gold);
   outline-offset: 2px;
   border-radius: 3px;
 }
@@ -623,8 +650,11 @@ const NOTE_PROSE_STYLE = `
   pointer-events: none;
 }
 .note-prose-root .video-block-caption {
+  /* 시안: segment caption = mono timecode, sub-color, tight tracking. */
+  font-family: var(--note-mono);
   font-size: 12px;
-  color: hsl(var(--muted-foreground));
+  letter-spacing: -0.01em;
+  color: var(--note-sub);
   text-align: center;
   margin: 0 0 28px;
 }

--- a/frontend/src/pages/learning/ui/RightPanel.tsx
+++ b/frontend/src/pages/learning/ui/RightPanel.tsx
@@ -96,7 +96,10 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
 
   return (
     <div
-      className="flex w-[400px] shrink-0 flex-col pr-5"
+      // §3 #4 — subtle left divider so the chatbot panel isn't visually fused
+      // with the note body. 6% white (matches sidebar separators); pl-5 gives the
+      // line breathing room without changing the 400px panel width.
+      className="flex w-[400px] shrink-0 flex-col border-l border-white/[0.06] pl-5 pr-5"
       onMouseEnter={() => setActiveRegion(activeTab === 'notes' ? 'notes' : 'chat')}
     >
       {/* CP445 (사용자 directive) — ViewModeToggle + [⋯] 우측 사이드바 상단


### PR DESCRIPTION
## What
노트 뷰 §3 — 시안(.dc.html) 에디토리얼 디자인 적용. **프레젠테이션만** (기능·데이터·스크롤 동기화·구간 재생·챗봇 불변).

## 적용 (시안 토큰 → `.note-prose-root` 스코프 CSS 변수)
- **토큰 1곳 정의** (산재 literal 0): `--note-gold #c9a36a` / `gold-text #e7c79a` / `title #f5f3ee` / `body #e8e6e1` / `serif 'Noto Serif KR'` / `mono 'JetBrains Mono'`. **전역 `.dark` 무영향** (스코프 격리 = 회귀 0).
- **위계 반전**(시안): 대제목 h2/h3 = **Noto Serif KR 700 세리프**, 본문 = system sans. **본문 컬럼 680px 중앙**(이전 full-width), line-height 1.78. 상단광원 radial-gradient 배경.
- **골드 액센트**: kicker/eyebrow, pull-quote 좌측 골드 2px 세로선, 코드칩 JetBrains Mono 골드틴트, 링크·focus 골드.
- **§2 캡션**: JetBrains Mono 타임코드.
- **폰트**: index.css에 Noto Serif KR(500/700) + JetBrains Mono 추가.
- **#4 챗봇 패널 경계**: RightPanel `border-l border-white/[0.06]` + pl-5 (6% 흰선, 본문/패널 구분, 400px 폭 불변).

## 검증
- FE tsc 0, build OK, **브라우저 스모크 / + /mandalas/new 200**, url-contract 1/1, 내 변경 lint 0.
- **동기화·구간재생·챗봇 로직 무변 = 회귀 0** (CSS 토큰 + 1 border만).
- 동적 Tailwind 조합 금지 준수(CSS 변수 토큰). `focusNoteEditor`는 pre-existing unused(CI BE-only 린트라 무관, scope creep 회피).

## 실측
James 화면 — 에디토리얼 위계(세리프 대제목)·골드 액센트·680px 컬럼·pull-quote·코드칩·챗봇 패널 경계. aa3092ca 노트.