### PR TITLE
fix(note): loop-1b — narrative note body = woven prose + atom citations (CP504 §4.5.1)

### DIFF
--- a/frontend/src/__tests__/note-document-generator-narrative.test.ts
+++ b/frontend/src/__tests__/note-document-generator-narrative.test.ts
@@ -1,0 +1,71 @@
+/**
+ * note-document-generator — loop-1b (§4.5.1) narrative render gate.
+ * Pure generator → no mocks. Locks the falsifiable P-1b structural checks:
+ *   P-1b-WEAVE      narrative book → woven prose IS the body; raw atom texts are
+ *                   NOT dumped as per-video paragraphs (the 따로국밥 list is gone).
+ *   P-1b-NO-DUP     no trailing keypoint blockquote (narrative is the body now).
+ *   P-1b-PROV-KEPT  source atoms still cited as per-vid video blocks (vid+ts seek).
+ *   R-1b (legacy)   no chapter intro → render byte-unchanged (atom paragraphs +
+ *                   narrative blockquote).
+ *   R-1b-FALLBACK   narrative book but empty section.narrative → legacy render.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildInitialNoteDoc } from '@/pages/learning/lib/note-document-generator';
+import type { MandalaBookData } from '@/shared/lib/api-client';
+
+type N = { type: string; content?: N[]; attrs?: { vid?: string } };
+const nodes = (doc: { content?: unknown[] }): N[] => (doc.content ?? []) as N[];
+const paraTexts = (ns: N[]): string[] =>
+  ns
+    .filter((n) => n.type === 'paragraph')
+    .map((p) => (p.content ?? []).map((c) => (c as { text?: string }).text ?? '').join(''))
+    .filter(Boolean);
+const blockquotes = (ns: N[]) => ns.filter((n) => n.type === 'blockquote');
+const videoBlocks = (ns: N[]) => ns.filter((n) => n.type === 'videoBlock');
+
+// A multi-video topic: atoms from vidA + vidB, a woven narrative, chapter intro.
+const book = (intro: string, narrative = 'WOVEN_BODY 식당 흐름이 이어진다'): MandalaBookData =>
+  ({
+    chapters: [
+      {
+        ch: 0,
+        title: '기초 회화',
+        intro,
+        sections: [
+          {
+            title: '식당에서',
+            narrative,
+            atoms: [
+              { vid: 'vidA', ts: 10, text: 'ATOM_TEXT_A 인사' },
+              { vid: 'vidB', ts: 20, text: 'ATOM_TEXT_B 주문' },
+            ],
+          },
+        ],
+      },
+    ],
+  }) as MandalaBookData;
+
+describe('note-document-generator — loop-1b narrative render', () => {
+  it('narrative mode (intro present): prose is the body, no atom-text dump, no blockquote, atoms cited as video blocks', () => {
+    const ns = nodes(buildInitialNoteDoc(book('이 장은 기초 회화를 다룬다')));
+    const texts = paraTexts(ns);
+    expect(texts).toContain('WOVEN_BODY 식당 흐름이 이어진다'); // P-1b-WEAVE: prose = body
+    expect(texts).not.toContain('ATOM_TEXT_A 인사'); // no per-video atom-text dump
+    expect(texts).not.toContain('ATOM_TEXT_B 주문');
+    expect(blockquotes(ns)).toHaveLength(0); // P-1b-NO-DUP: narrative not a footer
+    expect(videoBlocks(ns).map((v) => v.attrs?.vid).sort()).toEqual(['vidA', 'vidB']); // P-1b-PROV-KEPT
+  });
+
+  it('legacy mode (no intro): UNCHANGED — atom-text paragraphs + narrative blockquote', () => {
+    const ns = nodes(buildInitialNoteDoc(book('')));
+    const texts = paraTexts(ns);
+    expect(texts).toContain('ATOM_TEXT_A 인사'); // atom text dumped (legacy)
+    expect(texts).toContain('ATOM_TEXT_B 주문');
+    expect(blockquotes(ns)).toHaveLength(1); // narrative as keypoint blockquote
+  });
+
+  it('fallback: narrative mode but empty section.narrative → legacy render for that section', () => {
+    const ns = nodes(buildInitialNoteDoc(book('이 장은 기초 회화를 다룬다', '')));
+    expect(paraTexts(ns)).toContain('ATOM_TEXT_A 인사'); // fell through to legacy atom render
+  });
+});

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -170,7 +170,8 @@ function groupAtomsByVid(
 function renderSection(
   section: MandalaBookSection,
   chapterIdx: number,
-  sectionIdx: number
+  sectionIdx: number,
+  narrativeMode: boolean
 ): TiptapNode[] {
   const out: TiptapNode[] = [];
 
@@ -187,8 +188,29 @@ function renderSection(
   // Section heading (h3 inside chapter h2)
   out.push(heading(3, section.title));
 
-  // VideoBlocks + atom paragraphs (grouped by vid)
   const groups = groupAtomsByVid(section.atoms ?? []);
+
+  // §4.5.1 loop-1b — narrative book: the woven section.narrative IS the body
+  // (one flowing prose, NOT per-video atom snippets). Source atoms become
+  // citations: one video block per source vid (seek + provenance), AFTER the
+  // prose. Removes the per-video atom-text paragraph dump (the 따로국밥 list) and
+  // the trailing keypoint blockquote (narrative is the body now, not a wrap-up).
+  // Legacy books (no chapter intro → narrativeMode false) fall through to the
+  // unchanged path below. Empty narrative (weave/skeleton edge) also falls
+  // through → graceful legacy render (R-1b-FALLBACK).
+  if (narrativeMode && section.narrative && section.narrative.trim()) {
+    out.push(paragraph(section.narrative));
+    for (const g of groups) {
+      if (g.atoms.length === 0) continue;
+      const firstTs = g.atoms[0].ts ?? 0;
+      const endSec = groupEndSec(g.atoms);
+      out.push(videoBlockNode(g.vid, firstTs, endSec, section.title ?? null));
+    }
+    out.push(horizontalRule());
+    return out;
+  }
+
+  // VideoBlocks + atom paragraphs (grouped by vid) — LEGACY (unchanged).
   for (const g of groups) {
     if (g.atoms.length === 0) continue;
     const firstTs = g.atoms[0].ts ?? 0;
@@ -219,7 +241,7 @@ function renderSection(
   return out;
 }
 
-function renderChapter(chapter: MandalaBookChapter): TiptapNode[] {
+function renderChapter(chapter: MandalaBookChapter, narrativeMode: boolean): TiptapNode[] {
   const out: TiptapNode[] = [];
 
   // Chapter kicker ("CHAPTER NN · 챕터명 · 영상 N · 토픽 N") + h2 doc-title.
@@ -247,7 +269,7 @@ function renderChapter(chapter: MandalaBookChapter): TiptapNode[] {
 
   for (let i = 0; i < chapter.sections.length; i++) {
     const sec = chapter.sections[i];
-    out.push(...renderSection(sec, chapter.ch, i));
+    out.push(...renderSection(sec, chapter.ch, i, narrativeMode));
   }
 
   return out;
@@ -273,9 +295,15 @@ export function buildInitialNoteDoc(book: MandalaBookData | null | undefined): T
 
   const content: TiptapNode[] = [];
   const sortedChapters = book.chapters.slice().sort((a, b) => (a.ch ?? 0) - (b.ch ?? 0));
+  // §4.5.1 loop-1b — narrative-book detection (flag-independent render gate):
+  // skeleton books populate chapter.intro; legacy cell=chapter leaves it ''. A
+  // populated intro ⇒ narrative render (prose body + atom citations); else the
+  // legacy render (atom paragraphs + keypoint blockquote) is byte-unchanged —
+  // so flag-off prod notes are identical, narrative books get the woven body.
+  const narrativeMode = sortedChapters.some((ch) => !!(ch?.intro && ch.intro.trim()));
   for (const ch of sortedChapters) {
     if (!ch || !Array.isArray(ch.sections)) continue;
-    content.push(...renderChapter(ch));
+    content.push(...renderChapter(ch, narrativeMode));
   }
 
   // If the last node is a horizontalRule, drop it (clean trailing).


### PR DESCRIPTION
## loop-1b — body-weave render gap (flag-off, [LOOP-GO-ALL])
**DIAG (code-confirmed): (나) render problem.** `weaveChapterBody` (loop-1) already produces woven prose → `section.narrative`. But `note-document-generator.renderSection` dumped `section.atoms` as per-video text paragraphs (the body) + demoted `section.narrative` to a trailing keypoint **blockquote** → 따로국밥 list + duplicate layer.

**Fix (render only):** narrative books → `section.narrative` is the **body** (flowing prose); source atoms become **citations** (one video block per source vid, seek + provenance, after the prose); the per-video atom-text dump + trailing blockquote are removed. Gated by a **flag-independent** book-content signal (populated `chapter.intro`); legacy cell=chapter books (`intro=''`) render **byte-unchanged** → flag-off prod notes identical. Empty narrative → graceful legacy fallback.

## Gates (G-* common + P-1b)
- **G-DDL** none · **G-SHAPE** none (render-only, book_json untouched) · **G-MAIN** flag stays false.
- Fixture test (`note-document-generator-narrative.test.ts`, no LLM): **P-1b-WEAVE** (prose=body, no atom-text dump), **P-1b-NO-DUP** (no blockquote), **P-1b-PROV-KEPT** (atoms cited as per-vid video blocks), **R-1b** legacy byte-unchanged, **R-1b-FALLBACK**.
- Local: FE tsc 0 / vitest **411** (51f, +3) / vite build 0. (jest backend untouched.)
- **P-1b prose-reads-as-synthesis** (멀티영상 토픽이 엮인 서술인가) = James screen after flag-on (can't run LLM locally).

Next (loop-2): STORM research + Factcheck on this woven body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)