### PR TITLE
feat(note): bookmarked cards bypass relevance gate in note generation

### DIFF
--- a/src/config/book-gate.ts
+++ b/src/config/book-gate.ts
@@ -128,6 +128,21 @@ export function passesBookGate(
 }
 
 /**
+ * Gate decision INCLUDING the bookmark exception (pure). A card the user
+ * bookmarked (pinned) is kept in the book regardless of relevance — explicit
+ * user intent wins over the relevance gate. Otherwise defers to passesBookGate.
+ */
+export function passesBookGateOrBookmarked(
+  relevance: number | null,
+  bookmarked: boolean,
+  ctx: BookGateContext,
+  cfg: BookGateConfig
+): boolean {
+  if (bookmarked) return true;
+  return passesBookGate(relevance, ctx, cfg);
+}
+
+/**
  * §1⑤ topic synthesis on/off. Default TRUE (verified §1⑤ Done — 942 clickbait 0,
  * drop 0, content-name topics). Every fill now synthesizes content topics (one
  * Haiku call per non-empty cell). Code-revert-free rollback = set

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -15,7 +15,7 @@ import { buildBookJson, type CellInput, type CellVideoV2 } from './build-book';
 import { parseBookJson, type BookJsonInput } from './book-schema';
 import {
   loadBookGateConfig,
-  passesBookGate,
+  passesBookGateOrBookmarked,
   computeMandalaMedian,
   isBookTopicSynthesisEnabled,
   isBookNarrativeSkeletonEnabled,
@@ -61,6 +61,7 @@ interface Placement {
   videoId: string; // 11-char YouTube id
   title: string;
   relevance: number | null; // uvs/ulc relevance_pct; null = never scored
+  bookmarked: boolean; // pinned_at != null — bookmarked cards bypass the relevance gate
 }
 
 interface V2Columns {
@@ -97,6 +98,7 @@ export async function fillMandalaBook(params: {
       select: {
         cell_index: true,
         relevance_pct: true,
+        pinned_at: true,
         video: { select: { youtube_video_id: true, title: true } },
       },
     }),
@@ -108,6 +110,7 @@ export async function fillMandalaBook(params: {
         title: true,
         metadata_title: true,
         relevance_pct: true,
+        pinned_at: true,
       },
     }),
   ]);
@@ -128,6 +131,7 @@ export async function fillMandalaBook(params: {
       videoId: vid,
       title: r.video?.title ?? vid,
       relevance: r.relevance_pct ?? null,
+      bookmarked: r.pinned_at != null,
     });
   }
   for (const r of localCards) {
@@ -139,6 +143,7 @@ export async function fillMandalaBook(params: {
       videoId: r.video_id,
       title: r.title ?? r.metadata_title ?? r.video_id,
       relevance: r.relevance_pct ?? null,
+      bookmarked: r.pinned_at != null,
     });
   }
 
@@ -253,7 +258,9 @@ export async function fillMandalaBook(params: {
       if (seen.has(p.videoId)) continue; // dedup a video within one cell
       // §1③ GATE FIRST (before v2) — a scored-low / off-topic card is dropped
       // regardless of v2. Reordered: v2-absence no longer short-circuits the gate.
-      if (!passesBookGate(p.relevance, gateCtx, gate)) {
+      // Bookmark exception (user directive): a card the user bookmarked (pinned)
+      // stays in the book even below the relevance gate — explicit intent wins.
+      if (!passesBookGateOrBookmarked(p.relevance, p.bookmarked, gateCtx, gate)) {
         gatedLow += 1; // scored below the gate min → excluded from the book
         continue;
       }

--- a/tests/unit/modules/book-gate.test.ts
+++ b/tests/unit/modules/book-gate.test.ts
@@ -7,6 +7,7 @@
 
 import {
   passesBookGate,
+  passesBookGateOrBookmarked,
   computeMandalaMedian,
   loadBookGateConfig,
   isBookTopicSynthesisEnabled,
@@ -147,5 +148,16 @@ describe('loadNoteMaxSections — CP504 §1⑤ surface-fix #3', () => {
     expect(loadNoteMaxSections({ NOTE_MAX_SECTIONS: 'abc' })).toBe(20);
     expect(loadNoteMaxSections({ NOTE_MAX_SECTIONS: '0' })).toBe(20);
     expect(loadNoteMaxSections({ NOTE_MAX_SECTIONS: '-5' })).toBe(20);
+  });
+});
+
+describe('passesBookGateOrBookmarked — bookmark exception', () => {
+  it('bookmarked card stays in the book even below the gate min (and when unscored)', () => {
+    expect(passesBookGateOrBookmarked(10, true, NO_CTX, cfg({ minRelevance: 50 }))).toBe(true);
+    expect(passesBookGateOrBookmarked(null, true, NO_CTX, cfg({ passNull: false }))).toBe(true);
+  });
+  it('non-bookmarked card still obeys the relevance gate', () => {
+    expect(passesBookGateOrBookmarked(10, false, NO_CTX, cfg({ minRelevance: 50 }))).toBe(false);
+    expect(passesBookGateOrBookmarked(60, false, NO_CTX, cfg({ minRelevance: 50 }))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
Per decision on the relevance-exclusion request:
- **② v2 generation exclusion — SKIPPED** (no change). v2 is video-keyed (one summary shared across all users) while relevance is user-scoped, so excluding a video on one user's low score would deny it to others; and on-demand v2 only fires on bookmark (= the exception itself). No safe exclusion point.
- **③ note-material exclusion — bookmark exception added** (this PR). ≤30 (indeed <40) cards are *already* excluded from notes by the existing gate (`BOOK_GATE_MIN_RELEVANCE=40`, kept). The only missing piece was the exception: a **bookmarked (pinned) card now stays in the note regardless of relevance**.

## Change
- New pure helper `passesBookGateOrBookmarked(relevance, bookmarked, ctx, cfg)` in `src/config/book-gate.ts` — bookmarked → always keep, else defers to `passesBookGate` (gate unchanged).
- `fill-book.ts`: thread `pinned_at` → `Placement.bookmarked` through the uvs/ulc selects; gate call uses the new helper.

## Verification
- BE `tsc` 0 · `jest` book-gate 24/24 (incl. +2: bookmarked-below-min keeps; non-bookmarked still gated).
- `pinned_at` already exists on `user_video_states` / `user_local_cards` — **no migration**.
- No `frontend/src` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)