### PR TITLE
feat(note-cv): TRUE dark CV figures — theme='dark' render flag + dark plate

### DIFF
--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1254,12 +1254,12 @@ html.dark .lemonsqueezy-loader {
   --nm-sans: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --nm-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 
-  /* [CV-FIGURE-PRESENTATION] — CV figure plate. graphviz/matplotlib render dark
-     ink, so figures sit on a light "paper" plate to stay legible on the dark note. */
-  --nm-figure-bg: #faf9f6;          /* warm near-white plate */
-  --nm-figure-border: rgba(0,0,0,0.10);
-  --nm-figure-ink: #1a1a1a;         /* default dark ink (KaTeX/table/currentColor SVG) */
-  --nm-figure-th-bg: rgba(0,0,0,0.045);
+  /* [CV-FIGURE-PRESENTATION] — CV figure plate. theme='dark' SVGs render light
+     ink + transparent bg, so figures sit directly on a dark card on the note. */
+  --nm-figure-bg: rgba(255,255,255,0.03);  /* subtle elevated dark card surface */
+  --nm-figure-border: var(--nm-line);      /* subtle dark border */
+  --nm-figure-ink: var(--nm-text);         /* light ink (KaTeX/table/currentColor SVG) */
+  --nm-figure-th-bg: rgba(255,255,255,0.045);
 
   background: #0e0f10;
 }

--- a/frontend/src/pages/learning/lib/figure-block.tsx
+++ b/frontend/src/pages/learning/lib/figure-block.tsx
@@ -12,9 +12,9 @@
  *    the body width; falls back to a legacy <img> asset when no svg.
  *  - kind='table' → renders struct headers/rows as an HTML table.
  *
- * [CV-FIGURE-PRESENTATION] — each figure is framed on a light "paper" plate
- * (graphviz/matplotlib render dark ink → a light plate keeps them legible on the
- * dark note) with a muted caption + a dimmer "video title · mm:ss" source line.
+ * [CV-FIGURE-PRESENTATION] — each figure is framed on a dark card (theme='dark'
+ * SVGs render light ink + transparent bg, so they sit directly on the note's dark
+ * surface) with a muted caption + a dimmer "video title · mm:ss" source line.
  * Video title is resolved at render from useMandalaCards (the book has no title
  * map); it falls back to "영상 · mm:ss" when the card isn't found.
  *

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -751,8 +751,8 @@ const NOTE_PROSE_STYLE = `
 }
 
 /* [CV-FIGURE-PRESENTATION] — CV figures (svg chart/diagram, table, equation).
-   Framed on a light paper plate (legible dark ink), scaled to body width, with
-   a muted caption + dimmer "video title · mm:ss" source line below. */
+   Framed on a dark card (theme='dark' SVGs carry light ink), scaled to body
+   width, with a muted caption + dimmer "video title · mm:ss" source line below. */
 .note-prose-root .note-figure-block { margin: 40px auto; max-width: 600px; }
 .note-prose-root .note-figure-block.hidden { display: none; }
 .note-prose-root .note-figure {
@@ -762,7 +762,7 @@ const NOTE_PROSE_STYLE = `
   border-radius: 12px;
   padding: 20px 20px 16px;
   overflow: hidden;
