### PR TITLE
feat(note): loop-2 references render — 참고 자료 + 보강 자료 (P-REF-DUAL) (CP504 §4.5.1)

### DIFF
--- a/frontend/src/__tests__/note-document-generator-narrative.test.ts
+++ b/frontend/src/__tests__/note-document-generator-narrative.test.ts
@@ -69,3 +69,30 @@ describe('note-document-generator — loop-1b narrative render', () => {
     expect(paraTexts(ns)).toContain('ATOM_TEXT_A 인사'); // fell through to legacy atom render
   });
 });
+
+const headingTexts = (ns: N[]): string[] =>
+  ns
+    .filter((n) => n.type === 'heading')
+    .map((h) => (h.content ?? []).map((c) => (c as { text?: string }).text ?? '').join(''));
+
+describe('note-document-generator — loop-2 references render (P-REF-RENDER)', () => {
+  const enriched = (): MandalaBookData => {
+    const b = book('이 장은 기초 회화를 다룬다');
+    b.chapters[0]!.research = [{ perspective: '발음', fact: 'WEB_FACT 모음 발음 핵심', ref_id: 1 }];
+    b.references = [{ id: 1, title: 'Phonetics Guide', url: 'https://ex.com/p' }];
+    return b;
+  };
+
+  it('renders chapter 보강 자료 (fact [ref_id]) + bottom 참고 자료 (id, url)', () => {
+    const ns = nodes(buildInitialNoteDoc(enriched()));
+    const texts = paraTexts(ns);
+    expect(texts.some((t) => t.includes('WEB_FACT 모음 발음 핵심') && t.includes('[1]'))).toBe(true);
+    expect(headingTexts(ns)).toContain('참고 자료');
+    expect(texts.some((t) => t.includes('[1]') && t.includes('https://ex.com/p'))).toBe(true);
+  });
+
+  it('no references/research → no 참고 자료 section (legacy/normal book unchanged)', () => {
+    const ns = nodes(buildInitialNoteDoc(book('이 장은 기초 회화를 다룬다')));
+    expect(headingTexts(ns)).not.toContain('참고 자료');
+  });
+});

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -272,6 +272,16 @@ function renderChapter(chapter: MandalaBookChapter, narrativeMode: boolean): Tip
     out.push(...renderSection(sec, chapter.ch, i, narrativeMode));
   }
 
+  // CP504 loop-2-B — STORM gap-fill: web-sourced supplemental facts for this
+  // chapter, each marked [n] into the bottom 참고 자료 list (ref_id). Present only
+  // when enrich ran (BOOK_ENRICH_ENABLED); absent for normal books → no-op.
+  if (chapter.research && chapter.research.length > 0) {
+    out.push(heading(3, '보강 자료'));
+    for (const r of chapter.research) {
+      out.push(paragraph(`${r.fact} [${r.ref_id}]`));
+    }
+  }
+
   return out;
 }
 
@@ -304,6 +314,16 @@ export function buildInitialNoteDoc(book: MandalaBookData | null | undefined): T
   for (const ch of sortedChapters) {
     if (!ch || !Array.isArray(ch.sections)) continue;
     content.push(...renderChapter(ch, narrativeMode));
+  }
+
+  // CP504 loop-2-B (B) — bottom "참고 자료" web references (STORM). Video provenance
+  // (atom vid/ts) stays inline on the cards; this is the WEB half (P-REF-DUAL).
+  // Present only when enrich ran; absent for normal books → no section.
+  if (book.references && book.references.length > 0) {
+    content.push(heading(2, '참고 자료'));
+    for (const ref of book.references) {
+      content.push(paragraph(`[${ref.id}] ${ref.title} — ${ref.url}`));
+    }
   }
 
   // If the last node is a horizontalRule, drop it (clean trailing).

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -291,11 +291,20 @@ export interface MandalaBookAtom {
   seg_ref?: { from_sec: number; to_sec: number };
 }
 
+// CP504 loop-2-A — per-atom factcheck stored additively in section.verification.
+export interface MandalaBookFactcheck {
+  atom_text: string;
+  verdict: 'TRUE' | 'SUBSTANTIALLY_TRUE' | 'FALSE' | 'MISLEADING' | 'UNVERIFIABLE';
+  evidence_url?: string;
+  correction?: string; // proposal only (prose not rewritten)
+}
+
 export interface MandalaBookSection {
   title: string;
   narrative?: string;
   atoms?: MandalaBookAtom[];
   qa?: Array<{ q: string; a: string }>;
+  verification?: { status?: string; notes?: string; checks?: MandalaBookFactcheck[] }; // CP504 loop-2-A
 }
 
 export interface MandalaBookChapter {
@@ -303,6 +312,8 @@ export interface MandalaBookChapter {
   title: string;
   intro?: string;
   sections: MandalaBookSection[];
+  // CP504 loop-2-B — STORM gap-fill findings (web facts); ref_id → references[].
+  research?: Array<{ perspective: string; fact: string; ref_id: number }>;
 }
 
 export interface MandalaBookData {
@@ -314,6 +325,8 @@ export interface MandalaBookData {
   estimated_pages?: number;
   chapters: MandalaBookChapter[];
   stats?: Record<string, unknown>;
+  // CP504 loop-2-B (B) — web references (STORM). Rendered as bottom "참고 자료".
+  references?: Array<{ id: number; title: string; url: string }>;
 }
 
 export interface MandalaBookResponse {


### PR DESCRIPTION
Final Track-A piece (P-REF-RENDER). Renders loop-2 enrich data (#998) in the note: `chapter.research[]` → per-chapter **보강 자료** block (fact [ref_id]); `book.references[]` → bottom **참고 자료** section. Atom vid/ts stays inline (video half) + references[] (web half) = **P-REF-DUAL**. Additive FE types; **no section for normal/legacy books** (enrich data absent → render no-op). Test: renders both when present, none when absent. FE tsc 0 / vitest 413 / build 0. flag-off (prod inert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)