### PR TITLE
feat(card-grid): relevance % → tier badge (핵심/추천) — FE display-only

### DIFF
--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { InsightCard } from '@/entities/card/model/types';
 import { Card } from '@/shared/ui/card';
 import { cn } from '@/shared/lib/utils';
-import { GripVertical, NotepadText, Loader2, Play, Bookmark, Archive } from 'lucide-react';
+import { GripVertical, NotepadText, Loader2, Play, Bookmark, Archive, Sparkles } from 'lucide-react';
 import { useLikeCard } from '@/features/card-management/model/useLikeCard';
 import { useArchiveCard } from '@/features/card-management/model/useArchiveCard';
 import { useArchivedReaddToast } from '@/features/card-management/model/useArchivedReaddToast';
@@ -26,32 +26,43 @@ import { decodeHtmlEntities } from '@/shared/lib/decode-html-entities';
 // ── Constants ──────────────────────────────────────────────
 
 // CP499 #4 — A-stage relevance badge tiers (USER-SCOPED relevance_pct, 0-100).
-const RELEVANCE_BADGE_THRESHOLD_HIGH = 90;
-const RELEVANCE_BADGE_THRESHOLD_MID = 80;
-const RELEVANCE_BADGE_THRESHOLD_LOW = 70;
+// Relevance tier cuts — tune by looking at the live distribution (raw % is
+// never shown to the user, so these are display-only thresholds).
+const RELEVANCE_TIER_CORE = 80; // ≥80 → "핵심"
+const RELEVANCE_TIER_PICK = 70; // 70–79 → "추천" ; <70 → no badge (number never shown)
 const MAX_CARD_TAGS = 3;
+
+// Tier badge styles — complete class strings (RING_STYLES pattern, NO dynamic
+// Tailwind). Single indigo-intensity ladder on --primary (note/CV token parity);
+// deliberately NO traffic-light green/amber.
+const RELEVANCE_TIER_STYLES = {
+  // 핵심: indigo tinted pill + accent border + spark glyph — the one signal that draws the eye.
+  core: 'inline-flex items-center gap-0.5 rounded-full border border-[hsl(var(--primary)/0.45)] bg-[hsl(var(--primary)/0.15)] px-2 py-0.5 text-[10.5px] font-medium leading-none text-[hsl(var(--primary))]',
+  // 추천: ghost outline — transparent bg + faint indigo border/text, no glyph.
+  pick: 'inline-flex items-center rounded-full border border-[hsl(var(--primary)/0.30)] bg-transparent px-2 py-0.5 text-[10.5px] font-normal leading-none text-[hsl(var(--primary)/0.80)]',
+} as const;
 
 // ── Helpers ────────────────────────────────────────────────
 // formatDuration / formatViewCount live in shared/lib/format-number so
 // the Add Cards panel + future card surfaces share the same rules.
 
 /**
- * CP499 #4 — A-stage relevance badge from the USER-SCOPED relevance_pct
- * (InsightCard.relevancePct), NOT the video-keyed mandala_relevance_pct (which
- * stays the v2-completion signal for the dot/SSE only). Plain coloured text
- * (CP463 directive). null ⇒ no badge — the card is not yet scored; it appears
- * once wizard/manual/backfill fills relevance_pct (display = stored value).
+ * Relevance TIER badge from the USER-SCOPED relevance_pct (InsightCard.relevancePct),
+ * NOT the video-keyed mandala_relevance_pct (v2-completion dot/SSE signal only).
+ * The raw % is never rendered (negative-framing removed) — only a tier label, with
+ * the exact score available on hover. null/unscored ⇒ no badge; <70 (gate-passed
+ * but low) ⇒ no badge either. Tune cuts via RELEVANCE_TIER_CORE/PICK.
  */
 export function getRelevanceBadge(
   pct: number | null | undefined
-): { label: string; className: string } | null {
+): { tier: 'core' | 'pick'; label: string; className: string; raw: number; showSpark: boolean } | null {
   if (pct == null) return null;
-  const value = Math.max(0, Math.min(100, Math.round(pct)));
-  const label = `${value}%`;
-  if (value >= RELEVANCE_BADGE_THRESHOLD_HIGH) return { label, className: 'text-[#818cf8]' };
-  if (value >= RELEVANCE_BADGE_THRESHOLD_MID) return { label, className: 'text-[#34d399]' };
-  if (value >= RELEVANCE_BADGE_THRESHOLD_LOW) return { label, className: 'text-[#fbbf24]' };
-  return { label, className: 'text-[#94a3b8]' };
+  const raw = Math.max(0, Math.min(100, Math.round(pct)));
+  if (raw >= RELEVANCE_TIER_CORE)
+    return { tier: 'core', label: '핵심', className: RELEVANCE_TIER_STYLES.core, raw, showSpark: true };
+  if (raw >= RELEVANCE_TIER_PICK)
+    return { tier: 'pick', label: '추천', className: RELEVANCE_TIER_STYLES.pick, raw, showSpark: false };
+  return null;
 }
 
 /** Extract YouTube metadata from InsightCard.metadata (runtime fields beyond UrlMetadata type) */
