### PR TITLE
feat(note): polish CV figure presentation (size/bg/font/caption+source)

### DIFF
--- a/frontend/src/__tests__/note-document-generator-narrative.test.ts
+++ b/frontend/src/__tests__/note-document-generator-narrative.test.ts
@@ -97,14 +97,16 @@ describe('note-document-generator — loop-2 references render (P-REF-RENDER)', 
   });
 });
 
-// [CV-NOTE-WIRE] — CV figures attached to a section render as figureBlock nodes.
-// New base: chart/diagram → inline svg, table → struct, equation → latex.
-// The broken pod-local asset_path <img> path was removed.
+// [CV-NOTE-WIRE] / [CV-FIGURE-PRESENTATION] — CV figures render as figureBlock nodes.
 type FigAttrs = {
   kind?: string;
   latex?: string;
-  svg?: string;
-  struct?: { headers?: string[]; rows?: string[][] };
+  svg?: string | null;
+  assetPath?: string | null;
+  tableJson?: string | null;
+  caption?: string | null;
+  videoId?: string | null;
+  tsSec?: number | null;
 };
 const figureBlocks = (ns: N[]) =>
   ns.filter((n) => n.type === 'figureBlock').map((n) => (n.attrs ?? {}) as FigAttrs);
@@ -114,31 +116,76 @@ describe('note-document-generator — CV figures render ([CV-NOTE-WIRE])', () =>
     const b = book('이 장은 기초 회화를 다룬다');
     b.chapters[0]!.sections[0]!.figures = [
       { video_id: 'vidA', ts_sec: 10, kind: 'equation', latex: 'E=mc^2', verification_status: 'verified' },
-      { video_id: 'vidA', ts_sec: 12, kind: 'diagram', svg: '<svg><g/></svg>', verification_status: 'verified' },
-      { video_id: 'vidA', ts_sec: 14, kind: 'table', struct: { headers: ['A', 'B'], rows: [['1', '2']] }, verification_status: 'verified' },
-      { video_id: 'vidA', ts_sec: 15, kind: 'chart', svg: '', verification_status: 'verified' }, // DROP empty svg
-      { video_id: 'vidA', ts_sec: 16, kind: 'diagram', svg: '<svg/>', verification_status: 'unverified' }, // DROP unverified
-      { video_id: 'vidA', ts_sec: 18, kind: 'keyframe', asset_path: 'https://cdn.ex.com/kf.png', verification_status: 'verified' }, // DROP keyframe
+      { video_id: 'vidA', ts_sec: 12, kind: 'chart', asset_path: 'https://cdn.ex.com/chart.png', verification_status: 'verified' },
+      { video_id: 'vidA', ts_sec: 14, kind: 'diagram', asset_path: 'https://cdn.ex.com/diag.png', verification_status: 'unverified' }, // DROP unverified
+      { video_id: 'vidA', ts_sec: 16, kind: 'keyframe', asset_path: 'https://cdn.ex.com/kf.png', verification_status: 'verified' }, // DROP keyframe
     ];
     return b;
   };
 
