### PR TITLE
fix(note): remove orphaned mermaid 'Syntax error' element on parse failure

### DIFF
--- a/frontend/src/pages/learning/lib/mermaid-block.tsx
+++ b/frontend/src/pages/learning/lib/mermaid-block.tsx
@@ -51,6 +51,12 @@ function MermaidNodeView({ node, updateAttributes, editor }: NodeViewProps) {
         const { svg: out } = await mermaid.render(idRef.current, src);
         if (!cancelled) setSvg(out);
       } catch {
+        // mermaid injects an orphaned error element ("Syntax error" bomb) into
+        // <body> on parse failure — remove it so only our inline source fallback shows.
+        if (typeof document !== 'undefined') {
+          document.getElementById(idRef.current)?.remove();
+          document.getElementById(`d${idRef.current}`)?.remove();
+        }
         if (!cancelled) setFailed(true);
       }
     })();


### PR DESCRIPTION
## Problem
When a note's mermaid source has invalid syntax (LLM-generated), mermaid.render injects an orphaned 'Syntax error in text / mermaid version' bomb element into `<body>` (visible at the viewport corner) before throwing. Our catch already falls back to an inline source `<pre>`, but didn't remove mermaid's injected element.

## Fix
In the render catch, remove the orphaned element by its id and mermaid's `d`-prefixed id. Inline source fallback is the only thing shown; user can edit the source (PR #1024) to fix the diagram.

## Verify
tsc clean · vitest 46/46 (mermaid+note) · build clean · smoke / + /mandalas/new = 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)