### PR TITLE
fix(v2): on-demand enrich가 전역 v2 캐시 존중 (중복 Sonnet 차단)

### DIFF
--- a/src/modules/queue/handlers/enrich-rich-summary.ts
+++ b/src/modules/queue/handlers/enrich-rich-summary.ts
@@ -50,6 +50,7 @@ import { getJobQueue } from '../manager';
 import { JOB_NAMES, RICH_SUMMARY_RETRY_OPTIONS, type EnrichRichSummaryPayload } from '../types';
 import { enqueueMandalaBookFill } from './mandala-book-fill';
 import { bookRefillEnqueueOptions } from './book-refill-debounce';
+import { isCompleteV2 } from './v2-completeness';
 import { config } from '@/config/index';
 import { loadRichSummaryConfig } from '@/config/rich-summary';
 import { richSummaryWorkOptions } from './rich-summary-work-options';
@@ -99,12 +100,19 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
   // Pick a language hint so caption-extractor probes the spoken language
   // before falling through to its ko/en defaults.
   let langHint: string | undefined;
+  let cachedComplete = false;
   try {
     const prisma = getPrismaClient();
     const [rsRow, ytRow] = await Promise.all([
       prisma.video_rich_summaries.findUnique({
         where: { video_id: videoId },
-        select: { source_language: true },
+        // completeness fields reuse the full generator's skip-gate definition.
+        select: {
+          source_language: true,
+          template_version: true,
+          transcript_used: true,
+          mandala_relevance_pct: true,
+        },
       }),
       prisma.youtube_videos.findUnique({
         where: { youtube_video_id: videoId },
@@ -112,12 +120,39 @@ async function handleEnrichRichSummary(job: PgBoss.Job<EnrichRichSummaryPayload>
       }),
     ]);
     langHint = rsRow?.source_language ?? ytRow?.default_language ?? undefined;
+    // v2 atom is a GLOBAL cache (video_rich_summaries.video_id PK). If the row is
+    // already a complete v2 (transcript-grounded + relevance), a re-enrich here
+    // would re-call Haiku+Sonnet for content that already exists for every user.
+    // Short-circuit to honor the cache. (Quality-regen crons still force via
+    // forceRegen; this only guards the on-demand enrich handler.)
+    cachedComplete = isCompleteV2(rsRow);
   } catch (err) {
     logger.warn('enrich-rich-summary: lang-hint lookup failed (continuing without)', {
       jobId: job.id,
       videoId,
       error: err instanceof Error ? err.message : String(err),
     });
+  }
+
+  if (cachedComplete) {
+    logger.info('enrich-rich-summary: global v2 already complete — cache hit, skipping regen', {
+      jobId: job.id,
+      videoId,
+    });
+    // Still re-fill the book so THIS mandala reflects the already-global v2
+    // (the post-enrich book trigger would not fire when generation is skipped).
+    if (mandalaId) {
+      await enqueueMandalaBookFill(
+        { userId, mandalaId, trigger: 'enrich-cache-hit' },
+        bookRefillEnqueueOptions(mandalaId)
+      ).catch((err) => {
+        logger.warn('enrich-rich-summary: cache-hit book re-fill enqueue failed (non-fatal)', {
+          mandalaId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
+    return;
   }
 
   // CP500+ H fix — chokepoint: guarantee a youtube_videos row exists before the

--- a/src/modules/queue/handlers/v2-completeness.ts
+++ b/src/modules/queue/handlers/v2-completeness.ts
@@ -1,0 +1,21 @@
+/**
+ * "Complete v2" predicate — mirrors the full generator's skip-gate definition
+ * (rich-summary-v2-generator.ts: template_version==='v2' && mandala_relevance_pct
+ * != null && transcript_used). A complete row is an atom-bearing, transcript-
+ * grounded v2 in the GLOBAL cache (video_rich_summaries.video_id PK), so the
+ * on-demand enrich handler short-circuits on it instead of re-calling Haiku+Sonnet.
+ */
+export interface V2CompletenessRow {
+  template_version?: string | null;
+  transcript_used?: boolean | null;
+  mandala_relevance_pct?: number | null;
+}
+
+export function isCompleteV2(row: V2CompletenessRow | null | undefined): boolean {
+  return (
+    !!row &&
+    row.template_version === 'v2' &&
+    row.transcript_used === true &&
+    row.mandala_relevance_pct != null
+  );
+}

--- a/tests/smoke/v2-completeness.test.ts
+++ b/tests/smoke/v2-completeness.test.ts
@@ -1,0 +1,24 @@
+/**
+ * isCompleteV2 — the on-demand enrich handler's cache-hit guard. A complete
+ * GLOBAL v2 (transcript-grounded + relevance) must short-circuit so re-enrich
+ * (Heart re-click etc.) does NOT re-call Haiku+Sonnet for already-cached content.
+ */
+import { isCompleteV2 } from '../../src/modules/queue/handlers/v2-completeness';
+
+describe('isCompleteV2 (enrich cache-hit guard)', () => {
+  it('complete v2 (transcript + relevance) → cache hit', () => {
+    expect(isCompleteV2({ template_version: 'v2', transcript_used: true, mandala_relevance_pct: 70 })).toBe(true);
+  });
+  it('description-only v2 (no transcript) → NOT complete (regen)', () => {
+    expect(isCompleteV2({ template_version: 'v2', transcript_used: false, mandala_relevance_pct: 70 })).toBe(false);
+  });
+  it('v2 without relevance → NOT complete (regen)', () => {
+    expect(isCompleteV2({ template_version: 'v2', transcript_used: true, mandala_relevance_pct: null })).toBe(false);
+  });
+  it('v1 row → NOT complete (regen)', () => {
+    expect(isCompleteV2({ template_version: 'v1', transcript_used: true, mandala_relevance_pct: 70 })).toBe(false);
+  });
+  it('no row → NOT complete', () => {
+    expect(isCompleteV2(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 문제
v2 atom = **전역 캐시**(`video_rich_summaries.video_id` PK = 영상당 1행, 전 사용자 공유). 그러나 on-demand enrich 핸들러가 Quick(Haiku)+Full(Sonnet, `forceRegen:true`)를 **무조건** 실행 → 이미 complete v2인 영상에 Heart 재클릭 시 **이미 모두에게 존재하는 콘텐츠를 Haiku+Sonnet 재청구.** 캐시 곡선(사용자↑→재사용→단가↓)이 enrich 경로에서 누수.

## 수정
전역 행이 이미 **complete v2**(`isCompleteV2` = v2 + transcript_used + relevance, full generator skip-gate 미러)면 핸들러 **단락**:
- Quick+Full 둘 다 skip (Haiku·Sonnet 0).
- **단 book re-fill은 enqueue** — 이 만다라가 전역 v2를 반영하도록(generation skip 시 post-enrich 트리거 미발화 보완).
- **`forceRegen:true` 유지** — incomplete 영상에서 Quick(부분행)→Full(완성)이 돌게 하는 데 필요. quality-regen 크론의 의도적 forceRegen 무영향.
- §1④/fill-book 무영향(v2-없는것만 enqueue).

## 검증
jest **5/5**(complete→hit / description-only / null-rel / v1 / no-row), tsc 0, lint 0. 백엔드 only.

## 효과
인기 영상(여러 사용자 공유)은 첫 1회 v2 후 추가 사용자 한계비용 ≈ 0. pro 마진 직결.