### PR TITLE
feat(db): persist relevance rubric axes — relevance_detail jsonb (CP504 §0.7)

### DIFF
--- a/prisma/migrations/relevance-detail/001_relevance_detail.sql
+++ b/prisma/migrations/relevance-detail/001_relevance_detail.sql
@@ -1,0 +1,14 @@
+-- CP504 §0.7 — persist rubric axes for relevance scoring.
+--
+-- The rubric scorer (compute-card-relevance.ts) emits 3 raw axes
+-- (cell_fit_pct / goal_contribution_pct / actionability_pct) that compose into
+-- relevance_pct. They were LOG-ONLY (James 2026-06-11); persisting them lets the
+-- axis-weight re-tuning (0.4/0.4/0.2) be measured instead of guessed.
+--
+-- Column-add ONLY. No data backfill, no write-path/scoring change. Idempotent.
+ALTER TABLE public.user_video_states
+  ADD COLUMN IF NOT EXISTS relevance_detail jsonb;
+
+-- Postgrest schema reload so the Supabase client sees the new column
+-- (ALTER 직후 reload 누락 시 client silent-drop — CLAUDE.md ALTER 룰).
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,11 @@ model UserVideoState {
   /// leak. NULL = not yet backfilled; filled by the relevance-backfill queue.
   relevance_pct          Int?
   relevance_at           DateTime?      @db.Timestamptz(6)
+  /// CP504 §0.7 — raw rubric axes (cell_fit / goal_contribution / actionability)
+  /// that compose into relevance_pct. Was log-only; persisted so axis-weight
+  /// re-tuning (0.4/0.4/0.2) can be measured. No write-path/scoring change here.
+  /// Raw SQL DDL: prisma/migrations/relevance-detail/001_relevance_detail.sql
+  relevance_detail       Json?          @db.JsonB
   createdAt              DateTime       @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt              DateTime       @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
   users                  users          @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)


### PR DESCRIPTION
0단(§0.5) 채점 재설계 선결 — rubric 3축(cell_fit/goal_contribution/actionability) 영속화.

## Why
3축은 현재 LOG-ONLY (James 2026-06-11) → docker 로그 미보존으로 **불가측**. 영속화해야 축 가중치(0.4/0.4/0.2) 재튜닝을 측정으로 결정 가능.

## Change
- `user_video_states.relevance_detail jsonb` (nullable) 추가. **컬럼 추가만 — 데이터 backfill·write-path·채점 로직 변경 0.**
- raw SQL DDL 포함 (`prisma/migrations/relevance-detail/001`, force-add convention) — prisma-db-push-silent-fail 룰 준수.

## Verify
- **LOCAL 적용·검증 완료**: `\d user_video_states` → `relevance_detail | jsonb` 존재, postgrest reload, prisma generate, tsc 클린, validate 통과.
- **PROD = 별도 게이트** (수동 raw SQL via ssh psql + \d 검증 후 머지).

⚠️ **머지 보류** — 머지 시 CI/CD migrate가 prod 건드릴 수 있어 prod [GO] 전까지 미머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)