### PR TITLE
feat(book): relative book gate — per-mandala median+ ∧ floor (CP504 §0.3 D3)

### DIFF
--- a/src/config/book-gate.ts
+++ b/src/config/book-gate.ts
@@ -1,5 +1,5 @@
 /**
- * Book-index selection gate (ARCHITECTURE-bookindex.md §1③ / §2).
+ * Book-index selection gate (ARCHITECTURE-bookindex.md §1③ / §2 / §0.3 D3).
  *
  * fill-book sections a mandala's placed videos. This gate drops cards that do
  * NOT contribute to the book — scored-low (irrelevant) videos that would
@@ -7,16 +7,29 @@
  * video in an automation mandala). The gate filters the BOOK only; placement
  * (mandala data) is untouched.
  *
+ * CP504 §0.3 D3 — two modes (BOOK_GATE_MODE):
+ *   - 'absolute' (default, legacy): keep relevance >= minRelevance. Measured
+ *     no-op (93% pass) because the absolute score clusters at ~71 fleet-wide.
+ *   - 'relative': per-mandala median+ ∧ absolute floor. Validated (sim 1893
+ *     cards / 70 mandalas): 60% pass, `>= median` tie-pass protects tight
+ *     clusters (all-relevant mandalas keep ~all), floor drops the off-topic
+ *     3.9%. Self-calibrating across mandalas whose mean ranges 60..84.
+ *   Scoring is UNCHANGED — the relative gate consumes the same absolute scores.
+ *
  * null relevance = the card was never scored (measured 2026-06-23: only ~21% of
  * placed cards carry relevance_pct). PASS_NULL=true (default) lets unevaluated
  * cards through so the gate does NOT over-exclude 79% of legitimate content; it
  * still removes the scored-low ones. The null-pass count is logged (not silent).
- * Flip PASS_NULL=false once relevance is backfilled to make the gate strict.
+ * Flip PASS_NULL=false once relevance is backfilled (D4) to make the gate strict.
  *
- * Both are tuning knobs (not secrets): code default + env override.
+ * All are tuning knobs (not secrets): code default + env override. unset = inert
+ * (absolute legacy behavior).
  */
 
 import { z } from 'zod';
+
+export const BOOK_GATE_MODES = ['absolute', 'relative'] as const;
+export type BookGateMode = (typeof BOOK_GATE_MODES)[number];
 
 // 'false'/'0'/'no' → false, anything else truthy → true. (z.coerce.boolean
 // treats the string 'false' as true, so parse explicitly.)
