### PR TITLE
chore(observability): flip SEARCH_TRACE_ENABLED=true on prod (G1)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -225,6 +225,10 @@ services:
       # Arms the daily 🔴 multi-key alarm + the daily metrics report. Empty ⇒ jobs
       # log only, send no mail. Revert: delete this line → mail no-ops.
       - OBSERVABILITY_ALERT_EMAIL=admin@insighta.one
+      # G1 flag flip (2026-07-01, James-directed) — activate search-trace emission.
+      # Non-secret config (CP392). Off → no-op; on → async fire-and-forget INSERT
+      # of the Card Journey per v5 live search. Rollback: set false / delete line.
+      - SEARCH_TRACE_ENABLED=true
       # CP437 (2026-04-29) — Operator flip: enable v2 layered cron.
       # Default in code is `false` — cron stays dormant unless this env is
       # explicitly true. With this set, `startRichSummaryV2Cron()` schedules


### PR DESCRIPTION
## What
Flip `SEARCH_TRACE_ENABLED=true` in the prod compose `environment:` block (api service), activating search-trace emission on the v5 live search path.

## Why
G1 (observability prod activation). Merge (#1037) + DDL (3 tables present in prod) + deploy are all verified done; the only remaining step was the operator flag flip. James-directed.

## Details
- Non-secret config (CP392) — compose `environment:` literal is the SSOT (overrides `.env`); no deploy.yml/secret wiring needed.
- Emission is observation-only, fire-and-forget async INSERT — never blocks the serve path. Off = no-op.
- Tables already applied in prod: `search_trace`, `search_trace_candidate` (0 rows until this flips on), `search_metrics_daily` (rollup already firing).
- **Rollback**: set `false` or delete the line → next deploy no-ops emission.

## Verify after deploy
`docker exec insighta-api printenv | grep SEARCH_TRACE_ENABLED` → `true`, then a real add-cards/wizard run leaves rows in `search_trace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)