### PR TITLE
feat(note): targeted-CV figure wiring — flag-gated, insighta-only (CP505 [CV-NOTE-WIRE])

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "framer-motion": "^12.35.1",
     "i18next": "^25.8.14",
     "i18next-browser-languagedetector": "^8.2.1",
+    "katex": "^0.16.45",
     "lowlight": "^3.3.0",
     "lucide-react": "^0.562.0",
     "next-themes": "^0.3.0",

--- a/frontend/src/__tests__/note-document-generator-narrative.test.ts
+++ b/frontend/src/__tests__/note-document-generator-narrative.test.ts
@@ -96,3 +96,35 @@ describe('note-document-generator — loop-2 references render (P-REF-RENDER)', 
     expect(headingTexts(ns)).not.toContain('참고 자료');
   });
 });
+
+// [CV-NOTE-WIRE] — CV figures attached to a section render as figureBlock nodes.
+type FigAttrs = { kind?: string; latex?: string; assetPath?: string };
+const figureBlocks = (ns: N[]) =>
+  ns.filter((n) => n.type === 'figureBlock').map((n) => (n.attrs ?? {}) as FigAttrs);
+
+describe('note-document-generator — CV figures render ([CV-NOTE-WIRE])', () => {
+  const withFigures = (): MandalaBookData => {
+    const b = book('이 장은 기초 회화를 다룬다');
+    b.chapters[0]!.sections[0]!.figures = [
+      { video_id: 'vidA', ts_sec: 10, kind: 'equation', latex: 'E=mc^2', verification_status: 'verified' },
+      { video_id: 'vidA', ts_sec: 12, kind: 'chart', asset_path: 'https://cdn.ex.com/chart.png', verification_status: 'verified' },
+      { video_id: 'vidA', ts_sec: 14, kind: 'diagram', asset_path: 'https://cdn.ex.com/diag.png', verification_status: 'unverified' }, // DROP unverified
+      { video_id: 'vidA', ts_sec: 16, kind: 'keyframe', asset_path: 'https://cdn.ex.com/kf.png', verification_status: 'verified' }, // DROP keyframe
+    ];
+    return b;
+  };
+
+  it('renders equation + chart figureBlock nodes; drops unverified + keyframe', () => {
+    const figs = figureBlocks(nodes(buildInitialNoteDoc(withFigures())));
+    expect(figs.some((f) => f.kind === 'equation' && f.latex === 'E=mc^2')).toBe(true); // equation kept
+    expect(figs.some((f) => f.kind === 'chart' && f.assetPath === 'https://cdn.ex.com/chart.png')).toBe(true); // chart kept
+    expect(figs.some((f) => f.assetPath === 'https://cdn.ex.com/diag.png')).toBe(false); // unverified dropped
+    expect(figs.some((f) => f.kind === 'keyframe')).toBe(false); // keyframe dropped
+    expect(figs).toHaveLength(2);
+  });
+
+  it('no figures → no figureBlock nodes (existing books byte-unchanged)', () => {
+    const figs = figureBlocks(nodes(buildInitialNoteDoc(book('이 장은 기초 회화를 다룬다'))));
+    expect(figs).toHaveLength(0);
+  });
+});

--- a/frontend/src/pages/learning/lib/figure-block.tsx
+++ b/frontend/src/pages/learning/lib/figure-block.tsx
@@ -1,0 +1,142 @@
+/**
+ * FigureBlock — TipTap atomic Node for [CV-NOTE-WIRE] computer-vision figures
+ * attached to a note section (equation / chart / diagram / table).
+ *
+ * Mirrors the VideoBlock pattern (custom Node + ReactNodeViewRenderer) so the
+ * doc shape stays schema-valid — an unregistered node type would make
+ * ProseMirror throw on doc load and break the note.
+ *
+ *  - kind='equation' → lazy-loads KaTeX (dynamic import; only when an equation
+ *    figure mounts) and renders displayMode HTML.
+ *  - kind∈{chart,diagram,table} → renders the asset_path as an <img> + caption.
+ *
+ * Inert until the backend populates section.figures (flag-gated server-side).
+ */
+import { useEffect, useRef, useState } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
+
+export interface FigureBlockOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+export type FigureKind = 'chart' | 'diagram' | 'table' | 'equation';
+
+export interface FigureBlockAttrs {
+  kind: FigureKind;
+  latex: string | null;
+  assetPath: string | null;
+  caption: string | null;
+}
+
+// Lazy KaTeX render — dynamic import keeps the heavy lib out of the main bundle.
+function EquationView({ latex }: { latex: string }) {
+  const [html, setHtml] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const katex = (await import('katex')).default;
+        await import('katex/dist/katex.min.css');
+        if (cancelled) return;
+        setHtml(katex.renderToString(latex, { throwOnError: false, displayMode: true }));
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [latex]);
+
+  // Fallback to raw LaTeX text while loading / on failure (never blank).
+  if (failed || html === null) {
+    return <code className="note-figure-latex-fallback">{latex}</code>;
+  }
+  // KaTeX output is math markup (no user scripts); latex is backend-verified.
+  return <div className="note-figure-equation" dangerouslySetInnerHTML={{ __html: html }} />;
+}
+
+function FigureBlockNodeView({ node }: NodeViewProps) {
+  const attrs = node.attrs as unknown as FigureBlockAttrs;
+  const [imgBroken, setImgBroken] = useState(false);
+
+  return (
+    <NodeViewWrapper className="note-figure-block" data-kind={attrs.kind}>
+      {attrs.kind === 'equation' && attrs.latex ? (
+        <EquationView latex={attrs.latex} />
+      ) : attrs.assetPath && !imgBroken ? (
+        <figure className="note-figure-image">
+          <img
+            src={attrs.assetPath}
+            alt={attrs.caption ?? attrs.kind}
+            loading="lazy"
+            onError={() => setImgBroken(true)}
+          />
+          {attrs.caption && <figcaption>{attrs.caption}</figcaption>}
+        </figure>
+      ) : null}
+    </NodeViewWrapper>
+  );
+}
+
+export const FigureBlock = Node.create<FigureBlockOptions>({
+  name: 'figureBlock',
+
+  group: 'block',
+  atom: true,
+  draggable: true,
+  selectable: true,
+
+  addOptions() {
+    return { HTMLAttributes: {} };
+  },
+
+  addAttributes() {
+    return {
+      kind: {
+        default: 'chart',
+        parseHTML: (el) => el.getAttribute('data-kind') ?? 'chart',
+        renderHTML: (attrs) => ({ 'data-kind': String(attrs['kind']) }),
+      },
+      latex: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-latex'),
+        renderHTML: (attrs) => (attrs['latex'] ? { 'data-latex': String(attrs['latex']) } : {}),
+      },
+      assetPath: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-asset-path'),
+        renderHTML: (attrs) =>
+          attrs['assetPath'] ? { 'data-asset-path': String(attrs['assetPath']) } : {},
+      },
+      caption: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-caption'),
+        renderHTML: (attrs) =>
+          attrs['caption'] ? { 'data-caption': String(attrs['caption']) } : {},
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="figure-block"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    // Inert markup for editor.getHTML() export; live UI is the React NodeView.
+    return [
+      'div',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        'data-type': 'figure-block',
+        class: 'note-figure-block',
+      }),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(FigureBlockNodeView);
+  },
+});

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -35,6 +35,7 @@ import type {
   MandalaBookChapter,
   MandalaBookSection,
   MandalaBookAtom,
+  MandalaBookFigure,
 } from '@/shared/lib/api-client';
 import type { TiptapDoc, TiptapNode } from '@/features/video-side-panel/lib/note-parser';
 
