### PR TITLE
feat(note): render "핵심 요점" key-point callout from section.keyPoints [NOTE-DENSITY ①]

### DIFF
--- a/frontend/src/__tests__/note-document-generator-narrative.test.ts
+++ b/frontend/src/__tests__/note-document-generator-narrative.test.ts
@@ -11,7 +11,9 @@
  */
 import { describe, it, expect } from 'vitest';
 import { buildInitialNoteDoc } from '@/pages/learning/lib/note-document-generator';
+import { exportToMarkdown } from '@/pages/learning/lib/note-export';
 import type { MandalaBookData } from '@/shared/lib/api-client';
+import type { TiptapDoc } from '@/features/video-side-panel/lib/note-parser';
 
 type N = { type: string; content?: N[]; attrs?: { vid?: string } };
 const nodes = (doc: { content?: unknown[] }): N[] => (doc.content ?? []) as N[];
@@ -67,6 +69,51 @@ describe('note-document-generator — loop-1b narrative render', () => {
   it('fallback: narrative mode but empty section.narrative → legacy render for that section', () => {
     const ns = nodes(buildInitialNoteDoc(book('이 장은 기초 회화를 다룬다', '')));
     expect(paraTexts(ns)).toContain('ATOM_TEXT_A 인사'); // fell through to legacy atom render
+  });
+});
+
+// NOTE-DENSITY ① — "핵심 요점" key-point callout (blockquote wrapping a bulletList).
+const liTexts = (bq: N): string[] => {
+  const list = (bq.content ?? []).find((c) => c.type === 'bulletList');
+  return ((list?.content ?? []) as N[]).map((li) =>
+    (li.content ?? [])
+      .flatMap((p) => (p.content ?? []).map((c) => (c as { text?: string }).text ?? ''))
+      .join('')
+  );
+};
+
+describe('note-document-generator — NOTE-DENSITY ① key-point callout', () => {
+  const withKeyPoints = (kp?: string[]): MandalaBookData => {
+    const b = book('이 장은 기초 회화를 다룬다');
+    if (kp) b.chapters[0]!.sections[0]!.keyPoints = kp;
+    return b;
+  };
+
+  it('narrative mode + keyPoints → 핵심 요점 callout (blockquote > bulletList items)', () => {
+    const ns = nodes(buildInitialNoteDoc(withKeyPoints(['KP_ONE 인사 먼저', 'KP_TWO 주문 표현'])));
+    const bq = blockquotes(ns);
+    expect(bq).toHaveLength(1); // the callout (narrative is the body, not a blockquote)
+    const list = (bq[0].content ?? []).find((c) => c.type === 'bulletList');
+    expect(list).toBeDefined();
+    expect(liTexts(bq[0])).toEqual(['KP_ONE 인사 먼저', 'KP_TWO 주문 표현']);
+  });
+
+  it('narrative mode WITHOUT keyPoints → no callout (byte-unchanged)', () => {
+    expect(blockquotes(nodes(buildInitialNoteDoc(withKeyPoints())))).toHaveLength(0);
+  });
+
+  it('empty keyPoints array → no callout (flag-safe)', () => {
+    expect(blockquotes(nodes(buildInitialNoteDoc(withKeyPoints([]))))).toHaveLength(0);
+  });
+
+  it('markdown export → "핵심 요점" heading + plain bullets (not a > quote)', () => {
+    const md = exportToMarkdown(
+      buildInitialNoteDoc(withKeyPoints(['KP_ONE 인사 먼저', 'KP_TWO 주문 표현'])) as TiptapDoc
+    );
+    expect(md).toContain('**핵심 요점**');
+    expect(md).toContain('- KP_ONE 인사 먼저');
+    expect(md).toContain('- KP_TWO 주문 표현');
+    expect(md).not.toContain('> - KP_ONE'); // not serialized as a blockquote
   });
 });
 

