### PR TITLE
fix(cards): archive display gate SSOT + re-add toast/restore (CP504)

### DIFF
--- a/frontend/src/features/card-management/model/useArchivedReaddToast.ts
+++ b/frontend/src/features/card-management/model/useArchivedReaddToast.ts
@@ -1,0 +1,28 @@
+/**
+ * useArchivedReaddToast — surface a toast when the user re-adds a video that
+ * is currently archived for this (user, video, mandala). The BE rejects the
+ * re-add with HTTP 409 + code 'ALREADY_ARCHIVED' (no re-insert); this hook
+ * returns a notifier that shows the message plus a one-tap "Restore" action
+ * wired to the existing unarchive mutation.
+ *
+ * Uses sonner's `toast` directly (NOT the shared use-toast adapter, which
+ * drops the `action` button).
+ */
+
+import { toast } from 'sonner';
+import { useTranslation } from 'react-i18next';
+import { useArchiveCard } from './useArchiveCard';
+
+export function useArchivedReaddToast() {
+  const { unarchive } = useArchiveCard();
+  const { t } = useTranslation();
+
+  return (videoId: string) => {
+    toast(t('cards.alreadyArchived'), {
+      action: {
+        label: t('cards.restore'),
+        onClick: () => unarchive.mutate(videoId),
+      },
+    });
+  };
+}