@@ -163,6 +164,37 @@ function groupAtomsByVid(
   }));
 }
 
+// [CV-NOTE-WIRE] — render targeted CV figures attached to a section as
+// `figureBlock` nodes (registered in useNoteDocument extensions). Filters
+// defensively (backend already filters to verified + renderable): only
+// chart/table/diagram/equation, drops unverified + keyframe + empty payloads.
+const FIGURE_KINDS = new Set(['chart', 'table', 'diagram', 'equation']);
+function figureBlockNode(attrs: {
+  kind: string;
+  latex: string | null;
+  assetPath: string | null;
+  caption: string | null;
+}): TiptapNode {
+  return { type: 'figureBlock', attrs };
+}
+function renderFigures(figures: MandalaBookFigure[] | undefined): TiptapNode[] {
+  const out: TiptapNode[] = [];
+  for (const f of figures ?? []) {
+    if (!FIGURE_KINDS.has(f.kind)) continue; // drops keyframe
+    if (f.verification_status === 'unverified') continue; // defensive
+    if (f.kind === 'equation') {
+      const latex = (f.latex ?? '').trim();
+      if (!latex) continue;
+      out.push(figureBlockNode({ kind: 'equation', latex, assetPath: null, caption: null }));
+    } else {
+      const assetPath = (f.asset_path ?? '').trim();
+      if (!assetPath) continue;
+      out.push(figureBlockNode({ kind: f.kind, latex: null, assetPath, caption: f.kind }));
+    }
+  }
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // Section / chapter renderers
 // ---------------------------------------------------------------------------
@@ -206,6 +238,7 @@ function renderSection(
       const endSec = groupEndSec(g.atoms);
       out.push(videoBlockNode(g.vid, firstTs, endSec, section.title ?? null));
     }
+    out.push(...renderFigures(section.figures)); // [CV-NOTE-WIRE]
     out.push(horizontalRule());
     return out;
   }
@@ -234,6 +267,8 @@ function renderSection(
       content: [paragraph(section.narrative)],
     });
   }
+
+  out.push(...renderFigures(section.figures)); // [CV-NOTE-WIRE]
 
   // Section divider (skip after the last section — handled by caller).
   out.push(horizontalRule());

--- a/frontend/src/pages/learning/lib/note-export.ts
+++ b/frontend/src/pages/learning/lib/note-export.ts
@@ -116,6 +116,17 @@ function renderBlock(node: TiptapNode, depth: number): string {
       const url = `https://www.youtube.com/watch?v=${vid}&t=${Math.floor(fromSec)}s`;
       return `[${label}](${url})\n\n`;
     }
+    case 'figureBlock': {
+      // [CV-NOTE-WIRE] — equation → $$..$$ ; chart/diagram/table → ![caption](src).
+      const kind = (node.attrs?.['kind'] as string | undefined) ?? '';
+      if (kind === 'equation') {
+        const latex = (node.attrs?.['latex'] as string | undefined) ?? '';
+        return latex ? `$$\n${latex}\n$$\n\n` : '';
+      }
+      const assetPath = (node.attrs?.['assetPath'] as string | undefined) ?? '';
+      const caption = (node.attrs?.['caption'] as string | undefined) ?? kind;
+      return assetPath ? `![${caption}](${assetPath})\n\n` : '';
+    }
     default:
       // Fallback for unknown block types: render any text children.
       if (Array.isArray(node.content)) {

--- a/frontend/src/pages/learning/model/useNoteDocument.ts
+++ b/frontend/src/pages/learning/model/useNoteDocument.ts
@@ -33,6 +33,7 @@ import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import type { TiptapDoc } from '@/features/video-side-panel/lib/note-parser';
 
 import { VideoBlock } from '../lib/video-block';
+import { FigureBlock } from '../lib/figure-block';
 import { buildInitialNoteDoc } from '../lib/note-document-generator';
 
 // ---------------------------------------------------------------------------
@@ -140,6 +141,8 @@ export function useNoteDocument(input: UseNoteDocumentInput): UseNoteDocumentRes
       CodeBlockLowlight.configure({ lowlight }),
       // CP445.x — VideoBlock owns its click handling (inline iframe via store).
       VideoBlock.configure({ HTMLAttributes: {} }),
+      // [CV-NOTE-WIRE] — CV figures (equation: lazy KaTeX / chart|diagram|table: img).
+      FigureBlock.configure({ HTMLAttributes: {} }),
     ],
     []
   );

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -299,12 +299,26 @@ export interface MandalaBookFactcheck {
   correction?: string; // proposal only (prose not rewritten)
 }
 
+// [CV-NOTE-WIRE] — a targeted computer-vision figure attached to a section.
+// Backend writes this additively (flag-gated) AFTER filtering to verified +
+// renderable; the FE render filters defensively too.
+export interface MandalaBookFigure {
+  video_id: string;
+  ts_sec: number;
+  kind: 'chart' | 'diagram' | 'table' | 'equation' | 'keyframe';
+  latex?: string;
+  asset_path?: string;
+  struct?: Record<string, unknown>;
+  verification_status?: string;
+}
+
 export interface MandalaBookSection {
   title: string;
   narrative?: string;
   atoms?: MandalaBookAtom[];
   qa?: Array<{ q: string; a: string }>;
   verification?: { status?: string; notes?: string; checks?: MandalaBookFactcheck[] }; // CP504 loop-2-A
+  figures?: MandalaBookFigure[]; // [CV-NOTE-WIRE] inert until backend populates
 }
 
 export interface MandalaBookChapter {

--- a/src/config/book-gate.ts
+++ b/src/config/book-gate.ts
@@ -182,3 +182,14 @@ export function isBookEnrichEnabled(env: NodeJS.ProcessEnv = process.env): boole
     .toLowerCase();
   return v === 'true' || v === '1' || v === 'yes'; // unset ⇒ false (default off)
 }
