### PR TITLE
feat(note-density): keyPoints — schema + generation prompt + parser [NOTE-DENSITY ①]

### DIFF
--- a/src/modules/mandala-book/book-body.ts
+++ b/src/modules/mandala-book/book-body.ts
@@ -35,13 +35,20 @@ export interface BodyTopicInput {
   summary: string;
 }
 
+/** Per-section output carrying both the woven prose and the distilled key-points. */
+export interface BodySectionResult {
+  narrative: string;
+  keyPoints: string[]; // 2-3 compressed take-aways; empty when model omits
+}
+
 export type ChapterBodyResult =
-  | { ok: true; narratives: string[] } // index-aligned with the input topics
+  | { ok: true; sections: BodySectionResult[] } // index-aligned with the input topics
   | { ok: false; reason: string };
 
 interface LlmBodySection {
   idx?: unknown;
   narrative?: unknown;
+  keyPoints?: unknown; // NOTE-DENSITY ① — model may emit array of strings
 }
 
 /**
@@ -70,10 +77,11 @@ export function buildChapterBodyPrompt(
     `2. 연결·전환·맥락 문장은 창작해도 된다(예: "앞에서 다진 기초를 바탕으로"). 그러나 ★사실은 주어진 요약에 있는 것만 써라 — 요약에 없는 새 사실(표현·수치·이름·개념)을 절대 지어내지 마라.`,
     `3. 토픽 순서와 개수를 유지한다(입력 ${topics.length}개 → 출력 ${topics.length}개, idx 일치).`,
     `4. 각 narrative는 토픽 요약보다 풍부하되 간결하게(2-4문장). 영상제목·채널명 금지.`,
+    `5. 각 토픽에 대해 keyPoints(2-3개)를 작성한다: 독자가 반드시 기억해야 할 압축 핵심. ★중요: keyPoints는 narrative의 문장 반복이 아니다 — narrative를 읽지 않아도 핵심을 알 수 있는 밀도 높은 bullet(예: "INT8 양자화: 메모리 75%↓, 성능 손실 1-2%"). 수치·원칙·결론 중심, 각 항목 한 줄 이내.`,
     ``,
-    `★ 각 narrative는 한 줄(개행·줄바꿈 문자 절대 금지 — JSON 파싱 보호).`,
+    `★ narrative와 keyPoints 각 항목은 반드시 한 줄(개행·줄바꿈 문자 절대 금지 — JSON 파싱 보호).`,
     `JSON만 출력(코드펜스 금지):`,
-    `{"sections":[{"idx":0,"narrative":"..."}]}`,
+    `{"sections":[{"idx":0,"narrative":"...","keyPoints":["핵심1","핵심2"]}]}`,
   ]
     .filter((l) => l !== ``)
     .join('\n');
@@ -140,8 +148,10 @@ async function attemptBody(
 
 /**
  * Pure parse + index-map of the body response. Exported for fixture unit tests
- * (no live LLM). Returns narratives index-aligned with the input topics; any
- * topic the model omits keeps an empty slot (caller falls back to its summary).
+ * (no live LLM). Returns sections index-aligned with the input topics; any
+ * topic the model omits keeps an empty-narrative slot (caller falls back to its
+ * summary). keyPoints: trimmed non-empty strings, capped at 3, empty array when
+ * the model omits the field (flag-safe — existing call sites unaffected).
  * Fails only if the response is unusable (not JSON / no sections / none mapped).
  */
 export function parseChapterBodyResponse(raw: string, topicCount: number): ChapterBodyResult {
@@ -159,7 +169,10 @@ export function parseChapterBodyResponse(raw: string, topicCount: number): Chapt
   }
   if (!Array.isArray(json.sections)) return { ok: false, reason: 'no_sections_array' };
 
