### PR TITLE
chore(note): activate BOOK_NARRATIVE_SKELETON on prod (CP504 §4.5.1)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -261,6 +261,13 @@ services:
       # backfill = half-activation, intended). Scoring unchanged; single call
       # site (fill-book). Config-flip rollback = delete this line → 'absolute'.
       - BOOK_GATE_MODE=relative
+      # CP504 §4.5.1 — narrative book (skeleton + chapter-body weave). Activates
+      # PR #993 (merged flag-off). fill-book reconstructs cells' §1⑤ topics into a
+      # narrative book (기승전결, cross-cell, chapter intro) via Sonnet, and the
+      # note-mode sidebar renders book.chapters directly. Config-flip rollback =
+      # delete this line (or =false) → legacy cell=chapter. Adds N+1 Sonnet calls
+      # per book-fill (skeleton + per-chapter body); cost ~$0.25/book (§7.5).
+      - BOOK_NARRATIVE_SKELETON=true
       # CP500++ CONFIG-SSOT (2026-06-16) — MIGRATED from deploy.yml→.env to compose
       # (single SSOT; removes the §10-C dual-channel where compose silently wins).
       # Values preserved verbatim from prod printenv 2026-06-16 (value-invariant).


### PR DESCRIPTION
## 1-line prod activation of PR #993 (merged flag-off)
Adds `BOOK_NARRATIVE_SKELETON=true` to `docker-compose.prod.yml` api `environment:` (the activation SSOT per the env-drift lesson — compose literal wins over `.env`/gh-variable).

**Effect**: `fill-book` reconstructs cells' §1⑤ topics into a narrative book (기승전결, cross-cell merge, chapter intro via Sonnet) + per-chapter body weave; note-mode sidebar renders `book.chapters` directly. **Cost**: N+1 Sonnet calls per book-fill (~$0.25/book, §7.5). **Rollback**: delete the line / `=false` → legacy cell=chapter (config-flip, no code revert).

## Post-merge verify (the Done gate)
1. `docker exec <api> printenv | grep BOOK_NARRATIVE_SKELETON` → `true`.
2. Re-fill `7e3fb128`: deck button, or `POST /api/v1/admin/mandala-book-fill/run {userId, mandalaId}`.
3. **James screen** on `7e3fb128` note: (a) 기승전결 (b) 챕터 엮임 (c) 사실 출처근거(창작0) (d) 만다라 무게.

Good → loop-2 ([4] STORM/Factcheck) separate GO. Bad → flag off + report what's off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)