### PR TITLE
fix(v2): server-side atom marker-SNAP in upsert-direct (CP504)

### DIFF
--- a/src/api/routes/internal/transcript.ts
+++ b/src/api/routes/internal/transcript.ts
@@ -29,6 +29,7 @@ import {
   V2ValidationError,
 } from '@/modules/skills/rich-summary-v2-prompt';
 import { bridgeV2ToOntology } from '@/modules/ontology/v2-bridge';
+import { snapSegmentsToMarkers, type AtomSnapMeta } from '@/modules/skills/atom-marker-snap';
 import { Prisma as PrismaCli } from '@prisma/client';
 import { logger } from '@/utils/logger';
 import { computeV2Quality } from '@/modules/metrics/v2-quality-metrics';
@@ -329,6 +330,15 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
       analysis?: unknown;
       lora?: unknown;
       segments?: unknown;
+      /**
+       * CP504 — raw [mm:ss]-prefixed transcript. When present, the route runs
+       * server-side atom marker-SNAP (atom-marker-snap.ts) BEFORE validation:
+       * snap atoms to the nearest [mm:ss] marker, drop drift/over-duration/dup,
+       * align section bounds. SSOT guard replacing the per-client validate-
+       * atoms.py that CP488 dropped from the Mac Mini fork (hallucinated
+       * timestamps were only clamped, not corrected).
+       */
+      transcript?: string;
       sourceLanguage?: string;
       stampTranscriptFetchedAt?: boolean;
       /**
@@ -381,6 +391,33 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
       }
     }
 
+    // CP504 — server-side atom marker-SNAP (SSOT). Runs BEFORE validation so the
+    // validator + scoreCompleteness + the write all see the corrected segments.
+    // Replaces the client-side validate-atoms.py that CP488 dropped from the Mac
+    // Mini fork: claude -p's hallucinated atom timestamps were only clamped to
+    // duration (a wrong value capped, not snapped to the real transcript marker).
+    const prisma = getPrismaClient();
+    let snapDurationSec: number | null = null;
+    try {
+      const yvRow = await prisma.$queryRawUnsafe<{ duration_seconds: number | null }[]>(
+        'SELECT duration_seconds FROM youtube_videos WHERE youtube_video_id = $1 LIMIT 1',
+        videoId
+      );
+      snapDurationSec = yvRow[0]?.duration_seconds ?? null;
+    } catch {
+      snapDurationSec = null;
+    }
+    let segmentsForRoute: unknown = body.segments;
+    let snapMeta: AtomSnapMeta | null = null;
+    if (typeof body.transcript === 'string' && body.transcript.length > 0) {
+      const snapped = snapSegmentsToMarkers(body.segments, body.transcript, snapDurationSec);
+      segmentsForRoute = snapped.segments;
+      snapMeta = snapped.meta;
+      if (snapMeta.atom_dropped_count > 0 || snapMeta.snapped_count > 0) {
+        log.warn('v2 atom marker-snap', { videoId, ...snapMeta });
+      }
+    }
+
     let summary;
     try {
       // CP488+ root fix — forward `segments` so summary.segments populates
@@ -394,7 +431,7 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
         core: body.core,
         analysis: analysisForValidation,
         lora: body.lora,
-        segments: body.segments,
+        segments: segmentsForRoute,
       });
     } catch (err) {
       const path = err instanceof V2ValidationError ? err.path : '';
@@ -423,39 +460,29 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
         atomsCount: summary.segments?.atoms?.length ?? 0,
         enrichmentRich: score.enrichmentRich,
         enrichmentReasons: score.enrichmentReasons,
+        // CP504 — server-side SNAP telemetry so verify-one.sh / the DRY_RUN
+        // gate can confirm the DROP rate (high drop = sparse v2, do not ship).
+        snapMeta,
       });
     }
 
-    const prisma = getPrismaClient();
     const now = new Date();
 
-    // CP438+1: clamp atom timestamp_sec / section from_sec/to_sec to video
-    // duration. Even with the new prompt rule + transcript [mm:ss] markers,
-    // the LLM occasionally still emits values past the duration. Silent
-    // clamp + log keeps the row useful (text + type stay) instead of 422
-    // rejecting the whole row.
+    // CP438+1 / CP504: final duration clamp AFTER the marker-SNAP above — a
+    // safety net for any atom/section the SNAP left within markers but past the
+    // duration. SNAP corrects the position; this only caps residual outliers.
     let clampedAtomCount = 0;
     let clampedSectionCount = 0;
-    let durationSec: number | null = null;
-    let mutatedSegments: unknown = body.segments;
-    try {
-      const yvRow = await prisma.$queryRawUnsafe<{ duration_seconds: number | null }[]>(
-        'SELECT duration_seconds FROM youtube_videos WHERE youtube_video_id = $1 LIMIT 1',
-        videoId
-      );
-      durationSec = yvRow[0]?.duration_seconds ?? null;
-    } catch {
-      // duration unknown — skip clamp; fall back to legacy behavior
-      durationSec = null;
-    }
+    const durationSec = snapDurationSec;
+    let mutatedSegments: unknown = segmentsForRoute;
     if (
       typeof durationSec === 'number' &&
       durationSec > 0 &&
-      body.segments &&
-      typeof body.segments === 'object'
+      segmentsForRoute &&
+      typeof segmentsForRoute === 'object'
     ) {
       const cap = Math.max(0, durationSec - 1);
-      const segCopy = JSON.parse(JSON.stringify(body.segments)) as {
+      const segCopy = JSON.parse(JSON.stringify(segmentsForRoute)) as {
         atoms?: Array<{ timestamp_sec?: number | null }>;
         sections?: Array<{ from_sec?: number | null; to_sec?: number | null }>;
       };
@@ -546,15 +573,20 @@ export const internalTranscriptRoutes: FastifyPluginAsync = async (fastify) => {
         domain: summary.core.domain,
       });
 
-      // CP446+ — atom validation telemetry. process-one.sh's validate-atoms.py
-      // ships drop counts + reasons in body.validationMeta; persist them in
-      // pipeline_events for monitoring (drop-rate trend, marker-drift drift).
-      // Non-fatal; recordPipelineEvent already swallows errors.
-      if (body.validationMeta && typeof body.validationMeta === 'object') {
+      // CP446+ / CP504 — atom validation telemetry. Prefer the server-generated
+      // SNAP meta (now the SSOT guard); fall back to body.validationMeta for
+      // legacy clients still running validate-atoms.py. Persist in
+      // pipeline_events for drop-rate / marker-drift monitoring. Non-fatal.
+      const atomValidationPayload: Record<string, unknown> | null = snapMeta
+        ? { ...snapMeta }
+        : body.validationMeta && typeof body.validationMeta === 'object'
+          ? body.validationMeta
+          : null;
+      if (atomValidationPayload) {
         await recordPipelineEvent({
           stage: 'atom_validation',
           videoId,
-          payload: body.validationMeta,
+          payload: atomValidationPayload,
         });
       }
 

--- a/src/modules/skills/atom-marker-snap.ts
+++ b/src/modules/skills/atom-marker-snap.ts
@@ -1,0 +1,191 @@
+/**
+ * atom-marker-snap.ts — server-side timestamp validator (CP504).
+ *
+ * Port of the Mac Mini `validate-atoms.py` (CP446+) that CP488 dropped from the
+ * `process-one.sh` fork — leaving claude -p's hallucinated atom timestamps
+ * unguarded (the upsert-direct route only *clamps* to duration, which caps a
+ * wrong value instead of correcting it). Moving the guard server-side makes it
+ * the SSOT for EVERY client (Mac Mini bulk / prod cron / inline) so it cannot
+ * silently go missing per-client again.
+ *
+ * Spec (atoms — faithful to validate-atoms.py):
+ *   1. Extract every `[mm:ss]` marker from the transcript → sorted unique secs.
+ *   2. For each atom.timestamp_sec:
+ *        - ts > duration            → DROP (out_of_duration)
+ *        - nearest marker |diff|≤10 → SNAP atom.timestamp_sec to the marker
+ *        - nearest marker |diff|>10 → DROP (marker_drift_over_10s)
+ *        - duplicate snapped ts     → DROP second occurrence (duplicate_ts)
+ *   3. Sort surviving atoms ascending by timestamp_sec + re-index idx (the py
+ *      version preserved order; the model is required to emit ascending, so we
+ *      additionally guarantee it here — SNAP can reorder near-equal values).
+ *
+ * Spec (sections — light alignment, the py version left sections untouched):
+ *   Snap from_sec/to_sec to the nearest marker, clamp into [0, duration], and
+ *   keep boundaries monotonically non-decreasing (first from_sec forced to 0).
+ *   This stops the "sections run past the video / overlap" artefact without the
+ *   removed chunk-transcript.py pre-split.
+ *
+ * When the transcript is empty or has no markers, atoms/sections pass through
+ * unchanged (we cannot SNAP without ground-truth markers).
+ */
+
+const MARKER_SNAP_THRESHOLD_SEC = 10;
+
+export interface AtomSnapMeta {
+  atom_dropped_count: number;
+  drop_reasons: {
+    out_of_duration: number;
+    marker_drift_over_10s: number;
+    duplicate_ts: number;
+  };
+  atoms_in: number;
+  atoms_out: number;
+  snapped_count: number;
+  marker_count: number;
+  sections_aligned: number;
+}
+
+/** Parse every `[mm:ss]` (or `[h:mm:ss]` is emitted as `[mm:ss]` past an hour by
+ * the awk transformer — minutes can exceed 59) marker → sorted unique seconds. */
+export function extractMarkers(transcript: string): number[] {
+  const re = /\[(\d+):([0-5]\d)\]/g;
+  const set = new Set<number>();
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(transcript)) !== null) {
+    set.add(parseInt(m[1]!, 10) * 60 + parseInt(m[2]!, 10));
+  }
+  return Array.from(set).sort((a, b) => a - b);
+}
+
+/** Nearest marker (binary search on a sorted asc array) + abs diff. */
+function nearestMarker(ts: number, markers: number[]): { value: number; diff: number } {
+  if (markers.length === 0) return { value: ts, diff: 0 };
+  let lo = 0;
+  let hi = markers.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (markers[mid]! < ts) lo = mid + 1;
+    else hi = mid;
+  }
+  const cands: number[] = [];
+  if (lo > 0) cands.push(markers[lo - 1]!);
+  if (lo < markers.length) cands.push(markers[lo]!);
+  let best = cands[0]!;
+  for (const c of cands) if (Math.abs(c - ts) < Math.abs(best - ts)) best = c;
+  return { value: best, diff: Math.abs(best - ts) };
+}
+
+interface AtomLike {
+  idx?: number;
+  timestamp_sec?: number | null;
+  [k: string]: unknown;
+}
+interface SectionLike {
+  from_sec?: number | null;
+  to_sec?: number | null;
+  [k: string]: unknown;
+}
+
+/**
+ * SNAP/drop atoms + align sections against the transcript markers. Returns a
+ * deep-cloned segments object (input untouched) + telemetry meta. If `segments`
+ * is not a usable object, returns it unchanged with a zeroed meta.
+ */
+export function snapSegmentsToMarkers(
+  segments: unknown,
+  transcript: string,
+  durationSec: number | null
+): { segments: unknown; meta: AtomSnapMeta } {
+  const markers = extractMarkers(transcript);
+  const meta: AtomSnapMeta = {
+    atom_dropped_count: 0,
+    drop_reasons: { out_of_duration: 0, marker_drift_over_10s: 0, duplicate_ts: 0 },
+    atoms_in: 0,
+    atoms_out: 0,
+    snapped_count: 0,
+    marker_count: markers.length,
+    sections_aligned: 0,
+  };
+
+  if (!segments || typeof segments !== 'object') return { segments, meta };
+  const seg = JSON.parse(JSON.stringify(segments)) as {
+    atoms?: AtomLike[];
+    sections?: SectionLike[];
+  };
+
+  // ── atoms ───────────────────────────────────────────────────────────────
+  if (Array.isArray(seg.atoms)) {
+    const atoms = seg.atoms;
+    meta.atoms_in = atoms.length;
+    const seen = new Set<number>();
+    const kept: AtomLike[] = [];
+    for (const atom of atoms) {
+      let ts = atom.timestamp_sec;
+      if (typeof ts !== 'number' || !Number.isFinite(ts)) {
+        const n = Number(ts);
+        if (!Number.isFinite(n)) {
+          meta.drop_reasons.marker_drift_over_10s++;
+          continue;
+        }
+        ts = n;
+      }
+      ts = Math.floor(ts);
+      // Rule 3 — over duration
+      if (typeof durationSec === 'number' && durationSec > 0 && ts > durationSec) {
+        meta.drop_reasons.out_of_duration++;
+        continue;
+      }
+      // Rule 1+2 — marker snap / drift drop
+      let snapped = ts;
+      if (markers.length > 0) {
+        const { value, diff } = nearestMarker(ts, markers);
+        if (diff > MARKER_SNAP_THRESHOLD_SEC) {
+          meta.drop_reasons.marker_drift_over_10s++;
+          continue;
+        }
+        if (value !== ts) {
+          snapped = value;
+          meta.snapped_count++;
+        }
+      }
+      // Rule 4 — dedup
+      if (seen.has(snapped)) {
+        meta.drop_reasons.duplicate_ts++;
+        continue;
+      }
+      seen.add(snapped);
+      kept.push({ ...atom, timestamp_sec: snapped });
+    }
+    // ascending + re-index
+    kept.sort((a, b) => (a.timestamp_sec as number) - (b.timestamp_sec as number));
+    kept.forEach((a, i) => {
+      a.idx = i;
+    });
+    seg.atoms = kept;
+    meta.atoms_out = kept.length;
+    meta.atom_dropped_count = meta.atoms_in - kept.length;
+  }
+
+  // ── sections (light marker alignment + monotonic clamp) ───────────────────
+  if (Array.isArray(seg.sections) && markers.length > 0) {
+    const cap = typeof durationSec === 'number' && durationSec > 0 ? durationSec : Infinity;
+    let prevTo = 0;
+    seg.sections.forEach((s, i) => {
+      const snap = (v: number | null | undefined): number | null => {
+        if (typeof v !== 'number' || !Number.isFinite(v)) return null;
+        const { value, diff } = nearestMarker(Math.floor(v), markers);
+        return Math.min(cap, diff <= MARKER_SNAP_THRESHOLD_SEC ? value : Math.floor(v));
+      };
+      let from = i === 0 ? 0 : (snap(s.from_sec) ?? prevTo);
+      let to = snap(s.to_sec) ?? from;
+      if (from < prevTo) from = prevTo;
+      if (to < from) to = from;
+      if (s.from_sec !== from || s.to_sec !== to) meta.sections_aligned++;
+      s.from_sec = from;
+      s.to_sec = to;
+      prevTo = to;
+    });
+  }
+
+  return { segments: seg, meta };
+}

