### PR TITLE
fix(book): v2 enrichment 완료 시 book 재생성 (stale-book 레이스 — 빈 노트 PRIMARY)

### DIFF
--- a/src/modules/queue/handlers/book-refill-debounce.ts
+++ b/src/modules/queue/handlers/book-refill-debounce.ts
@@ -1,0 +1,21 @@
+import type PgBoss from 'pg-boss';
+
+/**
+ * Debounce for the post-enrich book re-fill. When v2 segments (the book's atom
+ * source) are written, the enrich handler enqueues a mandala book re-fill so
+ * videos enriched AFTER the book was first built are reflected (fixes the
+ * stale-book race that left new mandalas with empty "토픽 0" notes).
+ *
+ * A mandala with N videos produces N enrichments → without debounce that would
+ * be N re-fills (each re-running topic-synthesis Haiku per cell). singletonKey
+ * collapses the burst to one queued job per mandala; the 120s delay lets the
+ * burst finish first so the single re-fill sees all newly-written v2 atoms.
+ *
+ * Standalone (type-only import) so it stays free of the config/google-auth
+ * module chain — keeps it unit-testable without loading the full handler.
+ */
+const BOOK_REFILL_DEBOUNCE_SEC = 120;
+
+export function bookRefillEnqueueOptions(mandalaId: string): PgBoss.SendOptions {
+  return { singletonKey: `book-fill-${mandalaId}`, startAfter: BOOK_REFILL_DEBOUNCE_SEC };
+}

--- a/src/modules/queue/handlers/enrich-rich-summary.ts
+++ b/src/modules/queue/handlers/enrich-rich-summary.ts
@@ -48,6 +48,8 @@ import { getPrismaClient } from '../../database/client';
 import { logger } from '../../../utils/logger';
 import { getJobQueue } from '../manager';
 import { JOB_NAMES, RICH_SUMMARY_RETRY_OPTIONS, type EnrichRichSummaryPayload } from '../types';
+import { enqueueMandalaBookFill } from './mandala-book-fill';
+import { bookRefillEnqueueOptions } from './book-refill-debounce';
 import { config } from '@/config/index';
 import { loadRichSummaryConfig } from '@/config/rich-summary';
 import { richSummaryWorkOptions } from './rich-summary-work-options';
@@ -278,6 +280,25 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
         ? { completeness: v2Outcome.completeness }
         : { reason: v2Outcome.reason },
   });
+
+  // Book regen trigger — when v2 segments (the book's atom source) are written,
+  // re-fill the mandala's book so videos enriched AFTER the book was first
+  // generated are reflected (fixes the stale-book race that left new mandalas
+  // with empty "토픽 0" notes). Debounced: singletonKey = one queued re-fill per
+  // mandala, startAfter 120s collects an enrich burst into a single re-fill so
+  // topic-synthesis (Haiku) is not over-triggered. No new Sonnet/v2 cost — the
+  // re-fill reuses already-written v2 atoms.
+  if (v2Outcome.kind === 'pass' && mandalaId) {
+    await enqueueMandalaBookFill(
+      { userId, mandalaId, trigger: 'enrich-complete' },
+      bookRefillEnqueueOptions(mandalaId)
+    ).catch((err) => {
+      logger.warn('enrich-rich-summary: book re-fill enqueue failed (non-fatal)', {
+        mandalaId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
 }
 
 /**

--- a/tests/smoke/book-refill-trigger.test.ts
+++ b/tests/smoke/book-refill-trigger.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Book re-fill trigger (post-enrich) — debounce contract. When v2 segments (the
+ * book's atom source) are written, the enrich handler enqueues a mandala book
+ * re-fill so videos enriched AFTER the book was first built are reflected (fixes
+ * the stale-book race = empty "토픽 0" notes on new mandalas). The enqueue is
+ * debounced so a burst of per-video enrichments collapses into ONE re-fill per
+ * mandala (topic-synthesis Haiku is not over-triggered).
+ */
+import { bookRefillEnqueueOptions } from '../../src/modules/queue/handlers/book-refill-debounce';
+
+describe('bookRefillEnqueueOptions (post-enrich book re-fill debounce)', () => {
+  it('dedups per mandala via singletonKey', () => {
+    const a = bookRefillEnqueueOptions('mandala-A');
+    const b = bookRefillEnqueueOptions('mandala-B');
+    expect(a.singletonKey).toBe('book-fill-mandala-A');
+    expect(b.singletonKey).toBe('book-fill-mandala-B');
+    expect(bookRefillEnqueueOptions('mandala-A').singletonKey).toBe(a.singletonKey);
+  });
+
+  it('delays 120s to collect an enrich burst before re-filling', () => {
+    expect(bookRefillEnqueueOptions('m').startAfter).toBe(120);
+  });
+});


### PR DESCRIPTION
## 원인 (측정)
신규 만다라 빈 "토픽 0" 노트 = **book이 v2 enrichment 완료 前에 생성됨** (Azure 90c2c872: book@02:05 < v2@02:07) + **enrichment→book 재생성 트리거 부재**(grep 0). v2 atom 소스 = **OpenRouter Sonnet(paid, 가동)** — pod-down 아님(RunPod=챗봇/Ollama=임베딩, atom 무관).

## 수정
enrich-rich-summary 핸들러가 v2 segments 쓰여진 후(`v2Outcome.kind==='pass'`) 해당 만다라 book re-fill enqueue. `mandalaId` 이미 job payload에 있어 lookup 불필요.
**디바운스**(`book-refill-debounce.ts`): `singletonKey` 만다라당 + `startAfter:120s` → enrich 버스트를 1회 re-fill로 모음 = topic-synthesis(Haiku) 과트리거 0. **새 Sonnet/v2 비용 0**(기존 atom 재사용). enqueue 실패=non-fatal(로그).

## 효과
앞으로 모든 신규 만다라가 v2된 만큼 자동 반영 (Cursor 6주처럼 수작업 동기 불필요). stale 영구 방지.

## 검증
jest **2/2**(singletonKey dedup + 120s), lint 0, 내 파일 tsc 0. 백엔드 변경(브라우저 무관).
배포 후: Azure 등 빈 노트 만다라 → enrich 따라 book 자동 채워짐 → James 실측("토픽 0"→내용).

## 백로그 (별도 비용 결정)
v1→v2 백필 4004행 (cron OFF=`RICH_SUMMARY_V2_CRON_ENABLED=false`, bulk=Mac Mini). 본 트리거가 "v2된 건 자동 반영" 보장 → 커버리지는 그 위에서 결정.