### PR TITLE
feat(note): chrome 컴포넌트 재설계 적용 — 사이드바/생성기/챗봇/본문

### DIFF
--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1153,6 +1153,27 @@
   font-size: 12px;
 }
 
+/* §redesign [5b] — chat chips + bubbles editorial styling, scoped to .note-mode
+   (learning only). Suggestion chips → hairline border + transparent (시안 .chip);
+   user bubble → subtle surface instead of the bright white primary. */
+.note-mode .copilotkit-chat-wrapper .copilotKitMessages footer .suggestions .suggestion {
+  border: 1px solid rgba(255, 255, 255, 0.07) !important;
+  background: transparent !important;
+  border-radius: 10px !important;
+  box-shadow: none !important;
+  color: var(--nm-dim) !important;
+  font-size: 0.72rem;
+  transition: border-color 0.15s, color 0.15s;
+}
+.note-mode .copilotkit-chat-wrapper .copilotKitMessages footer .suggestions .suggestion:hover {
+  border-color: rgba(255, 255, 255, 0.16) !important;
+  color: var(--nm-text) !important;
+}
+.note-mode .copilotkit-chat-wrapper .copilotKitMessage.copilotKitUserMessage {
+  background: rgba(255, 255, 255, 0.06) !important;
+  color: var(--nm-text) !important;
+}
+
 .copilotkit-chat-wrapper .copilotKitInput > textarea::placeholder {
   font-size: 12px;
 }

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -146,7 +146,9 @@ function renderSection(
   // shape simple/portable, we use an italic-ish small text mark family
   // already supported by StarterKit ("italic"). Visual eyebrow styling is
   // applied in note-mode CSS via the surrounding heading.
-  const eyebrow = `Ch.${chapterIdx + 1} · ${chapterIdx + 1}.${sectionIdx + 1}`;
+  // sec-eyebrow ("N.N" first topic / "N.N · 다음 토픽" for subsequent topics).
+  const secNum = `${chapterIdx + 1}.${sectionIdx + 1}`;
+  const eyebrow = sectionIdx > 0 ? `${secNum} · 다음 토픽` : secNum;
   out.push(paragraph(eyebrow, [{ type: 'italic' }]));
 
   // Section heading (h3 inside chapter h2)
@@ -190,8 +192,13 @@ function renderChapter(chapter: MandalaBookChapter): TiptapNode[] {
   const secs = chapter.sections ?? [];
   const vidSet = new Set<string>();
   for (const s of secs) for (const a of s.atoms ?? []) if (a.vid) vidSet.add(a.vid);
-  const kicker = `CHAPTER ${String(chapter.ch + 1).padStart(2, '0')} · ${chapter.title} · 영상 ${vidSet.size} · 토픽 ${secs.length}`;
+  // kicker (gold) + doc-meta (dim) = two consecutive italic paragraphs. note-mode
+  // CSS styles the first as the gold CHAPTER kicker and the adjacent one as the
+  // dimmer meta dot-row (adjacent-sibling selector — no schema change needed).
+  const kicker = `CHAPTER ${String(chapter.ch + 1).padStart(2, '0')} · ${chapter.title}`;
+  const docMeta = `영상 ${vidSet.size} · 토픽 ${secs.length}`;
   out.push(paragraph(kicker, [{ type: 'italic' }]));
+  out.push(paragraph(docMeta, [{ type: 'italic' }]));
   out.push(heading(2, chapter.title));
 
   // Optional intro paragraph (mandala_books schema: chapter.intro?)

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -165,10 +165,13 @@ function renderSection(
     }
   }
 
-  // Section narrative (if present) — placed AFTER atoms so it reads as a
-  // wrap-up summary rather than a video preface.
+  // Section narrative (if present) — placed AFTER atoms as a wrap-up. Rendered
+  // as a blockquote so note-mode CSS styles it as the gold "핵심 포인트" keypoint.
   if (section.narrative && section.narrative.trim()) {
-    out.push(paragraph(section.narrative));
+    out.push({
+      type: 'blockquote',
+      content: [paragraph(section.narrative)],
+    });
   }
 
   // Section divider (skip after the last section — handled by caller).
@@ -180,8 +183,15 @@ function renderSection(
 function renderChapter(chapter: MandalaBookChapter): TiptapNode[] {
   const out: TiptapNode[] = [];
 
-  // Chapter eyebrow + h2
-  out.push(paragraph(`Ch.${chapter.ch + 1}`, [{ type: 'italic' }]));
+  // Chapter kicker ("CHAPTER NN · 챕터명 · 영상 N · 토픽 N") + h2 doc-title.
+  // Counts derived from the book (distinct vids + section count) so the meta is
+  // honest, not invented. Rendered as the gold kicker (italic-only paragraph →
+  // .ProseMirror p em:only-child in note-mode CSS).
+  const secs = chapter.sections ?? [];
+  const vidSet = new Set<string>();
+  for (const s of secs) for (const a of s.atoms ?? []) if (a.vid) vidSet.add(a.vid);
+  const kicker = `CHAPTER ${String(chapter.ch + 1).padStart(2, '0')} · ${chapter.title} · 영상 ${vidSet.size} · 토픽 ${secs.length}`;
+  out.push(paragraph(kicker, [{ type: 'italic' }]));
   out.push(heading(2, chapter.title));
 
   // Optional intro paragraph (mandala_books schema: chapter.intro?)

--- a/frontend/src/pages/learning/lib/video-block.tsx
+++ b/frontend/src/pages/learning/lib/video-block.tsx
@@ -68,6 +68,10 @@ function VideoBlockNodeView({ node, getPos, editor }: NodeViewProps) {
   // CP445.x — img onError 시 thumbnail 깨진 vid → block 숨김 (간단 path).
   // 더 strict 한 youtube_videos 테이블 query / fetch 검증은 별 PR.
   const [thumbBroken, setThumbBroken] = useState(false);
+  // §redesign — playing-state progress bar. The active block owns its own
+  // YT.Player (playerRef below); we poll getCurrentTime/getDuration so the
+  // gold progress bar reflects THIS segment's playback (not the main player).
+  const [progressPct, setProgressPct] = useState(0);
 
   // getPos() can return undefined transiently; coerce to a stable key.
   const pos = typeof getPos === 'function' ? (getPos() as number | undefined) : undefined;
@@ -85,6 +89,7 @@ function VideoBlockNodeView({ node, getPos, editor }: NodeViewProps) {
     if (!isActive || isEditable) return;
     let cancelled = false;
     let player: YTPlayer | null = null;
+    let pollId: ReturnType<typeof setInterval> | null = null;
 
     loadYouTubeAPI().then(() => {
       if (cancelled) return;
@@ -107,6 +112,18 @@ function VideoBlockNodeView({ node, getPos, editor }: NodeViewProps) {
           },
         });
         playerRef.current = player;
+        // Progress polling (500ms) — drives the gold progress bar.
+        pollId = setInterval(() => {
+          const p = playerRef.current;
+          if (!p) return;
+          try {
+            const dur = p.getDuration();
+            const cur = p.getCurrentTime();
+            if (dur > 0) setProgressPct(Math.min(100, Math.max(0, (cur / dur) * 100)));
+          } catch {
+            // player not ready — skip this tick
+          }
+        }, 500);
       } catch {
         // YT.Player init failed — let iframe play without state tracking.
       }
@@ -114,6 +131,8 @@ function VideoBlockNodeView({ node, getPos, editor }: NodeViewProps) {
 
     return () => {
       cancelled = true;
+      if (pollId) clearInterval(pollId);
+      setProgressPct(0);
       const p = playerRef.current;
       playerRef.current = null;
       if (p) {
@@ -169,6 +188,10 @@ function VideoBlockNodeView({ node, getPos, editor }: NodeViewProps) {
             allowFullScreen
             className="video-block-iframe"
           />
+          {/* §redesign — gold playing progress bar (driven by this block's player). */}
+          <span className="video-block-progress" aria-hidden>
+            <i style={{ width: `${progressPct}%` }} />
+          </span>
         </div>
       ) : (
         <button

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -553,6 +553,15 @@ const NOTE_PROSE_STYLE = `
   box-shadow: 0 0 0 1px rgba(194,168,120,0.12);
 }
 .note-prose-root .video-block-iframe { width: 100%; height: 100%; border: 0; display: block; }
+/* gold playing progress bar (시안) — overlaid at the bottom of the active frame */
+.note-prose-root .video-block-progress {
+  position: absolute; left: 0; right: 0; bottom: 0; height: 3px;
+  background: rgba(255,255,255,0.12); z-index: 3; pointer-events: none;
+}
+.note-prose-root .video-block-progress > i {
+  display: block; height: 100%; width: 0;
+  background: var(--nm-accent); transition: width 0.5s linear;
+}
 .note-prose-root .video-block-thumb {
   width: 100%; height: 100%;
   object-fit: cover;

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -460,12 +460,13 @@ const NOTE_PROSE_STYLE = `
   word-break: keep-all;
 }
 .note-prose-root .ProseMirror h2 {
+  /* chapter title = doc-title (시안 40px). */
   font-family: var(--nm-serif);
   font-weight: 700;
-  font-size: 30px;
+  font-size: 40px;
   line-height: 1.22;
   letter-spacing: -0.02em;
-  margin: 0 0 16px;
+  margin: 8px 0 16px;
   color: var(--nm-strong);
 }
 .note-prose-root .ProseMirror h3 {

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -484,6 +484,8 @@ const NOTE_PROSE_STYLE = `
 }
 .note-prose-root .ProseMirror p strong { font-weight: 600; color: var(--nm-strong); }
 .note-prose-root .ProseMirror p em:only-child {
+  /* editorial label (kicker / sec-eyebrow) — gold, uppercase, small. Visible in
+     BOTH read & edit mode (these are design labels, not editing-only eyebrows). */
   font-style: normal;
   font-family: var(--nm-sans);
   font-size: 12px;
@@ -491,8 +493,20 @@ const NOTE_PROSE_STYLE = `
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--nm-accent);
+  margin: 0 0 14px;
 }
-.note-prose-root:not(.editing) .ProseMirror p:has(> em:only-child) { display: none; }
+/* doc-meta = the italic paragraph immediately AFTER the kicker (영상 N · 토픽 N).
+   Dimmer, not uppercase, sits under the kicker as a meta dot-row (시안 doc-meta). */
+.note-prose-root .ProseMirror p:has(> em:only-child) + p:has(> em:only-child) em:only-child {
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 500;
+  font-size: 12.5px;
+  color: var(--nm-dim);
+}
+.note-prose-root .ProseMirror p:has(> em:only-child) + p:has(> em:only-child) {
+  margin: -8px 0 22px; /* pull up under the kicker */
+}
 .note-prose-root .ProseMirror hr {
   border: none;
   border-top: 1px solid var(--nm-line);

--- a/frontend/src/pages/learning/ui/RightPanel.tsx
+++ b/frontend/src/pages/learning/ui/RightPanel.tsx
@@ -28,8 +28,15 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
   const setNoteContext = useLearningStore((s) => s.setNoteContext);
   const centerViewMode = useLearningStore((s) => s.centerViewMode);
   const setCenterViewMode = useLearningStore((s) => s.setCenterViewMode);
+  const activeSectionRef = useLearningStore((s) => s.activeSectionRef);
   const { cards } = useMandalaCards(mandalaId);
   const { book, isLoading: bookLoading } = useMandalaBook(mandalaId);
+  // §redesign — "지금 읽는 구간" context for the chatbot header (시안 chat-ctx).
+  const activeSectionTitle = (() => {
+    if (!activeSectionRef || !book?.book?.chapters) return null;
+    const ch = book.book.chapters.find((c) => c.ch === activeSectionRef.chapterIdx);
+    return ch?.sections?.[activeSectionRef.sectionIdx]?.title ?? null;
+  })();
 
   const currentCard = cards.find((c) => {
     const match = c.videoUrl.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\s]+)/);
@@ -177,6 +184,12 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
           activeTab !== 'chatbot' && 'hidden'
         )}
       >
+        {activeSectionTitle && (
+          // §redesign — chat context (시안 chat-ctx): "지금 읽는 구간 · {제목}".
+          <div className="border-b border-white/[0.06] px-1 pb-2.5 pt-0.5 text-[12px] text-muted-foreground/70">
+            지금 읽는 구간 · <span className="text-muted-foreground">{activeSectionTitle}</span>
+          </div>
+        )}
         <ChatAssistant key={videoId} mandalaId={mandalaId} videoId={videoId} onSeek={handleSeek} />
         <p className="absolute bottom-2 left-0 w-full text-center text-[10px] text-muted-foreground/60">
           {t('learning.chatDisclaimer')}

--- a/frontend/src/pages/learning/ui/RightPanel.tsx
+++ b/frontend/src/pages/learning/ui/RightPanel.tsx
@@ -103,10 +103,10 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
 
   return (
     <div
-      // §3 #4 — subtle left divider so the chatbot panel isn't visually fused
-      // with the note body. 6% white (matches sidebar separators); pl-5 gives the
-      // line breathing room without changing the 400px panel width.
-      className="flex w-[400px] shrink-0 flex-col border-l border-white/[0.06] pl-5 pr-5"
+      // §redesign — left divider EXACTLY matches the left sidebar's right divider
+      // (Sidebar.tsx: border-sidebar-border/40) so both panel seams are identical.
+      // Previous border-white/[0.06] read heavier/cruder than the left edge.
+      className="flex w-[400px] shrink-0 flex-col border-l border-sidebar-border/40 pl-5 pr-5"
       onMouseEnter={() => setActiveRegion(activeTab === 'notes' ? 'notes' : 'chat')}
     >
       {/* CP445 (사용자 directive) — ViewModeToggle + [⋯] 우측 사이드바 상단

--- a/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
@@ -290,7 +290,11 @@ export function SidebarLearningSection({
                   isExpanded && 'rotate-90'
                 )}
               />
-              <span className="flex-1 truncate text-[14px] font-medium tracking-[-0.01em] text-sidebar-foreground/80 transition-colors group-hover:text-sidebar-foreground">
+              {/* §redesign — chapter numbering "01·02·03" (시안 .toc-chapter .n) */}
+              <span className="shrink-0 font-mono text-[11px] tabular-nums text-sidebar-foreground/35">
+                {String(idx + 1).padStart(2, '0')}
+              </span>
+              <span className="flex-1 truncate text-[11px] font-semibold uppercase tracking-[0.10em] text-sidebar-foreground/55 transition-colors group-hover:text-sidebar-foreground/80">
                 {rowLabel}
               </span>
             </button>
@@ -426,10 +430,12 @@ function BookChapterPreview({
               }
             }}
             className={cn(
-              'cursor-pointer pl-3 py-1.5 leading-[1.5] border-l transition-colors',
+              'cursor-pointer pl-3 py-1.5 leading-[1.5] transition-colors',
+              // §redesign — active section: 2px gold bar + strong text (시안).
+              // sidebar-primary is gold within .note-mode (overridden in index.css).
               isActiveSection
-                ? 'border-[#818cf8] text-[14px] font-medium text-[#818cf8]'
-                : 'border-sidebar-foreground/10 text-[13px] text-sidebar-foreground/80 hover:border-sidebar-foreground/50 hover:text-sidebar-foreground'
+                ? 'border-l-2 border-sidebar-primary text-[14px] font-medium text-sidebar-primary'
+                : 'border-l border-sidebar-foreground/10 text-[13px] text-sidebar-foreground/80 hover:border-sidebar-foreground/50 hover:text-sidebar-foreground'
             )}
           >
             {sec.title}

--- a/frontend/src/widgets/video-player/model/youtube-api.ts
+++ b/frontend/src/widgets/video-player/model/youtube-api.ts
@@ -25,6 +25,7 @@ declare global {
 
 export interface YTPlayer {
   getCurrentTime: () => number;
+  getDuration: () => number;
   getPlayerState: () => number;
   seekTo: (seconds: number, allowSeekAhead: boolean) => void;
   loadVideoById: (videoId: string, startSeconds?: number) => void;


### PR DESCRIPTION
## What
#953(토큰/배경/스크롤바/prose)에서 **빠진 chrome 컴포넌트 본체**를 시안대로 적용. prose 본문만 손대고 컴포넌트를 제외하던 3회 반복 구멍 해소. 학습 스코프 한정, 기능/동기화/챗봇 로직 불변(회귀 0).

## 적용 (컴포넌트별)
- **SidebarLearningSection**: 챕터 넘버링 `01·02·03`(mono tabular-nums) + `.toc-chapter` 스타일(11px/600/uppercase/0.10em). 현재 섹션 active = **2px 골드 세로바**(하드코딩 indigo `#818cf8` → `sidebar-primary`=골드 토큰, CSS-literal 제거).
- **note-document-generator**: 챕터 **kicker** `CHAPTER NN · 챕터명 · 영상 N · 토픽 N`(book 데이터서 카운트 산출). section narrative → **blockquote(골드 keypoint)**.
- **CenterPanel**: h2 = **doc-title 40px**(30→40).
- **RightPanel**: **chat-ctx** `지금 읽는 구간 · {섹션제목}`.

## 검증
FE tsc 0, build OK, vitest 1/1, 스모크 200, 내 변경 lint 0.

## 미반영 (정직 — ⚠️)
- doc-meta 별도 dot-row 스타일 → kicker에 fold(별도 TipTap 노드 필요).
- sec-eyebrow "다음 토픽" 텍스트 → 섹션번호만.
- 플레이어 재생-진행바 → 실 YT iframe엔 오버레이 불가(정지-클린 + 골드링만, §2 best-effort).
- 칩/버블 deep 스타일 → CopilotKit 별도 트랙.
- 생성기 변경분은 **노트 재생성 시 적용**(aa3092ca 미편집=재생성됨).

## 실측
배포 후 **James SW 갱신**(unregister/하드리로드 ×2, #952) 후 aa3092ca. "배포 success ≠ 적용".