### PR TITLE
feat(v2): config-driven v2 enrich model + DeepSeek pricing (CP504)

### DIFF
--- a/src/config/llm-pricing.ts
+++ b/src/config/llm-pricing.ts
@@ -33,6 +33,14 @@ export interface LLMPricing {
  * (e.g., 'qwen/qwen3-30b-a3b', NOT 'openrouter/qwen/qwen3-30b-a3b').
  */
 export const LLM_PRICING: Record<string, LLMPricing> = {
+  // --- OpenRouter: DeepSeek (CP504 — v2 enrich candidate, 2026-06-26) ---
+  // Key matches the normalized model id (provider strips the `openrouter/`
+  // prefix); without this entry cost_usd would log NULL for DeepSeek v2 enrich.
+  'deepseek/deepseek-v4-flash': {
+    inputPerToken: 0.00000014,
+    outputPerToken: 0.00000028,
+    source: 'simonw/llm-prices (2026-06): $0.14/M in, $0.28/M out',
+  },
   // --- OpenRouter: Qwen family (sourced 2026-04-27) ---
   'qwen/qwen3-30b-a3b': {
     inputPerToken: 0.00000008,

--- a/src/config/rich-summary.ts
+++ b/src/config/rich-summary.ts
@@ -77,6 +77,20 @@ export const richSummaryEnvSchema = z.object({
    * caps on Sonnet 4.6 / Haiku 4.5.
    */
   RICH_SUMMARY_V2_MAX_OUTPUT_TOKENS: positiveInt.transform((v) => v ?? 8192),
+  /**
+   * CP504 — v2 enrich LLM model id (OpenRouter; the provider prepends the
+   * `openrouter/` prefix). Default Sonnet 4.6 = the historical pinned model, so
+   * an unset env preserves existing behaviour and rollback is a one-line config
+   * flip. Flip to a cheaper model (e.g. 'deepseek/deepseek-v4-flash') via env.
+   * 15-cell eval (2026-06-26) found DeepSeek V4-Flash matched Sonnet on atom
+   * richness + timestamp coherence (SNAP-clean) at ~1.5% of Sonnet's cost.
+   */
+  RICH_SUMMARY_V2_MODEL: z
+    .preprocess(
+      (v) => (v == null || v === '' ? 'anthropic/claude-sonnet-4-6' : String(v).trim()),
+      z.string()
+    )
+    .default('anthropic/claude-sonnet-4-6'),
 });
 
 export interface RichSummaryConfig {
@@ -92,6 +106,8 @@ export interface RichSummaryConfig {
   transcriptMaxChars: number;
   /** Output token budget. Default 8192. */
   maxOutputTokens: number;
+  /** v2 enrich LLM model id (OpenRouter). Default 'anthropic/claude-sonnet-4-6'. */
+  enrichModel: string;
 }
 
 const FALLBACK_CONFIG: RichSummaryConfig = {
@@ -104,6 +120,7 @@ const FALLBACK_CONFIG: RichSummaryConfig = {
   maxDurationSeconds: 5400,
   transcriptMaxChars: 100000,
   maxOutputTokens: 8192,
+  enrichModel: 'anthropic/claude-sonnet-4-6',
 };
 
 export function loadRichSummaryConfig(env: NodeJS.ProcessEnv = process.env): RichSummaryConfig {
@@ -117,6 +134,7 @@ export function loadRichSummaryConfig(env: NodeJS.ProcessEnv = process.env): Ric
     RICH_SUMMARY_V2_MAX_DURATION_SECONDS: env['RICH_SUMMARY_V2_MAX_DURATION_SECONDS'],
     RICH_SUMMARY_V2_TRANSCRIPT_MAX_CHARS: env['RICH_SUMMARY_V2_TRANSCRIPT_MAX_CHARS'],
     RICH_SUMMARY_V2_MAX_OUTPUT_TOKENS: env['RICH_SUMMARY_V2_MAX_OUTPUT_TOKENS'],
+    RICH_SUMMARY_V2_MODEL: env['RICH_SUMMARY_V2_MODEL'],
   });
   if (!parsed.success) {
     return FALLBACK_CONFIG;
@@ -131,5 +149,6 @@ export function loadRichSummaryConfig(env: NodeJS.ProcessEnv = process.env): Ric
     maxDurationSeconds: parsed.data.RICH_SUMMARY_V2_MAX_DURATION_SECONDS,
     transcriptMaxChars: parsed.data.RICH_SUMMARY_V2_TRANSCRIPT_MAX_CHARS,
     maxOutputTokens: parsed.data.RICH_SUMMARY_V2_MAX_OUTPUT_TOKENS,
+    enrichModel: parsed.data.RICH_SUMMARY_V2_MODEL,
   };
 }

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -28,8 +28,11 @@ import { validateV2TimelineRange, V2TimelineRangeError } from './rich-summary-v2
 // (unsorted atom timestamps, narrator-perspective summaries, back half
 // uncovered). 491 rows marked `quality_flag='qwen3_low'`. Quick path
 // already uses claude-haiku-4.5 explicitly; this aligns the slow path on
-// the next tier up. Search-replace point for future model swaps.
-const SONNET_MODEL = 'anthropic/claude-sonnet-4-6';
+// the next tier up. CP504 — the model is now config-driven via
+// RICH_SUMMARY_V2_MODEL (richConfig.enrichModel; default = the Sonnet 4.6 id
+// 'anthropic/claude-sonnet-4-6') so it can be swapped (e.g. to the cheaper
+// deepseek/deepseek-v4-flash) without a code change. SNAP gate (PR #976) keeps
+// the timestamp-coherence guarantee regardless of model.
 
 import { detectContentLanguageFromTitle as detectLanguageFromTitle } from '@/utils/detect-language';
 import {
@@ -182,8 +185,9 @@ export async function generateRichSummaryV2(
     durationSeconds: effectiveDurationSec,
   });
 
-  // CP488+ — pinned Sonnet 4.6 (see SONNET_MODEL doc-comment above).
-  const provider = new OpenRouterGenerationProvider(SONNET_MODEL);
+  // CP504 — model config-driven (RICH_SUMMARY_V2_MODEL); default = the Sonnet
+  // 4.6 id (doc-comment above) so an unset env preserves prior behaviour.
+  const provider = new OpenRouterGenerationProvider(richConfig.enrichModel);
 
   let lastReason = 'unknown_error';
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {

--- a/tests/unit/modules/v2-enrich-model-config.test.ts
+++ b/tests/unit/modules/v2-enrich-model-config.test.ts
@@ -1,0 +1,19 @@
+import { loadRichSummaryConfig } from '@/config/rich-summary';
+import { calculateCost } from '@/config/llm-pricing';
+
+describe('v2 enrich model config (CP504)', () => {
+  it('defaults enrichModel to Sonnet (unset env = prior behaviour)', () => {
+    expect(loadRichSummaryConfig({}).enrichModel).toBe('anthropic/claude-sonnet-4-6');
+  });
+  it('reads RICH_SUMMARY_V2_MODEL override', () => {
+    expect(
+      loadRichSummaryConfig({ RICH_SUMMARY_V2_MODEL: 'deepseek/deepseek-v4-flash' }).enrichModel
+    ).toBe('deepseek/deepseek-v4-flash');
+  });
+  it('prices DeepSeek V4-Flash (normalized id) so cost_usd is not NULL', () => {
+    const c = calculateCost('openrouter/deepseek/deepseek-v4-flash', 10000, 5000);
+    expect(c).not.toBeNull();
+    // in 10000×$0.14/M + out 5000×$0.28/M = 0.0014 + 0.0014 = 0.0028
+    expect(c).toBeCloseTo(0.0028, 5);
+  });
+});


### PR DESCRIPTION
## Why
15-cell eval (Sonnet/Haiku/Qwen3.7Max/Gemini2.5Flash/DeepSeekV4Flash × 3 videos): **DeepSeek V4-Flash** matched Sonnet on atom richness (sufficient) + timestamp coherence (0 SNAP drop) at **~1.5% of Sonnet's cost** ($0.0016 vs $0.106/card). Make the model swappable by config.

## Changes (INERT — default Sonnet; flag flip is a separate step)
- `RICH_SUMMARY_V2_MODEL` env → `richConfig.enrichModel` (default `anthropic/claude-sonnet-4-6` → unset = prior behaviour, rollback = 1-line). generator uses it, not the hardcoded const.
- `llm-pricing`: add `deepseek/deepseek-v4-flash` ($0.14/$0.28 per M) so `cost_usd` records (else NULL) — mirrors #962.
- SNAP gate (PR #976) **unchanged**. per-run model already recorded (`provider.model`).
- 3 unit tests.

## NULL-cost finding (corrected)
Earlier "67% NULL = bug" was overstated: 56% error calls (no cost = correct) + 41% pre-#962 historical + 1.3% (10 calls) minor anomaly. #962 (06-24) already fixed Sonnet pricing. No systematic fix needed.

## Verify
tsc clean · eslint 0 · jest 3/3. Post-flag-flip: prod 1 call records `model=…deepseek-v4-flash` + non-null `cost_usd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)