### PR TITLE
feat(note): rich-markdown narrative + keyPoint prose synthesis [NOTE-DENSITY ①-v2]

### DIFF
--- a/src/modules/mandala-book/book-body.ts
+++ b/src/modules/mandala-book/book-body.ts
@@ -35,10 +35,11 @@ export interface BodyTopicInput {
   summary: string;
 }
 
-/** Per-section output carrying both the woven prose and the distilled key-points. */
+/** Per-section output: rich-markdown narrative + key-point prose synthesis. */
 export interface BodySectionResult {
-  narrative: string;
-  keyPoints: string[]; // 2-3 compressed take-aways; empty when model omits
+  narrative: string; // Rich markdown (newlines preserved); do NOT strip.
+  keyPoints: string[]; // Back-compat (old array contract). Empty by default; generation fills keyPoint.
+  keyPoint?: string; // 2-3 sentence prose synthesis; absent when model omits.
 }
 
 export type ChapterBodyResult =
@@ -48,7 +49,8 @@ export type ChapterBodyResult =
 interface LlmBodySection {
   idx?: unknown;
   narrative?: unknown;
-  keyPoints?: unknown; // NOTE-DENSITY ① — model may emit array of strings
+  keyPoints?: unknown; // Back-compat: old array contract (ignored by parser, kept for back-compat).
+  keyPoint?: unknown; // New: prose synthesis string.
 }
 
 /**
@@ -73,15 +75,26 @@ export function buildChapterBodyPrompt(
     indexed,
     ``,
     `본문 작성 규칙:`,
-    `1. 각 토픽 [n]에 대해, 그 토픽을 챕터 흐름 안에서 자연스럽게 읽히도록 다시 쓴다(서술 narrative).`,
-    `2. 연결·전환·맥락 문장은 창작해도 된다(예: "앞에서 다진 기초를 바탕으로"). 그러나 ★사실은 주어진 요약에 있는 것만 써라 — 요약에 없는 새 사실(표현·수치·이름·개념)을 절대 지어내지 마라.`,
-    `3. 토픽 순서와 개수를 유지한다(입력 ${topics.length}개 → 출력 ${topics.length}개, idx 일치).`,
-    `4. 각 narrative는 토픽 요약보다 풍부하되 간결하게(2-4문장). 영상제목·채널명 금지.`,
-    `5. 각 토픽에 대해 keyPoints(2-3개)를 작성한다: 독자가 반드시 기억해야 할 압축 핵심. ★중요: keyPoints는 narrative의 문장 반복이 아니다 — narrative를 읽지 않아도 핵심을 알 수 있는 밀도 높은 bullet(예: "INT8 양자화: 메모리 75%↓, 성능 손실 1-2%"). 수치·원칙·결론 중심, 각 항목 한 줄 이내.`,
+    `1. 각 토픽 [n]에 대해, 챕터 흐름 안에서 자연스럽게 읽히도록 다시 쓴다(narrative).`,
+    `2. 연결·전환·맥락 문장은 창작해도 된다(예: "앞에서 다진 기초를 바탕으로"). ★사실은 주어진 요약에 있는 것만 써라 — 요약에 없는 사실·수치·이름·개념을 절대 지어내지 마라.`,
+    `3. 토픽 순서·개수를 유지한다(입력 ${topics.length}개 → 출력 ${topics.length}개, idx 일치).`,
+    `4. 영상 제목·채널명 금지.`,
     ``,
-    `★ narrative와 keyPoints 각 항목은 반드시 한 줄(개행·줄바꿈 문자 절대 금지 — JSON 파싱 보호).`,
-    `JSON만 출력(코드펜스 금지):`,
-    `{"sections":[{"idx":0,"narrative":"...","keyPoints":["핵심1","핵심2"]}]}`,
+    `★ narrative는 RICH MARKDOWN — 내용에 적합한 도구를 선택(모든 섹션에 억지로 모든 도구 쓰지 말 것):`,
+    `• **굵게**: 정의되는 핵심 용어 + 결정적 수치("75%", "4비트") 전용. 장식·일반명사에 쓰지 말 것.`,
+    `• \`- \` 불릿 목록: 순서 없는 열거.`,
+    `• \`1. \` 번호 목록: 단계별 절차·순서.`,
+    `• \`> [!note]\` / \`> [!tip]\` / \`> [!warning]\`: 보충 callout (Obsidian admonition 형식).`,
+    `• \`\`\`mermaid\\n...\`\`\`: 흐름·관계·아키텍처(예: flowchart LR; A-->B). 실제 구조가 있을 때만.`,
+    `• \`| 열 | 열 |\` GFM 테이블: A vs B 비교가 있으면 반드시 테이블.`,
+    `• 그 외: 빈 줄로 구분된 산문 단락.`,
+    `도구 강제 원칙: 비교→테이블, 다단계 절차→번호 목록, 흐름·관계→mermaid. 밀도·학술적 명확성 우선.`,
+    ``,
+    `5. 각 토픽에 keyPoint를 작성한다: 이 섹션의 본질을 새 문장으로 압축한 2-3문장 산문 종합.`,
+    `   ★ 불릿 금지. narrative 문장 그대로 반복 금지. 독자가 기억해야 할 핵심 통찰만.`,
+    ``,
+    `JSON만 출력(코드펜스 없이). narrative 안의 개행은 \\n으로 이스케이프(JSON 문자열 규칙):`,
+    `{"sections":[{"idx":0,"narrative":"<마크다운>","keyPoint":"<2-3문장 산문>"}]}`,
   ]
     .filter((l) => l !== ``)
     .join('\n');
@@ -150,8 +163,9 @@ async function attemptBody(
  * Pure parse + index-map of the body response. Exported for fixture unit tests
  * (no live LLM). Returns sections index-aligned with the input topics; any
  * topic the model omits keeps an empty-narrative slot (caller falls back to its
- * summary). keyPoints: trimmed non-empty strings, capped at 3, empty array when
- * the model omits the field (flag-safe — existing call sites unaffected).
+ * summary). narrative is kept raw (markdown; newlines preserved — NOT collapsed).
+ * keyPoint: 2-3 sentence prose synthesis (optional; undefined when model omits).
+ * keyPoints: back-compat array (empty when omitted; generation now fills keyPoint).
  * Fails only if the response is unusable (not JSON / no sections / none mapped).
  */
 export function parseChapterBodyResponse(raw: string, topicCount: number): ChapterBodyResult {
@@ -177,18 +191,20 @@ export function parseChapterBodyResponse(raw: string, topicCount: number): Chapt
   for (const s of json.sections as LlmBodySection[]) {
     const i = typeof s.idx === 'number' ? s.idx : Number(s.idx);
     if (!Number.isInteger(i) || i < 0 || i >= topicCount) continue;
-    const narrative =
-      typeof s.narrative === 'string' ? s.narrative.replace(/\s*\n+\s*/g, ' ').trim() : '';
+    // Preserve raw markdown — do NOT strip newlines (markdown structure depends on them).
+    const narrative = typeof s.narrative === 'string' ? s.narrative.trim() : '';
     if (!narrative) continue;
     if (sections[i]!.narrative === '') mapped += 1; // first write for this idx
-    // Extract keyPoints: array of strings, trimmed, non-empty, capped at 3.
+    // keyPoint: 2-3 sentence prose synthesis (new contract). Optional string.
+    const keyPoint = typeof s.keyPoint === 'string' ? s.keyPoint.trim() || undefined : undefined;
+    // keyPoints: back-compat (old array contract). Trimmed, non-empty, capped at 3.
     const rawKp = Array.isArray(s.keyPoints) ? (s.keyPoints as unknown[]) : [];
     const keyPoints = rawKp
       .filter((k): k is string => typeof k === 'string')
       .map((k) => k.replace(/\s*\n+\s*/g, ' ').trim())
       .filter((k) => k.length > 0)
       .slice(0, 3);
-    sections[i] = { narrative, keyPoints };
+    sections[i] = { narrative, keyPoints, keyPoint };
   }
   if (mapped === 0) return { ok: false, reason: 'no_mapped_sections' };
   return { ok: true, sections };

--- a/src/modules/mandala-book/book-schema.ts
+++ b/src/modules/mandala-book/book-schema.ts
@@ -76,10 +76,16 @@ const bookFigureSchema = z.object({
 
 export const bookSectionSchema = z.object({
   title: z.string(),
-  narrative: z.string(), // 살붙임 body assembled from v2 analysis + segments
-  // NOTE-DENSITY ① — 2-3 compressed take-aways per section (distilled, NOT narrative repeat).
-  // Optional: absent/empty ⇒ renders nothing; existing books without this field stay valid.
+  // Rich markdown: **bold** on key terms/numbers, bullet/numbered lists, callouts,
+  // mermaid blocks, GFM tables, prose paragraphs. FE parses into TipTap nodes.
+  narrative: z.string(),
+  // NOTE-DENSITY ① (back-compat) — bullet take-away array from PR #1017 design.
+  // Kept optional; generation now fills keyPoint (singular prose synthesis) instead.
   keyPoints: z.array(z.string()).optional(),
+  // NOTE-DENSITY ①-v2 — 2-3 sentence prose synthesis (the "핵심 포인트" quote).
+  // Rendered as a left-bar QUOTE block. Optional: absent ⇒ nothing rendered;
+  // existing books without this field stay valid.
+  keyPoint: z.string().optional(),
   atoms: z.array(bookAtomSchema).default([]),
   qa: z.array(bookQaSchema).default([]),
   provenance: provenanceSchema, // Fork D placeholder

--- a/src/modules/mandala-book/build-book.ts
+++ b/src/modules/mandala-book/build-book.ts
@@ -174,8 +174,9 @@ function sectionFromTopic(
   return {
     title: topic.topic_title,
     narrative: topic.summary,
-    // NOTE-DENSITY ① — pass through keyPoints written by book-body weave step.
+    // NOTE-DENSITY ① back-compat + ①-v2 prose synthesis — threaded from book-body weave step.
     ...(topic.keyPoints && topic.keyPoints.length > 0 ? { keyPoints: topic.keyPoints } : {}),
+    ...(topic.keyPoint ? { keyPoint: topic.keyPoint } : {}),
     atoms,
     qa,
   };
@@ -295,10 +296,11 @@ export function buildBookJson(input: BuildBookInput): BuildBookResult {
           return {
             title: topic.topic_title,
             narrative: topic.summary,
-            // NOTE-DENSITY ① — carry keyPoints from the book-body weave step.
+            // NOTE-DENSITY ① back-compat + ①-v2 prose synthesis — threaded from book-body weave step.
             ...(topic.keyPoints && topic.keyPoints.length > 0
               ? { keyPoints: topic.keyPoints }
               : {}),
+            ...(topic.keyPoint ? { keyPoint: topic.keyPoint } : {}),
             atoms,
             qa,
           };

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -464,11 +464,12 @@ export async function fillMandalaBook(params: {
         mandala.title ?? ''
       );
       if (woven.ok) {
-        woven.sections.forEach(({ narrative, keyPoints }, i) => {
+        woven.sections.forEach(({ narrative, keyPoints, keyPoint }, i) => {
           const t = chTopics[i];
           if (!t) return;
           if (narrative) t.summary = narrative; // enrich in place; empty slot ⇒ keep original
-          if (keyPoints.length > 0) t.keyPoints = keyPoints; // NOTE-DENSITY ① — thread through
+          if (keyPoints.length > 0) t.keyPoints = keyPoints; // back-compat
+          if (keyPoint) t.keyPoint = keyPoint; // NOTE-DENSITY ①-v2 — prose synthesis quote
         });
         wovenChapters += 1;
       }

--- a/src/modules/mandala-book/topic-synthesis.ts
+++ b/src/modules/mandala-book/topic-synthesis.ts
@@ -54,8 +54,10 @@ export interface TopicSection {
   topic_title: string; // CONTENT name (e.g. "REST API 라우팅 구조"), NOT a video title
   summary: string; // 1-2 line topic framing (light synthesis, no invented facts)
   atom_refs: Array<{ vid: string; ts: number }>; // provenance — resolved from LLM indices
-  // NOTE-DENSITY ① — populated by book-body weave step; absent until then.
+  // NOTE-DENSITY ① (back-compat) — bullet take-away array. Absent until book-body weave step.
   keyPoints?: string[];
+  // NOTE-DENSITY ①-v2 — 2-3 sentence prose synthesis. Populated by book-body weave step.
+  keyPoint?: string;
 }
 
 /** Atoms intentionally dropped by compression (transparency — CP504 §4.5.0). */

--- a/tests/unit/modules/book-body.test.ts
+++ b/tests/unit/modules/book-body.test.ts
@@ -1,9 +1,11 @@
 /**
- * book-body (§4.5.1 [3] chapter body weave, CP504 + NOTE-DENSITY ①). OpenRouter
- * MOCKED (no live LLM). Locks: idx→section index-aligned map, keyPoints extracted
- * + capped at 3, omitted topic → empty slot (caller falls back), out-of-range idx
- * ignored, fence strip, newline collapse, honest fail (json / no-sections /
- * none-mapped), retry→fail, no_topics, legacy response without keyPoints accepted.
+ * book-body (§4.5.1 [3] chapter body weave, CP504 + NOTE-DENSITY ①/①-v2).
+ * OpenRouter MOCKED (no live LLM).
+ * Locks: idx→section index-aligned map, markdown narrative newlines PRESERVED
+ * (NOT collapsed), keyPoint extracted as prose string, keyPoints back-compat array
+ * (capped at 3), omitted topic → empty slot (caller falls back), out-of-range idx
+ * ignored, fence strip, honest fail (json / no-sections / none-mapped),
+ * retry→fail, no_topics, legacy response without keyPoint/keyPoints accepted.
  */
 
 const mockGenerate = jest.fn();
@@ -23,19 +25,38 @@ import {
 beforeEach(() => mockGenerate.mockReset());
 
 describe('parseChapterBodyResponse (pure — no LLM)', () => {
-  it('maps idx→section index-aligned, collapses newlines, strips fence, extracts keyPoints', () => {
+  it('maps idx→section index-aligned, strips fence, extracts keyPoint + keyPoints back-compat', () => {
     const raw =
       '```json\n{"sections":[' +
-      '{"idx":0,"narrative":"첫\\n문장","keyPoints":["핵심A","핵심B"]},' +
-      '{"idx":1,"narrative":"둘째","keyPoints":["포인트1"]}' +
+      '{"idx":0,"narrative":"**핵심 용어** 설명","keyPoint":"이 섹션의 핵심","keyPoints":["핵심A","핵심B"]},' +
+      '{"idx":1,"narrative":"둘째 단락","keyPoint":"두 번째 통찰"}' +
       ']}\n```';
     const r = parseChapterBodyResponse(raw, 2);
     expect(r.ok).toBe(true);
     if (!r.ok) return;
-    expect(r.sections[0]!.narrative).toBe('첫 문장');
+    expect(r.sections[0]!.narrative).toBe('**핵심 용어** 설명');
+    expect(r.sections[0]!.keyPoint).toBe('이 섹션의 핵심');
     expect(r.sections[0]!.keyPoints).toEqual(['핵심A', '핵심B']);
-    expect(r.sections[1]!.narrative).toBe('둘째');
-    expect(r.sections[1]!.keyPoints).toEqual(['포인트1']);
+    expect(r.sections[1]!.narrative).toBe('둘째 단락');
+    expect(r.sections[1]!.keyPoint).toBe('두 번째 통찰');
+  });
+
+  it('preserves markdown newlines in narrative (NOT collapsed — markdown depends on them)', () => {
+    const raw = '{"sections":[{"idx":0,"narrative":"첫 단락\\n\\n둘째 단락","keyPoint":"핵심"}]}';
+    const r = parseChapterBodyResponse(raw, 1);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // \n\n inside the JSON string becomes actual newlines after JSON.parse
+    expect(r.sections[0]!.narrative).toBe('첫 단락\n\n둘째 단락');
+  });
+
+  it('preserves mermaid blocks (multi-line narrative)', () => {
+    const mermaid = '```mermaid\nflowchart LR\nA-->B\n```';
+    const raw = `{"sections":[{"idx":0,"narrative":"${mermaid.replace(/\n/g, '\\n')}","keyPoint":"흐름"}]}`;
+    const r = parseChapterBodyResponse(raw, 1);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.sections[0]!.narrative).toBe(mermaid);
   });
 
   it('leaves an empty-narrative slot for an omitted topic (caller keeps original summary)', () => {
@@ -50,24 +71,25 @@ describe('parseChapterBodyResponse (pure — no LLM)', () => {
   });
 
   it('ignores out-of-range idx', () => {
-    const raw = '{"sections":[{"idx":0,"narrative":"ok","keyPoints":["k"]},{"idx":9,"narrative":"버림"}]}';
+    const raw =
+      '{"sections":[{"idx":0,"narrative":"ok","keyPoints":["k"]},{"idx":9,"narrative":"버림"}]}';
     const r = parseChapterBodyResponse(raw, 1);
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.sections[0]!.narrative).toBe('ok');
   });
 
-  it('accepts legacy response without keyPoints field — returns empty array', () => {
+  it('accepts legacy response without keyPoint/keyPoints — keyPoint undefined, keyPoints []', () => {
     const raw = '{"sections":[{"idx":0,"narrative":"레거시 응답 — 키포인트 없음"}]}';
     const r = parseChapterBodyResponse(raw, 1);
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.sections[0]!.keyPoints).toEqual([]);
+    expect(r.sections[0]!.keyPoint).toBeUndefined();
   });
 
   it('caps keyPoints at 3 even if model returns more', () => {
-    const raw =
-      '{"sections":[{"idx":0,"narrative":"n","keyPoints":["a","b","c","d","e"]}]}';
+    const raw = '{"sections":[{"idx":0,"narrative":"n","keyPoints":["a","b","c","d","e"]}]}';
     const r = parseChapterBodyResponse(raw, 1);
     expect(r.ok).toBe(true);
     if (!r.ok) return;
@@ -85,7 +107,9 @@ describe('parseChapterBodyResponse (pure — no LLM)', () => {
   it('fails on invalid JSON / non-array / none mapped', () => {
     expect(parseChapterBodyResponse('nope', 2).ok).toBe(false);
     expect(parseChapterBodyResponse('{"sections":"x"}', 2).ok).toBe(false);
-    expect(parseChapterBodyResponse('{"sections":[{"idx":5,"narrative":"oob"}]}', 2).ok).toBe(false);
+    expect(parseChapterBodyResponse('{"sections":[{"idx":5,"narrative":"oob"}]}', 2).ok).toBe(
+      false
+    );
   });
 });
 
@@ -95,19 +119,21 @@ describe('weaveChapterBody (OpenRouter mocked)', () => {
     { topicTitle: '주문', summary: '식당 주문 표현' },
   ];
 
-  it('returns index-aligned sections with narratives and keyPoints on success', async () => {
+  it('returns index-aligned sections with narratives, keyPoint, and keyPoints on success', async () => {
     mockGenerate.mockResolvedValueOnce(
       '{"sections":[' +
-        '{"idx":0,"narrative":"먼저 인사로 문을 연다","keyPoints":["인사=대화 시작점"]},' +
-        '{"idx":1,"narrative":"이어 주문으로 나아간다","keyPoints":["주문 공식: I\\'d like + 명사"]}' +
+        '{"idx":0,"narrative":"먼저 **인사**로 문을 연다","keyPoint":"인사는 대화의 시작점이다.","keyPoints":["인사=대화 시작점"]},' +
+        '{"idx":1,"narrative":"이어 주문으로 나아간다","keyPoint":"주문 표현은 공식 패턴이 지배한다."}' +
         ']}'
     );
     const r = await weaveChapterBody('도입', '맥락', topics, 'goal');
     expect(r.ok).toBe(true);
     if (!r.ok) return;
-    expect(r.sections[0]!.narrative).toBe('먼저 인사로 문을 연다');
+    expect(r.sections[0]!.narrative).toBe('먼저 **인사**로 문을 연다');
+    expect(r.sections[0]!.keyPoint).toBe('인사는 대화의 시작점이다.');
     expect(r.sections[0]!.keyPoints).toEqual(['인사=대화 시작점']);
     expect(r.sections[1]!.narrative).toBe('이어 주문으로 나아간다');
+    expect(r.sections[1]!.keyPoint).toBe('주문 표현은 공식 패턴이 지배한다.');
   });
 
   it('retries then fails on provider error (caller keeps summaries)', async () => {

--- a/tests/unit/modules/book-schema.test.ts
+++ b/tests/unit/modules/book-schema.test.ts
@@ -162,10 +162,11 @@ describe('book-schema v2 contract', () => {
   });
 });
 
-describe('book-schema — NOTE-DENSITY ① keyPoints (additive, optional)', () => {
+describe('book-schema — NOTE-DENSITY ① keyPoints back-compat (additive, optional)', () => {
   it('accepts a section with keyPoints present', () => {
     const b = validBook();
-    (b.chapters[0]!.sections[0] as Record<string, unknown>).keyPoints = [
+    // Use bracket notation: noPropertyAccessFromIndexSignature is strict in this project.
+    (b.chapters[0]!.sections[0] as Record<string, unknown>)['keyPoints'] = [
       'INT8 양자화: 메모리 75%↓, 성능 손실 1-2%',
       '배치 추론 병렬화: 처리량 4×↑',
     ];
@@ -184,8 +185,49 @@ describe('book-schema — NOTE-DENSITY ① keyPoints (additive, optional)', () =
 
   it('rejects a keyPoints value that is not an array', () => {
     const b = validBook();
-    (b.chapters[0]!.sections[0] as Record<string, unknown>).keyPoints = 'not-an-array';
+    (b.chapters[0]!.sections[0] as Record<string, unknown>)['keyPoints'] = 'not-an-array';
     expect(bookJsonSchema.safeParse(b).success).toBe(false);
+  });
+});
+
+describe('book-schema — NOTE-DENSITY ①-v2 keyPoint prose synthesis (additive, optional)', () => {
+  it('accepts a section with keyPoint (prose string)', () => {
+    const b = validBook();
+    (b.chapters[0]!.sections[0] as Record<string, unknown>)['keyPoint'] =
+      'INT8 양자화는 메모리를 75% 줄이면서 성능 손실을 1-2%로 억제한다. 배치 추론과 결합하면 처리량이 4배 향상된다.';
+    const parsed = parseBookJson(b);
+    expect(firstSection(parsed).keyPoint).toMatch(/INT8/);
+  });
+
+  it('accepts a section WITHOUT keyPoint — back-compat: existing books stay valid', () => {
+    const b = validBook(); // no keyPoint field
+    const parsed = parseBookJson(b);
+    expect(firstSection(parsed).keyPoint).toBeUndefined();
+  });
+
+  it('accepts both keyPoint and keyPoints on the same section', () => {
+    const b = validBook();
+    const sec = b.chapters[0]!.sections[0] as Record<string, unknown>;
+    sec['keyPoint'] = '핵심 통찰 요약 문장.';
+    sec['keyPoints'] = ['항목 A', '항목 B'];
+    const parsed = parseBookJson(b);
+    expect(firstSection(parsed).keyPoint).toBe('핵심 통찰 요약 문장.');
+    expect(firstSection(parsed).keyPoints).toEqual(['항목 A', '항목 B']);
+  });
+
+  it('rejects a keyPoint value that is not a string', () => {
+    const b = validBook();
+    (b.chapters[0]!.sections[0] as Record<string, unknown>)['keyPoint'] = 42;
+    expect(bookJsonSchema.safeParse(b).success).toBe(false);
+  });
+
+  it('narrative may contain rich markdown (newlines, bold, lists, callouts)', () => {
+    const b = validBook();
+    // Multi-line rich markdown — schema accepts any string; FE parser handles structure.
+    b.chapters[0]!.sections[0]!.narrative =
+      '**양자화**는 모델 크기를 줄이는 핵심 기술이다.\n\n- INT8: 메모리 75%↓\n- FP16: 균형점\n\n> [!note]\n> 성능 손실은 태스크에 따라 다르다.';
+    expect(() => parseBookJson(b)).not.toThrow();
+    expect(firstSection(parseBookJson(b)).narrative).toContain('**양자화**');
   });
 });
 
@@ -201,7 +243,12 @@ describe('book-schema — CP504 loop-2 additive keys (G-SHAPE: additive, no reje
     book.chapters[0]!.sections[0]!.verification = {
       status: 'verified',
       checks: [
-        { atom_text: 'claim a', verdict: 'FALSE', evidence_url: 'https://ex.com/a', correction: 'fixed' },
+        {
+          atom_text: 'claim a',
+          verdict: 'FALSE',
+          evidence_url: 'https://ex.com/a',
+          correction: 'fixed',
+        },
         { atom_text: 'claim b', verdict: 'TRUE' },
       ],
     };

--- a/tests/unit/modules/build-book-topics.test.ts
+++ b/tests/unit/modules/build-book-topics.test.ts
@@ -128,6 +128,27 @@ describe('buildBookJson — topic mode (§1⑤)', () => {
     expect(secs[0]!.title).toBe('VIDEO TITLE vidA');
   });
 
+  it('threads keyPoint (prose synthesis) from topic into section — NOTE-DENSITY ①-v2', () => {
+    const cell: CellInput = {
+      cellIndex: 0,
+      title: 'c',
+      videos: [vid('vidA', [10])],
+      topics: [
+        {
+          topic_title: '주제',
+          summary: '요약',
+          atom_refs: [{ vid: 'vidA', ts: 10 }],
+          keyPoint: '이 섹션의 핵심 통찰을 2-3문장으로 요약한 산문이다.',
+          keyPoints: ['항목 A'], // back-compat — both can coexist
+        },
+      ],
+    };
+    const { book } = buildBookJson(base([cell]));
+    const sec = sectionsOf(book)[0]! as Record<string, unknown>;
+    expect(sec['keyPoint']).toBe('이 섹션의 핵심 통찰을 2-3문장으로 요약한 산문이다.');
+    expect(sec['keyPoints']).toEqual(['항목 A']);
+  });
+
   it('source counters identical regardless of mode', () => {
     const videos = [vid('vidA', [10, 50]), vid('vidB', [30])];
     const legacy = buildBookJson(base([{ cellIndex: 0, title: 'c', videos }]));


### PR DESCRIPTION
## Summary

- **`book-schema.ts`**: add `keyPoint?: z.string()` to `bookSectionSchema` alongside back-compat `keyPoints?: z.array(z.string())`. narrative field comment updated to document RICH MARKDOWN contract.
- **`book-body.ts`**: rewrite `buildChapterBodyPrompt` to instruct the model to produce RICH MARKDOWN narrative (`**bold**` on key terms/numbers only, `- ` / `1. ` lists, `> [!note/tip/warning]` callouts, ` ```mermaid` blocks, `| GFM tables |`, prose paragraphs — right tool for content, not forced). `keyPoint` replaces `keyPoints[]` in the output JSON contract: a single 2-3 sentence prose synthesis rendered as a quote. `parseChapterBodyResponse` preserves narrative newlines (removes the old `.replace(/\s*\n+\s*/g, ' ')` collapse) and extracts `keyPoint` as an optional string; `keyPoints[]` back-compat parsing retained.
- **`topic-synthesis.ts`**: `TopicSection` gains `keyPoint?: string`.
- **`fill-book.ts`** + **`build-book.ts`**: thread `keyPoint` through body-weave → topic → section (both skeleton + non-skeleton topic assembly modes).

## Schema diff

```diff
 bookSectionSchema = z.object({
   title: z.string(),
-  narrative: z.string(), // 살붙임 body assembled from v2 analysis + segments
-  // NOTE-DENSITY ① — 2-3 compressed take-aways per section
+  // Rich markdown: **bold** on key terms/numbers, lists, callouts, mermaid, GFM tables, prose
+  narrative: z.string(),
+  // NOTE-DENSITY ① (back-compat) — bullet take-away array from PR #1017 design
   keyPoints: z.array(z.string()).optional(),
+  // NOTE-DENSITY ①-v2 — 2-3 sentence prose synthesis (rendered as left-bar quote)
+  keyPoint: z.string().optional(),
   ...
})
```

## Prompt instruction added (markdown toolset)

```
★ narrative는 RICH MARKDOWN — 내용에 적합한 도구를 선택(모든 섹션에 억지로 모든 도구 쓰지 말 것):
• **굵게**: 정의되는 핵심 용어 + 결정적 수치("75%", "4비트") 전용. 장식·일반명사에 쓰지 말 것.
• `- ` 불릿 목록: 순서 없는 열거.
• `1. ` 번호 목록: 단계별 절차·순서.
• `> [!note]` / `> [!tip]` / `> [!warning]`: 보충 callout (Obsidian admonition 형식).
• ```mermaid\n...```: 흐름·관계·아키텍처(예: flowchart LR; A-->B). 실제 구조가 있을 때만.
• `| 열 | 열 |` GFM 테이블: A vs B 비교가 있으면 반드시 테이블.
• 그 외: 빈 줄로 구분된 산문 단락.
도구 강제 원칙: 비교→테이블, 다단계 절차→번호 목록, 흐름·관계→mermaid. 밀도·학술적 명확성 우선.

5. 각 토픽에 keyPoint를 작성한다: 이 섹션의 본질을 새 문장으로 압축한 2-3문장 산문 종합.
   ★ 불릿 금지. narrative 문장 그대로 반복 금지. 독자가 기억해야 할 핵심 통찰만.
```

Output contract change: `{"sections":[{"idx":0,"narrative":"<마크다운>","keyPoint":"<2-3문장 산문>"}]}`

## Back-compat

- `keyPoints[]` field: retained in schema (optional) + parser still extracts it → old books parse without error, old FE rendering unchanged.
- `keyPoint` absent: `undefined` in `BodySectionResult`; section schema accepts its absence.
- Both fields can coexist on a single section.

## Test plan

- [x] `book-body.test.ts`: keyPoint extracted, markdown newlines preserved, mermaid block round-trip, back-compat (no keyPoint/keyPoints → undefined/[]), both fields coexist — 37 tests pass
- [x] `book-schema.test.ts`: keyPoint string accepted, absence back-compat valid, both fields coexist, non-string rejected, rich markdown narrative accepted — all pass
- [x] `build-book-topics.test.ts`: keyPoint threaded from TopicSection into book section — all pass
- [x] No regressions in build-book, book-gate, book-v2-retry modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)