### PR TITLE
fix(book): stuck '준비 중' 스피너 — qf='low'를 v2-pending에서 제외

### DIFF
--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -151,13 +151,18 @@ export async function fillMandalaBook(params: {
   const displayLang: 'ko' | 'en' = mandala.language === 'en' ? 'en' : 'ko';
 
   const v2ByVideo = new Map<string, V2Columns>();
-  // Terminally-skipped videos (quality_flag='skipped' = no transcript / un-enrichable).
-  // §1④ must NOT re-enqueue these every fill (the enrich handler would re-throw
-  // NO_TRANSCRIPT each time = caption-fetch churn). They are absent from the book
-  // (no content) but excluded from the v2-pending enqueue.
+  // Terminal v2 rows — already attempted, cannot yield usable segments:
+  //   - 'skipped' = no transcript / un-enrichable (enrich re-throws NO_TRANSCRIPT)
+  //   - 'low'     = generated but below the segment-quality bar (no usable atoms)
+  // Both are absent from the book (no content) AND excluded from the v2-pending
+  // enqueue. Counting them as pending = infinite re-enqueue + a "준비 중" spinner
+  // that never completes (v2_pending stuck > 0). They remain in the left TOC (raw
+  // card list, unchanged here); their "생성 불가" label is PR3's TOC work.
   const terminallySkipped = new Set<string>();
   for (const row of v2Rows) {
-    if (row.quality_flag === 'skipped') terminallySkipped.add(row.video_id);
+    if (row.quality_flag === 'skipped' || row.quality_flag === 'low') {
+      terminallySkipped.add(row.video_id);
+    }
     if (row.segments == null) continue; // no time-segments → not a usable 살붙임 source
     // PR-T2 — substitute the translated atoms when this atom's source language
     // differs from the display language AND a translation is stored. The


### PR DESCRIPTION
## 문제 (측정)
만다라 90c2c872의 "N개 영상이 북인덱스에 추가되는 중" 스피너가 **영구 정체** (v2_pending=2 고정). 측정 root: 배치카드 2장이 **quality_flag='low' + segments=null** (v2 생성됐으나 쓸 segments 없음).

fill-book이 `terminallySkipped`에서 **`qf='skipped'`만 제외**(line 160) → `qf='low'`는 **pending에 카운트 + 매 fill 재enqueue** → enrich가 segments 못 만듦 → v2_pending>0 영구 → 스피너 안 끝남.

## 수정
`quality_flag IN ('skipped','low')` = terminal(쓸 segments 불가) → **둘 다 v2-pending 제외.** v2_pending → 0 → 스피너 종료.

## 화면 처리 (명시 — 유령카드 안 만듦)
- 범위 = **pending 카운트만.** 이 카드는 이미 본문에 없었고(segments null), **좌측 TOC(원시 카드목록)엔 그대로 남음**(이 fix 무관).
- **"생성 불가"/placeholder 라벨 = PR3 TOC 작업** (여기선 안 함). 이 hotfix는 **거짓 "추가 중" 스피너만 끔.**
- §1④/번역/note_documents 무관, 독립.

## 검증
tsc0, lint0, book-gate 9/9. prod 실측(James): (a) v2_pending→0 (b) enrich 재enqueue 루프 정지 (c) 스피너 사라짐.