### PR TITLE
fix(player): video-mode thumbnail fallback depth + placeholder detection (CP504 track B)

### DIFF
--- a/frontend/src/__tests__/smoke/image-utils.test.ts
+++ b/frontend/src/__tests__/smoke/image-utils.test.ts
@@ -3,6 +3,7 @@ import {
   upgradeYouTubeThumbnail,
   getYouTubeFallback,
   handleThumbnailError,
+  nextYouTubeThumbnail,
 } from '@shared/lib/image-utils';
 
 describe('upgradeYouTubeThumbnail', () => {
@@ -53,5 +54,32 @@ describe('handleThumbnailError', () => {
     const img = { src: 'https://example.com/broken.jpg' } as HTMLImageElement;
     handleThumbnailError({ currentTarget: img });
     expect(img.src).toBe('/placeholder.svg');
+  });
+});
+
+describe('nextYouTubeThumbnail', () => {
+  // Regression (fix/video-thumbnail): the descent must be DEEP — walk every
+  // tier down to an always-present one, not stop after a single fallback.
+  it('descends the full chain maxres → sd → hq → mq → default', () => {
+    expect(nextYouTubeThumbnail('https://img.youtube.com/vi/abc/maxresdefault.jpg')).toBe(
+      'https://img.youtube.com/vi/abc/sddefault.jpg'
+    );
+    expect(nextYouTubeThumbnail('https://img.youtube.com/vi/abc/sddefault.jpg')).toBe(
+      'https://img.youtube.com/vi/abc/hqdefault.jpg'
+    );
+    expect(nextYouTubeThumbnail('https://img.youtube.com/vi/abc/hqdefault.jpg')).toBe(
+      'https://img.youtube.com/vi/abc/mqdefault.jpg'
+    );
+    expect(nextYouTubeThumbnail('https://img.youtube.com/vi/abc/mqdefault.jpg')).toBe(
+      'https://img.youtube.com/vi/abc/default.jpg'
+    );
+  });
+
+  it('returns null when the chain is exhausted (default tier)', () => {
+    expect(nextYouTubeThumbnail('https://img.youtube.com/vi/abc/default.jpg')).toBeNull();
+  });
+
+  it('returns null for non-YouTube / unrecognised URLs', () => {
+    expect(nextYouTubeThumbnail('https://example.com/broken.jpg')).toBeNull();
   });
 });

--- a/frontend/src/pages/learning/lib/video-block.tsx
+++ b/frontend/src/pages/learning/lib/video-block.tsx
@@ -25,6 +25,7 @@ import { ReactNodeViewRenderer, NodeViewWrapper, type NodeViewProps } from '@tip
 import { Play } from 'lucide-react';
 import { useLearningStore } from '@/pages/learning/model/useLearningStore';
 import { loadYouTubeAPI, type YTPlayer } from '@/widgets/video-player/model/youtube-api';
+import { nextYouTubeThumbnail, isYouTubePlaceholder } from '@/shared/lib/image-utils';
 
 // CP446.x — YT.PlayerState constants. Avoid relying on window.YT.PlayerState
 // at module load (loaded async).
