### PR TITLE
feat(note): PR3b — stale 노트 배너 + 사용자 트리거 재생성 (편집보존)

### DIFF
--- a/frontend/src/pages/learning/model/useNoteDocument.ts
+++ b/frontend/src/pages/learning/model/useNoteDocument.ts
@@ -68,6 +68,11 @@ export interface UseNoteDocumentResult {
   /** Most recent server doc id (null while pre-create). */
   docId: string | null;
   saveStatus: SaveStatus;
+  /** PR3 — book was re-filled after this note was generated (new cards / translations). */
+  stale: boolean;
+  /** PR3 — user-triggered regenerate from the current book (edit-preserving). */
+  regenerate: () => Promise<void>;
+  regenerating: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -233,6 +238,46 @@ export function useNoteDocument(input: UseNoteDocumentInput): UseNoteDocumentRes
     }
   }, [docId, editor, mandalaId, queryClient]);
 
+  // 7b. Stale detection (PR3) — the book was re-filled (new cards / translations)
+  // AFTER this note was generated. We do NOT auto-overwrite (the user may be
+  // reading / have edits); we surface a banner and regenerate only on click.
+  const bookVersion = mandalaBook?.version ?? 0;
+  const noteBasedOn = docQuery.data?.based_on_book_version ?? 0;
+  const stale = Boolean(docQuery.data && mandalaBook && bookVersion > noteBasedOn);
+
+  const [regenerating, setRegenerating] = useState(false);
+
+  // 7c. Regenerate from the current book (user-triggered). Edit preservation
+  // (C안, whole-doc — per-section is not possible): unedited note (content ==
+  // original) is fully refreshed; an EDITED note keeps content_json and only
+  // refreshes original_json (the baseline) so the user's edits survive.
+  const regenerate = useCallback(async () => {
+    if (!docId || !editor || !mandalaBook) return;
+    setRegenerating(true);
+    try {
+      const fresh = await apiClient.getNoteDocument(mandalaId as string);
+      const current = (fresh?.content_json as TiptapDoc | null | undefined) ?? null;
+      const original = (fresh?.original_json as TiptapDoc | null | undefined) ?? null;
+      const edited = JSON.stringify(current) !== JSON.stringify(original);
+      const rebuilt = buildInitialNoteDoc(mandalaBook.book);
+      // Unedited → adopt the rebuilt doc for both. Edited → keep content, refresh
+      // baseline. Either way bump based_on_book_version so stale clears.
+      const nextContent = edited ? (current ?? rebuilt) : rebuilt;
+      await apiClient.updateNoteDocument(docId, nextContent, {
+        original_json: rebuilt,
+        based_on_book_version: mandalaBook.version,
+      });
+      if (!edited) {
+        editor.commands.setContent(rebuilt, false);
+        const histAny = (editor as unknown as { commands: { clearHistory?: () => void } }).commands;
+        if (typeof histAny.clearHistory === 'function') histAny.clearHistory();
+      }
+      if (mandalaId) queryClient.invalidateQueries({ queryKey: queryKey(mandalaId) });
+    } finally {
+      setRegenerating(false);
+    }
+  }, [docId, editor, mandalaBook, mandalaId, queryClient]);
+
   // 8. Save status surface.
   const saveStatus: SaveStatus = updateMutation.isPending
     ? 'saving'
@@ -251,5 +296,8 @@ export function useNoteDocument(input: UseNoteDocumentInput): UseNoteDocumentRes
     restoreOriginal,
     docId,
     saveStatus,
+    stale,
+    regenerate,
+    regenerating,
   };
 }

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -363,6 +363,22 @@ export function CenterPanel({
                 </span>
               </div>
             )}
