### PR TITLE
fix(note): mermaid high-contrast dual-mode (+ strip LLM colors, orphan-error cleanup)

### DIFF
--- a/frontend/src/__tests__/mermaid-strip-color-directives.test.ts
+++ b/frontend/src/__tests__/mermaid-strip-color-directives.test.ts
@@ -1,0 +1,57 @@
+/**
+ * mermaid-strip-color-directives — locks the contrast fix (CONTRAST FIX).
+ *
+ * LLM-generated mermaid embeds `style/classDef/linkStyle` color directives whose
+ * pastel fills collide with the theme's light node text → invisible labels.
+ * stripMermaidColorDirectives() removes ONLY those directives, preserving all
+ * structure (nodes, edges, labels, subgraphs, `class X y` assignments).
+ */
+import { describe, it, expect } from 'vitest';
+import { stripMermaidColorDirectives } from '@/pages/learning/lib/mermaid-block';
+
+describe('stripMermaidColorDirectives', () => {
+  it('removes style / classDef / linkStyle lines', () => {
+    const out = stripMermaidColorDirectives(
+      [
+        'flowchart LR',
+        '  style A fill:#d0e8ff,stroke:#4a90d9',
+        '  classDef hot fill:#fee,stroke:#900',
+        '  linkStyle 0 stroke:#f00,stroke-width:2px',
+      ].join('\n')
+    );
+    expect(out).not.toMatch(/style/);
+    expect(out).not.toMatch(/classDef/);
+    expect(out).not.toMatch(/linkStyle/);
+    expect(out).toBe('flowchart LR');
+  });
+
+  it('preserves flowchart nodes, edges, and labels', () => {
+    const src = 'flowchart LR\n A["Start"] -->|"go"| B["End"]';
+    expect(stripMermaidColorDirectives(src)).toBe(src);
+  });
+
+  it('preserves subgraphs and harmless `class X y` assignments', () => {
+    const src = [
+      'flowchart TD',
+      '  subgraph S["Pipeline"]',
+      '    A --> B',
+      '  end',
+      '  class A important',
+    ].join('\n');
+    expect(stripMermaidColorDirectives(src)).toBe(src);
+  });
+
+  it('strips a realistic LLM diagram down to just the structure', () => {
+    const src = [
+      'flowchart LR',
+      ' A["x"] -->|"y"| B["z"]',
+      ' style A fill:#d0e8ff,stroke:#4a90d9',
+    ].join('\n');
+    expect(stripMermaidColorDirectives(src)).toBe('flowchart LR\n A["x"] -->|"y"| B["z"]');
+  });
+
+  it('does not touch node labels that merely contain the word "style"', () => {
+    const src = 'flowchart LR\n A["Style guide"] --> B["Done"]';
+    expect(stripMermaidColorDirectives(src)).toBe(src);
+  });
+});

--- a/frontend/src/pages/learning/lib/mermaid-block.tsx
+++ b/frontend/src/pages/learning/lib/mermaid-block.tsx
@@ -4,9 +4,15 @@
  *
  * Mirrors the figure-block.tsx lazy-import pattern: `mermaid` is a transitive
  * dependency (verified importable), dynamically imported only when a mermaid block
- * mounts (keeps the heavy lib out of the main bundle, like KaTeX). Theme is forced
- * dark to match note mode. On any parse/render failure it falls back to a monospace
- * code block of the raw source (never blank, never throws).
+ * mounts (keeps the heavy lib out of the main bundle, like KaTeX). On any
+ * parse/render failure it falls back to a monospace code block of the raw source
+ * (never blank, never throws).
+ *
+ * CONTRAST FIX: LLM-generated mermaid often embeds `style <node> fill:#<pastel>`
+ * directives. With mermaid's dark theme those pastel fills carry light node text →
+ * unreadable. We (1) strip the color directives so mermaid's own theme stays
+ * internally consistent, and (2) drive a curated high-contrast `base` palette that
+ * adapts to the note's effective background (dark today, light-ready).
  *
  * The diagram source lives in the `source` attribute (round-trips through the doc);
  * the SVG is a render artifact, not stored. In edit mode the NodeView exposes the
