### PR TITLE
feat(note): 보라 전수박멸(토큰+literal) + 문단묶기 + 키워드하이라이트 + 모드누수

### DIFF
--- a/frontend/src/__tests__/note-document-generator-segment.test.ts
+++ b/frontend/src/__tests__/note-document-generator-segment.test.ts
@@ -73,3 +73,37 @@ describe('note-document-generator — strong(4) heuristic', () => {
     expect(bolded.length).toBe(0);
   });
 });
+
+describe('note-document-generator — C6 paragraph grouping', () => {
+  const atom = (text: string, type: string) => ({ vid: 'v', ts: 1, text, type });
+  const book = (atoms: Array<{ vid: string; ts: number; text: string; type: string }>): MandalaBookData => ({
+    chapters: [{ ch: 0, title: '백엔드', sections: [{ title: 'API', atoms }] }],
+  });
+  const bodyParas = (doc: { content?: unknown[] }) =>
+    (doc.content ?? []).filter((n) => {
+      const t = n as { type: string; content?: Array<{ marks?: unknown[] }> };
+      return t.type === 'paragraph' && !(t.content?.[0]?.marks); // exclude italic kicker/meta
+    });
+
+  it('merges consecutive same-type atoms into one paragraph (not 1 line each)', () => {
+    const doc = buildInitialNoteDoc(
+      book([atom('첫 문장이다.', 'fact'), atom('둘째 문장이다.', 'fact'), atom('셋째 문장이다.', 'fact')])
+    );
+    // 3 fact atoms → 1 merged paragraph (text joined)
+    const merged = bodyParas(doc).find((p) =>
+      ((p as { content?: Array<{ text?: string }> }).content ?? []).some((t) => t.text?.includes('첫 문장'))
+    ) as { content?: Array<{ text?: string }> };
+    const text = (merged.content ?? []).map((t) => t.text ?? '').join('');
+    expect(text).toContain('첫 문장');
+    expect(text).toContain('셋째 문장'); // all three in ONE paragraph
+  });
+
+  it('starts a new paragraph on type change (thematic coherence)', () => {
+    const doc = buildInitialNoteDoc(book([atom('사실이다.', 'fact'), atom('팁이다.', 'tip')]));
+    const texts = bodyParas(doc).map((p) =>
+      ((p as { content?: Array<{ text?: string }> }).content ?? []).map((t) => t.text ?? '').join('')
+    );
+    const factPara = texts.find((x) => x.includes('사실'));
+    expect(factPara).not.toContain('팁이다'); // different type → separate paragraph
+  });
+});

