### PR TITLE
fix(sidebar): mandala list shows FULL title (was truncated centerLabel)

### DIFF
--- a/frontend/src/widgets/app-shell/ui/SidebarMandalaSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarMandalaSection.tsx
@@ -274,10 +274,14 @@ export function SidebarMandalaSection({
     .filter((m) => !deletingIds.has(m.id))
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
-  const getCenterLabel = (m: (typeof mandalas)[0]) => {
+  // Sidebar list shows the FULL mandala title. `centerLabel` is the truncated
+  // minimap center-cell abbreviation (e.g. "Docker 마이크" ← "Docker로 마이크로서비스 배포")
+  // — it was being shown here, clipping every list name. Title first; centerLabel
+  // is only a fallback when a mandala has no title.
+  const getMandalaListLabel = (m: (typeof mandalas)[0]) => {
     const rootLevel = m.levels?.find((l: { depth: number }) => l.depth === 0);
-    const label = (rootLevel as { centerLabel?: string | null } | undefined)?.centerLabel;
-    return label || m.title || '—';
+    const centerLabel = (rootLevel as { centerLabel?: string | null } | undefined)?.centerLabel;
+    return m.title || centerLabel || '—';
   };
 
   return (
@@ -331,8 +335,8 @@ export function SidebarMandalaSection({
                   {/* CP504→2026-06-30 — show the FULL mandala name: wrap instead of
                       clipping (DB stores the full title; ellipsis hid the rest).
                       title tooltip kept as a harmless extra. */}
-                  <span className="flex-1 break-words leading-snug" title={getCenterLabel(mandala)}>
-                    {getCenterLabel(mandala)}
+                  <span className="flex-1 break-words leading-snug" title={getMandalaListLabel(mandala)}>
+                    {getMandalaListLabel(mandala)}
                   </span>
                   {newlySyncedCount > 0 && (
                     <span


### PR DESCRIPTION
## Problem
Sidebar 만다라 리스트 names were cut ("Docker 마이크", "서비스 구축 및 마", "100일 일본어 회") — no ellipsis, no wrap.

## Root cause (measured on prod DOM, not a CSS clip)
The list name came from `getCenterLabel()` = `centerLabel || m.title`. `centerLabel` is the **minimap center-cell abbreviation** (a pre-truncated string, e.g. "Docker 마이크" ← "Docker로 마이크로서비스 배포"). So the text was cut **at the source** — the element wasn't CSS-clipped (`scrollW===clientW`, `whiteSpace:normal`, `break-words` all fine); the string itself was short, and the `title` tooltip carried the same cut value.

## Fix
List label = `m.title || centerLabel || '—'` (full title first; centerLabel only a fallback). Helper renamed `getCenterLabel` → `getMandalaListLabel`.

## Verification (live dev)
Long titles now render FULL and wrap: e.g. "학습과 비즈니스를 병행하며 7월까지 커리어 전환 달성하고 12월 월매출 50만원 돌파 (cloned)" → h=54 (3 lines); "아이슬란드 링로드(Route 1)…" → h=36 (2 lines). 57 names, rendered === title, 0 clipped. `tsc` 0 · `build` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)