### PR TITLE
feat(note): strong(4) 강조 휴리스틱 — 섹션 핵심어, 미디엄 극소량

### DIFF
--- a/frontend/src/__tests__/note-document-generator-segment.test.ts
+++ b/frontend/src/__tests__/note-document-generator-segment.test.ts
@@ -49,3 +49,27 @@ describe('note-document-generator — segment endSec', () => {
     expect(vbs.find((v) => v.attrs.vid === 'vidB')!.attrs.endSec).toBe(200);
   });
 });
+
+describe('note-document-generator — strong(4) heuristic', () => {
+  const bookWith = (title: string, text: string): MandalaBookData => ({
+    chapters: [{ ch: 0, title: '백엔드', sections: [{ title, atoms: [{ vid: 'v', ts: 1, text }] }] }],
+  });
+  const paras = (doc: { content?: unknown[] }) =>
+    (doc.content ?? []).filter((n) => (n as { type: string }).type === 'paragraph') as Array<{
+      content?: Array<{ text: string; marks?: Array<{ type: string }> }>;
+    }>;
+
+  it('bolds the section key term when it appears in the atom (max 1, sparse)', () => {
+    const doc = buildInitialNoteDoc(bookWith('REST API 라우팅 구조', '여기서 라우팅 으로 분기한다'));
+    // find the atom paragraph that contains a bold run
+    const bolded = paras(doc).flatMap((p) => p.content ?? []).filter((t) => t.marks?.some((m) => m.type === 'bold'));
+    expect(bolded.length).toBeGreaterThanOrEqual(1);
+    expect(bolded[0]!.text).toBe('라우팅'); // longest title token present in the atom
+  });
+
+  it('no emphasis when no section term appears (Medium-sparse, never over-bold)', () => {
+    const doc = buildInitialNoteDoc(bookWith('REST API 라우팅 구조', '완전히 무관한 문장입니다'));
+    const bolded = paras(doc).flatMap((p) => p.content ?? []).filter((t) => t.marks?.some((m) => m.type === 'bold'));
+    expect(bolded.length).toBe(0);
+  });
+});

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -69,6 +69,38 @@ function paragraph(
   };
 }
 
+/**
+ * strong(4) heuristic — pick the section title's most specific token that also
+ * appears in the atom text (longest-first, length ≥ 2). Returns null if none →
+ * no emphasis. Conservative by design: emphasis only when the atom literally
+ * restates a section key term, at most one phrase per atom (Medium-sparse).
+ */
+function pickKeyPhrase(sectionTitle: string, atomText: string): string | null {
+  const terms = sectionTitle
+    .split(/[\s·,，()/[\]{}]+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length >= 2)
+    .sort((a, b) => b.length - a.length);
+  for (const t of terms) {
+    if (atomText.includes(t)) return t;
+  }
+  return null;
+}
+
+/** Paragraph whose first occurrence of `phrase` is wrapped in <strong>. */
+function paragraphWithBold(text: string, phrase: string): TiptapNode {
+  const norm = normalizeText(text);
+  const idx = norm.indexOf(phrase);
+  if (idx < 0) return paragraph(text);
+  const before = norm.slice(0, idx);
+  const after = norm.slice(idx + phrase.length);
+  const content: Array<{ type: 'text'; text: string; marks?: Array<{ type: string }> }> = [];
+  if (before) content.push({ type: 'text', text: before });
+  content.push({ type: 'text', text: phrase, marks: [{ type: 'bold' }] });
+  if (after) content.push({ type: 'text', text: after });
+  return { type: 'paragraph', content } as TiptapNode;
+}
+
 function heading(level: 2 | 3, text: string): TiptapNode {
   return {
     type: 'heading',
@@ -162,8 +194,13 @@ function renderSection(
     const endSec = groupEndSec(g.atoms);
     out.push(videoBlockNode(g.vid, firstTs, endSec, section.title ?? null));
     // Each atom → its own paragraph. Keeps editing granularity natural.
+    // strong(4): bold the section's key term IF it appears in the atom (max 1
+    // per atom, none otherwise). Conservative — emphasis stays sparse (Medium).
     for (const a of g.atoms) {
-      if (a.text && a.text.trim()) out.push(paragraph(a.text));
+      if (a.text && a.text.trim()) {
+        const phrase = pickKeyPhrase(section.title ?? '', a.text);
+        out.push(phrase ? paragraphWithBold(a.text, phrase) : paragraph(a.text));
+      }
     }
   }
 


### PR DESCRIPTION
strong(4) — 승인된 기준 구현. **atom당 최대 1개**, **섹션 제목의 최장 토큰(len≥2)이 문장에 등장하면 그것만** `<strong>`, 없으면 0. 보수적 설계 = 과강조 절대 방지(미디엄 극소량).

- `pickKeyPhrase(title, atom)` + `paragraphWithBold(text, phrase)` (matched substring만 bold, 단락 전체 아님).
- `p strong` CSS 기존(weight 600 + nm-strong).
- 노트 **재생성 시** 적용.

검증: vitest **5/5**(핵심어 bold / 무관 시 over-bold 0), tsc0/build/lint0/스모크200.