### PR TITLE
feat(book): §1④ PR2 — coverage 진행도 영속 + 노트 '준비 중'(빈섹션 해소)

### DIFF
--- a/frontend/src/features/mandala/model/useMandalaBook.ts
+++ b/frontend/src/features/mandala/model/useMandalaBook.ts
@@ -26,6 +26,11 @@ export function useMandalaBook(mandalaId: string | null | undefined): UseMandala
     enabled: Boolean(mandalaId),
     staleTime: MANDALA_BOOK_STALE_MS,
     retry: false,
+    // §1④ PR2 — while the book is still filling (v2 pending), poll every 5s so
+    // the "준비 중" banner + chapters update live as v2 completes (#958 re-fill).
+    // Stops once v2_pending hits 0 (mirrors the deck-status 준비중 polling).
+    refetchInterval: (query) =>
+      (query.state.data?.coverage?.v2Pending ?? 0) > 0 ? 5000 : false,
   });
 
   return {

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -352,15 +352,27 @@ export function CenterPanel({
         onMouseEnter={() => setActiveRegion('book-index')}
       >
         {centerViewMode === 'note' ? (
-          <NoteEditorView
-            editor={noteDoc.editor}
-            loading={noteDoc.loading}
-            error={noteDoc.error}
-            isEditing={noteDoc.isEditing}
-            setIsEditing={noteDoc.setIsEditing}
-            restoreOriginal={noteDoc.restoreOriginal}
-            hasBook={Boolean(book?.book?.chapters?.length)}
-          />
+          <>
+            {/* §1④ PR2 — "준비 중": when the book is still filling (v2 pending),
+                show progress instead of letting empty chapters read as a bug. */}
+            {(book?.coverage?.v2Pending ?? 0) > 0 && (
+              <div className="mx-auto mt-3 flex max-w-[680px] items-center gap-2 rounded-md border border-white/[0.07] bg-white/[0.03] px-3.5 py-2 text-[12px] text-muted-foreground">
+                <span className="inline-block h-3 w-3 shrink-0 animate-spin rounded-full border-[1.5px] border-current border-t-transparent" />
+                <span>
+                  {book?.coverage?.v2Pending}개 영상이 북인덱스에 추가되는 중이에요 · {book?.coverage?.v2Done}/{book?.coverage?.gatePassed} 완료
+                </span>
+              </div>
+            )}
+            <NoteEditorView
+              editor={noteDoc.editor}
+              loading={noteDoc.loading}
+              error={noteDoc.error}
+              isEditing={noteDoc.isEditing}
+              setIsEditing={noteDoc.setIsEditing}
+              restoreOriginal={noteDoc.restoreOriginal}
+              hasBook={Boolean(book?.book?.chapters?.length)}
+            />
+          </>
         ) : (
           // CP445.x — 본문 영역 max-width = 영상 (49.5vh*16/9) 동일 + mx-auto
           // 좌우 정렬. 영상 ↔ AI요약/섹션 시각 일관성.

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -318,6 +318,8 @@ export interface MandalaBookResponse {
   version: number;
   sourceVideos: number;
   sourceAtoms: number;
+  /** §1④ coverage (PR2). v2Pending > 0 ⇒ the book is still filling. */
+  coverage?: { gatePassed: number; v2Done: number; v2Pending: number };
   generatedAt: string;
   updatedAt: string;
   book: MandalaBookData;

--- a/prisma/migrations/bookindex-coverage/001_add_coverage_columns.sql
+++ b/prisma/migrations/bookindex-coverage/001_add_coverage_columns.sql
@@ -1,0 +1,10 @@
+-- §1④ PR2 — book-fill coverage progress columns on mandala_books.
+-- gate_passed = gate-passed card count (denominator); v2_done = passed cards
+-- with usable v2 (in the book now); v2_pending = passed cards whose v2 is still
+-- being enqueued/generated. v2_pending > 0 drives the left-sidebar "준비 중"
+-- spinner + the note empty-section "준비 중" label.
+-- prisma db push silent-fails on Supabase (auth-schema ownership) → apply this
+-- raw DDL on local + prod (psql "$DIRECT_URL" -f ...), then verify \d mandala_books.
+ALTER TABLE mandala_books ADD COLUMN IF NOT EXISTS gate_passed integer NOT NULL DEFAULT 0;
+ALTER TABLE mandala_books ADD COLUMN IF NOT EXISTS v2_done     integer NOT NULL DEFAULT 0;
+ALTER TABLE mandala_books ADD COLUMN IF NOT EXISTS v2_pending  integer NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -652,6 +652,11 @@ model mandala_books {
   version       Int           @default(1)
   source_videos Int           @default(0)
   source_atoms  Int           @default(0)
+  /// §1④ coverage progress (PR2). gate_passed = denominator; v2_pending > 0 ⇒ the
+  /// book is still filling (left-sidebar "준비 중" spinner + empty-section label).
+  gate_passed   Int           @default(0)
+  v2_done       Int           @default(0)
+  v2_pending    Int           @default(0)
   generated_at  DateTime      @default(now()) @db.Timestamptz(6)
   updated_at    DateTime      @default(now()) @updatedAt @db.Timestamptz(6)
   mandala       user_mandalas @relation(fields: [mandala_id], references: [id], onDelete: Cascade, onUpdate: NoAction)

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -3003,12 +3003,15 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           version: number;
           source_videos: number;
           source_atoms: number;
+          gate_passed: number;
+          v2_done: number;
+          v2_pending: number;
           generated_at: Date;
           updated_at: Date;
         }>
       >(
         `SELECT mandala_id, book_json, version, source_videos, source_atoms,
-                generated_at, updated_at
+                gate_passed, v2_done, v2_pending, generated_at, updated_at
          FROM mandala_books
          WHERE mandala_id = $1::uuid
          LIMIT 1`,
@@ -3031,6 +3034,12 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           version: row.version,
           sourceVideos: row.source_videos,
           sourceAtoms: row.source_atoms,
+          // §1④ coverage (PR2) — v2_pending > 0 ⇒ book still filling.
+          coverage: {
+            gatePassed: row.gate_passed,
+            v2Done: row.v2_done,
+            v2Pending: row.v2_pending,
+          },
           generatedAt: row.generated_at.toISOString(),
           updatedAt: row.updated_at.toISOString(),
           book: row.book_json,

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -302,19 +302,26 @@ export async function fillMandalaBook(params: {
   // lag client regen on some deploys (same reason GET /:id/book uses raw SQL).
   const rows = await prisma.$queryRawUnsafe<Array<{ version: number }>>(
     `INSERT INTO mandala_books
-       (mandala_id, book_json, version, source_videos, source_atoms, generated_at, updated_at)
-     VALUES ($1::uuid, $2::jsonb, 1, $3, $4, NOW(), NOW())
+       (mandala_id, book_json, version, source_videos, source_atoms,
+        gate_passed, v2_done, v2_pending, generated_at, updated_at)
+     VALUES ($1::uuid, $2::jsonb, 1, $3, $4, $5, $6, $7, NOW(), NOW())
      ON CONFLICT (mandala_id) DO UPDATE SET
        book_json     = EXCLUDED.book_json,
        source_videos = EXCLUDED.source_videos,
        source_atoms  = EXCLUDED.source_atoms,
+       gate_passed   = EXCLUDED.gate_passed,
+       v2_done       = EXCLUDED.v2_done,
+       v2_pending    = EXCLUDED.v2_pending,
        version       = mandala_books.version + 1,
        updated_at    = NOW()
      RETURNING version`,
     mandalaId,
     JSON.stringify(validated),
     sourceVideos,
-    sourceAtoms
+    sourceAtoms,
+    gatePassed,
+    v2Done,
+    v2Pending.size
   );
 
   const version = rows[0]?.version ?? 1;


### PR DESCRIPTION
#964 coverage 반환값 소비 (표시 레이어 재계산 0). `{gate_passed, v2_done, v2_pending}` 영속 → 노트뷰가 빈 챕터 대신 "채워지는 중" 표시.

## 변경
- **DB**: mandala_books += `gate_passed/v2_done/v2_pending` (raw DDL `prisma/migrations/bookindex-coverage/001` — **prisma db push silent-fail → local+prod 수동 적용 + `\d` 검증 필수**). prisma 스키마 갱신.
- **fill-book**: INSERT가 3 coverage 컬럼 write (값은 #964서 이미 계산, 영속만).
- **GET /:id/book**: `coverage {gatePassed,v2Done,v2Pending}` 반환.
- **FE 노트뷰**: v2Pending>0 시 **"준비 중" 배너**(스피너 + "N개 영상 추가 중 · M/K 완료") = (e) 빈섹션 해소. `useMandalaBook`이 v2Pending>0 동안 5s 폴링 → 배너+챕터 라이브 갱신, 0서 정지(deck-status 준비중 패턴).

## 검증
tsc0, lint0, build, url-contract 1/1, 스모크200. **정본 경로 원칙**(fill이 카운트 생성, UI는 읽기만).

## 정직한 GAP
좌측 **만다라 리스트 스피너 미포함** — 리스트 쿼리(GET /mandalas)가 per-mandala v2_pending 미운반 → 리스트 coverage join 필요(thin follow-up). 노트뷰 "준비 중"(책 열렸을 때)은 제공.

## ⚠️ 배포 전 필수
DDL을 **prod에 먼저 수동 적용**(GET이 새 컬럼 SELECT — 미적용 시 500). CI deploy의 schema-sync 또는 수동 psql.