### PR TITLE
feat(note-cv): figure value gate — drop generic illustrations [NOTE-FULL-TOOLSET ④]

### DIFF
--- a/src/modules/mandala-book/figure-value-gate.ts
+++ b/src/modules/mandala-book/figure-value-gate.ts
@@ -1,0 +1,256 @@
+// Figure value gate — drops generic illustrations before attaching to book sections.
+//
+// A figure must ADD information the section text lacks. Generic metaphors or diagrams
+// that merely restate the prose are "어거지 삽화" (forced filler) with zero info increment.
+// Policy per kind:
+//   equation → KEEP always (formula = portable info, always additive).
+//   chart    → KEEP (renderFigureSvg non-null already proves non-flat variance).
+//   table    → KEEP if struct.headers + ≥2 rows.
+//   diagram  → Haiku judge: specific structure NOT stated in section text? KEEP else DROP.
+//              Conservative default: DROP on uncertainty / parse failure.
+//
+// Service module — the Haiku call is a PRODUCTION call via OpenRouter.
+// Unit tests MUST mock OpenRouterGenerationProvider (LLM-API ban).
+
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'mandala-book/figure-value-gate' });
+
+const HAIKU_MODEL = 'anthropic/claude-haiku-4.5';
+const DIAGRAM_JUDGE_MAX_TOKENS = 256;
+const DIAGRAM_JUDGE_TEMPERATURE = 0.1;
+
+// Max chars of section narrative sent to diagram judge (cost control).
+const NARRATIVE_EXCERPT_LEN = 300;
+// Max nodes/edges shown in diagram struct summary (cost control).
+const STRUCT_NODE_CAP = 10;
+const STRUCT_EDGE_CAP = 10;
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+/** Strict output expected from the Haiku diagram judge. */
+export interface DiagramJudgeResult {
+  keep: boolean;
+  reason: string;
+}
+
+// ---------------------------------------------------------------------------
+// Struct summariser (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Produce a compact text representation of a diagram struct for inclusion in
+ * the judge prompt. Handles common graph-like shapes (nodes[]/edges[]) and
+ * falls back to a JSON snippet for unknown shapes.
+ */
+export function summarizeDiagramStruct(struct: Record<string, unknown>): string {
+  const nodeList = Array.isArray(struct['nodes']) ? (struct['nodes'] as unknown[]) : null;
+  const edgeList = Array.isArray(struct['edges']) ? (struct['edges'] as unknown[]) : null;
+
+  const parts: string[] = [];
+
+  if (nodeList) {
+    const labels = nodeList.slice(0, STRUCT_NODE_CAP).map((n) => {
+      if (typeof n === 'object' && n !== null) {
+        const obj = n as Record<string, unknown>;
+        return String(obj['label'] ?? obj['id'] ?? obj['name'] ?? '?');
+      }
+      return String(n);
+    });
+    parts.push(`nodes: [${labels.join(', ')}]`);
+  }
+
+  if (edgeList) {
+    const arrows = edgeList.slice(0, STRUCT_EDGE_CAP).map((e) => {
+      if (typeof e === 'object' && e !== null) {
+        const obj = e as Record<string, unknown>;
+        const src = String(obj['from'] ?? obj['source'] ?? obj['src'] ?? '?');
+        const dst = String(obj['to'] ?? obj['target'] ?? obj['dst'] ?? '?');
+        return `${src}→${dst}`;
+      }
+      return String(e);
+    });
+    parts.push(`edges: [${arrows.join(', ')}]`);
+  }
+
+  if (parts.length > 0) return parts.join('; ');
+
+  // Fallback: truncated JSON for unknown struct shapes.
+  return JSON.stringify(struct).slice(0, 200);
+}
+
+// ---------------------------------------------------------------------------
+// Diagram judge prompt (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the Haiku prompt for the diagram value judge.
+ * Ask: does the diagram add SPECIFIC structure the section text already fully conveys?
+ */
+export function buildDiagramJudgePrompt(
+  structSummary: string,
+  sectionTitle: string,
+  sectionNarrative: string
+): string {
+  const excerpt = sectionNarrative.slice(0, NARRATIVE_EXCERPT_LEN);
+  return [
+    'You judge whether a diagram adds information not already stated in the section text.',
+    '',
+    `Section title: ${sectionTitle}`,
+    `Section text (excerpt): ${excerpt}`,
+    '',
+    `Diagram structure: ${structSummary}`,
+    '',
+    'Question: Does this diagram convey a SPECIFIC structure or relationship that is NOT',
+    'already fully stated in the section text? If the diagram merely illustrates what the',
+    'text already says in full, it is a generic filler and should be DROPPED.',
+    '',
+    'DROP examples: "neurons connecting" sketch for a neural-network intro section,',
+    '"boxer 120kg→60kg" metaphor for a weight-loss analogy, "chip→cloud" arrow restating',
+    '"edge computing" already described in prose.',
+    'KEEP examples: transformer attention-head matrix with specific layer names,',
+    'TCP three-way handshake state machine with state labels, backprop gradient flow',
+    'annotated with weight dimensions.',
+    '',
+    'Return JSON only (no code fence, no extra text):',
+    '{"keep": true|false, "reason": "one sentence"}',
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Judge response parser (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse Haiku judge raw output into DiagramJudgeResult.
+ * Conservative: any parse/shape failure returns keep=false.
+ */
+export function parseJudgeResponse(raw: string): DiagramJudgeResult {
+  const stripped = raw
+    .trim()
+    .replace(/^\s*```(?:json)?\s*\n?/i, '')
+    .replace(/\n?\s*```\s*$/i, '')
+    .trim();
+
+  try {
+    const parsed = JSON.parse(stripped) as unknown;
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof (parsed as Record<string, unknown>)['keep'] === 'boolean'
+    ) {
+      const obj = parsed as Record<string, unknown>;
+      return {
+        keep: obj['keep'] as boolean,
+        reason: typeof obj['reason'] === 'string' ? obj['reason'] : '',
+      };
+    }
+  } catch {
+    // JSON parse failure → conservative drop
+  }
+
+  return { keep: false, reason: 'parse-failure: conservative drop' };
+}
+
+// ---------------------------------------------------------------------------
+// Diagram judge (exported for tests + handler)
+// ---------------------------------------------------------------------------
+
+/**
+ * Judge a diagram figure via Haiku: does it add specific structure the section text lacks?
+ * Conservative default: DROP on LLM error, timeout, or parse failure.
+ */
+export async function judgeDiagram(
+  struct: Record<string, unknown> | undefined,
+  sectionTitle: string,
+  sectionNarrative: string
+): Promise<DiagramJudgeResult> {
+  if (!struct) {
+    return { keep: false, reason: 'no-struct: conservative drop' };
+  }
+
+  const structSummary = summarizeDiagramStruct(struct);
+  const prompt = buildDiagramJudgePrompt(structSummary, sectionTitle, sectionNarrative);
+
+  let raw: string;
+  try {
+    raw = await new OpenRouterGenerationProvider(HAIKU_MODEL).generate(prompt, {
+      format: 'json',
+      temperature: DIAGRAM_JUDGE_TEMPERATURE,
+      maxTokens: DIAGRAM_JUDGE_MAX_TOKENS,
+    });
+  } catch (err) {
+    log.warn('figure-value-gate: diagram judge LLM 호출 실패 → DROP', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { keep: false, reason: 'llm-error: conservative drop' };
+  }
+
+  const result = parseJudgeResponse(raw);
+  log.debug('figure-value-gate: diagram judge 결과', {
+    keep: result.keep,
+    reason: result.reason,
+  });
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Options for passesFigureValueGate. */
+export interface FigureValueGateOpts {
+  kind: string;
+  /** struct narrowed from FigureRef.struct (null/undefined when absent). */
+  struct: Record<string, unknown> | undefined;
+  /** Title of the section the figure would attach to (for diagram judge). */
+  sectionTitle: string;
+  /** Narrative body of the section (for diagram judge). */
+  sectionNarrative: string;
+}
+
+/**
+ * Value gate: decide whether to attach a figure to a section.
+ * Returns true → KEEP (attach); false → DROP.
+ *
+ * equation  — always KEEP.
+ * chart     — always KEEP (SVG presence already proved non-flat variance).
+ * table     — KEEP if struct has headers[] + ≥2 rows[].
+ * diagram   — Haiku judge per (struct, section); DROP on uncertainty (conservative).
+ * other     — DROP (unknown kinds are not information-bearing by policy).
+ *
+ * Never throws — all errors default to DROP.
+ */
+export async function passesFigureValueGate(opts: FigureValueGateOpts): Promise<boolean> {
+  const { kind, struct, sectionTitle, sectionNarrative } = opts;
+
+  switch (kind) {
+    case 'equation':
+      // Equations are always information-bearing: formula is portable + non-redundant.
+      return true;
+
+    case 'chart':
+      // renderFigureSvg non-null already proved non-flat data variance (slidegen gate).
+      return true;
+
+    case 'table': {
+      if (!struct) return false;
+      const hasHeaders =
+        Array.isArray(struct['headers']) && (struct['headers'] as unknown[]).length > 0;
+      const hasRows = Array.isArray(struct['rows']) && (struct['rows'] as unknown[]).length >= 2;
+      return hasHeaders && hasRows;
+    }
+
+    case 'diagram': {
+      const result = await judgeDiagram(struct, sectionTitle, sectionNarrative);
+      return result.keep;
+    }
+
+    default:
+      // Unknown kinds are not information-bearing by policy.
+      return false;
+  }
+}

--- a/src/modules/queue/handlers/note-cv-enrich.ts
+++ b/src/modules/queue/handlers/note-cv-enrich.ts
@@ -16,6 +16,7 @@ import { getJobQueue } from '../manager';
 import { JOB_NAMES, NOTE_CV_ENRICH_OPTIONS, type NoteCvEnrichPayload } from '../types';
 import { richSummaryWorkOptions } from './rich-summary-work-options';
 import type { BookFigure } from '@/modules/mandala-book/book-schema';
+import { passesFigureValueGate } from '@/modules/mandala-book/figure-value-gate';
 
 const log = logger.child({ module: 'queue/note-cv-enrich' });
 
@@ -96,7 +97,9 @@ export async function handleNoteCvEnrich(job: PgBoss.Job<NoteCvEnrichPayload>): 
   let kept = 0;
   let dropped = 0;
   let droppedNoSvg = 0; // chart/diagram where /render-figure returned null (degenerate)
+  let valueDropped = 0; // passed SVG filter but dropped by figure value gate
   let svgRendered = 0; // chart/diagram that got a valid SVG
+  let attached = 0; // figures actually pushed into section.figures
   let totalCalls = 0;
 
   for (const [videoId, videoTargets] of targetsByVideo) {
@@ -161,6 +164,28 @@ export async function handleNoteCvEnrich(job: PgBoss.Job<NoteCvEnrichPayload>): 
             ),
           ]
         : [];
+
+      // f. Value gate: drop generic illustrations that add no information beyond
+      // the section text. Evaluate once per figure using the first matched section
+      // as context (diagram judge needs section title+narrative; for diagrams
+      // the figure almost always maps to exactly one section). Skip when no
+      // matching target exists — no push will happen regardless.
+      if (matching.length > 0) {
+        const firstTarget = matching[0]!;
+        const firstCh = book.chapters[firstTarget.chapterIdx];
+        const firstSec = firstCh?.sections[firstTarget.sectionIdx];
+        const passes = await passesFigureValueGate({
+          kind: fig.kind,
+          struct,
+          sectionTitle: firstSec?.title ?? '',
+          sectionNarrative: firstSec?.narrative ?? '',
+        });
+        if (!passes) {
+          valueDropped++;
+          continue;
+        }
+      }
+
       for (const target of matching) {
         const ch = book.chapters[target.chapterIdx];
         if (!ch) continue;
@@ -172,6 +197,7 @@ export async function handleNoteCvEnrich(job: PgBoss.Job<NoteCvEnrichPayload>): 
         if (alreadyPresent) continue;
         if (!sec.figures) sec.figures = [];
         sec.figures.push(bookFig);
+        attached++;
       }
     }
   }
@@ -186,11 +212,13 @@ export async function handleNoteCvEnrich(job: PgBoss.Job<NoteCvEnrichPayload>): 
     kept,
     dropped,
     droppedNoSvg,
+    valueDropped,
     svgRendered,
+    attached,
     wallMs,
   });
 
