### PR TITLE
feat(v2): 노트/북인덱스가 영문 atom의 한글 번역 렌더 (PR-T2)

### DIFF
--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -21,6 +21,7 @@ import {
 import { synthesizeCellTopics } from './topic-synthesis';
 import { enqueueEnrichRichSummary } from '@/modules/queue';
 import { enqueueRelevanceBackfillForMandala } from '@/modules/relevance/relevance-backfill-trigger';
+import { getStoredTranslation } from '@/modules/skills/rich-summary-translator';
 import type {
   RichSummaryAnalysis,
   RichSummarySegments,
@@ -129,8 +130,25 @@ export async function fillMandalaBook(params: {
   const videoIds = Array.from(new Set(placements.map((p) => p.videoId)));
   const v2Rows = await prisma.video_rich_summaries.findMany({
     where: { video_id: { in: videoIds }, template_version: 'v2' },
-    select: { video_id: true, analysis: true, segments: true, lora: true, quality_flag: true },
+    select: {
+      video_id: true,
+      analysis: true,
+      segments: true,
+      lora: true,
+      quality_flag: true,
+      // PR-T2 — translation derived layer. When the mandala language differs from
+      // the atom's source language, display the stored ko/en translation instead
+      // of the source-language atoms. v2 atoms stay source-language-fixed (global
+      // cache untouched); this is a DISPLAY substitution only.
+      source_language: true,
+      translations: true,
+    },
   });
+
+  // Display language = mandala language (ko default). Off-language atoms are
+  // substituted with their stored translation if present (PR-T1 populates it on
+  // card-add close; absent ⇒ source-language atoms shown until it lands).
+  const displayLang: 'ko' | 'en' = mandala.language === 'en' ? 'en' : 'ko';
 
   const v2ByVideo = new Map<string, V2Columns>();
   // Terminally-skipped videos (quality_flag='skipped' = no transcript / un-enrichable).
@@ -141,9 +159,17 @@ export async function fillMandalaBook(params: {
   for (const row of v2Rows) {
     if (row.quality_flag === 'skipped') terminallySkipped.add(row.video_id);
     if (row.segments == null) continue; // no time-segments → not a usable 살붙임 source
+    // PR-T2 — substitute the translated atoms when this atom's source language
+    // differs from the display language AND a translation is stored. The
+    // translation mirrors the v2 structure (sameShape-validated at store time),
+    // so analysis/segments are drop-in. Falls back to source atoms when absent.
+    const tr =
+      row.source_language && row.source_language !== displayLang
+        ? getStoredTranslation(row.translations, displayLang)
+        : null;
     v2ByVideo.set(row.video_id, {
-      analysis: (row.analysis ?? null) as RichSummaryAnalysis | null,
-      segments: (row.segments ?? null) as unknown as RichSummarySegments | null,
+      analysis: (tr?.analysis ?? row.analysis ?? null) as RichSummaryAnalysis | null,
+      segments: (tr?.segments ?? row.segments ?? null) as unknown as RichSummarySegments | null,
       lora: (row.lora ?? null) as RichSummaryLora | null,
     });
   }


### PR DESCRIPTION
## 목적
fill-book의 v2ByVideo 빌드가 **source_language ≠ 만다라(표시)언어인 atom을 저장된 번역으로 치환.** 노트뷰/북인덱스는 book_json으로 렌더 → ko 만다라가 영문-소스 v2를 **한글로 표시**(PR-T1이 카드추가-닫힘 시 저장한 번역).

## 변경 (fill-book만)
- v2Rows select += `source_language, translations` (131-146).
- `displayLang` = mandala.language ('en'→en, else ko).
- v2ByVideo 빌드 (159-175): source_language ≠ displayLang ∧ 번역 존재 시 → **번역 analysis/segments 사용**(저장 시 sameShape 검증 = drop-in). 없으면 소스 atom fallback(번역 도착 전까지; PR-T1의 #958류 재반영으로 book 재-fill).
- **v2 atom 소스언어 고정 불변**(전역 캐시 무손상) — 표시 치환만.

## §1④ 무영향
게이트(passesBookGate 185-235) + coverage 카운터는 v2ByVideo **존재/부재**를 읽고, 이 PR은 그걸 보존(v2 있는 영상은 번역 여부 무관 v2Done). 번역 치환은 게이트 **상류·직교.** 
**fill-book 라인범위(동시편집 조율)**: §1④ 게이트 185-235 ↔ PR-T2 atom-read 131-175 = **비겹침.**

## 검증
tsc0, lint0, book-gate 9/9 회귀. **PR-T3(side-panel route+FE+롤링) 다음.** prod 검증 = James (e): ko 만다라 + 영문 카드 → 닫기 → translate-bulk + book 재-fill 완료 후 노트 한글 표시.