### PR TITLE
fix(mandala): race the wizard goal embed across both providers (CP504)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -186,6 +186,13 @@ services:
       # Revert: delete this line and redeploy — code default 'ollama'
       # restores the pre-Phase-1 behavior bit-identically.
       - MANDALA_EMBED_PROVIDER=openrouter
+      # CP504 — race the wizard goal embed across BOTH providers (OpenRouter +
+      # Mac Mini Ollama qwen3-embedding:8b), first success wins. Removes the
+      # OpenRouter-credit single point of failure (the 402 wizard outage): cloud
+      # wins on speed in the common case, Mac Mini survives the race if cloud
+      # dies. Config-only rollback: delete this line → code default false →
+      # the MANDALA_EMBED_PROVIDER selector above.
+      - MANDALA_EMBED_RACE=true
       # Mac Mini deprecation Phase D1 (2026-05-13) — flip iks-scorer
       # embedBatch from Mac-mini-first-with-OpenRouter-fallback to
       # OpenRouter-only. Removes a Mac Mini dependency for ~4 call sites

--- a/frontend/src/widgets/app-shell/ui/SidebarMandalaSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarMandalaSection.tsx
@@ -323,7 +323,12 @@ export function SidebarMandalaSection({
                 )}
               >
                 <span className="flex flex-1 min-w-0 items-center gap-2 text-left">
