### PR TITLE
fix(cost): v2 Sonnet 모델 단가 추가 — cost_usd NULL 복구 (실지출 추적)

### DIFF
--- a/src/config/llm-pricing.ts
+++ b/src/config/llm-pricing.ts
@@ -73,6 +73,14 @@ export const LLM_PRICING: Record<string, LLMPricing> = {
     outputPerToken: 0.000015,
     source: 'openrouter.ai/api/v1/models (2026-04-27)',
   },
+  // The rich-summary v2 generator pins this exact id (SONNET_MODEL). It was
+  // missing → calculateCost returned null → cost_usd NULL for ALL v2 calls
+  // (327/327 in 30d). $3/M in · $15/M out (2026-06 official).
+  'anthropic/claude-sonnet-4-6': {
+    inputPerToken: 0.000003,
+    outputPerToken: 0.000015,
+    source: 'anthropic.com/pricing (2026-06): $3/M in, $15/M out',
+  },
   'anthropic/claude-haiku-4.5': {
     inputPerToken: 0.000001,
     outputPerToken: 0.000005,

--- a/tests/smoke/llm-pricing-v2.test.ts
+++ b/tests/smoke/llm-pricing-v2.test.ts
@@ -1,0 +1,25 @@
+/**
+ * llm-pricing — the v2 (Sonnet) model id must be in the table so cost_usd is
+ * populated (it was NULL for all 327/30d v2 calls because the pinned id
+ * 'anthropic/claude-sonnet-4-6' was missing). Real tokens × official price.
+ */
+import { calculateCost, LLM_PRICING } from '../../src/config/llm-pricing';
+
+describe('llm-pricing — v2 Sonnet cost', () => {
+  it('the v2 generator model id is priced ($3/M in, $15/M out)', () => {
+    expect(LLM_PRICING['anthropic/claude-sonnet-4-6']).toBeDefined();
+    // avg v2 call (measured): 12120 in, 5022 out → $0.1117
+    const cost = calculateCost('openrouter/anthropic/claude-sonnet-4-6', 12120, 5022);
+    expect(cost).not.toBeNull();
+    expect(cost).toBeCloseTo(0.1117, 4);
+  });
+
+  it('Haiku relevance scoring is priced (1 call)', () => {
+    const cost = calculateCost('openrouter/anthropic/claude-haiku-4.5', 1164, 230);
+    expect(cost).toBeCloseTo(0.001164 + 0.00115, 5); // $1/M in + $5/M out
+  });
+
+  it('unknown model → null (does not fabricate a cost)', () => {
+    expect(calculateCost('openrouter/some/unlisted-model', 100, 100)).toBeNull();
+  });
+});


### PR DESCRIPTION
## 문제
로거는 이미 `calculateCost(model, in, out)`로 cost_usd를 계산함(LLM_PRICING SSOT 기준). 그러나 v2 생성기가 pin한 **`anthropic/claude-sonnet-4-6`가 단가맵에 없음**(`claude-sonnet-4`만 있음) → calculateCost null → **v2 호출 cost_usd 전부 NULL (327/327, 30일)** → pro 지출·마진 추적 불가.

## 수정
`anthropic/claude-sonnet-4-6` 단가맵 추가 ($3/M in·$15/M out, 2026-06 공식). **단가맵 = 한 곳**(llm-pricing.ts), 신규 모델 = 한 줄. cost_usd 이제 채워짐. 측정 평균(12120 in/5022 out=$0.1117)과 일치 검증.

## 검증
jest **3/3**(v2 priced / Haiku priced / unknown→null 무발명), tsc0, lint0.

## 정직한 잔여 gap (추측 안 함 — 틀린 숫자보다 NULL)
- `qwen/qwen3-embedding-8b`(3418/30d 전부 NULL)도 누락 — 임베딩 공식단가는 **OpenRouter fetch 필요**(파일 헤더 curl). 맹목 추가 안 함.
- `llm_call_logs.video_id` v2서 NULL — generic OpenRouter provider가 영상 컨텍스트를 logLLMCall에 안 넘김. 스레딩은 별 작업(무리한 역추적 금지).
- 배치(-50%)/캐시(-90%) 할인: 현재 미사용(플래그 없음). 도입 시 calculateCost 분기.