### PR TITLE
fix(note): heal empty-text-node collapse in learning note [NOTE-FULL-TOOLSET]

### DIFF
--- a/frontend/src/__tests__/note-document-generator-narrative.test.ts
+++ b/frontend/src/__tests__/note-document-generator-narrative.test.ts
@@ -237,7 +237,7 @@ describe('note-document-generator — CV figures render ([CV-NOTE-WIRE])', () =>
     expect(f.tsSec).toBe(565); // mm:ss formatting (→ 9:25) happens in the NodeView
   });
 
-  it('chart without insight → Korean kind-label caption (not the raw english word)', () => {
+  it('chart without insight → no caption (no kind-label fallback)', () => {
     const b = book('이 장은 기초 회화를 다룬다');
     b.chapters[0]!.sections[0]!.figures = [
       {
@@ -249,7 +249,7 @@ describe('note-document-generator — CV figures render ([CV-NOTE-WIRE])', () =>
       },
     ];
     const f = figureBlocks(nodes(buildInitialNoteDoc(b)))[0]!;
-    expect(f.caption).toBe('차트');
+    expect(f.caption).toBeNull();
   });
 
   it('table → struct headers/rows serialized to tableJson; equation gets no caption', () => {
@@ -285,7 +285,7 @@ describe('note-document-generator — CV figures render ([CV-NOTE-WIRE])', () =>
         ['3', '4'],
       ],
     });
-    expect(tableFig.caption).toBe('표');
+    expect(tableFig.caption).toBeNull(); // no insight → no caption (kind-label removed)
     const eqFig = figs.find((f) => f.kind === 'equation')!;
     expect(eqFig.caption).toBeNull(); // equation → neutral, no label
   });

--- a/frontend/src/__tests__/note-toolset-render.test.ts
+++ b/frontend/src/__tests__/note-toolset-render.test.ts
@@ -1,0 +1,291 @@
+/**
+ * note-toolset-render — [NOTE-FULL-TOOLSET regression]
+ *
+ * Reproduces the "learning note renders EMPTY" bug: a well-formed persisted
+ * content_json (heading + paragraph + callout + mermaid + markdownTable + list +
+ * blockquote + bold) silently collapses to a single empty paragraph because
+ * `schema.nodeFromJSON(doc)` throws and TipTap (enableContentCheck:false) swallows
+ * the error and falls back to an empty doc.
+ *
+ * The schema here is built from the EXACT extension set in useNoteDocument.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { getSchema } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import Placeholder from '@tiptap/extension-placeholder';
+import Link from '@tiptap/extension-link';
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import Blockquote from '@tiptap/extension-blockquote';
+import { createLowlight, common } from 'lowlight';
+
+import { VideoBlock } from '@/pages/learning/lib/video-block';
+import { FigureBlock } from '@/pages/learning/lib/figure-block';
+import { Callout } from '@/pages/learning/lib/callout-block';
+import { MermaidBlock } from '@/pages/learning/lib/mermaid-block';
+import { MarkdownTable } from '@/pages/learning/lib/markdown-table-block';
+import { buildInitialNoteDoc, sanitizeNoteDoc } from '@/pages/learning/lib/note-document-generator';
+import type { MandalaBookData } from '@/shared/lib/api-client';
+
+const lowlight = createLowlight(common);
+
+// Mirror useNoteDocument.ts KeyPointBlockquote.
+const KeyPointBlockquote = Blockquote.extend({
+  addAttributes() {
+    return {
+      keypoint: {
+        default: false,
+        parseHTML: (el) => el.getAttribute('data-keypoint') === 'true',
+        renderHTML: (attrs) => (attrs['keypoint'] ? { 'data-keypoint': 'true' } : {}),
+      },
+    };
+  },
+});
+
+// Mirror useNoteDocument.ts `extensions` exactly.
+const extensions = [
+  StarterKit.configure({
+    heading: { levels: [1, 2, 3] },
+    codeBlock: false,
+    blockquote: false,
+  }),
+  KeyPointBlockquote,
+  Placeholder.configure({ placeholder: 'x' }),
+  Link.configure({ openOnClick: false, autolink: true }),
+  CodeBlockLowlight.configure({ lowlight }),
+  VideoBlock.configure({ HTMLAttributes: {} }),
+  FigureBlock.configure({ HTMLAttributes: {} }),
+  Callout.configure({ HTMLAttributes: {} }),
+  MermaidBlock.configure({ HTMLAttributes: {} }),
+  MarkdownTable.configure({ HTMLAttributes: {} }),
+];
+
+// A doc shaped like the real persisted content_json (62KB) — the three new node
+// types plus a heading, paragraph (with bold), list and blockquote.
+const sampleDoc = {
+  type: 'doc',
+  content: [
+    { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: '학습 정리' }] },
+    {
+      type: 'paragraph',
+      content: [
+        { type: 'text', text: '핵심은 ' },
+        { type: 'text', text: '아키텍처', marks: [{ type: 'bold' }] },
+        { type: 'text', text: ' 이다.' },
+      ],
+    },
+    {
+      type: 'callout',
+      attrs: { kind: 'warning' },
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: '주의: 트레이드오프가 있다.' }] },
+      ],
+    },
+    {
+      type: 'mermaid',
+      attrs: { source: 'flowchart LR\n A[Start] --> B[End]\n' },
+    },
+    {
+      type: 'markdownTable',
+      attrs: {
+        tableJson: JSON.stringify({ headers: ['항목', '값'], rows: [['지연', '낮음']] }),
+      },
+    },
+    {
+      type: 'bulletList',
+      content: [
+        {
+          type: 'listItem',
+          content: [{ type: 'paragraph', content: [{ type: 'text', text: '항목1' }] }],
+        },
+      ],
+    },
+    {
+      type: 'blockquote',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: '인용문' }] }],
+    },
+  ],
+};
+
+describe('[NOTE-FULL-TOOLSET] persisted note doc round-trips through the schema', () => {
+  it('builds the schema without throwing', () => {
+    expect(() => getSchema(extensions)).not.toThrow();
+  });
+
+  it('nodeFromJSON does NOT collapse the doc (all node types preserved)', () => {
+    const schema = getSchema(extensions);
+    // This is the exact call TipTap makes internally (errorOnInvalidContent:false
+    // swallows the throw → empty fallback). If it throws here, the live editor
+    // would render a single empty paragraph.
+    const node = schema.nodeFromJSON(sampleDoc);
+
+    // The doc must keep all 7 top-level blocks — not collapse to 1 empty paragraph.
+    expect(node.childCount).toBe(sampleDoc.content.length);
+
+    const topTypes: string[] = [];
+    node.forEach((child) => topTypes.push(child.type.name));
+    expect(topTypes).toEqual([
+      'heading',
+      'paragraph',
+      'callout',
+      'mermaid',
+      'markdownTable',
+      'bulletList',
+      'blockquote',
+    ]);
+
+    // Attributes survive the JSON round-trip.
+    const callout = node.child(2);
+    expect(callout.attrs['kind']).toBe('warning');
+    const mermaid = node.child(3);
+    expect(mermaid.attrs['source']).toContain('flowchart');
+    const table = node.child(4);
+    expect(typeof table.attrs['tableJson']).toBe('string');
+    expect(table.attrs['tableJson']).toContain('항목');
+  });
+});
+
+// A rich-markdown narrative exercising EVERY construct the book pipeline emits
+// (heading, bold/italic/code/link inline marks, ordered + bullet lists, callout,
+// mermaid, GFM table, blockquote) — fed through the REAL generator so the doc
+// shape matches a persisted 62KB content_json.
+const RICH_NARRATIVE = [
+  '## 개요',
+  '',
+  '핵심은 **아키텍처** 와 *트레이드오프* 이며 `latency` 가 중요하다. 자세히는 [문서](https://example.com) 참고.',
+  '',
+  '> [!warning]',
+  '> 캐시 무효화는 어렵다.',
+  '',
+  '```mermaid',
+  'flowchart LR',
+  '  A[Start] --> B[End]',
+  '```',
+  '',
+  '| 항목 | 값 |',
+  '| --- | --- |',
+  '| 지연 | 낮음 |',
+  '',
+  '1. 첫째 단계',
+  '2. 둘째 단계',
+  '',
+  '- 포인트 A',
+  '- 포인트 B',
+  '',
+  '> 평범한 인용문이다.',
+].join('\n');
+
+const richBook: MandalaBookData = {
+  chapters: [
+    {
+      ch: 0,
+      title: '챕터 1',
+      intro: '이 챕터의 도입부 문단.', // populated intro → narrativeMode = true
+      sections: [
+        {
+          title: '섹션 1',
+          narrative: RICH_NARRATIVE,
+          atoms: [{ vid: 'abc123', ts: 12, text: '원자 텍스트', type: 'fact' }],
+          keyPoint: '핵심 포인트는 **단순함** 이다.', // → keypoint blockquote
+        },
+      ],
+    },
+  ],
+} as unknown as MandalaBookData;
+
+// A book where a SECTION carries an empty title (the BE rich-markdown pipeline can
+// emit a blank section.title). The generator's heading() helper emits the title as
+// a text node unconditionally → ProseMirror forbids empty text nodes → throw.
+const emptyTitleBook: MandalaBookData = {
+  chapters: [
+    {
+      ch: 0,
+      title: '챕터 1',
+      intro: '도입부.',
+      sections: [
+        {
+          title: '', // empty section title — heading(3, '') → empty text node
+          narrative: '본문 한 문단.',
+          atoms: [],
+          keyPoint: '',
+        },
+      ],
+    },
+  ],
+} as unknown as MandalaBookData;
+
+describe('[NOTE-FULL-TOOLSET] generator output round-trips through the schema', () => {
+  it('buildInitialNoteDoc with an EMPTY section title does NOT collapse (regression)', () => {
+    const doc = buildInitialNoteDoc(emptyTitleBook);
+    const schema = getSchema(extensions);
+    // This is the exact call TipTap makes; if it throws, the live editor collapses
+    // to one empty paragraph (errorOnInvalidContent:false swallows the throw).
+    expect(() => schema.nodeFromJSON(doc)).not.toThrow();
+  });
+
+  it('buildInitialNoteDoc rich-narrative doc does NOT collapse', () => {
+    const doc = buildInitialNoteDoc(richBook);
+    const schema = getSchema(extensions);
+
+    // Reproduces the live bug: if this throws, TipTap (errorOnInvalidContent:false)
+    // swallows it and renders a single empty paragraph.
+    const node = schema.nodeFromJSON(doc);
+
+    // The generated doc has many blocks; an empty fallback would be 1 paragraph.
+    expect(node.childCount).toBeGreaterThan(5);
+
+    const typeSet = new Set<string>();
+    node.descendants((child) => {
+      typeSet.add(child.type.name);
+    });
+    // Every rich construct must survive — not be swallowed into an empty doc.
+    for (const t of [
+      'callout',
+      'mermaid',
+      'markdownTable',
+      'orderedList',
+      'bulletList',
+      'blockquote',
+      'videoBlock',
+    ]) {
+      expect(typeSet.has(t)).toBe(true);
+    }
+  });
+});
+
+describe('[NOTE-FULL-TOOLSET] sanitizeNoteDoc heals already-persisted broken docs', () => {
+  // The real 62KB content_json was persisted by the pre-fix generator: a heading
+  // built from a blank section title carries an empty text node. Fixing the
+  // generator only helps NEW docs — existing rows must be healed on load.
+  const persistedBroken = {
+    type: 'doc' as const,
+    content: [
+      { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: '챕터' }] },
+      // The poison node: an empty text node inside a section heading.
+      { type: 'heading', attrs: { level: 3 }, content: [{ type: 'text', text: '' }] },
+      { type: 'paragraph', content: [{ type: 'text', text: '본문' }] },
+      {
+        type: 'callout',
+        attrs: { kind: 'note' },
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: '메모' }] }],
+      },
+    ],
+  };
+
+  it('raw persisted doc throws (reproduces the empty editor)', () => {
+    const schema = getSchema(extensions);
+    expect(() => schema.nodeFromJSON(persistedBroken)).toThrow(/Empty text nodes/);
+  });
+
+  it('sanitized doc loads without collapsing and preserves content', () => {
+    const schema = getSchema(extensions);
+    const healed = sanitizeNoteDoc(persistedBroken);
+    const node = schema.nodeFromJSON(healed);
+    // All 4 blocks survive (the empty h3 becomes an empty-content heading, valid).
+    expect(node.childCount).toBe(4);
+    expect(node.child(0).textContent).toBe('챕터');
+    expect(node.child(1).type.name).toBe('heading');
+    expect(node.child(1).childCount).toBe(0); // empty text node dropped
+    expect(node.child(2).textContent).toBe('본문');
+    expect(node.child(3).type.name).toBe('callout');
+  });
+});

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -195,17 +195,13 @@ function groupAtomsByVid(
 // headers/rows; equation carries latex. asset_path kept as a legacy fallback.
 const FIGURE_KINDS = new Set(['chart', 'table', 'diagram', 'equation']);
 
-// Korean kind labels for the caption fallback (never the raw english word).
-const KIND_LABEL_KO: Record<string, string> = { chart: '차트', diagram: '도식', table: '표' };
-
-/** Caption = what the figure shows: struct.insight when present, else a kind
- *  label. Equation gets no label (neutral). */
+/** Caption = what the figure shows: struct.insight when present, else none.
+ *  No kind-label fallback ("표"/"차트"/"도식") — a bare kind word adds noise,
+ *  not meaning (user directive 2026-06-30). */
 function figureCaption(f: MandalaBookFigure): string | null {
   const insight =
     typeof f.struct?.['insight'] === 'string' ? (f.struct['insight'] as string).trim() : '';
-  if (insight) return insight;
-  if (f.kind === 'equation') return null;
-  return KIND_LABEL_KO[f.kind] ?? null;
+  return insight || null;
 }
 
 /** Table struct → compact {headers, rows} JSON string (rendered as an HTML

--- a/frontend/src/pages/learning/lib/note-document-generator.ts
+++ b/frontend/src/pages/learning/lib/note-document-generator.ts
@@ -105,10 +105,17 @@ function groupAtomsIntoParagraphs(atoms: Array<{ text?: string; type?: string }>
 }
 
 function heading(level: 2 | 3, text: string): TiptapNode {
+  // Guard empty / whitespace-only titles like paragraph() does: ProseMirror
+  // forbids empty text nodes ({type:'text', text:''}). The #1020 rich-markdown BE
+  // can leave section.title blank (headings now live inside the narrative), and
+  // an unguarded text node here makes schema.nodeFromJSON throw "Empty text nodes
+  // are not allowed" — which TipTap (errorOnInvalidContent:false) swallows,
+  // collapsing the WHOLE note to one empty paragraph.
+  const normalized = normalizeText(text);
   return {
     type: 'heading',
     attrs: { level },
-    content: [{ type: 'text', text }],
+    content: normalized ? [{ type: 'text', text: normalized }] : [],
   };
 }
 
@@ -405,6 +412,43 @@ function renderChapter(chapter: MandalaBookChapter, narrativeMode: boolean): Tip
   }
 
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Doc sanitizer (load-path safety net)
+// ---------------------------------------------------------------------------
+
+const EMPTY_DOC: TiptapDoc = { type: 'doc', content: [{ type: 'paragraph' }] };
+
+/** Drop ProseMirror-invalid empty text nodes; recurse into content. Returns null
+ *  when the node itself is an empty text node (caller filters it out). */
+function sanitizeNode(node: TiptapNode): TiptapNode | null {
+  if (node.type === 'text') {
+    // ProseMirror rejects empty text nodes — drop them (a parent heading/paragraph
+    // with `content: []` is valid 'inline*').
+    return typeof node.text === 'string' && node.text.length > 0 ? node : null;
+  }
+  if (Array.isArray(node.content)) {
+    const content = node.content.map(sanitizeNode).filter((n): n is TiptapNode => n !== null);
+    return { ...node, content };
+  }
+  return node;
+}
+
+/**
+ * Heal a persisted note doc before handing it to TipTap. Strips empty text nodes
+ * ({type:'text', text:''}) that make schema.nodeFromJSON throw "Empty text nodes
+ * are not allowed" — which TipTap silently swallows (errorOnInvalidContent:false),
+ * collapsing the whole note to one empty paragraph. Existing docs persisted by the
+ * pre-fix generator are recovered on load. Pure: input is not mutated.
+ */
+export function sanitizeNoteDoc(doc: TiptapDoc | null | undefined): TiptapDoc {
+  if (!doc || typeof doc !== 'object') return EMPTY_DOC;
+  const cleaned = sanitizeNode(doc as TiptapNode);
+  if (!cleaned || !Array.isArray(cleaned.content) || cleaned.content.length === 0) {
+    return EMPTY_DOC;
+  }
+  return cleaned as TiptapDoc;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/learning/model/useNoteDocument.ts
+++ b/frontend/src/pages/learning/model/useNoteDocument.ts
@@ -38,7 +38,7 @@ import { FigureBlock } from '../lib/figure-block';
 import { Callout } from '../lib/callout-block';
 import { MermaidBlock } from '../lib/mermaid-block';
 import { MarkdownTable } from '../lib/markdown-table-block';
-import { buildInitialNoteDoc } from '../lib/note-document-generator';
+import { buildInitialNoteDoc, sanitizeNoteDoc } from '../lib/note-document-generator';
 
 // [NOTE-FULL-TOOLSET] — Blockquote with a `keypoint` attr so the note-mode CSS
 // "핵심 포인트" label targets ONLY the generated key-point quote (data-keypoint),
@@ -148,7 +148,11 @@ export function useNoteDocument(input: UseNoteDocumentInput): UseNoteDocumentRes
 
   // 4. Editor mount.
   const docId = (docQuery.data?.id ?? null) || null;
-  const initialContent = (docQuery.data?.content_json as TiptapDoc | null | undefined) ?? null;
+  // Sanitize on load: docs persisted by the pre-fix generator can carry empty text
+  // nodes (e.g. a heading from a blank section.title) that make TipTap silently
+  // collapse the whole note to one empty paragraph. Heal them before mount.
+  const rawContent = (docQuery.data?.content_json as TiptapDoc | null | undefined) ?? null;
+  const initialContent = rawContent ? sanitizeNoteDoc(rawContent) : null;
 
   const extensions = useMemo(
     () => [
@@ -259,7 +263,7 @@ export function useNoteDocument(input: UseNoteDocumentInput): UseNoteDocumentRes
     const fresh = mandalaId ? await apiClient.getNoteDocument(mandalaId) : null;
     const original = (fresh?.original_json as TiptapDoc | null | undefined) ?? null;
     if (!original) return;
-    editor.commands.setContent(original, false);
+    editor.commands.setContent(sanitizeNoteDoc(original), false);
     // Force-clear history so undo can't go past the restore point.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const histAny = (editor as any).commands as { clearHistory?: () => void };

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -887,7 +887,6 @@ const NOTE_PROSE_STYLE = `
   margin: 32px 0;
   padding: 16px 18px;
   border: 1px solid var(--nm-callout-border);
-  border-left: 3px solid var(--nm-callout-accent);
   border-radius: 10px;
   background: var(--nm-callout-bg);
   color: var(--nm-callout-ink);


### PR DESCRIPTION
## Symptom

The learning note rendered **EMPTY** — TipTap mounts `.ProseMirror` with a single empty paragraph (`contentLen=0`) even though a valid 62KB `note_documents.content_json` exists. Regression from #1020 ([NOTE-FULL-TOOLSET]). No hard console error fires.

## Root cause — the EXACT node that broke

A **heading with an empty text node** (`{type:'heading', content:[{type:'text', text:''}]}`).

- The generator's `heading()` helper emitted `content: [{type:'text', text}]` **unconditionally**, unlike `paragraph()` which already guards empty text.
- The #1020 rich-markdown BE moves section headings *into* the narrative markdown and leaves `section.title` blank, so `heading(3, '')` produces an empty text node.
- ProseMirror **forbids empty text nodes** → `schema.nodeFromJSON(doc)` throws `RangeError: Empty text nodes are not allowed`.
- TipTap inits with `errorOnInvalidContent:false` (the default, `enableContentCheck:false`). It **swallows** the RangeError — only `console.warn('[tiptap warn]: Invalid content.')` — and falls back to an empty doc (`createNodeFromContent('')`). Hence: empty editor, no error.

### Not the new extensions
A schema round-trip of every parser/generator-emittable node — including the new `callout` / `mermaid` / `markdownTable` — passes cleanly. Their `addAttributes` (`kind`/`source`/`tableJson`) round-trip correctly from JSON. The attr/content-model of the three new nodes is **correct**; the breaker is the unguarded heading text node.

## Fix (two parts)

1. **Prevent new broken docs** — `heading()` now guards empty/whitespace titles (mirrors `paragraph()`): emits `content: []` (valid `inline*`) when the title is blank.
2. **Heal already-persisted docs** — `sanitizeNoteDoc()`, a recursive load-path pass that strips empty text nodes, wired into `useNoteDocument` `initialContent` + the `restoreOriginal`/`regenerate` `setContent` paths. Recovers the existing 62KB rows persisted by the pre-fix generator (fixing the generator alone would not render them).

`figure-block` / `keyPoint` / `video-block` untouched.

## Tests

New `frontend/src/__tests__/note-toolset-render.test.ts` builds the schema from the **exact** `useNoteDocument` extension set:
- raw broken persisted doc → `schema.nodeFromJSON` throws `/Empty text nodes/` (reproduces the empty editor);
- after `sanitizeNoteDoc` → loads with all blocks preserved (empty h3 becomes a valid empty-content heading);
- `buildInitialNoteDoc` with a blank section title no longer collapses;
- full rich-narrative generator output (callout/mermaid/table/lists/blockquote/videoBlock) round-trips.

## Verification

- `tsc --noEmit`: clean
- `vitest` full suite: **452 passed** (incl. existing markdown-to-tiptap + note-document-generator tests)
- `npm run build`: clean (mermaid stays lazy-chunked)

Note: the repro test exercises the exact `schema.nodeFromJSON` path TipTap uses internally, so the automated gate directly covers the bug mechanism. **In-browser verification on a real persisted note is the recommended final operator step before merge.**

Do NOT merge (per task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)