### PR TITLE
fix(note): 본문 인라인 키워드 볼드 제거 (미디엄 본문=비볼드)

### DIFF
--- a/frontend/src/__tests__/note-document-generator-segment.test.ts
+++ b/frontend/src/__tests__/note-document-generator-segment.test.ts
@@ -50,27 +50,18 @@ describe('note-document-generator — segment endSec', () => {
   });
 });
 
-describe('note-document-generator — strong(4) heuristic', () => {
-  const bookWith = (title: string, text: string): MandalaBookData => ({
-    chapters: [{ ch: 0, title: '백엔드', sections: [{ title, atoms: [{ vid: 'v', ts: 1, text }] }] }],
-  });
-  const paras = (doc: { content?: unknown[] }) =>
-    (doc.content ?? []).filter((n) => (n as { type: string }).type === 'paragraph') as Array<{
-      content?: Array<{ text: string; marks?: Array<{ type: string }> }>;
-    }>;
-
-  it('bolds the section key term when it appears in the atom (max 1, sparse)', () => {
-    const doc = buildInitialNoteDoc(bookWith('REST API 라우팅 구조', '여기서 라우팅 으로 분기한다'));
-    // find the atom paragraph that contains a bold run
-    const bolded = paras(doc).flatMap((p) => p.content ?? []).filter((t) => t.marks?.some((m) => m.type === 'bold'));
-    expect(bolded.length).toBeGreaterThanOrEqual(1);
-    expect(bolded[0]!.text).toBe('라우팅'); // longest title token present in the atom
-  });
-
-  it('no emphasis when no section term appears (Medium-sparse, never over-bold)', () => {
-    const doc = buildInitialNoteDoc(bookWith('REST API 라우팅 구조', '완전히 무관한 문장입니다'));
-    const bolded = paras(doc).flatMap((p) => p.content ?? []).filter((t) => t.marks?.some((m) => m.type === 'bold'));
-    expect(bolded.length).toBe(0);
+describe('note-document-generator — body has NO inline bold (Medium body = un-bolded)', () => {
+  it('emits plain body paragraphs even when an atom restates the section title', () => {
+    const doc = buildInitialNoteDoc({
+      chapters: [
+        { ch: 0, title: '백엔드', sections: [{ title: 'REST API 라우팅 구조', atoms: [{ vid: 'v', ts: 1, text: '여기서 라우팅 으로 분기한다' }] }] },
+      ],
+    });
+    const bolded = (doc.content ?? [])
+      .filter((n) => (n as { type: string }).type === 'paragraph')
+      .flatMap((p) => (p as { content?: Array<{ marks?: Array<{ type: string }> }> }).content ?? [])
+      .filter((t) => t.marks?.some((m) => m.type === 'bold'));
+    expect(bolded.length).toBe(0); // running prose stays un-bolded
   });
 });
 

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -70,24 +70,6 @@ function paragraph(
 }
 
 /**
- * strong(4) heuristic — pick the section title's most specific token that also
- * appears in the atom text (longest-first, length ≥ 2). Returns null if none →
- * no emphasis. Conservative by design: emphasis only when the atom literally
- * restates a section key term, at most one phrase per atom (Medium-sparse).
- */
-function pickKeyPhrase(sectionTitle: string, atomText: string): string | null {
-  const terms = sectionTitle
-    .split(/[\s·,，()/[\]{}]+/)
-    .map((t) => t.trim())
-    .filter((t) => t.length >= 2)
-    .sort((a, b) => b.length - a.length);
-  for (const t of terms) {
-    if (atomText.includes(t)) return t;
-  }
-  return null;
-}
-
-/**
  * C6 — group consecutive atoms into Medium-style paragraphs. Merges adjacent
  * atoms that share the same `type` (fact/tip/argument) into one paragraph, so a
  * paragraph reads as a few related sentences instead of one subtitle line each.
@@ -118,20 +100,6 @@ function groupAtomsIntoParagraphs(atoms: Array<{ text?: string; type?: string }>
   }
   flush();
   return out;
-}
-
-/** Paragraph whose first occurrence of `phrase` is wrapped in <strong>. */
-function paragraphWithBold(text: string, phrase: string): TiptapNode {
-  const norm = normalizeText(text);
-  const idx = norm.indexOf(phrase);
-  if (idx < 0) return paragraph(text);
-  const before = norm.slice(0, idx);
-  const after = norm.slice(idx + phrase.length);
-  const content: Array<{ type: 'text'; text: string; marks?: Array<{ type: string }> }> = [];
-  if (before) content.push({ type: 'text', text: before });
-  content.push({ type: 'text', text: phrase, marks: [{ type: 'bold' }] });
-  if (after) content.push({ type: 'text', text: after });
-  return { type: 'paragraph', content } as TiptapNode;
 }
 
 function heading(level: 2 | 3, text: string): TiptapNode {
@@ -227,10 +195,12 @@ function renderSection(
     const endSec = groupEndSec(g.atoms);
     out.push(videoBlockNode(g.vid, firstTs, endSec, section.title ?? null));
     // C6 — group consecutive same-type atoms into Medium-style paragraphs
-    // (was 1 atom = 1 <p> = "picture-book"). strong: ≤1 key term per paragraph.
+    // (was 1 atom = 1 <p> = "picture-book"). Body stays UN-bolded: Medium body
+    // text has no inline keyword bold (the auto-strong heuristic turned common
+    // repeated words into gold noise). Emphasis lives ONLY in keypoint quotes +
+    // code chips, not running prose.
     for (const para of groupAtomsIntoParagraphs(g.atoms)) {
-      const phrase = pickKeyPhrase(section.title ?? '', para);
-      out.push(phrase ? paragraphWithBold(para, phrase) : paragraph(para));
+      out.push(paragraph(para));
     }
   }
 


### PR DESCRIPTION
## 원인 (James 지적, 타당)
auto-strong 휴리스틱(#955 C8)이 본문 단락 내 섹션 핵심어를 볼드 → 평범한 반복 단어("명령" 등)마다 골드 볼드 = **강조가 노이즈**. 미디엄 본문은 인라인 키워드 볼드 안 씀.

## 수정
- 생성기: `pickKeyPhrase`+`paragraphWithBold` 제거. 본문 atom = 일반 단락(묶기 유지). **본문 비볼드로 흐름.**
- **유지(불변)**: 인용 keypoint(골드 세로선+"핵심 포인트" 라벨, 섹션당 ≤1) + 인라인 코드칩(코드 식별, 강조 아님) — 미디엄도 둘 다 표시. `p strong` CSS는 수동 볼드용 유지.

## 검증
vitest **6/6**(본문 bold run 0 + 묶기 + segment), tsc0, lint0, build, 스모크200. 재생성 시 적용.