### PR TITLE
feat(note): loop-2 wiring — research + factcheck enrich (A1+B, flag-off) (CP504 §4.5.1)

### DIFF
--- a/src/config/book-gate.ts
+++ b/src/config/book-gate.ts
@@ -168,3 +168,17 @@ export function isBookNarrativeSkeletonEnabled(env: NodeJS.ProcessEnv = process.
     .toLowerCase();
   return v === 'true' || v === '1' || v === 'yes'; // unset ⇒ false (default off)
 }
+
+/**
+ * §4.5.1 [4] loop-2 enrichment (STORM research + Factcheck) on/off. Default FALSE
+ * — SEPARATE from the skeleton flag because it makes EXTERNAL calls (Google CSE +
+ * Haiku per atom/gap) with real cost/latency. Runs only when a narrative skeleton
+ * also exists. Lets James enable narrative-only (skeleton) vs narrative+enrich
+ * independently. Rollback = unset / BOOK_ENRICH_ENABLED=false.
+ */
+export function isBookEnrichEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['BOOK_ENRICH_ENABLED'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes'; // unset ⇒ false (default off)
+}

--- a/src/modules/mandala-book/book-schema.ts
+++ b/src/modules/mandala-book/book-schema.ts
@@ -39,10 +39,21 @@ const provenanceSchema = z
   })
   .nullish();
 
+// CP504 loop-2-A (A1) — per-atom factcheck stored ADDITIVELY in section.verification.
+// Atoms are the sourced fact units; the woven prose is NOT rewritten — `correction`
+// is a PROPOSAL only. Optional → books without it stay valid.
+const factcheckCheckSchema = z.object({
+  atom_text: z.string(),
+  verdict: z.enum(['TRUE', 'SUBSTANTIALLY_TRUE', 'FALSE', 'MISLEADING', 'UNVERIFIABLE']),
+  evidence_url: z.string().optional(),
+  correction: z.string().optional(), // proposal only (FALSE/MISLEADING, evidence-grounded)
+});
+
 const verificationSchema = z
   .object({
     status: z.enum(['unverified', 'verified', 'flagged']).default('unverified'),
     notes: z.string().optional(),
+    checks: z.array(factcheckCheckSchema).optional(), // CP504 loop-2-A factcheck proposals
   })
   .nullish();
 
@@ -55,11 +66,29 @@ export const bookSectionSchema = z.object({
   verification: verificationSchema, // Fork D placeholder
 });
 
