### PR TITLE
fix(chat): 챗봇 하단 가이드 문장 입력창 겹침 (absolute→normal flow)

### DIFF
--- a/frontend/src/pages/learning/ui/RightPanel.tsx
+++ b/frontend/src/pages/learning/ui/RightPanel.tsx
@@ -180,18 +180,23 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
       </div>
       <div
         className={cn(
-          'relative min-h-0 flex-1 overflow-hidden pb-[35px]',
+          // flex column so the disclaimer sits in normal flow BELOW the chat
+          // (CopilotKit input box). Previously the disclaimer was position:absolute
+          // bottom-2 and overlapped the input. min-h-0 lets the chat area shrink.
+          'flex min-h-0 flex-1 flex-col overflow-hidden',
           activeTab !== 'chatbot' && 'hidden'
         )}
       >
         {activeSectionTitle && (
           // §redesign — chat context (시안 chat-ctx): "지금 읽는 구간 · {제목}".
-          <div className="border-b border-white/[0.06] px-1 pb-2.5 pt-0.5 text-[12px] text-muted-foreground/70">
+          <div className="shrink-0 border-b border-white/[0.06] px-1 pb-2.5 pt-0.5 text-[12px] text-muted-foreground/70">
             지금 읽는 구간 · <span className="text-muted-foreground">{activeSectionTitle}</span>
           </div>
         )}
-        <ChatAssistant key={videoId} mandalaId={mandalaId} videoId={videoId} onSeek={handleSeek} />
-        <p className="absolute bottom-2 left-0 w-full text-center text-[10px] text-muted-foreground/60">
+        <div className="relative min-h-0 flex-1 overflow-hidden">
+          <ChatAssistant key={videoId} mandalaId={mandalaId} videoId={videoId} onSeek={handleSeek} />
+        </div>
+        <p className="shrink-0 w-full py-2 text-center text-[10px] text-muted-foreground/60">
           {t('learning.chatDisclaimer')}
         </p>
       </div>


### PR DESCRIPTION
## 원인 (측정)
챗봇 푸터 "챗봇은 실수할 수 있습니다…"가 `position:absolute bottom-2`로 패널 하단에 떠 있어 **CopilotKit 입력창(채팅 영역 하단)과 겹침**. `pb-[35px]`로 공간 예약했으나 absolute는 흐름 밖이라 여전히 입력창 위로 겹침.

## 수정
컨테이너 → flex column. 채팅 영역 = flex-1(min-h-0, 자체 입력창 포함), 가이드 = shrink-0 **normal flow로 그 아래**. → 입력창 + 가이드 **세로 분리, 겹침 0**. 입력 기능 불변(CopilotChat 내부). 푸터 레이아웃만 변경.

## 검증
tsc0, build, 스모크200. 챗봇 입력·다른 영역 회귀 0 (레이아웃만).