### PR TITLE
feat(note): render full academic toolset in learning note — markdown narrative parser + callout/mermaid/table extensions [NOTE-FULL-TOOLSET]

### DIFF
--- a/frontend/src/__tests__/markdown-to-tiptap.test.ts
+++ b/frontend/src/__tests__/markdown-to-tiptap.test.ts
@@ -1,0 +1,189 @@
+/**
+ * markdown-to-tiptap — [NOTE-FULL-TOOLSET] deterministic markdown → TipTap nodes.
+ * Locks each construct the book pipeline emits: inline marks, lists, callouts,
+ * mermaid, GFM tables, blockquotes, headings — plus the buildInitialNoteDoc
+ * integration (rich narrative → full tool node set) and the markdown-less
+ * byte-stability guarantee.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseMarkdownToTiptap, parseInline } from '@/pages/learning/lib/markdown-to-tiptap';
+import { buildInitialNoteDoc } from '@/pages/learning/lib/note-document-generator';
+import type { MandalaBookData } from '@/shared/lib/api-client';
+import type { TiptapNode } from '@/features/video-side-panel/lib/note-parser';
+
+const types = (ns: TiptapNode[]): string[] => ns.map((n) => n.type);
+const txt = (n: TiptapNode | undefined): string =>
+  (n?.content ?? []).map((c) => c.text ?? '').join('');
+
+describe('parseInline — marks', () => {
+  it('bold / italic / code / link', () => {
+    expect(parseInline('plain')).toEqual([{ type: 'text', text: 'plain' }]);
+
+    const bold = parseInline('a **b** c');
+    expect(bold).toEqual([
+      { type: 'text', text: 'a ' },
+      { type: 'text', text: 'b', marks: [{ type: 'bold' }] },
+      { type: 'text', text: ' c' },
+    ]);
+
+    const italic = parseInline('x *y* z');
+    expect(italic[1]).toEqual({ type: 'text', text: 'y', marks: [{ type: 'italic' }] });
+
+    const code = parseInline('use `npm run dev`');
+    expect(code[1]).toEqual({ type: 'text', text: 'npm run dev', marks: [{ type: 'code' }] });
+
+    const link = parseInline('see [docs](https://x.io)');
+    expect(link[1]).toEqual({
+      type: 'text',
+      text: 'docs',
+      marks: [{ type: 'link', attrs: { href: 'https://x.io', target: '_blank' } }],
+    });
+  });
+
+  it('composes nested marks (bold > italic)', () => {
+    const ns = parseInline('**bold _inner_**');
+    expect(ns[0]).toEqual({ type: 'text', text: 'bold ', marks: [{ type: 'bold' }] });
+    expect(ns[1]).toEqual({
+      type: 'text',
+      text: 'inner',
+      marks: [{ type: 'bold' }, { type: 'italic' }],
+    });
+  });
+});
+
+describe('parseMarkdownToTiptap — block constructs', () => {
+  it('blank-line separated paragraphs (soft-wrapped lines joined)', () => {
+    const ns = parseMarkdownToTiptap('line one\nline two\n\nsecond para');
+    expect(types(ns)).toEqual(['paragraph', 'paragraph']);
+    expect(txt(ns[0])).toBe('line one line two');
+    expect(txt(ns[1])).toBe('second para');
+  });
+
+  it('bullet list', () => {
+    const ns = parseMarkdownToTiptap('- first\n- second');
+    expect(ns[0].type).toBe('bulletList');
+    expect(ns[0].content).toHaveLength(2);
+    expect(ns[0].content![0].type).toBe('listItem');
+    expect(txt(ns[0].content![0].content![0])).toBe('first');
+  });
+
+  it('ordered list', () => {
+    const ns = parseMarkdownToTiptap('1. alpha\n2. beta');
+    expect(ns[0].type).toBe('orderedList');
+    expect(ns[0].content).toHaveLength(2);
+  });
+
+  it('headings (capped at level 3)', () => {
+    const ns = parseMarkdownToTiptap('# h1\n\n## h2\n\n#### h4-capped');
+    expect(ns.map((n) => n.attrs?.['level'])).toEqual([1, 2, 3]);
+    expect(txt(ns[0])).toBe('h1');
+  });
+
+  it('callout → callout node with kind + parsed body', () => {
+    const ns = parseMarkdownToTiptap('> [!warning] careful\n> second body line');
+    expect(ns[0].type).toBe('callout');
+    expect(ns[0].attrs?.['kind']).toBe('warning');
+    // body is parsed (paragraph), first line + continuation joined.
+    expect(ns[0].content![0].type).toBe('paragraph');
+    expect(txt(ns[0].content![0])).toBe('careful second body line');
+  });
+
+  it('callout kinds note/tip default-normalize', () => {
+    expect(parseMarkdownToTiptap('> [!note] n')[0].attrs?.['kind']).toBe('note');
+    expect(parseMarkdownToTiptap('> [!tip] t')[0].attrs?.['kind']).toBe('tip');
+  });
+
+  it('plain blockquote (no [!type]) → blockquote, NOT a callout', () => {
+    const ns = parseMarkdownToTiptap('> just a quote');
+    expect(ns[0].type).toBe('blockquote');
+    expect(txt(ns[0].content![0])).toBe('just a quote');
+  });
+
+  it('mermaid fence → mermaid node holding the source', () => {
+    const ns = parseMarkdownToTiptap('```mermaid\ngraph TD\nA-->B\n```');
+    expect(ns[0].type).toBe('mermaid');
+    expect(ns[0].attrs?.['source']).toBe('graph TD\nA-->B');
+  });
+
+  it('non-mermaid fence → codeBlock with language', () => {
+    const ns = parseMarkdownToTiptap('```ts\nconst x = 1;\n```');
+    expect(ns[0].type).toBe('codeBlock');
+    expect(ns[0].attrs?.['language']).toBe('ts');
+    expect(ns[0].content![0].text).toBe('const x = 1;');
+  });
+
+  it('GFM table → markdownTable node with {headers, rows}', () => {
+    const ns = parseMarkdownToTiptap('| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |');
+    expect(ns[0].type).toBe('markdownTable');
+    expect(JSON.parse(ns[0].attrs!['tableJson'] as string)).toEqual({
+      headers: ['A', 'B'],
+      rows: [
+        ['1', '2'],
+        ['3', '4'],
+      ],
+    });
+  });
+
+  it('--- alone → horizontalRule (not a table)', () => {
+    expect(types(parseMarkdownToTiptap('para\n\n---\n\nmore'))).toEqual([
+      'paragraph',
+      'horizontalRule',
+      'paragraph',
+    ]);
+  });
+
+  it('mixed document keeps order', () => {
+    const md = 'Intro **bold**.\n\n- a\n- b\n\n> [!tip] hi\n\n```mermaid\ngraph TD\n```';
+    expect(types(parseMarkdownToTiptap(md))).toEqual([
+      'paragraph',
+      'bulletList',
+      'callout',
+      'mermaid',
+    ]);
+  });
+
+  it('empty / whitespace input → []', () => {
+    expect(parseMarkdownToTiptap('')).toEqual([]);
+    expect(parseMarkdownToTiptap('   \n  ')).toEqual([]);
+    expect(parseMarkdownToTiptap(null)).toEqual([]);
+  });
+});
+
+describe('buildInitialNoteDoc — rich narrative integration', () => {
+  const richBook = (narrative: string): MandalaBookData =>
+    ({
+      chapters: [
+        {
+          ch: 0,
+          title: '챕터',
+          intro: '이 장 소개', // → narrative mode
+          sections: [{ title: '토픽', narrative, atoms: [] }],
+        },
+      ],
+    }) as MandalaBookData;
+
+  it('emits callout + mermaid + markdownTable nodes from rich narrative', () => {
+    const doc = buildInitialNoteDoc(
+      richBook(
+        '도입 문장.\n\n> [!note] 주의점\n\n```mermaid\ngraph TD\nA-->B\n```\n\n| A | B |\n| --- | --- |\n| 1 | 2 |'
+      )
+    );
+    const present = new Set((doc.content ?? []).map((n) => n.type));
+    expect(present.has('callout')).toBe(true);
+    expect(present.has('mermaid')).toBe(true);
+    expect(present.has('markdownTable')).toBe(true);
+  });
+
+  it('markdown-less narrative → single paragraph (byte-stable woven body)', () => {
+    const doc = buildInitialNoteDoc(richBook('한 줄 평범한 산문 본문이다'));
+    const paras = (doc.content ?? []).filter(
+      (n) => n.type === 'paragraph' && txt(n) === '한 줄 평범한 산문 본문이다'
+    );
+    expect(paras).toHaveLength(1);
+    // no toolset nodes leaked from plain prose.
+    const present = new Set((doc.content ?? []).map((n) => n.type));
+    expect(present.has('callout')).toBe(false);
+    expect(present.has('mermaid')).toBe(false);
+    expect(present.has('markdownTable')).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/note-document-generator-narrative.test.ts
+++ b/frontend/src/__tests__/note-document-generator-narrative.test.ts
@@ -55,7 +55,11 @@ describe('note-document-generator — loop-1b narrative render', () => {
     expect(texts).not.toContain('ATOM_TEXT_A 인사'); // no per-video atom-text dump
     expect(texts).not.toContain('ATOM_TEXT_B 주문');
     expect(blockquotes(ns)).toHaveLength(0); // P-1b-NO-DUP: narrative not a footer
-    expect(videoBlocks(ns).map((v) => v.attrs?.vid).sort()).toEqual(['vidA', 'vidB']); // P-1b-PROV-KEPT
+    expect(
+      videoBlocks(ns)
+        .map((v) => v.attrs?.vid)
+        .sort()
+    ).toEqual(['vidA', 'vidB']); // P-1b-PROV-KEPT
   });
 
   it('legacy mode (no intro): UNCHANGED — atom-text paragraphs + narrative blockquote', () => {
@@ -72,48 +76,46 @@ describe('note-document-generator — loop-1b narrative render', () => {
   });
 });
 
-// NOTE-DENSITY ① — "핵심 요점" key-point callout (blockquote wrapping a bulletList).
-const liTexts = (bq: N): string[] => {
-  const list = (bq.content ?? []).find((c) => c.type === 'bulletList');
-  return ((list?.content ?? []) as N[]).map((li) =>
-    (li.content ?? [])
-      .flatMap((p) => (p.content ?? []).map((c) => (c as { text?: string }).text ?? ''))
-      .join('')
-  );
-};
+// NOTE-DENSITY ① (revised) — "핵심 포인트" key-point QUOTE (blockquote > p, keypoint
+// attr). Revises the #1016 gold bullet callout → the legacy left-bar quote style.
+const bqText = (bq: N): string =>
+  (bq.content ?? [])
+    .flatMap((p) => (p.content ?? []).map((c) => (c as { text?: string }).text ?? ''))
+    .join('');
 
-describe('note-document-generator — NOTE-DENSITY ① key-point callout', () => {
-  const withKeyPoints = (kp?: string[]): MandalaBookData => {
+describe('note-document-generator — NOTE-DENSITY ① key-point quote', () => {
+  const withKeyPoint = (kp?: string): MandalaBookData => {
     const b = book('이 장은 기초 회화를 다룬다');
-    if (kp) b.chapters[0]!.sections[0]!.keyPoints = kp;
+    if (kp !== undefined) b.chapters[0]!.sections[0]!.keyPoint = kp;
     return b;
   };
 
-  it('narrative mode + keyPoints → 핵심 요점 callout (blockquote > bulletList items)', () => {
-    const ns = nodes(buildInitialNoteDoc(withKeyPoints(['KP_ONE 인사 먼저', 'KP_TWO 주문 표현'])));
-    const bq = blockquotes(ns);
-    expect(bq).toHaveLength(1); // the callout (narrative is the body, not a blockquote)
-    const list = (bq[0].content ?? []).find((c) => c.type === 'bulletList');
-    expect(list).toBeDefined();
-    expect(liTexts(bq[0])).toEqual(['KP_ONE 인사 먼저', 'KP_TWO 주문 표현']);
-  });
-
-  it('narrative mode WITHOUT keyPoints → no callout (byte-unchanged)', () => {
-    expect(blockquotes(nodes(buildInitialNoteDoc(withKeyPoints())))).toHaveLength(0);
-  });
-
-  it('empty keyPoints array → no callout (flag-safe)', () => {
-    expect(blockquotes(nodes(buildInitialNoteDoc(withKeyPoints([]))))).toHaveLength(0);
-  });
-
-  it('markdown export → "핵심 요점" heading + plain bullets (not a > quote)', () => {
-    const md = exportToMarkdown(
-      buildInitialNoteDoc(withKeyPoints(['KP_ONE 인사 먼저', 'KP_TWO 주문 표현'])) as TiptapDoc
+  it('narrative mode + keyPoint → 핵심 포인트 left-bar quote (blockquote > p, keypoint attr, no bullets)', () => {
+    const ns = nodes(
+      buildInitialNoteDoc(withKeyPoint('핵심은 인사와 주문 표현을 먼저 익히는 것이다'))
     );
-    expect(md).toContain('**핵심 요점**');
-    expect(md).toContain('- KP_ONE 인사 먼저');
-    expect(md).toContain('- KP_TWO 주문 표현');
-    expect(md).not.toContain('> - KP_ONE'); // not serialized as a blockquote
+    const bq = blockquotes(ns);
+    expect(bq).toHaveLength(1);
+    expect((bq[0] as N & { attrs?: { keypoint?: boolean } }).attrs?.keypoint).toBe(true);
+    expect((bq[0].content ?? []).some((c) => c.type === 'bulletList')).toBe(false); // prose, not bullets
+    expect(bqText(bq[0])).toBe('핵심은 인사와 주문 표현을 먼저 익히는 것이다');
+  });
+
+  it('narrative mode WITHOUT keyPoint → no quote (byte-unchanged)', () => {
+    expect(blockquotes(nodes(buildInitialNoteDoc(withKeyPoint())))).toHaveLength(0);
+  });
+
+  it('empty keyPoint string → no quote (flag-safe)', () => {
+    expect(blockquotes(nodes(buildInitialNoteDoc(withKeyPoint(''))))).toHaveLength(0);
+  });
+
+  it('markdown export → "> **핵심 포인트**" quote (not a 핵심 요점 bullet callout)', () => {
+    const md = exportToMarkdown(
+      buildInitialNoteDoc(withKeyPoint('핵심은 인사와 주문 표현을 먼저 익히는 것이다')) as TiptapDoc
+    );
+    expect(md).toContain('> **핵심 포인트**');
+    expect(md).toContain('> 핵심은 인사와 주문 표현을 먼저 익히는 것이다');
+    expect(md).not.toContain('**핵심 요점**'); // old bullet-callout label gone
   });
 });
 
@@ -133,7 +135,9 @@ describe('note-document-generator — loop-2 references render (P-REF-RENDER)', 
   it('renders chapter 보강 자료 (fact [ref_id]) + bottom 참고 자료 (id, url)', () => {
     const ns = nodes(buildInitialNoteDoc(enriched()));
     const texts = paraTexts(ns);
-    expect(texts.some((t) => t.includes('WEB_FACT 모음 발음 핵심') && t.includes('[1]'))).toBe(true);
+    expect(texts.some((t) => t.includes('WEB_FACT 모음 발음 핵심') && t.includes('[1]'))).toBe(
+      true
+    );
     expect(headingTexts(ns)).toContain('참고 자료');
     expect(texts.some((t) => t.includes('[1]') && t.includes('https://ex.com/p'))).toBe(true);
   });
@@ -162,10 +166,34 @@ describe('note-document-generator — CV figures render ([CV-NOTE-WIRE])', () =>
   const withFigures = (): MandalaBookData => {
     const b = book('이 장은 기초 회화를 다룬다');
     b.chapters[0]!.sections[0]!.figures = [
-      { video_id: 'vidA', ts_sec: 10, kind: 'equation', latex: 'E=mc^2', verification_status: 'verified' },
-      { video_id: 'vidA', ts_sec: 12, kind: 'chart', asset_path: 'https://cdn.ex.com/chart.png', verification_status: 'verified' },
-      { video_id: 'vidA', ts_sec: 14, kind: 'diagram', asset_path: 'https://cdn.ex.com/diag.png', verification_status: 'unverified' }, // DROP unverified
-      { video_id: 'vidA', ts_sec: 16, kind: 'keyframe', asset_path: 'https://cdn.ex.com/kf.png', verification_status: 'verified' }, // DROP keyframe
+      {
+        video_id: 'vidA',
+        ts_sec: 10,
+        kind: 'equation',
+        latex: 'E=mc^2',
+        verification_status: 'verified',
+      },
+      {
+        video_id: 'vidA',
+        ts_sec: 12,
+        kind: 'chart',
+        asset_path: 'https://cdn.ex.com/chart.png',
+        verification_status: 'verified',
+      },
+      {
+        video_id: 'vidA',
+        ts_sec: 14,
+        kind: 'diagram',
+        asset_path: 'https://cdn.ex.com/diag.png',
+        verification_status: 'unverified',
+      }, // DROP unverified
+      {
+        video_id: 'vidA',
+        ts_sec: 16,
+        kind: 'keyframe',
+        asset_path: 'https://cdn.ex.com/kf.png',
+        verification_status: 'verified',
+      }, // DROP keyframe
     ];
     return b;
   };
@@ -173,7 +201,9 @@ describe('note-document-generator — CV figures render ([CV-NOTE-WIRE])', () =>
   it('renders equation + chart figureBlock nodes; drops unverified + keyframe', () => {
     const figs = figureBlocks(nodes(buildInitialNoteDoc(withFigures())));
     expect(figs.some((f) => f.kind === 'equation' && f.latex === 'E=mc^2')).toBe(true); // equation kept
-    expect(figs.some((f) => f.kind === 'chart' && f.assetPath === 'https://cdn.ex.com/chart.png')).toBe(true); // chart kept (legacy image)
+    expect(
+      figs.some((f) => f.kind === 'chart' && f.assetPath === 'https://cdn.ex.com/chart.png')
+    ).toBe(true); // chart kept (legacy image)
     expect(figs.some((f) => f.assetPath === 'https://cdn.ex.com/diag.png')).toBe(false); // unverified dropped
     expect(figs.some((f) => f.kind === 'keyframe')).toBe(false); // keyframe dropped
     expect(figs).toHaveLength(2);
@@ -210,7 +240,13 @@ describe('note-document-generator — CV figures render ([CV-NOTE-WIRE])', () =>
   it('chart without insight → Korean kind-label caption (not the raw english word)', () => {
     const b = book('이 장은 기초 회화를 다룬다');
     b.chapters[0]!.sections[0]!.figures = [
-      { video_id: 'vidA', ts_sec: 30, kind: 'chart', svg: '<svg viewBox="0 0 4 4"></svg>', verification_status: 'verified' },
+      {
+        video_id: 'vidA',
+        ts_sec: 30,
+        kind: 'chart',
+        svg: '<svg viewBox="0 0 4 4"></svg>',
+        verification_status: 'verified',
+      },
     ];
     const f = figureBlocks(nodes(buildInitialNoteDoc(b)))[0]!;
     expect(f.caption).toBe('차트');
@@ -223,14 +259,32 @@ describe('note-document-generator — CV figures render ([CV-NOTE-WIRE])', () =>
         video_id: 'vidA',
         ts_sec: 40,
         kind: 'table',
-        struct: { headers: ['A', 'B'], rows: [['1', '2'], ['3', '4']] },
+        struct: {
+          headers: ['A', 'B'],
+          rows: [
+            ['1', '2'],
+            ['3', '4'],
+          ],
+        },
         verification_status: 'verified',
       },
-      { video_id: 'vidA', ts_sec: 50, kind: 'equation', latex: 'x^2', verification_status: 'verified' },
+      {
+        video_id: 'vidA',
+        ts_sec: 50,
+        kind: 'equation',
+        latex: 'x^2',
+        verification_status: 'verified',
+      },
     ];
     const figs = figureBlocks(nodes(buildInitialNoteDoc(b)));
     const tableFig = figs.find((f) => f.kind === 'table')!;
-    expect(JSON.parse(tableFig.tableJson!)).toEqual({ headers: ['A', 'B'], rows: [['1', '2'], ['3', '4']] });
+    expect(JSON.parse(tableFig.tableJson!)).toEqual({
+      headers: ['A', 'B'],
+      rows: [
+        ['1', '2'],
+        ['3', '4'],
+      ],
+    });
     expect(tableFig.caption).toBe('표');
     const eqFig = figs.find((f) => f.kind === 'equation')!;
     expect(eqFig.caption).toBeNull(); // equation → neutral, no label

--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1263,11 +1263,19 @@ html.dark .lemonsqueezy-loader {
   --nm-figure-bg: color-mix(in srgb, var(--nm-text) 4%, transparent);    /* subtle ink-tinted plate */
   --nm-figure-th-bg: color-mix(in srgb, var(--nm-text) 6%, transparent); /* table header tint */
 
