### PR TITLE
feat(card-grid): mockup-exact dashboard redesign — dark tokens, card/tag/divider, add-cards, channel meta

### DIFF
--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -221,7 +221,7 @@
     --sidebar-width: 22rem;
     /* CP441 — sidebar bg unified with content area (--background).
        CP445.x — ChatGPT-style neutral very dark. */
-    --sidebar-background: 0 0% 8%;
+    --sidebar-background: 228 17% 5.7%; /* #0C0D11 — mockup sidebar */
     --sidebar-foreground: 0 0% 95%;
     --sidebar-primary: 234 60% 72%;
     --sidebar-primary-foreground: 0 0% 10%;
@@ -229,7 +229,7 @@
     --sidebar-accent-foreground: 234 60% 75%;
     --sidebar-border: 0 0% 22%;
     --sidebar-ring: 234 60% 72%;
-    --sidebar: 0 0% 10%;
+    --sidebar: 228 17% 5.7%; /* #0C0D11 — mockup sidebar */
 
     /* Chart colors */
     --chart-1: 234 60% 72%;

--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -159,14 +159,14 @@
     --bg-sunken: 0 0% 8%;
 
     /* Core semantic tokens */
-    /* CP445.x — main surface 8% 단일 톤 (ChatGPT-flat). card/popover 도 통일. */
-    --background: 0 0% 8%;
+    /* CARD-GRID group1 — mockup-exact: grid/page bg #0A0B0D, card/popover #121419. */
+    --background: 220 13% 4.5%; /* #0A0B0D */
     --foreground: 0 0% 95%;
 
-    --card: 0 0% 8%;
+    --card: 223 16% 8.4%; /* #121419 */
     --card-foreground: 0 0% 95%;
 
-    --popover: 0 0% 8%;
+    --popover: 223 16% 8.4%; /* #121419 */
     --popover-foreground: 0 0% 95%;
 
     /* Accent color - Muted light indigo for dark mode (AA ~5.5:1) */