-  const narratives: string[] = new Array(topicCount).fill('');
+  const sections: BodySectionResult[] = Array.from({ length: topicCount }, () => ({
+    narrative: '',
+    keyPoints: [],
+  }));
   let mapped = 0;
   for (const s of json.sections as LlmBodySection[]) {
     const i = typeof s.idx === 'number' ? s.idx : Number(s.idx);
@@ -167,9 +180,16 @@ export function parseChapterBodyResponse(raw: string, topicCount: number): Chapt
     const narrative =
       typeof s.narrative === 'string' ? s.narrative.replace(/\s*\n+\s*/g, ' ').trim() : '';
     if (!narrative) continue;
-    if (narratives[i] === '') mapped += 1; // first write for this idx
-    narratives[i] = narrative;
+    if (sections[i]!.narrative === '') mapped += 1; // first write for this idx
+    // Extract keyPoints: array of strings, trimmed, non-empty, capped at 3.
+    const rawKp = Array.isArray(s.keyPoints) ? (s.keyPoints as unknown[]) : [];
+    const keyPoints = rawKp
+      .filter((k): k is string => typeof k === 'string')
+      .map((k) => k.replace(/\s*\n+\s*/g, ' ').trim())
+      .filter((k) => k.length > 0)
+      .slice(0, 3);
+    sections[i] = { narrative, keyPoints };
   }
   if (mapped === 0) return { ok: false, reason: 'no_mapped_sections' };
-  return { ok: true, narratives };
+  return { ok: true, sections };
 }