-  /* NOTE-DENSITY ① — "핵심 요점" key-point callout box: gold-tinted surface +
-     border (derived from --nm-accent #c2a878 = rgb 194,168,120) so it reads as a
-     distinct take-away box, not body prose. */
-  --nm-keypoint-bg: rgba(194,168,120,0.07);
-  --nm-keypoint-border: rgba(194,168,120,0.22);
+  /* [NOTE-FULL-TOOLSET] — markdown admonition callouts. Each kind gets a tinted
+     surface + border + accent: note = editorial gold (--nm-accent #c2a878 =
+     rgb 194,168,120), tip = muted sage, warning = amber. Tokens only (literals
+     live here, components reference them). */
+  --nm-callout-note-bg: rgba(194,168,120,0.07);
+  --nm-callout-note-border: rgba(194,168,120,0.22);
+  --nm-callout-note-accent: var(--nm-accent);
+  --nm-callout-tip-bg: rgba(120,180,140,0.08);
+  --nm-callout-tip-border: rgba(120,180,140,0.26);
+  --nm-callout-tip-accent: #7fbf95;
+  --nm-callout-warning-bg: rgba(210,160,90,0.09);
+  --nm-callout-warning-border: rgba(210,160,90,0.30);
+  --nm-callout-warning-accent: #d8a85f;
 
   background: #0e0f10;
 }

