### PR TITLE
feat(sidebar P1): per-mandala asset status (deck/note/v2) in listMandalas

### DIFF
--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -486,6 +486,14 @@ interface MandalaResponse {
   fillPendingCells?: number[];
   // CP500+ — cells whose fill run completed <60s ago (grace: invalidate once).
   fillCompletedCells?: number[];
+  // P1 — per-mandala asset status for the sidebar (deck/note/v2), from the LIST
+  // path only. Lets the sidebar show at-a-glance icons without per-mandala fetches.
+  assetStatus?: {
+    deck: string | null; // pending | building | done | failed | null=none
+    note: 'fresh' | 'stale' | 'none';
+    v2Done: number | null;
+    v2GatePassed: number | null;
+  };
   createdAt: string;
   updatedAt: string;
   levels: Array<{

--- a/src/modules/mandala/manager.ts
+++ b/src/modules/mandala/manager.ts
@@ -46,6 +46,47 @@ interface MandalaLevelData {
   parentLevelKey?: string | null;
 }
 
+/**
+ * P1 — per-mandala asset status for the sidebar (deck / note / v2), surfaced in
+ * the LIST response so the FE shows at-a-glance icons without an on-demand fetch
+ * per mandala. All three are cheap single-row lookups keyed by mandala_id.
+ */
+export interface MandalaAssetStatus {
+  /** slide_decks.status: pending | building | done | failed; null = no deck. */
+  deck: string | null;
+  /** note_documents presence + freshness vs mandala_books.version. */
+  note: 'fresh' | 'stale' | 'none';
+  /** mandala_books.v2_done / gate_passed — coverage snapshot at last fill. */
+  v2Done: number | null;
+  v2GatePassed: number | null;
+}
+
+/**
+ * Pure derivation of a mandala's asset status (exported for unit testing).
+ * note: no note row ⇒ 'none'; note present + book re-filled past it ⇒ 'stale'; else 'fresh'.
+ */
+export function deriveMandalaAssetStatus(input: {
+  deckStatus: string | null;
+  bookVersion: number | null;
+  v2Done: number | null;
+  v2GatePassed: number | null;
+  /** note_documents.based_on_book_version; null = no note. */
+  noteBasedOnVersion: number | null;
+}): MandalaAssetStatus {
+  const note: MandalaAssetStatus['note'] =
+    input.noteBasedOnVersion == null
+      ? 'none'
+      : input.bookVersion != null && input.bookVersion > input.noteBasedOnVersion
+        ? 'stale'
+        : 'fresh';
+  return {
+    deck: input.deckStatus,
+    note,
+    v2Done: input.v2Done,
+    v2GatePassed: input.v2GatePassed,
+  };
+}
+
 export interface MandalaWithLevels {
   id: string;
   userId: string;
@@ -73,6 +114,8 @@ export interface MandalaWithLevels {
   // (completed-grace). FE invalidates its card cache ONCE when it lands
   // inside this window (fast runs finish before the first meta fetch).
   fillCompletedCells: number[];
+  /** P1 — deck/note/v2 status (list path only; undefined on single-mandala fetches). */
+  assetStatus?: MandalaAssetStatus;
   createdAt: Date;
   updatedAt: Date;
   levels: {
@@ -170,7 +213,8 @@ export class MandalaManager {
     },
     cardCount?: number,
     fillPendingCells?: number[],
-    fillCompletedCells?: number[]
+    fillCompletedCells?: number[],
+    assetStatus?: MandalaAssetStatus
   ): MandalaWithLevels {
     return {
       id: mandala.id,
@@ -186,6 +230,7 @@ export class MandalaManager {
       cardCount: cardCount ?? 0,
       fillPendingCells: fillPendingCells ?? [],
       fillCompletedCells: fillCompletedCells ?? [],
+      ...(assetStatus ? { assetStatus } : {}),
       createdAt: mandala.created_at,
       updatedAt: mandala.updated_at,
       levels: mandala.levels.map((l) => ({
@@ -443,8 +488,41 @@ export class MandalaManager {
       }),
     ]);
 
+    // P1 — batch per-mandala asset status (deck/note/v2) in 3 indexed IN-lookups
+    // (no N+1) so the sidebar shows at-a-glance icons without per-mandala fetches.
+    const ids = mandalas.map((m) => m.id);
+    const [decks, books, notes] = await Promise.all([
+      this.prisma.slide_decks.findMany({
+        where: { mandala_id: { in: ids } },
+        select: { mandala_id: true, status: true },
+      }),
+      this.prisma.mandala_books.findMany({
+        where: { mandala_id: { in: ids } },
+        select: { mandala_id: true, gate_passed: true, v2_done: true, version: true },
+      }),
+      this.prisma.note_documents.findMany({
+        where: { mandala_id: { in: ids }, user_id: userId },
+        select: { mandala_id: true, based_on_book_version: true },
+      }),
+    ]);
+    const deckMap = new Map(decks.map((d) => [d.mandala_id, d.status]));
+    const bookMap = new Map(books.map((b) => [b.mandala_id, b]));
+    const noteVerMap = new Map(notes.map((n) => [n.mandala_id, n.based_on_book_version]));
+    const assetStatusFor = (id: string): MandalaAssetStatus => {
+      const book = bookMap.get(id);
+      return deriveMandalaAssetStatus({
+        deckStatus: deckMap.get(id) ?? null,
+        bookVersion: book?.version ?? null,
+        v2Done: book?.v2_done ?? null,
+        v2GatePassed: book?.gate_passed ?? null,
+        noteBasedOnVersion: noteVerMap.get(id) ?? null,
+      });
+    };
+
     return {
-      mandalas: mandalas.map((m) => this.mapMandala(m)),
+      mandalas: mandalas.map((m) =>
+        this.mapMandala(m, undefined, undefined, undefined, assetStatusFor(m.id))
+      ),
       total,
       page: hasLimit ? page : 1,
       limit: hasLimit ? limit : total,

--- a/tests/unit/modules/mandala-asset-status.test.ts
+++ b/tests/unit/modules/mandala-asset-status.test.ts
@@ -1,0 +1,67 @@
+/**
+ * P1 — deriveMandalaAssetStatus: per-mandala deck/note/v2 status for the sidebar.
+ * note = none (no note row) / stale (book re-filled past the note) / fresh.
+ */
+import { deriveMandalaAssetStatus } from '@/modules/mandala/manager';
+
+describe('deriveMandalaAssetStatus', () => {
+  it('note=none when there is no note row', () => {
+    expect(
+      deriveMandalaAssetStatus({
+        deckStatus: null,
+        bookVersion: 5,
+        v2Done: 3,
+        v2GatePassed: 4,
+        noteBasedOnVersion: null,
+      }).note
+    ).toBe('none');
+  });
+
+  it('note=stale when book.version > note.based_on_book_version', () => {
+    expect(
+      deriveMandalaAssetStatus({
+        deckStatus: 'done',
+        bookVersion: 7,
+        v2Done: 10,
+        v2GatePassed: 10,
+        noteBasedOnVersion: 5,
+      }).note
+    ).toBe('stale');
+  });
+
+  it('note=fresh when note is at (or ahead of) the current book version', () => {
+    expect(
+      deriveMandalaAssetStatus({
+        deckStatus: null,
+        bookVersion: 5,
+        v2Done: 5,
+        v2GatePassed: 5,
+        noteBasedOnVersion: 5,
+      }).note
+    ).toBe('fresh');
+  });
+
+  it('passes deck status and v2 coverage through unchanged', () => {
+    const s = deriveMandalaAssetStatus({
+      deckStatus: 'building',
+      bookVersion: 2,
+      v2Done: 16,
+      v2GatePassed: 18,
+      noteBasedOnVersion: 2,
+    });
+    expect(s).toEqual({ deck: 'building', note: 'fresh', v2Done: 16, v2GatePassed: 18 });
+  });
+
+  it('note=fresh (not stale) when a note exists but there is no book version', () => {
+    // defensive: note present, book missing → cannot be "re-filled past", treat as fresh
+    expect(
+      deriveMandalaAssetStatus({
+        deckStatus: null,
+        bookVersion: null,
+        v2Done: null,
+        v2GatePassed: null,
+        noteBasedOnVersion: 0,
+      }).note
+    ).toBe('fresh');
+  });
+});


### PR DESCRIPTION
Sidebar-commercial plan **P1** (BE data layer). Full plan: 사이드바 상용화 — 1줄 행 + 우측 상태 아이콘(덱/노트/v2) + `⋯`, ⌘K 통합검색(user-scoped, pg_trgm 필요), BETA 유지.

## What
The mandala LIST (`GET /mandalas/list`) now carries **per-mandala asset status** so the sidebar shows at-a-glance icons instead of an on-demand fetch per mandala (the reason users had to click each one to check deck/note/v2).

- `deck` ← `slide_decks.status` (pending|building|done|failed | null=none)
- `note` ← `note_documents` presence + freshness vs `mandala_books.version` → `fresh`/`stale`/`none`
- `v2` ← `mandala_books.v2_done` / `gate_passed` (coverage snapshot at last fill)

Cheap: 3 indexed `IN (...)` lookups (keyed by `mandala_id`), **no N+1**. Pure `deriveMandalaAssetStatus()` exported + unit-tested. `assetStatus` added to `MandalaWithLevels` (BE) + `MandalaResponse` (FE type). **List path only** (undefined on single-mandala fetches). FE rendering = P2.

## Verified
- BE `tsc` 0 · FE `tsc` 0 · `jest` 5/5 (none/stale/fresh + passthrough + no-book defensive).
- Prisma select fields type-checked against generated client.
- No pagination on the sidebar list (loads all) → JOIN cost measured after deploy (guard).
- Cross-checked: no in-flight conflict on manager.ts / api-client.ts.

## Notes
- v2 coverage is a **snapshot** from the last fill (documented); realtime freshness handled in P2/P3.
- Existing on-demand endpoints (`/deck-status`, `/note-documents/:id`, `/:id/book`) unchanged (detail view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)