-                  <span className="truncate flex-1">{getCenterLabel(mandala)}</span>
+                  {/* CP504 — narrow sidebar clips long names (DB stores the full
+                      title); keep the ellipsis for layout but expose the full
+                      name on hover via the native title tooltip. */}
+                  <span className="truncate flex-1" title={getCenterLabel(mandala)}>
+                    {getCenterLabel(mandala)}
+                  </span>
                   {newlySyncedCount > 0 && (
                     <span
                       className="shrink-0 flex items-center gap-1 text-[11px] text-primary font-medium"

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -70,6 +70,19 @@ const envSchema = z.object({
   // Default = ollama so flag-off = pre-Phase-1 behaviour (CLAUDE.md C5).
   MANDALA_EMBED_PROVIDER: z.enum(['ollama', 'openrouter']).default('ollama'),
 
+  // CP504 — race the wizard goal embed across BOTH providers (OpenRouter +
+  // Mac Mini Ollama) and take the first to SUCCEED. Eliminates the single
+  // point of failure that took the wizard down when OpenRouter ran out of
+  // credits (402): the fast cloud provider wins in the common case (speed
+  // preserved), but if it dies the Mac Mini qwen3-embedding:8b survives the
+  // race (availability). Both are same-family Qwen3-Embedding-8B @ 4096d, so
+  // either vector matches the existing mandala_embeddings corpus (search.ts).
+  // Default false = the MANDALA_EMBED_PROVIDER selector (existing behaviour);
+  // flip true in prod, config-only rollback.
+  MANDALA_EMBED_RACE: z
+    .preprocess((v) => String(v).toLowerCase() === 'true', z.boolean())
+    .default(false),
+
   // IKS-scorer / shared embedBatch provider switch (Issue #543, 2026-04-28).
   // Distinct from MANDALA_EMBED_PROVIDER: governs the multi-text batch
   // path used by ensureMandalaEmbeddings, v3 executor semantic gate,
@@ -336,6 +349,7 @@ export const config = {
   // 2026-04-22). See docs/design/wizard-service-redesign-2026-04-22.md.
   mandalaEmbed: {
     provider: env.MANDALA_EMBED_PROVIDER,
+    race: env.MANDALA_EMBED_RACE,
     openRouterBaseUrl: env.OPENROUTER_EMBED_BASE_URL,
     openRouterModel: env.OPENROUTER_EMBED_MODEL,
     openRouterDimension: env.OPENROUTER_EMBED_DIMENSION,

--- a/src/modules/mandala/search.ts
+++ b/src/modules/mandala/search.ts
@@ -124,19 +124,26 @@ const SYSTEM_TEMPLATES_USER_ID = '00000000-0000-0000-0000-000000000001';
 const inflightEmbeds = new Map<string, Promise<number[]>>();
 
 export async function embedGoalForMandala(goalText: string): Promise<number[]> {
+  const race = config.mandalaEmbed.race;
   const provider = config.mandalaEmbed.provider;
   // CP499 — cache by provider+goal: the embed is goal-deterministic, so the FE
   // search + server merged-gen + retries share one embed instead of N × ~3.7s.
-  const cacheKey = `${provider}:${goalText.trim()}`;
+  // CP504 — race mode caches under a single 'race' namespace (either provider's
+  // vector is corpus-compatible, so the winner is interchangeable).
+  const cacheKey = `${race ? 'race' : provider}:${goalText.trim()}`;
   const cached = goalEmbedCache.get(cacheKey);
   if (cached) return cached;
 
   const inflight = inflightEmbeds.get(cacheKey);
   if (inflight) return inflight;
 
-  const pending = (
-    provider === 'openrouter' ? embedViaOpenRouter(goalText) : embedViaOllama(goalText)
-  )
+  const source = race
+    ? embedViaRace(goalText)
+    : provider === 'openrouter'
+      ? embedViaOpenRouter(goalText)
+      : embedViaOllama(goalText);
+
+  const pending = source
     .then((vector) => {
       goalEmbedCache.set(cacheKey, vector);
       return vector;
@@ -146,6 +153,34 @@ export async function embedGoalForMandala(goalText: string): Promise<number[]> {
     });
   inflightEmbeds.set(cacheKey, pending);
   return pending;
+}
+
+/**
+ * CP504 — embed via BOTH providers in parallel, return the first to SUCCEED.
+ * The fast cloud provider (OpenRouter) wins in the common case (speed kept); if
+ * it fails (e.g. 402 out-of-credits) the Mac Mini Ollama embed survives the race
+ * so the wizard stays up (availability). `Promise.any` ignores the loser's
+ * rejection — only when BOTH reject does it throw an AggregateError, surfaced as
+ * a MandalaSearchError so upstream handlers keep their existing error contract.
+ * The loser is NOT cancelled (cheap; mirrors the generation LoRA fire-and-forget).
+ * Both providers are same-family Qwen3-Embedding-8B @ 4096d, so either vector
+ * matches the mandala_embeddings corpus (Phase 1 reuse guarantee).
+ */
+async function embedViaRace(goalText: string): Promise<number[]> {
+  try {
+    return await Promise.any([embedViaOpenRouter(goalText), embedViaOllama(goalText)]);
+  } catch (err) {
+    if (err instanceof AggregateError) {
+      const first = err.errors.find((e) => e instanceof MandalaSearchError);
+      if (first instanceof MandalaSearchError) throw first;
+      const msgs = err.errors
+        .map((e) => (e instanceof Error ? e.message : String(e)))
+        .join('; ')
+        .slice(0, 300);
+      throw new MandalaSearchError(`All embed providers failed: ${msgs}`, 'SERVICE_UNAVAILABLE');
+    }
+    throw err;
+  }
 }
 
 async function embedViaOllama(goalText: string): Promise<number[]> {

--- a/tests/unit/modules/mandala-embed-race.test.ts
+++ b/tests/unit/modules/mandala-embed-race.test.ts
@@ -1,0 +1,97 @@
+/**
+ * CP504 — wizard goal-embed RACE (MANDALA_EMBED_RACE=true).
+ *
+ * The OpenRouter-only embed was a single point of failure: when OpenRouter ran
+ * out of credits (402) the wizard "목표 분석" died at the embed step. The race
+ * calls BOTH providers and takes the first to SUCCEED — cloud wins on speed in
+ * the common case, Mac Mini Ollama survives the race if cloud dies.
+ *
+ * Per CLAUDE.md Hard Rule on LLM API usage, this test NEVER makes a real
+ * OpenRouter/Ollama call — config is statically mocked and global fetch is
+ * spied in every case. Providers are told apart by URL: OpenRouter hits
+ * `…/embeddings`, Ollama hits `…/api/embed`. Each test uses a UNIQUE goal
+ * string (the module-level goalEmbedCache is intentionally not reset).
+ */
+
+const mockConfig = {
+  mandalaEmbed: {
+    provider: 'openrouter' as const,
+    race: true,
+    openRouterBaseUrl: 'https://openrouter.test/api/v1',
+    openRouterModel: 'qwen/qwen3-embedding-8b',
+    openRouterDimension: 4096,
+  },
+  mandalaGen: {
+    url: 'http://ollama.local:11434',
+    model: 'mandala-gen',
+    embedModel: 'qwen3-embedding:8b',
+    embedDimension: 4096,
+  },
+  openrouter: { apiKey: 'test-key', model: 'qwen/qwen3-30b-a3b' },
+};
+
+jest.mock('../../../src/config', () => ({
+  config: new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'mandalaEmbed') return mockConfig.mandalaEmbed;
+        if (prop === 'mandalaGen') return mockConfig.mandalaGen;
+        if (prop === 'openrouter') return mockConfig.openrouter;
+        if (prop === 'app')
+          return { env: 'test', isProduction: false, isTest: true, logLevel: 'silent' };
+        return undefined;
+      },
+    }
+  ),
+}));
+
+jest.mock('@/modules/database/client', () => ({ getPrismaClient: () => ({}) }));
+jest.mock('@/utils/logger', () => ({
+  logger: { child: () => ({ info: jest.fn(), warn: jest.fn() }), info: jest.fn(), warn: jest.fn() },
+}));
+
+import { embedGoalForMandala } from '../../../src/modules/mandala/search';
+
+const VEC_OR = Array(4096).fill(0.002);
+const VEC_OL = Array(4096).fill(0.003);
+const orOk = () => new Response(JSON.stringify({ data: [{ embedding: VEC_OR }] }), { status: 200 });
+const olOk = () => new Response(JSON.stringify({ embeddings: [VEC_OL] }), { status: 200 });
+const isOpenRouter = (u: unknown) => String(u).includes('/embeddings');
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('embedGoalForMandala race (CP504)', () => {
+  it('calls BOTH providers; the fast one (OpenRouter) wins', async () => {
+    const spy = jest.spyOn(globalThis, 'fetch').mockImplementation(async (u) => {
+      if (isOpenRouter(u)) return orOk();
+      await new Promise((r) => setTimeout(r, 40)); // Ollama is the slow loser
+      return olOk();
+    });
+    const vec = await embedGoalForMandala('race both ok — cloud fast A');
+    expect(vec[0]).toBe(0.002); // OpenRouter vector
+    expect(spy).toHaveBeenCalledTimes(2); // both fired — Mac Mini still called
+  });
+
+  it('survives OpenRouter 402 — Mac Mini Ollama wins the race', async () => {
+    jest.spyOn(globalThis, 'fetch').mockImplementation(async (u) => {
+      if (isOpenRouter(u)) return new Response('Insufficient credits', { status: 402 });
+      return olOk();
+    });
+    const vec = await embedGoalForMandala('race cloud-402 ollama-wins B');
+    expect(vec[0]).toBe(0.003); // Ollama vector — wizard stays up
+  });
+
+  it('throws MandalaSearchError only when BOTH providers fail', async () => {
+    jest
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (u) =>
+        isOpenRouter(u)
+          ? new Response('402', { status: 402 })
+          : new Response('500', { status: 500 })
+      );
+    await expect(embedGoalForMandala('race both fail C')).rejects.toMatchObject({
+      code: 'SERVICE_UNAVAILABLE',
+    });
+  });
+});


### PR DESCRIPTION
## Root (measured, code)
Wizard "목표 분석" died on OpenRouter 402 (out of credits). The goal embed `embedGoalForMandala` was a single-provider **selector** routed to OpenRouter (`MANDALA_EMBED_PROVIDER=openrouter`, Phase 1, for speed). The Mac Mini Ollama embed (`embedViaOllama`) existed but was unselected → OpenRouter outage took **both** wizard race branches down at the embed step.

Also confirmed: the generation "race" is **not** a race — user result = `generateMandalaWithHaiku` (OpenRouter) only; the Mac Mini LoRA is background fire-and-forget accumulation. So embed + generation are **both** OpenRouter single-points.

## Fix — embed RACE
- `MANDALA_EMBED_RACE` flag (default false = existing selector; prod ON via `docker-compose.prod.yml`, config-only rollback).
- `embedGoalForMandala` → `Promise.any([embedViaOpenRouter, embedViaOllama])`: cloud wins on speed in the common case, Mac Mini survives the race if cloud dies. Loser not cancelled. Both fail → `MandalaSearchError` (existing contract).
- **Vector compat verified in code** (NOT via a forbidden OpenRouter test call, CLAUDE.md Hard Rule): both same-family Qwen3-Embedding-8B @ 4096d; Phase 1 reuses the same `mandala_embeddings` corpus across the provider flip → same vector space → race-safe.
- 3 unit tests (cloud wins / 402→Ollama wins / both fail→throws).

## Also
Sidebar mandala-list label clipped (DB stores full title; FE `truncate` clips) → full name on hover via title tooltip.

## Out of scope (tracked separately)
Generation Haiku is still OpenRouter-single (LoRA race reverted for quality). Wizard full availability also needs a generation fallback.

## Verify
tsc clean (BE+FE) · eslint 0 · BE jest 3/3 · FE build OK. Post-deploy: wizard works; resilient if cloud embed blocked (Mac Mini wins) — without a forbidden live OpenRouter test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)