-  color: var(--nm-figure-ink); /* KaTeX/table text + currentColor SVG render dark */
+  color: var(--nm-figure-ink); /* KaTeX/table text + currentColor SVG render light */
 }
 .note-prose-root .note-figure-canvas {
   display: flex;
@@ -777,7 +777,7 @@ const NOTE_PROSE_STYLE = `
   width: 100%;
   height: auto;
   max-width: 100%;
-  /* fix #2 bg — neutralize the SVG's own opaque bg so only the plate shows. */
+  /* fix #2 bg — theme='dark' SVG bg is transparent; keep belt so only the plate shows. */
   background: transparent;
 }
 /* fix #3 font — override graphviz/matplotlib default sans so labels (esp.

--- a/src/modules/snapshot/render-figure-client.ts
+++ b/src/modules/snapshot/render-figure-client.ts
@@ -2,8 +2,10 @@
  * render-figure client (CP505 [CV-NOTE-WIRE]) — calls the slidegen-service
  * POST /render-figure to convert a structured figure (struct) to an SVG string.
  *
- * Contract: body {kind, struct} → {svg: string|null}
+ * Contract: body {kind, struct, theme} → {svg: string|null}
  * svg=null = degenerate/unrenderable figure (caller MUST drop the figure).
+ * theme='dark' so SVGs render light ink + transparent bg for the dark note
+ * (the endpoint defaults to "light" for the deck).
  *
  * Fail-closed: any error, non-2xx, timeout, or null svg → returns null.
  * CPU render only (no vision pipeline); 20s is generous for SVG generation.
@@ -42,7 +44,8 @@ export async function renderFigureSvg(kind: string, struct: unknown): Promise<st
         'content-type': 'application/json',
         authorization: `Bearer ${cfg.serviceToken}`,
       },
-      body: JSON.stringify({ kind, struct }),
+      // theme:'dark' → light ink + transparent bg SVG for the dark note plate.
+      body: JSON.stringify({ kind, struct, theme: 'dark' }),
       signal: controller.signal,
     });
 


### PR DESCRIPTION
## Summary

Switches note CV figures to a **TRUE dark theme**, replacing the interim LIGHT "paper plate" workaround from #1013. The slidegen `/render-figure` endpoint now supports `theme="dark"` (returns light-ink `#E2E8F0` + transparent-bg SVG), so a figure can sit directly on a dark card instead of being boxed on a light plate to stay legible.

## Changes

**BE — `src/modules/snapshot/render-figure-client.ts`**
- POST body to `/render-figure` now includes `theme: 'dark'` (`{ kind, struct, theme: 'dark' }`). The endpoint defaults to `"light"` for the deck; the note explicitly requests `"dark"`.

**FE — `--nm-figure-*` tokens (`frontend/src/app/styles/index.css`) + figure CSS (`CenterPanel.tsx`) + header comments (`figure-block.tsx`)**
- Flipped the figure plate from light to a dark card. Token values (light #1013 → dark):

| token | #1013 (light) | this PR (dark) |
|---|---|---|
| `--nm-figure-bg` | `#faf9f6` | `rgba(255,255,255,0.03)` (subtle elevated dark card surface) |
| `--nm-figure-border` | `rgba(0,0,0,0.10)` | `var(--nm-line)` (reuse existing subtle dark border) |
| `--nm-figure-ink` | `#1a1a1a` | `var(--nm-text)` (reuse existing light ink) |
| `--nm-figure-th-bg` | `rgba(0,0,0,0.045)` | `rgba(255,255,255,0.045)` |

- Tokens defined in the existing `.note-mode` token block (consistent with the surrounding `--nm-*` literal style); consuming CSS references `var(...)` only — no hardcoded literals at consumption sites. `border`/`ink` reuse existing semantic `--nm-*` tokens.
- #1013's caption / source / size-fit (width 100% + viewBox scale) / SVG font-override / sanitizer / table (HTML) / equation (KaTeX) logic is **unchanged** — only the plate COLORS flip light→dark. Table + equation now render on the dark card via the light ink token.

## Operational follow-up (parent handles, NOT in this PR)

Figure SVGs already stored in `book_json` are **LIGHT-themed** (rendered before theme support). After this ships + the BE redeploys, those figures must be **RE-RENDERED with `theme="dark"`** to actually get light-ink SVG. That re-render is a separate operational step.

## Verification

- `frontend tsc --noEmit` — PASS (exit 0)
- `vitest run note-document-generator` — PASS (16/16; figure attrs unchanged, no test edit needed)
- `vite build` — PASS
- BE `tsc` not run locally (broken toolchain — `node_modules/.bin/tsc` is a broken symlink, "Too many levels of symbolic links"; same env breakage that failed the husky pre-commit hook). The BE change is a plain object-literal field passed to `JSON.stringify` (no type constraint) — manually type-reviewed; relying on CI.

Figure-less notes are byte-unchanged (only the figure plate styling + the BE request flag changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)