@@ -211,16 +212,25 @@ function VideoBlockNodeView({ node, getPos, editor }: NodeViewProps) {
             className="video-block-thumb"
             draggable={false}
             onError={(e) => {
-              // CP504 — prefer maxresdefault (1280×720). It 404s for videos that
-              // never produced a maxres thumb, so fall back to hqdefault (480×360,
-              // always exists); only mark broken if even that fails.
+              // Prefer maxresdefault (1280×720). When a quality tier 404s
+              // (older/short videos lack maxres/sd) descend the FULL chain
+              // maxres → sd → hq → mq → default — hq/mq/default effectively
+              // always exist — instead of stopping after one step. Only hide
+              // the block once every tier is gone (deleted/private vid).
+              const next = nextYouTubeThumbnail(e.currentTarget.src);
+              if (next) e.currentTarget.src = next;
+              else setThumbBroken(true);
+            }}
+            onLoad={(e) => {
+              // YouTube serves a 120×90 grey placeholder with HTTP 200 (no
+              // onError) when a quality tier is missing. Detect it by natural
+              // dimensions and descend until a real thumbnail loads, so a
+              // remounted block never latches the blurry/blank low-res poster.
               const img = e.currentTarget;
-              if (!img.dataset.fellBack) {
-                img.dataset.fellBack = '1';
-                img.src = `https://img.youtube.com/vi/${attrs.vid}/hqdefault.jpg`;
-              } else {
-                setThumbBroken(true);
-              }
+              if (!isYouTubePlaceholder(img)) return;
+              const next = nextYouTubeThumbnail(img.src);
+              if (next) img.src = next;
+              else setThumbBroken(true);
             }}
           />
           <span className="video-block-overlay" />

--- a/frontend/src/shared/lib/image-utils.ts
+++ b/frontend/src/shared/lib/image-utils.ts
@@ -45,22 +45,27 @@ export function isYouTubePlaceholder(img: HTMLImageElement): boolean {
 }
 
 /**
+ * Pure descent helper: given a YouTube thumbnail URL, return the next
+ * lower-quality URL in the chain (maxresdefault → sddefault → hqdefault →
+ * mqdefault → default), or `null` when the chain is exhausted or the URL is
+ * not a recognised YouTube thumbnail quality. Does not mutate. Callers decide
+ * the terminal action (local placeholder, hide the element, …).
+ */
+export function nextYouTubeThumbnail(src: string): string | null {
+  const currentIdx = YT_FALLBACK_CHAIN.findIndex((q) => src.includes(q));
+  if (currentIdx >= 0 && currentIdx < YT_FALLBACK_CHAIN.length - 1) {
+    return src.replace(YT_FALLBACK_CHAIN[currentIdx], YT_FALLBACK_CHAIN[currentIdx + 1]);
+  }
+  return null;
+}
+
+/**
  * onError handler: walks the full YouTube quality chain, then falls back to local placeholder.
  */
 export function handleThumbnailError(e: { currentTarget: HTMLImageElement }): void {
   const img = e.currentTarget;
-  const src = img.src;
-
-  // YouTube thumbnail — try next quality level
-  const currentIdx = YT_FALLBACK_CHAIN.findIndex((q) => src.includes(q));
-  if (currentIdx >= 0 && currentIdx < YT_FALLBACK_CHAIN.length - 1) {
-    const next = YT_FALLBACK_CHAIN[currentIdx + 1];
-    img.src = src.replace(YT_FALLBACK_CHAIN[currentIdx], next);
-    return;
-  }
-
   // All YouTube qualities exhausted or non-YouTube image — local placeholder
-  img.src = '/placeholder.svg';
+  img.src = nextYouTubeThumbnail(img.src) ?? '/placeholder.svg';
 }
 
 /**
@@ -75,15 +80,7 @@ export function handleThumbnailLoad(e: { currentTarget: HTMLImageElement }): voi
   if (img.src.endsWith('/placeholder.svg')) return;
   if (!isYouTubePlaceholder(img)) return;
 
-  const src = img.src;
-  const currentIdx = YT_FALLBACK_CHAIN.findIndex((q) => src.includes(q));
-  if (currentIdx >= 0 && currentIdx < YT_FALLBACK_CHAIN.length - 1) {
-    const next = YT_FALLBACK_CHAIN[currentIdx + 1];
-    img.src = src.replace(YT_FALLBACK_CHAIN[currentIdx], next);
-    return;
-  }
-
-  img.src = '/placeholder.svg';
+  img.src = nextYouTubeThumbnail(img.src) ?? '/placeholder.svg';
 }
 
 /**


### PR DESCRIPTION
Video-mode (player) thumbnail bugs — **separate track, no feature flag** (player always active → prod-immediate; rollback = `git revert`). Independent of the note pipeline.

## Measured root causes (code SSOT; hypotheses refuted with evidence)
- **Bug 1 (black poster)**: `video-block.tsx` did a ONE-step `onError` fallback (`maxres→hq`) then hid the block; never descended to always-present `mqdefault`/`default`. Also YouTube serves a **120×90 grey placeholder with HTTP 200** for some videos → `onError` never fires → blank/blurry poster with no recovery (no `onLoad` handler).
- **Bug 2 (low-res after note→video remount)**: SW-cache hypothesis **REFUTED** (`vite.config.ts` runtimeCaching only caches fonts; `i.ytimg.com` not cached). Remount-latches-low-res **REFUTED** (src recomputes to maxres each mount). Actual = the same grey HTTP-200 placeholder surfacing on a given mount.

## Fix
- `image-utils.ts`: extracted pure `nextYouTubeThumbnail(src)` (deep descent `maxres→sd→hq→mq→default`, null at exhaustion); `handleThumbnailError`/`handleThumbnailLoad` delegate to it; `isYouTubePlaceholder` (120×90) detection.
- `video-block.tsx`: replaced one-step onError with deep descent + added `onLoad` placeholder-descent. Aligns video-block (the lone outlier) with the standard `thumbnailImgHandlers` used by 11+ components. Hide-deleted/private semantics preserved.
- +3 regression tests.

## Gates
- **P-THUMB-1** deep chain to always-present tiers · **P-THUMB-2** onLoad descends past grey placeholder (remount stays hi-res) · **P-THUMB-REG** tsc 0 / vitest **414** / build 0. **No SW/cache change** → no user re-caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)