### PR TITLE
feat(v2): 카드추가 닫힘 시 영문 v2 atom 한글 번역 (PR-T1)

### DIFF
--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1033,6 +1033,18 @@ class ApiClient {
     );
   }
 
+  /**
+   * PR-T1 — v2 translations bulk trigger (card-add panel close). Enqueues one
+   * debounced bulk-translate job for the mandala's off-language v2 atoms.
+   * BE: POST /api/v1/mandalas/:id/translate-bulk. Fire-and-forget.
+   */
+  async translateMandalaBulk(mandalaId: string): Promise<void> {
+    await this.request<{ status: 'ok'; data: unknown }>(
+      `/mandalas/${mandalaId}/translate-bulk`,
+      { method: 'POST', body: JSON.stringify({}) }
+    );
+  }
+
   // ─── CP456 Billing (Lemon Squeezy, MoR subscription) ──────────────────────
 
   /**

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -430,6 +430,13 @@ export function AddCardsPanel() {
       void apiClient.triggerMandalaRelevance(mandalaId).catch(() => {
         /* never block close UX; idempotent trigger self-heals on the next close */
       });
+      // PR-T1 — v2 translations bulk trigger on close. Same guard/fire-and-forget
+      // shape as relevance: a ko mandala that picked English cards gets their v2
+      // atoms translated (display layer). Insert is untouched; dedup + global
+      // cache make a re-fire cheap. Errors swallowed — never block close.
+      void apiClient.translateMandalaBulk(mandalaId).catch(() => {
+        /* never block close UX; debounced + idempotent → self-heals next close */
+      });
     }
     setIsClosingLocal(true);
     if (closeTimerRef.current) clearTimeout(closeTimerRef.current);

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -1,6 +1,8 @@
 import { FastifyPluginCallback } from 'fastify';
 import { getMandalaManager } from '../../modules/mandala';
 import { enqueueMandalaBookFill } from '../../modules/queue/handlers/mandala-book-fill';
+import { enqueueTranslateMandalaBulk } from '../../modules/queue/handlers/translate-mandala-bulk';
+import { translateBulkEnqueueOptions } from '../../modules/queue/handlers/book-refill-debounce';
 import { enqueueSegmentRelevanceForMandala } from '../../modules/relevance/segment-relevance-trigger';
 import { markDeckPending, getDeckState } from '../../modules/deck/deck-status';
 import { enqueueDeckBuild } from '../../modules/queue/handlers/deck-build';
@@ -158,6 +160,31 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
 
     return reply.send({ mandala });
   });
+
+  /**
+   * POST /api/v1/mandalas/:id/translate-bulk — v2 translations (PR-T1).
+   * Fired on card-add panel CLOSE. Enqueues ONE debounced bulk-translate job for
+   * the mandala: off-language v2 atoms → mandala language (Haiku, dedup against
+   * the global translations cache). Insert is unaffected — this is display-layer
+   * only. Returns immediately (the job runs async; the note shows the existing
+   * "generating" rolling until translations land, then re-renders via book-fill).
+   */
+  fastify.post(
+    '/:id/translate-bulk',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const userId = getUserId(request, reply);
+      if (!userId) return;
+      const mandalaId = (request.params as { id: string }).id;
+
+      const jobId = await enqueueTranslateMandalaBulk(
+        { userId, mandalaId, trigger: 'add-cards-close' },
+        translateBulkEnqueueOptions(mandalaId)
+      ).catch(() => null);
+
+      return reply.send({ status: 'ok', data: { enqueued: jobId != null, jobId } });
+    }
+  );
 
   /**
    * PUT /api/v1/mandalas - Upsert default mandala with all levels (backward-compatible)

--- a/src/modules/queue/handlers/book-refill-debounce.ts
+++ b/src/modules/queue/handlers/book-refill-debounce.ts
@@ -19,3 +19,17 @@ const BOOK_REFILL_DEBOUNCE_SEC = 120;
 export function bookRefillEnqueueOptions(mandalaId: string): PgBoss.SendOptions {
   return { singletonKey: `book-fill-${mandalaId}`, startAfter: BOOK_REFILL_DEBOUNCE_SEC };
 }
+
+/**
+ * PR-T1 — debounce for the card-add-close bulk translation. Multiple closes (or
+ * a close fired alongside other events) collapse to ONE queued bulk pass per
+ * mandala; the short delay lets the just-added cards' rows settle first.
+ */
+const TRANSLATE_BULK_DEBOUNCE_SEC = 20;
+
+export function translateBulkEnqueueOptions(mandalaId: string): PgBoss.SendOptions {
+  return {
+    singletonKey: `translate-bulk-${mandalaId}`,
+    startAfter: TRANSLATE_BULK_DEBOUNCE_SEC,
+  };
+}

