### PR TITLE
feat(note): PR3a — note_documents.based_on_book_version (stale 감지 기반, DDL+BE)

### DIFF
--- a/prisma/migrations/note_book_version/001_add_based_on_book_version.sql
+++ b/prisma/migrations/note_book_version/001_add_based_on_book_version.sql
@@ -1,0 +1,7 @@
+-- PR3a — note_documents.based_on_book_version: the mandala_books.version this
+-- note was generated from. Drives stale detection (book.version > this ⇒ the
+-- book was re-filled with new cards/translations ⇒ note is stale).
+-- prisma db push silent-fails on Supabase (auth-schema ownership) → apply this
+-- raw DDL on local + prod (psql "$DIRECT_URL" -f ...), verify \d note_documents,
+-- BEFORE deploying the code that SELECTs the column (PR2 GET-500 lesson).
+ALTER TABLE note_documents ADD COLUMN IF NOT EXISTS based_on_book_version integer NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -696,6 +696,10 @@ model note_documents {
   mandala_id    String        @db.Uuid
   content_json  Json          @db.JsonB
   original_json Json          @db.JsonB
+  /// PR3 — the mandala_books.version this note was generated from. note view
+  /// compares book.version > based_on_book_version ⇒ STALE (book re-filled with
+  /// new cards/translations) ⇒ user-triggered regenerate. 0 = pre-PR3 / unknown.
+  based_on_book_version Int     @default(0)
   created_at    DateTime      @default(now()) @db.Timestamptz(6)
   updated_at    DateTime      @default(now()) @updatedAt @db.Timestamptz(6)
   user          users         @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)

--- a/src/api/routes/note-documents.ts
+++ b/src/api/routes/note-documents.ts
@@ -48,6 +48,11 @@ const CreateBodySchema = z.object({
 
 const UpdateBodySchema = z.object({
   content_json: TiptapDocSchema,
+  // PR3 regenerate path (PR3b): when the note is rebuilt from a newer book, the
+  // client also pushes the fresh original_json + the book version it was built
+  // from. Both optional — a plain auto-save sends content_json only.
+  original_json: TiptapDocSchema.optional(),
+  based_on_book_version: z.number().int().nonnegative().optional(),
 });
 
 const ParamsByMandalaSchema = z.object({ mandalaId: UuidSchema });
@@ -87,6 +92,7 @@ export const noteDocumentsRoutes: FastifyPluginCallback = (fastify, _opts, done)
           mandala_id: doc.mandala_id,
           content_json: doc.content_json,
           original_json: doc.original_json,
+          based_on_book_version: doc.based_on_book_version,
           created_at: doc.created_at,
           updated_at: doc.updated_at,
         },
@@ -110,6 +116,14 @@ export const noteDocumentsRoutes: FastifyPluginCallback = (fastify, _opts, done)
         .send(createErrorResponse(ErrorCode.INVALID_INPUT, body.error.message, request.url));
     }
     const userId = request.user.userId;
+    // PR3 — stamp the book version this note is generated from, so the note view
+    // can later detect staleness (book.version > based_on_book_version). Looked
+    // up BE-side from the canonical mandala_books (SSOT); 0 when no book yet.
+    const bookRow = await prisma.mandala_books.findUnique({
+      where: { mandala_id: body.data.mandalaId },
+      select: { version: true },
+    });
+    const basedOnBookVersion = bookRow?.version ?? 0;
     // Upsert by unique (user_id, mandala_id) — first call creates, subsequent
     // calls are idempotent (e.g., concurrent first-paint races on different tabs).
     const doc = await prisma.note_documents.upsert({
@@ -119,6 +133,7 @@ export const noteDocumentsRoutes: FastifyPluginCallback = (fastify, _opts, done)
         mandala_id: body.data.mandalaId,
         content_json: body.data.content_json as Prisma.InputJsonValue,
         original_json: body.data.original_json as Prisma.InputJsonValue,
+        based_on_book_version: basedOnBookVersion,
       },
       update: {
         // Existing row: do NOT overwrite original_json. content_json sync
@@ -133,6 +148,7 @@ export const noteDocumentsRoutes: FastifyPluginCallback = (fastify, _opts, done)
           mandala_id: doc.mandala_id,
           content_json: doc.content_json,
           original_json: doc.original_json,
+          based_on_book_version: doc.based_on_book_version,
           created_at: doc.created_at,
           updated_at: doc.updated_at,
         },
@@ -167,7 +183,18 @@ export const noteDocumentsRoutes: FastifyPluginCallback = (fastify, _opts, done)
     // someone else's doc even if the id leaks.
     const result = await prisma.note_documents.updateMany({
       where: { id: params.data.id, user_id: userId },
-      data: { content_json: body.data.content_json as Prisma.InputJsonValue },
+      data: {
+        content_json: body.data.content_json as Prisma.InputJsonValue,
+        // PR3 regenerate: when the client rebuilds from a newer book it also
+        // pushes the fresh original_json + book version. Plain auto-save omits
+        // both → only content_json changes.
+        ...(body.data.original_json !== undefined
+          ? { original_json: body.data.original_json as Prisma.InputJsonValue }
+          : {}),
+        ...(body.data.based_on_book_version !== undefined
+          ? { based_on_book_version: body.data.based_on_book_version }
+          : {}),
+      },
     });
     if (result.count === 0) {
       return reply
@@ -185,6 +212,7 @@ export const noteDocumentsRoutes: FastifyPluginCallback = (fastify, _opts, done)
               mandala_id: doc.mandala_id,
               content_json: doc.content_json,
               original_json: doc.original_json,
+              based_on_book_version: doc.based_on_book_version,
               created_at: doc.created_at,
               updated_at: doc.updated_at,
             }


### PR DESCRIPTION
## PR3 기반 (note·TOC = book_json SSOT 뷰)
note가 어느 `mandala_books.version`서 생성됐는지 기록 → 노트뷰가 stale 감지(`book.version > based_on_book_version` = book 재-fill로 새 카드/번역 들어옴 = stale → 사용자 트리거 재생성). **FE 동작 변경 없음 — PR3b가 소비.**

## 변경
- **DDL**: `note_documents += based_on_book_version int default 0` (raw SQL `001`). ⚠️ **prod 선적용 + `\d` 검증 후 배포** — GET/POST/PUT이 컬럼 SELECT, 부재 시 500 (PR2 교훈). prisma schema 갱신.
- **POST create**: `based_on_book_version = 현 mandala_books.version` (BE에서 SSOT 조회, book 없으면 0).
- **PUT**: optional `original_json` + `based_on_book_version` 수용 → PR3b의 "새 book서 재생성"이 original_json 교체 + version 갱신을 한 콜에. 일반 auto-save는 content_json만.
- **GET/POST/PUT 응답**: based_on_book_version 반환 (PR3b가 book.version과 비교).

## 검증
tsc0, lint0. 백엔드 only. prod 검증: DDL 적용 → note 생성 → based_on_book_version == 그 만다라 book version.

## 다음 (직렬, 3a 후)
- **PR3b**: useNoteDocument stale 감지 + C안 (미편집/편집 둘 다 **사용자 트리거**, 편집보존 분기만).
- **PR3c**: LeftPanel TOC = book_json + **BE 단일계산** `{cell:{generated,preparing,failed}}` (FE 라벨만).

## ⚠️ 머지 후
DDL을 **prod에 먼저 수동 적용**(version SELECT 전 컬럼 보장) 후 배포.