--- a/tests/unit/modules/atom-marker-snap.test.ts
+++ b/tests/unit/modules/atom-marker-snap.test.ts
@@ -1,0 +1,49 @@
+import { extractMarkers, snapSegmentsToMarkers } from '@/modules/skills/atom-marker-snap';
+
+describe('atom-marker-snap (CP504 server-side timestamp guard)', () => {
+  // markers at 0, 10, 30, 60s
+  const transcript = '[0:00] intro\n[0:10] point a\n[0:30] point b\n[1:00] outro';
+
+  it('extractMarkers parses [mm:ss] to sorted unique seconds', () => {
+    expect(extractMarkers(transcript)).toEqual([0, 10, 30, 60]);
+    expect(extractMarkers('(no transcript)')).toEqual([]);
+  });
+
+  it('snaps ≤10s, drops drift>10s / over-duration / duplicate, sorts ascending', () => {
+    const segments = {
+      atoms: [
+        { idx: 0, type: 'fact', text: 'snap-up', timestamp_sec: 8 }, // → 10 (diff 2, snap)
+        { idx: 1, type: 'tip', text: 'drift', timestamp_sec: 45 }, // nearest 30/60 diff 15 → DROP
+        { idx: 2, type: 'fact', text: 'over-dur', timestamp_sec: 120 }, // > 70 → DROP
+        { idx: 3, type: 'fact', text: 'exact-zero', timestamp_sec: 0 }, // keep
+        { idx: 4, type: 'fact', text: 'dup', timestamp_sec: 12 }, // → 10, already seen → DROP
+      ],
+      sections: [{ from_sec: 0, to_sec: 200, title: 's' }],
+    };
+    const { segments: out, meta } = snapSegmentsToMarkers(segments, transcript, 70);
+    const atoms = (out as { atoms: Array<{ timestamp_sec: number; idx: number }> }).atoms;
+
+    // surviving atoms snapped + sorted ascending + re-indexed
+    expect(atoms.map((a) => a.timestamp_sec)).toEqual([0, 10]);
+    expect(atoms.map((a) => a.idx)).toEqual([0, 1]);
+
+    expect(meta.atoms_in).toBe(5);
+    expect(meta.atoms_out).toBe(2);
+    expect(meta.drop_reasons.marker_drift_over_10s).toBe(1);
+    expect(meta.drop_reasons.out_of_duration).toBe(1);
+    expect(meta.drop_reasons.duplicate_ts).toBe(1);
+    expect(meta.atom_dropped_count).toBe(3);
+
+    // section to_sec (200) clamped into [0, duration 70]
+    const sec = (out as { sections: Array<{ from_sec: number; to_sec: number }> }).sections[0]!;
+    expect(sec.to_sec).toBeLessThanOrEqual(70);
+  });
+
+  it('passes through unchanged when transcript has no markers (cannot SNAP)', () => {
+    const segments = { atoms: [{ idx: 0, type: 'fact', text: 'x', timestamp_sec: 999 }] };
+    const { segments: out, meta } = snapSegmentsToMarkers(segments, '(no transcript)', null);
+    expect((out as { atoms: Array<{ timestamp_sec: number }> }).atoms[0]!.timestamp_sec).toBe(999);
+    expect(meta.marker_count).toBe(0);
+    expect(meta.atoms_out).toBe(1);
+  });
+});


