### PR TITLE
fix(sidebar): note-mode TOC uses bullets, not cell-index numbers (CP504)

### DIFF
--- a/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
@@ -403,14 +403,18 @@ export function SidebarLearningSection({
               className="group flex w-full items-center gap-2 px-2 py-1 text-left transition-colors"
             >
               {/* §redesign — chapter number replaces the chevron (시안 .toc-chapter
-                  .n). Row click still toggles expand/collapse. */}
+                  .n). Row click still toggles expand/collapse.
+                  CP504 — note mode drops the cell-index number: after the §3.1
+                  empty-cell filter the numbers go gappy (02·03·06…), which reads
+                  oddly and contradicts the compression/narrative concept. Note
+                  mode uses a bullet; player mode keeps 01–08 = spatial position. */}
               <span
                 className={cn(
                   'shrink-0 font-mono text-[11px] tabular-nums transition-colors',
                   chapterActive ? 'text-sidebar-foreground/80' : 'text-sidebar-foreground/35'
                 )}
               >
-                {String(idx + 1).padStart(2, '0')}
+                {centerViewMode === 'note' ? '•' : String(idx + 1).padStart(2, '0')}
               </span>
               <span
                 className={cn(


### PR DESCRIPTION
## Why
Follow-on to #991 (§3.1). In note mode the chapter heading number is the **mandala cell index** (`String(idx+1).padStart(2,'0')`), not a sequential position. After §3.1 filters empty cells, the visible numbers go **gappy** (`02·03·06·07…`) — which reads oddly and contradicts the compression/narrative concept (a book's chapters are a flow, not addressed grid cells). James prod-confirmed the gap on `7e3fb128`.

## Change (1 line, mode-aware)
`SidebarLearningSection.tsx` chapter-number span:
```tsx
{centerViewMode === 'note' ? '•' : String(idx + 1).padStart(2, '0')}
```
- **Note mode** → bullet (sequential flow, no gappy indices).
- **Player mode** → keeps `01–08` — the number encodes the cell's **spatial position** in the mandala grid, which users navigate by. Untouched.
- Same component + `centerViewMode === 'note'` branch as #991.

## Verification
| Check | Result |
|-------|--------|
| frontend `tsc --noEmit` | ✅ 0 errors |
| `vitest run` | ✅ 50 files / 408 tests |
| `vite build` | ✅ exit 0 (direct binary; `npm run` wrapper shows a flaky 194, underlying build succeeds) |
| browser visual | ⏳ James prod screen (bullet glyph/alignment is a visual-convergence call) |

## Next
After merge + deploy → measure note-mode bullet TOC line count → decide §3.2 cap (`NOTE_MAX_SECTIONS` 20/12/10). §4.5.1 (narrative arc) stays gated behind cap + player-mode regression confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)