+            {/* PR3b — note is behind the (settled) book: new cards/translations
+                landed after this note was generated. User-triggered refresh only
+                (no auto-overwrite); edits are preserved on regenerate. */}
+            {noteDoc.stale && (book?.coverage?.v2Pending ?? 0) === 0 && (
+              <div className="mx-auto mt-3 flex max-w-[680px] items-center justify-between gap-3 rounded-md border border-white/[0.07] bg-white/[0.03] px-3.5 py-2 text-[12px] text-muted-foreground">
+                <span>새 내용이 북인덱스에 추가됐어요. 노트를 새로고침하면 반영됩니다.</span>
+                <button
+                  type="button"
+                  onClick={() => void noteDoc.regenerate()}
+                  disabled={noteDoc.regenerating}
+                  className="shrink-0 rounded-md border border-white/[0.12] px-2.5 py-1 text-[12px] text-foreground transition-colors hover:bg-white/[0.06] disabled:opacity-50"
+                >
+                  {noteDoc.regenerating ? '새로고침 중…' : '새로고침'}
+                </button>
+              </div>
+            )}
             <NoteEditorView
               editor={noteDoc.editor}
               loading={noteDoc.loading}

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -233,6 +233,9 @@ export interface NoteDocumentResponse {
   mandala_id: string;
   content_json: unknown;
   original_json: unknown;
+  /** PR3 — the mandala_books.version this note was generated from. stale when
+   *  the current book.version is greater (book re-filled with new content). */
+  based_on_book_version?: number;
   created_at: string;
   updated_at: string;
 }
@@ -1193,11 +1196,28 @@ class ApiClient {
     return res.data.doc;
   }
 
-  /** Auto-save: update content_json only (original_json immutable). */
-  async updateNoteDocument(id: string, content_json: unknown): Promise<NoteDocumentResponse> {
+  /**
+   * Auto-save: update content_json. opts (PR3 regenerate) optionally rewrites
+   * original_json + based_on_book_version in the same call — used when the note
+   * is rebuilt from a newer book. Plain auto-save passes content_json only.
+   */
+  async updateNoteDocument(
+    id: string,
+    content_json: unknown,
+    opts?: { original_json?: unknown; based_on_book_version?: number }
+  ): Promise<NoteDocumentResponse> {
     const res = await this.request<{ success: boolean; data: { doc: NoteDocumentResponse } }>(
       `/note-documents/${id}`,
-      { method: 'PUT', body: JSON.stringify({ content_json }) }
+      {
+        method: 'PUT',
+        body: JSON.stringify({
+          content_json,
+          ...(opts?.original_json !== undefined ? { original_json: opts.original_json } : {}),
+          ...(opts?.based_on_book_version !== undefined
+            ? { based_on_book_version: opts.based_on_book_version }
+            : {}),
+        }),
+      }
     );
     return res.data.doc;
   }


### PR DESCRIPTION
## PR3a 소비 — stale 감지 + C안 배너
book이 재-fill(새 카드/번역)된 뒤 생성된 note는 뒤처짐. **C안**: 자동 덮어쓰기 **금지**(사용자가 읽는 중/편집분 있을 수 있음) → 배너 표시, **클릭 시에만 재생성.**

## 변경
- **useNoteDocument**: `stale = book.version > note.based_on_book_version`. `regenerate()` = 현 book서 재구성 + **편집보존(whole-doc)**:
  - 미편집(content==original) → 전체 새로고침.
  - **편집됨(content≠original) → content_json 보존, original_json(baseline)만 갱신** → 사용자 편집 생존.
  - 둘 다 based_on_book_version 갱신(PR3a PUT) → stale 해소.
- **CenterPanel**: "새 내용이 북인덱스에 추가됐어요 · 새로고침" 배너 — **stale ∧ v2_pending==0**일 때만(PR2 "준비 중" 스피너와 비중첩, 두 상태 구분: 채워지는 중 vs 채워졌으나 note 뒤처짐).

## 의의
book-fill/번역/coverage 변경이 **노트에 실제로 보이게** 하는 핵심 (노트뷰=note_documents 렌더, book_json 직접 아님 — stale 갭이 (c) root cause).

## ★조정1 반영
미편집도 **자동재생성 X** — 둘 다 사용자 트리거. 편집보존 분기만(미편집→전체/편집됨→content 보존+baseline 갱신).

## 검증
FE tsc0/lint0/url-contract 1/1/build/스모크200. **James 실측 게이트**(book_json 측정만으로 "완성" 금지): ko 만다라 note → "새로고침" → 새 카드/번역 반영 + 편집 보존 확인. (하드리로드 ×2/SW unregister.)

## 다음
PR3c (TOC = book_json + BE 단일계산 `{cell:{generated,preparing,failed}}`, FE 라벨만).