--- a/frontend/src/pages/learning/lib/callout-block.tsx
+++ b/frontend/src/pages/learning/lib/callout-block.tsx
@@ -1,0 +1,93 @@
+/**
+ * Callout — TipTap content node for markdown admonitions (`> [!note|tip|warning]`).
+ *
+ * Mirrors the figure-block.tsx custom-node pattern (Node.create + ReactNodeView)
+ * so the doc shape stays schema-valid — an unregistered node type makes
+ * ProseMirror throw on load. Unlike FigureBlock this is NOT an atom: it carries
+ * editable `block+` content (the admonition body) rendered through NodeViewContent.
+ *
+ * Three kinds (note / tip / warning) each get an icon + Korean label header and a
+ * note-mode-tokened box (CSS in CenterPanel NOTE_PROSE_STYLE + index.css). The
+ * `kind` attribute is the discriminator; renderHTML emits a content hole (0) so
+ * editor.getHTML()/paste round-trips, while the live UI is the React NodeView.
+ */
+import { Node, mergeAttributes } from '@tiptap/core';
+import {
+  ReactNodeViewRenderer,
+  NodeViewWrapper,
+  NodeViewContent,
+  type NodeViewProps,
+} from '@tiptap/react';
+import { Info, Lightbulb, AlertTriangle } from 'lucide-react';
+
+export interface CalloutOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+export type CalloutKind = 'note' | 'tip' | 'warning';
+
+const KIND_META: Record<CalloutKind, { label: string; Icon: typeof Info }> = {
+  note: { label: '노트', Icon: Info },
+  tip: { label: '팁', Icon: Lightbulb },
+  warning: { label: '주의', Icon: AlertTriangle },
+};
+
+function normalizeKind(raw: unknown): CalloutKind {
+  return raw === 'tip' || raw === 'warning' ? raw : 'note';
+}
+
+function CalloutNodeView({ node }: NodeViewProps) {
+  const kind = normalizeKind(node.attrs['kind']);
+  const { label, Icon } = KIND_META[kind];
+  return (
+    <NodeViewWrapper className="note-callout" data-kind={kind}>
+      <div className="note-callout-head" contentEditable={false}>
+        <Icon className="note-callout-icon" aria-hidden />
+        <span className="note-callout-label">{label}</span>
+      </div>
+      <NodeViewContent className="note-callout-body" />
+    </NodeViewWrapper>
+  );
+}
+
+export const Callout = Node.create<CalloutOptions>({
+  name: 'callout',
+
+  group: 'block',
+  content: 'block+',
+  defining: true,
+
+  addOptions() {
+    return { HTMLAttributes: {} };
+  },
+
+  addAttributes() {
+    return {
+      kind: {
+        default: 'note',
+        parseHTML: (el) => normalizeKind(el.getAttribute('data-kind')),
+        renderHTML: (attrs) => ({ 'data-kind': normalizeKind(attrs['kind']) }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="callout"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    // 0 = content hole for serialization (editor.getHTML / paste). Live UI = NodeView.
+    return [
+      'div',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        'data-type': 'callout',
+        class: 'note-callout',
+      }),
+      0,
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(CalloutNodeView);
+  },
+});

--- a/frontend/src/pages/learning/lib/markdown-table-block.tsx
+++ b/frontend/src/pages/learning/lib/markdown-table-block.tsx
@@ -1,0 +1,115 @@
+/**
+ * MarkdownTable — read-only TipTap atomic node for GFM tables in note narrative.
+ *
+ * `@tiptap/extension-table` is not installed (and a fully editable table is out
+ * of scope for generated note bodies), so this is a focused read-only node that
+ * mirrors the figure-block.tsx pattern: headers/rows are stored as a compact JSON
+ * string in the `tableJson` attribute and rendered as a note-mode-styled HTML
+ * table. renderHTML emits inert markup for editor.getHTML(); live UI is the
+ * React NodeView.
+ */
+import { useMemo } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
+
+export interface MarkdownTableOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+interface ParsedTable {
+  headers: string[];
+  rows: string[][];
+}
+
+function parseTableJson(json: string | null | undefined): ParsedTable | null {
+  if (!json) return null;
+  try {
+    const parsed = JSON.parse(json) as ParsedTable;
+    const headers = Array.isArray(parsed.headers) ? parsed.headers.map(String) : [];
+    const rows = Array.isArray(parsed.rows)
+      ? parsed.rows.map((r) => (Array.isArray(r) ? r.map(String) : [String(r)]))
+      : [];
+    if (headers.length === 0 && rows.length === 0) return null;
+    return { headers, rows };
+  } catch {
+    return null;
+  }
+}
+
+function MarkdownTableNodeView({ node }: NodeViewProps) {
+  const table = useMemo(
+    () => parseTableJson(node.attrs['tableJson'] as string | null),
+    [node.attrs]
+  );
+
+  if (!table) {
+    return <NodeViewWrapper className="note-md-table-block hidden" data-type="markdown-table" />;
+  }
+
+  return (
+    <NodeViewWrapper className="note-md-table-block" data-type="markdown-table">
+      <table className="note-md-table">
+        {table.headers.length > 0 && (
+          <thead>
+            <tr>
+              {table.headers.map((h, i) => (
+                <th key={i}>{h}</th>
+              ))}
+            </tr>
+          </thead>
+        )}
+        <tbody>
+          {table.rows.map((row, ri) => (
+            <tr key={ri}>
+              {row.map((cell, ci) => (
+                <td key={ci}>{cell}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </NodeViewWrapper>
+  );
+}
+
+export const MarkdownTable = Node.create<MarkdownTableOptions>({
+  name: 'markdownTable',
+
+  group: 'block',
+  atom: true,
+  draggable: true,
+  selectable: true,
+
+  addOptions() {
+    return { HTMLAttributes: {} };
+  },
+
+  addAttributes() {
+    return {
+      tableJson: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-table'),
+        renderHTML: (attrs) =>
+          attrs['tableJson'] ? { 'data-table': String(attrs['tableJson']) } : {},
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="markdown-table"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        'data-type': 'markdown-table',
+        class: 'note-md-table-block',
+      }),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(MarkdownTableNodeView);
+  },
+});

--- a/frontend/src/pages/learning/lib/markdown-to-tiptap.ts
+++ b/frontend/src/pages/learning/lib/markdown-to-tiptap.ts
@@ -1,0 +1,281 @@
+/**
+ * markdown-to-tiptap — deterministic, dependency-free markdown → TipTap nodes.
+ *
+ * Converts the rich-markdown `section.narrative` (woven prose with inline marks,
+ * lists, admonitions, mermaid, GFM tables) into the TipTap node array consumed by
+ * note-document-generator. No markdown library is bundled (package.json has none),
+ * so this is a focused line-based parser covering exactly the constructs the book
+ * pipeline emits — kept deterministic + unit-tested (markdown-to-tiptap.test.ts).
+ *
+ * Supported block constructs (one block per detector, checked in this order):
+ *   ```mermaid … ```          → mermaid node      (source kept verbatim)
+ *   ``` / ```lang … ```       → codeBlock         (lowlight; language attr)
+ *   > [!note|tip|warning] …   → callout node      (kind + parsed body)
+ *   | a | b |  + |---|---|    → markdownTable     (GFM; {headers, rows})
+ *   > …                       → blockquote        (plain quote; parsed body)
+ *   #…###### …                → heading           (level capped at 3)
+ *   --- or *** or ___ (alone) → horizontalRule
+ *   "- " / "* " / "+ " item   → bulletList        (flat; one paragraph / item)
+ *   "1. " item                → orderedList       (flat)
+ *   (anything else)           → paragraph         (soft-wrapped lines joined)
+ *
+ * Supported inline marks (parseInline): `code`, [label](url) link, bold (double
+ * asterisk or "__"), italic (single asterisk or "_") — composable (e.g. nested
+ * bold + italic).
+ *
+ * Nodes emitted here that are NOT in StarterKit (mermaid, callout, markdownTable)
+ * MUST be registered as TipTap extensions in useNoteDocument — an unregistered
+ * node type makes ProseMirror throw on doc load. Pure function, 0 LLM calls.
+ */
+import type { TiptapNode } from '@/features/video-side-panel/lib/note-parser';
+
+type Mark = { type: string; attrs?: Record<string, unknown> };
+
+// ---------------------------------------------------------------------------
+// Inline (text + marks)
+// ---------------------------------------------------------------------------
+
+// Ordered alternation: code span, link, bold (** / __), italic (* / _). Code is
+// first so its literal content is never re-parsed for emphasis.
+const INLINE_RE =
+  /(`[^`]+`)|(\[[^\]]+\]\([^)\s]+\))|(\*\*[^*]+?\*\*)|(__[^_]+?__)|(\*[^*\n]+?\*)|(_[^_\n]+?_)/;
+
+function textNode(text: string, marks: Mark[]): TiptapNode {
+  return marks.length
+    ? { type: 'text', text, marks: marks.map((m) => ({ ...m })) }
+    : { type: 'text', text };
+}
+
+/**
+ * Parse one line of inline markdown into TipTap text nodes. `marks` carries the
+ * enclosing emphasis so nested spans (bold > italic, link > bold) compose.
+ */
+export function parseInline(input: string, marks: Mark[] = []): TiptapNode[] {
+  const out: TiptapNode[] = [];
+  let rest = input;
+  while (rest.length > 0) {
+    const m = INLINE_RE.exec(rest);
+    if (!m) {
+      out.push(textNode(rest, marks));
+      break;
+    }
+    const idx = m.index;
+    if (idx > 0) out.push(textNode(rest.slice(0, idx), marks));
+    const tok = m[0];
+    if (m[1]) {
+      // code span — literal content, no further emphasis parsing.
+      out.push(textNode(tok.slice(1, -1), [...marks, { type: 'code' }]));
+    } else if (m[2]) {
+      const lm = /^\[([^\]]+)\]\(([^)\s]+)\)$/.exec(tok)!;
+      out.push(
+        ...parseInline(lm[1], [
+          ...marks,
+          { type: 'link', attrs: { href: lm[2], target: '_blank' } },
+        ])
+      );
+    } else if (m[3] || m[4]) {
+      out.push(...parseInline(tok.slice(2, -2), [...marks, { type: 'bold' }]));
+    } else if (m[5] || m[6]) {
+      out.push(...parseInline(tok.slice(1, -1), [...marks, { type: 'italic' }]));
+    }
+    rest = rest.slice(idx + tok.length);
+  }
+  return out.filter((n) => n.type !== 'text' || (typeof n.text === 'string' && n.text.length > 0));
+}
+
+function paragraphNode(text: string): TiptapNode {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  return { type: 'paragraph', content: normalized ? parseInline(normalized) : [] };
+}
+
+// ---------------------------------------------------------------------------
+// Block detectors
+// ---------------------------------------------------------------------------
+
+const FENCE_RE = /^```(\w*)\s*$/;
+const CALLOUT_RE = /^>\s*\[!(note|tip|warning)\]\s?(.*)$/i;
+const QUOTE_RE = /^>\s?(.*)$/;
+const HEADING_RE = /^(#{1,6})\s+(.*)$/;
+const HR_RE = /^(-{3,}|\*{3,}|_{3,})$/;
+const BULLET_RE = /^[-*+]\s+(.*)$/;
+const ORDERED_RE = /^\d+\.\s+(.*)$/;
+
+/** A GFM delimiter row: pipe-separated cells of only dashes/colons (e.g. | --- | :-: |). */
+function isTableDelimiter(line: string): boolean {
+  const t = line.trim();
+  if (!t.includes('|') || !t.includes('-')) return false;
+  const cells = t.replace(/^\|/, '').replace(/\|$/, '').split('|');
+  return cells.length >= 1 && cells.every((c) => /^\s*:?-+:?\s*$/.test(c));
+}
+
+/** Split a GFM table row into trimmed cells (tolerates optional leading/trailing pipe). */
+function splitTableRow(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split('|')
+    .map((c) => c.trim());
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a rich-markdown string into a flat array of TipTap block nodes.
+ * Empty / whitespace-only input → [] (caller decides the fallback).
+ */
+export function parseMarkdownToTiptap(md: string | null | undefined): TiptapNode[] {
+  const text = (md ?? '').replace(/\r\n?/g, '\n');
+  const lines = text.split('\n');
+  const out: TiptapNode[] = [];
+  let para: string[] = [];
+
+  const flushPara = () => {
+    if (para.length === 0) return;
+    const joined = para.join(' ');
+    para = [];
+    const node = paragraphNode(joined);
+    if (node.content && node.content.length > 0) out.push(node);
+  };
+
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    // Blank line → paragraph boundary.
+    if (trimmed === '') {
+      flushPara();
+      i++;
+      continue;
+    }
+
+    // Fenced code / mermaid.
+    const fence = FENCE_RE.exec(trimmed);
+    if (fence) {
+      flushPara();
+      const lang = (fence[1] ?? '').toLowerCase();
+      const buf: string[] = [];
+      i++;
+      while (i < lines.length && !/^```/.test(lines[i].trim())) {
+        buf.push(lines[i]);
+        i++;
+      }
+      if (i < lines.length) i++; // consume closing fence
+      const src = buf.join('\n');
+      if (lang === 'mermaid') {
+        out.push({ type: 'mermaid', attrs: { source: src } });
+      } else {
+        out.push({
+          type: 'codeBlock',
+          ...(lang ? { attrs: { language: lang } } : {}),
+          content: src ? [{ type: 'text', text: src }] : [],
+        });
+      }
+      continue;
+    }
+
+    // Admonition callout: > [!note] … (subsequent > lines are the body).
+    const callout = CALLOUT_RE.exec(line);
+    if (callout) {
+      flushPara();
+      const kind = callout[1].toLowerCase();
+      const bodyLines: string[] = [];
+      if (callout[2] && callout[2].trim()) bodyLines.push(callout[2]);
+      i++;
+      while (i < lines.length && lines[i].trimStart().startsWith('>')) {
+        const q = QUOTE_RE.exec(lines[i]);
+        bodyLines.push(q ? q[1] : '');
+        i++;
+      }
+      const inner = parseMarkdownToTiptap(bodyLines.join('\n'));
+      out.push({
+        type: 'callout',
+        attrs: { kind },
+        content: inner.length ? inner : [{ type: 'paragraph' }],
+      });
+      continue;
+    }
+
+    // GFM table: a header row followed by a delimiter row.
+    if (line.includes('|') && i + 1 < lines.length && isTableDelimiter(lines[i + 1])) {
+      flushPara();
+      const headers = splitTableRow(line);
+      i += 2; // skip header + delimiter
+      const rows: string[][] = [];
+      while (i < lines.length && lines[i].includes('|') && lines[i].trim() !== '') {
+        rows.push(splitTableRow(lines[i]));
+        i++;
+      }
+      out.push({ type: 'markdownTable', attrs: { tableJson: JSON.stringify({ headers, rows }) } });
+      continue;
+    }
+
+    // Plain blockquote: > … (no [!type] — that was handled above).
+    if (line.trimStart().startsWith('>')) {
+      flushPara();
+      const bodyLines: string[] = [];
+      while (i < lines.length && lines[i].trimStart().startsWith('>')) {
+        const q = QUOTE_RE.exec(lines[i]);
+        bodyLines.push(q ? q[1] : '');
+        i++;
+      }
+      const inner = parseMarkdownToTiptap(bodyLines.join('\n'));
+      out.push({ type: 'blockquote', content: inner.length ? inner : [{ type: 'paragraph' }] });
+      continue;
+    }
+
+    // ATX heading (capped at h3 — note schema enables levels 1-3).
+    const heading = HEADING_RE.exec(trimmed);
+    if (heading) {
+      flushPara();
+      const level = Math.min(3, heading[1].length) as 1 | 2 | 3;
+      out.push({ type: 'heading', attrs: { level }, content: parseInline(heading[2].trim()) });
+      i++;
+      continue;
+    }
+
+    // Thematic break.
+    if (HR_RE.test(trimmed)) {
+      flushPara();
+      out.push({ type: 'horizontalRule' });
+      i++;
+      continue;
+    }
+
+    // Bullet list (flat).
+    if (BULLET_RE.test(trimmed)) {
+      flushPara();
+      const items: TiptapNode[] = [];
+      while (i < lines.length && BULLET_RE.test(lines[i].trim())) {
+        const m = BULLET_RE.exec(lines[i].trim())!;
+        items.push({ type: 'listItem', content: [paragraphNode(m[1])] });
+        i++;
+      }
+      out.push({ type: 'bulletList', content: items });
+      continue;
+    }
+
+    // Ordered list (flat).
+    if (ORDERED_RE.test(trimmed)) {
+      flushPara();
+      const items: TiptapNode[] = [];
+      while (i < lines.length && ORDERED_RE.test(lines[i].trim())) {
+        const m = ORDERED_RE.exec(lines[i].trim())!;
+        items.push({ type: 'listItem', content: [paragraphNode(m[1])] });
+        i++;
+      }
+      out.push({ type: 'orderedList', content: items });
+      continue;
+    }
+
+    // Default: accumulate into the current paragraph (soft-wrapped lines join).
+    para.push(trimmed);
+    i++;
+  }
+
+  flushPara();
+  return out;
+}

--- a/frontend/src/pages/learning/lib/mermaid-block.tsx
+++ b/frontend/src/pages/learning/lib/mermaid-block.tsx
@@ -1,0 +1,116 @@
+/**
+ * MermaidBlock — TipTap atomic node rendering a ```mermaid diagram to SVG.
+ *
+ * Mirrors the figure-block.tsx custom-node + lazy-import pattern: `mermaid` is a
+ * transitive dependency (verified importable), dynamically imported only when a
+ * mermaid block mounts (keeps the heavy lib out of the main bundle, like KaTeX).
+ * Theme is forced dark to match note mode. On any parse/render failure it falls
+ * back to a monospace code block of the raw source (never blank, never throws).
+ *
+ * Atom node: the diagram source lives in the `source` attribute; the SVG is a
+ * render artifact, not stored in the doc. renderHTML emits inert markup for
+ * editor.getHTML(); the live UI is the React NodeView.
+ */
+import { useEffect, useRef, useState } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, type NodeViewProps } from '@tiptap/react';
+
+export interface MermaidBlockOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+let mermaidIdSeq = 0;
+
+function MermaidNodeView({ node }: NodeViewProps) {
+  const source = (node.attrs['source'] as string | undefined) ?? '';
+  const [svg, setSvg] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const idRef = useRef(`note-mermaid-${(mermaidIdSeq += 1)}`);
+
+  useEffect(() => {
+    let cancelled = false;
+    const src = source.trim();
+    if (!src) {
+      setFailed(true);
+      return;
+    }
+    (async () => {
+      try {
+        const mermaid = (await import('mermaid')).default;
+        // theme-aware: note mode is always dark. startOnLoad off — we render manually.
+        mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'strict' });
+        const { svg: out } = await mermaid.render(idRef.current, src);
+        if (!cancelled) setSvg(out);
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [source]);
+
+  if (failed) {
+    // Fallback — show the raw source as a code block so content is never lost.
+    return (
+      <NodeViewWrapper className="note-mermaid note-mermaid--fallback" data-type="mermaid">
+        <pre className="note-mermaid-fallback">
+          <code>{source}</code>
+        </pre>
+      </NodeViewWrapper>
+    );
+  }
+
+  if (svg === null) {
+    return <NodeViewWrapper className="note-mermaid note-mermaid--loading" data-type="mermaid" />;
+  }
+
+  // mermaid output is sanitized SVG markup (securityLevel:'strict'); source is
+  // backend-generated diagram text, not user HTML.
+  return (
+    <NodeViewWrapper className="note-mermaid" data-type="mermaid">
+      <div className="note-mermaid-canvas" dangerouslySetInnerHTML={{ __html: svg }} />
+    </NodeViewWrapper>
+  );
+}
+
+export const MermaidBlock = Node.create<MermaidBlockOptions>({
+  name: 'mermaid',
+
+  group: 'block',
+  atom: true,
+  draggable: true,
+  selectable: true,
+
+  addOptions() {
+    return { HTMLAttributes: {} };
+  },
+
+  addAttributes() {
+    return {
+      source: {
+        default: '',
+        parseHTML: (el) => el.getAttribute('data-source') ?? el.textContent ?? '',
+        renderHTML: (attrs) => (attrs['source'] ? { 'data-source': String(attrs['source']) } : {}),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="mermaid"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        'data-type': 'mermaid',
+        class: 'note-mermaid',
+      }),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(MermaidNodeView);
+  },
+});

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -38,6 +38,7 @@ import type {
   MandalaBookFigure,
 } from '@/shared/lib/api-client';
 import type { TiptapDoc, TiptapNode } from '@/features/video-side-panel/lib/note-parser';
+import { parseMarkdownToTiptap, parseInline } from './markdown-to-tiptap';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -127,24 +128,18 @@ function videoBlockNode(
   };
 }
 
-// NOTE-DENSITY ① — "핵심 요점" key-point callout. Reuses the registered
-// blockquote + bulletList nodes (no new TipTap extension); the bulletList child
-// distinguishes it from the legacy narrative blockquote (> p) for note-mode CSS
-// (blockquote:has(> ul)) and markdown export. Returns null when no real points.
-function keyPointBlockNode(keyPoints: string[] | undefined): TiptapNode | null {
-  const points = (keyPoints ?? []).map((p) => normalizeText(p ?? '')).filter(Boolean);
-  if (points.length === 0) return null;
+// NOTE-DENSITY ① (revised) — "핵심 포인트" key-point quote. `section.keyPoint` is a
+// prose synthesis string; render it as a left-bar quote (blockquote > p, keypoint
+// attr → note-mode "핵심 포인트" label) — the legacy quote style the user prefers,
+// NOT a gold callout box or bullets. Inline marks (**bold**) are parsed. Returns
+// null when absent/empty (flag-safe: existing notes byte-unchanged).
+function keyPointQuoteNode(keyPoint: string | undefined): TiptapNode | null {
+  const text = normalizeText(keyPoint ?? '');
+  if (!text) return null;
   return {
     type: 'blockquote',
-    content: [
-      {
-        type: 'bulletList',
-        content: points.map((p) => ({
-          type: 'listItem',
-          content: [paragraph(p)],
-        })),
-      },
-    ],
+    attrs: { keypoint: true },
+    content: [{ type: 'paragraph', content: parseInline(text) }],
   };
 }
 
@@ -199,7 +194,8 @@ const KIND_LABEL_KO: Record<string, string> = { chart: '차트', diagram: '도�
 /** Caption = what the figure shows: struct.insight when present, else a kind
  *  label. Equation gets no label (neutral). */
 function figureCaption(f: MandalaBookFigure): string | null {
-  const insight = typeof f.struct?.['insight'] === 'string' ? (f.struct['insight'] as string).trim() : '';
+  const insight =
+    typeof f.struct?.['insight'] === 'string' ? (f.struct['insight'] as string).trim() : '';
   if (insight) return insight;
   if (f.kind === 'equation') return null;
   return KIND_LABEL_KO[f.kind] ?? null;
@@ -209,7 +205,9 @@ function figureCaption(f: MandalaBookFigure): string | null {
  *  table in the NodeView). null when no tabular payload. */
 function serializeTable(struct: Record<string, unknown> | undefined): string | null {
   if (!struct) return null;
-  const headers = Array.isArray(struct['headers']) ? (struct['headers'] as unknown[]).map(String) : [];
+  const headers = Array.isArray(struct['headers'])
+    ? (struct['headers'] as unknown[]).map(String)
+    : [];
   const rows = Array.isArray(struct['rows'])
     ? (struct['rows'] as unknown[]).map((r) => (Array.isArray(r) ? r.map(String) : [String(r)]))
     : [];
@@ -245,7 +243,14 @@ function renderFigures(figures: MandalaBookFigure[] | undefined): TiptapNode[] {
       const latex = (f.latex ?? '').trim();
       if (!latex) continue;
       out.push(
-        figureBlockNode({ kind: 'equation', latex, svg: null, assetPath: null, tableJson: null, ...base })
+        figureBlockNode({
+          kind: 'equation',
+          latex,
+          svg: null,
+          assetPath: null,
+          tableJson: null,
+          ...base,
+        })
       );
     } else if (f.kind === 'table') {
       const tableJson = serializeTable(f.struct);
@@ -303,7 +308,11 @@ function renderSection(
   // unchanged path below. Empty narrative (weave/skeleton edge) also falls
   // through → graceful legacy render (R-1b-FALLBACK).
   if (narrativeMode && section.narrative && section.narrative.trim()) {
-    out.push(paragraph(section.narrative));
+    // [NOTE-FULL-TOOLSET] section.narrative is rich markdown (bold/lists/callouts/
+    // mermaid/tables) — parse it into the full TipTap node set instead of a single
+    // plain paragraph. Plain prose (no markdown) still parses to one paragraph, so
+    // pre-toolset narrative books are visually unchanged.
+    out.push(...parseMarkdownToTiptap(section.narrative));
     for (const g of groups) {
       if (g.atoms.length === 0) continue;
       const firstTs = g.atoms[0].ts ?? 0;
@@ -311,10 +320,10 @@ function renderSection(
       out.push(videoBlockNode(g.vid, firstTs, endSec, section.title ?? null));
     }
     out.push(...renderFigures(section.figures)); // [CV-NOTE-WIRE]
-    // NOTE-DENSITY ① — real key-point take-aways AFTER prose + figures (flag-safe:
-    // absent/empty keyPoints → emit nothing → existing notes byte-unchanged).
-    const keyPoints = keyPointBlockNode(section.keyPoints);
-    if (keyPoints) out.push(keyPoints);
+    // NOTE-DENSITY ① — the distilled take-away AFTER prose + figures, as a left-bar
+    // "핵심 포인트" quote (flag-safe: absent keyPoint → nothing → byte-unchanged).
+    const keyPoint = keyPointQuoteNode(section.keyPoint);
+    if (keyPoint) out.push(keyPoint);
     out.push(horizontalRule());
     return out;
   }
@@ -336,10 +345,12 @@ function renderSection(
   }
 
   // Section narrative (if present) — placed AFTER atoms as a wrap-up. Rendered
-  // as a blockquote so note-mode CSS styles it as the gold "핵심 포인트" keypoint.
+  // as a keypoint blockquote so note-mode CSS styles it as the gold "핵심 포인트"
+  // quote (keypoint attr gates the label, so plain markdown quotes stay unlabeled).
   if (section.narrative && section.narrative.trim()) {
     out.push({
       type: 'blockquote',
+      attrs: { keypoint: true },
       content: [paragraph(section.narrative)],
     });
   }

--- a/frontend/src/pages/learning/lib/note-export.ts
+++ b/frontend/src/pages/learning/lib/note-export.ts
@@ -90,21 +90,18 @@ function renderBlock(node: TiptapNode, depth: number): string {
     case 'orderedList':
       return renderList(node, '1.', depth);
     case 'blockquote': {
-      // NOTE-DENSITY ① — "핵심 요점" key-point callout = blockquote wrapping only
-      // a bulletList. Serialize as a labeled heading + plain bullets (not a quote).
-      const children = node.content ?? [];
-      if (children.length > 0 && children.every((c) => c.type === 'bulletList')) {
-        const bullets = children.map((c) => renderBlock(c, depth)).join('');
-        return `**핵심 요점**\n\n${bullets}\n`;
-      }
       const inner = (node.content ?? []).map((c) => renderBlock(c, depth)).join('');
-      return (
-        inner
-          .split('\n')
-          .map((line) => (line ? `> ${line}` : ''))
-          .join('\n')
-          .trimEnd() + '\n\n'
-      );
+      const quoted = inner
+        .split('\n')
+        .map((line) => (line ? `> ${line}` : ''))
+        .join('\n')
+        .trimEnd();
+      // NOTE-DENSITY ① — the key-point quote (keypoint attr) carries a labeled
+      // "핵심 포인트" line; a plain markdown quote serializes as a bare blockquote.
+      if (node.attrs?.['keypoint']) {
+        return `> **핵심 포인트**\n>\n${quoted}\n\n`;
+      }
+      return quoted + '\n\n';
     }
     case 'codeBlock': {
       const lang = (node.attrs?.['language'] as string | undefined) ?? '';
@@ -149,6 +146,26 @@ function renderBlock(node: TiptapNode, depth: number): string {
       const srcLine = source ? `_${source}_\n\n` : '';
       return `${img}${capLine}${srcLine}`;
     }
+    case 'callout': {
+      // [NOTE-FULL-TOOLSET] admonition → Obsidian/GFM `> [!kind]` block.
+      const kind = (node.attrs?.['kind'] as string | undefined) ?? 'note';
+      const inner = (node.content ?? []).map((c) => renderBlock(c, depth)).join('');
+      const body = inner
+        .split('\n')
+        .map((line) => (line ? `> ${line}` : ''))
+        .join('\n')
+        .replace(/(?:^|\n)>\s*(?=\n|$)/g, '') // drop blank quote lines
+        .trimEnd();
+      return `> [!${kind}]\n${body}\n\n`;
+    }
+    case 'mermaid': {
+      // [NOTE-FULL-TOOLSET] mermaid diagram → fenced ```mermaid block.
+      const source = ((node.attrs?.['source'] as string | undefined) ?? '').replace(/\s+$/, '');
+      return '```mermaid\n' + source + '\n```\n\n';
+    }
+    case 'markdownTable':
+      // [NOTE-FULL-TOOLSET] read-only GFM table → pipe-delimited markdown.
+      return renderMarkdownTable(node) + '\n';
     default:
       // Fallback for unknown block types: render any text children.
       if (Array.isArray(node.content)) {
@@ -157,6 +174,35 @@ function renderBlock(node: TiptapNode, depth: number): string {
       }
       return '';
   }
+}
+
+/**
+ * [NOTE-FULL-TOOLSET] markdownTable node → GFM table. Reads the {headers, rows}
+ * JSON stored in `tableJson`; returns '' on empty/parse failure.
+ */
+function renderMarkdownTable(node: TiptapNode): string {
+  const json = (node.attrs?.['tableJson'] as string | null | undefined) ?? null;
+  if (!json) return '';
+  let headers: string[] = [];
+  let rows: string[][] = [];
+  try {
+    const parsed = JSON.parse(json) as { headers?: unknown; rows?: unknown };
+    headers = Array.isArray(parsed.headers) ? parsed.headers.map(String) : [];
+    rows = Array.isArray(parsed.rows)
+      ? parsed.rows.map((r) => (Array.isArray(r) ? r.map(String) : [String(r)]))
+      : [];
+  } catch {
+    return '';
+  }
+  if (headers.length === 0 && rows.length === 0) return '';
+  const width = Math.max(headers.length, ...rows.map((r) => r.length), 1);
+  const pad = (cells: string[]) => {
+    const c = cells.slice();
+    while (c.length < width) c.push('');
+    return `| ${c.map((x) => x.replace(/\|/g, '\\|')).join(' | ')} |`;
+  };
+  const lines = [pad(headers), `| ${Array(width).fill('---').join(' | ')} |`, ...rows.map(pad)];
+  return lines.join('\n') + '\n';
 }
 
 function renderList(node: TiptapNode, marker: string, depth: number): string {

--- a/frontend/src/pages/learning/model/useNoteDocument.ts
+++ b/frontend/src/pages/learning/model/useNoteDocument.ts
@@ -25,6 +25,7 @@ import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
 import Link from '@tiptap/extension-link';
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import Blockquote from '@tiptap/extension-blockquote';
 import { createLowlight, common } from 'lowlight';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -34,7 +35,26 @@ import type { TiptapDoc } from '@/features/video-side-panel/lib/note-parser';
 
 import { VideoBlock } from '../lib/video-block';
 import { FigureBlock } from '../lib/figure-block';
+import { Callout } from '../lib/callout-block';
+import { MermaidBlock } from '../lib/mermaid-block';
+import { MarkdownTable } from '../lib/markdown-table-block';
 import { buildInitialNoteDoc } from '../lib/note-document-generator';
+
+// [NOTE-FULL-TOOLSET] — Blockquote with a `keypoint` attr so the note-mode CSS
+// "핵심 포인트" label targets ONLY the generated key-point quote (data-keypoint),
+// leaving plain markdown blockquotes from narrative unlabeled. StarterKit's own
+// blockquote is disabled (below) and this extended one registered in its place.
+const KeyPointBlockquote = Blockquote.extend({
+  addAttributes() {
+    return {
+      keypoint: {
+        default: false,
+        parseHTML: (el) => el.getAttribute('data-keypoint') === 'true',
+        renderHTML: (attrs) => (attrs['keypoint'] ? { 'data-keypoint': 'true' } : {}),
+      },
+    };
+  },
+});
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -135,7 +155,11 @@ export function useNoteDocument(input: UseNoteDocumentInput): UseNoteDocumentRes
       StarterKit.configure({
         heading: { levels: [1, 2, 3] },
         codeBlock: false,
+        // [NOTE-FULL-TOOLSET] — disable the built-in blockquote; register the
+        // keypoint-aware one below so the "핵심 포인트" label can be scoped.
+        blockquote: false,
       }),
+      KeyPointBlockquote,
       Placeholder.configure({ placeholder: '내용을 작성하거나 ▶ 영상으로 돌아가세요.' }),
       Link.configure({ openOnClick: false, autolink: true }),
       CodeBlockLowlight.configure({ lowlight }),
@@ -143,6 +167,12 @@ export function useNoteDocument(input: UseNoteDocumentInput): UseNoteDocumentRes
       VideoBlock.configure({ HTMLAttributes: {} }),
       // [CV-NOTE-WIRE] — CV figures (equation: lazy KaTeX / chart|diagram|table: img).
       FigureBlock.configure({ HTMLAttributes: {} }),
+      // [NOTE-FULL-TOOLSET] — rich-markdown narrative nodes (must be registered or
+      // ProseMirror throws on doc load): admonition callout, mermaid diagram,
+      // read-only GFM table.
+      Callout.configure({ HTMLAttributes: {} }),
+      MermaidBlock.configure({ HTMLAttributes: {} }),
+      MarkdownTable.configure({ HTMLAttributes: {} }),
     ],
     []
   );

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -646,8 +646,9 @@ const NOTE_PROSE_STYLE = `
   font-size: 17.5px;
   line-height: 1.7;
 }
-/* "핵심 포인트" label above the keypoint (시안 .lbl) — CSS-only, no generator change. */
-.note-prose-root .ProseMirror blockquote::before {
+/* NOTE-DENSITY ① (revised) — "핵심 포인트" label gated to the generated key-point
+   quote (data-keypoint) so plain markdown quotes from narrative stay UNlabeled. */
+.note-prose-root .ProseMirror blockquote[data-keypoint="true"]::before {
   content: "핵심 포인트";
   display: block;
   font-family: var(--nm-sans);
@@ -658,32 +659,6 @@ const NOTE_PROSE_STYLE = `
   color: var(--nm-accent);
   margin-bottom: 10px;
 }
-/* NOTE-DENSITY ① — "핵심 요점" key-point callout: a gold-tinted box (distinct
-   from body prose + from the legacy gold left-rule keypoint). Discriminated from
-   the narrative blockquote (> p) by its bulletList child. Academic/dense look. */
-.note-prose-root .ProseMirror blockquote:has(> ul) {
-  border-left: none;
-  background: var(--nm-keypoint-bg);
-  border: 1px solid var(--nm-keypoint-border);
-  border-radius: 10px;
-  padding: 18px 22px;
-  margin: 40px 0;
-}
-.note-prose-root .ProseMirror blockquote:has(> ul)::before { content: "핵심 요점"; }
-.note-prose-root .ProseMirror blockquote:has(> ul) ul {
-  margin: 0;
-  padding-left: 1.15em;
-  list-style: disc;
-}
-.note-prose-root .ProseMirror blockquote:has(> ul) li {
-  font-family: var(--nm-serif);
-  font-size: 16px;
-  line-height: 1.65;
-  color: var(--nm-strong);
-  margin: 0 0 0.5em;
-}
-.note-prose-root .ProseMirror blockquote:has(> ul) li:last-child { margin-bottom: 0; }
-.note-prose-root .ProseMirror blockquote:has(> ul) li::marker { color: var(--nm-accent); }
 .note-prose-root .ProseMirror code {
   font-family: var(--nm-mono);
   font-size: 0.82em;
@@ -864,6 +839,135 @@ const NOTE_PROSE_STYLE = `
   font-size: 11.5px;
   letter-spacing: -0.01em;
   color: var(--nm-faint);
+}
+
+/* [NOTE-FULL-TOOLSET] — markdown narrative now emits real lists, code blocks,
+   callouts, mermaid diagrams and GFM tables. Below styles each in note-mode tokens. */
+
+/* lists (top-level bullet/ordered from narrative) */
+.note-prose-root .ProseMirror ul,
+.note-prose-root .ProseMirror ol {
+  margin: 0 0 1.55em;
+  padding-left: 1.4em;
+}
+.note-prose-root .ProseMirror ul { list-style: disc; }
+.note-prose-root .ProseMirror ol { list-style: decimal; }
+.note-prose-root .ProseMirror li {
+  margin: 0 0 0.4em;
+  color: var(--nm-text);
+}
+.note-prose-root .ProseMirror li::marker { color: var(--nm-accent); }
+.note-prose-root .ProseMirror li > p { margin: 0 0 0.4em; }
+
+/* fenced code block (CodeBlockLowlight → pre > code) */
+.note-prose-root .ProseMirror pre {
+  font-family: var(--nm-mono);
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--nm-strong);
+  background: var(--nm-figure-bg);
+  border: 1px solid var(--nm-line);
+  border-radius: 10px;
+  padding: 16px 18px;
+  margin: 28px 0;
+  overflow-x: auto;
+}
+.note-prose-root .ProseMirror pre code {
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  white-space: pre;
+}
+
+/* admonition callout (note / tip / warning) */
+.note-prose-root .note-callout {
+  margin: 32px 0;
+  padding: 16px 18px;
+  border: 1px solid var(--nm-callout-border);
+  border-left: 3px solid var(--nm-callout-accent);
+  border-radius: 10px;
+  background: var(--nm-callout-bg);
+  color: var(--nm-callout-ink);
+}
+.note-prose-root .note-callout[data-kind="note"] {
+  --nm-callout-bg: var(--nm-callout-note-bg);
+  --nm-callout-border: var(--nm-callout-note-border);
+  --nm-callout-accent: var(--nm-callout-note-accent);
+}
+.note-prose-root .note-callout[data-kind="tip"] {
+  --nm-callout-bg: var(--nm-callout-tip-bg);
+  --nm-callout-border: var(--nm-callout-tip-border);
+  --nm-callout-accent: var(--nm-callout-tip-accent);
+}
+.note-prose-root .note-callout[data-kind="warning"] {
+  --nm-callout-bg: var(--nm-callout-warning-bg);
+  --nm-callout-border: var(--nm-callout-warning-border);
+  --nm-callout-accent: var(--nm-callout-warning-accent);
+}
+.note-prose-root .note-callout-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  color: var(--nm-callout-accent);
+}
+.note-prose-root .note-callout-icon { width: 15px; height: 15px; flex: 0 0 auto; }
+.note-prose-root .note-callout-label {
+  font-family: var(--nm-sans);
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.note-prose-root .note-callout-body > :last-child { margin-bottom: 0; }
+.note-prose-root .note-callout-body p {
+  margin: 0 0 0.6em;
+  font-size: 15.5px;
+  line-height: 1.7;
+  color: var(--nm-text);
+}
+
+/* mermaid diagram (rendered SVG, centered) + raw-source fallback */
+.note-prose-root .note-mermaid { margin: 32px auto; max-width: 600px; text-align: center; }
+.note-prose-root .note-mermaid-canvas svg { max-width: 100%; height: auto; }
+.note-prose-root .note-mermaid-fallback {
+  font-family: var(--nm-mono);
+  font-size: 13px;
+  line-height: 1.6;
+  text-align: left;
+  color: var(--nm-strong);
+  background: var(--nm-figure-bg);
+  border: 1px solid var(--nm-line);
+  border-radius: 10px;
+  padding: 16px 18px;
+  overflow-x: auto;
+}
+
+/* GFM table (read-only markdownTable node) */
+.note-prose-root .note-md-table-block { margin: 28px 0; overflow-x: auto; }
+.note-prose-root .note-md-table-block.hidden { display: none; }
+.note-prose-root .note-md-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--nm-sans);
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--nm-text);
+}
+.note-prose-root .note-md-table th,
+.note-prose-root .note-md-table td {
+  border: 1px solid var(--nm-line);
+  padding: 8px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+.note-prose-root .note-md-table thead th {
+  background: var(--nm-figure-th-bg);
+  font-weight: 600;
+  color: var(--nm-strong);
 }
 `;
 


### PR DESCRIPTION
## What

BE is changing `section.narrative` to **rich markdown** (bold, lists, `> [!callouts]`, ` ```mermaid `, GFM tables) and `section.keyPoint` to a **prose synthesis string**. The note generator previously emitted `narrative` as ONE plain paragraph. This PR parses the markdown into the full TipTap node set, registers the missing block extensions, and revises #1016's gold-bullet keypoint into the legacy "핵심 포인트" left-bar quote. 정공법 — every tool is gen-emitted AND rendered.

Based on `origin/main` (includes #1016).

## Changes

**1. Markdown → TipTap parser** — `markdown-to-tiptap.ts` (new). No markdown lib exists in `package.json` (no marked/markdown-it/remark), so this is a focused, deterministic, dependency-free line-based parser covering exactly the constructs the book pipeline emits: inline `**bold**`/`*italic*`/`` `code` ``/`[link](url)` marks, `- `/`1. ` lists, `> [!note|tip|warning]` callouts, ` ```mermaid ` blocks, GFM `| a | b |` tables, plain `> ` blockquotes, ATX headings (≤h3), `---` hr. The generator narrative path now parses instead of emitting one paragraph; **plain prose still → one paragraph**, so pre-toolset narrative books are visually unchanged.

**2. Three new TipTap extensions** (figure-block.tsx custom-node pattern; registered in `useNoteDocument`):
- **Callout** — content node (`block+`, editable body) with a per-kind icon + Korean label header, note-mode tokened box (note/tip/warning).
- **MermaidBlock** — atom; **lazy-imports `mermaid`** (transitive dep, verified importable) like KaTeX in figure-block, renders dark theme-aware SVG; falls back to a code block of the raw source on failure. Mermaid stays in its own async chunk (not in the main bundle).
- **MarkdownTable** — read-only GFM table node (`@tiptap/extension-table` is **not** installed; a fully editable table is out of scope for generated bodies).

**3. keyPoint revision (★ revises #1016)** — `section.keyPoint` prose → a `keypoint`-attr blockquote rendered as the gold left-bar **"핵심 포인트"** quote (the legacy quote style, NOT a gold callout box, NOT bullets). The label is now gated to `blockquote[data-keypoint]` — `Blockquote` is extended with a `keypoint` attribute and StarterKit's built-in blockquote disabled — so **plain markdown quotes from narrative stay unlabeled**. Removed the #1016 gold bullet-callout (its CSS, `--nm-keypoint-*` tokens, and the plural `keyPoints` type). Flag-safe: absent keyPoint → nothing.

**4. CSS** — `CenterPanel` `NOTE_PROSE_STYLE` + `index.css`, **note-mode tokens only** (callout color literals live in the token block; components reference them): callout (note/tip/warning), mermaid, GFM table, plus general list + code-block styling now that narrative emits them.

**5. `note-export.ts`** — serializes the new nodes back to markdown: callout → `> [!kind]`, mermaid → ` ```mermaid `, markdownTable → GFM, keypoint quote → `> **핵심 포인트**`.

**6. Tests** — `markdown-to-tiptap.test.ts` (new): per-construct + inline-mark + `buildInitialNoteDoc` integration (callout/mermaid/table emitted) + markdown-less byte-stability. `note-document-generator-narrative.test.ts` revised for the keyPoint quote.

## Constraints honored
- New nodes registered in `useNoteDocument` (unregistered node = ProseMirror throws on load).
- Mermaid/KaTeX lazy-imported.
- #1013 figure size/caption + #1015 currentColor sanitizer untouched.
- Comments English.

## Verification
`cd frontend && tsc --noEmit` (0) `&& vitest run note-document-generator markdown-to-tiptap` (37 passed) `&& vite build` (built, mermaid split into its own async chunk).

Do NOT merge — pending review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)