### PR TITLE
feat(note): loop-2 skill modules — STORM research + Factcheck (unwired) (CP504 §4.5.1)

### DIFF
--- a/src/modules/mandala-book/book-factcheck.ts
+++ b/src/modules/mandala-book/book-factcheck.ts
@@ -45,9 +45,7 @@ export interface CheckResult {
   correction?: string;
 }
 
-export type FactcheckResult =
-  | { ok: true; results: CheckResult[] }
-  | { ok: false; reason: string };
+export type FactcheckResult = { ok: true; results: CheckResult[] } | { ok: false; reason: string };
 
 // CSE client interface (minimal — matches createGoogleCseClient return shape).
 interface CseClient {
@@ -197,10 +195,7 @@ export function parseFactcheckResponse(
 // Stage 2 — CSE + Haiku verify for one batch of claims
 // ---------------------------------------------------------------------------
 
-async function verifyClaims(
-  claims: FactSentence[],
-  cseClient: CseClient
-): Promise<CheckResult[]> {
+async function verifyClaims(claims: FactSentence[], cseClient: CseClient): Promise<CheckResult[]> {
   // Gather CSE evidence for each claim (3 snippets per claim).
   const enriched = await Promise.all(
     claims.map(async (c) => {
@@ -229,7 +224,10 @@ async function verifyClaims(
     } catch (err) {
       lastReason = `provider_error: ${err instanceof Error ? err.message : String(err)}`;
       if (attempt < VERIFY_ATTEMPTS) {
-        log.warn('book-factcheck verify attempt failed — retrying', { attempt, reason: lastReason });
+        log.warn('book-factcheck verify attempt failed — retrying', {
+          attempt,
+          reason: lastReason,
+        });
         continue;
       }
       throw new Error(lastReason);

--- a/src/modules/mandala-book/book-factcheck.ts
+++ b/src/modules/mandala-book/book-factcheck.ts
@@ -1,0 +1,310 @@
+// §4.5.1 loop-2-A Factcheck-GPT-style fact verification for chapter bodies (CP504).
+//
+// Pipeline: selectCheckWorthy → (per claim) CSE search + Haiku stance → verdict → correction.
+// Creation boundary ([P-3A-NARRATIVE-EXEMPT]): only sentences with hasSource===true (atom/ref
+// backed fact claims) enter the verification queue. Narrative/connective sentences are exempt —
+// they carry no external fact to verify and would produce false positives.
+//
+// Service module — OpenRouter Haiku and CSE are PRODUCTION calls. Unit tests MUST mock both.
+// CC MUST NOT execute them (LLM-API ban).
+
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import { logger } from '@/utils/logger';
+import type { CseSearchResult } from '@/modules/google-cse/client';
+
+const log = logger.child({ module: 'mandala-book/book-factcheck' });
+
+// Haiku: fast, cost-effective Korean scorer — DeepSeek disqualified (P-3A-MODEL).
+const HAIKU_MODEL = 'anthropic/claude-haiku-4.5';
+const MAX_TOKENS = 1024;
+// One retry per claim on transient provider error.
+const VERIFY_ATTEMPTS = 2;
+const TEMPERATURE = 0.1; // near-deterministic for fact verdicts
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A sentence from a chapter body, tagged by whether it carries an atom reference. */
+export interface FactSentence {
+  text: string;
+  /** true = sentence is backed by an atom_idx/reference (fact claim); false = narrative/connective. */
+  hasSource: boolean;
+}
+
+/** Factcheck verdict per sentence. */
+export type Verdict = 'TRUE' | 'SUBSTANTIALLY_TRUE' | 'FALSE' | 'MISLEADING' | 'UNVERIFIABLE';
+
+/** Result for one checked sentence. */
+export interface CheckResult {
+  sentence: string;
+  verdict: Verdict;
+  /** Supporting evidence URL (required for FALSE/MISLEADING corrections). */
+  evidenceUrl?: string;
+  /** Corrected wording (only for FALSE/MISLEADING, evidence-grounded). */
+  correction?: string;
+}
+
+export type FactcheckResult =
+  | { ok: true; results: CheckResult[] }
+  | { ok: false; reason: string };
+
+// CSE client interface (minimal — matches createGoogleCseClient return shape).
+interface CseClient {
+  searchWeb(query: string, opts?: { num?: number }): Promise<CseSearchResult>;
+}
+
+// Internal shape expected from Haiku JSON.
+interface LlmCheckItem {
+  sentence?: unknown;
+  verdict?: unknown;
+  evidenceUrl?: unknown;
+  correction?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Stage 1 — check-worthiness gate (pure, exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter sentences to only those that are check-worthy:
+ * fact claims with a source reference (hasSource===true).
+ * Narrative/connective/opinion sentences (hasSource===false) are ALWAYS excluded.
+ * Pure function — no side effects, heavily tested ([P-3A-NARRATIVE-EXEMPT]).
+ */
+export function selectCheckWorthy(sentences: FactSentence[]): FactSentence[] {
+  return sentences.filter((s) => s.hasSource === true);
+}
+
+// ---------------------------------------------------------------------------
+// Prompt builder (exported for inspection in tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the Haiku verification prompt for a batch of claim sentences + CSE evidence.
+ * Instructs Haiku to assign one of 5 verdicts and produce style-preserving corrections
+ * only for FALSE/MISLEADING — evidence-grounded (carrying evidenceUrl).
+ */
+export function buildFactcheckPrompt(
+  claims: Array<{ sentence: string; evidenceSnippets: Array<{ url: string; snippet: string }> }>
+): string {
+  const claimBlocks = claims.map((c, i) => {
+    const ev = c.evidenceSnippets
+      .map((e, j) => `  [ev${j}] url="${e.url}" snippet="${e.snippet}"`)
+      .join('\n');
+    return `[${i}] claim: "${c.sentence}"\nevidence:\n${ev || '  (none)'}`;
+  });
+
+  return [
+    '당신은 팩트체크 전문가다. 아래 각 CLAIM을 주어진 evidence 기반으로 검증하라.',
+    '',
+    '판정 기준:',
+    '- TRUE: evidence가 claim을 직접 지지',
+    '- SUBSTANTIALLY_TRUE: 대체로 맞으나 세부 수치/표현 일부 부정확',
+    '- FALSE: evidence가 claim을 반박',
+    '- MISLEADING: 과장/오해유도 표현 (사실이지만 왜곡)',
+    '- UNVERIFIABLE: evidence 없거나 판단 불가',
+    '',
+    '★ correction 규칙:',
+    '- FALSE/MISLEADING만 correction 생성. 사실 토큰만 수정, 문장 스타일/어조 유지.',
+    '- correction에는 반드시 evidenceUrl을 함께 제시 (근거 없는 correction 금지).',
+    '- TRUE/SUBSTANTIALLY_TRUE/UNVERIFIABLE: correction 없음 (correction 키 생략).',
+    '',
+    'JSON 배열만 출력 (코드펜스 금지):',
+    '[{"sentence":"원문","verdict":"TRUE","evidenceUrl":"url"},...]',
+    '',
+    '검증 대상:',
+    claimBlocks.join('\n\n'),
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Stage 3/4 — parse Haiku response (pure, exported for tests)
+// ---------------------------------------------------------------------------
+
+const VALID_VERDICTS = new Set<string>([
+  'TRUE',
+  'SUBSTANTIALLY_TRUE',
+  'FALSE',
+  'MISLEADING',
+  'UNVERIFIABLE',
+]);
+
+/**
+ * Parse and validate the raw Haiku JSON response into CheckResult[].
+ * Drops out-of-shape items. Strips code fences. Pure function ([P-3A-STYLE-KEEP]).
+ * Returns ok:false on JSON parse failure or empty result.
+ */
+export function parseFactcheckResponse(
+  raw: string,
+  sentences: string[]
+): { ok: true; results: CheckResult[] } | { ok: false; reason: string } {
+  // Strip code fences (```json...``` or ```...```)
+  const stripped = raw
+    .trim()
+    .replace(/^\s*```(?:json)?\s*\n?/i, '')
+    .replace(/\n?\s*```\s*$/i, '')
+    .trim();
+
+  let json: unknown;
+  try {
+    json = JSON.parse(stripped);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `json_parse: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (!Array.isArray(json)) return { ok: false, reason: 'expected_array' };
+
+  const sentenceSet = new Set(sentences);
+  const results: CheckResult[] = [];
+
+  for (const item of json as LlmCheckItem[]) {
+    const sentence = typeof item.sentence === 'string' ? item.sentence.trim() : '';
+    if (!sentence) continue;
+    // Only accept sentences we sent (prevents hallucinated extras).
+    if (sentenceSet.size > 0 && !sentenceSet.has(sentence)) continue;
+
+    const verdictRaw = typeof item.verdict === 'string' ? item.verdict.trim().toUpperCase() : '';
+    if (!VALID_VERDICTS.has(verdictRaw)) continue;
+    const verdict = verdictRaw as Verdict;
+
+    const evidenceUrl =
+      typeof item.evidenceUrl === 'string' && item.evidenceUrl.trim()
+        ? item.evidenceUrl.trim()
+        : undefined;
+
+    // [P-3A-STYLE-KEEP]: correction ONLY for FALSE/MISLEADING, and only when evidence-grounded.
+    let correction: string | undefined;
+    if ((verdict === 'FALSE' || verdict === 'MISLEADING') && evidenceUrl) {
+      correction =
+        typeof item.correction === 'string' && item.correction.trim()
+          ? item.correction.trim()
+          : undefined;
+    }
+
+    // [P-3A-NO-NEW-ERROR]: if FALSE/MISLEADING but no evidenceUrl, record without correction.
+    results.push({ sentence, verdict, evidenceUrl, correction });
+  }
+
+  if (results.length === 0) return { ok: false, reason: 'no_valid_items' };
+  return { ok: true, results };
+}
+
+// ---------------------------------------------------------------------------
+// Stage 2 — CSE + Haiku verify for one batch of claims
+// ---------------------------------------------------------------------------
+
+async function verifyClaims(
+  claims: FactSentence[],
+  cseClient: CseClient
+): Promise<CheckResult[]> {
+  // Gather CSE evidence for each claim (3 snippets per claim).
+  const enriched = await Promise.all(
+    claims.map(async (c) => {
+      const res = await cseClient.searchWeb(c.text, { num: 3 });
+      const evidenceSnippets = (res.items ?? []).slice(0, 3).map((it) => ({
+        url: it.link,
+        snippet: it.snippet,
+      }));
+      return { sentence: c.text, evidenceSnippets };
+    })
+  );
+
+  const prompt = buildFactcheckPrompt(enriched);
+  const sentenceTexts = claims.map((c) => c.text);
+
+  // Retry Haiku once on failure (VERIFY_ATTEMPTS).
+  let lastReason = 'unknown';
+  for (let attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt++) {
+    let raw: string;
+    try {
+      raw = await new OpenRouterGenerationProvider(HAIKU_MODEL).generate(prompt, {
+        format: 'json',
+        temperature: TEMPERATURE,
+        maxTokens: MAX_TOKENS,
+      });
+    } catch (err) {
+      lastReason = `provider_error: ${err instanceof Error ? err.message : String(err)}`;
+      if (attempt < VERIFY_ATTEMPTS) {
+        log.warn('book-factcheck verify attempt failed — retrying', { attempt, reason: lastReason });
+        continue;
+      }
+      throw new Error(lastReason);
+    }
+
+    const parsed = parseFactcheckResponse(raw, sentenceTexts);
+    if (parsed.ok) {
+      if (attempt > 1) log.info('book-factcheck recovered on retry', { attempt });
+      return parsed.results;
+    }
+
+    lastReason = parsed.reason;
+    if (attempt < VERIFY_ATTEMPTS) {
+      log.warn('book-factcheck parse failed — retrying', { attempt, reason: lastReason });
+    }
+  }
+
+  throw new Error(`hard_fail: ${lastReason}`);
+}
+
+// ---------------------------------------------------------------------------
+// Top-level orchestrator (exported)
+// ---------------------------------------------------------------------------
+
+/**
+ * Factcheck a chapter body's sentences.
+ * Stages: selectCheckWorthy → CSE search + Haiku stance → verdict → style-preserving correction.
+ * Narrative/connective sentences (hasSource===false) are exempt from verification.
+ * Honest fail → ok:false. Logs verdict distribution for observability.
+ *
+ * @param sentences  - All sentences in the chapter body, tagged with hasSource.
+ * @param cseClient  - Google CSE client (injected; defaults to disabled client for safety).
+ */
+export async function factcheckChapterBody(
+  sentences: FactSentence[],
+  cseClient?: CseClient
+): Promise<FactcheckResult> {
+  if (sentences.length === 0) return { ok: false, reason: 'no_sentences' };
+
+  // Default CSE client returns empty results (safe no-op if caller omits it).
+  const client: CseClient = cseClient ?? {
+    searchWeb: async () => ({ items: [], totalResults: 0, error: 'no_cse_client' }),
+  };
+
+  const checkWorthy = selectCheckWorthy(sentences);
+
+  log.info('book-factcheck start', {
+    total: sentences.length,
+    checkWorthy: checkWorthy.length,
+    narrative: sentences.length - checkWorthy.length,
+  });
+
+  if (checkWorthy.length === 0) {
+    // All sentences are narrative — return empty verified result (nothing to correct).
+    return { ok: true, results: [] };
+  }
+
+  let results: CheckResult[];
+  try {
+    results = await verifyClaims(checkWorthy, client);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    log.error('book-factcheck HARD FAIL', { reason });
+    return { ok: false, reason };
+  }
+
+  // Log verdict distribution for observability.
+  const dist: Partial<Record<Verdict, number>> = {};
+  for (const r of results) dist[r.verdict] = (dist[r.verdict] ?? 0) + 1;
+  log.info('book-factcheck done', {
+    total: sentences.length,
+    checkWorthy: checkWorthy.length,
+    verified: results.length,
+    verdicts: dist,
+  });
+
+  return { ok: true, results };
+}

--- a/src/modules/mandala-book/book-research.ts
+++ b/src/modules/mandala-book/book-research.ts
@@ -1,0 +1,253 @@
+// §4.5.1 [4] STORM-style research gap-fill (CP504 loop-2-B).
+//
+// Finds perspective GAPS in the book's woven chapters (loop-1b output) + the
+// mandala center goal, generates a web-search query per gap (one Haiku call),
+// retrieves CSE snippets, and returns reference-tracked supplemental facts.
+//
+// Scope boundary: returns ResearchFinding[] keyed to EXISTING chapterTitles.
+// This module never generates chapters, sections, or outline structure — that
+// is Sonnet's domain (book-skeleton). A finding MUST carry a real CSE reference;
+// gaps with no CSE result are silently dropped (no fabrication, P-2B-REF).
+//
+// Service module — OpenRouter Haiku + CSE are PRODUCTION calls. CC MUST NOT
+// call them for tests; unit tests mock both (LLM-API ban).
+
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import { logger } from '@/utils/logger';
+import { createGoogleCseClient, loadGoogleCseConfig } from '@/modules/google-cse';
+import type { CseSearchResult, SearchWebOptions } from '@/modules/google-cse';
+
+const log = logger.child({ module: 'mandala-book/book-research' });
+
+// Haiku: cheap + fast for gap identification; same model id used project-wide.
+const HAIKU_MODEL = 'anthropic/claude-haiku-4.5';
+const MAX_TOKENS = 2000;
+const RESEARCH_ATTEMPTS = 2;
+const TEMPERATURE = 0.3;
+// Caps total gaps to bound CSE quota + cost (3 results/gap × MAX_GAPS calls).
+const MAX_GAPS = 6;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** Woven narrative chapter passed in as research input (from loop-1b). */
+export interface ResearchChapterInput {
+  title: string;
+  intro: string;
+  sectionSummaries: string[];
+}
+
+/** A web reference from a CSE result item. */
+export interface ResearchReference {
+  title: string;
+  url: string; // from CseItem.link — non-empty (P-2B-REF enforced at retrieval)
+}
+
+/** One research finding: fact from a CSE snippet, tied to an existing chapter. */
+export interface ResearchFinding {
+  chapterTitle: string; // references an existing chapter — never a new structure
+  perspective: string; // the gap angle this fills
+  fact: string; // concise factual statement derived from the CSE snippet
+  reference: ResearchReference; // always non-empty (P-2B-REF: no finding without a ref)
+}
+
+export type ResearchResult =
+  | { ok: true; findings: ResearchFinding[] }
+  | { ok: false; reason: string };
+
+/** One identified knowledge gap with its generated web-search query. */
+export interface ResearchGap {
+  chapterTitle: string;
+  perspective: string;
+  query: string;
+}
+
+/** CSE client interface — accepts the real createGoogleCseClient() return value or a mock. */
+export interface CseClient {
+  searchWeb: (query: string, opts?: SearchWebOptions) => Promise<CseSearchResult>;
+}
+
+// ─── Perspective module ───────────────────────────────────────────────────────
+
+/**
+ * Build the Haiku prompt to identify missing perspectives in the book's chapters.
+ * The model outputs gap objects only — no structural proposals.
+ */
+export function buildPerspectivePrompt(
+  chapters: ResearchChapterInput[],
+  centerGoal: string
+): string {
+  const chapterList = chapters
+    .map(
+      (ch, i) =>
+        `[${i}] "${ch.title}"\n  intro: ${ch.intro || '(none)'}\n  sections: ${ch.sectionSummaries.join(' | ')}`
+    )
+    .join('\n\n');
+  return [
+    `You are a research assistant for a book on the goal: "${centerGoal}".`,
+    `Below are the existing chapters (title, intro, section summaries):`,
+    ``,
+    chapterList,
+    ``,
+    `Task: identify THIN or MISSING perspectives a complete book on "${centerGoal}" should cover but the chapters above lack.`,
+    `For each gap output { "chapterTitle": <existing title>, "perspective": <1-2 sentences describing the gap>, "query": <concise web search query to find facts filling this gap> }.`,
+    ``,
+    `Rules:`,
+    `- Identify gaps ONLY. Do NOT propose new chapters, sections, or structural changes.`,
+    `- chapterTitle must exactly match one of the existing chapter titles above.`,
+    `- Max ${MAX_GAPS} gaps total.`,
+    `- Output JSON only: {"gaps":[{"chapterTitle":"...","perspective":"...","query":"..."}]}`,
+  ].join('\n');
+}
+
+/**
+ * Pure parse of the Haiku gaps response. Exported for unit tests (no live LLM).
+ * Caps at MAX_GAPS; drops entries with missing or empty required fields.
+ * Code-fence strip mirrors book-skeleton pattern.
+ */
+export function parsePerspectiveResponse(
+  raw: string
+): { ok: true; perspectives: ResearchGap[] } | { ok: false; reason: string } {
+  const stripped = raw
+    .trim()
+    .replace(/^\s*```(?:json)?\s*\n?/i, '')
+    .replace(/\n?\s*```\s*$/i, '')
+    .trim();
+
+  let json: { gaps?: unknown };
+  try {
+    json = JSON.parse(stripped) as { gaps?: unknown };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `json_parse: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (!Array.isArray(json.gaps)) return { ok: false, reason: 'no_gaps_array' };
+
+  const perspectives: ResearchGap[] = [];
+  for (const g of (json.gaps as Array<Record<string, unknown>>).slice(0, MAX_GAPS)) {
+    const chapterTitle =
+      typeof g['chapterTitle'] === 'string' ? g['chapterTitle'].trim() : '';
+    const perspective =
+      typeof g['perspective'] === 'string' ? g['perspective'].trim() : '';
+    const query = typeof g['query'] === 'string' ? g['query'].trim() : '';
+    if (!chapterTitle || !perspective || !query) continue;
+    perspectives.push({ chapterTitle, perspective, query });
+  }
+
+  if (perspectives.length === 0) return { ok: false, reason: 'no_valid_gaps' };
+  return { ok: true, perspectives };
+}
+
+// ─── Question module ──────────────────────────────────────────────────────────
+
+/**
+ * Extract the web-search query for each gap.
+ * Distinct testable unit satisfying the "question module" boundary; the query
+ * field is produced inline by the Haiku perspective call above.
+ */
+export function gapsToQueries(gaps: ResearchGap[]): string[] {
+  return gaps.map((g) => g.query);
+}
+
+// ─── Retrieval module ─────────────────────────────────────────────────────────
+
+/**
+ * Retrieve CSE facts for each gap. Gaps with errors or no results are silently
+ * skipped — a finding MUST have a real CSE reference (P-2B-REF).
+ * Accept the CSE client as a param (dependency injection for tests).
+ */
+export async function retrieveForGaps(
+  gaps: ResearchGap[],
+  cseClient: CseClient
+): Promise<ResearchFinding[]> {
+  const findings: ResearchFinding[] = [];
+  for (const gap of gaps) {
+    const result = await cseClient.searchWeb(gap.query, { num: 3 });
+    if (result.error || result.items.length === 0) continue; // no fabrication
+
+    const item = result.items[0];
+    if (!item || !item.link) continue; // noUncheckedIndexedAccess + empty-url guard
+
+    const fact = item.snippet
+      ? item.snippet.replace(/\s*\n+\s*/g, ' ').trim()
+      : item.title;
+    if (!fact) continue;
+
+    findings.push({
+      chapterTitle: gap.chapterTitle,
+      perspective: gap.perspective,
+      fact,
+      reference: { title: item.title, url: item.link },
+    });
+  }
+  return findings;
+}
+
+// ─── Top-level orchestrator ───────────────────────────────────────────────────
+
+/**
+ * STORM-style research loop: Haiku identifies perspective gaps → CSE retrieves
+ * reference-tracked facts. Returns findings keyed to existing chapterTitles;
+ * never returns new chapters or outline structure (P-2B-NO-ARTICLE).
+ * Retries the Haiku call once on parse/provider failure (like book-skeleton).
+ * Honest fail → ok:false (caller may proceed without supplemental research).
+ */
+export async function researchBookGaps(
+  chapters: ResearchChapterInput[],
+  centerGoal: string,
+  cseClient?: CseClient
+): Promise<ResearchResult> {
+  if (chapters.length === 0) return { ok: false, reason: 'no_chapters' };
+
+  const client = cseClient ?? createGoogleCseClient(loadGoogleCseConfig());
+
+  let gaps: ResearchGap[] | null = null;
+  let lastReason = 'unknown';
+  for (let attempt = 1; attempt <= RESEARCH_ATTEMPTS; attempt++) {
+    const r = await attemptPerspective(chapters, centerGoal);
+    if (r.ok) {
+      if (attempt > 1) log.info('book-research perspective recovered on retry', { attempt });
+      gaps = r.perspectives;
+      break;
+    }
+    lastReason = r.reason;
+    if (attempt < RESEARCH_ATTEMPTS) {
+      log.warn('book-research perspective attempt failed — retrying', {
+        attempt,
+        reason: r.reason,
+      });
+    }
+  }
+
+  if (gaps === null) {
+    log.error('book-research HARD FAIL after retries', { reason: lastReason });
+    return { ok: false, reason: `hard_fail: ${lastReason}` };
+  }
+
+  log.info('book-research gaps identified', { count: gaps.length });
+  const findings = await retrieveForGaps(gaps, client);
+  log.info('book-research done', { gaps: gaps.length, findings: findings.length });
+  return { ok: true, findings };
+}
+
+async function attemptPerspective(
+  chapters: ResearchChapterInput[],
+  centerGoal: string
+): Promise<{ ok: true; perspectives: ResearchGap[] } | { ok: false; reason: string }> {
+  const prompt = buildPerspectivePrompt(chapters, centerGoal);
+  let raw: string;
+  try {
+    raw = await new OpenRouterGenerationProvider(HAIKU_MODEL).generate(prompt, {
+      format: 'json',
+      temperature: TEMPERATURE,
+      maxTokens: MAX_TOKENS,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `provider_error: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  return parsePerspectiveResponse(raw);
+}

--- a/src/modules/mandala-book/book-research.ts
+++ b/src/modules/mandala-book/book-research.ts
@@ -126,10 +126,8 @@ export function parsePerspectiveResponse(
 
   const perspectives: ResearchGap[] = [];
   for (const g of (json.gaps as Array<Record<string, unknown>>).slice(0, MAX_GAPS)) {
-    const chapterTitle =
-      typeof g['chapterTitle'] === 'string' ? g['chapterTitle'].trim() : '';
-    const perspective =
-      typeof g['perspective'] === 'string' ? g['perspective'].trim() : '';
+    const chapterTitle = typeof g['chapterTitle'] === 'string' ? g['chapterTitle'].trim() : '';
+    const perspective = typeof g['perspective'] === 'string' ? g['perspective'].trim() : '';
     const query = typeof g['query'] === 'string' ? g['query'].trim() : '';
     if (!chapterTitle || !perspective || !query) continue;
     perspectives.push({ chapterTitle, perspective, query });
@@ -169,9 +167,7 @@ export async function retrieveForGaps(
     const item = result.items[0];
     if (!item || !item.link) continue; // noUncheckedIndexedAccess + empty-url guard
 
-    const fact = item.snippet
-      ? item.snippet.replace(/\s*\n+\s*/g, ' ').trim()
-      : item.title;
+    const fact = item.snippet ? item.snippet.replace(/\s*\n+\s*/g, ' ').trim() : item.title;
     if (!fact) continue;
 
     findings.push({

--- a/tests/unit/modules/book-factcheck.test.ts
+++ b/tests/unit/modules/book-factcheck.test.ts
@@ -1,0 +1,393 @@
+/**
+ * book-factcheck (§4.5.1 loop-2-A, CP504) — Factcheck-GPT-style verification.
+ * OpenRouter Haiku is MOCKED (no live LLM — LLM-API ban). CSE is also mocked.
+ * Locks:
+ *   - P-3A-NARRATIVE-EXEMPT: selectCheckWorthy excludes hasSource===false sentences
+ *   - P-3A-MODEL: HAIKU_MODEL const contains "haiku", never "deepseek"
+ *   - P-3A-STYLE-KEEP: correction only for FALSE/MISLEADING; TRUE/etc → none
+ *   - P-3A-NO-NEW-ERROR: FALSE/MISLEADING corrections carry evidenceUrl
+ *   - parse: non-JSON / out-of-shape → ok:false; fence-strip
+ */
+
+const mockGenerate = jest.fn();
+jest.mock('@/modules/llm/openrouter', () => ({
+  OpenRouterGenerationProvider: jest.fn().mockImplementation(() => ({ generate: mockGenerate })),
+}));
+jest.mock('@/config/index', () => ({
+  config: { paths: { logs: '/tmp' }, app: { isTest: true } },
+}));
+
+import {
+  selectCheckWorthy,
+  parseFactcheckResponse,
+  factcheckChapterBody,
+  buildFactcheckPrompt,
+  type FactSentence,
+  type CheckResult,
+} from '../../../src/modules/mandala-book/book-factcheck';
+
+// Minimal mock CSE client (never throws, returns controlled items).
+function makeMockCse(items: Array<{ title: string; link: string; snippet: string }> = []) {
+  return {
+    searchWeb: jest.fn().mockResolvedValue({
+      items: items.map((i) => ({ ...i, displayLink: i.link })),
+      totalResults: items.length,
+    }),
+  };
+}
+
+beforeEach(() => mockGenerate.mockReset());
+
+// ---------------------------------------------------------------------------
+// Stage 1 — selectCheckWorthy (pure)
+// ---------------------------------------------------------------------------
+
+describe('selectCheckWorthy — P-3A-NARRATIVE-EXEMPT', () => {
+  const sentences: FactSentence[] = [
+    { text: '이 영상은 2023년에 출시되었다.', hasSource: true },
+    { text: '따라서 우리는 다음 단계로 넘어갈 수 있다.', hasSource: false },
+    { text: 'Python의 GIL은 CPython 3.12에서 제거되지 않았다.', hasSource: true },
+    { text: '앞에서 살펴본 바와 같이', hasSource: false },
+    { text: '만다라 수련법은 14세기 티베트에서 유래했다.', hasSource: true },
+  ];
+
+  it('returns ONLY hasSource===true sentences (fact claims)', () => {
+    const result = selectCheckWorthy(sentences);
+    expect(result).toHaveLength(3);
+    expect(result.every((s) => s.hasSource === true)).toBe(true);
+  });
+
+  it('excludes ALL hasSource===false sentences (narrative/connective)', () => {
+    const result = selectCheckWorthy(sentences);
+    const excluded = result.filter((s) => s.hasSource === false);
+    expect(excluded).toHaveLength(0);
+  });
+
+  it('returns specific fact texts — connective texts are NOT in queue', () => {
+    const result = selectCheckWorthy(sentences);
+    const texts = result.map((s) => s.text);
+    expect(texts).not.toContain('따라서 우리는 다음 단계로 넘어갈 수 있다.');
+    expect(texts).not.toContain('앞에서 살펴본 바와 같이');
+    expect(texts).toContain('이 영상은 2023년에 출시되었다.');
+    expect(texts).toContain('Python의 GIL은 CPython 3.12에서 제거되지 않았다.');
+    expect(texts).toContain('만다라 수련법은 14세기 티베트에서 유래했다.');
+  });
+
+  it('returns empty array when all sentences are narrative (hasSource===false)', () => {
+    const onlyNarrative: FactSentence[] = [
+      { text: '그래서', hasSource: false },
+      { text: '따라서 결론적으로', hasSource: false },
+    ];
+    expect(selectCheckWorthy(onlyNarrative)).toHaveLength(0);
+  });
+
+  it('returns all sentences when all are fact claims (hasSource===true)', () => {
+    const onlyFacts: FactSentence[] = [
+      { text: '주장 A', hasSource: true },
+      { text: '주장 B', hasSource: true },
+    ];
+    expect(selectCheckWorthy(onlyFacts)).toHaveLength(2);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(selectCheckWorthy([])).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P-3A-MODEL gate (model const check — no live call needed)
+// ---------------------------------------------------------------------------
+
+describe('P-3A-MODEL — model id check', () => {
+  it('HAIKU_MODEL contains "haiku" (DeepSeek disqualified)', () => {
+    // Import the module at runtime to inspect the const via the prompt builder.
+    // We assert via buildFactcheckPrompt (pure, exported) that the module loads without error,
+    // then verify the model via a mockGenerate call capture.
+    const fakeCse = makeMockCse([{ title: 't', link: 'http://x.com', snippet: 's' }]);
+    const haiku5Response = JSON.stringify([
+      { sentence: 'claim A', verdict: 'TRUE', evidenceUrl: 'http://x.com' },
+    ]);
+    mockGenerate.mockResolvedValueOnce(haiku5Response);
+
+    // Capture the model passed to OpenRouterGenerationProvider constructor.
+    const { OpenRouterGenerationProvider } = jest.requireMock('@/modules/llm/openrouter') as {
+      OpenRouterGenerationProvider: jest.Mock;
+    };
+    OpenRouterGenerationProvider.mockClear();
+
+    return factcheckChapterBody(
+      [{ text: 'claim A', hasSource: true }],
+      fakeCse
+    ).then(() => {
+      expect(OpenRouterGenerationProvider).toHaveBeenCalledWith(
+        expect.stringMatching(/haiku/i)
+      );
+      expect(OpenRouterGenerationProvider).not.toHaveBeenCalledWith(
+        expect.stringMatching(/deepseek/i)
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFactcheckResponse (pure)
+// ---------------------------------------------------------------------------
+
+describe('parseFactcheckResponse — parse + validation', () => {
+  const sents = ['Python GIL은 CPython 3.12에서 제거되지 않았다.', '2023년에 출시되었다.'];
+
+  it('parses well-formed JSON array into CheckResult[]', () => {
+    const raw = JSON.stringify([
+      { sentence: sents[0], verdict: 'TRUE', evidenceUrl: 'http://a.com' },
+      { sentence: sents[1], verdict: 'UNVERIFIABLE' },
+    ]);
+    const r = parseFactcheckResponse(raw, sents);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.results).toHaveLength(2);
+      expect(r.results[0]!.verdict).toBe('TRUE');
+      expect(r.results[1]!.verdict).toBe('UNVERIFIABLE');
+    }
+  });
+
+  it('strips code fences (```json...```)', () => {
+    const inner = JSON.stringify([
+      { sentence: sents[0], verdict: 'FALSE', evidenceUrl: 'http://b.com', correction: '제거됐다.' },
+    ]);
+    const raw = `\`\`\`json\n${inner}\n\`\`\``;
+    const r = parseFactcheckResponse(raw, sents);
+    expect(r.ok).toBe(true);
+  });
+
+  it('returns ok:false on non-JSON input', () => {
+    const r = parseFactcheckResponse('not json at all', sents);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/json_parse/);
+  });
+
+  it('returns ok:false when response is a JSON object (not array)', () => {
+    const r = parseFactcheckResponse('{"sentence":"x","verdict":"TRUE"}', sents);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('expected_array');
+  });
+
+  it('drops items with invalid/missing verdict', () => {
+    const raw = JSON.stringify([
+      { sentence: sents[0], verdict: 'DEFINITELY_TRUE' }, // invalid
+      { sentence: sents[1], verdict: 'SUBSTANTIALLY_TRUE', evidenceUrl: 'http://c.com' },
+    ]);
+    const r = parseFactcheckResponse(raw, sents);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.results).toHaveLength(1);
+      expect(r.results[0]!.verdict).toBe('SUBSTANTIALLY_TRUE');
+    }
+  });
+
+  it('drops items whose sentence is not in the provided sentences set', () => {
+    const raw = JSON.stringify([
+      { sentence: '이건 안 보낸 문장이다.', verdict: 'TRUE' },
+      { sentence: sents[0], verdict: 'FALSE', evidenceUrl: 'http://d.com', correction: 'fix' },
+    ]);
+    const r = parseFactcheckResponse(raw, sents);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.results).toHaveLength(1);
+      expect(r.results[0]!.sentence).toBe(sents[0]);
+    }
+  });
+
+  it('returns ok:false when all items are out-of-shape (no valid items)', () => {
+    const raw = JSON.stringify([
+      { sentence: '', verdict: 'TRUE' }, // empty sentence
+    ]);
+    const r = parseFactcheckResponse(raw, sents);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('no_valid_items');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P-3A-STYLE-KEEP — correction only for FALSE/MISLEADING
+// ---------------------------------------------------------------------------
+
+describe('P-3A-STYLE-KEEP — verdict → correction policy', () => {
+  const sent = '이 기술은 1990년에 발명되었다.';
+
+  it('FALSE with evidenceUrl → correction is preserved', () => {
+    const raw = JSON.stringify([
+      {
+        sentence: sent,
+        verdict: 'FALSE',
+        evidenceUrl: 'http://evidence.com',
+        correction: '이 기술은 2001년에 발명되었다.',
+      },
+    ]);
+    const r = parseFactcheckResponse(raw, [sent]);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.results[0]!.correction).toBe('이 기술은 2001년에 발명되었다.');
+      expect(r.results[0]!.evidenceUrl).toBe('http://evidence.com');
+    }
+  });
+
+  it('MISLEADING with evidenceUrl → correction is preserved', () => {
+    const raw = JSON.stringify([
+      {
+        sentence: sent,
+        verdict: 'MISLEADING',
+        evidenceUrl: 'http://evidence2.com',
+        correction: '이 기술은 1990년대에 개발되기 시작했다.',
+      },
+    ]);
+    const r = parseFactcheckResponse(raw, [sent]);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.results[0]!.correction).toBeDefined();
+    }
+  });
+
+  it('TRUE → no correction (P-3A-STYLE-KEEP)', () => {
+    const raw = JSON.stringify([
+      { sentence: sent, verdict: 'TRUE', evidenceUrl: 'http://evidence.com', correction: '수정본' },
+    ]);
+    const r = parseFactcheckResponse(raw, [sent]);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.results[0]!.correction).toBeUndefined();
+  });
+
+  it('SUBSTANTIALLY_TRUE → no correction', () => {
+    const raw = JSON.stringify([
+      {
+        sentence: sent,
+        verdict: 'SUBSTANTIALLY_TRUE',
+        evidenceUrl: 'http://e.com',
+        correction: '수정',
+      },
+    ]);
+    const r = parseFactcheckResponse(raw, [sent]);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.results[0]!.correction).toBeUndefined();
+  });
+
+  it('UNVERIFIABLE → no correction', () => {
+    const raw = JSON.stringify([{ sentence: sent, verdict: 'UNVERIFIABLE' }]);
+    const r = parseFactcheckResponse(raw, [sent]);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.results[0]!.correction).toBeUndefined();
+  });
+
+  it('FALSE without evidenceUrl → accepted but no correction (P-3A-NO-NEW-ERROR)', () => {
+    // No evidenceUrl → correction must not be fabricated.
+    const raw = JSON.stringify([
+      { sentence: sent, verdict: 'FALSE', correction: '수정본 (근거 없음)' },
+    ]);
+    const r = parseFactcheckResponse(raw, [sent]);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.results[0]!.verdict).toBe('FALSE');
+      expect(r.results[0]!.correction).toBeUndefined(); // no evidenceUrl → no correction
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// factcheckChapterBody (orchestrator — mocked LLM + CSE)
+// ---------------------------------------------------------------------------
+
+describe('factcheckChapterBody (orchestrator)', () => {
+  const mixed: FactSentence[] = [
+    { text: '이 기술은 1990년에 발명되었다.', hasSource: true },
+    { text: '따라서 다음 단계로 넘어간다.', hasSource: false },
+    { text: '2023년에 출시되었다.', hasSource: true },
+  ];
+
+  it('returns ok:true with results for check-worthy sentences only', async () => {
+    const fakeCse = makeMockCse([{ title: 't', link: 'http://e.com', snippet: 'evidence' }]);
+    const haikuResponse = JSON.stringify([
+      { sentence: '이 기술은 1990년에 발명되었다.', verdict: 'FALSE', evidenceUrl: 'http://e.com', correction: '2001년' },
+      { sentence: '2023년에 출시되었다.', verdict: 'TRUE', evidenceUrl: 'http://e.com' },
+    ]);
+    mockGenerate.mockResolvedValueOnce(haikuResponse);
+
+    const r = await factcheckChapterBody(mixed, fakeCse);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      // Narrative sentence is NOT in results.
+      const texts = r.results.map((x) => x.sentence);
+      expect(texts).not.toContain('따라서 다음 단계로 넘어간다.');
+      expect(r.results.some((x) => x.verdict === 'FALSE')).toBe(true);
+    }
+  });
+
+  it('returns ok:true with empty results when all sentences are narrative', async () => {
+    const allNarrative: FactSentence[] = [
+      { text: '따라서', hasSource: false },
+      { text: '그래서 결론적으로', hasSource: false },
+    ];
+    const r = await factcheckChapterBody(allNarrative, makeMockCse());
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.results).toHaveLength(0);
+    // No LLM call when no check-worthy sentences.
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('returns ok:false on empty input', async () => {
+    const r = await factcheckChapterBody([], makeMockCse());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('no_sentences');
+  });
+
+  it('retries Haiku once on provider error then hard-fails → ok:false', async () => {
+    const fakeCse = makeMockCse();
+    mockGenerate.mockRejectedValue(new Error('provider boom'));
+    const r = await factcheckChapterBody(
+      [{ text: '사실 주장', hasSource: true }],
+      fakeCse
+    );
+    expect(r.ok).toBe(false);
+    expect(mockGenerate).toHaveBeenCalledTimes(2); // VERIFY_ATTEMPTS
+  });
+
+  it('retries Haiku once on parse failure then hard-fails → ok:false', async () => {
+    const fakeCse = makeMockCse();
+    mockGenerate.mockResolvedValue('not json');
+    const r = await factcheckChapterBody(
+      [{ text: '사실 주장', hasSource: true }],
+      fakeCse
+    );
+    expect(r.ok).toBe(false);
+    expect(mockGenerate).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses no-op cse client when cseClient is omitted', async () => {
+    const haikuResponse = JSON.stringify([
+      { sentence: '사실 주장', verdict: 'UNVERIFIABLE' },
+    ]);
+    mockGenerate.mockResolvedValueOnce(haikuResponse);
+    // No cseClient argument — should not throw.
+    const r = await factcheckChapterBody([{ text: '사실 주장', hasSource: true }]);
+    expect(r.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFactcheckPrompt (pure — structural smoke test)
+// ---------------------------------------------------------------------------
+
+describe('buildFactcheckPrompt', () => {
+  it('includes claim text and evidence snippet in output', () => {
+    const prompt = buildFactcheckPrompt([
+      { sentence: 'claim X', evidenceSnippets: [{ url: 'http://z.com', snippet: 'some evidence' }] },
+    ]);
+    expect(prompt).toContain('claim X');
+    expect(prompt).toContain('some evidence');
+    expect(prompt).toContain('http://z.com');
+  });
+
+  it('handles empty evidence snippets gracefully', () => {
+    const prompt = buildFactcheckPrompt([{ sentence: 'claim Y', evidenceSnippets: [] }]);
+    expect(prompt).toContain('claim Y');
+    expect(prompt).toContain('(none)');
+  });
+});

--- a/tests/unit/modules/book-research.test.ts
+++ b/tests/unit/modules/book-research.test.ts
@@ -1,0 +1,267 @@
+/**
+ * book-research (§4.5.1 loop-2-B STORM research, CP504).
+ * OpenRouter (Haiku) + CSE are MOCKED — LLM-API ban enforced.
+ * Gates locked:
+ *   P-2B-REF    every ResearchFinding.reference.url is non-empty
+ *   P-2B-NO-ARTICLE  result has only findings[], never chapters/outline
+ *   P-2B-BORDER fact comes from CSE snippet, module does not invent
+ *   parse       non-JSON / no gaps array / all invalid → ok:false; fence-strip; cap MAX_GAPS
+ *   retrieval   CSE error or empty items → gap dropped; items → finding with reference
+ */
+
+const mockGenerate = jest.fn();
+jest.mock('@/modules/llm/openrouter', () => ({
+  OpenRouterGenerationProvider: jest.fn().mockImplementation(() => ({ generate: mockGenerate })),
+}));
+jest.mock('@/config/index', () => ({
+  config: { paths: { logs: '/tmp' }, app: { isTest: true } },
+}));
+jest.mock('@/modules/google-cse', () => ({
+  createGoogleCseClient: jest.fn().mockReturnValue({ searchWeb: jest.fn() }),
+  loadGoogleCseConfig: jest.fn().mockReturnValue({ apiKey: '', cx: '', enabled: false }),
+}));
+
+import {
+  parsePerspectiveResponse,
+  gapsToQueries,
+  retrieveForGaps,
+  researchBookGaps,
+  type ResearchChapterInput,
+  type ResearchGap,
+} from '../../../src/modules/mandala-book/book-research';
+
+const mockCse = { searchWeb: jest.fn() };
+
+beforeEach(() => {
+  mockGenerate.mockReset();
+  mockCse.searchWeb.mockReset();
+});
+
+// ─── parsePerspectiveResponse (pure — no LLM) ────────────────────────────────
+
+describe('parsePerspectiveResponse (pure — no LLM)', () => {
+  it('parses valid gaps JSON and returns perspectives', () => {
+    const raw = JSON.stringify({
+      gaps: [{ chapterTitle: '기초', perspective: 'missing context', query: 'context query' }],
+    });
+    const r = parsePerspectiveResponse(raw);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.perspectives).toHaveLength(1);
+      expect(r.perspectives[0]).toEqual({
+        chapterTitle: '기초',
+        perspective: 'missing context',
+        query: 'context query',
+      });
+    }
+  });
+
+  it('strips code fences before parsing', () => {
+    const raw =
+      '```json\n{"gaps":[{"chapterTitle":"A","perspective":"p","query":"q"}]}\n```';
+    const r = parsePerspectiveResponse(raw);
+    expect(r.ok).toBe(true);
+  });
+
+  it('returns ok:false on non-JSON input', () => {
+    expect(parsePerspectiveResponse('not json').ok).toBe(false);
+  });
+
+  it('returns ok:false when gaps is not an array', () => {
+    expect(parsePerspectiveResponse('{"gaps":"wrong"}').ok).toBe(false);
+  });
+
+  it('drops entries with missing or empty required fields', () => {
+    const raw = JSON.stringify({
+      gaps: [
+        { chapterTitle: '', perspective: 'x', query: 'q' }, // empty chapterTitle → drop
+        { chapterTitle: 'A', perspective: 'p', query: 'q' }, // valid
+      ],
+    });
+    const r = parsePerspectiveResponse(raw);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.perspectives).toHaveLength(1);
+  });
+
+  it('returns ok:false when all gap entries are invalid', () => {
+    const raw = JSON.stringify({ gaps: [{ chapterTitle: '', perspective: '', query: '' }] });
+    expect(parsePerspectiveResponse(raw).ok).toBe(false);
+  });
+
+  it('caps at MAX_GAPS (6) entries even if LLM returns more', () => {
+    const gaps = Array.from({ length: 10 }, (_, i) => ({
+      chapterTitle: `Ch${i}`,
+      perspective: `p${i}`,
+      query: `q${i}`,
+    }));
+    const r = parsePerspectiveResponse(JSON.stringify({ gaps }));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.perspectives.length).toBeLessThanOrEqual(6);
+  });
+});
+
+// ─── gapsToQueries (pure) ────────────────────────────────────────────────────
+
+describe('gapsToQueries (pure)', () => {
+  it('extracts query strings from gaps', () => {
+    const gaps: ResearchGap[] = [
+      { chapterTitle: 'A', perspective: 'p1', query: 'foo search' },
+      { chapterTitle: 'B', perspective: 'p2', query: 'bar search' },
+    ];
+    expect(gapsToQueries(gaps)).toEqual(['foo search', 'bar search']);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(gapsToQueries([])).toEqual([]);
+  });
+});
+
+// ─── retrieveForGaps ─────────────────────────────────────────────────────────
+
+describe('retrieveForGaps', () => {
+  const gap: ResearchGap = {
+    chapterTitle: '기초 챕터',
+    perspective: 'missing historical context',
+    query: 'history context query',
+  };
+
+  it('P-2B-REF: every finding has a non-empty reference.url from CSE item.link', async () => {
+    mockCse.searchWeb.mockResolvedValueOnce({
+      items: [
+        {
+          title: 'Web Article',
+          link: 'https://example.com/art',
+          snippet: 'Key fact here.',
+          displayLink: 'example.com',
+        },
+      ],
+      totalResults: 1,
+    });
+    const findings = await retrieveForGaps([gap], mockCse);
+    expect(findings).toHaveLength(1);
+    const f = findings[0]!;
+    expect(f.reference.url).toBe('https://example.com/art');
+    expect(f.reference.url).not.toBe('');
+  });
+
+  it('P-2B-BORDER: fact is derived from CSE snippet, not invented', async () => {
+    const snippet = 'This is a factual snippet from the web.';
+    mockCse.searchWeb.mockResolvedValueOnce({
+      items: [
+        { title: 'T', link: 'https://src.com', snippet, displayLink: 'src.com' },
+      ],
+      totalResults: 1,
+    });
+    const findings = await retrieveForGaps([gap], mockCse);
+    expect(findings[0]!.fact).toBe(snippet);
+  });
+
+  it('drops gap when CSE returns an error (no fabrication)', async () => {
+    mockCse.searchWeb.mockResolvedValueOnce({
+      items: [],
+      totalResults: 0,
+      error: 'CSE API HTTP 429',
+    });
+    const findings = await retrieveForGaps([gap], mockCse);
+    expect(findings).toHaveLength(0);
+  });
+
+  it('drops gap when CSE returns empty items (no fabrication)', async () => {
+    mockCse.searchWeb.mockResolvedValueOnce({ items: [], totalResults: 0 });
+    const findings = await retrieveForGaps([gap], mockCse);
+    expect(findings).toHaveLength(0);
+  });
+
+  it('fills findings for successful gaps, drops failed ones (partial)', async () => {
+    const gap2: ResearchGap = { chapterTitle: 'B', perspective: 'p', query: 'q2' };
+    mockCse.searchWeb
+      .mockResolvedValueOnce({ items: [], totalResults: 0, error: 'fail' })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            title: 'T2',
+            link: 'https://b.com',
+            snippet: 'B fact',
+            displayLink: 'b.com',
+          },
+        ],
+        totalResults: 1,
+      });
+    const findings = await retrieveForGaps([gap, gap2], mockCse);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.chapterTitle).toBe('B');
+  });
+});
+
+// ─── researchBookGaps (integration — LLM + CSE both mocked) ──────────────────
+
+describe('researchBookGaps', () => {
+  const chapters: ResearchChapterInput[] = [
+    { title: '기초', intro: '기초 소개', sectionSummaries: ['개요', '역사'] },
+    { title: '실전', intro: '실전 응용', sectionSummaries: ['사례', '연습'] },
+  ];
+
+  const gapsJson = JSON.stringify({
+    gaps: [{ chapterTitle: '기초', perspective: 'missing depth', query: 'deep dive query' }],
+  });
+
+  it('ok path: gaps → findings with references (P-2B-REF + P-2B-NO-ARTICLE)', async () => {
+    mockGenerate.mockResolvedValueOnce(gapsJson);
+    mockCse.searchWeb.mockResolvedValueOnce({
+      items: [
+        {
+          title: 'Ref Title',
+          link: 'https://ref.com',
+          snippet: 'A real fact.',
+          displayLink: 'ref.com',
+        },
+      ],
+      totalResults: 1,
+    });
+    const r = await researchBookGaps(chapters, '목표', mockCse);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.findings.length).toBeGreaterThan(0);
+      // P-2B-REF: every finding has non-empty url
+      for (const f of r.findings) {
+        expect(f.reference.url).not.toBe('');
+      }
+      // P-2B-NO-ARTICLE: result shape has only findings, no chapters/outline/sections
+      expect(r).not.toHaveProperty('chapters');
+      expect(r).not.toHaveProperty('outline');
+      expect(r).not.toHaveProperty('sections');
+    }
+  });
+
+  it('returns ok:false immediately on empty chapters — no LLM call', async () => {
+    const r = await researchBookGaps([], '목표', mockCse);
+    expect(r.ok).toBe(false);
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('retries then hard-fails on provider error', async () => {
+    mockGenerate.mockRejectedValue(new Error('network down'));
+    const r = await researchBookGaps(chapters, '목표', mockCse);
+    expect(r.ok).toBe(false);
+    expect(mockGenerate).toHaveBeenCalledTimes(2); // RESEARCH_ATTEMPTS
+  });
+
+  it('retries then hard-fails on repeated parse failure', async () => {
+    mockGenerate.mockResolvedValue('not json at all');
+    const r = await researchBookGaps(chapters, '목표', mockCse);
+    expect(r.ok).toBe(false);
+    expect(mockGenerate).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns ok:true with empty findings when all CSE gaps fail (no fabrication)', async () => {
+    mockGenerate.mockResolvedValueOnce(gapsJson);
+    mockCse.searchWeb.mockResolvedValueOnce({
+      items: [],
+      totalResults: 0,
+      error: 'cse disabled',
+    });
+    const r = await researchBookGaps(chapters, '목표', mockCse);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.findings).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Two verified, **unwired** (inert) skill modules — research (STORM) + factcheck. Built by parallel agents, tsc-verified + gate-reviewed by me. Fixture tests run in this PR's CI. **Integration is BLOCKED on a design decision (see chat) — STOP condition 5.** Merging inert is prod-safe (nothing calls them, flag-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)