+
+// CP505 [CV-NOTE-WIRE] — note targeted-CV (slidegen figures). Default OFF.
+// Gates the async NOTE_CV_ENRICH job (Haiku detect → /numerize → section.figures).
+// Independent of SNAPSHOT_SERVICE_TOKEN: even when this is on, an unset token makes
+// extraction a graceful no-op ([] figures). slidegen repo untouched.
+export function isVisualCvEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['VISUAL_CV_ENABLED'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes'; // unset ⇒ false (default off)
+}

--- a/src/modules/mandala-book/book-figure-detect.ts
+++ b/src/modules/mandala-book/book-figure-detect.ts
@@ -1,0 +1,207 @@
+// §CV-NOTE-WIRE (CP505) — Haiku-powered figure-target detection for visual CV enrichment.
+//
+// Reads book sections (title + narrative + atoms{vid,ts,text}) and returns a SMALL
+// pinpoint set of (videoId, tsSec) where a chart/table/diagram/equation would aid
+// comprehension. All returned tsSec values are grounded in real section atoms — no
+// invented timestamps. Graceful: LLM / parse failure → [] (never throws).
+// Pure-ish: one Haiku call + parse (no DB I/O).
+//
+// Service module — OpenRouter Haiku is a PRODUCTION call. Unit tests MUST mock it
+// (LLM-API ban). See book-factcheck pattern for the mock shape.
+
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import { logger } from '@/utils/logger';
+import type { BookJson } from './book-schema';
+
+const log = logger.child({ module: 'mandala-book/book-figure-detect' });
+
+// Same Haiku model used across the book pipeline (factcheck, research).
+const HAIKU_MODEL = 'anthropic/claude-haiku-4.5';
+const MAX_TOKENS = 1024;
+// Low temperature for factual timestamp grounding; avoid creative timestamps.
+const TEMPERATURE = 0.2;
+
+// Hard cap: never exceed this many targets per book regardless of maxTargets arg.
+const DEFAULT_MAX_TARGETS = 8;
+// Atoms per section sent to the prompt (cost control).
+const MAX_ATOMS_PER_SECTION = 12;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** One detected figure target — (videoId, tsSec) grounded in a real section atom. */
+export interface FigureTarget {
+  videoId: string;
+  tsSec: number;
+  chapterIdx: number;
+  sectionIdx: number;
+  reason: string;
+}
+
+// Internal shape expected from Haiku JSON response.
+interface LlmTarget {
+  chapterIdx?: unknown;
+  sectionIdx?: unknown;
+  videoId?: unknown;
+  tsSec?: unknown;
+  reason?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt builder (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the Haiku detection prompt from the book's sections.
+ * Each section contributes: chapterIdx/sectionIdx indices, title, narrative excerpt,
+ * and up to MAX_ATOMS_PER_SECTION atoms with their (vid, ts, text).
+ */
+export function buildFigureDetectPrompt(
+  book: BookJson,
+  centerGoal: string,
+  maxTargets: number
+): string {
+  const sectionBlocks: string[] = [];
+
+  for (let ci = 0; ci < book.chapters.length; ci++) {
+    const ch = book.chapters[ci];
+    if (!ch) continue;
+    for (let si = 0; si < ch.sections.length; si++) {
+      const sec = ch.sections[si];
+      if (!sec) continue;
+      const atomLines = sec.atoms
+        .slice(0, MAX_ATOMS_PER_SECTION)
+        .map((a) => `    {vid:"${a.vid}",ts:${a.ts},"${a.text.slice(0, 80)}"}`)
+        .join('\n');
+      sectionBlocks.push(
+        `[ch:${ci} sec:${si}] "${sec.title}"\n` +
+          `  narrative: ${sec.narrative.slice(0, 120)}\n` +
+          `  atoms:\n${atomLines || '    (none)'}`
+      );
+    }
+  }
+
+  return [
+    `Book goal: "${centerGoal}"`,
+    `Identify up to ${maxTargets} video timestamps where a chart, table, diagram, or equation would CONCRETELY aid comprehension.`,
+    '',
+    'Rules:',
+    '- STEM / AI-ML topics: prioritize equations first, then charts/tables/diagrams.',
+    '- tsSec MUST be the exact ts value of an atom in that section — no invented timestamps.',
+    '- Prefer sections with dense technical content over narrative/intro sections.',
+    '- Return [] if nothing qualifies (no STEM content, no suitable atoms).',
+    `- Output JSON only (no code fence): [{"chapterIdx":0,"sectionIdx":0,"videoId":"...","tsSec":123,"reason":"..."}]`,
+    '',
+    'Sections:',
+    sectionBlocks.join('\n\n'),
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Response parser (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse and validate the Haiku JSON response into FigureTarget[].
+ * Enforces maxTargets hard cap. Drops items where tsSec is not a real atom ts
+ * for the given section (prevents fabricated timestamps). Code-fence strip
+ * mirrors other book modules. Returns [] on JSON parse failure.
+ */
+export function parseFigureDetectResponse(
+  raw: string,
+  book: BookJson,
+  maxTargets: number
+): FigureTarget[] {
+  // Strip code fences (```json...``` or ```...```)
+  const stripped = raw
+    .trim()
+    .replace(/^\s*```(?:json)?\s*\n?/i, '')
+    .replace(/\n?\s*```\s*$/i, '')
+    .trim();
+
+  let json: unknown;
+  try {
+    json = JSON.parse(stripped);
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(json)) return [];
+
+  const result: FigureTarget[] = [];
+
+  for (const item of json as LlmTarget[]) {
+    if (result.length >= maxTargets) break; // hard cap
+
+    const ci = typeof item.chapterIdx === 'number' ? Math.floor(item.chapterIdx) : -1;
+    const si = typeof item.sectionIdx === 'number' ? Math.floor(item.sectionIdx) : -1;
+    const videoId = typeof item.videoId === 'string' ? item.videoId.trim() : '';
+    const tsSec = typeof item.tsSec === 'number' ? Math.floor(item.tsSec) : -1;
+    const reason = typeof item.reason === 'string' ? item.reason.trim() : '';
+
+    if (!videoId || tsSec < 0 || !reason || ci < 0 || si < 0) continue;
+
+    // Chapter and section must exist in the book.
+    const ch = book.chapters[ci];
+    if (!ch) continue;
+    const sec = ch.sections[si];
+    if (!sec) continue;
+
+    // tsSec MUST match an atom in that section for the given videoId.
+    const grounded = sec.atoms.some((a) => a.vid === videoId && a.ts === tsSec);
+    if (!grounded) continue;
+
+    result.push({ videoId, tsSec, chapterIdx: ci, sectionIdx: si, reason });
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect figure targets in the book's sections using one Haiku call.
+ * Returns ≤ maxTargets (default 8, HARD cap) FigureTargets grounded in real
+ * section atoms. Graceful: returns [] on LLM / parse failure (never throws).
+ *
+ * @param book       - Parsed book (v2 schema).
+ * @param opts.centerGoal  - Mandala center goal (context for the LLM).
+ * @param opts.maxTargets  - Override cap; still clamped to DEFAULT_MAX_TARGETS.
+ */
+export async function detectFigureTargets(
+  book: BookJson,
+  opts: { centerGoal: string; maxTargets?: number }
+): Promise<FigureTarget[]> {
+  // Clamp to the HARD cap regardless of caller input.
+  const maxTargets = Math.min(opts.maxTargets ?? DEFAULT_MAX_TARGETS, DEFAULT_MAX_TARGETS);
+
+  // No atoms anywhere → skip the LLM call entirely.
+  const hasAtoms = book.chapters.some((ch) => ch.sections.some((s) => s.atoms.length > 0));
+  if (!hasAtoms) return [];
+
+  const prompt = buildFigureDetectPrompt(book, opts.centerGoal, maxTargets);
+
+  let raw: string;
+  try {
+    raw = await new OpenRouterGenerationProvider(HAIKU_MODEL).generate(prompt, {
+      format: 'json',
+      temperature: TEMPERATURE,
+      maxTokens: MAX_TOKENS,
+    });
+  } catch (err) {
+    log.warn('book-figure-detect: LLM 호출 실패 → []', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+
+  const targets = parseFigureDetectResponse(raw, book, maxTargets);
+  log.info('book-figure-detect 완료', {
+    chaptersInBook: book.chapters.length,
+    detected: targets.length,
+  });
+  return targets;
+}

--- a/src/modules/mandala-book/book-schema.ts
+++ b/src/modules/mandala-book/book-schema.ts
@@ -57,6 +57,22 @@ const verificationSchema = z
   })
   .nullish();
 
+// CP505 [CV-NOTE-WIRE] — targeted CV figures attached to a section (ADDITIVE).
+// Sourced from the slidegen /numerize service (cached in video_figure_snapshots),
+// mirroring snapshot FigureRef. The note CV enrich job stores ONLY verified,
+// renderable kinds (chart/table/diagram/equation); keyframe + unverified dropped.
+// Optional → books without CV stay valid. Render: equation→KaTeX(latex),
+// chart/table/diagram→img(asset_path). slidegen repo untouched.
+const bookFigureSchema = z.object({
+  video_id: z.string(),
+  ts_sec: z.number().int(),
+  kind: z.enum(['chart', 'diagram', 'table', 'equation', 'keyframe']),
+  latex: z.string().optional(), // equation → LaTeX (KaTeX render)
+  asset_path: z.string().optional(), // chart/table/diagram → image
+  struct: z.record(z.unknown()).optional(), // mode-B JSON (chart/table/diagram)
+  verification_status: z.string().optional(),
+});
+
 export const bookSectionSchema = z.object({
   title: z.string(),
   narrative: z.string(), // 살붙임 body assembled from v2 analysis + segments
@@ -64,6 +80,7 @@ export const bookSectionSchema = z.object({
   qa: z.array(bookQaSchema).default([]),
   provenance: provenanceSchema, // Fork D placeholder
   verification: verificationSchema, // Fork D placeholder
+  figures: z.array(bookFigureSchema).optional(), // CP505 [CV-NOTE-WIRE] (additive)
 });
 
 // CP504 loop-2-B — STORM gap-fill findings attached to a chapter (additive).
@@ -117,6 +134,7 @@ export type BookJsonInput = z.input<typeof bookJsonSchema>;
 export type BookAtom = z.infer<typeof bookAtomSchema>;
 export type BookSection = z.infer<typeof bookSectionSchema>;
 export type BookChapter = z.infer<typeof bookChapterSchema>;
+export type BookFigure = z.infer<typeof bookFigureSchema>;
 export type BookJson = z.infer<typeof bookJsonSchema>;
 
 /** Throws ZodError on shape violation — call before upserting a generated book. */

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -20,6 +20,7 @@ import {
   isBookTopicSynthesisEnabled,
   isBookNarrativeSkeletonEnabled,
   isBookEnrichEnabled,
+  isVisualCvEnabled,
   loadNoteMaxSections,
 } from '@/config/book-gate';
 import { synthesizeCellTopics } from './topic-synthesis';
@@ -28,7 +29,7 @@ import { weaveChapterBody } from './book-body';
 import { researchBookGaps } from './book-research';
 import { factcheckChapterBody } from './book-factcheck';
 import { createGoogleCseClient, loadGoogleCseConfig } from '@/modules/google-cse';
-import { enqueueEnrichRichSummary } from '@/modules/queue';
+import { enqueueEnrichRichSummary, enqueueNoteCvEnrich } from '@/modules/queue';
 import { enqueueRelevanceBackfillForMandala } from '@/modules/relevance/relevance-backfill-trigger';
 import { getStoredTranslation } from '@/modules/skills/rich-summary-translator';
 import { getArchivedVideoIds } from '@/modules/exclude/archived-videos';
@@ -495,6 +496,15 @@ export async function fillMandalaBook(params: {
   // woven prose is NOT rewritten, A1). Best-effort; failures leave book unchanged.
   if (skeleton && isBookEnrichEnabled()) {
     await enrichBookLoop2(book, mandala.title ?? '', mandalaId);
+    // [CV-NOTE-WIRE] CP505 — fire-and-forget visual CV figure enrich (default inert)
+    if (isVisualCvEnabled()) {
+      enqueueNoteCvEnrich(mandalaId, userId).catch((err) => {
+        log.warn('note-cv-enrich enqueue failed (non-fatal)', {
+          mandalaId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
   }
 
   let validated;

--- a/src/modules/queue/handlers/note-cv-enrich.ts
+++ b/src/modules/queue/handlers/note-cv-enrich.ts
@@ -1,0 +1,189 @@
+/**
+ * Note visual-CV enrich worker (CP505 [CV-NOTE-WIRE]).
+ *
+ * Async job: load book_json → Haiku detects figure targets in sections →
+ * getOrExtractSnapshots per video → filter renderable kinds (chart/table/diagram/
+ * equation, drop keyframe + unverified) → attach BookFigure to section.figures
+ * (additive) → re-validate → write back. Flag-gated (VISUAL_CV_ENABLED); inert
+ * when SNAPSHOT_SERVICE_TOKEN is unset (getOrExtractSnapshots returns [] gracefully).
+ *
+ * Never blocks the fill path — triggered fire-and-forget from fill-book.ts.
+ */
+
+import PgBoss from 'pg-boss';
+import { logger } from '@/utils/logger';
+import { getJobQueue } from '../manager';
+import { JOB_NAMES, NOTE_CV_ENRICH_OPTIONS, type NoteCvEnrichPayload } from '../types';
+import { richSummaryWorkOptions } from './rich-summary-work-options';
+import type { BookFigure } from '@/modules/mandala-book/book-schema';
+
+const log = logger.child({ module: 'queue/note-cv-enrich' });
+
+// Trap-proof option shape (teamSize:N + teamRefill) so raising this later parallelizes.
+const NOTE_CV_ENRICH_CONCURRENCY = 2;
+
+// Renderable kinds the renderer supports; keyframe is binary-only (deferred).
+const RENDERABLE_KINDS = new Set<string>(['chart', 'table', 'diagram', 'equation']);
+
+export async function registerNoteCvEnrichWorker(): Promise<void> {
+  const boss = getJobQueue().getInstance();
+  await boss.work<NoteCvEnrichPayload>(
+    JOB_NAMES.NOTE_CV_ENRICH,
+    richSummaryWorkOptions(NOTE_CV_ENRICH_CONCURRENCY),
+    handleNoteCvEnrich
+  );
+  log.info('note-cv-enrich worker registered', { concurrency: NOTE_CV_ENRICH_CONCURRENCY });
+}
+
+export async function handleNoteCvEnrich(job: PgBoss.Job<NoteCvEnrichPayload>): Promise<void> {
+  const { mandalaId, userId } = job.data ?? ({} as NoteCvEnrichPayload);
+  if (!mandalaId || !userId) {
+    log.warn('note-cv-enrich: mandalaId/userId 누락, 드롭', { jobId: job.id });
+    return;
+  }
+
+  const startMs = Date.now();
+
+  // Lazy imports keep the queue boot path free of the enrichment chain.
+  const { getPrismaClient } = await import('@/modules/database/client');
+  const { safeParseBookJson, parseBookJson } = await import('@/modules/mandala-book/book-schema');
+  const { detectFigureTargets } = await import('@/modules/mandala-book/book-figure-detect');
+  const { getOrExtractSnapshots } = await import('@/modules/snapshot/get-or-extract');
+
+  const prisma = getPrismaClient();
+
+  // a. Load book_json (parse with parseBookJson contract).
+  const bookRow = await prisma.mandala_books.findUnique({
+    where: { mandala_id: mandalaId },
+    select: { book_json: true },
+  });
+  if (!bookRow?.book_json) {
+    log.warn('note-cv-enrich: book_json 없음', { jobId: job.id, mandalaId });
+    return;
+  }
+
+  const parsed = safeParseBookJson(bookRow.book_json);
+  if (!parsed.success) {
+    log.warn('note-cv-enrich: book_json 스키마 오류', { jobId: job.id, mandalaId });
+    return;
+  }
+  const book = parsed.data;
+  const centerGoal = book.mandala_title;
+
+  // b. Detect figure targets via one Haiku call.
+  const targets = await detectFigureTargets(book, { centerGoal });
+  if (targets.length === 0) {
+    log.info('note-cv-enrich: 감지된 타겟 없음', { mandalaId, wallMs: Date.now() - startMs });
+    return;
+  }
+
+  // c. Group targets by videoId, then call getOrExtractSnapshots per video.
+  const targetsByVideo = new Map<string, typeof targets>();
+  for (const t of targets) {
+    const bucket = targetsByVideo.get(t.videoId) ?? [];
+    bucket.push(t);
+    targetsByVideo.set(t.videoId, bucket);
+  }
+
+  let cacheHits = 0;
+  let extractCount = 0;
+  let kept = 0;
+  let dropped = 0;
+  let totalCalls = 0;
+
+  for (const [videoId, videoTargets] of targetsByVideo) {
+    const tsList = videoTargets.map((t) => t.tsSec);
+    totalCalls += tsList.length;
+    const refs = await getOrExtractSnapshots(videoId, tsList);
+
+    for (const fig of refs) {
+      if (fig.source === 'cache') cacheHits++;
+      else extractCount++;
+
+      // d. Filter: renderable kinds only, drop unverified.
+      if (!RENDERABLE_KINDS.has(fig.kind) || fig.verificationStatus === 'unverified') {
+        dropped++;
+        continue;
+      }
+      kept++;
+
+      // Map FigureRef → BookFigure (struct narrowed from unknown to Record<string,unknown>).
+      const struct =
+        typeof fig.struct === 'object' && fig.struct !== null && !Array.isArray(fig.struct)
+          ? (fig.struct as Record<string, unknown>)
+          : undefined;
+      const bookFig: BookFigure = {
+        video_id: fig.videoId,
+        ts_sec: fig.tsSec,
+        kind: fig.kind,
+        ...(fig.latex != null ? { latex: fig.latex } : {}),
+        ...(fig.assetPath != null ? { asset_path: fig.assetPath } : {}),
+        ...(struct != null ? { struct } : {}),
+        verification_status: fig.verificationStatus,
+      };
+
+      // e. Attach to section.figures — additive, dedup by (video_id, ts_sec).
+      const matching = videoTargets.filter((t) => t.tsSec === fig.tsSec);
+      for (const target of matching) {
+        const ch = book.chapters[target.chapterIdx];
+        if (!ch) continue;
+        const sec = ch.sections[target.sectionIdx];
+        if (!sec) continue;
+        const alreadyPresent = (sec.figures ?? []).some(
+          (f) => f.video_id === bookFig.video_id && f.ts_sec === bookFig.ts_sec
+        );
+        if (alreadyPresent) continue;
+        if (!sec.figures) sec.figures = [];
+        sec.figures.push(bookFig);
+      }
+    }
+  }
+
+  // g. LOG in Korean per project style: calls, cache-hit/extract ratio, wall-time, kept/dropped.
+  const wallMs = Date.now() - startMs;
+  log.info('note-cv-enrich 완료', {
+    mandalaId,
+    totalCalls,
+    cacheHits,
+    extractCount,
+    kept,
+    dropped,
+    wallMs,
+  });
+
+  if (kept === 0) return; // Nothing to write back.
+
+  // f. Bump generated_at, re-validate with parseBookJson before write.
+  book.generated_at = new Date().toISOString();
+  let validated;
+  try {
+    validated = parseBookJson(book);
+  } catch (err) {
+    log.error('note-cv-enrich: 재검증 실패 — 저장 취소', {
+      mandalaId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  // Raw SQL — mirrors fill-book.ts upsert note about Prisma model lag on some deploys.
+  await prisma.$executeRawUnsafe(
+    `UPDATE mandala_books
+     SET book_json  = $1::jsonb,
+         updated_at = NOW()
+     WHERE mandala_id = $2::uuid`,
+    JSON.stringify(validated),
+    mandalaId
+  );
+
+  log.info('note-cv-enrich book_json 저장 완료', { mandalaId, figuresKept: kept });
+}
+
+/** Enqueue a note-cv-enrich job for one mandala. Returns the pg-boss job id (or null). */
+export async function enqueueNoteCvEnrich(
+  mandalaId: string,
+  userId: string
+): Promise<string | null> {
+  const boss = getJobQueue().getInstance();
+  return boss.send(JOB_NAMES.NOTE_CV_ENRICH, { mandalaId, userId }, NOTE_CV_ENRICH_OPTIONS);
+}

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -22,6 +22,7 @@ export { enqueueEnrichRichSummary } from './handlers/enrich-rich-summary';
 export { enqueueBatchVideoCollectorRun } from './handlers/batch-video-collector';
 export { enqueuePoolMaintenanceRun } from './handlers/pool-maintenance';
 export { enqueueRelevanceQuick } from './handlers/enrich-relevance-quick';
+export { enqueueNoteCvEnrich } from './handlers/note-cv-enrich';
 
 import { getJobQueue } from './manager';
 import { registerEnrichVideoWorker } from './handlers/enrich-video';
@@ -36,6 +37,7 @@ import { registerMandalaBookFillWorker } from './handlers/mandala-book-fill';
 import { registerTranslateMandalaBulkWorker } from './handlers/translate-mandala-bulk';
 import { registerSegmentRelevanceFillWorker } from './handlers/segment-relevance-fill';
 import { registerDeckBuildWorker } from './handlers/deck-build';
+import { registerNoteCvEnrichWorker } from './handlers/note-cv-enrich';
 import { logger } from '../../utils/logger';
 
 /**
@@ -62,6 +64,7 @@ export async function initJobQueue(): Promise<void> {
   await registerTranslateMandalaBulkWorker();
   await registerSegmentRelevanceFillWorker();
   await registerDeckBuildWorker();
+  await registerNoteCvEnrichWorker();
 
-  logger.info('Job queue fully initialized (pg-boss + 10 workers)');
+  logger.info('Job queue fully initialized (pg-boss + 13 workers)');
 }

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -70,6 +70,13 @@ export const JOB_NAMES = {
    * per segment. relevance_pct comes ONLY from the scorer (no interpolation).
    */
   SEGMENT_RELEVANCE_FILL: 'segment-relevance-fill',
+  /**
+   * CP505 [CV-NOTE-WIRE] — note targeted visual CV enrich. Haiku detects figure
+   * targets in the book's sections → /numerize extraction (cached) → filter
+   * chart/table/diagram/equation → attach to section.figures (additive). Flag-gated
+   * (VISUAL_CV_ENABLED=true) and inert when SNAPSHOT_SERVICE_TOKEN is unset (graceful []).
+   */
+  NOTE_CV_ENRICH: 'note-cv-enrich',
 } as const;
 
 export type JobName = (typeof JOB_NAMES)[keyof typeof JOB_NAMES];
@@ -350,6 +357,25 @@ export interface DeckBuildPayload {
   userId: string;
   mandalaId: string;
 }
+
+/**
+ * CP505 [CV-NOTE-WIRE] — figure detection + extraction + section attachment.
+ * Runs asynchronously after a successful book fill (VISUAL_CV_ENABLED gate).
+ * Extraction is ~148s/ts; up to 8 targets (hard cap) per book run worst case.
+ */
+export interface NoteCvEnrichPayload {
+  mandalaId: string;
+  userId: string;
+}
+
+// Extraction can take ~148s per timestamp (up to 8 targets hard cap); generous
+// expiry absorbs worst-case fan-out. Retry once for transient DB/network errors.
+export const NOTE_CV_ENRICH_OPTIONS = {
+  retryLimit: 1,
+  retryDelay: 30,
+  retryBackoff: true,
+  expireInMinutes: 30,
+} as const;
 
 // ============================================================================
 // Queue Configuration

--- a/tests/unit/modules/book-figure-detect.test.ts
+++ b/tests/unit/modules/book-figure-detect.test.ts
@@ -1,0 +1,316 @@
+/**
+ * book-figure-detect (CP505 [CV-NOTE-WIRE]) — Haiku-powered figure target detection.
+ * OpenRouter Haiku is MOCKED (no live LLM — LLM-API ban).
+ * Locks:
+ *   - Cap enforcement: detectFigureTargets never returns more than 8 targets
+ *   - Atom grounding: tsSec MUST be an atom ts for (videoId, section)
+ *   - Empty book (no atoms): returns [] without calling LLM
+ *   - LLM / parse failure → [] (never throws)
+ */
+
+const mockGenerate = jest.fn();
+jest.mock('@/modules/llm/openrouter', () => ({
+  OpenRouterGenerationProvider: jest.fn().mockImplementation(() => ({ generate: mockGenerate })),
+}));
+jest.mock('@/config/index', () => ({
+  config: { paths: { logs: '/tmp' }, app: { isTest: true } },
+}));
+
+import {
+  detectFigureTargets,
+  parseFigureDetectResponse,
+  buildFigureDetectPrompt,
+} from '../../../src/modules/mandala-book/book-figure-detect';
+import type { BookJson } from '../../../src/modules/mandala-book/book-schema';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const VID_A = 'dQw4w9WgXcQ';
+const VID_B = 'aBcDeFgHiJk';
+
+const ATOMS_A = [
+  { vid: VID_A, ts: 10, text: 'Gradient descent minimizes the loss function L = sum(errors^2).' },
+  { vid: VID_A, ts: 45, text: 'Backpropagation applies the chain rule to compute ∂L/∂w.' },
+  { vid: VID_A, ts: 90, text: 'The softmax activation: σ(z)_i = e^(z_i) / sum(e^(z_j)).' },
+];
+
+/** Minimal valid BookJson with one chapter, one section, and ATOMS_A. */
+function makeBook(overrideAtoms?: typeof ATOMS_A): BookJson {
+  return {
+    schema_version: 2,
+    mandala_id: '00000000-0000-0000-0000-000000000001',
+    mandala_title: 'Deep Learning Fundamentals',
+    generated_at: '2026-01-01T00:00:00.000Z',
+    source_videos: 1,
+    source_atoms: (overrideAtoms ?? ATOMS_A).length,
+    chapters: [
+      {
+        ch: 0,
+        title: 'Optimization Methods',
+        intro: 'Introduction to gradient-based optimization.',
+        sections: [
+          {
+            title: 'Gradient Descent',
+            narrative: 'Gradient descent iteratively updates weights to minimize the loss.',
+            atoms: overrideAtoms ?? ATOMS_A,
+            qa: [],
+            provenance: null,
+            verification: null,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/** Book with 2 chapters × 2 sections, each with 5 atoms from different videos. */
+function makeLargeBook(): BookJson {
+  const chapters = [0, 1].map((ci) => ({
+    ch: ci,
+    title: `Chapter ${ci}`,
+    intro: 'Chapter intro.',
+    sections: [0, 1].map((si) => ({
+      title: `Section ${ci}.${si}`,
+      narrative: 'Dense technical content.',
+      atoms: [0, 1, 2, 3, 4].map((ai) => ({
+        vid: `vid_${ci}_${si}`,
+        ts: ai * 10,
+        text: `Atom ${ai} technical text.`,
+      })),
+      qa: [] as [],
+      provenance: null as null,
+      verification: null as null,
+    })),
+  }));
+  return {
+    schema_version: 2,
+    mandala_id: '00000000-0000-0000-0000-000000000002',
+    mandala_title: 'AI Systems',
+    generated_at: '2026-01-01T00:00:00.000Z',
+    source_videos: 4,
+    source_atoms: 20,
+    chapters,
+  };
+}
+
+/** Empty book with no sections. */
+const EMPTY_BOOK: BookJson = {
+  schema_version: 2,
+  mandala_id: '00000000-0000-0000-0000-000000000003',
+  mandala_title: 'Empty',
+  generated_at: '2026-01-01T00:00:00.000Z',
+  source_videos: 0,
+  source_atoms: 0,
+  chapters: [],
+};
+
+beforeEach(() => mockGenerate.mockReset());
+
+// ---------------------------------------------------------------------------
+// detectFigureTargets — high-level orchestrator (mocked LLM)
+// ---------------------------------------------------------------------------
+
+describe('detectFigureTargets', () => {
+  it('returns valid grounded targets on well-formed LLM response', async () => {
+    const response = JSON.stringify([
+      { chapterIdx: 0, sectionIdx: 0, videoId: VID_A, tsSec: 90, reason: 'Softmax equation.' },
+    ]);
+    mockGenerate.mockResolvedValueOnce(response);
+
+    const targets = await detectFigureTargets(makeBook(), { centerGoal: 'Deep Learning' });
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({ videoId: VID_A, tsSec: 90, chapterIdx: 0, sectionIdx: 0 });
+  });
+
+  it('returns [] without calling LLM when book has no atoms', async () => {
+    const targets = await detectFigureTargets(EMPTY_BOOK, { centerGoal: 'Empty' });
+    expect(targets).toHaveLength(0);
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('returns [] and does not throw when LLM throws', async () => {
+    mockGenerate.mockRejectedValueOnce(new Error('provider failure'));
+    const targets = await detectFigureTargets(makeBook(), { centerGoal: 'Deep Learning' });
+    expect(targets).toHaveLength(0);
+  });
+
+  it('returns [] when LLM returns non-JSON', async () => {
+    mockGenerate.mockResolvedValueOnce('not json at all');
+    const targets = await detectFigureTargets(makeBook(), { centerGoal: 'Deep Learning' });
+    expect(targets).toHaveLength(0);
+  });
+
+  it('drops targets whose tsSec is not in section atoms', async () => {
+    const response = JSON.stringify([
+      { chapterIdx: 0, sectionIdx: 0, videoId: VID_A, tsSec: 999, reason: 'Invented timestamp.' },
+      { chapterIdx: 0, sectionIdx: 0, videoId: VID_A, tsSec: 45, reason: 'Real timestamp.' },
+    ]);
+    mockGenerate.mockResolvedValueOnce(response);
+
+    const targets = await detectFigureTargets(makeBook(), { centerGoal: 'Deep Learning' });
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.tsSec).toBe(45);
+  });
+
+  it('enforces hard cap of 8 regardless of LLM output length', async () => {
+    const largeBook = makeLargeBook();
+    // Build 10 valid items (all grounded in the large book's atoms).
+    const items = [0, 1].flatMap((ci) =>
+      [0, 1].flatMap((si) =>
+        [0, 1, 2].map((ai) => ({
+          chapterIdx: ci,
+          sectionIdx: si,
+          videoId: `vid_${ci}_${si}`,
+          tsSec: ai * 10,
+          reason: `Reason ${ci}.${si}.${ai}`,
+        }))
+      )
+    );
+    expect(items.length).toBeGreaterThan(8);
+    mockGenerate.mockResolvedValueOnce(JSON.stringify(items));
+
+    const targets = await detectFigureTargets(largeBook, { centerGoal: 'AI Systems' });
+    expect(targets.length).toBeLessThanOrEqual(8);
+  });
+
+  it('uses the Haiku model (P-MODEL: contains "haiku")', async () => {
+    mockGenerate.mockResolvedValueOnce(JSON.stringify([]));
+    const { OpenRouterGenerationProvider } = jest.requireMock('@/modules/llm/openrouter') as {
+      OpenRouterGenerationProvider: jest.Mock;
+    };
+    OpenRouterGenerationProvider.mockClear();
+
+    await detectFigureTargets(makeBook(), { centerGoal: 'Deep Learning' });
+    expect(OpenRouterGenerationProvider).toHaveBeenCalledWith(expect.stringMatching(/haiku/i));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFigureDetectResponse — pure parser (no mocks needed)
+// ---------------------------------------------------------------------------
+
+describe('parseFigureDetectResponse', () => {
+  const book = makeBook();
+
+  it('returns valid targets for a well-formed JSON array', () => {
+    const raw = JSON.stringify([
+      { chapterIdx: 0, sectionIdx: 0, videoId: VID_A, tsSec: 10, reason: 'Gradient descent.' },
+    ]);
+    const result = parseFigureDetectResponse(raw, book, 8);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.tsSec).toBe(10);
+  });
+
+  it('strips code fences before parsing', () => {
+    const inner = JSON.stringify([
+      { chapterIdx: 0, sectionIdx: 0, videoId: VID_A, tsSec: 45, reason: 'Backprop.' },
+    ]);
+    const result = parseFigureDetectResponse(`\`\`\`json\n${inner}\n\`\`\``, book, 8);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns [] on non-JSON input', () => {
+    expect(parseFigureDetectResponse('not json', book, 8)).toHaveLength(0);
+  });
+
+  it('returns [] when JSON is an object (not array)', () => {
+    expect(
+      parseFigureDetectResponse('{"chapterIdx":0,"sectionIdx":0}', book, 8)
+    ).toHaveLength(0);
+  });
+
+  it('drops items with tsSec not in section atoms (invented timestamp)', () => {
+    const raw = JSON.stringify([
+      { chapterIdx: 0, sectionIdx: 0, videoId: VID_A, tsSec: 999, reason: 'Fake.' },
+    ]);
+    expect(parseFigureDetectResponse(raw, book, 8)).toHaveLength(0);
+  });
+
+  it('drops items with videoId not matching any atom in that section', () => {
+    const raw = JSON.stringify([
+      { chapterIdx: 0, sectionIdx: 0, videoId: VID_B, tsSec: 10, reason: 'Wrong video.' },
+    ]);
+    expect(parseFigureDetectResponse(raw, book, 8)).toHaveLength(0);
+  });
+
+  it('drops items with out-of-bounds chapter index', () => {
+    const raw = JSON.stringify([
+      { chapterIdx: 99, sectionIdx: 0, videoId: VID_A, tsSec: 10, reason: 'Bad chapter.' },
+    ]);
+    expect(parseFigureDetectResponse(raw, book, 8)).toHaveLength(0);
+  });
+
+  it('drops items with out-of-bounds section index', () => {
+    const raw = JSON.stringify([
+      { chapterIdx: 0, sectionIdx: 99, videoId: VID_A, tsSec: 10, reason: 'Bad section.' },
+    ]);
+    expect(parseFigureDetectResponse(raw, book, 8)).toHaveLength(0);
+  });
+
+  it('enforces maxTargets cap — excess items are dropped', () => {
+    const items = ATOMS_A.map((a) => ({
+      chapterIdx: 0,
+      sectionIdx: 0,
+      videoId: a.vid,
+      tsSec: a.ts,
+      reason: 'Test.',
+    }));
+    // 3 valid items, cap at 2.
+    const result = parseFigureDetectResponse(JSON.stringify(items), book, 2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns [] for empty JSON array', () => {
+    expect(parseFigureDetectResponse('[]', book, 8)).toHaveLength(0);
+  });
+
+  it('drops items with negative or missing tsSec', () => {
+    const raw = JSON.stringify([
+      { chapterIdx: 0, sectionIdx: 0, videoId: VID_A, tsSec: -1, reason: 'Negative ts.' },
+      { chapterIdx: 0, sectionIdx: 0, videoId: VID_A, reason: 'No tsSec.' },
+    ]);
+    expect(parseFigureDetectResponse(raw, book, 8)).toHaveLength(0);
+  });
+
+  it('drops items with empty reason string', () => {
+    const raw = JSON.stringify([
+      { chapterIdx: 0, sectionIdx: 0, videoId: VID_A, tsSec: 10, reason: '' },
+    ]);
+    expect(parseFigureDetectResponse(raw, book, 8)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFigureDetectPrompt — pure builder (structural smoke test)
+// ---------------------------------------------------------------------------
+
+describe('buildFigureDetectPrompt', () => {
+  it('includes the centerGoal in the prompt', () => {
+    const prompt = buildFigureDetectPrompt(makeBook(), 'Neural Architecture Search', 8);
+    expect(prompt).toContain('Neural Architecture Search');
+  });
+
+  it('includes section title and atom timestamps', () => {
+    const prompt = buildFigureDetectPrompt(makeBook(), 'Deep Learning', 8);
+    expect(prompt).toContain('Gradient Descent');
+    expect(prompt).toContain('ts:10');
+    expect(prompt).toContain('ts:90');
+  });
+
+  it('includes STEM-specific instructions (equations prioritized)', () => {
+    const prompt = buildFigureDetectPrompt(makeBook(), 'Deep Learning', 8);
+    expect(prompt).toMatch(/equation/i);
+    expect(prompt).toMatch(/STEM/i);
+  });
+
+  it('includes the maxTargets value in the prompt', () => {
+    const prompt = buildFigureDetectPrompt(makeBook(), 'Deep Learning', 5);
+    expect(prompt).toContain('5');
+  });
+
+  it('handles empty chapters gracefully (no crash)', () => {
+    expect(() => buildFigureDetectPrompt(EMPTY_BOOK, 'Empty', 8)).not.toThrow();
+  });
+});


### PR DESCRIPTION
Wires slidegen figure extraction into the note. **slidegen repo UNTOUCHED. INERT until `VISUAL_CV_ENABLED=true`.**

**Flow (insighta-only):** 2-pass — `book-figure-detect.ts` (Haiku, ≤8 pinpoint targets grounded in real atom ts, STEM→equation priority) → async **`NOTE_CV_ENRICH`** queue job (detect → `getOrExtractSnapshots` → filter → write `section.figures` → save), fire-and-forget post-fill trigger. **Render:** `section.figures` → `FigureBlock` node (equation→KaTeX, chart/table/diagram→img; keyframe + unverified dropped).

**Schema** `section.figures` additive (no DDL). **Async only** (~148s/ts). **Graceful:** SNAPSHOT token unset → `[]` → no-op.

**★ Filter note (review):** slidegen emits `verification_status = pending|unverified` (no `'verified'`) → used `!== 'unverified'` (drops low-conf garbage) so figures actually render. Confirm this is the intended gate.

Verify: BE tsc 0 / FE tsc 0 / FE vitest 13 / FE build 0. **BE jest → CI** (local jest env-broken: node_modules symlink loop — not claiming a local BE-test pass; CI Test-Backend is the gate). DDL none, flag default-off → safe to merge inert; you flip `VISUAL_CV_ENABLED` on 1 mandala to judge rendered figures.