### PR TITLE
fix(enrich/note): stop perpetual spinner + stale-note refresh + hi-res thumb (CP504)

### DIFF
--- a/frontend/src/pages/learning/lib/video-block.tsx
+++ b/frontend/src/pages/learning/lib/video-block.tsx
@@ -206,11 +206,22 @@ function VideoBlockNodeView({ node, getPos, editor }: NodeViewProps) {
           onDragStart={(e) => e.preventDefault()}
         >
           <img
-            src={`https://img.youtube.com/vi/${attrs.vid}/hqdefault.jpg`}
+            src={`https://img.youtube.com/vi/${attrs.vid}/maxresdefault.jpg`}
             alt=""
             className="video-block-thumb"
             draggable={false}
-            onError={() => setThumbBroken(true)}
+            onError={(e) => {
+              // CP504 — prefer maxresdefault (1280×720). It 404s for videos that
+              // never produced a maxres thumb, so fall back to hqdefault (480×360,
+              // always exists); only mark broken if even that fails.
+              const img = e.currentTarget;
+              if (!img.dataset.fellBack) {
+                img.dataset.fellBack = '1';
+                img.src = `https://img.youtube.com/vi/${attrs.vid}/hqdefault.jpg`;
+              } else {
+                setThumbBroken(true);
+              }
+            }}
           />
           <span className="video-block-overlay" />
           <span

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -367,7 +367,13 @@ export function CenterPanel({
             {/* PR3b — note is behind the (settled) book: new cards/translations
                 landed after this note was generated. User-triggered refresh only
                 (no auto-overwrite); edits are preserved on regenerate. */}
-            {noteDoc.stale && (book?.coverage?.v2Pending ?? 0) === 0 && (
+            {/* CP504 — show the refresh affordance whenever the note is stale
+                (book version > note's based_on version). The old `v2Pending === 0`
+                gate hid it for the entire enrich window, so a note built early
+                (e.g. v3) could never refresh to a newer book (v6) while videos
+                without captions kept v2Pending perpetually > 0. A stale note
+                should always be refreshable to the CURRENT book. */}
+            {noteDoc.stale && (
               <div className="mx-auto mt-3 flex max-w-[680px] items-center justify-between gap-3 rounded-md border border-white/[0.07] bg-white/[0.03] px-3.5 py-2 text-[12px] text-muted-foreground">
                 <span>새 내용이 북인덱스에 추가됐어요. 노트를 새로고침하면 반영됩니다.</span>
                 <button

--- a/src/modules/skills/mark-skipped-summary.ts
+++ b/src/modules/skills/mark-skipped-summary.ts
@@ -36,9 +36,15 @@ export async function markSkippedSummary(
   try {
     const existing = await prisma.video_rich_summaries.findUnique({
       where: { video_id: videoId },
-      select: { quality_flag: true },
+      select: { quality_flag: true, template_version: true },
     });
-    if (existing?.quality_flag === 'pass') return; // never overwrite a good row
+    // CP504 — protect a real V2 pass only. A v1/pass row is an OLD summary that
+    // could not upgrade to v2 (e.g. NO_TRANSCRIPT); leaving it 'pass' means
+    // fill-book never sees the video as terminally skipped, so it re-enqueues it
+    // every book build → the enrich job re-throws NO_TRANSCRIPT forever (measured:
+    // one video failed 12×) and the FE spinner never ends. Overwrite v1/pass with
+    // the terminal skipped marker so re-enqueue + the v2-pending count both stop.
+    if (existing?.quality_flag === 'pass' && existing?.template_version === 'v2') return;
     const skipCore = { skip_reason: reason } as unknown as Prisma.InputJsonValue;
     await prisma.video_rich_summaries.upsert({
       where: { video_id: videoId },

--- a/tests/unit/skills/mark-skipped-summary.test.ts
+++ b/tests/unit/skills/mark-skipped-summary.test.ts
@@ -20,10 +20,20 @@ describe('markSkippedSummary', () => {
     upsert.mockResolvedValue({});
   });
 
-  it('does NOT clobber a row that already passed', async () => {
-    findUnique.mockResolvedValue({ quality_flag: 'pass' });
+  it('does NOT clobber a real V2 pass row', async () => {
+    findUnique.mockResolvedValue({ quality_flag: 'pass', template_version: 'v2' });
     await markSkippedSummary('v1', 'no_transcript', 'u1');
     expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('CP504 — overwrites a v1/pass row with skipped (it cannot upgrade to v2)', async () => {
+    // A v1 'pass' is an OLD summary; if v2 generation can never succeed
+    // (NO_TRANSCRIPT), the video must be marked terminal so fill-book stops
+    // re-enqueuing it and the spinner ends.
+    findUnique.mockResolvedValue({ quality_flag: 'pass', template_version: 'v1' });
+    await markSkippedSummary('v1', 'no_transcript', 'u1');
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(upsert.mock.calls[0][0].update.quality_flag).toBe('skipped');
   });
 
   it('upserts a skipped row (quality_flag=skipped + core.skip_reason) when absent', async () => {


### PR DESCRIPTION
James prod (mandala 7e3fb128 "100일 일본어"): enrich 스피너 영구(≈10 정지), 노트 4/14 v2, 노트탭 썸네일 저화질.

## 측정 근거
- enrich-rich-summary **failed 120건 전부 NO_TRANSCRIPT** / 같은 영상 **12회·9회 반복 실패**(재enqueue).
- 51영상 중 **30 v1/pass** (v2/skipped 단 2) → 자막 없는 영상이 terminal 마킹 안 됨.

## 수정
- **1a/1b 영구 스피너 root**: `markSkippedSummary`가 모든 'pass' overwrite 거부 → **v1/pass(v2 못 올린 옛 요약)도 보호** → 자막없는 영상 영구 재enqueue(120 실패). **fix: v2/pass만 보호, v1/pass→skipped overwrite**. fill-book는 이미 skipped를 v2Pending+재enqueue서 제외(fill-book.ts:268) → 스피너 종료.
- **1c stale 노트 갱신 불가**: 새로고침이 `v2Pending===0` 게이트 → 영구 pending이라 v3→v6 갱신 불가. **fix: stale(book>note)이면 항상 표시**.
- **2 썸네일**: hqdefault(480×360) → **maxresdefault(1280×720) + onError fallback**.

## 검증
backend tsc / FE tsc / vitest 50/50 / FE build / 브라우저 스모크(`/`+`/learning/[note]` 200) PASS. mark-skipped 테스트 갱신+신규. (무관 pre-existing 2 backend 실패 = LAYER_BLOCKS/video-discover.)

## 범위 밖
1a 자막없는 37영상 복원 = §12 CV 별도. **DDL 없음**(기존 quality_flag='skipped' 재사용).

**머지 전 James 검토.** 검증 = 스피너 끝남 + 새로고침 버튼 + 썸네일 고화질.

🤖 Generated with [Claude Code](https://claude.com/claude-code)