### PR TITLE
feat(observability): G2-a Search-Trace Explorer — Card Journey admin view

### DIFF
--- a/frontend/src/app/router/index.tsx
+++ b/frontend/src/app/router/index.tsx
@@ -18,6 +18,7 @@ import { AdminSearchAlgorithms } from '@/pages/admin/ui/AdminSearchAlgorithms';
 import { AdminV2QualityAudit } from '@/pages/admin/ui/AdminV2QualityAudit';
 import { AdminV4ArbiterRuns } from '@/pages/admin/ui/AdminV4ArbiterRuns';
 import { AdminPoolHealth } from '@/pages/admin/ui/AdminPoolHealth';
+import { AdminSearchTraceExplorer } from '@/pages/admin/ui/AdminSearchTraceExplorer';
 
 const IndexPage = lazy(() => import('@/pages/index'));
 const LoginPage = lazy(() => import('@/pages/login'));
@@ -159,6 +160,8 @@ export function AppRouter() {
           <Route path="v4-arbiter-runs" element={<AdminV4ArbiterRuns />} />
           {/* Content Pool Health — 5-section pool dashboard. */}
           <Route path="pool-health" element={<AdminPoolHealth />} />
+          {/* Observability G2 — Search-Trace Explorer (Card Journey debug view). */}
+          <Route path="search-trace" element={<AdminSearchTraceExplorer />} />
         </Route>
 
         <Route path="*" element={<NotFoundPage />} />

--- a/frontend/src/pages/admin/ui/AdminLayout.tsx
+++ b/frontend/src/pages/admin/ui/AdminLayout.tsx
@@ -14,6 +14,7 @@ import {
   SlidersHorizontal,
   Activity,
   Gauge,
+  Footprints,
 } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 
@@ -36,6 +37,8 @@ const NAV_ITEMS = [
   { to: '/admin/v4-arbiter-runs', icon: Activity, label: 'V4 Arbiter Runs' },
   // Content Pool Health — 5-section dashboard (volume/enrich/source/reuse/promote).
   { to: '/admin/pool-health', icon: Gauge, label: 'Pool Health' },
+  // Observability G2 — Search-Trace Explorer (Card Journey debug view).
+  { to: '/admin/search-trace', icon: Footprints, label: 'Search Trace' },
 ] as const;
 
 export function AdminLayout() {

--- a/frontend/src/pages/admin/ui/AdminSearchTraceExplorer.tsx
+++ b/frontend/src/pages/admin/ui/AdminSearchTraceExplorer.tsx
@@ -1,0 +1,273 @@
+/**
+ * Admin — Search-Trace Explorer (Observability G2)
+ *
+ * The debug-core view (design SSOT §6.2): pick a recent trace (or paste a
+ * trace_id / mandala_id) → see the full Card Journey — generated queries →
+ * raw YouTube counts → per-candidate keep/drop decision + reason → placed
+ * cells. Backs GET /api/v1/admin/search-trace/* (read-only, observation-only).
+ *
+ * Operator-grade, not user-facing. Tailwind + semantic tokens only.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { apiClient } from '@/shared/lib/api-client';
+
+interface TraceSummary {
+  trace_id: string;
+  mandala_id: string | null;
+  user_id: string | null;
+  trigger: string;
+  started_at: string;
+  finished_at: string | null;
+  queries_generated: unknown;
+  quota_units: number | null;
+  queries_attempted: number | null;
+  queries_succeeded: number | null;
+  queries_failed: number | null;
+  counts: Record<string, number> | null;
+  outcome: Record<string, unknown> | null;
+  algorithm_version: string | null;
+  created_at: string;
+}
+
+interface Candidate {
+  video_id: string;
+  channel_title: string | null;
+  source_kind: string;
+  source_cell_index: number | null;
+  source_query_text: string | null;
+  source_tier: string | null;
+  decision: string;
+  drop_reason: string | null;
+  relevance_gc: number | null;
+  view_count: number | null;
+  duration_sec: number | null;
+  final_cell_index: number | null;
+}
+
+interface Journey {
+  trace: TraceSummary;
+  candidate_count: number;
+  funnel: { decision: string; drop_reason: string | null; count: number }[];
+  placed_by_cell: { cell: number; cards: Candidate[] }[];
+  candidates: Candidate[];
+}
+
+const TRIGGER_TONE: Record<string, string> = {
+  add_cards: 'bg-primary/15 text-primary',
+  wizard: 'bg-accent text-accent-foreground',
+  pool_serve: 'bg-muted text-muted-foreground',
+};
+
+function Pill({ children, tone }: { children: React.ReactNode; tone?: string }) {
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${tone ?? 'bg-muted text-muted-foreground'}`}>
+      {children}
+    </span>
+  );
+}
+
+function fmtTime(iso: string): string {
+  return iso.replace('T', ' ').replace(/\.\d+Z$/, 'Z');
+}
+
+export function AdminSearchTraceExplorer() {
+  const [recent, setRecent] = useState<TraceSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [idInput, setIdInput] = useState('');
+  const [journey, setJourney] = useState<Journey | null>(null);
+  const [journeyLoading, setJourneyLoading] = useState(false);
+
+  const reloadRecent = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiClient.getSearchTraceRecent();
+      setRecent(res.traces);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to load traces');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reloadRecent();
+  }, [reloadRecent]);
+
+  const openJourney = useCallback(async (traceId: string) => {
+    if (!traceId.trim()) return;
+    setJourneyLoading(true);
+    setError(null);
+    try {
+      const res = await apiClient.getSearchTraceJourney(traceId.trim());
+      setJourney(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to load journey');
+      setJourney(null);
+    } finally {
+      setJourneyLoading(false);
+    }
+  }, []);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="border-b border-border bg-card px-6 py-4">
+        <h1 className="text-lg font-semibold">Search-Trace Explorer</h1>
+        <p className="text-sm text-muted-foreground">
+          Card Journey — 쿼리 → raw → keep/drop 사유 → 셀. 관찰 전용 (서빙 무변경).
+        </p>
+        <div className="mt-3 flex gap-2">
+          <input
+            value={idInput}
+            onChange={(e) => setIdInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void openJourney(idInput);
+            }}
+            placeholder="trace_id 붙여넣기 → Enter"
+            className="w-96 rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+          />
+          <button
+            onClick={() => void openJourney(idInput)}
+            className="rounded-md border border-border bg-background px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            여정 조회
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Left — recent traces */}
+        <aside className="w-80 shrink-0 overflow-y-auto border-r border-border">
+          <div className="border-b border-border px-4 py-2 text-xs font-medium text-muted-foreground">
+            최근 요청 ({recent.length})
+          </div>
+          {loading && <div className="px-4 py-3 text-sm text-muted-foreground">로딩…</div>}
+          {recent.map((t) => (
+            <button
+              key={t.trace_id}
+              onClick={() => {
+                setIdInput(t.trace_id);
+                void openJourney(t.trace_id);
+              }}
+              className={`w-full border-b border-border px-4 py-2 text-left hover:bg-accent ${
+                journey?.trace.trace_id === t.trace_id ? 'bg-accent' : ''
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <Pill tone={TRIGGER_TONE[t.trigger]}>{t.trigger}</Pill>
+                <span className="text-xs text-muted-foreground">
+                  {(t.outcome?.cards_count as number | undefined) ?? '?'}장 · {t.quota_units ?? '?'}u
+                </span>
+              </div>
+              <div className="mt-1 truncate text-xs text-muted-foreground">{fmtTime(t.created_at)}</div>
+              <div className="truncate font-mono text-[11px] text-muted-foreground">{t.trace_id}</div>
+            </button>
+          ))}
+        </aside>
+
+        {/* Right — journey */}
+        <main className="flex-1 overflow-y-auto p-6">
+          {error && <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-2 text-sm text-destructive">{error}</div>}
+          {journeyLoading && <div className="text-sm text-muted-foreground">여정 로딩…</div>}
+          {!journey && !journeyLoading && (
+            <div className="text-sm text-muted-foreground">왼쪽에서 요청을 선택하거나 trace_id 를 입력하세요.</div>
+          )}
+          {journey && (
+            <div className="space-y-6">
+              {/* Request summary */}
+              <section className="rounded-lg border border-border bg-card p-4">
+                <div className="flex items-center gap-2">
+                  <Pill tone={TRIGGER_TONE[journey.trace.trigger]}>{journey.trace.trigger}</Pill>
+                  <span className="text-sm text-muted-foreground">{fmtTime(journey.trace.started_at)}</span>
+                  {journey.trace.algorithm_version && <Pill>{journey.trace.algorithm_version}</Pill>}
+                </div>
+                <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1 text-sm sm:grid-cols-4">
+                  <div><span className="text-muted-foreground">quota</span> {journey.trace.quota_units ?? '—'}u</div>
+                  <div><span className="text-muted-foreground">쿼리</span> {journey.trace.queries_succeeded ?? '?'}/{journey.trace.queries_attempted ?? '?'} 성공</div>
+                  <div><span className="text-muted-foreground">후보</span> {journey.candidate_count}</div>
+                  <div><span className="text-muted-foreground">카드</span> {(journey.trace.outcome?.cards_count as number | undefined) ?? '?'}</div>
+                </div>
+                {journey.trace.counts && (
+                  <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                    {Object.entries(journey.trace.counts).map(([k, v]) => (
+                      <span key={k} className="rounded bg-muted px-1.5 py-0.5">{k}: {v}</span>
+                    ))}
+                  </div>
+                )}
+              </section>
+
+              {/* Generated queries */}
+              {Array.isArray(journey.trace.queries_generated) && (
+                <section>
+                  <h2 className="mb-2 text-sm font-semibold">생성 쿼리 → raw</h2>
+                  <div className="space-y-1">
+                    {(journey.trace.queries_generated as { query: string; source?: string; rawCount?: number; cellIndex?: number }[]).map((q, i) => (
+                      <div key={i} className="flex items-center gap-2 rounded border border-border px-3 py-1.5 text-sm">
+                        <span className="w-8 shrink-0 text-xs text-muted-foreground">c{q.cellIndex ?? '?'}</span>
+                        <span className="flex-1 truncate">{q.query}</span>
+                        {q.source && <Pill>{q.source}</Pill>}
+                        <span className={`w-14 text-right text-xs ${(q.rawCount ?? 0) < 10 ? 'text-destructive' : 'text-muted-foreground'}`}>
+                          raw {q.rawCount ?? 0}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {/* Funnel */}
+              <section>
+                <h2 className="mb-2 text-sm font-semibold">퍼널 (decision × drop 사유)</h2>
+                <div className="flex flex-wrap gap-2">
+                  {journey.funnel.map((f) => (
+                    <span
+                      key={`${f.decision}:${f.drop_reason}`}
+                      className={`rounded-md px-2 py-1 text-xs ${
+                        f.decision === 'PLACED' ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'
+                      }`}
+                    >
+                      {f.decision === 'PLACED' ? 'PLACED' : `drop:${f.drop_reason ?? '?'}`} · {f.count}
+                    </span>
+                  ))}
+                </div>
+              </section>
+
+              {/* Placed cards by cell */}
+              <section>
+                <h2 className="mb-2 text-sm font-semibold">배치된 카드 (셀별)</h2>
+                {journey.placed_by_cell.length === 0 && (
+                  <div className="text-sm text-muted-foreground">배치된 카드 없음.</div>
+                )}
+                {journey.placed_by_cell.map(({ cell, cards }) => (
+                  <div key={cell} className="mb-3">
+                    <div className="mb-1 text-xs font-medium text-muted-foreground">cell {cell}</div>
+                    <div className="overflow-hidden rounded-md border border-border">
+                      <table className="w-full text-sm">
+                        <tbody>
+                          {cards.map((c) => (
+                            <tr key={c.video_id} className="border-b border-border last:border-0">
+                              <td className="px-3 py-1.5 font-mono text-xs text-muted-foreground">{c.video_id}</td>
+                              <td className="max-w-[220px] truncate px-3 py-1.5">{c.channel_title ?? '—'}</td>
+                              <td className={`px-3 py-1.5 text-right ${(c.view_count ?? 0) < 1000 ? 'text-destructive' : ''}`}>
+                                {c.view_count ?? '?'} views
+                              </td>
+                              <td className="px-3 py-1.5 text-right text-xs text-muted-foreground">
+                                gc {c.relevance_gc ?? '—'} · {c.source_kind}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                ))}
+              </section>
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -635,6 +635,30 @@ export interface AdminPoolHealthDetailResponse {
   notes?: string;
 }
 
+/** Observability G2 — one candidate row in a search-trace Card Journey. */
+export interface SearchTraceCandidateDTO {
+  video_id: string;
+  channel_id: string | null;
+  channel_title: string | null;
+  source_kind: string;
+  source_cell_index: number | null;
+  source_query_text: string | null;
+  source_tier: string | null;
+  stage_reached: string | null;
+  decision: string;
+  drop_reason: string | null;
+  relevance_gc: number | null;
+  ts_rank: number | null;
+  cosine: number | null;
+  llm_pick_score: number | null;
+  llm_pick_reason: string | null;
+  view_count: number | null;
+  duration_sec: number | null;
+  published_at: string | null;
+  final_cell_level: number | null;
+  final_cell_index: number | null;
+}
+
 class ApiClient {
   private baseUrl: string;
   private accessToken: string | null = null;
@@ -3057,6 +3081,53 @@ class ApiClient {
   // ========================================
   // Admin — Search Algorithm Versions (CP488)
   // ========================================
+  // Observability G2 — Search-Trace Explorer (Card Journey debug view).
+  // BE routes (super_admin only): src/api/routes/admin/search-trace-explorer.ts
+  //   GET /admin/search-trace/recent?limit=&mandala_id=&trigger=
+  //   GET /admin/search-trace/by-mandala/:mandalaId
+  //   GET /admin/search-trace/journey/:traceId
+  async getSearchTraceRecent(params?: {
+    limit?: number;
+    mandala_id?: string;
+    trigger?: string;
+  }): Promise<{
+    count: number;
+    traces: Array<{
+      trace_id: string;
+      mandala_id: string | null;
+      user_id: string | null;
+      trigger: string;
+      started_at: string;
+      finished_at: string | null;
+      queries_generated: unknown;
+      quota_units: number | null;
+      queries_attempted: number | null;
+      queries_succeeded: number | null;
+      queries_failed: number | null;
+      counts: Record<string, number> | null;
+      outcome: Record<string, unknown> | null;
+      algorithm_version: string | null;
+      created_at: string;
+    }>;
+  }> {
+    const qs = new URLSearchParams();
+    if (params?.limit) qs.set('limit', String(params.limit));
+    if (params?.mandala_id) qs.set('mandala_id', params.mandala_id);
+    if (params?.trigger) qs.set('trigger', params.trigger);
+    const suffix = qs.toString() ? `?${qs.toString()}` : '';
+    return this.request(`/admin/search-trace/recent${suffix}`);
+  }
+
+  async getSearchTraceJourney(traceId: string): Promise<{
+    trace: Awaited<ReturnType<ApiClient['getSearchTraceRecent']>>['traces'][number];
+    candidate_count: number;
+    funnel: Array<{ decision: string; drop_reason: string | null; count: number }>;
+    placed_by_cell: Array<{ cell: number; cards: SearchTraceCandidateDTO[] }>;
+    candidates: SearchTraceCandidateDTO[];
+  }> {
+    return this.request(`/admin/search-trace/journey/${encodeURIComponent(traceId)}`);
+  }
+
   // Catalog of named search-algorithm rows (parameters as JSONB). Lets
   // super_admin flip the global default or apply a per-mandala override
   // without a code release; the v3 executor's `resolveAlgorithm` reads

--- a/src/api/routes/admin/index.ts
+++ b/src/api/routes/admin/index.ts
@@ -29,6 +29,7 @@ import { adminRelevanceBackfillRoutes } from './relevance-backfill';
 import { adminMandalaBookFillRoutes } from './mandala-book-fill';
 import { adminSegmentRelevanceFillRoutes } from './segment-relevance-fill';
 import { adminPoolServeRoutes } from './pool-serve';
+import { adminSearchTraceExplorerRoutes } from './search-trace-explorer';
 
 /**
  * Admin routes plugin.
@@ -80,5 +81,8 @@ export async function adminRoutes(fastify: FastifyInstance) {
   await fastify.register(adminSegmentRelevanceFillRoutes, { prefix: '/segment-relevance-fill' });
   // CP499+ — pool-serve canary trigger (deficit-cell fill, flag bypassed).
   await fastify.register(adminPoolServeRoutes, { prefix: '/pool-serve' });
+  // Observability G2 — Search-Trace Explorer (Card Journey debug view over
+  // search_trace / search_trace_candidate). Read-only; observation-only.
+  await fastify.register(adminSearchTraceExplorerRoutes, { prefix: '/search-trace' });
   // await fastify.register(stripeWebhookRoutes, { prefix: '/webhooks/stripe' });
 }

--- a/src/api/routes/admin/search-trace-explorer.ts
+++ b/src/api/routes/admin/search-trace-explorer.ts
@@ -1,0 +1,203 @@
+/**
+ * Admin Search-Trace Explorer — read-only Card Journey for the v5 live search.
+ *
+ * Reconstructs, for one request (trace_id) or one mandala, the full journey from
+ * §3 of the observability design SSOT: generated queries → raw YouTube results →
+ * per-candidate keep/drop decision + reason → final cell. Powers the debug view
+ * ("this mandala returned garbage — why?").
+ *
+ * Read-only over search_trace / search_trace_candidate. Never touches the serve
+ * path (observation-only). Guarded by authenticate + authenticateAdmin, mirroring
+ * admin/discover-traces.ts.
+ */
+
+import { FastifyPluginCallback } from 'fastify';
+import { getPrismaClient } from '@/modules/database';
+
+const RECENT_DEFAULT = 100;
+const RECENT_MAX = 1000;
+const CANDIDATE_CAP = 5000;
+
+/** BigInt (view_count) is not JSON-serializable — coerce to number for the wire. */
+function viewToNumber(v: bigint | null): number | null {
+  return v == null ? null : Number(v);
+}
+
+/** Summary row shape shared by the list endpoints (no candidates). */
+function toTraceSummary(r: {
+  trace_id: string;
+  mandala_id: string | null;
+  user_id: string | null;
+  trigger: string;
+  started_at: Date;
+  finished_at: Date | null;
+  queries_generated: unknown;
+  quota_units: number | null;
+  queries_attempted: number | null;
+  queries_succeeded: number | null;
+  queries_failed: number | null;
+  counts: unknown;
+  outcome: unknown;
+  algorithm_version: string | null;
+  created_at: Date;
+}) {
+  return {
+    trace_id: r.trace_id,
+    mandala_id: r.mandala_id,
+    user_id: r.user_id,
+    trigger: r.trigger,
+    started_at: r.started_at.toISOString(),
+    finished_at: r.finished_at?.toISOString() ?? null,
+    queries_generated: r.queries_generated,
+    quota_units: r.quota_units,
+    queries_attempted: r.queries_attempted,
+    queries_succeeded: r.queries_succeeded,
+    queries_failed: r.queries_failed,
+    counts: r.counts,
+    outcome: r.outcome,
+    algorithm_version: r.algorithm_version,
+    created_at: r.created_at.toISOString(),
+  };
+}
+
+export const adminSearchTraceExplorerRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  /**
+   * GET /api/v1/admin/search-trace/recent?limit=N&mandala_id=&trigger=
+   * — most recent request traces (list view for the Explorer landing).
+   */
+  fastify.get<{ Querystring: { limit?: string; mandala_id?: string; trigger?: string } }>(
+    '/recent',
+    adminAuth,
+    async (request, reply) => {
+      const limit = Math.min(
+        Number(request.query.limit ?? String(RECENT_DEFAULT)) || RECENT_DEFAULT,
+        RECENT_MAX
+      );
+      const prisma = getPrismaClient();
+      const rows = await prisma.search_trace.findMany({
+        where: {
+          ...(request.query.mandala_id ? { mandala_id: request.query.mandala_id } : {}),
+          ...(request.query.trigger ? { trigger: request.query.trigger } : {}),
+        },
+        orderBy: { created_at: 'desc' },
+        take: limit,
+      });
+      return reply.send({ count: rows.length, traces: rows.map(toTraceSummary) });
+    }
+  );
+
+  /**
+   * GET /api/v1/admin/search-trace/by-mandala/:mandalaId?limit=N
+   * — request traces for one mandala, newest first.
+   */
+  fastify.get<{ Params: { mandalaId: string }; Querystring: { limit?: string } }>(
+    '/by-mandala/:mandalaId',
+    adminAuth,
+    async (request, reply) => {
+      const limit = Math.min(
+        Number(request.query.limit ?? String(RECENT_DEFAULT)) || RECENT_DEFAULT,
+        RECENT_MAX
+      );
+      const prisma = getPrismaClient();
+      const rows = await prisma.search_trace.findMany({
+        where: { mandala_id: request.params.mandalaId },
+        orderBy: { created_at: 'desc' },
+        take: limit,
+      });
+      return reply.send({
+        mandalaId: request.params.mandalaId,
+        count: rows.length,
+        traces: rows.map(toTraceSummary),
+      });
+    }
+  );
+
+  /**
+   * GET /api/v1/admin/search-trace/journey/:traceId
+   *
+   * The Card Journey (§3): the request row + every candidate with its keep/drop
+   * decision, plus a pre-computed funnel (decision × drop_reason attrition) and
+   * the placed cards grouped by cell — so the FE renders without re-aggregating.
+   */
+  fastify.get<{ Params: { traceId: string } }>(
+    '/journey/:traceId',
+    adminAuth,
+    async (request, reply) => {
+      const traceId = request.params.traceId;
+      const prisma = getPrismaClient();
+
+      const trace = await prisma.search_trace.findFirst({
+        where: { trace_id: traceId },
+        orderBy: { created_at: 'desc' },
+      });
+      if (!trace) {
+        return reply.code(404).send({ error: 'trace_not_found', traceId });
+      }
+
+      const candidates = await prisma.search_trace_candidate.findMany({
+        where: { trace_id: traceId },
+        orderBy: [{ decision: 'asc' }, { final_cell_index: 'asc' }, { view_count: 'desc' }],
+        take: CANDIDATE_CAP,
+      });
+
+      // Funnel: decision × drop_reason attrition (drives the §4 funnel chart).
+      const funnelMap = new Map<string, number>();
+      // Placed cards grouped by cell — the "what the user actually got" view.
+      const placedByCell = new Map<number, unknown[]>();
+
+      const cand = candidates.map((c) => {
+        const key = `${c.decision}:${c.drop_reason ?? '-'}`;
+        funnelMap.set(key, (funnelMap.get(key) ?? 0) + 1);
+        const row = {
+          video_id: c.video_id,
+          channel_id: c.channel_id,
+          channel_title: c.channel_title,
+          source_kind: c.source_kind,
+          source_cell_index: c.source_cell_index,
+          source_query_text: c.source_query_text,
+          source_tier: c.source_tier,
+          stage_reached: c.stage_reached,
+          decision: c.decision,
+          drop_reason: c.drop_reason,
+          relevance_gc: c.relevance_gc,
+          ts_rank: c.ts_rank,
+          cosine: c.cosine,
+          llm_pick_score: c.llm_pick_score,
+          llm_pick_reason: c.llm_pick_reason,
+          view_count: viewToNumber(c.view_count),
+          duration_sec: c.duration_sec,
+          published_at: c.published_at?.toISOString() ?? null,
+          final_cell_level: c.final_cell_level,
+          final_cell_index: c.final_cell_index,
+        };
+        if (c.final_cell_index != null) {
+          const bucket = placedByCell.get(c.final_cell_index) ?? [];
+          bucket.push(row);
+          placedByCell.set(c.final_cell_index, bucket);
+        }
+        return row;
+      });
+
+      const funnel = [...funnelMap.entries()]
+        .map(([key, count]) => {
+          const [decision, drop_reason] = key.split(':');
+          return { decision, drop_reason: drop_reason === '-' ? null : drop_reason, count };
+        })
+        .sort((a, b) => b.count - a.count);
+
+      return reply.send({
+        trace: toTraceSummary(trace),
+        candidate_count: cand.length,
+        funnel,
+        placed_by_cell: [...placedByCell.entries()]
+          .sort((a, b) => a[0] - b[0])
+          .map(([cell, cards]) => ({ cell, cards })),
+        candidates: cand,
+      });
+    }
+  );
+
+  done();
+};


### PR DESCRIPTION
## What (Observability G2-a)
Read-only admin debug view (design SSOT §6.2) over `search_trace` / `search_trace_candidate`: pick a recent trace or paste trace_id/mandala_id → the full **Card Journey** — generated queries → raw YouTube counts → per-candidate keep/drop + reason → placed cells.

Turns "this mandala returned garbage — why?" from a psql session into a screen (rawCount<10 red = self-starvation, view<1000 flagged, per-cell placement visible).

## How (reuse, no new stack)
- **BE**: `admin/search-trace-explorer.ts` — `/recent`, `/by-mandala/:id`, `/journey/:traceId`. Mirrors `discover-traces.ts`. adminAuth-guarded, read-only, observation-only (no serve-path change). Journey pre-computes funnel (decision×drop_reason) + placed-by-cell so FE doesn't re-aggregate.
- **FE**: `AdminSearchTraceExplorer` page (clones `AdminSearchAlgorithms`), api-client methods + `SearchTraceCandidateDTO`, AdminLayout nav ("Search Trace"), router route. Semantic tokens only (no hardcoded colors).
- **No new tables / DDL / stack.** Prisma models already shipped in #1037.

## Verified
- BE `tsc --noEmit` = 0 errors
- FE `vite build` = 0 errors; new files tsc-clean (pre-existing test-file tsc noise unrelated)
- `api-url-contract` smoke = 15/15
- Post-deploy: browser render check on prod `/admin/search-trace` (admin-only, isolated route, rollback-safe)

## Done gate
James opens `/admin/search-trace`, views trace `b657610c` (중등영어) journey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)