@@ -27,39 +40,90 @@ const boolFromEnv = z.preprocess((v) => {
 }, z.boolean());
 
 export const bookGateEnvSchema = z.object({
-  // A placed card needs relevance_pct >= this to be sectioned. 0 disables the
-  // gate. Default 40: drops clearly-off-topic cards (rel=5 stock video, the
-  // defect-2 case) while keeping borderline-relevant ones (e.g. rel=45 marketing
-  // automation in an automation mandala) — avoids over-exclusion.
+  // A placed card needs relevance_pct >= this to be sectioned in ABSOLUTE mode
+  // (also the relative-mode fallback for small/unscored mandalas). 0 disables.
+  // Default 40: drops clearly-off-topic cards (rel=5 stock video, the defect-2
+  // case) while keeping borderline-relevant ones — avoids over-exclusion.
   BOOK_GATE_MIN_RELEVANCE: z.coerce.number().min(0).max(100).default(40),
   // true ⇒ cards with null relevance_pct (unscored) pass; false ⇒ they are dropped.
   BOOK_GATE_PASS_NULL_RELEVANCE: boolFromEnv.default(true),
+  // CP504 §0.3 D3 — gate mode. unset/'absolute' = inert legacy. 'relative' =
+  // per-mandala median+ ∧ floor. Config-flip rollback = remove → 'absolute'.
+  BOOK_GATE_MODE: z.enum(BOOK_GATE_MODES).default('absolute'),
+  // Relative-mode absolute floor: a card below this is dropped even if it beats
+  // the mandala median (blocks weak-mandala book pollution).
+  BOOK_GATE_FLOOR_RELEVANCE: z.coerce.number().min(0).max(100).default(35),
+  // Relative mode needs at least this many SCORED cards for a stable median;
+  // below it the gate falls back to absolute (small-mandala guard).
+  BOOK_GATE_MIN_SCORED_FOR_RELATIVE: z.coerce.number().int().min(1).default(5),
 });
 
 export interface BookGateConfig {
+  mode: BookGateMode;
   minRelevance: number;
+  floorRelevance: number;
+  minScoredForRelative: number;
   passNull: boolean;
+}
+
+/** Per-mandala context for relative gating (computed once by the caller). */
+export interface BookGateContext {
+  /** Median relevance_pct over the mandala's SCORED placed cards; null if none. */
+  median: number | null;
+  /** Count of scored (non-null relevance) placed cards in the mandala. */
+  scoredCount: number;
 }
 
 export function loadBookGateConfig(env: NodeJS.ProcessEnv = process.env): BookGateConfig {
   const parsed = bookGateEnvSchema.parse({
     BOOK_GATE_MIN_RELEVANCE: env['BOOK_GATE_MIN_RELEVANCE'],
     BOOK_GATE_PASS_NULL_RELEVANCE: env['BOOK_GATE_PASS_NULL_RELEVANCE'],
+    BOOK_GATE_MODE: env['BOOK_GATE_MODE'],
+    BOOK_GATE_FLOOR_RELEVANCE: env['BOOK_GATE_FLOOR_RELEVANCE'],
+    BOOK_GATE_MIN_SCORED_FOR_RELATIVE: env['BOOK_GATE_MIN_SCORED_FOR_RELATIVE'],
   });
   return {
+    mode: parsed.BOOK_GATE_MODE,
     minRelevance: parsed.BOOK_GATE_MIN_RELEVANCE,
+    floorRelevance: parsed.BOOK_GATE_FLOOR_RELEVANCE,
+    minScoredForRelative: parsed.BOOK_GATE_MIN_SCORED_FOR_RELATIVE,
     passNull: parsed.BOOK_GATE_PASS_NULL_RELEVANCE,
   };
 }
 
 /**
- * Gate decision for one placed card (pure). Returns true = keep in the book.
- *   - relevance >= minRelevance  → keep
- *   - relevance <  minRelevance  → drop (scored-low, the defect-2 case)
- *   - relevance == null          → passNull
+ * Compute the per-mandala median over SCORED relevance values (null-free).
+ * Returns null when there are no scored cards. Tie-inclusive `>= median`
+ * downstream is what protects tight clusters (all-relevant mandalas keep ~all).
  */
