### PR TITLE
feat(note-toc): centerViewMode tab-branch + toc_label label source (PR3c-a + CP504)

### DIFF
--- a/frontend/src/features/card-management/model/useV2Summaries.ts
+++ b/frontend/src/features/card-management/model/useV2Summaries.ts
@@ -23,6 +23,8 @@ import { apiClient } from '@/shared/lib/api-client';
 export interface V2SummaryItem {
   videoId: string;
   oneLiner: string | null;
+  /** CP504 — short noun-form TOC label; null on legacy/quick rows (FE falls back to oneLiner). */
+  tocLabel: string | null;
   /**
    * CP474 — v2 `analysis.core_argument` (2-3 sentences capturing the
    * central thesis). Grid card blockquote prefers this over `oneLiner`

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -250,7 +250,7 @@ export function CenterPanel({
   return (
     <div className="flex flex-1 min-w-0 flex-col overflow-hidden pl-4 pr-3 pt-[5px]">
       <div
-        className={cn('shrink-0', centerViewMode === 'note' && 'hidden')}
+        className={cn('mt-2 shrink-0', centerViewMode === 'note' && 'hidden')}
         onMouseEnter={() => {
           setActiveRegion('player');
           onPlayerHoverIn?.();
@@ -359,7 +359,8 @@ export function CenterPanel({
               <div className="mx-auto mt-3 flex max-w-[680px] items-center gap-2 rounded-md border border-white/[0.07] bg-white/[0.03] px-3.5 py-2 text-[12px] text-muted-foreground">
                 <span className="inline-block h-3 w-3 shrink-0 animate-spin rounded-full border-[1.5px] border-current border-t-transparent" />
                 <span>
-                  {book?.coverage?.v2Pending}개 영상이 북인덱스에 추가되는 중이에요 · {book?.coverage?.v2Done}/{book?.coverage?.gatePassed} 완료
+                  {book?.coverage?.v2Pending}개 영상이 북인덱스에 추가되는 중이에요 ·{' '}
+                  {book?.coverage?.v2Done}/{book?.coverage?.gatePassed} 완료
                 </span>
               </div>
             )}
@@ -392,7 +393,10 @@ export function CenterPanel({
         ) : (
           // CP445.x — 본문 영역 max-width = 영상 (49.5vh*16/9) 동일 + mx-auto
           // 좌우 정렬. 영상 ↔ AI요약/섹션 시각 일관성.
-          <div className="mx-auto w-full p-4" style={{ maxWidth: 'calc(49.5vh * 16 / 9)' }}>
+          <div
+            className="mx-auto w-full p-4"
+            style={{ maxWidth: 'min(calc(49.5vh * 16 / 9), 760px)' }}
+          >
             {centerTab === 'summary' && (
               <PanelAISummary videoSummary={undefined} videoUrl={videoUrl} />
             )}

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1826,6 +1826,7 @@
     "qaLabel": "Q&A",
     "goal": "Learning Goal",
     "videoCount": "{{count}} videos",
+    "videoCountSummarizing": "{{count}} videos · {{pct}}% summarizing",
     "noVideos": "No videos yet",
     "chatTitle": "Learning Assistant",
     "chatInitial": "Ask questions about this video",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1834,6 +1834,7 @@
     "qaLabel": "Q&A",
     "goal": "학습 목표",
     "videoCount": "{{count}}개 영상",
+    "videoCountSummarizing": "{{count}}개 · {{pct}}% 요약 중",
     "noVideos": "아직 영상이 없습니다",
     "chatTitle": "학습 어시스턴트",
     "chatInitial": "이 영상에 대해 질문하세요",

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1044,10 +1044,10 @@ class ApiClient {
    * BE: POST /api/v1/mandalas/:id/translate-bulk. Fire-and-forget.
    */
   async translateMandalaBulk(mandalaId: string): Promise<void> {
-    await this.request<{ status: 'ok'; data: unknown }>(
-      `/mandalas/${mandalaId}/translate-bulk`,
-      { method: 'POST', body: JSON.stringify({}) }
-    );
+    await this.request<{ status: 'ok'; data: unknown }>(`/mandalas/${mandalaId}/translate-bulk`, {
+      method: 'POST',
+      body: JSON.stringify({}),
+    });
   }
 
   // ─── CP456 Billing (Lemon Squeezy, MoR subscription) ──────────────────────
@@ -1751,6 +1751,8 @@ class ApiClient {
       items: Array<{
         videoId: string;
         oneLiner: string | null;
+        /** CP504 — short noun-form TOC label; null on legacy/quick rows (FE falls back to oneLiner). */
+        tocLabel: string | null;
         /** CP474 — `analysis.core_argument`, the v2 essence (2-3 sentences). */
         coreArgument: string | null;
         /** Top `analysis.key_concepts[].term` values (≤ 3). */

--- a/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { BookOpen, ChevronRight, ChevronsDownUp, ChevronsUpDown, PanelTop } from 'lucide-react';
+import { BookOpen, ChevronsDownUp, ChevronsUpDown, PanelTop } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useMandalaQuery } from '@/features/mandala';
 import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
@@ -54,15 +54,13 @@ export function SidebarLearningSection({
     }
   }
 
-  // Group cards by cellIndex so each sub-goal lists its own videos.
-  // CP475+ — user directive 2026-05-20: "북인덱스의 항목은 - 북마크 후에만
-  // 생성되도록 해". Skip cards that the user hasn't bookmarked yet.
-  // `pinnedAt` is the server source-of-truth for "liked" / bookmarked.
-  const cardsByCell = useMemo(() => {
+  // PR3c-a — player tab "videos I collected": all cards in the cell.
+  // mandalaCards is already URL-deduped + cellIndex>=0 (useMandalaCards); no
+  // bookmark / v2-oneLiner gate (the list reflects what the user collected).
+  const cardsByCellAll = useMemo(() => {
     const map = new Map<number, InsightCard[]>();
     for (const card of mandalaCards) {
       if (typeof card.cellIndex !== 'number' || card.cellIndex < 1) continue;
-      if (!card.pinnedAt) continue; // bookmark gate
       const list = map.get(card.cellIndex) ?? [];
       list.push(card);
       map.set(card.cellIndex, list);
@@ -70,8 +68,10 @@ export function SidebarLearningSection({
     return map;
   }, [mandalaCards]);
 
-  // Pull v2 key-concept terms for every liked video so the sub-goal tree
-  // can render keyword-style book-index entries instead of raw titles.
+  // PR3c-a label source — v2 oneLiner per collected video. Player list shows
+  // only summarized videos (label = oneLiner) for a uniform look; videos still
+  // summarizing are omitted from the list and accounted for by the header
+  // "% 요약 중" progress. Bookmark gate stays removed (only the v2 filter).
   const likedVideoIds = useMemo(() => {
     const ids: string[] = [];
     for (const card of mandalaCards) {
@@ -183,8 +183,8 @@ export function SidebarLearningSection({
   const headerTooltip = centerLabelText && centerGoal ? centerGoal : undefined;
 
   return (
-    <div className="pl-5 pr-2 flex flex-col" onMouseEnter={() => setActiveRegion('sidebar')}>
-      <div className="px-3 py-2">
+    <div className="pl-2 pr-2 flex flex-col" onMouseEnter={() => setActiveRegion('sidebar')}>
+      <div className="px-2 py-2">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1">
             {headerTooltip ? (
@@ -205,14 +205,32 @@ export function SidebarLearningSection({
             )}
             {/* CP445 D18=B — 영상 모드 = 만다라 mapped 전체 영상 / 노트 모드 =
                 mandala_books 가 인용한 distinct vid 수 (필수 영상). */}
-            <p className="mt-0.5 text-[13px] text-sidebar-foreground/50">
-              {t('learning.videoCount', {
-                count:
-                  centerViewMode === 'note' && typeof bookResponse?.book?.source_videos === 'number'
-                    ? bookResponse.book.source_videos
-                    : mandalaCards.length,
-              })}
-            </p>
+            {(() => {
+              const headerCount =
+                centerViewMode === 'note' && typeof bookResponse?.book?.source_videos === 'number'
+                  ? bookResponse.book.source_videos
+                  : mandalaCards.length;
+              // §1④ book-fill progress — surface coverage, no new compute.
+              // v2Pending > 0 ⇒ "N · {pct}% 요약 중" + spinner; else "N 영상".
+              const coverage = bookResponse?.coverage;
+              if ((coverage?.v2Pending ?? 0) > 0) {
+                const pct =
+                  coverage && coverage.gatePassed > 0
+                    ? Math.round((coverage.v2Done / coverage.gatePassed) * 100)
+                    : 0;
+                return (
+                  <p className="mt-0.5 flex items-center gap-1.5 text-[13px] text-sidebar-foreground/50">
+                    <span className="inline-block h-3 w-3 shrink-0 animate-spin rounded-full border-[1.5px] border-current border-t-transparent" />
+                    <span>{t('learning.videoCountSummarizing', { count: headerCount, pct })}</span>
+                  </p>
+                );
+              }
+              return (
+                <p className="mt-0.5 text-[13px] text-sidebar-foreground/50">
+                  {t('learning.videoCount', { count: headerCount })}
+                </p>
+              );
+            })()}
           </div>
           <div className="mt-0.5 flex shrink-0 items-center gap-0.5">
             <Tooltip>
@@ -278,23 +296,45 @@ export function SidebarLearningSection({
           const rowLabel = labelText || goal;
           const rowTooltip = labelText && goal ? goal : undefined;
 
+          // Highlight the chapter (sector) that contains the active item, and
+          // keep it lit (mirrors the hover-bright look). note: activeSectionRef
+          // is in this chapter; player: a card in this cell == currentVideoId.
+          const chapterActive =
+            centerViewMode === 'note'
+              ? !!bookChapter && activeSectionRef?.chapterIdx === bookChapter.ch
+              : !!currentVideoId &&
+                (cardsByCellAll.get(idx + 1) ?? []).some((c) => {
+                  try {
+                    return extractYouTubeVideoId(new URL(c.videoUrl)) === currentVideoId;
+                  } catch {
+                    return false;
+                  }
+                });
+
           const chapterButton = (
             <button
               type="button"
               onClick={() => toggleChapter(idx)}
               className="group flex w-full items-center gap-2 px-2 py-1 text-left transition-colors"
             >
-              <ChevronRight
+              {/* §redesign — chapter number replaces the chevron (시안 .toc-chapter
+                  .n). Row click still toggles expand/collapse. */}
+              <span
                 className={cn(
-                  'h-3.5 w-3.5 shrink-0 text-sidebar-foreground/35 transition-colors group-hover:text-sidebar-foreground',
-                  isExpanded && 'rotate-90'
+                  'shrink-0 font-mono text-[11px] tabular-nums transition-colors',
+                  chapterActive ? 'text-sidebar-foreground/80' : 'text-sidebar-foreground/35'
                 )}
-              />
-              {/* §redesign — chapter numbering "01·02·03" (시안 .toc-chapter .n) */}
-              <span className="shrink-0 font-mono text-[11px] tabular-nums text-sidebar-foreground/35">
+              >
                 {String(idx + 1).padStart(2, '0')}
               </span>
-              <span className="flex-1 truncate text-[11px] font-semibold uppercase tracking-[0.10em] text-sidebar-foreground/55 transition-colors group-hover:text-sidebar-foreground/80">
+              <span
+                className={cn(
+                  'flex-1 truncate text-[11px] font-semibold uppercase tracking-[0.10em] transition-colors',
+                  chapterActive
+                    ? 'text-sidebar-foreground/80'
+                    : 'text-sidebar-foreground/55 group-hover:text-sidebar-foreground/80'
+                )}
+              >
                 {rowLabel}
               </span>
             </button>
@@ -312,8 +352,16 @@ export function SidebarLearningSection({
                 chapterButton
               )}
 
-              {isExpanded && bookChapter && (
-                <div className="ml-9 pt-0.5">
+              {/* PR3c-a — branch the TOC by centerViewMode so the two SSOTs
+                  never co-render (was: both blocks always rendered → one video
+                  highlighted as oneLiner AND auto-set section = double-select +
+                  1px/2px asymmetry, James-observed prod bug).
+                  note   = book sections (SSOT book_json). active = activeSectionRef
+                           (disambiguates a vid cited by multiple sections).
+                  player = collected cards (SSOT cards). active = vid===currentVideoId.
+                  Same 2px bar in both; one block per tab = bug structurally gone. */}
+              {isExpanded && centerViewMode === 'note' && bookChapter && (
+                <div className="ml-3.5 pt-0.5">
                   <BookChapterPreview
                     chapter={bookChapter}
                     mandalaId={mandalaId}
@@ -326,18 +374,10 @@ export function SidebarLearningSection({
                   />
                 </div>
               )}
-              {/* Book-index entries: keyword tokens distilled from v2
-                  analysis.key_concepts. Cards without a v2 row are
-                  omitted; they reappear once enrich-rich-summary lands. */}
               {isExpanded &&
+                centerViewMode === 'player' &&
                 (() => {
-                  const cellCards = cardsByCell.get(idx + 1) ?? [];
-                  // CP475+ — user directive 2026-05-20: entry text = v2
-                  // core.one_liner only (없으면 entry 자체 미표시). 3-4초
-                  // 안에 fast-path 가 oneLiner 채우므로 잠시 entry 부재는
-                  // 자연스러움. Previous keyConcepts joined pattern
-                  // "체크 · 준비 기간" was rejected as low quality.
-                  const indexedEntries = cellCards
+                  const entries = (cardsByCellAll.get(idx + 1) ?? [])
                     .map((card) => {
                       let vid: string | null = null;
                       try {
@@ -346,31 +386,31 @@ export function SidebarLearningSection({
                         vid = null;
                       }
                       if (!vid) return null;
+                      // CP504 — TOC label = short toc_label; fall back to oneLiner
+                      // when a v2 row predates toc_label (legacy/quick rows).
                       const v2 = summariesByVideoId.get(vid);
-                      const oneLiner = v2?.oneLiner?.trim();
-                      if (!oneLiner) return null;
-                      return { cardId: card.id, vid, indexName: oneLiner };
+                      const label = v2?.tocLabel?.trim() || v2?.oneLiner?.trim();
+                      if (!label) return null; // not yet summarized → header accounts for it
+                      return { cardId: card.id, vid, label };
                     })
-                    .filter(
-                      (e): e is { cardId: string; vid: string; indexName: string } => e !== null
-                    );
-                  if (indexedEntries.length === 0) return null;
+                    .filter((e): e is { cardId: string; vid: string; label: string } => e !== null);
+                  if (entries.length === 0) return null;
                   return (
-                    <ul className="ml-9 pt-0.5">
-                      {indexedEntries.map((entry) => {
+                    <ul className="ml-3.5 pt-0.5">
+                      {entries.map((entry) => {
                         const isActive = entry.vid === currentVideoId;
                         return (
                           <li
                             key={entry.cardId}
                             onClick={() => navigate(`/learning/${mandalaId}/${entry.vid}`)}
                             className={cn(
-                              'cursor-pointer pl-3 py-1.5 leading-[1.5] border-l transition-colors',
+                              'cursor-pointer pl-3.5 py-1.5 leading-[1.5] transition-colors',
                               isActive
-                                ? 'border-sidebar-primary text-[14px] font-medium text-sidebar-primary'
-                                : 'border-sidebar-foreground/10 text-[13px] text-sidebar-foreground/80 hover:border-sidebar-foreground/50 hover:text-sidebar-foreground'
+                                ? 'border-l-2 border-sidebar-primary text-[14px] font-medium text-sidebar-primary'
+                                : 'border-l border-sidebar-foreground/10 text-[13px] text-sidebar-foreground/50 hover:border-sidebar-foreground/50 hover:text-sidebar-foreground'
                             )}
                           >
-                            {entry.indexName}
+                            {entry.label}
                           </li>
                         );
                       })}
@@ -430,12 +470,12 @@ function BookChapterPreview({
               }
             }}
             className={cn(
-              'cursor-pointer pl-3 py-1.5 leading-[1.5] transition-colors',
+              'cursor-pointer pl-3.5 py-1.5 leading-[1.5] transition-colors',
               // §redesign — active section: 2px gold bar + strong text (시안).
               // sidebar-primary is gold within .note-mode (overridden in index.css).
               isActiveSection
                 ? 'border-l-2 border-sidebar-primary text-[14px] font-medium text-sidebar-primary'
-                : 'border-l border-sidebar-foreground/10 text-[13px] text-sidebar-foreground/80 hover:border-sidebar-foreground/50 hover:text-sidebar-foreground'
+                : 'border-l border-sidebar-foreground/10 text-[13px] text-sidebar-foreground/50 hover:border-sidebar-foreground/50 hover:text-sidebar-foreground'
             )}
           >
             {sec.title}

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -1013,14 +1013,20 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               // already filters those out. A separate operator action
               // re-enqueues these rows for v2 backfill (see runbook
               // docs/runbook/v2-summary-user-audit-cleansing.md §7).
-              const core = (r?.core ?? null) as { one_liner?: unknown } | null;
+              const core = (r?.core ?? null) as { one_liner?: unknown; toc_label?: unknown } | null;
               const oneLinerOut =
                 core && typeof core.one_liner === 'string' && core.one_liner.length > 0
                   ? core.one_liner
                   : null;
+              // CP504 — short TOC label; FE falls back to oneLiner when absent.
+              const tocLabelOut =
+                core && typeof core.toc_label === 'string' && core.toc_label.length > 0
+                  ? core.toc_label
+                  : null;
               return {
                 videoId: vid,
                 oneLiner: oneLinerOut,
+                tocLabel: tocLabelOut,
                 coreArgument,
                 keyConcepts,
                 fallbackTags,

--- a/src/modules/skills/rich-summary-v2-prompt.ts
+++ b/src/modules/skills/rich-summary-v2-prompt.ts
@@ -26,6 +26,10 @@ export type SubjectivityLevel = 'low' | 'medium' | 'high';
 
 export interface RichSummaryCore {
   one_liner: string;
+  /** CP504 — short noun-form label for the left TOC (≤~18 chars), distilled
+   *  from one_liner with context preserved. Optional: legacy/quick rows omit it
+   *  and the FE falls back to one_liner. */
+  toc_label?: string;
   domain: DomainSlug;
   depth_level: DepthLevel;
   content_type: ContentType;
@@ -142,6 +146,8 @@ export interface RichSummaryV2Layered {
 // ============================================================================
 
 export const ONE_LINER_MAX_LEN = 20;
+/** CP504 — max length for the short TOC label (core.toc_label). */
+export const TOC_LABEL_MAX_LEN = 22;
 export const PASS_THRESHOLD = 0.7;
 export const MIN_KEY_CONCEPTS = 3;
 export const MIN_ACTIONABLES = 3;
@@ -203,7 +209,8 @@ User mandala center goal (the learning objective the viewer is pursuing; empty w
 Respond with this exact JSON structure (no extra keys, no comments):
 {{
   "core": {{
-    "one_liner": "{language_label}: 20 characters or less",
+    "one_liner": "{language_label}: ONE sentence (~30-60 chars) capturing the video's core point WITH context (used for summary/tooltip/chatbot)",
+    "toc_label": "{language_label}: short NOUN phrase <= 18 chars distilled from one_liner, context preserved (used as the left table-of-contents label)",
     "domain": "one of: tech | learning | health | business | finance | social | creative | lifestyle | mind",
     "depth_level": "beginner | intermediate | advanced",
     "content_type": "tutorial | lecture | vlog | interview | documentary | review",
@@ -257,7 +264,8 @@ Respond with this exact JSON structure (no extra keys, no comments):
 }}
 
 Field rules:
-- core.one_liner: ≤ 20 chars, no quotes, no trailing punctuation.
+- core.one_liner: ONE sentence (~30-60 chars) capturing the video's core point WITH enough context to stand alone as a summary/tooltip. No quotes.
+- core.toc_label: a short NOUN phrase (<= 18 chars) distilled from one_liner while PRESERVING its meaning — never a blind truncation. End on a noun and drop filler like "및 구성/관리/방법" when it adds no meaning. Examples: "AI 스케일 확대에 따른 창발 능력과 통제 불가능성의 위험" → "창발 능력과 통제 위험"; "Azure Virtual Network 생성 및 구성" → "가상 네트워크 구성".
 - core.domain: MUST be one of the 9 slugs above. No other values, no labels in Korean/English.
 - analysis.key_concepts: 3-5 entries.
 - analysis.entities: 3-10 entries. Each has a 'name' (bare label, no quotes) and a 'type' that MUST be one of: concept | person | tool | framework | organization. Use 'concept' for ideas/methods, 'person' for named individuals, 'tool' for software/products, 'framework' for named methodologies/processes, 'organization' for companies/institutions. When unsure, default to 'concept'. Entries should be distinct (no duplicate names). These are the KG bridge nodes — segments.atoms[].entity_refs should reference these names verbatim.
@@ -412,9 +420,16 @@ export function validateV2Layered(parsed: unknown): RichSummaryV2Layered {
     throw new V2ValidationError(`unknown content_type '${contentType}'`, 'core.content_type');
   }
   const targetAudience = requireString(c['target_audience'], 'core.target_audience');
+  // CP504 — toc_label optional: validate length only when present (legacy/quick
+  // rows omit it; the FE falls back to one_liner).
+  const tocLabel =
+    c['toc_label'] === undefined || c['toc_label'] === null
+      ? undefined
+      : requireString(c['toc_label'], 'core.toc_label', TOC_LABEL_MAX_LEN * 4);
 
   const core: RichSummaryCore = {
     one_liner: oneLiner,
+    ...(tocLabel !== undefined ? { toc_label: tocLabel } : {}),
     domain: domain as DomainSlug,
     depth_level: depthLevel as DepthLevel,
     content_type: contentType as ContentType,
@@ -712,12 +727,12 @@ export function scoreCompleteness(s: RichSummaryV2Layered): CompletenessResult {
   const reasons: string[] = [];
 
   // core (5 × 0.1)
-  if (s.core.one_liner.length > 0 && s.core.one_liner.length <= ONE_LINER_MAX_LEN) {
+  // CP504 — one_liner is now a richer one-sentence (length cap relaxed). Score
+  // it on non-emptiness; the short-label constraint moved to optional toc_label.
+  if (s.core.one_liner.length > 0) {
     score += 0.1;
   } else {
-    reasons.push(
-      `core.one_liner length ${s.core.one_liner.length} (expected 1-${ONE_LINER_MAX_LEN})`
-    );
+    reasons.push('core.one_liner empty');
   }
   if (VALID_DOMAIN_SET.has(s.core.domain)) score += 0.1;
   else reasons.push(`core.domain '${s.core.domain}' not in 9 slugs`);


### PR DESCRIPTION
## Summary
- **PR3c-a**: branch the left book-index by `centerViewMode` so the video/note SSOTs never co-render (kills the double-select + 1px/2px asymmetry James found in prod). player tab = collected cards, note tab = book sections; one active per tab; chapter chevron → number; active line aligned to the numbering column. CenterPanel: video top margin + body max-width cap.
- **toc_label (CP504)**: new OPTIONAL `core.toc_label` (short noun-form TOC label distilled from a richer `one_liner`). Prompt/type/`validateV2Layered`/scorer updated; `one_liner` length cap relaxed (~30-60 chars). `cards.ts` v2-summaries serves `tocLabel`; FE TOC reads `tocLabel ?? oneLiner` so un-backfilled rows never blank.

## Verify
- FE vitest 408/408 pass · FE build ✓ · tsc clean (changed files) · browser-verified on dev (label fallback / header progress / tab-branch single-active / active-line at numbering).
- Bulk convergence (76 pinned-incomplete) + toc_label backfill (3936) are follow-up writes, NOT in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)