--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1237,6 +1237,11 @@ html.dark .lemonsqueezy-loader {
      current chapter/section marker matches the 시안 accent. */
   --sidebar-primary: 38 39% 62%;
   --sidebar-accent: 210 7% 11%;
+  /* --primary → gold within learning. Kills ALL token-based indigo (border-primary
+     RightPanel tab / CenterPanel toggle / VideoStrip ring + the indigo literals in
+     PanelAISummary·EditorToolbar·EditorSlashMenu that were converted to text/bg/
+     border-primary). Other routes (IndexPage VideoSidePanel) keep the default. */
+  --primary: 38 39% 62%;
 
   /* editorial tokens (referenced by NOTE_PROSE_STYLE + components) */
   --nm-line: rgba(255,255,255,0.07);

--- a/frontend/src/features/video-side-panel/ui/EditorSlashMenu.tsx
+++ b/frontend/src/features/video-side-panel/ui/EditorSlashMenu.tsx
@@ -92,11 +92,11 @@ export function EditorSlashMenu({ onSelect, onClose }: EditorSlashMenuProps) {
           className={cn(
             'flex items-center gap-2.5 w-full px-3 py-1.5 text-left text-[12px] transition-colors',
             i === selected
-              ? 'bg-[rgba(129,140,248,0.12)] text-[#ededf0]'
+              ? 'bg-primary/[0.12] text-[#ededf0]'
               : 'text-[#9394a0] hover:text-[#ededf0]'
           )}
         >
-          <span className={i === selected ? 'text-[#818cf8]' : 'text-[#5a5b68]'}>{item.icon}</span>
+          <span className={i === selected ? 'text-primary' : 'text-[#5a5b68]'}>{item.icon}</span>
           <span className="flex-1">{t(item.i18nKey)}</span>
           {item.shortcut && <span className="text-[10px] text-[#3a3b46]">{item.shortcut}</span>}
         </button>

--- a/frontend/src/features/video-side-panel/ui/EditorToolbar.tsx
+++ b/frontend/src/features/video-side-panel/ui/EditorToolbar.tsx
@@ -34,7 +34,7 @@ function ToolbarButton({ active, onClick, label, children, mono }: ToolbarButton
         'text-[11px] font-semibold transition-all duration-100',
         mono && "font-['JetBrains_Mono',monospace] text-[10px]",
         active
-          ? 'bg-[rgba(129,140,248,0.15)] text-[#818cf8]'
+          ? 'bg-primary/[0.15] text-primary'
           : 'text-[#9394a0] hover:bg-[rgba(255,255,255,0.07)] hover:text-[#ededf0]'
       )}
     >
@@ -122,7 +122,7 @@ export function EditorToolbar({ editor }: EditorToolbarProps) {
         <button
           type="button"
           onClick={applyLink}
-          className="flex h-6 items-center rounded-[5px] bg-[rgba(129,140,248,0.15)] px-2 text-[11px] font-medium text-[#818cf8] hover:bg-[rgba(129,140,248,0.25)]"
+          className="flex h-6 items-center rounded-[5px] bg-primary/[0.15] px-2 text-[11px] font-medium text-primary hover:bg-primary/[0.25]"
         >
           ✓
         </button>

--- a/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelAISummary.tsx
@@ -209,7 +209,7 @@ export function PanelAISummary({ videoSummary, videoUrl }: PanelAISummaryProps) 
                 {tags.map((tag) => (
                   <span
                     key={tag}
-                    className="inline-block rounded-[4px] bg-[rgba(129,140,248,0.08)] px-[7px] py-[2px] text-[10px] font-semibold text-[#818cf8]"
+                    className="inline-block rounded-[4px] bg-primary/[0.08] px-[7px] py-[2px] text-[10px] font-semibold text-primary"
                   >
                     {tag}
                   </span>
@@ -247,7 +247,7 @@ function RichSummaryV1Block({ structured }: RichSummaryBlockProps) {
     <div className="space-y-4">
       {tlDr && (
         <section>
-          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#818cf8]">
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-primary">
             {t('learning.oneLiner')}
           </h3>
           <p className="text-[13px] leading-[1.6] text-[#ededf0]">{tlDr}</p>
@@ -256,13 +256,13 @@ function RichSummaryV1Block({ structured }: RichSummaryBlockProps) {
 
       {keyPoints.length > 0 && (
         <section>
-          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#818cf8]">
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-primary">
             {t('learning.keyPoints')}
           </h3>
           <ul className="space-y-1.5 text-[13px] leading-[1.55] text-[rgba(237,237,240,0.84)]">
             {keyPoints.map((pt, idx) => (
               <li key={idx} className="flex gap-2">
-                <span aria-hidden className="mt-[6px] h-1 w-1 shrink-0 rounded-full bg-[#818cf8]" />
+                <span aria-hidden className="mt-[6px] h-1 w-1 shrink-0 rounded-full bg-primary" />
                 <span>{pt}</span>
               </li>
             ))}
@@ -272,7 +272,7 @@ function RichSummaryV1Block({ structured }: RichSummaryBlockProps) {
 
       {actionables.length > 0 && (
         <section>
-          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#818cf8]">
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-primary">
             {t('learning.actionables')}
           </h3>
           <ul className="space-y-1.5 text-[13px] leading-[1.55] text-[rgba(237,237,240,0.84)]">
@@ -280,7 +280,7 @@ function RichSummaryV1Block({ structured }: RichSummaryBlockProps) {
               <li key={idx} className="flex gap-2">
                 <span
                   aria-hidden
-                  className="mt-[2px] flex h-[14px] w-[14px] shrink-0 items-center justify-center rounded-[3px] border border-[#818cf8] text-[10px] text-[#818cf8]"
+                  className="mt-[2px] flex h-[14px] w-[14px] shrink-0 items-center justify-center rounded-[3px] border border-primary text-[10px] text-primary"
                 >
                   →
                 </span>
@@ -293,7 +293,7 @@ function RichSummaryV1Block({ structured }: RichSummaryBlockProps) {
 
       {chapters.length > 0 && (
         <section>
-          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#818cf8]">
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-primary">
             {t('learning.chapters')}
           </h3>
           <ul className="divide-y divide-[rgba(255,255,255,0.04)] rounded-[6px] bg-[rgba(255,255,255,0.02)]">
@@ -302,7 +302,7 @@ function RichSummaryV1Block({ structured }: RichSummaryBlockProps) {
                 key={idx}
                 className="flex gap-3 px-3 py-2 text-[12px] text-[rgba(237,237,240,0.84)]"
               >
-                <span className="w-[46px] shrink-0 font-mono text-[11px] text-[#818cf8]">
+                <span className="w-[46px] shrink-0 font-mono text-[11px] text-primary">
                   {formatSeconds(ch.start_sec)}
                 </span>
                 <span>{ch.title}</span>
@@ -328,7 +328,7 @@ function RichSummaryV2Block({ structured }: RichSummaryBlockProps) {
           <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#4e4f5c]">
             {t('learning.coreSummary')}
           </h3>
-          <p className="rounded-r-[6px] border-l-2 border-[#818cf8] bg-[rgba(99,102,241,0.06)] px-[14px] py-[10px] text-[13px] leading-[1.65] text-[#ededf0]">
+          <p className="rounded-r-[6px] border-l-2 border-primary bg-primary/[0.06] px-[14px] py-[10px] text-[13px] leading-[1.65] text-[#ededf0]">
             {tlDr}
           </p>
         </section>
@@ -356,7 +356,7 @@ function RichSummaryV2Block({ structured }: RichSummaryBlockProps) {
             {entities.map((ent) => (
               <span
                 key={ent.name}
-                className="inline-block rounded-[4px] bg-[rgba(129,140,248,0.08)] px-[7px] py-[2px] text-[10px] font-semibold text-[#818cf8]"
+                className="inline-block rounded-[4px] bg-primary/[0.08] px-[7px] py-[2px] text-[10px] font-semibold text-primary"
               >
                 {ent.name}
               </span>
@@ -390,7 +390,7 @@ function SectionRow({ section }: { section: SectionData }) {
     <div className="rounded-[6px] transition-colors hover:bg-[rgba(255,255,255,0.02)]">
       <div className="flex items-center gap-3 px-3 py-[10px]">
         <div className="w-[76px] shrink-0">
-          <span className="font-mono text-[10px] text-[#818cf8]">
+          <span className="font-mono text-[10px] text-primary">
             {formatSeconds(section.from_sec)} — {formatSeconds(section.to_sec)}
           </span>
         </div>
@@ -484,7 +484,7 @@ function RichSummaryV2NewBlock({
       {/* coreArgument in the headline slot. */}
       {coreArg && (
         <section>
-          <p className="rounded-[6px] bg-[rgba(99,102,241,0.06)] px-[14px] py-[10px] text-[13px] leading-[1.65] text-[#ededf0]">
+          <p className="rounded-[6px] bg-primary/[0.06] px-[14px] py-[10px] text-[13px] leading-[1.65] text-[#ededf0]">
             {coreArg}
           </p>
         </section>
@@ -498,7 +498,7 @@ function RichSummaryV2NewBlock({
               const inner = (
                 <>
                   <div className="flex items-baseline gap-3">
-                    <span className="font-mono text-[10px] text-[#818cf8] shrink-0">
+                    <span className="font-mono text-[10px] text-primary shrink-0">
                       {formatSeconds(sec.from_sec)} — {formatSeconds(sec.to_sec)}
                     </span>
                     <p className="flex-1 text-[14px] font-semibold leading-[1.35] text-[rgba(237,237,240,0.92)]">
@@ -534,7 +534,7 @@ function RichSummaryV2NewBlock({
                 </>
               );
               const baseCls =
-                'block rounded-[6px] px-3 py-[10px] transition-colors hover:bg-[rgba(129,140,248,0.06)]';
+                'block rounded-[6px] px-3 py-[10px] transition-colors hover:bg-primary/[0.06]';
               return jump ? (
                 <Link key={idx} to={jump} className={`${baseCls} cursor-pointer`}>
                   {inner}
@@ -558,7 +558,7 @@ function RichSummaryV2NewBlock({
             {entities.map((ent) => (
               <Tooltip key={`${ent.type}:${ent.name}`}>
                 <TooltipTrigger asChild>
-                  <span className="inline-block rounded-[4px] bg-[rgba(129,140,248,0.08)] px-[7px] py-[2px] text-[10px] font-semibold text-[#818cf8] cursor-default">
+                  <span className="inline-block rounded-[4px] bg-primary/[0.08] px-[7px] py-[2px] text-[10px] font-semibold text-primary cursor-default">
                     {ent.name}
                   </span>
                 </TooltipTrigger>
@@ -588,7 +588,7 @@ function RichSummaryV2NewBlock({
 
       {actionables.length > 0 && (
         <section>
-          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-[#818cf8]">
+          <h3 className="mb-[5px] text-[10px] font-bold uppercase tracking-[0.7px] text-primary">
             {t('learning.actionables')}
           </h3>
           <ul className="space-y-1.5 text-[13px] leading-[1.55] text-[rgba(237,237,240,0.84)]">
@@ -596,7 +596,7 @@ function RichSummaryV2NewBlock({
               <li key={idx} className="flex gap-2">
                 <span
                   aria-hidden
-                  className="mt-[2px] flex h-[14px] w-[14px] shrink-0 items-center justify-center rounded-[3px] border border-[#818cf8] text-[10px] text-[#818cf8]"
+                  className="mt-[2px] flex h-[14px] w-[14px] shrink-0 items-center justify-center rounded-[3px] border border-primary text-[10px] text-primary"
                 >
                   →
                 </span>
@@ -615,7 +615,7 @@ function RichSummaryV2NewBlock({
           <ul className="space-y-2 text-[13px] leading-[1.5]">
             {keyConcepts.map((kc, idx) => (
               <li key={idx} className="rounded-[6px] bg-[rgba(255,255,255,0.02)] px-3 py-2">
-                <p className="text-[14px] font-semibold text-[#818cf8]">{kc.term}</p>
+                <p className="text-[14px] font-semibold text-primary">{kc.term}</p>
                 <p className="mt-[2px] text-[13px] text-[rgba(237,237,240,0.74)]">
                   {kc.definition}
                 </p>
@@ -646,7 +646,7 @@ function RichSummaryV2NewBlock({
             </summary>
             <ul className="mt-[8px] space-y-2 text-[12px]">
               {qaPairs.map((qa, idx) => (
-                <li key={idx} className="border-l-2 border-[rgba(129,140,248,0.4)] pl-3">
+                <li key={idx} className="border-l-2 border-primary/[0.4] pl-3">
                   <p className="font-semibold text-[#ededf0]">Q. {qa.q}</p>
                   <p className="mt-[2px] text-[rgba(237,237,240,0.66)]">A. {qa.a}</p>
                 </li>
@@ -701,7 +701,7 @@ function AtomRow({ atom, jumpUrl }: { atom: VideoRichSummaryAtom; jumpUrl: strin
         {jumpUrl && Number.isFinite(atom.timestamp_sec) && (
           <Link
             to={jumpUrl}
-            className="ml-2 inline-flex items-center gap-0.5 rounded-[3px] bg-[rgba(129,140,248,0.1)] px-[5px] py-[1px] font-mono text-[10px] text-[#818cf8] hover:bg-[rgba(129,140,248,0.2)]"
+            className="ml-2 inline-flex items-center gap-0.5 rounded-[3px] bg-primary/[0.1] px-[5px] py-[1px] font-mono text-[10px] text-primary hover:bg-primary/[0.2]"
           >
             ▶ {formatSeconds(atom.timestamp_sec ?? 0)}
           </Link>

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -87,6 +87,39 @@ function pickKeyPhrase(sectionTitle: string, atomText: string): string | null {
   return null;
 }
 
+/**
+ * C6 — group consecutive atoms into Medium-style paragraphs. Merges adjacent
+ * atoms that share the same `type` (fact/tip/argument) into one paragraph, so a
+ * paragraph reads as a few related sentences instead of one subtitle line each.
+ * Caps prevent over-merge (≤ 4 atoms / ≤ 280 chars → a new paragraph). A type
+ * change also starts a new paragraph (keeps each paragraph thematically coherent).
+ */
+const PARA_MAX_ATOMS = 4;
+const PARA_MAX_CHARS = 280;
+function groupAtomsIntoParagraphs(atoms: Array<{ text?: string; type?: string }>): string[] {
+  const out: string[] = [];
+  let buf: string[] = [];
+  let bufType: string | undefined;
+  let bufLen = 0;
+  const flush = () => {
+    if (buf.length) out.push(buf.join(' '));
+    buf = [];
+    bufLen = 0;
+  };
+  for (const a of atoms) {
+    const text = (a.text ?? '').trim();
+    if (!text) continue;
+    const type = a.type;
+    const wouldOverflow = buf.length >= PARA_MAX_ATOMS || bufLen + text.length > PARA_MAX_CHARS;
+    if (buf.length && (type !== bufType || wouldOverflow)) flush();
+    if (buf.length === 0) bufType = type;
+    buf.push(text);
+    bufLen += text.length;
+  }
+  flush();
+  return out;
+}
+
 /** Paragraph whose first occurrence of `phrase` is wrapped in <strong>. */
 function paragraphWithBold(text: string, phrase: string): TiptapNode {
   const norm = normalizeText(text);
@@ -193,14 +226,11 @@ function renderSection(
     const firstTs = g.atoms[0].ts ?? 0;
     const endSec = groupEndSec(g.atoms);
     out.push(videoBlockNode(g.vid, firstTs, endSec, section.title ?? null));
-    // Each atom → its own paragraph. Keeps editing granularity natural.
-    // strong(4): bold the section's key term IF it appears in the atom (max 1
-    // per atom, none otherwise). Conservative — emphasis stays sparse (Medium).
-    for (const a of g.atoms) {
-      if (a.text && a.text.trim()) {
-        const phrase = pickKeyPhrase(section.title ?? '', a.text);
-        out.push(phrase ? paragraphWithBold(a.text, phrase) : paragraph(a.text));
-      }
+    // C6 — group consecutive same-type atoms into Medium-style paragraphs
+    // (was 1 atom = 1 <p> = "picture-book"). strong: ≤1 key term per paragraph.
+    for (const para of groupAtomsIntoParagraphs(g.atoms)) {
+      const phrase = pickKeyPhrase(section.title ?? '', para);
+      out.push(phrase ? paragraphWithBold(para, phrase) : paragraph(para));
     }
   }
 

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -543,7 +543,25 @@ const NOTE_PROSE_STYLE = `
   margin: 0 0 1.55em;
   color: var(--nm-text);
 }
-.note-prose-root .ProseMirror p strong { font-weight: 600; color: var(--nm-strong); }
+/* C8 — keyword highlight (NOT plain bold): subtle gold tint block, distinct from
+   the code chip (no border, sans). Sparse by the generator heuristic. */
+.note-prose-root .ProseMirror p strong {
+  font-weight: 500;
+  color: var(--nm-gold-text, #e7c79a);
+  background: rgba(194, 168, 120, 0.13);
+  padding: 0 3px;
+  border-radius: 3px;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+/* B5 — sec-eyebrow ("N.N · 다음 토픽" = em-only paragraph right before an h3) is
+   an editing index; hide it in READ mode. kicker(before doc-meta)+doc-meta stay. */
+.note-prose-root:not(.editing) .ProseMirror p:has(> em:only-child):has(+ h3) {
+  display: none;
+}
+/* A4 — keypoint inner paragraph: kill the body 1.55em margin so the quote has no
+   leading gap under the "핵심 포인트" label. */
+.note-prose-root .ProseMirror blockquote p { margin: 0; }
 .note-prose-root .ProseMirror p em:only-child {
   /* editorial label (kicker / sec-eyebrow) — gold, uppercase, small. Visible in
      BOTH read & edit mode (these are design labels, not editing-only eyebrows). */


### PR DESCRIPTION
전체 코드베이스 검증 기반 (넘겨짚기 0). James SW갱신(#952) 후 aa3092ca 실측 = SSOT.

## A — 보라 전수 (토큰 + literal 둘 다)
- **note-mode `--primary`→골드**: RightPanel:148(챗봇 탭)·CenterPanel:291·VideoStrip:70 (토큰 경유 일괄).
- **indigo literal→토큰**: PanelAISummary·EditorToolbar·EditorSlashMenu (IndexPage VideoSidePanel과 **공유**) → note-mode서만 골드, **IndexPage 기본 인디고 유지=회귀 0**.
- keypoint `blockquote p{margin:0}` (라벨 아래 공백 0).

## B — 모드 누수
sec-eyebrow("N.N 다음 토픽") **읽기모드 숨김**(`:not(.editing) p:has(em):has(+h3)`), kicker/doc-meta 유지.

## C — 미디엄화 3레버 (4번째 리치 보류)
- **C6 문단 묶기**: 연속 같은-type atom→1 `<p>` (cap 4 atom/280자, type 변경 분리). "1문장=1줄 그림책" 해소.
- **C8 strong→키워드 하이라이트**: 골드 틴트 블록(코드칩과 별개), 문단당 ≤1 sparse.
- **C7 type 스타일 = 보류**: TipTap paragraph type-attr(스키마 확장) 필요 + **미디엄은 type 색구분 안 함**(과장식 위험). 묶기가 이미 type-coherent라 토대는 마련 — 시각 구분은 별도 결정.

## 검증
vitest **7/7**, tsc0, build, 스모크200, **학습경로 indigo literal grep=0**. 생성기 변경분 재생성 시 적용.

## 보류 (별도 트랙)
진짜 리치(코드블록/이미지/불렛) = v2 enrichment 데이터 확장 (§1⑥ 연계).