-export function passesBookGate(relevance: number | null, cfg: BookGateConfig): boolean {
+export function computeMandalaMedian(relevances: Array<number | null>): BookGateContext {
+  const scored = relevances.filter((r): r is number => r != null).sort((a, b) => a - b);
+  if (scored.length === 0) return { median: null, scoredCount: 0 };
+  const mid = Math.floor(scored.length / 2);
+  const median = scored.length % 2 === 1 ? scored[mid]! : (scored[mid - 1]! + scored[mid]!) / 2;
+  return { median, scoredCount: scored.length };
+}
+
+/**
+ * Gate decision for one placed card (pure). Returns true = keep in the book.
+ *   - relevance == null            → passNull
+ *   - relative mode (median present, enough sample):
+ *       relevance >= floor ∧ relevance >= mandala median   (tie-pass)
+ *   - absolute mode / fallback:    relevance >= minRelevance
+ */
+export function passesBookGate(
+  relevance: number | null,
+  ctx: BookGateContext,
+  cfg: BookGateConfig
+): boolean {
   if (relevance == null) return cfg.passNull;
+  if (
+    cfg.mode === 'relative' &&
+    ctx.median != null &&
+    ctx.scoredCount >= cfg.minScoredForRelative
+  ) {
+    return relevance >= cfg.floorRelevance && relevance >= ctx.median;
+  }
   return relevance >= cfg.minRelevance;
 }
 

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -16,6 +16,7 @@ import { parseBookJson } from './book-schema';
 import {
   loadBookGateConfig,
   passesBookGate,
+  computeMandalaMedian,
   isBookTopicSynthesisEnabled,
 } from '@/config/book-gate';
 import { synthesizeCellTopics } from './topic-synthesis';
@@ -205,6 +206,14 @@ export async function fillMandalaBook(params: {
   // (default pass, logged — not a silent leak). Placement (mandala data) is
   // untouched; the gate filters the BOOK only.
   const gate = loadBookGateConfig();
+  // CP504 §0.3 D3 — per-mandala median over SCORED placed cards (one video =
+  // one vote; dedup so a video in two cells doesn't double-weight). Inert in
+  // absolute mode; used only when BOOK_GATE_MODE=relative.
+  const relByVideo = new Map<string, number | null>();
+  for (const pl of placements) {
+    if (!relByVideo.has(pl.videoId)) relByVideo.set(pl.videoId, pl.relevance);
+  }
+  const gateCtx = computeMandalaMedian(Array.from(relByVideo.values()));
   let gatedLow = 0;
   let gatedNullPass = 0;
   // §1④ coverage — the book targets the GATE-PASSED cards as a whole. The order
@@ -235,7 +244,7 @@ export async function fillMandalaBook(params: {
       if (seen.has(p.videoId)) continue; // dedup a video within one cell
       // §1③ GATE FIRST (before v2) — a scored-low / off-topic card is dropped
       // regardless of v2. Reordered: v2-absence no longer short-circuits the gate.
-      if (!passesBookGate(p.relevance, gate)) {
+      if (!passesBookGate(p.relevance, gateCtx, gate)) {
         gatedLow += 1; // scored below the gate min → excluded from the book
         continue;
       }

--- a/tests/unit/modules/book-gate.test.ts
+++ b/tests/unit/modules/book-gate.test.ts
@@ -1,56 +1,121 @@
 /**
- * book-gate (§1③ selection gate) — pure gate decision + config.
- * Locks: keep >= min, drop < min (defect-2 rel=5 case), null → passNull policy.
+ * book-gate (§1③ / §0.3 D3 selection gate) — pure gate decision + config.
+ * Locks: absolute keep>=min / drop<min (defect-2 rel=5) / null→passNull, AND the
+ * CP504 relative mode (per-mandala median+ ∧ floor, tie-pass, small-mandala
+ * fallback) + computeMandalaMedian.
  */
 
 import {
   passesBookGate,
+  computeMandalaMedian,
   loadBookGateConfig,
   isBookTopicSynthesisEnabled,
   type BookGateConfig,
+  type BookGateContext,
 } from '../../../src/config/book-gate';
 
 const cfg = (over: Partial<BookGateConfig> = {}): BookGateConfig => ({
+  mode: 'absolute',
   minRelevance: 50,
+  floorRelevance: 35,
+  minScoredForRelative: 5,
   passNull: true,
   ...over,
 });
+// Absolute mode ignores ctx; relative tests pass an explicit one.
+const NO_CTX: BookGateContext = { median: null, scoredCount: 0 };
 
-describe('passesBookGate', () => {
+describe('passesBookGate — absolute (legacy, default)', () => {
   it('keeps a card scored at/above the min', () => {
-    expect(passesBookGate(50, cfg())).toBe(true);
-    expect(passesBookGate(92, cfg())).toBe(true);
+    expect(passesBookGate(50, NO_CTX, cfg())).toBe(true);
+    expect(passesBookGate(92, NO_CTX, cfg())).toBe(true);
   });
-
   it('drops a card scored below the min (defect 2: rel=5 stock video)', () => {
-    expect(passesBookGate(5, cfg())).toBe(false);
-    expect(passesBookGate(49, cfg())).toBe(false);
+    expect(passesBookGate(5, NO_CTX, cfg())).toBe(false);
+    expect(passesBookGate(49, NO_CTX, cfg())).toBe(false);
   });
-
   it('null relevance follows passNull policy', () => {
-    expect(passesBookGate(null, cfg({ passNull: true }))).toBe(true);
-    expect(passesBookGate(null, cfg({ passNull: false }))).toBe(false);
+    expect(passesBookGate(null, NO_CTX, cfg({ passNull: true }))).toBe(true);
+    expect(passesBookGate(null, NO_CTX, cfg({ passNull: false }))).toBe(false);
+  });
+  it('min=0 disables the gate (everything scored passes)', () => {
+    expect(passesBookGate(0, NO_CTX, cfg({ minRelevance: 0 }))).toBe(true);
+  });
+});
+
+describe('passesBookGate — relative (CP504 §0.3 D3)', () => {
+  const rel = cfg({ mode: 'relative', floorRelevance: 35, minScoredForRelative: 5 });
+  const ctx = (median: number | null, scoredCount = 10): BookGateContext => ({
+    median,
+    scoredCount,
   });
 
-  it('min=0 disables the gate (everything scored passes)', () => {
-    expect(passesBookGate(0, cfg({ minRelevance: 0 }))).toBe(true);
-    expect(passesBookGate(5, cfg({ minRelevance: 0 }))).toBe(true);
+  it('keeps cards at/above the mandala median (tie-pass)', () => {
+    expect(passesBookGate(72, ctx(72), rel)).toBe(true); // == median passes (tie)
+    expect(passesBookGate(85, ctx(72), rel)).toBe(true);
+  });
+  it('drops cards below the mandala median', () => {
+    expect(passesBookGate(60, ctx(72), rel)).toBe(false);
+  });
+  it('floor overrides relative: below floor drops even if above median', () => {
+    // weak mandala (median 30): a 32 card beats the median but is below floor 35
+    expect(passesBookGate(32, ctx(30), rel)).toBe(false);
+    expect(passesBookGate(40, ctx(30), rel)).toBe(true); // above floor AND median
+  });
+  it('tight cluster: all-equal scores all pass (>= median, no arbitrary cut)', () => {
+    // a mandala of [78,78,78,78,82] → median 78 → every 78 passes
+    expect(passesBookGate(78, ctx(78), rel)).toBe(true);
+    expect(passesBookGate(82, ctx(78), rel)).toBe(true);
+  });
+  it('small-mandala fallback: too few scored ⇒ absolute min, not median', () => {
+    // scoredCount 3 < 5 ⇒ absolute: 60 >= min(50) passes regardless of median 72
+    expect(passesBookGate(60, ctx(72, 3), rel)).toBe(true);
+    expect(passesBookGate(45, ctx(72, 3), rel)).toBe(false); // below absolute min
+  });
+  it('null median ⇒ absolute fallback', () => {
+    expect(passesBookGate(60, ctx(null, 10), rel)).toBe(true);
+  });
+  it('null relevance still follows passNull in relative mode', () => {
+    expect(passesBookGate(null, ctx(72), rel)).toBe(true);
+    expect(passesBookGate(null, ctx(72), cfg({ mode: 'relative', passNull: false }))).toBe(false);
+  });
+});
+
+describe('computeMandalaMedian', () => {
+  it('odd count → middle, excludes nulls', () => {
+    const c = computeMandalaMedian([40, null, 80, null, 60]);
+    expect(c.median).toBe(60);
+    expect(c.scoredCount).toBe(3);
+  });
+  it('even count → mean of the two middles', () => {
+    expect(computeMandalaMedian([60, 80, 70, 90]).median).toBe(75);
+  });
+  it('no scored cards → null median', () => {
+    expect(computeMandalaMedian([null, null])).toEqual({ median: null, scoredCount: 0 });
   });
 });
 
 describe('loadBookGateConfig', () => {
-  it('defaults: min 40, passNull true', () => {
+  it('defaults: mode absolute, min 40, floor 35, minScored 5, passNull true (inert)', () => {
     const c = loadBookGateConfig({});
-    expect(c.minRelevance).toBe(40);
-    expect(c.passNull).toBe(true);
+    expect(c).toEqual({
+      mode: 'absolute',
+      minRelevance: 40,
+      floorRelevance: 35,
+      minScoredForRelative: 5,
+      passNull: true,
+    });
   });
-
-  it('env overrides threshold + null policy', () => {
+  it('env flips to relative + overrides floor/minScored/null policy', () => {
     const c = loadBookGateConfig({
-      BOOK_GATE_MIN_RELEVANCE: '70',
+      BOOK_GATE_MODE: 'relative',
+      BOOK_GATE_FLOOR_RELEVANCE: '30',
+      BOOK_GATE_MIN_SCORED_FOR_RELATIVE: '8',
       BOOK_GATE_PASS_NULL_RELEVANCE: 'false',
     });
-    expect(c.minRelevance).toBe(70);
+    expect(c.mode).toBe('relative');
+    expect(c.floorRelevance).toBe(30);
+    expect(c.minScoredForRelative).toBe(8);
     expect(c.passNull).toBe(false);
   });
 });


### PR DESCRIPTION
Opt-in per-mandala RELATIVE book gate (`BOOK_GATE_MODE=relative`). **Scoring unchanged** — consumes same absolute relevance_pct.

## Why
Absolute rel>=40 gate = no-op (93% pass on ~71-clustered scores). Absolute re-anchor of the scorer was tried + **retired** (sample N=39: sd compression + low-band inflation = fragile). The GATE is the lever.

## Validated (sim 1893 cards / 70 mandalas)
median+ = 60% pass, `>= median` tie-pass protects tight clusters, floor(35) drops off-topic 3.9%. Self-calibrating (mandala mean 60..84).

## Change (single call site, inert by default)
- `book-gate.ts`: BOOK_GATE_MODE / FLOOR / MIN_SCORED_FOR_RELATIVE + `passesBookGate(rel, ctx, cfg)` + `computeMandalaMedian`. Small-mandala → absolute fallback.
- `fill-book.ts`: per-mandala median once → gate. PASS_NULL kept until D4.
- 19 unit tests. tsc clean, eslint 0.

**Inert until `BOOK_GATE_MODE=relative`. Rollback = unset.** Merge/prod flip = separate gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)