### PR TITLE
feat(note-cv): adaptive dual-mode figures (theme='auto' + #808080→currentColor) + copyable LaTeX

### DIFF
--- a/frontend/src/__tests__/figure-block-sanitize.test.ts
+++ b/frontend/src/__tests__/figure-block-sanitize.test.ts
@@ -1,0 +1,47 @@
+/**
+ * sanitizeSvg — adaptive-figure (theme='auto') sentinel swap + existing scrubs.
+ * Regression for [CV-NOTE-WIRE] dual-mode figures: the #808080 ink sentinel must
+ * become currentColor so the figure inherits the note's text color per mode.
+ */
+import { describe, it, expect } from 'vitest';
+import { sanitizeSvg } from '@/pages/learning/lib/figure-block';
+
+describe('sanitizeSvg — adaptive ink sentinel → currentColor', () => {
+  it('swaps #808080 in fill=, stroke=, stop-color and style attrs (case-insensitive)', () => {
+    const raw =
+      '<svg viewBox="0 0 10 10">' +
+      '<text fill="#808080">노드</text>' +
+      '<line stroke="#808080" x1="0" y1="0" x2="10" y2="10"/>' +
+      '<stop stop-color="#808080"/>' +
+      '<rect style="fill:#808080;stroke:#808080"/>' +
+      '<path stroke="#808080"/>' +
+      '</svg>';
+    const out = sanitizeSvg(raw);
+    expect(out).not.toMatch(/#808080/i);
+    expect(out).toContain('currentColor');
+  });
+
+  it('keeps category accent-color borders untouched (non-sentinel hues)', () => {
+    const raw = '<svg viewBox="0 0 4 4"><rect stroke="#c2a878" fill="#808080"/></svg>';
+    const out = sanitizeSvg(raw);
+    expect(out).toContain('#c2a878'); // accent border preserved
+    expect(out).not.toMatch(/#808080/i); // ink swapped
+  });
+
+  it('still strips width/height, <script> and on* handlers', () => {
+    const raw =
+      '<svg width="500" height="300" viewBox="0 0 10 10" onload="x()">' +
+      '<script>alert(1)</script><text fill="#808080" onclick="y()">t</text></svg>';
+    const out = sanitizeSvg(raw);
+    expect(out).not.toMatch(/<script/i);
+    expect(out).not.toMatch(/onload=/i);
+    expect(out).not.toMatch(/onclick=/i);
+    expect(out).not.toMatch(/width="500"/);
+    expect(out).not.toMatch(/height="300"/);
+    expect(out).toContain('preserveAspectRatio');
+  });
+
+  it('returns empty string on parse failure', () => {
+    expect(sanitizeSvg('not-svg <<<')).toBe('');
+  });
+});

--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1254,12 +1254,14 @@ html.dark .lemonsqueezy-loader {
   --nm-sans: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --nm-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 
-  /* [CV-FIGURE-PRESENTATION] — CV figure plate. theme='dark' SVGs render light
-     ink + transparent bg, so figures sit directly on a dark card on the note. */
-  --nm-figure-bg: rgba(255,255,255,0.03);  /* subtle elevated dark card surface */
-  --nm-figure-border: var(--nm-line);      /* subtle dark border */
-  --nm-figure-ink: var(--nm-text);         /* light ink (KaTeX/table/currentColor SVG) */
-  --nm-figure-th-bg: rgba(255,255,255,0.045);
+  /* [CV-FIGURE-PRESENTATION] — CV figure plate. theme='auto' SVGs paint ink with
+     the #808080 sentinel that the FE swaps to currentColor, so figure ink follows
+     --nm-text (the note body ink). Plate tones are ink-derived (not hardcoded white)
+     so they track whatever --nm-text resolves to — one image, mode-agnostic. */
+  --nm-figure-ink: var(--nm-text);                                       /* drives currentColor SVG + KaTeX/table text */
+  --nm-figure-border: var(--nm-line);                                    /* matches the note's hairline dividers */
+  --nm-figure-bg: color-mix(in srgb, var(--nm-text) 4%, transparent);    /* subtle ink-tinted plate */
+  --nm-figure-th-bg: color-mix(in srgb, var(--nm-text) 6%, transparent); /* table header tint */
 
   background: #0e0f10;
 }

--- a/frontend/src/pages/learning/lib/figure-block.tsx
+++ b/frontend/src/pages/learning/lib/figure-block.tsx
@@ -12,9 +12,10 @@
  *    the body width; falls back to a legacy <img> asset when no svg.
  *  - kind='table' → renders struct headers/rows as an HTML table.
  *
- * [CV-FIGURE-PRESENTATION] — each figure is framed on a dark card (theme='dark'
- * SVGs render light ink + transparent bg, so they sit directly on the note's dark
- * surface) with a muted caption + a dimmer "video title · mm:ss" source line.
+ * [CV-FIGURE-PRESENTATION] — each figure is framed on an ink-tinted plate. theme='auto'
+ * SVGs carry transparent bg + #808080 sentinel ink which sanitizeSvg swaps to
+ * currentColor, so the ink inherits the note body color (one image, dual-mode). A
+ * muted caption + a dimmer "video title · mm:ss" source line sit below.
  * Video title is resolved at render from useMandalaCards (the book has no title
  * map); it falls back to "영상 · mm:ss" when the card isn't found.
  *
@@ -68,12 +69,19 @@ function useVideoTitle(videoId: string | null): string | null {
   }, [cards, videoId]);
 }
 
+// Adaptive (theme='auto') SVGs paint ALL ink (text/edges/labels) in this sentinel
+// hex; we swap it for currentColor so the figure inherits the note's text color per
+// mode. Category accent-color borders use other hues and are left untouched.
+const ADAPTIVE_INK_SENTINEL_RE = /#808080/gi;
+
 /**
  * Sanitize a server-rendered SVG before inlining it. Drops <script>, event
  * handlers (on*) and javascript: hrefs; strips the root width/height so CSS
- * scales the figure by its viewBox (fix #1). Returns '' on parse failure.
+ * scales the figure by its viewBox (fix #1). Swaps the adaptive ink sentinel
+ * #808080 → currentColor (theme='auto', dual-mode). Returns '' on parse failure.
+ * Exported for unit tests.
  */
-function sanitizeSvg(raw: string): string {
+export function sanitizeSvg(raw: string): string {
   if (typeof window === 'undefined' || !window.DOMParser) return '';
   let doc: Document;
   try {
@@ -100,7 +108,9 @@ function sanitizeSvg(raw: string): string {
   svg.removeAttribute('width');
   svg.removeAttribute('height');
   svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
-  return svg.outerHTML;
+  // Swap adaptive ink sentinel → currentColor across fill=/stroke=/stop-color/color:/style.
+  // The sentinel is a dedicated color value, so a single serialized replace is exhaustive.
+  return svg.outerHTML.replace(ADAPTIVE_INK_SENTINEL_RE, 'currentColor');
 }
 
 interface ParsedTable {
@@ -131,8 +141,18 @@ function EquationView({ latex }: { latex: string }) {
       try {
         const katex = (await import('katex')).default;
         await import('katex/dist/katex.min.css');
+        // copy-tex self-registers a global copy handler that rewrites a selected
+        // equation to its LaTeX source via the MathML <annotation>; lazy so it only
+        // loads with an equation figure. output:'htmlAndMathml' guarantees the annotation.
+        await import('katex/contrib/copy-tex');
         if (cancelled) return;
-        setHtml(katex.renderToString(latex, { throwOnError: false, displayMode: true }));
+        setHtml(
+          katex.renderToString(latex, {
+            throwOnError: false,
+            displayMode: true,
+            output: 'htmlAndMathml',
+          })
+        );
       } catch {
         if (!cancelled) setFailed(true);
       }

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -751,7 +751,8 @@ const NOTE_PROSE_STYLE = `
 }
 
 /* [CV-FIGURE-PRESENTATION] — CV figures (svg chart/diagram, table, equation).
-   Framed on a dark card (theme='dark' SVGs carry light ink), scaled to body
+   Framed on an ink-tinted plate; theme='auto' SVG ink is currentColor (= --nm-figure-ink
+   = note body ink), so the figure adapts to the note's text color. Scaled to body
    width, with a muted caption + dimmer "video title · mm:ss" source line below. */
 .note-prose-root .note-figure-block { margin: 40px auto; max-width: 600px; }
 .note-prose-root .note-figure-block.hidden { display: none; }
@@ -762,7 +763,7 @@ const NOTE_PROSE_STYLE = `
   border-radius: 12px;
   padding: 20px 20px 16px;
   overflow: hidden;
-  color: var(--nm-figure-ink); /* KaTeX/table text + currentColor SVG render light */
+  color: var(--nm-figure-ink); /* KaTeX/table text + the currentColor SVG ink inherit this */
 }
 .note-prose-root .note-figure-canvas {
   display: flex;
@@ -777,7 +778,7 @@ const NOTE_PROSE_STYLE = `
   width: 100%;
   height: auto;
   max-width: 100%;
-  /* fix #2 bg — theme='dark' SVG bg is transparent; keep belt so only the plate shows. */
+  /* fix #2 bg — theme='auto' SVG bg is transparent; keep belt so only the plate shows. */
   background: transparent;
 }
 /* fix #3 font — override graphviz/matplotlib default sans so labels (esp.

--- a/src/modules/snapshot/render-figure-client.ts
+++ b/src/modules/snapshot/render-figure-client.ts
@@ -4,8 +4,10 @@
  *
  * Contract: body {kind, struct, theme} → {svg: string|null}
  * svg=null = degenerate/unrenderable figure (caller MUST drop the figure).
- * theme='dark' so SVGs render light ink + transparent bg for the dark note
- * (the endpoint defaults to "light" for the deck).
+ * theme='auto' emits an ADAPTIVE SVG: transparent bg, transparent node fills,
+ * category accent-color borders kept, and ALL ink (node text, edges, cluster/graph
+ * labels) in a single sentinel hex #808080. The FE swaps #808080 → currentColor so
+ * the figure inherits the page text color per mode (works in BOTH dark and light).
  *
  * Fail-closed: any error, non-2xx, timeout, or null svg → returns null.
  * CPU render only (no vision pipeline); 20s is generous for SVG generation.
@@ -44,8 +46,9 @@ export async function renderFigureSvg(kind: string, struct: unknown): Promise<st
         'content-type': 'application/json',
         authorization: `Bearer ${cfg.serviceToken}`,
       },
-      // theme:'dark' → light ink + transparent bg SVG for the dark note plate.
-      body: JSON.stringify({ kind, struct, theme: 'dark' }),
+      // theme:'auto' → adaptive SVG (transparent bg + #808080 sentinel ink the FE
+      // swaps to currentColor) so one image works in both dark and light note modes.
+      body: JSON.stringify({ kind, struct, theme: 'auto' }),
       signal: controller.signal,
     });
 


### PR DESCRIPTION
## What

Make CV note figures work in **both dark and light** with **one image**, and make equation math **copyable as LaTeX**. Builds on #1013/#1014 (base = `main`).

### Changes
1. **BE `src/modules/snapshot/render-figure-client.ts`** — POST body `theme: 'dark'` → `'auto'`. The adaptive output emits a transparent bg, transparent node fills, category accent-color borders, and ALL ink in the sentinel hex `#808080`. Contract comment updated.
2. **FE `figure-block.tsx` `sanitizeSvg`** — after the existing strip (width/height/`<script>`/`on*`/`javascript:`), add a global case-insensitive replace `#808080` → `currentColor` on the serialized SVG. The sentinel is a dedicated color value, so one replace covers `fill=`/`stroke=`/`stop-color`/`color:`/`style`. Inline SVG ink now inherits the container's CSS `color`.
3. **FE figure container** — `--nm-figure-*` tokens redefined: ink = `var(--nm-text)` (note body ink, drives the `currentColor` SVG), border = `var(--nm-line)` (note hairline), bg/th-bg = `color-mix(in srgb, var(--nm-text) 4%/6%, transparent)` (ink-derived, replaces the hardcoded-dark `rgba(255,255,255,…)` from #1014). Comments in `index.css` + `CenterPanel.tsx` + `figure-block.tsx` updated. No hardcoded color literals at component sites.
4. **FE equation copyable LaTeX** — lazy side-effect `import 'katex/contrib/copy-tex'` (self-registers a global copy handler reading the MathML `<annotation encoding="application/x-tex">`) + explicit `output: 'htmlAndMathml'` so the annotation is always present. Select rendered math → copy → get the LaTeX source.

### Theme-system finding (reported, not assumed)
The `/learning` note view is **dark-only**: `.note-mode` forces a near-black surface **regardless of the global light/dark toggle**, and the `--nm-*` editorial tokens do **not** flip per mode (the note prose deliberately uses `--nm-text`, not `--foreground`, because `--foreground` would be wrong under light-global + `.note-mode`). FigureBlock is registered only in the learning note editor, so figures render only in this dark context. Dual-mode is therefore delivered by the **adaptive `currentColor` image**: it auto-follows `--nm-text` if the note ever gains a light mode, with zero re-render. I did not assume a light note mode exists.

### Operational follow-up (parent handles)
Existing `book_json` SVGs were rendered with `theme="dark"` (light ink `#E2E8F0`) — they need a **RE-RENDER with `theme="auto"`** to carry the `#808080` sentinel. Until then those legacy figures keep their baked light ink (fine on the current dark note).

## Verify
- `frontend tsc --noEmit` → PASS
- `vitest run note-document-generator figure-block-sanitize` → 20 passed (incl. new sentinel-swap regression test)
- `vite build` → PASS
- Backend `tsc` is broken locally (root `node_modules` is a self-referential symlink → npx 194); BE change is a 2-line string/comment edit with no type impact → manual review + rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)