-  it('renders diagram(svg) + table(struct) + equation(latex); drops unverified/keyframe/empty', () => {
+  it('renders equation + chart figureBlock nodes; drops unverified + keyframe', () => {
     const figs = figureBlocks(nodes(buildInitialNoteDoc(withFigures())));
     expect(figs.some((f) => f.kind === 'equation' && f.latex === 'E=mc^2')).toBe(true); // equation kept
-    expect(figs.some((f) => f.kind === 'diagram' && f.svg === '<svg><g/></svg>')).toBe(true); // diagram svg kept
-    expect(
-      figs.some(
-        (f) => f.kind === 'table' && f.struct?.headers?.[0] === 'A' && f.struct?.rows?.[0]?.[1] === '2'
-      )
-    ).toBe(true); // table struct kept
-    expect(figs.some((f) => f.kind === 'chart')).toBe(false); // empty svg dropped
+    expect(figs.some((f) => f.kind === 'chart' && f.assetPath === 'https://cdn.ex.com/chart.png')).toBe(true); // chart kept (legacy image)
+    expect(figs.some((f) => f.assetPath === 'https://cdn.ex.com/diag.png')).toBe(false); // unverified dropped
     expect(figs.some((f) => f.kind === 'keyframe')).toBe(false); // keyframe dropped
-    expect(figs).toHaveLength(3);
+    expect(figs).toHaveLength(2);
   });
 
   it('no figures → no figureBlock nodes (existing books byte-unchanged)', () => {
     const figs = figureBlocks(nodes(buildInitialNoteDoc(book('이 장은 기초 회화를 다룬다'))));
     expect(figs).toHaveLength(0);
+  });
+
+  it('threads server SVG + source (video_id/ts_sec) + struct.insight caption (CV-FIGURE-PRESENTATION)', () => {
+    const b = book('이 장은 기초 회화를 다룬다');
+    b.chapters[0]!.sections[0]!.figures = [
+      {
+        video_id: 'vidA',
+        ts_sec: 565,
+        kind: 'diagram',
+        svg: '<svg viewBox="0 0 10 10"><text>노드</text></svg>',
+        struct: { insight: '핵심 흐름을 보여준다' },
+        verification_status: 'verified',
+      },
+    ];
+    const figs = figureBlocks(nodes(buildInitialNoteDoc(b)));
+    expect(figs).toHaveLength(1);
+    const f = figs[0]!;
+    expect(f.kind).toBe('diagram');
+    expect(f.svg).toContain('<svg');
+    expect(f.assetPath).toBeNull();
+    expect(f.caption).toBe('핵심 흐름을 보여준다'); // struct.insight → caption
+    expect(f.videoId).toBe('vidA'); // source provenance
+    expect(f.tsSec).toBe(565); // mm:ss formatting (→ 9:25) happens in the NodeView
+  });
+
+  it('chart without insight → Korean kind-label caption (not the raw english word)', () => {
+    const b = book('이 장은 기초 회화를 다룬다');
+    b.chapters[0]!.sections[0]!.figures = [
+      { video_id: 'vidA', ts_sec: 30, kind: 'chart', svg: '<svg viewBox="0 0 4 4"></svg>', verification_status: 'verified' },
+    ];
+    const f = figureBlocks(nodes(buildInitialNoteDoc(b)))[0]!;
+    expect(f.caption).toBe('차트');
+  });
+
+  it('table → struct headers/rows serialized to tableJson; equation gets no caption', () => {
+    const b = book('이 장은 기초 회화를 다룬다');
+    b.chapters[0]!.sections[0]!.figures = [
+      {
+        video_id: 'vidA',
+        ts_sec: 40,
+        kind: 'table',
+        struct: { headers: ['A', 'B'], rows: [['1', '2'], ['3', '4']] },
+        verification_status: 'verified',
+      },
+      { video_id: 'vidA', ts_sec: 50, kind: 'equation', latex: 'x^2', verification_status: 'verified' },
+    ];
+    const figs = figureBlocks(nodes(buildInitialNoteDoc(b)));
+    const tableFig = figs.find((f) => f.kind === 'table')!;
+    expect(JSON.parse(tableFig.tableJson!)).toEqual({ headers: ['A', 'B'], rows: [['1', '2'], ['3', '4']] });
+    expect(tableFig.caption).toBe('표');
+    const eqFig = figs.find((f) => f.kind === 'equation')!;
+    expect(eqFig.caption).toBeNull(); // equation → neutral, no label
   });
 });

--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1254,6 +1254,13 @@ html.dark .lemonsqueezy-loader {
   --nm-sans: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --nm-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 
+  /* [CV-FIGURE-PRESENTATION] — CV figure plate. graphviz/matplotlib render dark
+     ink, so figures sit on a light "paper" plate to stay legible on the dark note. */
+  --nm-figure-bg: #faf9f6;          /* warm near-white plate */
+  --nm-figure-border: rgba(0,0,0,0.10);
+  --nm-figure-ink: #1a1a1a;         /* default dark ink (KaTeX/table/currentColor SVG) */
+  --nm-figure-th-bg: rgba(0,0,0,0.045);
+
   background: #0e0f10;
 }
 

--- a/frontend/src/pages/learning/lib/figure-block.tsx
+++ b/frontend/src/pages/learning/lib/figure-block.tsx
@@ -8,15 +8,23 @@
  *
  *  - kind='equation' → lazy-loads KaTeX (dynamic import; only when an equation
  *    figure mounts) and renders displayMode HTML.