--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1261,6 +1261,12 @@ html.dark .lemonsqueezy-loader {
   --nm-figure-ink: var(--nm-text);         /* light ink (KaTeX/table/currentColor SVG) */
   --nm-figure-th-bg: rgba(255,255,255,0.045);
 
+  /* NOTE-DENSITY ① — "핵심 요점" key-point callout box: gold-tinted surface +
+     border (derived from --nm-accent #c2a878 = rgb 194,168,120) so it reads as a
+     distinct take-away box, not body prose. */
+  --nm-keypoint-bg: rgba(194,168,120,0.07);
+  --nm-keypoint-border: rgba(194,168,120,0.22);
+
   background: #0e0f10;
 }
 

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -127,6 +127,27 @@ function videoBlockNode(
   };
 }
 
+// NOTE-DENSITY ① — "핵심 요점" key-point callout. Reuses the registered
+// blockquote + bulletList nodes (no new TipTap extension); the bulletList child
+// distinguishes it from the legacy narrative blockquote (> p) for note-mode CSS
+// (blockquote:has(> ul)) and markdown export. Returns null when no real points.
+function keyPointBlockNode(keyPoints: string[] | undefined): TiptapNode | null {
+  const points = (keyPoints ?? []).map((p) => normalizeText(p ?? '')).filter(Boolean);
+  if (points.length === 0) return null;
+  return {
+    type: 'blockquote',
+    content: [
+      {
+        type: 'bulletList',
+        content: points.map((p) => ({
+          type: 'listItem',
+          content: [paragraph(p)],
+        })),
+      },
+    ],
+  };
+}
+
 /**
  * Segment end for a vid group: the furthest segment boundary (max seg_ref.to_sec)
  * so playback covers the group's whole span, not just up to the last atom START.
@@ -290,6 +311,10 @@ function renderSection(
       out.push(videoBlockNode(g.vid, firstTs, endSec, section.title ?? null));
     }
     out.push(...renderFigures(section.figures)); // [CV-NOTE-WIRE]
+    // NOTE-DENSITY ① — real key-point take-aways AFTER prose + figures (flag-safe:
+    // absent/empty keyPoints → emit nothing → existing notes byte-unchanged).
+    const keyPoints = keyPointBlockNode(section.keyPoints);
+    if (keyPoints) out.push(keyPoints);
     out.push(horizontalRule());
     return out;
   }

--- a/frontend/src/pages/learning/lib/note-export.ts
+++ b/frontend/src/pages/learning/lib/note-export.ts
@@ -90,6 +90,13 @@ function renderBlock(node: TiptapNode, depth: number): string {
     case 'orderedList':
       return renderList(node, '1.', depth);
     case 'blockquote': {
+      // NOTE-DENSITY ① — "핵심 요점" key-point callout = blockquote wrapping only
+      // a bulletList. Serialize as a labeled heading + plain bullets (not a quote).
+      const children = node.content ?? [];
+      if (children.length > 0 && children.every((c) => c.type === 'bulletList')) {
+        const bullets = children.map((c) => renderBlock(c, depth)).join('');
+        return `**핵심 요점**\n\n${bullets}\n`;
+      }
       const inner = (node.content ?? []).map((c) => renderBlock(c, depth)).join('');
       return (
         inner

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -658,6 +658,32 @@ const NOTE_PROSE_STYLE = `
   color: var(--nm-accent);
   margin-bottom: 10px;
 }
+/* NOTE-DENSITY ① — "핵심 요점" key-point callout: a gold-tinted box (distinct
+   from body prose + from the legacy gold left-rule keypoint). Discriminated from
+   the narrative blockquote (> p) by its bulletList child. Academic/dense look. */
+.note-prose-root .ProseMirror blockquote:has(> ul) {
+  border-left: none;
+  background: var(--nm-keypoint-bg);
+  border: 1px solid var(--nm-keypoint-border);
+  border-radius: 10px;
+  padding: 18px 22px;
+  margin: 40px 0;
+}
+.note-prose-root .ProseMirror blockquote:has(> ul)::before { content: "핵심 요점"; }
+.note-prose-root .ProseMirror blockquote:has(> ul) ul {
+  margin: 0;
+  padding-left: 1.15em;
+  list-style: disc;
+}
+.note-prose-root .ProseMirror blockquote:has(> ul) li {
+  font-family: var(--nm-serif);
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--nm-strong);
+  margin: 0 0 0.5em;
+}
+.note-prose-root .ProseMirror blockquote:has(> ul) li:last-child { margin-bottom: 0; }
+.note-prose-root .ProseMirror blockquote:has(> ul) li::marker { color: var(--nm-accent); }
 .note-prose-root .ProseMirror code {
   font-family: var(--nm-mono);
   font-size: 0.82em;

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -316,6 +316,9 @@ export interface MandalaBookFigure {
 export interface MandalaBookSection {
   title: string;
   narrative?: string;
+  // NOTE-DENSITY ① — 2-3 distilled take-aways per section, distinct from the
+  // flowing narrative. Rendered as a "핵심 요점" callout (narrative mode only).
+  keyPoints?: string[];
   atoms?: MandalaBookAtom[];
   qa?: Array<{ q: string; a: string }>;
   verification?: { status?: string; notes?: string; checks?: MandalaBookFactcheck[] }; // CP504 loop-2-A


### PR DESCRIPTION
## What

Notes currently show zero key-point boxes. The narrative render path emits prose + citations + figures then returns early, bypassing the legacy keypoint blockquote — and that legacy blockquote was just `section.narrative` reused, not a real key-point. This PR renders the **real** `section.keyPoints` data (BE adds it in parallel via `bookSectionSchema`) as a styled "핵심 요점" callout.

## Key-point block structure

Reuses the **registered** TipTap nodes (no new extension): a `blockquote` wrapping a single `bulletList` of `listItem > paragraph(point)`. The bulletList child is what distinguishes it from the legacy narrative blockquote (which wraps a `paragraph`), giving both the note-mode CSS and the markdown exporter a clean, schema-free discriminator.

## Changes

- **`api-client.ts`** — `MandalaBookSection.keyPoints?: string[]` (matches BE `bookSectionSchema.keyPoints`).
- **`note-document-generator.ts`** — `keyPointBlockNode()` reuses `blockquote`+`bulletList`+`listItem`; emitted in the **narrative path only**, after prose + figures, before the divider. Absent/empty `keyPoints` → emits nothing. The legacy path (`narrativeMode===false`) is untouched.
- **`CenterPanel.tsx` (NOTE_PROSE_STYLE)** — `blockquote:has(> ul)` styled as a gold-tinted box (border + radius + tint), label overridden to "핵심 요점", gold `::marker`. Academic/dense look, distinct from body prose and from the legacy gold left-rule keypoint.
- **`index.css`** — two new note-mode design tokens `--nm-keypoint-bg` / `--nm-keypoint-border` (derived from the existing `--nm-accent` gold). No hardcoded color literals in component CSS.
- **`note-export.ts`** — a blockquote wrapping only a `bulletList` serializes to a `**핵심 요점**` heading + plain `- ` bullets (not a `> ` quote).
- **tests** — narrative + keyPoints → callout renders; without → no block (byte-unchanged); empty array → no-op; markdown export round-trip.

## CSS / tokens

| token | value | use |
|-------|-------|-----|
| `--nm-keypoint-bg` | `rgba(194,168,120,0.07)` | box surface tint (accent gold) |
| `--nm-keypoint-border` | `rgba(194,168,120,0.22)` | box border |

Reuses existing `--nm-accent`, `--nm-serif`, `--nm-strong`.

## Verify

- `tsc --noEmit` → **PASS** (exit 0)
- `vitest run note-document-generator` → **PASS** (20 tests)
- `vite build` → **PASS** (built in ~12s)

## Note

Existing `book_json` has no `keyPoints` yet — a mandala must be **re-generated via the prod pipeline** (parent/BE handles) for the callout to appear. Flag-safe until then: existing notes are byte-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)