### PR TITLE
fix(sidebar): hide empty-chapter headings in note mode (CP504 §3.1)

### DIFF
--- a/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
@@ -366,6 +366,12 @@ export function SidebarLearningSection({
           })()}
         {subGoals.map((goal, idx) => {
           const bookChapter = bookChaptersByIdx.get(idx);
+          // CP504 §3.1 — note mode TOC must mirror book content. Empty cells
+          // (no book chapter / 0 sections) leaked a bare heading into the
+          // sidebar even though PR #989 filtered them from book_json. Player
+          // mode keeps every heading so collected-video cards still render.
+          const hasBookSections = (bookChapter?.sections?.length ?? 0) > 0;
+          if (centerViewMode === 'note' && !hasBookSections) return null;
           const isExpanded = isChapterExpanded(idx);
           // Row text = short cell label; tooltip = long-form sub-goal.
           // When the label is explicitly set, the tooltip always surfaces


### PR DESCRIPTION
## Problem (James prod screen)
The book note body is clean (PR #989 removed empty chapters from `book_json`), but the **left sidebar TOC still shows empty numbered chapter headings** (e.g. `01`/`05`/`08`) in **note mode**. Root cause: the sidebar is a separate component (`SidebarLearningSection`) whose `subGoals.map` renders one heading per cell (8 cells) unconditionally — PR #989's empty-chapter filter only applied to `book_json` (the center panel body), not the sidebar.

## Fix (1 guard, mode-aware)
`SidebarLearningSection.tsx` — right after `const bookChapter = bookChaptersByIdx.get(idx)`:
```ts
const hasBookSections = (bookChapter?.sections?.length ?? 0) > 0;
if (centerViewMode === 'note' && !hasBookSections) return null;
```
- **Note mode**: cells with no book chapter / 0 sections are skipped → TOC mirrors `book_json`.
- **Player mode**: untouched — every heading stays so each cell's collected-video cards (`renderPlayerList`) and the cell-0 "개요" group still render. **No regression by construction** (the guard only fires for `centerViewMode === 'note'`; player code paths are byte-identical to main).
- No React hooks are called inside the `subGoals.map` callback, so the early `return null` is rules-of-hooks safe.

## Verification
| Check | Result |
|-------|--------|
| frontend `tsc --noEmit` | ✅ PASS (0 errors) |
| `vitest run` (full) | ✅ PASS (50 files / 408 tests) |
| `vite build` | ✅ PASS (fresh dist) |
| browser smoke (visual) | ⏳ deferred to prod — see below |

**Browser visual = James prod screen** (per recovery doc: Done = James 화면). The targeted check needs prod mandala `7e3fb128` + its generated book (v9 = 5 chapters / 12 sections), which isn't reproducible in the dev sandbox. Expected after merge:
- Note mode → empty headings `01/05/08` gone; TOC ≈ 5 headings + 12 sections (~17 lines), matches body.
- Player mode → empty cells' video cards still display (regression = 0).

## Out of scope (deliberate)
§3.2 cap (`NOTE_MAX_SECTIONS` 20→12/10) **not touched** — to be decided after measuring note-mode TOC length on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)