@@ -687,8 +698,12 @@ export function InsightCardItemV2({
             </span>
             {relevanceBadge ? (
               <span
-                className={cn('text-xs font-semibold shrink-0 tabular-nums', relevanceBadge.className)}
+                className={cn('shrink-0', relevanceBadge.className)}
+                title={`주제 적합도 ${relevanceBadge.raw}`}
               >
+                {relevanceBadge.showSpark && (
+                  <Sparkles className="w-2.5 h-2.5" strokeWidth={2.2} aria-hidden="true" />
+                )}
                 {relevanceBadge.label}
               </span>
             ) : v2EnrichmentPending && !showFailedGlow ? (

--- a/frontend/src/widgets/card-list/ui/relevanceBadge.test.ts
+++ b/frontend/src/widgets/card-list/ui/relevanceBadge.test.ts
@@ -1,31 +1,50 @@
 /**
- * CP499 #4 — getRelevanceBadge: the revived A-stage relevance badge.
+ * getRelevanceBadge — relevance TIER badge (raw % replaced by 핵심/추천 tiers).
  *
- * Reads the USER-SCOPED relevance_pct (InsightCard.relevancePct), shown only
- * when non-null (display = stored value). null ⇒ no badge (unscored card →
- * appears once wizard/manual/backfill fills it). Color tiers: ≥90 / ≥80 / ≥70 /
- * else. Distinct from the video-keyed mandala_relevance_pct (dot/SSE signal).
+ * Reads the USER-SCOPED relevance_pct (InsightCard.relevancePct). The raw score
+ * is never rendered — only a tier label, with the exact value on hover (`raw`).
+ * Tiers: ≥80 → "핵심" (spark), 70–79 → "추천" (ghost), <70 / null ⇒ no badge.
+ * Single indigo ladder on --primary; no traffic-light green/amber.
  */
 import { describe, it, expect } from 'vitest';
 import { getRelevanceBadge } from './InsightCardItemV2';
 
-describe('getRelevanceBadge — user-scoped relevance display', () => {
+describe('getRelevanceBadge — relevance tier display', () => {
   it('null / undefined ⇒ no badge (unscored card hidden)', () => {
     expect(getRelevanceBadge(null)).toBeNull();
     expect(getRelevanceBadge(undefined)).toBeNull();
   });
 
-  it('renders "<n>%" and clamps to 0..100', () => {
-    expect(getRelevanceBadge(82)?.label).toBe('82%');
-    expect(getRelevanceBadge(0)?.label).toBe('0%'); // 0 is a score, shown (not null)
-    expect(getRelevanceBadge(140)?.label).toBe('100%');
-    expect(getRelevanceBadge(-5)?.label).toBe('0%');
+  it('<70 (gate-passed but low) ⇒ no badge (number never shown)', () => {
+    expect(getRelevanceBadge(69)).toBeNull();
+    expect(getRelevanceBadge(40)).toBeNull();
+    expect(getRelevanceBadge(0)).toBeNull();
   });
 
-  it('color tiers: ≥90 indigo / ≥80 green / ≥70 amber / else gray', () => {
-    expect(getRelevanceBadge(95)?.className).toContain('#818cf8'); // high
-    expect(getRelevanceBadge(82)?.className).toContain('#34d399'); // mid
-    expect(getRelevanceBadge(72)?.className).toContain('#fbbf24'); // low
-    expect(getRelevanceBadge(40)?.className).toContain('#94a3b8'); // below
+  it('≥80 ⇒ "핵심" tier with spark glyph', () => {
+    const b = getRelevanceBadge(85);
+    expect(b?.tier).toBe('core');
+    expect(b?.label).toBe('핵심');
+    expect(b?.showSpark).toBe(true);
+  });
+
+  it('70–79 ⇒ "추천" tier, no glyph', () => {
+    const b = getRelevanceBadge(72);
+    expect(b?.tier).toBe('pick');
+    expect(b?.label).toBe('추천');
+    expect(b?.showSpark).toBe(false);
+  });
+
+  it('keeps the raw score (for the hover tooltip) and clamps to 0..100', () => {
+    expect(getRelevanceBadge(82)?.raw).toBe(82);
+    expect(getRelevanceBadge(140)?.raw).toBe(100);
+    expect(getRelevanceBadge(80.4)?.raw).toBe(80);
+  });
+
+  it('uses the --primary indigo token, never traffic-light green/amber', () => {
+    expect(getRelevanceBadge(95)?.className).toContain('--primary');
+    expect(getRelevanceBadge(72)?.className).toContain('--primary');
+    expect(getRelevanceBadge(95)?.className).not.toContain('#34d399');
+    expect(getRelevanceBadge(72)?.className).not.toContain('#fbbf24');
   });
 });


### PR DESCRIPTION
## Summary
Replace the raw relevance percent on cards (69%/76%/85%, traffic-light coloured) with brand **tier badges**. Score already exists (#933) — this is a display swap only. **No BE / schema / scoring change.**

### Tier mapping (cuts in `RELEVANCE_TIER_CORE`/`PICK`, tune by distribution)
- `rel ≥ 80` → **"핵심"** — indigo tinted pill + spark glyph + accent border (the one signal that draws the eye)
- `rel 70–79` → **"추천"** — ghost outline (transparent bg, faint indigo border/text), no glyph
- `rel < 70` (gate-passed) / `null` → **no badge** (raw number never shown — negative framing removed)

### Detail
- Single indigo-intensity ladder on `--primary` (note/CV token parity), **no traffic-light green/amber**.
- Exact score kept **on hover**: `title="주제 적합도 {raw}"`.
- Tier styles = complete class-string constants (RING_STYLES pattern, no dynamic Tailwind).
- Same trailing meta slot; raw `%` render removed.
- Single display point (`InsightCardItemV2`); list/mandala/side-panel don't render this badge.

## Verification (live, local DB relevance injected then reverted)
- 핵심 = indigo pill `rgba(141,149,226,.15)` + border .45 + **spark svg** + tooltip; 추천 = ghost; <70 = **hidden**; colour `rgb(141,149,226)` = `--primary`.
- `tsc` 0 · `vitest` 19/19 (tier cuts / labels / spark / raw-clamp / token-colour / <70-hidden) · `build` OK.

## Done criteria (James, prod)
Hard-reload a mandala with scored cards (e.g. SaaS 강의 시작, 8cbabeaa) → 핵심/추천 badges by tier, low-score cards have no badge, hover shows the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)