### PR DESCRIPTION
## Root (measured)
CP488 dropped `validate-atoms.py` from the Mac Mini `process-one.sh` fork. The prompt is raw-[mm:ss]-by-design (model derives timestamps), claude -p hallucinates, and `upsert-direct` only **clamps** to duration (caps a wrong value, doesn't snap). Measured: 2/5 Mac Mini DRY_RUN outputs had atoms past the video length (1137s for a 740s video) + descending + cross-check mismatch.

## Fix — SSOT server-side guard
- `atom-marker-snap.ts` (port of validate-atoms.py): extract `[mm:ss]` markers → SNAP atom to nearest marker (≤10s) / DROP drift>10s / over-duration / duplicate → sort ascending + re-index. Light section-bound alignment + monotonic clamp.
- `upsert-direct`: accept `transcript`, run SNAP **before** validation; residual duration-clamp kept as safety. `snapMeta` returned in dry-run + stamped to `pipeline_events` (drop-rate telemetry). No per-client dependency (Mac Mini / cron / inline all protected).
- Unit test (3 cases). Follow-up: `process-one.sh` adds `transcript` to the upsert payload (Mac Mini local, gitignored).

## Verify
tsc clean · eslint 0 errors · jest 3/3. Post-deploy: re-run Mac Mini DRY_RUN → SNAP fixes the broken timestamps + report DROP rate (high drop = sparse v2 = do not ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)