### PR TITLE
fix(mandala): never truncate center_label/sub_labels (mid-word slice corrupted DB)

### DIFF
--- a/src/modules/mandala/generator.ts
+++ b/src/modules/mandala/generator.ts
@@ -354,16 +354,13 @@ function extractJsonRobust(text: string): GeneratedMandala | null {
  * sub_goals look ugly in mini grid cells.
  */
 async function enrichLabels(m: GeneratedMandala): Promise<GeneratedMandala> {
-  if (!m.center_label && m.center_goal) {
-    m.center_label = m.center_goal.length > 20 ? m.center_goal.slice(0, 20) : m.center_goal;
-  }
-  if (!m.sub_labels || m.sub_labels.length === 0) {
-    // Phase 1 slice 3: log the fallback hit so the metric is observable
-    // in prod. Structure-phase should provide sub_labels under the new
-    // 700-token budget; hitting this branch means either the model
-    // still truncated or the response was malformed. Rate should drop
-    // materially vs pre-slice-3 baseline.
-    logger.info('[TIMING] enrichLabels: fallback triggered (sub_labels missing in structure)');
+  // NEVER truncate the goal into a label (a mid-word slice corrupts the stored
+  // label and can't be recovered). If EITHER label is missing, regenerate proper
+  // short labels via the LLM; on failure leave them empty and let the UI fall
+  // back to the goals.
+  const needsLabels = !m.center_label || !m.sub_labels || m.sub_labels.length === 0;
+  if (needsLabels && m.center_goal) {
+    logger.info('[TIMING] enrichLabels: fallback triggered (labels missing in structure)');
     const fallbackStart = Date.now();
     try {
       const lang = m.language === 'ko' || m.language === 'en' ? m.language : 'en';
@@ -372,16 +369,16 @@ async function enrichLabels(m: GeneratedMandala): Promise<GeneratedMandala> {
         sub_goals: m.sub_goals,
         language: lang,
       });
-      m.center_label = labels.center_label;
-      m.sub_labels = labels.sub_labels;
+      if (!m.center_label) m.center_label = labels.center_label;
+      if (!m.sub_labels || m.sub_labels.length === 0) m.sub_labels = labels.sub_labels;
       logger.info(`[TIMING] enrichLabels: fallback succeeded in ${Date.now() - fallbackStart}ms`);
     } catch (err) {
-      // Label generation failed — leave sub_labels empty.
-      // UI falls back to sub_goals. NEVER truncate sub_goals as labels.
-      logger.warn(`enrichLabels: sub_labels generation failed, leaving empty: ${err}`);
+      // Label generation failed — leave labels empty. UI falls back to goals.
+      // NEVER truncate goals into labels.
+      logger.warn(`enrichLabels: label generation failed, leaving empty: ${err}`);
     }
   } else {
-    logger.info('[TIMING] enrichLabels: skipped (sub_labels present from structure)');
+    logger.info('[TIMING] enrichLabels: skipped (labels present from structure)');
   }
   return m;
 }
@@ -905,21 +902,19 @@ export async function generateMandalaWithQueries(
  */
 export function normalizeStructureLabels(
   parsed: { center_label?: unknown; sub_labels?: unknown; sub_goals: unknown[] },
-  lang: 'ko' | 'en'
+  _lang: 'ko' | 'en'
 ): { hadSubLabels: boolean } {
-  const labelMaxLen = lang === 'ko' ? 10 : 15;
-  if (typeof parsed.center_label === 'string') {
-    parsed.center_label = parsed.center_label.slice(0, labelMaxLen);
-  } else if (parsed.center_label !== undefined) {
+  // Do NOT char-truncate labels: a mid-word slice corrupts the STORED label
+  // (irrecoverable — the source goal survives, but the short label is lost).
+  // Minimap cells apply CSS line-clamp for display; the data stays whole.
+  if (typeof parsed.center_label !== 'string' && parsed.center_label !== undefined) {
     delete parsed.center_label;
   }
   const hadSubLabels =
     Array.isArray(parsed.sub_labels) &&
     parsed.sub_labels.length === parsed.sub_goals.length &&
     parsed.sub_labels.every((l) => typeof l === 'string' && l.length > 0);
-  if (hadSubLabels) {
-    parsed.sub_labels = (parsed.sub_labels as string[]).map((l) => l.slice(0, labelMaxLen));
-  } else {
+  if (!hadSubLabels) {
     delete parsed.sub_labels;
   }
   return { hadSubLabels };
@@ -1137,7 +1132,6 @@ export async function generateLabels(input: LabelGenerateInput): Promise<Generat
   }
 
   const lang = input.language ?? 'en';
-  const maxLen = lang === 'ko' ? KO_SUB_LABEL_MAX : EN_SUB_LABEL_MAX;
 
   logger.info(
     `Label generation started (Haiku): goal="${input.center_goal}" subs=${input.sub_goals.length} lang=${lang}`
@@ -1172,11 +1166,10 @@ export async function generateLabels(input: LabelGenerateInput): Promise<Generat
     throw new MandalaGenError('Label generation: missing fields', 'VALIDATION_FAILED');
   }
 
-  // Enforce max length (trim if LLM exceeded, but never truncate to make labels)
-  parsed.center_label = parsed.center_label.slice(0, maxLen);
-  parsed.sub_labels = parsed.sub_labels
-    .slice(0, input.sub_goals.length)
-    .map((l) => l.slice(0, maxLen));
+  // Enforce COUNT only (one label per sub_goal). Do NOT char-truncate labels —
+  // a mid-word slice corrupts them (irrecoverable); the LLM is already prompted
+  // for short labels, and display surfaces apply CSS line-clamp instead.
+  parsed.sub_labels = parsed.sub_labels.slice(0, input.sub_goals.length);
 
   logger.info(
     `Label generation complete (Haiku): center="${parsed.center_label}" subs=[${parsed.sub_labels.join(', ')}]`

--- a/src/modules/mandala/generator.ts
+++ b/src/modules/mandala/generator.ts
@@ -1084,8 +1084,10 @@ export interface GeneratedLabels {
 }
 
 const LABEL_MAX_TOKENS = 800;
-const EN_SUB_LABEL_MAX = 15;
-const KO_SUB_LABEL_MAX = 10;
+// Prompt guidance only (labels are no longer hard-sliced). Loosened per user
+// feedback — 10/15 read as over-compressed; allow fuller, complete labels.
+const EN_SUB_LABEL_MAX = 22;
+const KO_SUB_LABEL_MAX = 15;
 
 function buildLabelPrompt(input: LabelGenerateInput): string {
   const lang = input.language ?? 'en';

--- a/tests/unit/modules/mandala-structure-labels.test.ts
+++ b/tests/unit/modules/mandala-structure-labels.test.ts
@@ -11,7 +11,7 @@
 import { normalizeStructureLabels } from '@/modules/mandala/generator';
 
 describe('normalizeStructureLabels — slice 3 in-band label parsing', () => {
-  test('valid 8-element sub_labels → hadSubLabels=true + trimmed to EN cap 15', () => {
+  test('valid 8-element sub_labels → hadSubLabels=true + labels kept FULL (no truncation)', () => {
     const parsed: {
       center_label?: unknown;
       sub_labels?: unknown;
@@ -32,12 +32,12 @@ describe('normalizeStructureLabels — slice 3 in-band label parsing', () => {
     };
     const { hadSubLabels } = normalizeStructureLabels(parsed, 'en');
     expect(hadSubLabels).toBe(true);
-    expect(parsed.center_label).toBe('Focus on Daily ');
-    expect((parsed.sub_labels as string[]).every((l) => l.length <= 15)).toBe(true);
-    expect((parsed.sub_labels as string[])[0]).toBe('Morning Routine');
+    // No truncation: labels pass through whole (mid-word slice corrupted the data).
+    expect(parsed.center_label).toBe('Focus on Daily Habit Building');
+    expect((parsed.sub_labels as string[])[0]).toBe('Morning Routine Extensive Block');
   });
 
-  test('valid 8-element sub_labels in KO → trimmed to cap 10', () => {
+  test('valid 8-element sub_labels in KO → kept FULL (no cap truncation)', () => {
     const parsed: {
       center_label?: unknown;
       sub_labels?: unknown;
@@ -58,8 +58,9 @@ describe('normalizeStructureLabels — slice 3 in-band label parsing', () => {
     };
     const { hadSubLabels } = normalizeStructureLabels(parsed, 'ko');
     expect(hadSubLabels).toBe(true);
-    expect((parsed.center_label as string).length).toBeLessThanOrEqual(10);
-    expect((parsed.sub_labels as string[]).every((l) => l.length <= 10)).toBe(true);
+    // No 10-char cap: the full Korean label is preserved (was sliced mid-word before).
+    expect(parsed.center_label).toBe('인생을바꾸는데일리루틴완성');
+    expect((parsed.sub_labels as string[])[0]).toBe('아침루틴 확장 세션');
   });
 
   test('sub_labels count mismatch (7 vs 8 sub_goals) → deleted', () => {
@@ -106,7 +107,8 @@ describe('normalizeStructureLabels — slice 3 in-band label parsing', () => {
     const { hadSubLabels } = normalizeStructureLabels(parsed, 'en');
     expect(hadSubLabels).toBe(false);
     expect(parsed.sub_labels).toBeUndefined();
-    expect(parsed.center_label).toBe('This is a very ');
+    // Kept full (no 15-char slice).
+    expect(parsed.center_label).toBe('This is a very long center label indeed');
   });
 
   test('center_label is non-string → deleted (only string labels accepted)', () => {


### PR DESCRIPTION
## Root cause (measured, not guessed)
"일부 만다라 리스트 라벨 잘림" — the label was being **hard-sliced at generation/write time** and stored truncated in the DB (mid-word, irrecoverable). The READ path never touches it; the source `center_goal` stays intact.

Prod audit (read-only): **167 / 2236 depth-0 labels are cut, and 167/167 have an intact center_goal** (→ 100% repairable). Detection: prefix-of-goal (115) + Korean labels at the 10-char cap (55). e.g. `GraphQL마이그`←"…마이그레이션", `MLOps파이프라인`, `Docker 마이크`.

## Fix (this PR — Part 1, prevent new corruption)
Remove ALL char-slices in `generator.ts`:
- `normalizeStructureLabels`: drop `.slice(0, 10 ko / 15 en)` on center_label + sub_labels.
- `enrichLabels`: drop `center_goal.slice(0, 20)` fallback → regenerate a proper label via `generateLabels` when missing.
- `generateLabels`: drop `.slice(0, maxLen)` char-cut (keep the one-per-sub_goal count limit).

Labels are now stored **whole**. The LLM is already prompted for short labels (KO/EN_SUB_LABEL_MAX in the prompt), and display already clamps: minimap `HeatCell` = `line-clamp-2 break-words`, sidebar list = `break-words`. So no display overflow.

## Verification
BE `tsc` 0 · `mandala-structure-labels` 7/7 (assertions flipped from "trimmed to cap" → full pass-through). BE-only, no `frontend/src`.

## Part 2 (separate — repair existing 167)
Regenerate `center_label` for the 167 cut mandalas from the intact `center_goal` via the **prod service** `generateLabels` path (OpenRouter is prod-service-only per project rule), then UPDATE prod DB (backup-first). Plan pending James's go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)