- *  - kind∈{chart,diagram} → renders the server-generated inline SVG (sanitized).
- *  - kind='table' → renders an HTML <table> from struct.headers/rows.
- *  The broken pod-local asset_path <img> path was removed.
+ *  - kind∈{chart,diagram} → renders the server SVG inline (sanitized), scaled to
+ *    the body width; falls back to a legacy <img> asset when no svg.
+ *  - kind='table' → renders struct headers/rows as an HTML table.
+ *
+ * [CV-FIGURE-PRESENTATION] — each figure is framed on a light "paper" plate
+ * (graphviz/matplotlib render dark ink → a light plate keeps them legible on the
+ * dark note) with a muted caption + a dimmer "video title · mm:ss" source line.
+ * Video title is resolved at render from useMandalaCards (the book has no title
+ * map); it falls back to "영상 · mm:ss" when the card isn't found.
  *
  * Inert until the backend populates section.figures (flag-gated server-side).
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { Node, mergeAttributes } from '@tiptap/core';
 import { ReactNodeViewRenderer, NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
+import { useMandalaCards } from '@/pages/learning/model/useMandalaCards';
 
 export interface FigureBlockOptions {
   HTMLAttributes: Record<string, unknown>;
@@ -24,30 +32,92 @@ export interface FigureBlockOptions {
 
 export type FigureKind = 'chart' | 'diagram' | 'table' | 'equation';
 
-export interface FigureStruct {
-  headers?: string[];
-  rows?: string[][];
-}
-
 export interface FigureBlockAttrs {
   kind: FigureKind;
   latex: string | null;
   svg: string | null;
-  struct: FigureStruct | null;
+  assetPath: string | null;
+  tableJson: string | null;
   caption: string | null;
+  videoId: string | null;
+  tsSec: number | null;
 }
 
-// Minimal SVG sanitizer (no DOMPurify dep). Server SVG is graphviz/matplotlib
-// output, but we still strip the XSS surface before dangerouslySetInnerHTML:
-// <script>, on* event handlers, <foreignObject>, external <image> refs and
-// javascript: URLs.
-function sanitizeSvg(svg: string): string {
-  return svg
-    .replace(/<script[\s\S]*?<\/script>/gi, '')
-    .replace(/<foreignObject[\s\S]*?<\/foreignObject>/gi, '')
-    .replace(/<image\b[\s\S]*?>/gi, '')
-    .replace(/\son[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '')
-    .replace(/(href|xlink:href)\s*=\s*("javascript:[^"]*"|'javascript:[^']*'|javascript:[^\s>]+)/gi, '');
+const YT_URL_RE = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\s]+)/;
+
+function formatTs(sec: number): string {
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+/**
+ * Resolve a YouTube video_id → its card title (the book carries no title map;
+ * useMandalaCards is the same source VideoStrip uses). null when unavailable.
+ */
+function useVideoTitle(videoId: string | null): string | null {
+  const { mandalaId } = useParams<{ mandalaId?: string }>();
+  const { cards } = useMandalaCards(mandalaId ?? '');
+  return useMemo(() => {
+    if (!videoId) return null;
+    for (const c of cards) {
+      const m = c.videoUrl.match(YT_URL_RE);
+      if (m?.[1] === videoId) return c.title?.trim() || null;
+    }
+    return null;
+  }, [cards, videoId]);
+}
+
+/**
+ * Sanitize a server-rendered SVG before inlining it. Drops <script>, event
+ * handlers (on*) and javascript: hrefs; strips the root width/height so CSS
+ * scales the figure by its viewBox (fix #1). Returns '' on parse failure.
+ */
+function sanitizeSvg(raw: string): string {
+  if (typeof window === 'undefined' || !window.DOMParser) return '';
+  let doc: Document;
+  try {
+    doc = new window.DOMParser().parseFromString(raw, 'image/svg+xml');
+  } catch {
+    return '';
+  }
+  if (doc.querySelector('parsererror')) return '';
+  const svg = doc.querySelector('svg');
+  if (!svg) return '';
+  svg.querySelectorAll('script').forEach((el) => el.remove());
+  const scrub = (el: Element) => {
+    for (const attr of Array.from(el.attributes)) {
+      const name = attr.name.toLowerCase();
+      const val = attr.value.trim().toLowerCase();
+      if (name.startsWith('on')) el.removeAttribute(attr.name);
+      else if ((name === 'href' || name === 'xlink:href') && val.startsWith('javascript:'))
+        el.removeAttribute(attr.name);
+    }
+    Array.from(el.children).forEach(scrub);
+  };
+  scrub(svg);
+  // fix #1 — let CSS control size via viewBox (graphviz/matplotlib both emit one).
+  svg.removeAttribute('width');
+  svg.removeAttribute('height');
+  svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+  return svg.outerHTML;
+}
+
+interface ParsedTable {
+  headers: string[];
+  rows: string[][];
+}
+function parseTable(json: string | null): ParsedTable | null {
+  if (!json) return null;
+  try {
+    const parsed = JSON.parse(json) as ParsedTable;
+    const headers = Array.isArray(parsed.headers) ? parsed.headers : [];
+    const rows = Array.isArray(parsed.rows) ? parsed.rows : [];
+    if (headers.length === 0 && rows.length === 0) return null;
+    return { headers, rows };
+  } catch {
+    return null;
+  }
 }
 
 // Lazy KaTeX render — dynamic import keeps the heavy lib out of the main bundle.
@@ -80,60 +150,78 @@ function EquationView({ latex }: { latex: string }) {
   return <div className="note-figure-equation" dangerouslySetInnerHTML={{ __html: html }} />;
 }
 
-// Table figure → semantic HTML <table> from struct headers/rows.
-function TableView({ struct }: { struct: FigureStruct }) {
-  const headers = Array.isArray(struct.headers) ? struct.headers : [];
-  const rows = Array.isArray(struct.rows) ? struct.rows : [];
-  if (headers.length === 0 && rows.length === 0) return null;
+function FigureTable({ table }: { table: ParsedTable }) {
   return (
-    <figure className="note-figure-table">
-      <table>
-        {headers.length > 0 && (
-          <thead>
-            <tr>
-              {headers.map((h, i) => (
-                <th key={i}>{h}</th>
-              ))}
-            </tr>
-          </thead>
-        )}
-        <tbody>
-          {rows.map((row, ri) => (
-            <tr key={ri}>
-              {row.map((cell, ci) => (
-                <td key={ci}>{cell}</td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </figure>
+    <table className="note-figure-table">
+      {table.headers.length > 0 && (
+        <thead>
+          <tr>
+            {table.headers.map((h, i) => (
+              <th key={i}>{h}</th>
+            ))}
+          </tr>
+        </thead>
+      )}
+      <tbody>
+        {table.rows.map((row, ri) => (
+          <tr key={ri}>
+            {row.map((cell, ci) => (
+              <td key={ci}>{cell}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 
 function FigureBlockNodeView({ node }: NodeViewProps) {
   const attrs = node.attrs as unknown as FigureBlockAttrs;
+  const [imgBroken, setImgBroken] = useState(false);
 
-  let body: JSX.Element | null = null;
+  // fix #4 — source line "video title · mm:ss" (title from cards, ts always).
+  const title = useVideoTitle(attrs.videoId);
+  const ts = typeof attrs.tsSec === 'number' ? formatTs(attrs.tsSec) : null;
+  const sourceText = title ? (ts ? `${title} · ${ts}` : title) : ts ? `영상 · ${ts}` : null;
+
+  const cleanSvg = useMemo(() => (attrs.svg ? sanitizeSvg(attrs.svg) : ''), [attrs.svg]);
+  const table = useMemo(() => parseTable(attrs.tableJson), [attrs.tableJson]);
+
+  let body: React.ReactNode = null;
   if (attrs.kind === 'equation' && attrs.latex) {
     body = <EquationView latex={attrs.latex} />;
-  } else if (attrs.kind === 'table' && attrs.struct) {
-    body = <TableView struct={attrs.struct} />;
-  } else if ((attrs.kind === 'chart' || attrs.kind === 'diagram') && attrs.svg) {
-    // SVG is server-generated; sanitized above to close the XSS surface.
-    const html = sanitizeSvg(attrs.svg);
+  } else if (cleanSvg) {
+    // Server SVG is backend-rendered + sanitized above (script/handlers stripped).
+    body = <div className="note-figure-svg" dangerouslySetInnerHTML={{ __html: cleanSvg }} />;
+  } else if (table) {
+    body = <FigureTable table={table} />;
+  } else if (attrs.assetPath && !imgBroken) {
     body = (
-      <figure className="note-figure-image">
-        <div className="note-figure-svg" dangerouslySetInnerHTML={{ __html: html }} />
-        {attrs.caption && <figcaption>{attrs.caption}</figcaption>}
-      </figure>
+      <img
+        src={attrs.assetPath}
+        alt={attrs.caption ?? attrs.kind}
+        loading="lazy"
+        onError={() => setImgBroken(true)}
+      />
     );
   }
 
-  // Missing/empty payload → render nothing inside the wrapper (no broken img).
+  // Nothing renderable (broken legacy image / empty payload) → drop the block.
+  if (!body) {
+    return <NodeViewWrapper className="note-figure-block hidden" data-kind={attrs.kind} />;
+  }
+
   return (
     <NodeViewWrapper className="note-figure-block" data-kind={attrs.kind}>
-      {body}
+      <figure className="note-figure" data-figkind={attrs.kind}>
+        <div className="note-figure-canvas">{body}</div>
+        {(attrs.caption || sourceText) && (
+          <figcaption className="note-figure-meta">
+            {attrs.caption && <div className="note-figure-caption">{attrs.caption}</div>}
+            {sourceText && <div className="note-figure-source">{sourceText}</div>}
+          </figcaption>
+        )}
+      </figure>
     </NodeViewWrapper>
   );
 }
@@ -167,25 +255,37 @@ export const FigureBlock = Node.create<FigureBlockOptions>({
         parseHTML: (el) => el.getAttribute('data-svg'),
         renderHTML: (attrs) => (attrs['svg'] ? { 'data-svg': String(attrs['svg']) } : {}),
       },
-      struct: {
+      assetPath: {
         default: null,
-        parseHTML: (el) => {
-          const raw = el.getAttribute('data-struct');
-          if (!raw) return null;
-          try {
-            return JSON.parse(raw);
-          } catch {
-            return null;
-          }
-        },
+        parseHTML: (el) => el.getAttribute('data-asset-path'),
         renderHTML: (attrs) =>
-          attrs['struct'] ? { 'data-struct': JSON.stringify(attrs['struct']) } : {},
+          attrs['assetPath'] ? { 'data-asset-path': String(attrs['assetPath']) } : {},
+      },
+      tableJson: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-table'),
+        renderHTML: (attrs) => (attrs['tableJson'] ? { 'data-table': String(attrs['tableJson']) } : {}),
       },
       caption: {
         default: null,
         parseHTML: (el) => el.getAttribute('data-caption'),
         renderHTML: (attrs) =>
           attrs['caption'] ? { 'data-caption': String(attrs['caption']) } : {},
+      },
+      videoId: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-video-id'),
+        renderHTML: (attrs) =>
+          attrs['videoId'] ? { 'data-video-id': String(attrs['videoId']) } : {},
+      },
+      tsSec: {
+        default: null,
+        parseHTML: (el) => {
+          const v = el.getAttribute('data-ts-sec');
+          return v == null ? null : Number(v);
+        },
+        renderHTML: (attrs) =>
+          attrs['tsSec'] != null ? { 'data-ts-sec': String(attrs['tsSec']) } : {},
       },
     };
   },

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -164,20 +164,49 @@ function groupAtomsByVid(
   }));
 }
 
-// [CV-NOTE-WIRE] — render targeted CV figures attached to a section as
-// `figureBlock` nodes (registered in useNoteDocument extensions). Base is the
-// DURABLE payload (svg for chart/diagram, struct for table, latex for equation);
-// the broken pod-local asset_path is dropped. Filters defensively: only
+// [CV-NOTE-WIRE] / [CV-FIGURE-PRESENTATION] — render targeted CV figures attached
+// to a section as `figureBlock` nodes (registered in useNoteDocument extensions).
+// Filters defensively (backend already filters to verified + renderable): only
 // chart/table/diagram/equation, drops unverified + keyframe + empty payloads.
+// CP505: chart/diagram carry a server-rendered `svg`; table carries struct
+// headers/rows; equation carries latex. asset_path kept as a legacy fallback.
 const FIGURE_KINDS = new Set(['chart', 'table', 'diagram', 'equation']);
-type FigureStruct = { headers?: string[]; rows?: string[][] };
-function figureBlockNode(attrs: {
+
+// Korean kind labels for the caption fallback (never the raw english word).
+const KIND_LABEL_KO: Record<string, string> = { chart: '차트', diagram: '도식', table: '표' };
+
+/** Caption = what the figure shows: struct.insight when present, else a kind
+ *  label. Equation gets no label (neutral). */
+function figureCaption(f: MandalaBookFigure): string | null {
+  const insight = typeof f.struct?.['insight'] === 'string' ? (f.struct['insight'] as string).trim() : '';
+  if (insight) return insight;
+  if (f.kind === 'equation') return null;
+  return KIND_LABEL_KO[f.kind] ?? null;
+}
+
+/** Table struct → compact {headers, rows} JSON string (rendered as an HTML
+ *  table in the NodeView). null when no tabular payload. */
+function serializeTable(struct: Record<string, unknown> | undefined): string | null {
+  if (!struct) return null;
+  const headers = Array.isArray(struct['headers']) ? (struct['headers'] as unknown[]).map(String) : [];
+  const rows = Array.isArray(struct['rows'])
+    ? (struct['rows'] as unknown[]).map((r) => (Array.isArray(r) ? r.map(String) : [String(r)]))
+    : [];
+  if (headers.length === 0 && rows.length === 0) return null;
+  return JSON.stringify({ headers, rows });
+}
+
+interface FigureNodeAttrs {
   kind: string;
   latex: string | null;
   svg: string | null;
-  struct: FigureStruct | null;
+  assetPath: string | null;
+  tableJson: string | null;
   caption: string | null;
-}): TiptapNode {
+  videoId: string | null;
+  tsSec: number | null;
+}
+function figureBlockNode(attrs: FigureNodeAttrs): TiptapNode {
   return { type: 'figureBlock', attrs };
 }
 function renderFigures(figures: MandalaBookFigure[] | undefined): TiptapNode[] {
@@ -185,31 +214,33 @@ function renderFigures(figures: MandalaBookFigure[] | undefined): TiptapNode[] {
   for (const f of figures ?? []) {
     if (!FIGURE_KINDS.has(f.kind)) continue; // drops keyframe
     if (f.verification_status === 'unverified') continue; // defensive
+    // Shared source/caption — drives the caption + "title · mm:ss" provenance line.
+    const base = {
+      caption: figureCaption(f),
+      videoId: f.video_id ?? null,
+      tsSec: typeof f.ts_sec === 'number' ? f.ts_sec : null,
+    };
     if (f.kind === 'equation') {
       const latex = (f.latex ?? '').trim();
       if (!latex) continue;
       out.push(
-        figureBlockNode({ kind: 'equation', latex, svg: null, struct: null, caption: null })
+        figureBlockNode({ kind: 'equation', latex, svg: null, assetPath: null, tableJson: null, ...base })
       );
     } else if (f.kind === 'table') {
-      const s = (f.struct ?? {}) as FigureStruct;
-      const headers = Array.isArray(s.headers) ? s.headers : [];
-      const rows = Array.isArray(s.rows) ? s.rows : [];
-      if (headers.length === 0 && rows.length === 0) continue;
+      const tableJson = serializeTable(f.struct);
+      const assetPath = (f.asset_path ?? '').trim() || null;
+      if (!tableJson && !assetPath) continue;
       out.push(
-        figureBlockNode({
-          kind: 'table',
-          latex: null,
-          svg: null,
-          struct: { headers, rows },
-          caption: null,
-        })
+        figureBlockNode({ kind: 'table', latex: null, svg: null, assetPath, tableJson, ...base })
       );
     } else {
-      // chart | diagram → server-rendered inline SVG (asset_path is dropped).
-      const svg = (f.svg ?? '').trim();
-      if (!svg) continue;
-      out.push(figureBlockNode({ kind: f.kind, latex: null, svg, struct: null, caption: f.kind }));
+      // chart | diagram → prefer inline SVG, fall back to a legacy image pointer.
+      const svg = (f.svg ?? '').trim() || null;
+      const assetPath = (f.asset_path ?? '').trim() || null;
+      if (!svg && !assetPath) continue;
+      out.push(
+        figureBlockNode({ kind: f.kind, latex: null, svg, assetPath, tableJson: null, ...base })
+      );
     }
   }
   return out;

--- a/frontend/src/pages/learning/lib/note-export.ts
+++ b/frontend/src/pages/learning/lib/note-export.ts
@@ -30,21 +30,6 @@
 import type { Editor } from '@tiptap/react';
 import type { TiptapDoc, TiptapNode } from '@/features/video-side-panel/lib/note-parser';
 
-// [CV-NOTE-WIRE] — table figure → GitHub-flavored markdown table from headers/rows.
-function renderMarkdownTable(struct: { headers?: string[]; rows?: string[][] }): string {
-  const headers = Array.isArray(struct.headers) ? struct.headers : [];
-  const rows = Array.isArray(struct.rows) ? struct.rows : [];
-  if (headers.length === 0 && rows.length === 0) return '';
-  const colCount = headers.length || rows[0]?.length || 0;
-  const head = headers.length ? headers : Array.from({ length: colCount }, () => '');
-  const headerLine = `| ${head.join(' | ')} |`;
-  const sepLine = `| ${head.map(() => '---').join(' | ')} |`;
-  const bodyLines = rows.map((r) => `| ${r.join(' | ')} |`).join('\n');
-  return bodyLines
-    ? `${headerLine}\n${sepLine}\n${bodyLines}\n\n`
-    : `${headerLine}\n${sepLine}\n\n`;
-}
-
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -132,21 +117,30 @@ function renderBlock(node: TiptapNode, depth: number): string {
       return `[${label}](${url})\n\n`;
     }
     case 'figureBlock': {
-      // [CV-NOTE-WIRE] — equation → $$..$$ ; table → markdown table ;
-      // chart/diagram → inline SVG (markdown allows raw HTML); empty → skip.
+      // [CV-NOTE-WIRE] / [CV-FIGURE-PRESENTATION] — equation → $$..$$ ;
+      // chart/diagram/table → caption + "title · mm:ss" source line (+ legacy image).
       const kind = (node.attrs?.['kind'] as string | undefined) ?? '';
+      const caption = (node.attrs?.['caption'] as string | null | undefined) ?? null;
+      const videoId = (node.attrs?.['videoId'] as string | null | undefined) ?? null;
+      const tsSecRaw = node.attrs?.['tsSec'];
+      const ts = typeof tsSecRaw === 'number' ? formatTs(tsSecRaw) : null;
+      // Source: keep ts (+ video link when known); title isn't in the doc attrs.
+      const source = videoId
+        ? `[영상 ${ts ?? ''}](https://www.youtube.com/watch?v=${videoId}${ts ? `&t=${Math.floor(Number(tsSecRaw))}s` : ''})`
+        : ts
+          ? `영상 · ${ts}`
+          : null;
       if (kind === 'equation') {
         const latex = (node.attrs?.['latex'] as string | undefined) ?? '';
-        return latex ? `$$\n${latex}\n$$\n\n` : '';
+        if (!latex) return '';
+        return `$$\n${latex}\n$$\n\n${source ? `_${source}_\n\n` : ''}`;
       }
-      if (kind === 'table') {
-        const struct = node.attrs?.['struct'] as
-          | { headers?: string[]; rows?: string[][] }
-          | undefined;
-        return struct ? renderMarkdownTable(struct) : '';
-      }
-      const svg = (node.attrs?.['svg'] as string | undefined) ?? '';
-      return svg ? `${svg}\n\n` : '';
+      const assetPath = (node.attrs?.['assetPath'] as string | undefined) ?? '';
+      const cap = caption ?? kind;
+      const img = assetPath ? `![${cap}](${assetPath})\n\n` : '';
+      const capLine = caption ? `**${caption}**\n\n` : '';
+      const srcLine = source ? `_${source}_\n\n` : '';
+      return `${img}${capLine}${srcLine}`;
     }
     default:
       // Fallback for unknown block types: render any text children.

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -749,6 +749,95 @@ const NOTE_PROSE_STYLE = `
   letter-spacing: -0.01em;
   color: var(--nm-dim);
 }
+
+/* [CV-FIGURE-PRESENTATION] — CV figures (svg chart/diagram, table, equation).
+   Framed on a light paper plate (legible dark ink), scaled to body width, with
+   a muted caption + dimmer "video title · mm:ss" source line below. */
+.note-prose-root .note-figure-block { margin: 40px auto; max-width: 600px; }
+.note-prose-root .note-figure-block.hidden { display: none; }
+.note-prose-root .note-figure {
+  margin: 0;
+  background: var(--nm-figure-bg);
+  border: 1px solid var(--nm-figure-border);
+  border-radius: 12px;
+  padding: 20px 20px 16px;
+  overflow: hidden;
+  color: var(--nm-figure-ink); /* KaTeX/table text + currentColor SVG render dark */
+}
+.note-prose-root .note-figure-canvas {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.note-prose-root .note-figure-canvas > * { max-width: 100%; }
+/* fix #1 size — inline SVG scales to the plate width, aspect ratio preserved. */
+.note-prose-root .note-figure-svg { width: 100%; }
+.note-prose-root .note-figure-svg svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  /* fix #2 bg — neutralize the SVG's own opaque bg so only the plate shows. */
+  background: transparent;
+}
+/* fix #3 font — override graphviz/matplotlib default sans so labels (esp.
+   Korean) use the note body font. !important beats inline style/presentation. */
+.note-prose-root .note-figure-svg svg text,
+.note-prose-root .note-figure-svg svg tspan {
+  font-family: var(--nm-sans) !important;
+}
+.note-prose-root .note-figure-canvas img {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  border-radius: 6px;
+}
+.note-prose-root .note-figure-equation {
+  width: 100%;
+  overflow-x: auto;
+  text-align: center;
+}
+.note-prose-root .note-figure-latex-fallback {
+  font-family: var(--nm-mono);
+  font-size: 13px;
+  color: var(--nm-figure-ink);
+}
+/* table figure — struct headers/rows as a clean bordered table on the plate. */
+.note-prose-root .note-figure-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--nm-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--nm-figure-ink);
+}
+.note-prose-root .note-figure-table th,
+.note-prose-root .note-figure-table td {
+  border: 1px solid var(--nm-figure-border);
+  padding: 6px 10px;
+  text-align: left;
+  vertical-align: top;
+}
+.note-prose-root .note-figure-table thead th {
+  background: var(--nm-figure-th-bg);
+  font-weight: 600;
+}
+/* fix #4 caption + source — muted caption, dimmer source, centered below figure. */
+.note-prose-root .note-figure-meta { margin-top: 14px; text-align: center; }
+.note-prose-root .note-figure-caption {
+  font-family: var(--nm-sans);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--nm-dim);
+}
+.note-prose-root .note-figure-source {
+  margin-top: 4px;
+  font-family: var(--nm-mono);
+  font-size: 11.5px;
+  letter-spacing: -0.01em;
+  color: var(--nm-faint);
+}
 `;
 
 function NoteEditorView({

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -307,12 +307,9 @@ export interface MandalaBookFigure {
   ts_sec: number;
   kind: 'chart' | 'diagram' | 'table' | 'equation' | 'keyframe';
   latex?: string;
-  // Server-rendered inline SVG (graphviz/matplotlib) for chart/diagram — durable.
-  svg?: string;
-  // Tabular payload for kind='table' (headers + rows), durable.
-  struct?: { headers?: string[]; rows?: string[][]; [k: string]: unknown };
-  // DEPRECATED — RunPod pod-local /tmp path, broken in the browser. Do not use.
-  asset_path?: string;
+  asset_path?: string; // legacy image pointer (no longer written by enrich job)
+  struct?: Record<string, unknown>; // mode-B JSON (chart/table/diagram); struct.insight = caption
+  svg?: string; // chart/diagram → server-rendered SVG (CP505 struct→SVG)
   verification_status?: string;
 }
 


### PR DESCRIPTION
## [CV-FIGURE-PRESENTATION]

Polish how note CV figures are **presented**. Render/presentation layer only — the struct→SVG generation (slidegen, separate repo) is untouched. The diagram data was already correct (right nodes/edges/labels); this PR fixes the raw look. Flag-independent.

Before: figures had **no CSS at all** (`note-figure-*` classes were referenced but never styled), and the generator only threaded the legacy `asset_path` — so the new server `svg`/`struct` figures (CP505) weren't even rendered. Now they render, framed and legible.

### The four fixes
1. **Size** — inline SVG scales to the note body width: `sanitizeSvg` strips the root `width`/`height` so CSS (`width:100%; height:auto; max-width:100%`) scales by `viewBox` (graphviz/matplotlib both emit one). No more overflow/clipping.
2. **Background** — each figure is framed on a light "paper" plate (rounded, bordered, padded) via new `--nm-figure-bg/-border/-ink/-th-bg` tokens defined in the `.note-mode` block. graphviz/matplotlib render **dark ink**, so a light plate keeps content legible on the dark note; the SVG's own bg is set transparent so only the plate shows. (Chose a light plate over `hsl(var(--card))` because the dark-on-light SVG content would be invisible on a near-black card.)
3. **Font** — `.note-figure-svg svg text/tspan { font-family: var(--nm-sans) !important }` overrides the graphviz/matplotlib default sans so labels (esp. Korean) use the note body font.
4. **Caption + source** — below each figure: a muted **caption** (`struct.insight` when present, else a Korean kind label — 차트/도식/표; equation = none) and a dimmer **source** line `"<video title> · mm:ss"`. The video **title is the real one**, resolved at render via `useMandalaCards` (same source `VideoStrip` uses — the book_json has no title map). Falls back to `"영상 · mm:ss"` (ts only) when the card isn't found.

Equation (KaTeX), table (struct headers/rows → HTML table), and legacy `<img>` all get the same plate + caption/source treatment. `sanitizeSvg` strips `<script>`, `on*` handlers, and `javascript:` hrefs before the inline `dangerouslySetInnerHTML`.

### Files changed
- `frontend/src/shared/lib/api-client.ts` — add `svg?` to `MandalaBookFigure`.
- `frontend/src/pages/learning/lib/note-document-generator.ts` — thread `svg`/`struct`(table)/`video_id`/`ts_sec`/caption through `figureBlock` attrs.
- `frontend/src/pages/learning/lib/figure-block.tsx` — sanitized inline SVG, table render, title resolution, plate + caption/source markup.
- `frontend/src/pages/learning/ui/CenterPanel.tsx` — figure CSS in `NOTE_PROSE_STYLE`.
- `frontend/src/app/styles/index.css` — `--nm-figure-*` tokens in `.note-mode`.
- `frontend/src/pages/learning/lib/note-export.ts` — caption/source in markdown export (secondary).
- `frontend/src/__tests__/note-document-generator-narrative.test.ts` — regression tests for new attrs.

### Verify
- `tsc --noEmit` — clean
- `vitest run note-document-generator` — 16 passed
- `vite build` — success

Figure-less notes are byte-unchanged (generator only emits figure attrs when `section.figures` is populated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)