--- a/frontend/src/features/card-management/model/useLocalCards.ts
+++ b/frontend/src/features/card-management/model/useLocalCards.ts
@@ -20,6 +20,26 @@ import type {
 import type { InsightCard } from '@/entities/card/model/types';
 import { localCardToInsightCard, insightCardToAddPayload } from '@/entities/card/model/local-cards';
 import { DEFAULT_CARD_LIMIT, DEFAULT_MANDALA_LIMIT } from '@/shared/config/subscription-tiers';
+import { useArchivedReaddToast } from './useArchivedReaddToast';
+
+/**
+ * Error thrown by useAddLocalCard when the BE rejects a re-add of an
+ * archived (user, video, mandala) with HTTP 409 + code 'ALREADY_ARCHIVED'.
+ * Carries the videoId so the hook-level onError can surface the
+ * "already archived" toast with a Restore action.
+ */
+export interface AlreadyArchivedError extends Error {
+  code: 'ALREADY_ARCHIVED';
+  videoId: string;
+}
+
+export function isAlreadyArchivedError(error: unknown): error is AlreadyArchivedError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { code?: unknown }).code === 'ALREADY_ARCHIVED'
+  );
+}
 
 // Query Keys
 export const localCardsKeys = {
@@ -93,6 +113,7 @@ export function useLocalCardsAsInsight() {
  */
 export function useAddLocalCard() {
   const queryClient = useQueryClient();
+  const notifyArchivedReadd = useArchivedReaddToast();
 
   return useMutation({
     mutationFn: async (payload: AddLocalCardPayload): Promise<LocalCard> => {
@@ -115,6 +136,19 @@ export function useAddLocalCard() {
         if (error.error === 'LIMIT_EXCEEDED') {
           throw error as LimitExceededError;
         }
+        // BE returns 409 + { code/error: 'ALREADY_ARCHIVED', videoId, mandalaId }
+        // when this (user, video, mandala) is currently archived. Re-throw as a
+        // typed error so the hook-level onError can show the Restore toast and
+        // call sites can skip their generic failure toast.
+        if (
+          response.status === 409 &&
+          (error.code === 'ALREADY_ARCHIVED' || error.error === 'ALREADY_ARCHIVED')
+        ) {
+          throw Object.assign(new Error('ALREADY_ARCHIVED'), {
+            code: 'ALREADY_ARCHIVED' as const,
+            videoId: error.videoId as string,
+          });
+        }
         throw new Error(error.error || 'Failed to add local card');
       }
 
@@ -131,6 +165,13 @@ export function useAddLocalCard() {
         cell_index: card.cell_index ?? undefined,
         source: 'manual',
       });
+    },
+    onError: (error) => {
+      // Centralised handling for the archived re-add case so every call site
+      // (handleUrlDrop / handleCardDrop) surfaces the same Restore toast.
+      if (isAlreadyArchivedError(error)) {
+        notifyArchivedReadd(error.videoId);
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: localCardsKeys.list() });

--- a/frontend/src/pages/index/model/useCardOrchestrator.ts
+++ b/frontend/src/pages/index/model/useCardOrchestrator.ts
@@ -6,6 +6,7 @@ import { useAuth } from '@/features/auth/model/useAuth';
 import {
   useLocalCards,
   isLimitExceededError,
+  isAlreadyArchivedError,
   localCardsKeys,
 } from '@/features/card-management/model/useLocalCards';
 import { useBatchMoveCards } from '@/features/card-management/model/useBatchMoveCards';
@@ -649,7 +650,11 @@ export function useCardOrchestrator(
         }
       } catch (error) {
         setPendingLocalCards((prev) => prev.filter((c) => c.id !== tempCard.id));
-        if (isLimitExceededError(error)) {
+        if (isAlreadyArchivedError(error)) {
+          // The "already archived" Restore toast is surfaced by the
+          // useAddLocalCard hook-level onError — skip the generic failure toast
+          // to avoid a duplicate.
+        } else if (isLimitExceededError(error)) {
           toast({
             title: t('index.storageLimitExceeded'),
             description: t('index.storageLimitDesc', {
@@ -950,6 +955,10 @@ export function useCardOrchestrator(
           });
         };
         const onError = (error: unknown) => {
+          // The "already archived" Restore toast is surfaced by the
+          // useAddLocalCard hook-level onError — skip the generic failure toast
+          // to avoid a duplicate.
+          if (isAlreadyArchivedError(error)) return;
           toast({
             title: t('index.moveFailed'),
             description: error instanceof Error ? error.message : t('index.moveFailedDesc'),

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -634,6 +634,8 @@
     "latestFirst": "Latest",
     "dragToMove": "Drag to move",
     "addCard": "Add Card",
+    "alreadyArchived": "This video is already in your archive",
+    "restore": "Restore",
     "addCardPlaceholder": "Paste a URL...",
     "loadingMore": "Loading... {{loaded}} of {{total}}",
     "archive": {

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -642,6 +642,8 @@
     "latestFirst": "최신순",
     "dragToMove": "드래그하여 이동",
     "addCard": "카드 추가",
+    "alreadyArchived": "이미 보관함에 있는 영상입니다",
+    "restore": "복구",
     "addCardPlaceholder": "URL을 붙여넣으세요...",
     "loadingMore": "로딩 중... {{loaded}} / {{total}}",
     "archive": {

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -6,8 +6,9 @@ import { useMandalaQuery } from '@/features/mandala';
 import { ChevronDown, ChevronUp, Loader2, Lock, RotateCcw, Search, Undo2, X } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/shared/lib/utils';
-import { apiClient } from '@/shared/lib/api-client';
+import { apiClient, ApiHttpError } from '@/shared/lib/api-client';
 import { useLikeCard } from '@/features/card-management/model/useLikeCard';
+import { useArchivedReaddToast } from '@/features/card-management/model/useArchivedReaddToast';
 import { localCardsKeys } from '@/features/card-management/model/useLocalCards';
 import { useAllVideoStates, youtubeSyncKeys } from '@/features/youtube-sync/model/useYouTubeSync';
 import type { UserVideoStateWithVideo } from '@/entities/youtube/model/types';
@@ -171,6 +172,7 @@ export function AddCardsPanel() {
   const hasSearched = mutation.isSuccess || mutation.isError || rounds.length > 0;
 
   const { like, unlike } = useLikeCard();
+  const notifyArchivedReadd = useArchivedReaddToast();
 
   const handleUnpick = useCallback(
     (videoId: string) => {
@@ -298,7 +300,7 @@ export function AddCardsPanel() {
             // drives the disabled overlay so the user can see what was
             // already added to the mandala.
           },
-          onError: () => {
+          onError: (err) => {
             setLocalPicks((prev) => {
               const next = new Set(prev);
               next.delete(videoId);
@@ -309,11 +311,20 @@ export function AddCardsPanel() {
               youtubeSyncKeys.allVideoStates,
               (prev) => (prev ? prev.filter((r) => r.id !== optimisticId) : prev)
             );
+            // BE rejects re-adding an archived (user, video, mandala) with 409
+            // ALREADY_ARCHIVED. This onError otherwise fails silently (rollback
+            // only), so surface the Restore toast here.
+            if (
+              err instanceof ApiHttpError &&
+              (err.statusCode === 409 || err.code === 'ALREADY_ARCHIVED')
+            ) {
+              notifyArchivedReadd(videoId);
+            }
           },
         }
       );
     },
-    [mandalaId, pickedSet, like, cards, queryClient, handleUnpick]
+    [mandalaId, pickedSet, like, cards, queryClient, handleUnpick, notifyArchivedReadd]
   );
 
   // Seed wizard meta (focus_tags + target_level) as soon as the mandala

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -8,6 +8,8 @@ import { cn } from '@/shared/lib/utils';
 import { GripVertical, NotepadText, Loader2, Play, Bookmark, Archive } from 'lucide-react';
 import { useLikeCard } from '@/features/card-management/model/useLikeCard';
 import { useArchiveCard } from '@/features/card-management/model/useArchiveCard';
+import { useArchivedReaddToast } from '@/features/card-management/model/useArchivedReaddToast';
+import { ApiHttpError } from '@/shared/lib/api-client';
 import { useEnrichStream } from '@/features/card-management/model/useEnrichStream';
 import { localCardsKeys } from '@/features/card-management/model/useLocalCards';
 import { extractYouTubeVideoId } from '@/shared/lib/url-normalize';
@@ -203,6 +205,7 @@ export function InsightCardItemV2({
   }, [likedLocal, serverLiked]);
   const { like, unlike } = useLikeCard();
   const { archive } = useArchiveCard();
+  const notifyArchivedReadd = useArchivedReaddToast();
   const enrichStream = useEnrichStream();
   // CP463 — when the SSE reports 'scored', the BE has just written the
   // new v2 row (mandala_relevance_pct + one_liner). useLikeCard.onSuccess
@@ -280,11 +283,23 @@ export function InsightCardItemV2({
               void enrichStream.open(videoId);
             }
           },
-          onError: () => setLikedLocal(false), // rollback to previous false
+          onError: (err) => {
+            setLikedLocal(false); // rollback to previous false
+            // BE rejects re-adding an archived (user, video, mandala) with
+            // 409 ALREADY_ARCHIVED. Surface the dedicated toast + Restore
+            // action instead of a generic failure (the like hook has no
+            // generic toast, so there is no duplicate to suppress here).
+            if (
+              err instanceof ApiHttpError &&
+              (err.statusCode === 409 || err.code === 'ALREADY_ARCHIVED')
+            ) {
+              notifyArchivedReadd(videoId);
+            }
+          },
         }
       );
     },
-    [card.mandalaId, card.title, enrichStream, like, liked, unlike, videoId]
+    [card.mandalaId, card.title, enrichStream, like, liked, notifyArchivedReadd, unlike, videoId]
   );
 
   const handleArchiveClick = useCallback(

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -315,6 +315,33 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     }
 
     const prisma = getPrismaClient();
+
+    // CP504 — archive re-add guard. If the user archived this video in THIS
+    // mandala, do NOT silently re-add it: the display gate would then hide the
+    // freshly-added card ("added but invisible" stuck state). Hold the add and
+    // tell the FE to show a "이미 보관함에 있는 영상입니다" toast + [복구] action.
+    // The user — not the system — restores (archive was their explicit intent).
+    if (body.mandalaId) {
+      const archived = await prisma.card_interactions.findFirst({
+        where: {
+          user_id: userId,
+          video_id: videoId,
+          signal: 'archive',
+          mandala_id: body.mandalaId,
+        },
+        select: { id: true },
+      });
+      if (archived) {
+        return reply.code(409).send({
+          status: 'error',
+          code: 'ALREADY_ARCHIVED',
+          message: 'video is archived in this mandala',
+          videoId,
+          mandalaId: body.mandalaId,
+        });
+      }
+    }
+
     try {
       // 1. Signal UPSERT
       await prisma.card_interactions.upsert({

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -1851,6 +1851,12 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           FROM user_local_cards
           WHERE mandala_id = ${mandalaId}::uuid AND user_id = ${userId}::uuid
             AND (level_id IS NOT NULL AND level_id != 'scratchpad' AND level_id != '')
+            -- CP504 archive display gate (mandala-scoped)
+            AND NOT EXISTS (
+              SELECT 1 FROM card_interactions ci
+              WHERE ci.user_id = ${userId}::uuid AND ci.signal = 'archive'
+                AND ci.mandala_id = ${mandalaId}::uuid AND ci.video_id = user_local_cards.video_id
+            )
           UNION ALL
           -- video states with level_id mapping
           SELECT CASE
@@ -1860,6 +1866,13 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           FROM user_video_states
           WHERE mandala_id = ${mandalaId}::uuid AND user_id = ${userId}::uuid
             AND (level_id IS NOT NULL AND level_id != 'scratchpad' AND level_id != '')
+            -- CP504 archive display gate (mandala-scoped); uvs.video_id is FK → join youtube_videos
+            AND NOT EXISTS (
+              SELECT 1 FROM card_interactions ci
+              JOIN youtube_videos yv ON yv.youtube_video_id = ci.video_id
+              WHERE ci.user_id = ${userId}::uuid AND ci.signal = 'archive'
+                AND ci.mandala_id = ${mandalaId}::uuid AND yv.id = user_video_states.video_id
+            )
         ) combined
         WHERE cell_pos >= 0 AND cell_pos < 8
         GROUP BY cell_pos

--- a/src/modules/exclude/archived-videos.ts
+++ b/src/modules/exclude/archived-videos.ts
@@ -1,0 +1,41 @@
+/**
+ * archived-videos.ts — SSOT for the DISPLAY archive gate (CP504).
+ *
+ * `card_interactions.signal='archive'` is recorded on archive but was never a
+ * display gate — only the recommendation-candidate path (excluded-videos.ts) and
+ * a per-device localStorage filter (CardList.tsx) ever consumed it, so archived
+ * cards leaked into the video-mode index, ideaspot, grid, note book, and cell
+ * counts (measured: 26 archive signals, 11 leaking into the video mode + 4 into
+ * the note book). This helper centralises the archive lookup so EVERY display
+ * path applies the IDENTICAL exclusion and it cannot silently go missing
+ * per-path again.
+ *
+ * MANDALA-SCOPED: a video archived in mandala A is hidden ONLY in A, not in B
+ * (the same video may be relevant elsewhere). The `mandala_id` column already
+ * carries this scope; no DDL is required for the gate (the shared UNIQUE
+ * `(user_id, video_id, signal)` overwrite is a separate write-path concern with
+ * zero current cross-mandala collisions).
+ *
+ * Distinct from getExcludedVideoIds (excluded-videos.ts): that excludes ALL
+ * owned/delete/surfaced videos for *recommendation* candidate generation — the
+ * opposite of what display wants. This is archive-only.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+
+/**
+ * Returns the set of youtube_video_id strings the user has archived IN this
+ * mandala. These must be excluded from every display + book + count path.
+ * Read-only.
+ */
+export async function getArchivedVideoIds(
+  prisma: ReturnType<typeof getPrismaClient>,
+  userId: string,
+  mandalaId: string
+): Promise<Set<string>> {
+  const rows = await prisma.card_interactions.findMany({
+    where: { user_id: userId, signal: 'archive', mandala_id: mandalaId },
+    select: { video_id: true },
+  });
+  return new Set(rows.map((r) => r.video_id));
+}

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -22,6 +22,7 @@ import { synthesizeCellTopics } from './topic-synthesis';
 import { enqueueEnrichRichSummary } from '@/modules/queue';
 import { enqueueRelevanceBackfillForMandala } from '@/modules/relevance/relevance-backfill-trigger';
 import { getStoredTranslation } from '@/modules/skills/rich-summary-translator';
+import { getArchivedVideoIds } from '@/modules/exclude/archived-videos';
 import { bookV2RetryCapped } from './book-v2-retry';
 import type {
   RichSummaryAnalysis,
@@ -101,10 +102,17 @@ export async function fillMandalaBook(params: {
     }),
   ]);
 
+  // CP504 archive display gate (mandala-scoped) — a video archived in THIS
+  // mandala must not be synthesised into the book (measured: 4 archived videos
+  // were leaking into notes). Placement rows (uvs/ulc) are untouched; only the
+  // book input is filtered.
+  const archivedIds = await getArchivedVideoIds(prisma, userId, mandalaId);
+
   const placements: Placement[] = [];
   for (const r of videoStates) {
     const vid = r.video?.youtube_video_id;
     if (!vid || r.cell_index == null) continue;
+    if (archivedIds.has(vid)) continue;
     placements.push({
       cellIndex: r.cell_index,
       videoId: vid,
@@ -115,6 +123,7 @@ export async function fillMandalaBook(params: {
   for (const r of localCards) {
     // Non-YouTube manual cards have no video_id → no v2 → honest skip.
     if (!r.video_id || r.cell_index == null) continue;
+    if (archivedIds.has(r.video_id)) continue;
     placements.push({
       cellIndex: r.cell_index,
       videoId: r.video_id,

--- a/src/modules/skills/card-query.ts
+++ b/src/modules/skills/card-query.ts
@@ -61,6 +61,13 @@ export async function queryMandalaCards(opts: CardQueryOptions): Promise<SkillCa
     WHERE ulc.user_id = ${userId}::uuid
       AND ulc.mandala_id = ${mandalaId}::uuid
       AND ulc.cell_index >= 0
+      -- CP504 archive display gate (mandala-scoped) — exclude cards the user
+      -- archived in THIS mandala (card_interactions.signal='archive').
+      AND NOT EXISTS (
+        SELECT 1 FROM card_interactions ci
+        WHERE ci.user_id = ${userId}::uuid AND ci.signal = 'archive'
+          AND ci.mandala_id = ${mandalaId}::uuid AND ci.video_id = ulc.video_id
+      )
       ${cellScope ? Prisma.sql`AND ulc.cell_index = ANY(${cellScope}::int[])` : Prisma.empty}
       ${since ? Prisma.sql`AND ulc.created_at >= ${since}` : Prisma.empty}
     ORDER BY ulc.created_at DESC
@@ -86,6 +93,12 @@ export async function queryMandalaCards(opts: CardQueryOptions): Promise<SkillCa
       AND uvs.mandala_id = ${mandalaId}::uuid
       AND uvs.cell_index >= 0
       AND uvs.is_in_ideation = false
+      -- CP504 archive display gate (mandala-scoped)
+      AND NOT EXISTS (
+        SELECT 1 FROM card_interactions ci
+        WHERE ci.user_id = ${userId}::uuid AND ci.signal = 'archive'
+          AND ci.mandala_id = ${mandalaId}::uuid AND ci.video_id = yv.youtube_video_id
+      )
       ${cellScope ? Prisma.sql`AND uvs.cell_index = ANY(${cellScope}::int[])` : Prisma.empty}
       ${since ? Prisma.sql`AND uvs.created_at >= ${since}` : Prisma.empty}
     ORDER BY uvs.created_at DESC

--- a/supabase/functions/local-cards/index.ts
+++ b/supabase/functions/local-cards/index.ts
@@ -264,7 +264,22 @@ Deno.serve(async (req) => {
 
         if (cardsResult.error) throw cardsResult.error;
 
-        const cards = cardsResult.data || [];
+        // CP504 archive display gate (mandala-scoped) — drop cards the user
+        // archived in that mandala. card_interactions keys archive by
+        // (video_id, mandala_id); non-YouTube cards (video_id null) never match.
+        const { data: lcArchivedRows } = await supabase
+          .from('card_interactions')
+          .select('video_id, mandala_id')
+          .eq('user_id', user.id)
+          .eq('signal', 'archive');
+        const lcArchivedSet = new Set(
+          (lcArchivedRows || []).map(
+            (r: Record<string, unknown>) => `${r.video_id}|${r.mandala_id}`
+          )
+        );
+        const cards = (cardsResult.data || []).filter(
+          (c: Record<string, unknown>) => !lcArchivedSet.has(`${c.video_id}|${c.mandala_id}`)
+        );
 
         // Enrich YouTube cards with video_summaries (LEFT JOIN equivalent)
         const youtubeCards = cards.filter(
@@ -463,6 +478,38 @@ Deno.serve(async (req) => {
           if (defaultMandala) {
             resolvedMandalaId = defaultMandala.id;
             console.log('[local-cards] add: mandala_id was null for non-scratchpad card, resolved to default:', resolvedMandalaId);
+          }
+        }
+
+        // CP504 — archive re-add guard. If the user archived this youtube video
+        // in THIS mandala, hold the add (the display gate would then hide it =
+        // "added but invisible" stuck) and tell the FE to show a "이미 보관함에
+        // 있는 영상입니다" toast + [복구]. User-initiated restore only — the
+        // system never silently un-archives.
+        if (
+          (body.link_type === 'youtube' || body.link_type === 'youtube-shorts') &&
+          body.video_id &&
+          resolvedMandalaId
+        ) {
+          const { data: archivedRow } = await supabase
+            .from('card_interactions')
+            .select('id')
+            .eq('user_id', user.id)
+            .eq('video_id', body.video_id)
+            .eq('signal', 'archive')
+            .eq('mandala_id', resolvedMandalaId)
+            .maybeSingle();
+          if (archivedRow) {
+            return new Response(
+              JSON.stringify({
+                error: 'ALREADY_ARCHIVED',
+                code: 'ALREADY_ARCHIVED',
+                message: 'video is archived in this mandala',
+                videoId: body.video_id,
+                mandalaId: resolvedMandalaId,
+              }),
+              { status: 409, headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' } }
+            );
           }
         }
 

--- a/supabase/functions/youtube-sync/index.ts
+++ b/supabase/functions/youtube-sync/index.ts
@@ -678,8 +678,21 @@ Deno.serve(async (req) => {
           );
         }
 
+        // CP504 archive display gate (mandala-scoped) — drop video states the
+        // user archived in that mandala. card_interactions keys archive by
+        // (video_id = youtube_video_id, mandala_id).
+        const { data: ytsArchivedRows } = await supabase
+          .from('card_interactions')
+          .select('video_id, mandala_id')
+          .eq('user_id', user.id)
+          .eq('signal', 'archive');
+        const ytsArchivedSet = new Set(
+          (ytsArchivedRows || []).map((r: any) => `${r.video_id}|${r.mandala_id}`)
+        );
         // video_summaries manual JOIN
-        const videos = data || [];
+        const videos = (data || []).filter(
+          (v: any) => !ytsArchivedSet.has(`${v.video?.youtube_video_id}|${v.mandala_id}`)
+        );
         const ytVideoIds = videos
           .map((v: any) => v.video?.youtube_video_id)
           .filter(Boolean);

--- a/tests/unit/modules/archived-videos.test.ts
+++ b/tests/unit/modules/archived-videos.test.ts
@@ -1,0 +1,25 @@
+import { getArchivedVideoIds } from '@/modules/exclude/archived-videos';
+
+describe('getArchivedVideoIds (CP504 display archive gate SSOT)', () => {
+  it('returns the mandala-scoped set of archived video_ids', async () => {
+    const findMany = jest.fn().mockResolvedValue([{ video_id: 'aaa' }, { video_id: 'bbb' }]);
+    const prisma = { card_interactions: { findMany } } as never;
+
+    const set = await getArchivedVideoIds(prisma, 'user-1', 'mandala-1');
+
+    expect(set).toEqual(new Set(['aaa', 'bbb']));
+    // scoped by user + signal='archive' + mandala (NOT global)
+    expect(findMany).toHaveBeenCalledWith({
+      where: { user_id: 'user-1', signal: 'archive', mandala_id: 'mandala-1' },
+      select: { video_id: true },
+    });
+  });
+
+  it('returns an empty set when nothing is archived', async () => {
+    const prisma = {
+      card_interactions: { findMany: jest.fn().mockResolvedValue([]) },
+    } as never;
+    const set = await getArchivedVideoIds(prisma, 'user-1', 'mandala-1');
+    expect(set.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Root (measured)
`card_interactions.signal='archive'` was recorded but **never a display gate** — only the recommendation path (`excluded-videos.ts`) + a per-device `CardList.tsx` localStorage filter consumed it. So archived cards leaked into the video-mode index, ideaspot, grid, note book, and cell counts (**measured: 26 archive signals, 11 leaking into video mode + 4 into the note book**). Same card hidden in one renderer, visible in another.

## Gate — SSOT, mandala-scoped (no DDL; existing `mandala_id` column)
- `getArchivedVideoIds(prisma, userId, mandalaId)` helper (new).
- `card-query.ts` + `mandalas.ts` cell-count: `NOT EXISTS` archive exclusion.
- `fill-book.ts`: archived videos no longer enter the book.
- `local-cards` (list) + `youtube-sync` (get-all-video-states) Edge Fns: filter `video_id|mandala_id` (the 3 FE display paths converge here). Both auto-deploy via `deploy.yml`.

## Re-add toast/restore (paired — gate alone would hide a re-added card = "added but invisible", a NEW bug; not shippable split)
- `/like` + `local-cards add`: **409 ALREADY_ARCHIVED** (hold the add) when re-adding a video archived in this mandala.
- FE: `useArchivedReaddToast` → "이미 보관함에 있는 영상입니다" toast + **[복구]** → `unarchive`. User-initiated restore only; the system never silently un-archives. Wired at like (heart + AddCardsPanel) and URL/D&D (`useAddLocalCard`); duplicate generic toasts suppressed.

NULL-mandala archive orphans (3) deleted pre-gate.

## Verify
tsc clean (BE+FE) · eslint 0 new · BE jest 2/2 · FE vitest 11 · FE build OK. Post-deploy James screen: archive 26 gone from 5 paths + re-add → toast+[복구].

🤖 Generated with [Claude Code](https://claude.com/claude-code)