@@ -26,13 +32,103 @@ export interface MermaidBlockOptions {
 
 let mermaidIdSeq = 0;
 
+type Mode = 'dark' | 'light';
+
+/**
+ * Strip LLM-injected color directives (`style` / `classDef` / `linkStyle`) so the
+ * diagram inherits our curated theme instead of unreadable pastel fills. Structure
+ * (nodes, edges, labels, subgraphs, harmless `class X y` assignments) is preserved.
+ * Pure + exported for unit testing.
+ */
+export function stripMermaidColorDirectives(src: string): string {
+  const COLOR_DIRECTIVE = /^\s*(style|classDef|linkStyle)\s/;
+  return src
+    .split('\n')
+    .filter((line) => !COLOR_DIRECTIVE.test(line))
+    .join('\n');
+}
+
+// Curated high-contrast palettes — the ONE place diagram colors live. mermaid
+// themeVariables need resolved hex (CSS vars are not honored here). Tuned to the
+// note aesthetic: dark = near-black surface + off-white ink; light = soft fill +
+// near-black ink. Text is always high-contrast against its node fill.
+const FONT_STACK = "'Noto Sans KR', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+const FONT_SIZE = '14px';
+
+const DARK_PALETTE = {
+  primaryColor: '#23262d', // node fill (lifts off the ~#0E0F11 note bg)
+  primaryTextColor: '#f4f2ee', // off-white ink, high contrast on dark fill
+  primaryBorderColor: '#4a4e57',
+  lineColor: '#b8bcc4', // edges, legible on dark bg
+  secondaryColor: '#2c3038',
+  tertiaryColor: '#33373f',
+  fontFamily: FONT_STACK,
+  fontSize: FONT_SIZE,
+} as const;
+
+const LIGHT_PALETTE = {
+  primaryColor: '#eef1f5', // soft light node fill
+  primaryTextColor: '#1a1d21', // near-black ink, high contrast on light fill
+  primaryBorderColor: '#c2c7d0',
+  lineColor: '#5a5f68', // edges, legible on white bg
+  secondaryColor: '#e3e7ec',
+  tertiaryColor: '#d9dde3',
+  fontFamily: FONT_STACK,
+  fontSize: FONT_SIZE,
+} as const;
+
+// Perceived-luminance coefficients (ITU-R BT.601) + the dark/light split point.
+const LUMA_R = 0.299;
+const LUMA_G = 0.587;
+const LUMA_B = 0.114;
+const MAX_CHANNEL = 255;
+const DARK_LUMA_THRESHOLD = 0.5;
+
+/** Parse the `rgb()/rgba()` string getComputedStyle returns. null = transparent. */
+function parseRgb(color: string): [number, number, number, number] | null {
+  const m = color.match(/rgba?\(([^)]+)\)/);
+  if (!m) return null;
+  const parts = m[1].split(',').map((p) => parseFloat(p.trim()));
+  const [r, g, b, a = 1] = parts;
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+  return [r, g, b, a];
+}
+
+/** Walk up to the first non-transparent ancestor background; dark if luminance < 0.5. */
+function detectMode(el: HTMLElement | null): Mode {
+  let node: HTMLElement | null = el;
+  while (node) {
+    const rgb = parseRgb(getComputedStyle(node).backgroundColor);
+    if (rgb && rgb[3] > 0) {
+      const [r, g, b] = rgb;
+      const luma = (LUMA_R * r + LUMA_G * g + LUMA_B * b) / MAX_CHANNEL;
+      return luma < DARK_LUMA_THRESHOLD ? 'dark' : 'light';
+    }
+    node = node.parentElement;
+  }
+  return 'dark'; // note mode is dark-only today
+}
+
 function MermaidNodeView({ node, updateAttributes, editor }: NodeViewProps) {
   const source = (node.attrs['source'] as string | undefined) ?? '';
   const [svg, setSvg] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
+  const [mode, setMode] = useState<Mode>('dark');
   const idRef = useRef(`note-mermaid-${(mermaidIdSeq += 1)}`);
+  const hostRef = useRef<HTMLDivElement>(null);
 
-  // Render the committed source → SVG. Re-runs when `source` changes (incl. edits).
+  // Detect the effective theme from the rendered background, and re-detect when the
+  // app's dark-class toggles (adapts automatically if a light note-mode ships).
+  useEffect(() => {
+    const sync = () => setMode(detectMode(hostRef.current));
+    sync();
+    if (typeof MutationObserver === 'undefined' || typeof document === 'undefined') return;
+    const observer = new MutationObserver(sync);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, []);
+
+  // Render the committed source → SVG. Re-runs when `source` or `mode` changes.
   useEffect(() => {
     let cancelled = false;
     const src = source.trim();
@@ -46,18 +142,31 @@ function MermaidNodeView({ node, updateAttributes, editor }: NodeViewProps) {
     (async () => {
       try {
         const mermaid = (await import('mermaid')).default;
-        // theme-aware: note mode is always dark. startOnLoad off — we render manually.
-        mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'strict' });
-        const { svg: out } = await mermaid.render(idRef.current, src);
+        // base theme + curated palette; strip LLM pastel fills first. startOnLoad
+        // off — we render manually.
+        mermaid.initialize({
+          startOnLoad: false,
+          securityLevel: 'strict',
+          theme: 'base',
+          themeVariables: mode === 'dark' ? DARK_PALETTE : LIGHT_PALETTE,
+        });
+        const stripped = stripMermaidColorDirectives(src);
+        const { svg: out } = await mermaid.render(idRef.current, stripped);
         if (!cancelled) setSvg(out);
       } catch {
+        // mermaid leaks an orphaned "Syntax error" element into <body> on parse
+        // failure — remove it before falling back (supersedes PR #1026).
+        if (typeof document !== 'undefined') {
+          document.getElementById(idRef.current)?.remove();
+          document.getElementById(`d${idRef.current}`)?.remove();
+        }
         if (!cancelled) setFailed(true);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [source]);
+  }, [source, mode]);
 
   // Diagram preview — fallback to raw source on failure, never blank (mermaid
   // output is sanitized SVG via securityLevel:'strict'; source is diagram text).
@@ -73,13 +182,15 @@ function MermaidNodeView({ node, updateAttributes, editor }: NodeViewProps) {
 
   return (
     <NodeViewWrapper className="note-mermaid" data-type="mermaid">
-      <EditableSource
-        source={source}
-        editable={editor.isEditable}
-        onCommit={(next) => updateAttributes({ source: next })}
-        label="소스 편집"
-        preview={preview}
-      />
+      <div ref={hostRef} style={{ display: 'contents' }}>
+        <EditableSource
+          source={source}
+          editable={editor.isEditable}
+          onCommit={(next) => updateAttributes({ source: next })}
+          label="소스 편집"
+          preview={preview}
+        />
+      </div>
     </NodeViewWrapper>
   );
 }


### PR DESCRIPTION
## Root cause
Learning-note mermaid diagrams rendered with **invisible node text**. LLM-generated mermaid source embeds `style <node> fill:#<light-pastel>` directives (e.g. `style A fill:#d0e8ff,stroke:#4a90d9`), and `mermaid-block.tsx` initialized `mermaid.initialize({ theme: 'dark' })`. The dark theme paints node text in a **light** color → light text on a light pastel fill = unreadable.

## Changes (render-side only, 4 parts)
1. **Strip LLM color directives** — new pure exported helper `stripMermaidColorDirectives(src)` removes lines matching `^\s*(style|classDef|linkStyle)\s` before render. Keeps all structure (nodes, edges, labels, subgraphs, harmless `class X y`). This alone restores contrast because mermaid's own theme is internally consistent once the pastel fills are gone.
2. **Curated high-contrast dual-mode palettes** — switched to `theme: 'base'` with two named `themeVariables` palettes (`DARK_PALETTE` / `LIGHT_PALETTE`), each with high-contrast `primaryTextColor` vs `primaryColor` fill, plus border/line/secondary/tertiary/font. Concrete hex (mermaid themeVariables can't take CSS vars) — the one place diagram colors live, documented inline.
3. **Mode detection + re-render on toggle** — walks up from a NodeView host ref to the first non-transparent ancestor background, computes BT.601 luminance (named coeffs/threshold), picks the matching palette (dark <0.5). A `MutationObserver` on `document.documentElement[class]` bumps a `mode` state (included in the render effect deps); observer cleaned up on unmount. Resolves to dark today, auto-adapts if a light note-mode ships.
4. **Orphan-error-element cleanup** — on parse failure, removes mermaid's leaked `#<id>` / `#d<id>` "Syntax error" nodes from `<body>` before the `<pre>` fallback. **Supersedes PR #1026** (same one-line-area fix) — #1026 can be closed.

EditableSource NodeView, lazy `import('mermaid')`, and `securityLevel:'strict'` all kept intact.

## Tests
- New `mermaid-strip-color-directives.test.ts` (5 cases): style/classDef/linkStyle removed; flowchart nodes/edges/labels & subgraphs/`class` preserved; the realistic `style A fill:#d0e8ff` sample strips to structure; node labels containing the word "style" untouched.
- `npx tsc --noEmit` clean · `npx vitest run mermaid note` → 51 passed · `npm run build` clean (mermaid stays in its own lazy chunk) · dev smoke `/` + `/mandalas/new` → 200.

## Scope
Render-side only — no data, schema, or env change. Applies to all existing notes immediately, **no regeneration required**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)