--- a/src/modules/queue/handlers/translate-mandala-bulk.ts
+++ b/src/modules/queue/handlers/translate-mandala-bulk.ts
@@ -1,0 +1,184 @@
+/**
+ * Translate-mandala-bulk worker (v2 translations — PR-T1).
+ *
+ * Trigger: the card-add panel CLOSE (one bulk job per mandala) — NOT per-card.
+ * Scans the mandala's placed videos whose v2 atom source_language differs from
+ * the mandala language and have NO stored translation yet, then translates each
+ * into the mandala language (Haiku via OpenRouter — the allowed SERVICE path).
+ *
+ * Cost levers (no Anthropic Batch API: OpenRouter has no -50% batch + Anthropic-
+ * direct is a Hard-Rule violation):
+ *   1. Dedup — skip videos whose translations[lang] already exists. The
+ *      translations jsonb is GLOBAL (video_rich_summaries.video_id PK), so a
+ *      translation made for any user is reused by all (same principle as #961).
+ *   2. One job per mandala (not per atom) — debounced singletonKey collects a
+ *      card-add burst into a single bulk pass.
+ *
+ * On completion, enqueues a book re-fill so the note/book-index re-renders with
+ * the translated atoms (same #958-style lazy re-reflection as v2 generation).
+ */
+
+import PgBoss from 'pg-boss';
+import { logger } from '@/utils/logger';
+import { getPrismaClient } from '@/modules/database/client';
+import { getMandalaManager } from '@/modules/mandala/manager';
+import { getJobQueue } from '../manager';
+import {
+  JOB_NAMES,
+  TRANSLATE_MANDALA_BULK_OPTIONS,
+  type TranslateMandalaBulkPayload,
+} from '../types';
+import { richSummaryWorkOptions } from './rich-summary-work-options';
+import { enqueueMandalaBookFill } from './mandala-book-fill';
+import { bookRefillEnqueueOptions } from './book-refill-debounce';
+
+const log = logger.child({ module: 'queue/translate-mandala-bulk' });
+
+// Low volume (one job per panel-close); trap-proof option shape so raising this
+// later actually parallelizes (CP498 teamSize:1 serial trap). Named constant.
+const TRANSLATE_BULK_CONCURRENCY = 2;
+
+export async function registerTranslateMandalaBulkWorker(): Promise<void> {
+  const boss = getJobQueue().getInstance();
+  await boss.work<TranslateMandalaBulkPayload>(
+    JOB_NAMES.TRANSLATE_MANDALA_BULK,
+    richSummaryWorkOptions(TRANSLATE_BULK_CONCURRENCY),
+    handleTranslateMandalaBulk
+  );
+  log.info('translate-mandala-bulk worker registered', {
+    concurrency: TRANSLATE_BULK_CONCURRENCY,
+  });
+}
+
+export async function handleTranslateMandalaBulk(
+  job: PgBoss.Job<TranslateMandalaBulkPayload>
+): Promise<void> {
+  const { userId, mandalaId } = job.data ?? ({} as TranslateMandalaBulkPayload);
+  if (!userId || !mandalaId) {
+    log.warn('translate-mandala-bulk: missing userId/mandalaId, dropping', { jobId: job.id });
+    return;
+  }
+
+  const prisma = getPrismaClient();
+
+  // Mandala language = display language. Only ko/en supported.
+  const mandala = await getMandalaManager().getMandalaById(userId, mandalaId);
+  const targetLang: 'ko' | 'en' | null = mandala ? (mandala.language === 'en' ? 'en' : 'ko') : null;
+  if (!targetLang) {
+    log.warn('translate-mandala-bulk: mandala not found, dropping', { jobId: job.id, mandalaId });
+    return;
+  }
+
+  // Placed video ids across both user-scoped tables (cell_index >= 0).
+  const [videoStates, localCards] = await Promise.all([
+    prisma.userVideoState.findMany({
+      where: { user_id: userId, mandala_id: mandalaId, cell_index: { gte: 0 } },
+      select: { video: { select: { youtube_video_id: true } } },
+    }),
+    prisma.user_local_cards.findMany({
+      where: { user_id: userId, mandala_id: mandalaId, cell_index: { gte: 0 } },
+      select: { video_id: true },
+    }),
+  ]);
+  const videoIds = Array.from(
+    new Set(
+      [
+        ...videoStates.map((r) => r.video?.youtube_video_id),
+        ...localCards.map((r) => r.video_id),
+      ].filter((v): v is string => Boolean(v))
+    )
+  );
+  if (videoIds.length === 0) {
+    log.info('translate-mandala-bulk: no placed videos', { jobId: job.id, mandalaId });
+    return;
+  }
+
+  // Candidates = complete v2 whose source language differs from the mandala
+  // language. The actual dedup (translations[lang] exists) + failure-cap is
+  // applied per-row below via the translator's own guards.
+  const rows = await prisma.video_rich_summaries.findMany({
+    where: {
+      video_id: { in: videoIds },
+      template_version: 'v2',
+      source_language: { not: targetLang },
+    },
+    select: {
+      video_id: true,
+      one_liner: true,
+      core: true,
+      analysis: true,
+      segments: true,
+      translations: true,
+      source_language: true,
+    },
+  });
+
+  // Lazy import keeps the queue boot path free of the translator import chain.
+  const { getStoredTranslation, translateAndStore } =
+    await import('@/modules/skills/rich-summary-translator');
+
+  let translated = 0;
+  let skipped = 0;
+  let failed = 0;
+  for (const row of rows) {
+    // No usable atoms (segments null) → nothing to translate.
+    if (row.segments == null) {
+      skipped += 1;
+      continue;
+    }
+    // Dedup — global translation already present ⇒ reuse, no LLM call.
+    if (getStoredTranslation(row.translations, targetLang)) {
+      skipped += 1;
+      continue;
+    }
+    const out = await translateAndStore({
+      videoId: row.video_id,
+      targetLang,
+      payload: {
+        one_liner: row.one_liner ?? null,
+        core: row.core ?? null,
+        analysis: row.analysis ?? null,
+        segments: row.segments ?? null,
+      },
+      translations: row.translations,
+    });
+    if (out) translated += 1;
+    else failed += 1;
+  }
+
+  log.info('translate-mandala-bulk done', {
+    jobId: job.id,
+    mandalaId,
+    targetLang,
+    candidates: rows.length,
+    translated,
+    skipped,
+    failed,
+  });
+
+  // Re-reflect — when any translation was stored, re-fill the book so the note /
+  // book-index renders the translated atoms (PR-T2 reads translations[lang]).
+  if (translated > 0) {
+    await enqueueMandalaBookFill(
+      { userId, mandalaId, trigger: 'translate-bulk-complete' },
+      bookRefillEnqueueOptions(mandalaId)
+    ).catch((err) => {
+      log.warn('translate-mandala-bulk: book re-fill enqueue failed (non-fatal)', {
+        mandalaId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
+}
+
+/** Enqueue a bulk-translate job for one mandala. Returns the pg-boss job id (or null). */
+export async function enqueueTranslateMandalaBulk(
+  payload: TranslateMandalaBulkPayload,
+  options?: PgBoss.SendOptions
+): Promise<string | null> {
+  const boss = getJobQueue().getInstance();
+  return boss.send(JOB_NAMES.TRANSLATE_MANDALA_BULK, payload, {
+    ...TRANSLATE_MANDALA_BULK_OPTIONS,
+    ...options,
+  });
+}

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -33,6 +33,7 @@ import { registerEnrichRelevanceQuickWorker } from './handlers/enrich-relevance-
 import { registerPoolServeFillWorker } from './handlers/pool-serve-fill';
 import { registerMandalaActionsFillWorker } from './handlers/mandala-actions-fill';
 import { registerMandalaBookFillWorker } from './handlers/mandala-book-fill';
+import { registerTranslateMandalaBulkWorker } from './handlers/translate-mandala-bulk';
 import { registerSegmentRelevanceFillWorker } from './handlers/segment-relevance-fill';
 import { registerDeckBuildWorker } from './handlers/deck-build';
 import { logger } from '../../utils/logger';
@@ -58,6 +59,7 @@ export async function initJobQueue(): Promise<void> {
   await registerPoolServeFillWorker();
   await registerMandalaActionsFillWorker();
   await registerMandalaBookFillWorker();
+  await registerTranslateMandalaBulkWorker();
   await registerSegmentRelevanceFillWorker();
   await registerDeckBuildWorker();
 

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -52,6 +52,12 @@ export const JOB_NAMES = {
    */
   MANDALA_BOOK_FILL: 'mandala-book-fill',
   /**
+   * v2 translations (PR-T1) — bulk-translate a mandala's off-language v2 atoms
+   * into the mandala language. Triggered on card-add panel CLOSE (one job per
+   * mandala, debounced). Dedup + global translations cache; OpenRouter Haiku.
+   */
+  TRANSLATE_MANDALA_BULK: 'translate-mandala-bulk',
+  /**
    * Deck build (③ e2e) — assemble book_json + figures, call slidegen
    * /slides/build (job poll), store the returned presigned pptx_url in
    * slide_decks. Worker = handleDeckBuild.
@@ -311,6 +317,20 @@ export const MANDALA_BOOK_FILL_OPTIONS = {
 } as const;
 
 export interface MandalaBookFillPayload {
+  userId: string;
+  mandalaId: string;
+  trigger?: string;
+}
+
+/** PR-T1 — bulk-translate options. singletonKey is set per-mandala at enqueue. */
+export const TRANSLATE_MANDALA_BULK_OPTIONS = {
+  retryLimit: 2,
+  retryDelay: 30,
+  retryBackoff: true,
+  expireInMinutes: 15,
+} as const;
+
+export interface TranslateMandalaBulkPayload {
   userId: string;
   mandalaId: string;
   trigger?: string;

--- a/src/modules/skills/rich-summary-translator.ts
+++ b/src/modules/skills/rich-summary-translator.ts
@@ -1,0 +1,210 @@
+/**
+ * v2 rich-summary translations (CP499+ 출시 트랙, James-approved 4-axis design).
+ *
+ * Storage: the RESERVED `video_rich_summaries.translations` jsonb (CP437 v2
+ * schema, Phase 2 seat — zero schema change):
+ *   { "<lang>": { one_liner, core, analysis, segments },
+ *     "_failures": { "<lang>": { n, last_at } } }
+ *
+ * - New rows: enrich-time co-generation when mandala language ≠ source
+ *   language (ko video on ko mandala = no call, cost 0).
+ * - Existing rows: on-demand at display time (translate → store; revisit is
+ *   0-cost). Fail-open: translation failure serves the original, and after
+ *   MAX_TRANSLATE_FAILURES the original is pinned (no per-view re-fire).
+ * - Structure preservation is VERIFIED (#896 lineage): parse mirrors the
+ *   proven fence/brace strip, then key-shape equality vs the source payload
+ *   (same keys, same array lengths, numbers/booleans byte-equal). Any
+ *   mismatch = failure.
+ */
+
+import { logger } from '@/utils/logger';
+import { getPrismaClient } from '@/modules/database';
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import {
+  RICH_SUMMARY_TRANSLATE_MODEL,
+  RICH_SUMMARY_TRANSLATE_TEMPERATURE,
+  RICH_SUMMARY_TRANSLATE_MAX_TOKENS,
+  buildRichSummaryTranslatePrompt,
+} from '@/prompts/rich-summary-translator';
+
+const log = logger.child({ module: 'rich-summary-translator' });
+
+export const MAX_TRANSLATE_FAILURES = 3;
+
+export type TranslateLang = 'ko' | 'en';
+
+export interface TranslatablePayload {
+  one_liner: string | null;
+  core: unknown;
+  analysis: unknown;
+  segments: unknown;
+}
+
+export type GenerateImpl = (
+  prompt: string,
+  opts?: { temperature?: number; maxTokens?: number; format?: 'json' }
+) => Promise<string>;
+
+interface TranslationsShape {
+  [lang: string]: unknown;
+  _failures?: Record<string, { n: number; last_at: string }>;
+}
+
+// ─── translations jsonb accessors ───────────────────────────────────────────
+
+export function getStoredTranslation(
+  translations: unknown,
+  lang: TranslateLang
+): TranslatablePayload | null {
+  if (!translations || typeof translations !== 'object') return null;
+  const t = (translations as TranslationsShape)[lang];
+  if (!t || typeof t !== 'object') return null;
+  return t as TranslatablePayload;
+}
+
+export function translationFailureCount(translations: unknown, lang: TranslateLang): number {
+  if (!translations || typeof translations !== 'object') return 0;
+  const f = (translations as TranslationsShape)._failures?.[lang];
+  return typeof f?.n === 'number' ? f.n : 0;
+}
+
+// ─── structure verification (#896 lineage) ──────────────────────────────────
+
+/**
+ * Recursive key-shape equality: objects must have the SAME key set, arrays
+ * the SAME length (elementwise recursion), and numbers/booleans must be
+ * byte-equal (translation may only change strings). Null/undefined must
+ * match in kind. Strings are free to differ.
+ */
+export function sameShape(src: unknown, out: unknown): boolean {
+  if (src === null || src === undefined) return out === null || out === undefined;
+  if (typeof src === 'string') return typeof out === 'string';
+  if (typeof src === 'number' || typeof src === 'boolean') return src === out;
+  if (Array.isArray(src)) {
+    if (!Array.isArray(out) || out.length !== src.length) return false;
+    return src.every((v, i) => sameShape(v, out[i]));
+  }
+  if (typeof src === 'object') {
+    if (typeof out !== 'object' || out === null || Array.isArray(out)) return false;
+    const sk = Object.keys(src as Record<string, unknown>).sort();
+    const ok = Object.keys(out as Record<string, unknown>).sort();
+    if (sk.length !== ok.length || sk.some((k, i) => k !== ok[i])) return false;
+    return sk.every((k) =>
+      sameShape((src as Record<string, unknown>)[k], (out as Record<string, unknown>)[k])
+    );
+  }
+  return false;
+}
+
+/** Fence/brace strip + JSON.parse, mirroring the proven #896 parser shape. */
+export function parseTranslateResponse(raw: string): unknown | null {
+  let text = (raw ?? '').trim();
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fence?.[1]) text = fence[1].trim();
+  const brace = text.match(/\{[\s\S]*\}/);
+  if (brace) text = brace[0];
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+// ─── translate ──────────────────────────────────────────────────────────────
+
+/**
+ * Translate the v2 payload. Fail-open: any failure (LLM error, parse fail,
+ * SHAPE MISMATCH) returns null — the caller records the failure and serves
+ * the original.
+ */
+export async function translateRichSummaryPayload(
+  payload: TranslatablePayload,
+  targetLang: TranslateLang,
+  opts: { generateImpl?: GenerateImpl } = {}
+): Promise<TranslatablePayload | null> {
+  const generate =
+    opts.generateImpl ??
+    ((p: string, o?: { temperature?: number; maxTokens?: number; format?: 'json' }) =>
+      new OpenRouterGenerationProvider(RICH_SUMMARY_TRANSLATE_MODEL).generate(p, o));
+
+  try {
+    const raw = await generate(buildRichSummaryTranslatePrompt(payload, targetLang), {
+      temperature: RICH_SUMMARY_TRANSLATE_TEMPERATURE,
+      maxTokens: RICH_SUMMARY_TRANSLATE_MAX_TOKENS,
+      format: 'json',
+    });
+    const parsed = parseTranslateResponse(raw);
+    if (!parsed) {
+      log.warn(`v2-translate parse failed (lang=${targetLang}) — fail-open`);
+      return null;
+    }
+    if (!sameShape(payload, parsed)) {
+      log.warn(`v2-translate SHAPE MISMATCH (lang=${targetLang}) — fail-open (#896 lineage)`);
+      return null;
+    }
+    return parsed as TranslatablePayload;
+  } catch (err) {
+    log.warn(
+      `v2-translate LLM call failed (lang=${targetLang}) — fail-open: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return null;
+  }
+}
+
+// ─── translate + persist (failure-cap aware) ────────────────────────────────
+
+export interface TranslateAndStoreInput {
+  videoId: string;
+  targetLang: TranslateLang;
+  payload: TranslatablePayload;
+  /** Current translations jsonb (for failure count + merge). */
+  translations: unknown;
+  generateImpl?: GenerateImpl;
+}
+
+/**
+ * Translate and persist into the translations jsonb. Returns the stored
+ * payload, or null when translation failed or the failure cap is reached
+ * (cap ⇒ no LLM call at all — the original is pinned).
+ */
+export async function translateAndStore(
+  input: TranslateAndStoreInput
+): Promise<TranslatablePayload | null> {
+  const { videoId, targetLang, payload } = input;
+  const prisma = getPrismaClient();
+
+  const failures = translationFailureCount(input.translations, targetLang);
+  if (failures >= MAX_TRANSLATE_FAILURES) return null;
+
+  const translated = await translateRichSummaryPayload(payload, targetLang, {
+    generateImpl: input.generateImpl,
+  });
+
+  const base =
+    input.translations && typeof input.translations === 'object'
+      ? { ...(input.translations as TranslationsShape) }
+      : ({} as TranslationsShape);
+
+  if (translated) {
+    base[targetLang] = translated;
+    await prisma.video_rich_summaries.update({
+      where: { video_id: videoId },
+      data: { translations: base as object },
+    });
+    log.info(`v2-translate stored: video=${videoId} lang=${targetLang}`);
+    return translated;
+  }
+
+  base._failures = {
+    ...(base._failures ?? {}),
+    [targetLang]: { n: failures + 1, last_at: new Date().toISOString() },
+  };
+  await prisma.video_rich_summaries.update({
+    where: { video_id: videoId },
+    data: { translations: base as object },
+  });
+  log.warn(
+    `v2-translate failure recorded: video=${videoId} lang=${targetLang} n=${failures + 1}/${MAX_TRANSLATE_FAILURES}`
+  );
+  return null;
+}

--- a/src/prompts/rich-summary-translator.ts
+++ b/src/prompts/rich-summary-translator.ts
@@ -1,0 +1,33 @@
+/**
+ * v2 rich-summary translation prompt (CP499+ 출시 트랙).
+ *
+ * Structure-preserving: the LLM receives the EXACT nested JSON and must
+ * return the SAME shape with only human-readable string values translated.
+ * Numbers / booleans / ids / timestamps / URLs stay byte-identical — the
+ * caller verifies key-shape equality after parse (#896 lineage: LLMs
+ * routinely bend output formats; verification is mandatory, not optional).
+ */
+
+export const RICH_SUMMARY_TRANSLATE_MODEL = 'anthropic/claude-haiku-4.5';
+export const RICH_SUMMARY_TRANSLATE_TEMPERATURE = 0.1;
+export const RICH_SUMMARY_TRANSLATE_MAX_TOKENS = 8000;
+
+const TARGET_LABEL: Record<string, string> = {
+  ko: 'Korean',
+  en: 'English',
+};
+
+export function buildRichSummaryTranslatePrompt(payload: unknown, targetLang: 'ko' | 'en'): string {
+  const target = TARGET_LABEL[targetLang] ?? targetLang;
+  return [
+    `Translate every human-readable string value in this JSON to natural ${target}.`,
+    'STRICT rules:',
+    '- Return ONLY the JSON object, with EXACTLY the same keys and array lengths.',
+    '- Do NOT translate or alter: numbers, booleans, ids, timestamps (e.g. "12:34"),',
+    '  URLs, video ids, percentages, or enum-like machine values.',
+    '- Proper nouns / tool names stay as-is.',
+    '- No commentary, no markdown fence.',
+    '',
+    JSON.stringify(payload),
+  ].join('\n');
+}

--- a/tests/unit/modules/rich-summary-translator.test.ts
+++ b/tests/unit/modules/rich-summary-translator.test.ts
@@ -1,0 +1,64 @@
+/**
+ * v2 translations (PR-T1) — sameShape guard validates the v2 atom/section
+ * structure. Structure-preserving mock (NO live OpenRouter); sameShape must pass
+ * the real-shape payload and reject a shape mismatch.
+ */
+process.env['ENCRYPTION_SECRET'] ??=
+  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+import {
+  translateRichSummaryPayload,
+  sameShape,
+  getStoredTranslation,
+} from '../../../src/modules/skills/rich-summary-translator';
+
+// Structurally faithful v2 payload (one_liner/core/analysis/segments{atoms,sections}).
+const PAYLOAD = {
+  one_liner: 'A short English summary.',
+  core: { thesis: 'Main point in English', tags: ['cloud', 'docker'] },
+  analysis: {
+    entities: [{ name: 'Docker', kind: 'tool' }],
+    key_concepts: ['containers', 'images'],
+    core_argument: 'Containers remove guest-OS overhead.',
+  },
+  segments: {
+    atoms: [
+      { timestamp_sec: 12, text: 'Docker uses the host kernel.' },
+      { timestamp_sec: 48, text: 'Images are layered.' },
+    ],
+    sections: [{ title: 'Basics', narrative: 'An English narrative.' }],
+  },
+};
+
+function translateLeaves(v: any): any {
+  if (typeof v === 'string') return v.length ? '[ko] ' + v : v;
+  if (Array.isArray(v)) return v.map(translateLeaves);
+  if (v && typeof v === 'object') {
+    const o: any = {};
+    for (const k of Object.keys(v)) o[k] = translateLeaves(v[k]);
+    return o;
+  }
+  return v;
+}
+
+describe('rich-summary-translator — sameShape guard', () => {
+  const mock = async () => JSON.stringify(translateLeaves(PAYLOAD));
+
+  it('structure-preserving translation → translateRichSummaryPayload non-null + sameShape true', async () => {
+    const out = await translateRichSummaryPayload(PAYLOAD as any, 'ko', { generateImpl: mock });
+    expect(out).not.toBeNull();
+    expect(sameShape(PAYLOAD, out)).toBe(true);
+  });
+
+  it('shape mismatch (dropped segments) → sameShape false (guard catches)', () => {
+    const broken = JSON.parse(JSON.stringify(translateLeaves(PAYLOAD)));
+    delete broken.segments;
+    expect(sameShape(PAYLOAD, broken)).toBe(false);
+  });
+
+  it('getStoredTranslation reads the lang key + null when absent', () => {
+    expect(getStoredTranslation({ ko: { x: 1 } }, 'ko')).toEqual({ x: 1 });
+    expect(getStoredTranslation({ ko: { x: 1 } }, 'en')).toBeNull();
+    expect(getStoredTranslation(null, 'ko')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 목적
ko 만다라가 영문-소스 v2(수동 추가 영문 카드)를 표시. **v2 생성은 소스언어 고정 불변**(영어영상→영어 v2, 전역캐시 무손상) + **ko 번역 파생 레이어**를 만다라 언어≠소스언어일 때만 표시.

## 구현
- **파킹된 a6957f62 translator skill 부활**(git-restore, 동일 코드, sameShape 가드가 **현 v2 atom/section 구조 통과** jest 검증) + **RESERVED `video_rich_summaries.translations` jsonb** 저장(lang 키, 전역 PK 행=파생, atom 무손상). **스키마 변경 0.**
- **트리거 = 카드추가 닫힘 → 만다라당 debounced 벌크 1잡** (per-card/per-select 아님). insert 무변경 = 표시 레이어만.
  - `TRANSLATE_MANDALA_BULK` 잡: source_language≠만다라언어인 배치 영상 스캔 → 만다라 언어로 번역.
  - **dedup**: `translations[lang]` 존재분 skip — jsonb 전역 → 타 사용자 번역 재사용(#961 원리).
  - 완료 → **book re-fill(#958류)** → 노트/북인덱스 번역 atom 재렌더 (PR-T2가 fill-book서 translations[lang] read).
  - FE: AddCardsPanel.handleClose가 기존 relevance 트리거 옆에 translateMandalaBulk fire (동일 guard, fire-and-forget).
- 모델 = `anthropic/claude-haiku-4.5` 구조보존 JSON, cost_usd 자동계측(#962).

## ★ -50% 배치 불가 (정직)
OpenRouter는 배치 할인 없음 + Anthropic-direct는 HARD RULE 위반 → **-50% 배치 제외.** 비용 레버 = **dedup(전역 재사용) + 1잡 벌크 구조.**

## 검증
jest 3/3, BE tsc0/lint0, FE tsc0/lint0/build, url-contract 1/1, 스모크 200. **live Haiku shape 충실도 = prod 서비스 경로(허용)로 첫 카드추가-닫힘 시 검증** (James (e)). PR-T2(fill-book 노트뷰 sub) = 같은 트랙 다음.