--- a/src/modules/mandala-book/book-schema.ts
+++ b/src/modules/mandala-book/book-schema.ts
@@ -77,6 +77,9 @@ const bookFigureSchema = z.object({
 export const bookSectionSchema = z.object({
   title: z.string(),
   narrative: z.string(), // 살붙임 body assembled from v2 analysis + segments
+  // NOTE-DENSITY ① — 2-3 compressed take-aways per section (distilled, NOT narrative repeat).
+  // Optional: absent/empty ⇒ renders nothing; existing books without this field stay valid.
+  keyPoints: z.array(z.string()).optional(),
   atoms: z.array(bookAtomSchema).default([]),
   qa: z.array(bookQaSchema).default([]),
   provenance: provenanceSchema, // Fork D placeholder

--- a/src/modules/mandala-book/build-book.ts
+++ b/src/modules/mandala-book/build-book.ts
@@ -296,7 +296,9 @@ export function buildBookJson(input: BuildBookInput): BuildBookResult {
             title: topic.topic_title,
             narrative: topic.summary,
             // NOTE-DENSITY ① — carry keyPoints from the book-body weave step.
-            ...(topic.keyPoints && topic.keyPoints.length > 0 ? { keyPoints: topic.keyPoints } : {}),
+            ...(topic.keyPoints && topic.keyPoints.length > 0
+              ? { keyPoints: topic.keyPoints }
+              : {}),
             atoms,
             qa,
           };

--- a/src/modules/mandala-book/build-book.ts
+++ b/src/modules/mandala-book/build-book.ts
@@ -171,7 +171,14 @@ function sectionFromTopic(
       seenQa.add(k);
       return true;
     });
-  return { title: topic.topic_title, narrative: topic.summary, atoms, qa };
+  return {
+    title: topic.topic_title,
+    narrative: topic.summary,
+    // NOTE-DENSITY ① — pass through keyPoints written by book-body weave step.
+    ...(topic.keyPoints && topic.keyPoints.length > 0 ? { keyPoints: topic.keyPoints } : {}),
+    atoms,
+    qa,
+  };
 }
 
 /**
@@ -285,7 +292,14 @@ export function buildBookJson(input: BuildBookInput): BuildBookResult {
               seenQa.add(k);
               return true;
             });
-          return { title: topic.topic_title, narrative: topic.summary, atoms, qa };
+          return {
+            title: topic.topic_title,
+            narrative: topic.summary,
+            // NOTE-DENSITY ① — carry keyPoints from the book-body weave step.
+            ...(topic.keyPoints && topic.keyPoints.length > 0 ? { keyPoints: topic.keyPoints } : {}),
+            atoms,
+            qa,
+          };
         });
       } else {
         // LEGACY mode: one section per video (synthesis off/failed → safe fallback;

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -464,9 +464,11 @@ export async function fillMandalaBook(params: {
         mandala.title ?? ''
       );
       if (woven.ok) {
-        woven.narratives.forEach((nv, i) => {
+        woven.sections.forEach(({ narrative, keyPoints }, i) => {
           const t = chTopics[i];
-          if (t && nv) t.summary = nv; // enrich in place; empty slot ⇒ keep original
+          if (!t) return;
+          if (narrative) t.summary = narrative; // enrich in place; empty slot ⇒ keep original
+          if (keyPoints.length > 0) t.keyPoints = keyPoints; // NOTE-DENSITY ① — thread through
         });
         wovenChapters += 1;
       }

--- a/src/modules/mandala-book/topic-synthesis.ts
+++ b/src/modules/mandala-book/topic-synthesis.ts
@@ -54,6 +54,8 @@ export interface TopicSection {
   topic_title: string; // CONTENT name (e.g. "REST API 라우팅 구조"), NOT a video title
   summary: string; // 1-2 line topic framing (light synthesis, no invented facts)
   atom_refs: Array<{ vid: string; ts: number }>; // provenance — resolved from LLM indices
+  // NOTE-DENSITY ① — populated by book-body weave step; absent until then.
+  keyPoints?: string[];
 }
 
 /** Atoms intentionally dropped by compression (transparency — CP504 §4.5.0). */

--- a/tests/unit/modules/book-body.test.ts
+++ b/tests/unit/modules/book-body.test.ts
@@ -1,8 +1,9 @@
 /**
- * book-body (§4.5.1 [3] chapter body weave, CP504). OpenRouter MOCKED (no live
- * LLM). Locks: idx→narrative index-aligned map, omitted topic → empty slot
- * (caller falls back), out-of-range idx ignored, fence strip, newline collapse,
- * honest fail (json / no-sections / none-mapped), retry→fail, no_topics.
+ * book-body (§4.5.1 [3] chapter body weave, CP504 + NOTE-DENSITY ①). OpenRouter
+ * MOCKED (no live LLM). Locks: idx→section index-aligned map, keyPoints extracted
+ * + capped at 3, omitted topic → empty slot (caller falls back), out-of-range idx
+ * ignored, fence strip, newline collapse, honest fail (json / no-sections /
+ * none-mapped), retry→fail, no_topics, legacy response without keyPoints accepted.
  */
 
 const mockGenerate = jest.fn();
@@ -22,25 +23,63 @@ import {
 beforeEach(() => mockGenerate.mockReset());
 
 describe('parseChapterBodyResponse (pure — no LLM)', () => {
-  it('maps idx→narrative index-aligned, collapses newlines, strips fence', () => {
-    const raw = '```json\n{"sections":[{"idx":0,"narrative":"첫\\n문장"},{"idx":1,"narrative":"둘째"}]}\n```';
+  it('maps idx→section index-aligned, collapses newlines, strips fence, extracts keyPoints', () => {
+    const raw =
+      '```json\n{"sections":[' +
+      '{"idx":0,"narrative":"첫\\n문장","keyPoints":["핵심A","핵심B"]},' +
+      '{"idx":1,"narrative":"둘째","keyPoints":["포인트1"]}' +
+      ']}\n```';
     const r = parseChapterBodyResponse(raw, 2);
     expect(r.ok).toBe(true);
-    if (r.ok) expect(r.narratives).toEqual(['첫 문장', '둘째']);
+    if (!r.ok) return;
+    expect(r.sections[0]!.narrative).toBe('첫 문장');
+    expect(r.sections[0]!.keyPoints).toEqual(['핵심A', '핵심B']);
+    expect(r.sections[1]!.narrative).toBe('둘째');
+    expect(r.sections[1]!.keyPoints).toEqual(['포인트1']);
   });
 
-  it('leaves an empty slot for an omitted topic (caller keeps original summary)', () => {
-    const raw = '{"sections":[{"idx":1,"narrative":"둘째만"}]}';
+  it('leaves an empty-narrative slot for an omitted topic (caller keeps original summary)', () => {
+    const raw = '{"sections":[{"idx":1,"narrative":"둘째만","keyPoints":["k1"]}]}';
     const r = parseChapterBodyResponse(raw, 3);
     expect(r.ok).toBe(true);
-    if (r.ok) expect(r.narratives).toEqual(['', '둘째만', '']);
+    if (!r.ok) return;
+    expect(r.sections[0]!.narrative).toBe('');
+    expect(r.sections[0]!.keyPoints).toEqual([]);
+    expect(r.sections[1]!.narrative).toBe('둘째만');
+    expect(r.sections[2]!.narrative).toBe('');
   });
 
   it('ignores out-of-range idx', () => {
-    const raw = '{"sections":[{"idx":0,"narrative":"ok"},{"idx":9,"narrative":"버림"}]}';
+    const raw = '{"sections":[{"idx":0,"narrative":"ok","keyPoints":["k"]},{"idx":9,"narrative":"버림"}]}';
     const r = parseChapterBodyResponse(raw, 1);
     expect(r.ok).toBe(true);
-    if (r.ok) expect(r.narratives).toEqual(['ok']);
+    if (!r.ok) return;
+    expect(r.sections[0]!.narrative).toBe('ok');
+  });
+
+  it('accepts legacy response without keyPoints field — returns empty array', () => {
+    const raw = '{"sections":[{"idx":0,"narrative":"레거시 응답 — 키포인트 없음"}]}';
+    const r = parseChapterBodyResponse(raw, 1);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.sections[0]!.keyPoints).toEqual([]);
+  });
+
+  it('caps keyPoints at 3 even if model returns more', () => {
+    const raw =
+      '{"sections":[{"idx":0,"narrative":"n","keyPoints":["a","b","c","d","e"]}]}';
+    const r = parseChapterBodyResponse(raw, 1);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.sections[0]!.keyPoints).toHaveLength(3);
+  });
+
+  it('drops empty or whitespace-only keyPoint strings', () => {
+    const raw = '{"sections":[{"idx":0,"narrative":"n","keyPoints":["ok","  ","","valid"]}]}';
+    const r = parseChapterBodyResponse(raw, 1);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.sections[0]!.keyPoints).toEqual(['ok', 'valid']);
   });
 
   it('fails on invalid JSON / non-array / none mapped', () => {
@@ -56,13 +95,19 @@ describe('weaveChapterBody (OpenRouter mocked)', () => {
     { topicTitle: '주문', summary: '식당 주문 표현' },
   ];
 
-  it('returns index-aligned narratives on success', async () => {
+  it('returns index-aligned sections with narratives and keyPoints on success', async () => {
     mockGenerate.mockResolvedValueOnce(
-      '{"sections":[{"idx":0,"narrative":"먼저 인사로 문을 연다"},{"idx":1,"narrative":"이어 주문으로 나아간다"}]}'
+      '{"sections":[' +
+        '{"idx":0,"narrative":"먼저 인사로 문을 연다","keyPoints":["인사=대화 시작점"]},' +
+        '{"idx":1,"narrative":"이어 주문으로 나아간다","keyPoints":["주문 공식: I\\'d like + 명사"]}' +
+        ']}'
     );
     const r = await weaveChapterBody('도입', '맥락', topics, 'goal');
     expect(r.ok).toBe(true);
-    if (r.ok) expect(r.narratives).toEqual(['먼저 인사로 문을 연다', '이어 주문으로 나아간다']);
+    if (!r.ok) return;
+    expect(r.sections[0]!.narrative).toBe('먼저 인사로 문을 연다');
+    expect(r.sections[0]!.keyPoints).toEqual(['인사=대화 시작점']);
+    expect(r.sections[1]!.narrative).toBe('이어 주문으로 나아간다');
   });
 
   it('retries then fails on provider error (caller keeps summaries)', async () => {

--- a/tests/unit/modules/book-schema.test.ts
+++ b/tests/unit/modules/book-schema.test.ts
@@ -162,6 +162,33 @@ describe('book-schema v2 contract', () => {
   });
 });
 
+describe('book-schema — NOTE-DENSITY ① keyPoints (additive, optional)', () => {
+  it('accepts a section with keyPoints present', () => {
+    const b = validBook();
+    (b.chapters[0]!.sections[0] as Record<string, unknown>).keyPoints = [
+      'INT8 양자화: 메모리 75%↓, 성능 손실 1-2%',
+      '배치 추론 병렬화: 처리량 4×↑',
+    ];
+    const parsed = parseBookJson(b);
+    expect(firstSection(parsed).keyPoints).toEqual([
+      'INT8 양자화: 메모리 75%↓, 성능 손실 1-2%',
+      '배치 추론 병렬화: 처리량 4×↑',
+    ]);
+  });
+
+  it('accepts a section WITHOUT keyPoints — existing books stay valid', () => {
+    const b = validBook(); // no keyPoints field
+    const parsed = parseBookJson(b);
+    expect(firstSection(parsed).keyPoints).toBeUndefined();
+  });
+
+  it('rejects a keyPoints value that is not an array', () => {
+    const b = validBook();
+    (b.chapters[0]!.sections[0] as Record<string, unknown>).keyPoints = 'not-an-array';
+    expect(bookJsonSchema.safeParse(b).success).toBe(false);
+  });
+});
+
 describe('book-schema — CP504 loop-2 additive keys (G-SHAPE: additive, no rejection)', () => {
   it('legacy book WITHOUT references/research/verification.checks still parses', () => {
     expect(() => parseBookJson(validBook())).not.toThrow();


### PR DESCRIPTION
## Summary

Adds real distilled key-points to the mandala-book generation pipeline (BE only). Companion to the FE rendering PR (`feat/note-keypoints-render`).

- **`book-schema.ts`**: `bookSectionSchema` gains `keyPoints: z.array(z.string()).optional()`. Additive — existing `book_json` rows without the field parse unchanged.
- **`book-body.ts`**: `buildChapterBodyPrompt` rule-5 instructs the model to produce 2-3 distilled take-aways per section that are explicitly NOT a repeat of the narrative (dense bullet: numbers/principles/conclusions, ≤1 line each). `ChapterBodyResult` ok-branch changed from `{narratives:string[]}` to `{sections:BodySectionResult[]}`. `parseChapterBodyResponse` extracts keyPoints (trimmed, non-empty, capped at 3, `[]` when model omits — flag-safe).
- **`topic-synthesis.ts`**: `TopicSection` gains `keyPoints?: string[]` populated by the book-body weave step.
- **`fill-book.ts`**: `woven.sections.forEach` threads both `narrative` and `keyPoints` in-place (empty keyPoints → no write, original preserved).
- **`build-book.ts`**: `sectionFromTopic` + inline cell-topic path conditionally spread `keyPoints` (absent → output byte-identical, all legacy books unaffected).

## keyPoints prompt instruction (verbatim)

> 5. 각 토픽에 대해 keyPoints(2-3개)를 작성한다: 독자가 반드시 기억해야 할 압축 핵심. ★중요: keyPoints는 narrative의 문장 반복이 아니다 — narrative를 읽지 않아도 핵심을 알 수 있는 밀도 높은 bullet(예: "INT8 양자화: 메모리 75%↓, 성능 손실 1-2%"). 수치·원칙·결론 중심, 각 항목 한 줄 이내.

Updated JSON output contract:
```json
{"sections":[{"idx":0,"narrative":"...","keyPoints":["핵심1","핵심2"]}]}
```

## Parser handling

- Walks `sections[]`, filters `keyPoints` to strings only, collapses stray newlines, trims, drops empty/whitespace, slices to max 3.
- Model omits field → empty array `[]` (no error, caller gets `keyPoints: []`).
- Invalid JSON / no sections / none mapped → `ok: false` (existing fail modes unchanged).

## Where keyPoints lands in book_json

1. `fill-book.ts` line 467: `woven.sections.forEach(({narrative, keyPoints}, i) => ... t.keyPoints = keyPoints)`
2. `build-book.ts` `sectionFromTopic` + inline cell-topic path: `...(topic.keyPoints?.length ? { keyPoints: topic.keyPoints } : {})`
3. Schema validates via `bookSectionSchema.keyPoints: z.array(z.string()).optional()`

## Tests

- **`book-body.test.ts`**: 4 new cases — keyPoints extracted + newline-collapsed, cap-3 enforced, empty/whitespace strings dropped, legacy model response without keyPoints field → `[]`. Existing tests updated to `sections` API.
- **`book-schema.test.ts`**: 3 new cases — section with keyPoints parses correctly, section without keyPoints valid (backward compat), non-array value rejected.
- Local toolchain exits 194 (node_modules is a circular symlink) — CI is the verification gate.

## Test plan

- [ ] CI Jest passes on `book-body.test.ts` and `book-schema.test.ts`
- [ ] Prod `safeParseBookJson` on existing `book_json` rows succeeds (no keyPoints — backward compat)
- [ ] After re-generating a mandala book: sections contain `keyPoints` arrays with 2-3 dense bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)