### PR TITLE
fix(note): per-chapter video dedup — first embed, then timestamp pill (CP505 B)

### DIFF
--- a/frontend/src/__tests__/note-document-generator-narrative.test.ts
+++ b/frontend/src/__tests__/note-document-generator-narrative.test.ts
@@ -96,3 +96,38 @@ describe('note-document-generator — loop-2 references render (P-REF-RENDER)', 
     expect(headingTexts(ns)).not.toContain('참고 자료');
   });
 });
+
+const linkHrefs = (ns: N[]): string[] =>
+  ns
+    .filter((n) => n.type === 'paragraph')
+    .flatMap((p) => (p.content ?? []) as Array<{ marks?: Array<{ type: string; attrs?: { href?: string } }> }>)
+    .flatMap((c) => c.marks ?? [])
+    .filter((m) => m.type === 'link')
+    .map((m) => m.attrs?.href ?? '');
+
+describe('note-document-generator — CP505 B per-chapter video dedup', () => {
+  const repeatBook = (): MandalaBookData =>
+    ({
+      chapters: [
+        {
+          ch: 0,
+          title: '워밍업',
+          intro: '',
+          sections: [
+            { title: '도입', atoms: [{ vid: 'vidA', ts: 9, text: 'intro' }] },
+            { title: '루틴', atoms: [{ vid: 'vidA', ts: 192, text: 'routine' }] },
+            { title: '주의', atoms: [{ vid: 'vidB', ts: 30, text: 'caution' }] },
+          ],
+        },
+      ],
+    }) as MandalaBookData;
+
+  it('same vid repeated in a chapter → ONE full embed + timestamp pill (not re-embedded)', () => {
+    const ns = nodes(buildInitialNoteDoc(repeatBook()));
+    const vb = videoBlocks(ns);
+    expect(vb.filter((v) => v.attrs?.vid === 'vidA')).toHaveLength(1); // embedded ONCE
+    expect(vb.filter((v) => v.attrs?.vid === 'vidB')).toHaveLength(1);
+    // the vidA repeat (ts=192) → timestamp pill linking to t=192 (seeks embedded player)
+    expect(linkHrefs(ns).some((h) => h.includes('vidA') && h.includes('t=192'))).toBe(true);
+  });
+});

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -167,11 +167,49 @@ function groupAtomsByVid(
 // Section / chapter renderers
 // ---------------------------------------------------------------------------
 
+/** seconds → "M:SS" label for the dedup pill. */
+function formatTs(sec: number): string {
+  const s = Math.max(0, Math.floor(sec));
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+}
+
+/**
+ * CP505 B — per-chapter video dedup. A vid's FIRST section gets the full
+ * videoBlock embed; later sections of the SAME vid (the §1⑤ over-decomposition
+ * surfaces one comprehensive video across N topics) get a compact timestamp PILL
+ * — a link with `t=<sec>` that TimestampPlugin seeks the already-embedded player
+ * to (the repeats are the same chapter video at different timestamps, so onSeek
+ * targets the right player). Kills the "same thumbnail N times" repeat without
+ * touching topic structure (root fix = §1⑤, separate). Mutates `embeddedVids`.
+ */
+function videoNodeForGroup(
+  vid: string,
+  firstTs: number,
+  endSec: number,
+  sectionTitle: string | null,
+  embeddedVids: Set<string>
+): TiptapNode {
+  if (!embeddedVids.has(vid)) {
+    embeddedVids.add(vid);
+    return videoBlockNode(vid, firstTs, endSec, sectionTitle);
+  }
+  return paragraph(`▶ ${formatTs(firstTs)} 이어서 보기`, [
+    {
+      type: 'link',
+      attrs: {
+        href: `https://www.youtube.com/watch?v=${vid}&t=${Math.floor(firstTs)}`,
+        target: '_blank',
+      },
+    },
+  ]);
+}
+
 function renderSection(
   section: MandalaBookSection,
   chapterIdx: number,
   sectionIdx: number,
-  narrativeMode: boolean
+  narrativeMode: boolean,
+  embeddedVids: Set<string>
 ): TiptapNode[] {
   const out: TiptapNode[] = [];
 
@@ -204,7 +242,7 @@ function renderSection(
       if (g.atoms.length === 0) continue;
       const firstTs = g.atoms[0].ts ?? 0;
       const endSec = groupEndSec(g.atoms);
-      out.push(videoBlockNode(g.vid, firstTs, endSec, section.title ?? null));
+      out.push(videoNodeForGroup(g.vid, firstTs, endSec, section.title ?? null, embeddedVids));
     }
     out.push(horizontalRule());
     return out;
@@ -215,7 +253,7 @@ function renderSection(
     if (g.atoms.length === 0) continue;
     const firstTs = g.atoms[0].ts ?? 0;
     const endSec = groupEndSec(g.atoms);
-    out.push(videoBlockNode(g.vid, firstTs, endSec, section.title ?? null));
+    out.push(videoNodeForGroup(g.vid, firstTs, endSec, section.title ?? null, embeddedVids));
     // C6 — group consecutive same-type atoms into Medium-style paragraphs
     // (was 1 atom = 1 <p> = "picture-book"). Body stays UN-bolded: Medium body
     // text has no inline keyword bold (the auto-strong heuristic turned common
@@ -267,9 +305,12 @@ function renderChapter(chapter: MandalaBookChapter, narrativeMode: boolean): Tip
     out.push(paragraph(chapter.intro));
   }
 
+  // CP505 B — dedup repeated video embeds WITHIN this chapter: a vid's first
+  // section = full embed, later same-vid sections = timestamp pill. Reset per chapter.
+  const embeddedVids = new Set<string>();
   for (let i = 0; i < chapter.sections.length; i++) {
     const sec = chapter.sections[i];
-    out.push(...renderSection(sec, chapter.ch, i, narrativeMode));
+    out.push(...renderSection(sec, chapter.ch, i, narrativeMode, embeddedVids));
   }
 
   // CP504 loop-2-B — STORM gap-fill: web-sourced supplemental facts for this


### PR DESCRIPTION
**Diagnosis (가) confirmed (code+data):** §1⑤ content-clusters a cell's atoms with no per-video-spread constraint → a comprehensive video becomes N topics, each embedding the same video. Data: chapters with 2–12 videos available yet one video spanning 2–8 topics (387f5309 ch4 = 1 video / 8 topics / 11 videos). Flag-independent (topic-synthesis).

**B (immediate, render-only):** per chapter, a vid's first section keeps the full embed; later same-vid sections become a compact timestamp pill (a `t=` link → TimestampPlugin seeks the already-embedded player; repeats are the same chapter video at different timestamps). Topic text/atoms untouched; only the duplicate embed is replaced. Both narrative + legacy render. Test: same vid x3 sections → 1 embed + a t=192 pill. FE tsc 0 / vitest 417 / build 0. DDL none.

Root fix (A — §1⑤ over-decomposition) = separate follow-up. Prod-visible (flag-independent), revert-rollback. Ships before #1001 activation so the a/b/c/d eval is not polluted by repeats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)