### PR TITLE
fix(note-cv): window-match figure↔target/cache ts — was exact-ts → 0 figures (CP505)

### DIFF
--- a/src/modules/queue/handlers/note-cv-enrich.ts
+++ b/src/modules/queue/handlers/note-cv-enrich.ts
@@ -25,6 +25,11 @@ const NOTE_CV_ENRICH_CONCURRENCY = 2;
 // Renderable kinds the renderer supports; keyframe is binary-only (deferred).
 const RENDERABLE_KINDS = new Set<string>(['chart', 'table', 'diagram', 'equation']);
 
+// numerize returns a figure within ±NUMERIZE_WINDOW_SEC (slidegen=10s) of a requested
+// ts, so the figure's ACTUAL ts (slide-display time) rarely equals the target ts
+// (subtitle/atom time). Match within this window, not exact ts. = slidegen NUMERIZE_WINDOW_SEC.
+const FIGURE_TS_WINDOW_SEC = 10;
+
 export async function registerNoteCvEnrichWorker(): Promise<void> {
   const boss = getJobQueue().getInstance();
   await boss.work<NoteCvEnrichPayload>(
@@ -123,7 +128,19 @@ export async function handleNoteCvEnrich(job: PgBoss.Job<NoteCvEnrichPayload>): 
       };
 
       // e. Attach to section.figures — additive, dedup by (video_id, ts_sec).
-      const matching = videoTargets.filter((t) => t.tsSec === fig.tsSec);
+      // Figure ts (actual slide location) ≠ target ts (subtitle time) but is within
+      // numerize's ±window → match the NEAREST target in that window. Exact-ts match
+      // dropped every figure (e.g. figure@184 vs target 150/190 → 0 attached → book 0).
+      const inWindow = videoTargets.filter(
+        (t) => Math.abs(t.tsSec - fig.tsSec) <= FIGURE_TS_WINDOW_SEC
+      );
+      const matching = inWindow.length
+        ? [
+            inWindow.reduce((a, b) =>
+              Math.abs(a.tsSec - fig.tsSec) <= Math.abs(b.tsSec - fig.tsSec) ? a : b
+            ),
+          ]
+        : [];
       for (const target of matching) {
         const ch = book.chapters[target.chapterIdx];
         if (!ch) continue;

--- a/src/modules/snapshot/get-or-extract.ts
+++ b/src/modules/snapshot/get-or-extract.ts
@@ -21,6 +21,12 @@ import type { FigureKind, FigureRef } from './types';
 
 const log = logger.child({ module: 'snapshot/get-or-extract' });
 
+// A figure's stored ts (actual slide/figure location) rarely equals the requested
+// ts (subtitle/atom time); numerize returns it within ±NUMERIZE_WINDOW_SEC (slidegen
+// =10s). Cache lookup must match by window, not exact ts — exact match never hit a
+// real figure (figure@184 vs request 150/190 → perpetual re-extract + 148s timeouts).
+const FIGURE_TS_WINDOW_SEC = 10;
+
 interface CacheRow {
   video_id: string;
   ts_sec: number;
@@ -85,19 +91,24 @@ export async function getOrExtractSnapshots(
   const uniqueTs = Array.from(new Set(tsList.filter((t) => Number.isFinite(t))));
   if (uniqueTs.length === 0) return [];
 
-  // GET — serve from cache (non-expired). Independent of the extractor.
+  // GET — serve cached figures within ±FIGURE_TS_WINDOW_SEC of any requested ts
+  // (not exact ts — see const note). Non-expired only. Independent of the extractor.
   const cached = await prisma.$queryRawUnsafe<CacheRow[]>(
     `SELECT video_id, ts_sec, kind, struct, latex, asset_path, verification_status, source
      FROM video_figure_snapshots
-     WHERE video_id = $1 AND ts_sec = ANY($2::int[]) AND expires_at > NOW()`,
+     WHERE video_id = $1 AND expires_at > NOW()
+       AND EXISTS (SELECT 1 FROM unnest($2::int[]) t WHERE ts_sec BETWEEN t - $3 AND t + $3)`,
     videoId,
-    uniqueTs
+    uniqueTs,
+    FIGURE_TS_WINDOW_SEC
   );
-  const cachedTs = new Set(cached.map((r) => r.ts_sec));
   const result: FigureRef[] = cached.map(rowToFigure);
 
-  // EXTRACT — only the missing timestamps. Empty result ⇒ those ts stay absent.
-  const missingTs = uniqueTs.filter((t) => !cachedTs.has(t));
+  // EXTRACT — only requested ts with NO cached figure within the window. A covered ts
+  // (figure already within ±window) is NOT re-extracted (was: exact-ts miss → re-extract).
+  const missingTs = uniqueTs.filter(
+    (t) => !cached.some((r) => Math.abs(r.ts_sec - t) <= FIGURE_TS_WINDOW_SEC)
+  );
   if (missingTs.length > 0) {
     const extracted = await extractFigures(videoId, missingTs);
     for (const fig of extracted) {
@@ -107,7 +118,7 @@ export async function getOrExtractSnapshots(
     log.info('get-or-extract', {
       videoId,
       requested: uniqueTs.length,
-      cacheHit: cachedTs.size,
+      cacheHit: cached.length,
       extracted: extracted.length,
     });
   }


### PR DESCRIPTION
**Bug (prod mandala f1550dfa):** detect returned 8 good targets ✓, numerize cached 25 figures ✓, but the book had **0 section.figures**. Root: numerize returns a figure at its ACTUAL slide ts (e.g. 184) — within numerize's ±10s window of a requested subtitle ts (150/190), but NOT equal. Two spots matched **exact ts** and dropped every figure:
1. `get-or-extract.ts:92` cache lookup `ts_sec = ANY(requested)` → 184≠150/190 → perpetual cache miss → re-extract (148s) every call → handler timed out → `[]`.
2. `note-cv-enrich.ts:126` attach `t.tsSec === fig.tsSec` → 184≠150/190 → `matching=[]` → figure `kept++` but never attached → 0 written.

**Fix:** both match within `FIGURE_TS_WINDOW_SEC=10` (= slidegen `NUMERIZE_WINDOW_SEC`): cache serves figures within ±window; handler attaches each figure to the NEAREST target in the window. BE-only, flag-gated path; CI gate (local backend toolchain broken). After deploy → re-trigger NOTE_CV_ENRICH (cache warm → windowed hit → figures attach).