+// CP504 loop-2-B — STORM gap-fill findings attached to a chapter (additive).
+// Each fact carries a ref_id into book.references[] (web provenance). Optional.
+const chapterResearchSchema = z.object({
+  perspective: z.string(),
+  fact: z.string(),
+  ref_id: z.number().int(),
+});
+
 export const bookChapterSchema = z.object({
   ch: z.number().int(),
   title: z.string(),
   intro: z.string(),
   sections: z.array(bookSectionSchema),
+  research: z.array(chapterResearchSchema).optional(), // CP504 loop-2-B (additive)
+});
+
+// CP504 loop-2-B (B) — web references from STORM research. Video provenance stays
+// inline on atoms (atom.vid/ts); this is the WEB half of dual-source tracking
+// (P-REF-DUAL). Rendered as a bottom "참고 자료" section. Optional → legacy valid.
+const bookReferenceSchema = z.object({
+  id: z.number().int(),
+  title: z.string(),
+  url: z.string(),
 });
 
 export const bookJsonSchema = z.object({
@@ -80,6 +109,7 @@ export const bookJsonSchema = z.object({
   // Fork D placeholder — book-level completeness, fill job not implemented.
   completeness: z.object({ status: z.string(), checked_at: z.string() }).nullish(),
   chapters: z.array(bookChapterSchema),
+  references: z.array(bookReferenceSchema).optional(), // CP504 loop-2-B web refs (additive)
 });
 
 /** Pre-parse input shape (defaults + Fork-D placeholders optional) — for fixtures/generators. */

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -12,18 +12,22 @@ import { getPrismaClient } from '@/modules/database/client';
 import { getMandalaManager } from '@/modules/mandala/manager';
 import { logger } from '@/utils/logger';
 import { buildBookJson, type CellInput, type CellVideoV2 } from './build-book';
-import { parseBookJson } from './book-schema';
+import { parseBookJson, type BookJsonInput } from './book-schema';
 import {
   loadBookGateConfig,
   passesBookGate,
   computeMandalaMedian,
   isBookTopicSynthesisEnabled,
   isBookNarrativeSkeletonEnabled,
+  isBookEnrichEnabled,
   loadNoteMaxSections,
 } from '@/config/book-gate';
 import { synthesizeCellTopics } from './topic-synthesis';
 import { synthesizeBookSkeleton, type BookSkeleton } from './book-skeleton';
 import { weaveChapterBody } from './book-body';
+import { researchBookGaps } from './book-research';
+import { factcheckChapterBody } from './book-factcheck';
+import { createGoogleCseClient, loadGoogleCseConfig } from '@/modules/google-cse';
 import { enqueueEnrichRichSummary } from '@/modules/queue';
 import { enqueueRelevanceBackfillForMandala } from '@/modules/relevance/relevance-backfill-trigger';
 import { getStoredTranslation } from '@/modules/skills/rich-summary-translator';
@@ -483,6 +487,16 @@ export async function fillMandalaBook(params: {
     skeleton, // §4.5.1 — undefined ⇒ legacy cell=chapter assembly
   });
 
+  // 4b. §4.5.1 [4] loop-2 enrichment — research gap-fill (STORM) + factcheck.
+  // ONLY when a narrative skeleton exists AND enrich is enabled (separate flag —
+  // external CSE + Haiku calls, real cost). Augments `book` ADDITIVELY before
+  // validation: book.references[] + chapter.research[] (web facts) and
+  // section.verification.checks[] (per-atom verdict + correction PROPOSAL — the
+  // woven prose is NOT rewritten, A1). Best-effort; failures leave book unchanged.
+  if (skeleton && isBookEnrichEnabled()) {
+    await enrichBookLoop2(book, mandala.title ?? '', mandalaId);
+  }
+
   let validated;
   try {
     validated = parseBookJson(book);
@@ -548,4 +562,102 @@ export async function fillMandalaBook(params: {
     version,
     coverage: { gatePassed, v2Done, v2Pending: v2Pending.size },
   };
+}
+
+// Bound external CSE+Haiku calls per book-fill (cost guard, RPT-5).
+const MAX_FACTCHECK_ATOMS = 24;
+
+/**
+ * §4.5.1 [4] loop-2 enrichment — mutates `book` ADDITIVELY (caller gates on
+ * skeleton + BOOK_ENRICH_ENABLED). research (STORM): web gap-fill → book.references[]
+ * + chapter.research[] (fact + ref_id). factcheck (A1): per-section atoms (the
+ * sourced fact units) → section.verification.checks[] (verdict + correction
+ * PROPOSAL; the woven prose is NOT rewritten). Each half is best-effort (try/catch)
+ * so a CSE/LLM failure leaves the book unchanged. External call counts logged.
+ */
+async function enrichBookLoop2(
+  book: BookJsonInput,
+  centerGoal: string,
+  mandalaId: string
+): Promise<void> {
+  const chapters = book.chapters ?? [];
+  const cse = createGoogleCseClient(loadGoogleCseConfig());
+
+  // research (loop-2-B) — web gap-fill, reference-tracked (P-2B-REF).
+  try {
+    const chapterInputs = chapters.map((c) => ({
+      title: c.title,
+      intro: c.intro ?? '',
+      sectionSummaries: (c.sections ?? []).map((s) => s.narrative).filter(Boolean),
+    }));
+    const research = await researchBookGaps(chapterInputs, centerGoal, cse);
+    if (research.ok && research.findings.length > 0) {
+      const refs: Array<{ id: number; title: string; url: string }> = [];
+      const idByUrl = new Map<string, number>();
+      for (const f of research.findings) {
+        let id = idByUrl.get(f.reference.url);
+        if (id == null) {
+          id = refs.length + 1;
+          idByUrl.set(f.reference.url, id);
+          refs.push({ id, title: f.reference.title, url: f.reference.url });
+        }
+        const ch = chapters.find((c) => c.title === f.chapterTitle);
+        if (ch) (ch.research ??= []).push({ perspective: f.perspective, fact: f.fact, ref_id: id });
+      }
+      if (refs.length > 0) book.references = refs;
+      log.info('book research enrich (CSE)', {
+        mandalaId,
+        findings: research.findings.length,
+        references: refs.length,
+        cseCalls: research.findings.length, // ~1 CSE search per gap (RPT-5)
+      });
+    }
+  } catch (err) {
+    log.warn('book research enrich failed (non-fatal)', {
+      mandalaId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // factcheck (loop-2-A, A1) — atoms are the sourced fact units; verdicts +
+  // correction PROPOSALS land in section.verification (prose untouched). Capped.
+  try {
+    let budget = MAX_FACTCHECK_ATOMS;
+    let sectionsChecked = 0;
+    for (const ch of chapters) {
+      for (const s of ch.sections ?? []) {
+        if (budget <= 0) break;
+        const atoms = (s.atoms ?? []).slice(0, budget);
+        if (atoms.length === 0) continue;
+        budget -= atoms.length;
+        sectionsChecked += 1;
+        const fc = await factcheckChapterBody(
+          atoms.map((a) => ({ text: a.text, hasSource: true })),
+          cse
+        );
+        if (fc.ok && fc.results.length > 0) {
+          s.verification = {
+            status: 'verified',
+            checks: fc.results.map((r) => ({
+              atom_text: r.sentence,
+              verdict: r.verdict,
+              ...(r.evidenceUrl ? { evidence_url: r.evidenceUrl } : {}),
+              ...(r.correction ? { correction: r.correction } : {}),
+            })),
+          };
+        }
+      }
+      if (budget <= 0) break;
+    }
+    log.info('book factcheck enrich (CSE+Haiku)', {
+      mandalaId,
+      sectionsChecked,
+      atomsBudgetUsed: MAX_FACTCHECK_ATOMS - budget,
+    });
+  } catch (err) {
+    log.warn('book factcheck enrich failed (non-fatal)', {
+      mandalaId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }

--- a/tests/unit/modules/book-schema.test.ts
+++ b/tests/unit/modules/book-schema.test.ts
@@ -161,3 +161,35 @@ describe('book-schema v2 contract', () => {
     expect(bookJsonSchema.safeParse(book).success).toBe(false);
   });
 });
+
+describe('book-schema — CP504 loop-2 additive keys (G-SHAPE: additive, no rejection)', () => {
+  it('legacy book WITHOUT references/research/verification.checks still parses', () => {
+    expect(() => parseBookJson(validBook())).not.toThrow();
+  });
+
+  it('book WITH references[] + chapter.research[] + section.verification.checks[] parses', () => {
+    const book = validBook();
+    book.references = [{ id: 1, title: 'Source A', url: 'https://ex.com/a' }];
+    book.chapters[0]!.research = [{ perspective: 'gap X', fact: 'web fact', ref_id: 1 }];
+    book.chapters[0]!.sections[0]!.verification = {
+      status: 'verified',
+      checks: [
+        { atom_text: 'claim a', verdict: 'FALSE', evidence_url: 'https://ex.com/a', correction: 'fixed' },
+        { atom_text: 'claim b', verdict: 'TRUE' },
+      ],
+    };
+    const parsed = parseBookJson(book);
+    expect(parsed.references?.[0]?.url).toBe('https://ex.com/a');
+    expect(parsed.chapters[0]?.research?.[0]?.ref_id).toBe(1);
+    expect(parsed.chapters[0]?.sections[0]?.verification?.checks?.[0]?.verdict).toBe('FALSE');
+  });
+
+  it('rejects an invalid factcheck verdict', () => {
+    const book = validBook();
+    book.chapters[0]!.sections[0]!.verification = {
+      status: 'verified',
+      checks: [{ atom_text: 'x', verdict: 'BOGUS' as 'TRUE' }],
+    };
+    expect(bookJsonSchema.safeParse(book).success).toBe(false);
+  });
+});


### PR DESCRIPTION
Wires the merged loop-2 modules (#997) into fill-book, ADDITIVELY, gated by **BOOK_ENRICH_ENABLED (default false)** + narrative skeleton → prod untouched, external CSE+Haiku only on explicit enable.

**Schema (additive, G-SHAPE ✓ / G-DDL clear — zod strips unknown, jsonb, no column):** `section.verification.checks[]` (A1 per-atom verdict+correction PROPOSAL) · `chapter.research[]` · `book.references[]` (web half; atoms stay inline = video half, P-REF-DUAL).

**fill-book `enrichBookLoop2`:** research (gap-fill → refs[] + chapter.research[]) + factcheck (section.atoms = sourced facts → verification.checks, **prose not rewritten** A1), best-effort, capped (MAX_FACTCHECK_ATOMS=24, RPT-5 logs).

**Gates:** book-schema test (additive parses + legacy parses + bad verdict rejected); backend tsc 0; jest → CI. **references RENDER = next PR (P-REF-RENDER).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)