--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -990,7 +990,7 @@ function AuthenticatedApp() {
             <div className="flex h-full overflow-hidden">
               <div
                 data-scroll-container
-                className={`flex-1 h-full px-6 md:px-10 lg:px-[70px] py-6 ${modal.isModalOpen ? 'overflow-hidden' : 'overflow-y-auto scrollbar-pro'} ${
+                className={`flex-1 h-full px-4 md:px-6 lg:px-8 py-6 ${modal.isModalOpen ? 'overflow-hidden' : 'overflow-y-auto scrollbar-pro'} ${
                   isSidePanelOpen
                     ? '[&_[data-card-item]]:opacity-40 [&_[data-card-item]]:grayscale [&_[data-card-item]]:transition-[opacity,filter] [&_[data-card-item]]:duration-300 [&_[data-card-item]:hover]:opacity-100 [&_[data-card-item]:hover]:grayscale-0 [&_[data-card-chrome]]:opacity-40 [&_[data-card-chrome]]:grayscale [&_[data-card-chrome]]:transition-[opacity,filter] [&_[data-card-chrome]]:duration-300'
                     : ''

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
@@ -172,7 +172,7 @@ export function AddCardsList({
           <div className="px-5 pt-1 sm:px-6 text-[11px] text-muted-foreground">
             {formatRelativeDate(activeRound.at)}
           </div>
-          <ul className="grid grid-cols-3 gap-3 px-5 py-3 sm:px-6">
+          <ul className="grid grid-cols-2 gap-3 px-5 py-3 sm:px-6">
             {activeRound.cards.map((card) => (
               <CardItem
                 key={card.videoId}

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -28,7 +28,7 @@ import { AddCardsFilters } from './AddCardsFilters';
 import { TargetLevelChips } from './TargetLevelChips';
 import { AddCardsList } from './AddCardsList';
 
-const PANEL_WIDTH_CLASS = 'w-full md:w-[45vw] md:max-w-[720px]';
+const PANEL_WIDTH_CLASS = 'w-full md:w-[58vw] md:max-w-[936px]';
 const CLOSE_ANIMATION_MS = 200;
 const SCROLL_COLLAPSE_THRESHOLD_PX = 32;
 

--- a/frontend/src/widgets/app-shell/ui/AppShell.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppShell.tsx
@@ -130,7 +130,7 @@ export function AppShell({ children }: AppShellProps) {
             />
           )}
 
-          <main id="main-content" className="flex-1 overflow-y-auto">
+          <main id="main-content" className="flex-1 overflow-y-auto bg-background">
             {children}
           </main>
         </div>

--- a/frontend/src/widgets/card-list-view/ui/CardListView.tsx
+++ b/frontend/src/widgets/card-list-view/ui/CardListView.tsx
@@ -69,8 +69,10 @@ const COMPACT_THRESHOLD = 5;
 // area). Previously cards dropped to 1-col below 600px, which made every
 // card read as a thumbnail strip when the video panel was expanded.
 const SHOW_GRID_SLIDER = false;
-const CONTAINER_5COL = 1600;
-const CONTAINER_4COL = 1300;
+// group1 #3 — thresholds raised so 3 columns dominate (collapsing the sidebar
+// grows the cards instead of adding a 4th smaller one).
+const CONTAINER_5COL = 2300;
+const CONTAINER_4COL = 1900;
 const CONTAINER_3COL = 1050;
 // Minimum legible card width is ~220px (matches user screenshot showing
 // 2-col at ~460px container where thumbnails are still readable). Below
@@ -645,7 +647,7 @@ export function CardListView({
         onDrop={handleExternalDrop}
         // OUTER: drop hit area only — extend across the lg:px-[70px] padding
         // applied by IndexPage's main content. Visual is intentionally none.
-        className="-mx-6 md:-mx-10 lg:-mx-[70px] px-6 md:px-10 lg:px-[70px]"
+        className="-mx-4 md:-mx-6 lg:-mx-8 px-4 md:px-6 lg:px-8"
       >
         <div
           ref={containerRef}
@@ -678,8 +680,18 @@ export function CardListView({
               </div>
             </div>
           )}
-          {contextHeaderElement}
-          {sectorPillsElement}
+          {/* group1 #5 — pin title + filter chips while the grid scrolls. The
+              `-top-6 -mt-6 pt-6` (cards>0) covers the scroll container's top
+              padding so no card peeks above; empty state keeps the spinner clear. */}
+          <div
+            className={cn(
+              'sticky z-20 bg-background pb-2',
+              sortedCards.length > 0 ? '-top-6 -mt-6 pt-6' : 'top-0'
+            )}
+          >
+            {contextHeaderElement}
+            {sectorPillsElement}
+          </div>
           <CardList
             cards={sortedCards}
             isLoading={isLoading}

--- a/frontend/src/widgets/card-list-view/ui/CardListView.tsx
+++ b/frontend/src/widgets/card-list-view/ui/CardListView.tsx
@@ -699,6 +699,7 @@ export function CardListView({
             gridColumns={gridColumns}
             compact={gridColumns >= COMPACT_THRESHOLD}
             sectorSubjects={sectorSubjects}
+            showChannel={selectedCellIndex != null && selectedCellIndex >= 0}
             onCardClick={onCardClick ? (card) => onCardClick(card, sortedCards) : undefined}
             onCardDragStart={onCardDragStart}
             onMultiCardDragStart={onMultiCardDragStart}

--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -74,6 +74,9 @@ interface CardListProps {
   /** CP463 — 8 sector names from currentLevel.subjects, used to render
    *  the per-card sector label in the new footer row. */
   sectorSubjects?: string[];
+  /** When a specific sector filter is active, cards show channel name instead of
+   *  sector name in the meta row (sector is redundant when all cards share it). */
+  showChannel?: boolean;
 }
 
 // Wrapper to make each card slot a droppable for reorder.
@@ -133,6 +136,7 @@ export function CardList({
   gridColumns = 4,
   compact = false,
   sectorSubjects,
+  showChannel = false,
 }: CardListProps) {
   const { t } = useTranslation();
 
@@ -515,6 +519,7 @@ export function CardList({
                     ? sectorSubjects[card.cellIndex]
                     : null
                 }
+                showChannel={showChannel}
                 tags={(() => {
                   const vid = safeVideoId(card.videoUrl);
                   const v2 = vid ? v2SummariesMap.get(vid) : undefined;

--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -113,7 +113,7 @@ const PAGE_SIZE = 24;
  * The minHeight keeps the empty area a drag/drop target; do not remove.
  */
 const CARD_GRID_CLASS =
-  'grid grid-cols-1 gap-4 p-3 min-h-full flex-1 pb-20 justify-items-center transition-all duration-200';
+  'grid grid-cols-1 gap-3 p-3 min-h-full flex-1 pb-20 transition-all duration-200';
 function cardGridStyle(gridColumns: number): CSSProperties {
   return {
     minHeight: 'calc(100vh - 200px)',
@@ -426,7 +426,7 @@ export function CardList({
     return (
       <div className={CARD_GRID_CLASS} style={cardGridStyle(gridColumns)}>
         {Array.from({ length: gridColumns * 2 }).map((_, i) => (
-          <CardSkeletonCell key={i} index={i} className="w-[95%]" />
+          <CardSkeletonCell key={i} index={i} className="w-full" />
         ))}
       </div>
     );
@@ -515,6 +515,15 @@ export function CardList({
                     ? sectorSubjects[card.cellIndex]
                     : null
                 }
+                tags={(() => {
+                  const vid = safeVideoId(card.videoUrl);
+                  const v2 = vid ? v2SummariesMap.get(vid) : undefined;
+                  const kc = v2?.keyConcepts ?? [];
+                  if (kc.length) return kc;
+                  const ft = v2?.fallbackTags ?? [];
+                  if (ft.length) return ft;
+                  return card.videoSummary?.tags ?? [];
+                })()}
                 onArchived={handleArchived}
               />
             </CardSlot>
@@ -529,7 +538,7 @@ export function CardList({
         {hasMore && (
           <>
             {Array.from({ length: Math.min(sortedCards.length - visibleCount, 6) }).map((_, i) => (
-              <CardSkeletonCell key={`skeleton-${i}`} index={i} className="w-[95%]" />
+              <CardSkeletonCell key={`skeleton-${i}`} index={i} className="w-full" />
             ))}
             <div ref={sentinelRef} aria-hidden className="col-span-full h-1" />
           </>

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -645,8 +645,9 @@ export function InsightCardItemV2({
           </div>
         )}
 
-        {/* meta — views · date + relevance % (sector → category dot is group2) */}
-        {(footerLeft ||
+        {/* meta — sector · views · date + relevance % */}
+        {(sectorLabel ||
+          footerLeft ||
           footerRight ||
           relevanceBadge ||
           (v2EnrichmentPending && !showFailedGlow)) && (
@@ -654,6 +655,11 @@ export function InsightCardItemV2({
             <span className="truncate flex items-center gap-1.5 min-w-0">
               {(() => {
                 const parts: { key: string; node: React.ReactNode }[] = [];
+                if (sectorLabel)
+                  parts.push({
+                    key: 'sector',
+                    node: <span className="truncate text-foreground/80">{sectorLabel}</span>,
+                  });
                 if (footerRight)
                   parts.push({
                     key: 'views',

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -622,13 +622,14 @@ export function InsightCardItemV2({
           {decodeHtmlEntities(card.title)}
         </h4>
 
-        {/* essence — "AI 핵심" label replaced by a divider (white/7%, 1px) */}
+        {/* divider under the title — ALWAYS (consistent whether or not the card
+            has a summary). 1px white/7%, matches the card border. */}
+        <div className="mt-3 border-t border-white/[0.07]" />
+
         {cardSummary && (
-          <div className="mt-3 border-t border-white/[0.07] pt-3">
-            <p className="text-[12.5px] leading-snug text-[#aeb4be] line-clamp-2 break-words">
-              {decodeHtmlEntities(cardSummary)}
-            </p>
-          </div>
+          <p className="mt-3 text-[12.5px] leading-snug text-[#aeb4be] line-clamp-2 break-words">
+            {decodeHtmlEntities(cardSummary)}
+          </p>
         )}
 
         {/* keyword chips — mockup .chip: pill, accent/12% bg, 13px, #f4f5f7 */}
@@ -637,7 +638,7 @@ export function InsightCardItemV2({
             {tags.slice(0, MAX_CARD_TAGS).map((tg) => (
               <span
                 key={tg}
-                className="rounded-full bg-[rgba(54,214,195,0.12)] px-3.5 py-[5px] text-[12px] leading-none text-[#f4f5f7]"
+                className="rounded-full bg-[rgba(54,214,195,0.12)] px-2.5 py-1 text-[11px] leading-none text-[#f4f5f7]"
               >
                 #{tg}
               </span>

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -618,14 +618,10 @@ export function InsightCardItemV2({
           {decodeHtmlEntities(card.title)}
         </h4>
 
-        {/* AI 핵심 — mockup: teal #36d6c3 label 11px/700/.55px + essence 13.5px #aeb4be */}
+        {/* essence — "AI 핵심" label replaced by a divider (white/7%, 1px) */}
         {cardSummary && (
-          <div className="mt-3">
-            <div className="flex items-center gap-1 text-[11px] font-bold tracking-[0.55px] text-[#36d6c3]">
-              <span aria-hidden="true">✦</span>
-              <span>AI 핵심</span>
-            </div>
-            <p className="mt-1 text-[13.5px] leading-snug text-[#aeb4be] line-clamp-2 break-words">
+          <div className="mt-3 border-t border-white/[0.07] pt-3">
+            <p className="text-[13.5px] leading-snug text-[#aeb4be] line-clamp-2 break-words">
               {decodeHtmlEntities(cardSummary)}
             </p>
           </div>

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -614,14 +614,14 @@ export function InsightCardItemV2({
             same height regardless of summary length. */}
       {/* group1 body — mockup-exact (measured). Category dot is group2 (deferred). */}
       <div className="px-4 pt-[15px] pb-[17px]">
-        <h4 className="text-[15.5px] font-[650] leading-[1.35] text-[#ebedf0] line-clamp-2">
+        <h4 className="text-[14.5px] font-[650] leading-[1.35] text-[#ebedf0] line-clamp-2">
           {decodeHtmlEntities(card.title)}
         </h4>
 
         {/* essence — "AI 핵심" label replaced by a divider (white/7%, 1px) */}
         {cardSummary && (
           <div className="mt-3 border-t border-white/[0.07] pt-3">
-            <p className="text-[13.5px] leading-snug text-[#aeb4be] line-clamp-2 break-words">
+            <p className="text-[12.5px] leading-snug text-[#aeb4be] line-clamp-2 break-words">
               {decodeHtmlEntities(cardSummary)}
             </p>
           </div>
@@ -633,7 +633,7 @@ export function InsightCardItemV2({
             {tags.slice(0, MAX_CARD_TAGS).map((tg) => (
               <span
                 key={tg}
-                className="rounded-full bg-[rgba(54,214,195,0.12)] px-3.5 py-[5px] text-[13px] leading-none text-[#f4f5f7]"
+                className="rounded-full bg-[rgba(54,214,195,0.12)] px-3.5 py-[5px] text-[12px] leading-none text-[#f4f5f7]"
               >
                 #{tg}
               </span>

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -638,7 +638,7 @@ export function InsightCardItemV2({
             {tags.slice(0, MAX_CARD_TAGS).map((tg) => (
               <span
                 key={tg}
-                className="rounded-full bg-[rgba(54,214,195,0.12)] px-2.5 py-1 text-[11px] font-normal leading-none text-[#f4f5f7]"
+                className="rounded-full bg-[rgba(54,214,195,0.12)] px-2.5 py-1 text-[11px] font-light leading-none text-[#cdd2da]"
               >
                 #{tg}
               </span>

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -29,6 +29,7 @@ import { decodeHtmlEntities } from '@/shared/lib/decode-html-entities';
 const RELEVANCE_BADGE_THRESHOLD_HIGH = 90;
 const RELEVANCE_BADGE_THRESHOLD_MID = 80;
 const RELEVANCE_BADGE_THRESHOLD_LOW = 70;
+const MAX_CARD_TAGS = 3;
 
 // ── Helpers ────────────────────────────────────────────────
 // formatDuration / formatViewCount live in shared/lib/format-number so
@@ -147,6 +148,8 @@ interface InsightCardItemV2Props {
    * relevance % badge on the right.
    */
   sectorLabel?: string | null;
+  /** Keyword/tag chips (≤3): v2 keyConcepts → fallbackTags → video_summaries.tags. */
+  tags?: string[];
 }
 
 // ── Component ──────────────────────────────────────────────
@@ -169,6 +172,7 @@ export function InsightCardItemV2({
   isV2Loading = false,
   onArchived,
   sectorLabel,
+  tags,
 }: InsightCardItemV2Props) {
   const { t } = useTranslation();
   const isSelected = selectedCardIds?.has(card.id) ?? false;
@@ -417,14 +421,16 @@ export function InsightCardItemV2({
       onDragStart={(e) => e.preventDefault()}
       className={cn(
         'group relative cursor-pointer transition-all duration-200',
-        'border-0 shadow-none bg-transparent rounded-[10px]',
-        'hover:-translate-y-0.5 hover:ring-1 hover:ring-border/60',
+        // group1 — mockup .ist-card: bg #121419, 1px white/7% border, 16px
+        // radius, no shadow, overflow-hidden.
+        'bg-card border border-white/[0.07] rounded-2xl overflow-hidden',
+        'hover:-translate-y-0.5 hover:border-white/15',
         // CP473 — card sizes itself to its own content so the hover
         // ring only outlines the visible body. The grid cell
         // (CardSlot) still stretches to the row's max height via the
         // CSS-grid default, so empty space below a short card sits
         // outside the card (in the cell) and not inside the ring.
-        'w-[95%]',
+        'w-full',
         // CP463 — outer glow / pulse removed per user directive
         // 2026-05-17: "수집중/분석중일때 카드가 심각하게 깜빡임. 매우
         // 어지러움 ... 카드 외곽하일라이트 > 하단 프로그래스로 수정".
@@ -463,7 +469,7 @@ export function InsightCardItemV2({
       )}
 
       {/* ── Thumbnail ── */}
-      <div className="relative aspect-video overflow-hidden rounded-[10px] bg-gradient-to-br from-[#1a1c28] to-[#13141c] transition-[filter] duration-300 group-hover:brightness-[0.96] group-hover:contrast-[1.04]">
+      <div className="relative aspect-video overflow-hidden bg-gradient-to-br from-[#1a1c28] to-[#13141c] transition-[filter] duration-300 group-hover:brightness-[0.96] group-hover:contrast-[1.04]">
         <img
           src={upgradeYouTubeThumbnail(card.thumbnail) ?? card.thumbnail}
           alt={card.title}
@@ -606,31 +612,48 @@ export function InsightCardItemV2({
             so longer summaries truncate with "…" instead of stretching
             the card. min-h reserves the 3-line slot so cards stay the
             same height regardless of summary length. */}
-      <div className="px-3 pt-2 pb-4">
-        <h4 className="text-[13px] font-semibold leading-[1.4] text-foreground line-clamp-2 tracking-[-0.1px]">
+      {/* group1 body — mockup-exact (measured). Category dot is group2 (deferred). */}
+      <div className="px-4 pt-[15px] pb-[17px]">
+        <h4 className="text-[15.5px] font-[650] leading-[1.35] text-[#ebedf0] line-clamp-2">
           {decodeHtmlEntities(card.title)}
         </h4>
 
+        {/* AI 핵심 — mockup: teal #36d6c3 label 11px/700/.55px + essence 13.5px #aeb4be */}
+        {cardSummary && (
+          <div className="mt-3">
+            <div className="flex items-center gap-1 text-[11px] font-bold tracking-[0.55px] text-[#36d6c3]">
+              <span aria-hidden="true">✦</span>
+              <span>AI 핵심</span>
+            </div>
+            <p className="mt-1 text-[13.5px] leading-snug text-[#aeb4be] line-clamp-2 break-words">
+              {decodeHtmlEntities(cardSummary)}
+            </p>
+          </div>
+        )}
+
+        {/* keyword chips — mockup .chip: pill, accent/12% bg, 13px, #f4f5f7 */}
+        {tags && tags.length > 0 && (
+          <div className="mt-3 flex flex-wrap items-center gap-1.5">
+            {tags.slice(0, MAX_CARD_TAGS).map((tg) => (
+              <span
+                key={tg}
+                className="rounded-full bg-[rgba(54,214,195,0.12)] px-3.5 py-[5px] text-[13px] leading-none text-[#f4f5f7]"
+              >
+                #{tg}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* meta — views · date + relevance % (sector → category dot is group2) */}
         {(footerLeft ||
           footerRight ||
-          sectorLabel ||
           relevanceBadge ||
-          isEnrichFailed ||
-          showFailedGlow) && (
-          <div className="mt-2 flex items-center justify-between gap-2 text-[10.5px] text-muted-foreground/70">
+          (v2EnrichmentPending && !showFailedGlow)) && (
+          <div className="mt-3 flex items-center justify-between gap-2 text-xs text-muted-foreground/70">
             <span className="truncate flex items-center gap-1.5 min-w-0">
               {(() => {
-                // CP473 user directive 2026-05-19:
-                //   "장애 제거 70.2K 7 months ago   85%"
-                //   "채널명은 표기하지 않는거야."
-                // Order: sector → views → date | relevance %.
-                // Channel intentionally omitted from the row.
                 const parts: { key: string; node: React.ReactNode }[] = [];
-                if (sectorLabel)
-                  parts.push({
-                    key: 'sector',
-                    node: <span className="truncate text-foreground/80">{sectorLabel}</span>,
-                  });
                 if (footerRight)
                   parts.push({
                     key: 'views',
@@ -653,25 +676,13 @@ export function InsightCardItemV2({
                 );
               })()}
             </span>
-            {/* Right slot priority (CP499 #4 — badge revived on the USER-SCOPED
-                relevance_pct, NOT the video-keyed mandala_relevance_pct):
-                  scored (relevancePct != null) → relevance % (color-tiered)
-                  else liked && v2-pending && !failed → breathing dot
-                  else → empty
-                The dot still keys off mandalaRelevancePct==null (v2-completion
-                signal) — distinct source from this user-scoped badge. */}
             {relevanceBadge ? (
               <span
-                className={cn(
-                  'text-[10.5px] font-semibold shrink-0 tabular-nums',
-                  relevanceBadge.className
-                )}
+                className={cn('text-xs font-semibold shrink-0 tabular-nums', relevanceBadge.className)}
               >
                 {relevanceBadge.label}
               </span>
             ) : v2EnrichmentPending && !showFailedGlow ? (
-              // CP475+ — breathing dot for the Heart-enrichment window (bookmark
-              // click → quick-result arrival); stops when v2 lands.
               <span
                 className="block w-1.5 h-1.5 rounded-full bg-foreground/40 shrink-0 animate-[breathe_1.6s_ease-in-out_infinite]"
                 aria-label={t('cards.enrichingAria')}
@@ -679,18 +690,6 @@ export function InsightCardItemV2({
               />
             ) : null}
           </div>
-        )}
-
-        {/* CP473 — summary at the bottom + line-clamp-3 with "…" for
-            long content. When the one-liner is missing, the block is
-            NOT rendered — the parent `flex-grow` body absorbs the
-            leftover space and the empty area sits flush at the card's
-            bottom (YouTube-style: no empty line between meta and the
-            absent summary). */}
-        {cardSummary && (
-          <blockquote className="mt-2 text-[10.5px] italic text-muted-foreground/75 leading-relaxed line-clamp-3 break-words">
-            {decodeHtmlEntities(cardSummary)}
-          </blockquote>
         )}
       </div>
     </Card>

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -638,7 +638,7 @@ export function InsightCardItemV2({
             {tags.slice(0, MAX_CARD_TAGS).map((tg) => (
               <span
                 key={tg}
-                className="rounded-full bg-[rgba(54,214,195,0.12)] px-2.5 py-1 text-[11px] leading-none text-[#f4f5f7]"
+                className="rounded-full bg-[rgba(54,214,195,0.12)] px-2.5 py-1 text-[11px] font-normal leading-none text-[#f4f5f7]"
               >
                 #{tg}
               </span>

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -150,6 +150,9 @@ interface InsightCardItemV2Props {
   sectorLabel?: string | null;
   /** Keyword/tag chips (≤3): v2 keyConcepts → fallbackTags → video_summaries.tags. */
   tags?: string[];
+  /** When true (a specific sector filter is active), the meta leads with the
+   *  channel name instead of the sector (sector is redundant in that view). */
+  showChannel?: boolean;
 }
 
 // ── Component ──────────────────────────────────────────────
@@ -173,6 +176,7 @@ export function InsightCardItemV2({
   onArchived,
   sectorLabel,
   tags,
+  showChannel = false,
 }: InsightCardItemV2Props) {
   const { t } = useTranslation();
   const isSelected = selectedCardIds?.has(card.id) ?? false;
@@ -651,10 +655,12 @@ export function InsightCardItemV2({
             <span className="truncate flex items-center gap-1.5 min-w-0">
               {(() => {
                 const parts: { key: string; node: React.ReactNode }[] = [];
-                if (sectorLabel)
+                // 전체 보기 → sector name; 특정 섹터 필터 → channel name (less redundant).
+                const firstLabel = showChannel ? (ytMeta.channelTitle ?? sectorLabel) : sectorLabel;
+                if (firstLabel)
                   parts.push({
-                    key: 'sector',
-                    node: <span className="truncate text-foreground/80">{sectorLabel}</span>,
+                    key: 'label',
+                    node: <span className="truncate text-foreground/80">{firstLabel}</span>,
                   });
                 if (footerRight)
                   parts.push({


### PR DESCRIPTION
## Summary
Mockup-exact redesign of the dashboard card grid (measured values, no approximation), rebased clean onto latest main. **11 commits**, conflict-free.

### Dashboard / cards
- **Global dark tokens** (`.dark` in index.css): `--background` #0A0B0D, `--card`/`--popover` #121419, `--sidebar`/`--sidebar-background` #0C0D11. **App-wide dark redesign — intended** (cross-checked with concurrent session; light mode `:root` untouched = separate work).
- Card surface: bg-card #121419, 1px white/7% border, 16px radius, no shadow, full-width cell.
- Title/essence/tags resized; "AI 핵심" label replaced by a divider under the title (always rendered, consistent). Tag chips smaller + non-bold.
- Meta row: leads with **sector name** in 전체 view, **channel name** when a specific sector filter is active.
- Grid background now matches the header (`<main>` bg-background); 3-col-dominant thresholds; tighter bezel/gutter; sticky header.

### Add-cards panel
- Panel width +30% (45vw/720px → 58vw/936px); candidate grid 3→2 cols (larger cards).

### Notes
- Sidebar bullets + full mandala names were **dropped here** — already shipped on main via #1022 (would have been a duplicate/conflict).

## Verification
- `tsc --noEmit` ✓ 0 · `vitest` ✓ 31/31 (card / card-view / add-cards / dnd) · `npm run build` ✓
- Dark runtime: dashboard renders (cards/divider/tags/sector-meta, no double sidebar bullets), NotFound/bg-background renders, **console 0 errors**.

## Blast radius
- App-wide: index.css dark tokens (50+ files use bg-card/bg-background) + `<main>` bg-background (all routes). Verified no regression; concurrent note-editor session is disjoint (only index.css = different region ~1100 lines apart, auto-merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)