### PR TITLE
fix(book): §1④ v2-pending 재enqueue cap — stuck 스피너 (전용 카운터, #968 대체)

### DIFF
--- a/src/modules/mandala-book/book-v2-retry.ts
+++ b/src/modules/mandala-book/book-v2-retry.ts
@@ -1,0 +1,33 @@
+/**
+ * §1④ v2-pending retry cap (PR: book-spinner-retry-cap).
+ *
+ * A placed card that passed the gate but has no usable v2 segments
+ * (quality_flag='low' = all generation attempts failed, INCLUDING transient
+ * provider errors — the reason is NOT persisted, so transient vs structural is
+ * indistinguishable) is re-enqueued by §1④. Without a cap that re-enqueue is
+ * infinite and the "준비 중" spinner (v2_pending > 0) never completes.
+ *
+ * The cap counter lives in video_rich_summaries.translations._book_v2_retry — a
+ * jsonb key the v2 generator + cron NEVER write (verified), so it survives the
+ * generator's quality_flag='low' overwrite (sharing the cron's low_retried flag
+ * was unsafe: the generator resets it, and §1④'s retry is async so it can't
+ * post-mark like the cron's synchronous retry).
+ *
+ * Standalone (no fill-book import) so it is unit-testable without the queue /
+ * google-auth module chain.
+ */
+
+/** Re-enqueue a still-pending (segments-less) v2 card at most this many times. */
+export const BOOK_V2_RETRY_CAP = 2;
+
+/** Read the §1④ dedicated retry counter from the translations jsonb. */
+export function readBookV2Retry(translations: unknown): number {
+  if (!translations || typeof translations !== 'object') return 0;
+  const n = (translations as Record<string, unknown>)['_book_v2_retry'];
+  return typeof n === 'number' && Number.isFinite(n) ? n : 0;
+}
+
+/** True when the card has been re-enqueued to the cap → treat as terminal. */
+export function bookV2RetryCapped(translations: unknown): boolean {
+  return readBookV2Retry(translations) >= BOOK_V2_RETRY_CAP;
+}

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -22,6 +22,7 @@ import { synthesizeCellTopics } from './topic-synthesis';
 import { enqueueEnrichRichSummary } from '@/modules/queue';
 import { enqueueRelevanceBackfillForMandala } from '@/modules/relevance/relevance-backfill-trigger';
 import { getStoredTranslation } from '@/modules/skills/rich-summary-translator';
+import { bookV2RetryCapped } from './book-v2-retry';
 import type {
   RichSummaryAnalysis,
   RichSummarySegments,
@@ -156,8 +157,15 @@ export async function fillMandalaBook(params: {
   // NO_TRANSCRIPT each time = caption-fetch churn). They are absent from the book
   // (no content) but excluded from the v2-pending enqueue.
   const terminallySkipped = new Set<string>();
+  // §1④ retry counts per video (translations._book_v2_retry). At the cap, the
+  // card is terminal (can't yield segments) → excluded from v2-pending so the
+  // spinner ends. NOT a blanket quality_flag='low' exclude (that would drop
+  // transiently-failed cards permanently — #968 was held for this reason).
   for (const row of v2Rows) {
-    if (row.quality_flag === 'skipped') terminallySkipped.add(row.video_id);
+    // Terminal: no-transcript skip, OR §1④ re-enqueued to the cap with no segments.
+    if (row.quality_flag === 'skipped' || bookV2RetryCapped(row.translations)) {
+      terminallySkipped.add(row.video_id);
+    }
     if (row.segments == null) continue; // no time-segments → not a usable 살붙임 source
     // PR-T2 — substitute the translated atoms when this atom's source language
     // differs from the display language AND a translation is stored. The
@@ -245,6 +253,25 @@ export async function fillMandalaBook(params: {
     if (enqueuedGlobal.has(videoId)) continue;
     enqueuedGlobal.add(videoId);
     const title = placements.find((p) => p.videoId === videoId)?.title ?? videoId;
+    // §1④ retry-cap — count this re-enqueue in the dedicated jsonb counter
+    // (atomic jsonb_set so concurrent fills don't lose increments). At the cap,
+    // the NEXT fill's terminallySkipped excludes this card → v2_pending drops →
+    // spinner ends. No-op when the row doesn't exist yet (first attempt); the
+    // enrich then creates the row and the counter applies on subsequent retries.
+    prisma
+      .$executeRawUnsafe(
+        `UPDATE video_rich_summaries
+         SET translations = jsonb_set(
+           COALESCE(translations, '{}'::jsonb),
+           '{_book_v2_retry}',
+           to_jsonb(COALESCE((translations->>'_book_v2_retry')::int, 0) + 1)
+         )
+         WHERE video_id = $1`,
+        videoId
+      )
+      .catch(() => {
+        /* counter bump is best-effort; a missed increment just allows one extra retry */
+      });
     enqueueEnrichRichSummary({ videoId, userId, mandalaId, title }).catch((err) => {
       log.warn('§1④ v2 enqueue failed (non-fatal)', {
         videoId,

--- a/tests/unit/modules/book-v2-retry.test.ts
+++ b/tests/unit/modules/book-v2-retry.test.ts
@@ -1,0 +1,26 @@
+/**
+ * §1④ retry-cap counter — translations._book_v2_retry. Dedicated jsonb counter
+ * (generator/cron never write translations) so v2-pending spinner can't stick on
+ * quality_flag='low' cards, while still giving transient failures CAP attempts
+ * (#968 blanket-exclude was held: it dropped transient cards permanently).
+ */
+import {
+  readBookV2Retry,
+  bookV2RetryCapped,
+  BOOK_V2_RETRY_CAP,
+} from '../../../src/modules/mandala-book/book-v2-retry';
+
+describe('book-v2-retry counter', () => {
+  it('reads the counter', () => expect(readBookV2Retry({ _book_v2_retry: 2 })).toBe(2));
+  it('missing key → 0', () => expect(readBookV2Retry({ ko: {} })).toBe(0));
+  it('null / non-object → 0', () => {
+    expect(readBookV2Retry(null)).toBe(0);
+    expect(readBookV2Retry('x')).toBe(0);
+  });
+  it('non-finite → 0', () => expect(readBookV2Retry({ _book_v2_retry: NaN })).toBe(0));
+  it('capped at CAP', () => {
+    expect(bookV2RetryCapped({ _book_v2_retry: BOOK_V2_RETRY_CAP })).toBe(true);
+    expect(bookV2RetryCapped({ _book_v2_retry: BOOK_V2_RETRY_CAP - 1 })).toBe(false);
+    expect(bookV2RetryCapped(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 문제 (#968 대체)
v2_pending=2 고정 → "준비 중" 스피너 영구. 2장 = quality_flag='low' + segments=null. §1④이 `qf='skipped'`만 pending 제외 → 'low'는 매 fill 재enqueue + pending 카운트 → 영구.

## #968 블랭킷 제외를 보류한 이유 (측정)
'low' = **전 생성 시도 실패(transient provider 에러 포함)** 후 마킹 + **사유 미영속**(log만) → transient/구조적 구분 불가. 블랭킷 제외 시 **transient로 'low' 된 카드 영구 손실**.

## 수정 — §1④ 전용 카운터 (quality_flag/low_retried 공유 아님)
- **`translations._book_v2_retry`** — v2 generator+cron이 **절대 안 쓰는 jsonb 키**(검증) → generator의 `quality_flag='low'` 덮어쓰기 생존. (low_retried 공유 불가: generator가 리셋 + §1④ retry는 비동기).
- **< CAP(2)**: 재enqueue(transient 기회) + atomic `jsonb_set` 증가.
- **≥ CAP**: terminallySkipped → pending 제외 → v2_pending 하락 → **스피너 종료.** 구조적 'low'는 CAP 후 정지, transient는 CAP 내 회복.
- quality_flag와 독립 → generator/cron 무간섭.

## 화면 (유령 방지 명시)
범위 = pending 카운트+retry만. capped 카드는 **좌측 TOC(원시 카드목록)에 그대로 남음**(이 fix 무관). "생성 불가" 라벨 = PR3 TOC 작업.

## 검증
jest **14/14**(카운터 reader + cap + book-gate 회귀), tsc0, lint0. prod 실측(James): (a) v2_pending→0, 스피너 사라짐 (b) transient 'low'는 CAP 내 회복(영구손실 0, #968 대조) (c) generator/cron이 카운터 안 건드림.