### PR TITLE
fix(note-cv): enqueue NOTE_CV_ENRICH after book upsert (design align — completed note → detect) (CP505)

### DIFF
--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -496,15 +496,6 @@ export async function fillMandalaBook(params: {
   // woven prose is NOT rewritten, A1). Best-effort; failures leave book unchanged.
   if (skeleton && isBookEnrichEnabled()) {
     await enrichBookLoop2(book, mandala.title ?? '', mandalaId);
-    // [CV-NOTE-WIRE] CP505 — fire-and-forget visual CV figure enrich (default inert)
-    if (isVisualCvEnabled()) {
-      enqueueNoteCvEnrich(mandalaId, userId).catch((err) => {
-        log.warn('note-cv-enrich enqueue failed (non-fatal)', {
-          mandalaId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
-    }
   }
 
   let validated;
@@ -545,6 +536,20 @@ export async function fillMandalaBook(params: {
   );
 
   const version = rows[0]?.version ?? 1;
+
+  // [CV-NOTE-WIRE] CP505 — visual CV figure enrich, enqueued AFTER the book is
+  // committed (above). The handler reads the SAVED book_json; enqueuing pre-save
+  // raced → detect read a stale/absent note (fresh mandala → "book_json 없음" → 0
+  // figures). Now it always sees the completed note. Fire-and-forget; default inert.
+  if (skeleton && isVisualCvEnabled()) {
+    enqueueNoteCvEnrich(mandalaId, userId).catch((err) => {
+      log.warn('note-cv-enrich enqueue failed (non-fatal)', {
+        mandalaId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
+
   log.info('mandala book filled', {
     mandalaId,
     sourceVideos,


### PR DESCRIPTION
**Design check (code-verified):** [VISUAL-TARGETED-CV] = completed note → Haiku detect → targeted CV. The handler IS structurally correct — a separate async job that loads the **saved** `book_json` and runs detect on completed sections (title+narrative+atoms), not parallel to generation.

**Bug:** the enqueue fired in the enrich block (`fill-book` ~:500) **before** the `book_json` upsert (~:523). The async handler loads `book_json` from DB → raced the save → fresh mandala = `book_json 없음` → **0 figures**; re-fill = stale prior version. (Combined with the pod being down → numerize `[]`, this explained the empty figures.)

**Fix:** move the fire-and-forget enqueue to **after the committed upsert** (gate `skeleton && isVisualCvEnabled()`) → detect always reads the just-saved completed note. Flag-gated, inert default (no behavior change when off). BE-only → CI is the verify gate (local backend toolchain broken this session).