-  if (kept === 0) return; // Nothing to write back.
+  if (attached === 0) return; // Nothing to write back.
 
   // f. Bump generated_at, re-validate with parseBookJson before write.
   book.generated_at = new Date().toISOString();

--- a/tests/unit/modules/figure-value-gate.test.ts
+++ b/tests/unit/modules/figure-value-gate.test.ts
@@ -1,0 +1,386 @@
+/**
+ * figure-value-gate — value gate that drops generic filler figures.
+ *
+ * Locks:
+ *   - equation: always KEEP (no LLM call)
+ *   - chart:    always KEEP (no LLM call)
+ *   - table:    KEEP only if struct has headers[] + ≥2 rows[]
+ *   - diagram:  KEEP when judge returns keep:true; DROP when keep:false or error
+ *   - conservative default: DROP on parse failure or LLM error
+ *
+ * OpenRouterGenerationProvider is MOCKED (LLM-API ban).
+ */
+
+const mockGenerate = jest.fn();
+jest.mock('@/modules/llm/openrouter', () => ({
+  OpenRouterGenerationProvider: jest.fn().mockImplementation(() => ({ generate: mockGenerate })),
+}));
+jest.mock('@/config/index', () => ({
+  config: { paths: { logs: '/tmp' }, app: { isTest: true } },
+}));
+
+import {
+  passesFigureValueGate,
+  judgeDiagram,
+  parseJudgeResponse,
+  buildDiagramJudgePrompt,
+  summarizeDiagramStruct,
+} from '../../../src/modules/mandala-book/figure-value-gate';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SECTION_TITLE = 'Backpropagation';
+const SECTION_NARRATIVE =
+  'Backpropagation applies the chain rule to propagate error gradients through layers.';
+
+const SPECIFIC_DIAGRAM_STRUCT = {
+  nodes: [
+    { id: 'L1', label: 'Input layer' },
+    { id: 'L2', label: 'Hidden layer (ReLU)' },
+    { id: 'L3', label: 'Output layer (softmax)' },
+  ],
+  edges: [
+    { from: 'L1', to: 'L2', label: '∂L/∂w1' },
+    { from: 'L2', to: 'L3', label: '∂L/∂w2' },
+  ],
+};
+
+const GENERIC_DIAGRAM_STRUCT = {
+  nodes: [{ label: 'neurons' }, { label: 'connections' }],
+  edges: [{ from: 'neurons', to: 'connections' }],
+};
+
+const TABLE_GOOD_STRUCT = {
+  headers: ['Layer', 'Activation', 'Params'],
+  rows: [
+    ['Conv1', 'ReLU', '9.4k'],
+    ['Conv2', 'ReLU', '73.7k'],
+    ['FC', 'Softmax', '400k'],
+  ],
+};
+
+const TABLE_SINGLE_ROW_STRUCT = {
+  headers: ['Metric', 'Value'],
+  rows: [['Accuracy', '95%']],
+};
+
+const TABLE_NO_HEADERS_STRUCT = {
+  rows: [
+    ['a', 'b'],
+    ['c', 'd'],
+  ],
+};
+
+beforeEach(() => mockGenerate.mockReset());
+
+// ---------------------------------------------------------------------------
+// passesFigureValueGate — equation
+// ---------------------------------------------------------------------------
+
+describe('passesFigureValueGate: equation', () => {
+  it('always KEEP, no LLM call', async () => {
+    const result = await passesFigureValueGate({
+      kind: 'equation',
+      struct: undefined,
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(true);
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// passesFigureValueGate — chart
+// ---------------------------------------------------------------------------
+
+describe('passesFigureValueGate: chart', () => {
+  it('always KEEP (SVG presence proves non-flat variance), no LLM call', async () => {
+    const result = await passesFigureValueGate({
+      kind: 'chart',
+      struct: { type: 'bar', data: [] },
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(true);
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// passesFigureValueGate — table
+// ---------------------------------------------------------------------------
+
+describe('passesFigureValueGate: table', () => {
+  it('KEEP when struct has headers and ≥2 rows', async () => {
+    const result = await passesFigureValueGate({
+      kind: 'table',
+      struct: TABLE_GOOD_STRUCT,
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(true);
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('DROP when struct has only 1 row', async () => {
+    const result = await passesFigureValueGate({
+      kind: 'table',
+      struct: TABLE_SINGLE_ROW_STRUCT,
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('DROP when struct has no headers', async () => {
+    const result = await passesFigureValueGate({
+      kind: 'table',
+      struct: TABLE_NO_HEADERS_STRUCT,
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('DROP when struct is undefined', async () => {
+    const result = await passesFigureValueGate({
+      kind: 'table',
+      struct: undefined,
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// passesFigureValueGate — diagram
+// ---------------------------------------------------------------------------
+
+describe('passesFigureValueGate: diagram', () => {
+  it('KEEP when Haiku judge returns keep:true (specific structure)', async () => {
+    mockGenerate.mockResolvedValueOnce(JSON.stringify({ keep: true, reason: 'Specific layers.' }));
+
+    const result = await passesFigureValueGate({
+      kind: 'diagram',
+      struct: SPECIFIC_DIAGRAM_STRUCT,
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(true);
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('DROP when Haiku judge returns keep:false (generic metaphor)', async () => {
+    mockGenerate.mockResolvedValueOnce(
+      JSON.stringify({ keep: false, reason: 'Generic neuron sketch.' })
+    );
+
+    const result = await passesFigureValueGate({
+      kind: 'diagram',
+      struct: GENERIC_DIAGRAM_STRUCT,
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('DROP (conservative) when LLM throws', async () => {
+    mockGenerate.mockRejectedValueOnce(new Error('provider failure'));
+
+    const result = await passesFigureValueGate({
+      kind: 'diagram',
+      struct: SPECIFIC_DIAGRAM_STRUCT,
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('DROP (conservative) when LLM returns unparseable output', async () => {
+    mockGenerate.mockResolvedValueOnce('not json at all');
+
+    const result = await passesFigureValueGate({
+      kind: 'diagram',
+      struct: SPECIFIC_DIAGRAM_STRUCT,
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('DROP (conservative) when LLM returns JSON missing "keep" field', async () => {
+    mockGenerate.mockResolvedValueOnce(JSON.stringify({ reason: 'I forgot the keep field.' }));
+
+    const result = await passesFigureValueGate({
+      kind: 'diagram',
+      struct: SPECIFIC_DIAGRAM_STRUCT,
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('DROP when struct is undefined (no-struct path)', async () => {
+    const result = await passesFigureValueGate({
+      kind: 'diagram',
+      struct: undefined,
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(false);
+    // No LLM call when struct is missing.
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// passesFigureValueGate — unknown kind
+// ---------------------------------------------------------------------------
+
+describe('passesFigureValueGate: unknown kind', () => {
+  it('DROP for any unrecognised kind', async () => {
+    const result = await passesFigureValueGate({
+      kind: 'keyframe',
+      struct: undefined,
+      sectionTitle: SECTION_TITLE,
+      sectionNarrative: SECTION_NARRATIVE,
+    });
+    expect(result).toBe(false);
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// judgeDiagram — unit tests for the diagram judge directly
+// ---------------------------------------------------------------------------
+
+describe('judgeDiagram', () => {
+  it('returns keep:true for a specific structural diagram (mock)', async () => {
+    mockGenerate.mockResolvedValueOnce(
+      JSON.stringify({ keep: true, reason: 'Annotated layer dimensions.' })
+    );
+    const result = await judgeDiagram(SPECIFIC_DIAGRAM_STRUCT, SECTION_TITLE, SECTION_NARRATIVE);
+    expect(result.keep).toBe(true);
+  });
+
+  it('returns keep:false (conservative) on JSON parse failure', async () => {
+    mockGenerate.mockResolvedValueOnce('{bad json');
+    const result = await judgeDiagram(SPECIFIC_DIAGRAM_STRUCT, SECTION_TITLE, SECTION_NARRATIVE);
+    expect(result.keep).toBe(false);
+    expect(result.reason).toMatch(/parse-failure/);
+  });
+
+  it('returns keep:false (conservative) on LLM error', async () => {
+    mockGenerate.mockRejectedValueOnce(new Error('timeout'));
+    const result = await judgeDiagram(SPECIFIC_DIAGRAM_STRUCT, SECTION_TITLE, SECTION_NARRATIVE);
+    expect(result.keep).toBe(false);
+    expect(result.reason).toMatch(/llm-error/);
+  });
+
+  it('uses the Haiku model (contains "haiku")', async () => {
+    mockGenerate.mockResolvedValueOnce(JSON.stringify({ keep: true, reason: 'ok' }));
+    const { OpenRouterGenerationProvider } = jest.requireMock('@/modules/llm/openrouter') as {
+      OpenRouterGenerationProvider: jest.Mock;
+    };
+    OpenRouterGenerationProvider.mockClear();
+
+    await judgeDiagram(SPECIFIC_DIAGRAM_STRUCT, SECTION_TITLE, SECTION_NARRATIVE);
+    expect(OpenRouterGenerationProvider).toHaveBeenCalledWith(expect.stringMatching(/haiku/i));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseJudgeResponse — pure parser
+// ---------------------------------------------------------------------------
+
+describe('parseJudgeResponse', () => {
+  it('parses keep:true response', () => {
+    const result = parseJudgeResponse(JSON.stringify({ keep: true, reason: 'Specific.' }));
+    expect(result).toEqual({ keep: true, reason: 'Specific.' });
+  });
+
+  it('parses keep:false response', () => {
+    const result = parseJudgeResponse(JSON.stringify({ keep: false, reason: 'Generic.' }));
+    expect(result).toEqual({ keep: false, reason: 'Generic.' });
+  });
+
+  it('strips code fences before parsing', () => {
+    const inner = JSON.stringify({ keep: true, reason: 'ok' });
+    const result = parseJudgeResponse(`\`\`\`json\n${inner}\n\`\`\``);
+    expect(result.keep).toBe(true);
+  });
+
+  it('returns keep:false on invalid JSON', () => {
+    const result = parseJudgeResponse('not json');
+    expect(result.keep).toBe(false);
+    expect(result.reason).toMatch(/parse-failure/);
+  });
+
+  it('returns keep:false when "keep" field is missing', () => {
+    const result = parseJudgeResponse(JSON.stringify({ reason: 'no keep field' }));
+    expect(result.keep).toBe(false);
+  });
+
+  it('returns keep:false when JSON is a non-object value', () => {
+    expect(parseJudgeResponse('"just a string"').keep).toBe(false);
+    expect(parseJudgeResponse('42').keep).toBe(false);
+    expect(parseJudgeResponse('null').keep).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDiagramJudgePrompt — structural smoke tests
+// ---------------------------------------------------------------------------
+
+describe('buildDiagramJudgePrompt', () => {
+  it('includes section title and narrative excerpt', () => {
+    const prompt = buildDiagramJudgePrompt('nodes: [A, B]', SECTION_TITLE, SECTION_NARRATIVE);
+    expect(prompt).toContain(SECTION_TITLE);
+    expect(prompt).toContain(SECTION_NARRATIVE.slice(0, 50));
+  });
+
+  it('includes the struct summary', () => {
+    const prompt = buildDiagramJudgePrompt('nodes: [A, B]', SECTION_TITLE, SECTION_NARRATIVE);
+    expect(prompt).toContain('nodes: [A, B]');
+  });
+
+  it('mentions DROP and KEEP examples', () => {
+    const prompt = buildDiagramJudgePrompt('nodes: [A]', SECTION_TITLE, SECTION_NARRATIVE);
+    expect(prompt).toMatch(/DROP/);
+    expect(prompt).toMatch(/KEEP/);
+  });
+
+  it('requests JSON output with keep field', () => {
+    const prompt = buildDiagramJudgePrompt('nodes: [A]', SECTION_TITLE, SECTION_NARRATIVE);
+    expect(prompt).toContain('"keep"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeDiagramStruct — pure struct → text
+// ---------------------------------------------------------------------------
+
+describe('summarizeDiagramStruct', () => {
+  it('produces node and edge summary for standard graph struct', () => {
+    const summary = summarizeDiagramStruct(SPECIFIC_DIAGRAM_STRUCT);
+    expect(summary).toContain('nodes:');
+    expect(summary).toContain('Input layer');
+    expect(summary).toContain('edges:');
+    expect(summary).toContain('→');
+  });
+
+  it('falls back to JSON snippet for unknown struct shapes', () => {
+    const summary = summarizeDiagramStruct({ something: 'unusual', nested: { x: 1 } });
+    expect(typeof summary).toBe('string');
+    expect(summary.length).toBeGreaterThan(0);
+  });
+
+  it('handles empty nodes and edges arrays', () => {
+    const summary = summarizeDiagramStruct({ nodes: [], edges: [] });
+    expect(summary).toContain('nodes: []');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/modules/mandala-book/figure-value-gate.ts` — per-kind value gate that drops generic metaphor illustrations ("어거지 삽화") and retains only information-bearing figures before attaching to `section.figures`
- Modifies `src/modules/queue/handlers/note-cv-enrich.ts` — runs the gate per figure (after SVG render, before section push); adds `valueDropped` + `attached` counters to the completion log; write-skip guard now uses `attached === 0` (more accurate: no section modified = no DB write)
- Adds `tests/unit/modules/figure-value-gate.test.ts` — 30 tests, all pass; OpenRouter mocked (LLM-API ban enforced)

## Gate rules per kind

| Kind | Rule |
|------|------|
| `equation` | Always KEEP — formula is portable and non-redundant by definition |
| `chart` | Always KEEP — `renderFigureSvg` non-null already proved non-flat data variance via the slidegen gate |
| `table` | KEEP if `struct.headers[]` non-empty AND `struct.rows[]` ≥ 2 |
| `diagram` | Haiku judge call: does the diagram convey a SPECIFIC structure NOT already stated in section text? Conservative default = DROP on uncertainty, parse failure, or LLM error |

## Diagram judge prompt (key fragment)

```
Question: Does this diagram convey a SPECIFIC structure or relationship that is NOT
already fully stated in the section text? If the diagram merely illustrates what the
text already says in full, it is a generic filler and should be DROPPED.

DROP examples: "neurons connecting" sketch, "boxer 120kg→60kg" metaphor, "chip→cloud" arrow
KEEP examples: transformer attention-head matrix with layer names, TCP handshake state machine
```

## Gate placement in handler

```
getOrExtractSnapshots() → kind/verification filter → renderFigureSvg (chart/diagram)
→ kept++ → build bookFig → compute matching section(s)
→ [NEW] passesFigureValueGate(kind, struct, firstSec.title, firstSec.narrative)
   → valueDropped++ + continue on false
→ sec.figures.push(bookFig) + attached++
```

## Test plan

- [x] `npm test tests/unit/modules/figure-value-gate.test.ts` — 30/30 pass
- [x] TypeScript: zero new errors (`tsc --noEmit`)
- [x] Prettier + ESLint clean (pre-commit hook passed)
- [ ] Prod: deploy and observe `valueDropped` in `note-cv-enrich 완료` log to confirm gate fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)