### PR TITLE
feat(observability): G2-b Phase-3 Eval Harness — golden-cohort gc baseline

### DIFF
--- a/src/api/routes/admin/eval-harness.ts
+++ b/src/api/routes/admin/eval-harness.ts
@@ -1,0 +1,54 @@
+/**
+ * Admin Eval Harness route (Observability G2-b).
+ *
+ * Triggers the Phase 3 golden-cohort gc baseline (run-harness.ts) and returns
+ * the distribution. This is the G3 before/after baseline surface.
+ *
+ *   GET  /api/v1/admin/eval-harness/cohort  → the fixed golden cohort (confirm)
+ *   POST /api/v1/admin/eval-harness/run     → run + upsert search_metrics_daily
+ *        body { cacheOnly?: boolean, capPerMandala?: number }
+ *
+ * ⚠️ Governance: `cacheOnly=false` scores cache-misses via OpenRouter Haiku —
+ * that is a PROD runtime admin action (James triggers, aware of scale/cost).
+ * `cacheOnly=true` uses only stored relevance_pct (no LLM) and is the safe verify.
+ *
+ * Guarded by authenticate + authenticateAdmin.
+ */
+
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+
+import { createSuccessResponse } from '../../schemas/common.schema';
+import { runGoldenCohortHarness } from '@/modules/eval-harness/run-harness';
+import { GOLDEN_COHORT } from '@/modules/eval-harness/golden-cohort';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'AdminEvalHarness' });
+
+const RunBodySchema = z.object({
+  cacheOnly: z.boolean().optional(),
+  capPerMandala: z.number().int().positive().max(200).optional(),
+});
+
+export async function adminEvalHarnessRoutes(fastify: FastifyInstance) {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  /** GET /cohort — the frozen golden cohort (James confirms this set). */
+  fastify.get('/cohort', adminAuth, async (_request: FastifyRequest, reply: FastifyReply) => {
+    return reply.send(
+      createSuccessResponse({ count: GOLDEN_COHORT.length, cohort: GOLDEN_COHORT })
+    );
+  });
+
+  /**
+   * POST /run — run the golden-cohort gc baseline.
+   * cacheOnly=true → no Haiku (safe). cacheOnly=false → prod Haiku scoring of
+   * cache-misses up to capPerMandala. Upserts today's search_metrics_daily.
+   */
+  fastify.post('/run', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
+    const { cacheOnly, capPerMandala } = RunBodySchema.parse(request.body ?? {});
+    log.info('eval harness run requested', { cacheOnly, capPerMandala });
+    const result = await runGoldenCohortHarness({ cacheOnly, capPerMandala });
+    return reply.send(createSuccessResponse(result));
+  });
+}

--- a/src/api/routes/admin/index.ts
+++ b/src/api/routes/admin/index.ts
@@ -30,6 +30,7 @@ import { adminMandalaBookFillRoutes } from './mandala-book-fill';
 import { adminSegmentRelevanceFillRoutes } from './segment-relevance-fill';
 import { adminPoolServeRoutes } from './pool-serve';
 import { adminSearchTraceExplorerRoutes } from './search-trace-explorer';
+import { adminEvalHarnessRoutes } from './eval-harness';
 
 /**
  * Admin routes plugin.
@@ -84,5 +85,8 @@ export async function adminRoutes(fastify: FastifyInstance) {
   // Observability G2 — Search-Trace Explorer (Card Journey debug view over
   // search_trace / search_trace_candidate). Read-only; observation-only.
   await fastify.register(adminSearchTraceExplorerRoutes, { prefix: '/search-trace' });
+  // Observability G2-b — Phase 3 Eval Harness (golden-cohort gc baseline).
+  // gc miss-scoring is prod-only Haiku (admin-triggered); cacheOnly=safe verify.
+  await fastify.register(adminEvalHarnessRoutes, { prefix: '/eval-harness' });
   // await fastify.register(stripeWebhookRoutes, { prefix: '/webhooks/stripe' });
 }

--- a/src/modules/eval-harness/golden-cohort.ts
+++ b/src/modules/eval-harness/golden-cohort.ts
@@ -1,0 +1,81 @@
+/**
+ * Golden cohort — the FIXED mandala set for the Phase 3 Eval Harness (G2-b).
+ *
+ * WHY fixed IDs (not name lookup): the harness's whole value is comparing the
+ * SAME cohort before/after an intervention (embedding backfill, algorithm
+ * version). Resolving by title at run time would silently drift the set when a
+ * title is duplicated or renamed → before/after becomes invalid. So the IDs are
+ * resolved ONCE (prod query, 2026-07-01) and frozen here as the SSOT.
+ *
+ * Selection (matches the horizon-0 / M2 core set + SSOT §7 spec: tech-ko ≥2,
+ * volatile ≥2, evergreen ≥2). Card counts (uvs) resolved 2026-07-01; two entries
+ * (K8S 전문가 60, K8s 상용운영 55) match the horizon-0 doc's card counts exactly,
+ * confirming these are the M2-measured mandalas.
+ *
+ * ⚠️ James confirms this set ("이 만다라들이 맞나"). English coverage is thin in
+ * prod (few en mandalas with meaningful card counts) → 8 ko + 2 en vs the 5+5
+ * target; adjust here if a different cohort is preferred. Editing this list is
+ * the ONLY way the cohort changes — never resolve by title at run time.
+ */
+
+export interface GoldenCohortEntry {
+  mandalaId: string;
+  title: string;
+  /** Rough tags for read-side grouping (tech/finance/evergreen/volatile). */
+  tags: string[];
+}
+
+export const GOLDEN_COHORT: readonly GoldenCohortEntry[] = [
+  {
+    mandalaId: '9bb88bfb-7226-4f28-a679-5378cccf6ac4',
+    title: '중등 영문법 한 달 완성하기',
+    tags: ['ko', 'evergreen', 'language'],
+  },
+  {
+    mandalaId: '387f5309-bf24-4aba-ab02-62e53babca44',
+    title: '100일 영어 회화 완성하기',
+    tags: ['ko', 'evergreen', 'language'],
+  },
+  {
+    mandalaId: '54d55a78-dd50-4184-9387-ef54c29568b3',
+    title: 'K8S 전문가 되기',
+    tags: ['tech', 'volatile'],
+  }, // horizon-0 uvs=60 ✓
+  {
+    mandalaId: 'e2b565c1-e7d1-44d2-8156-55da59f68722',
+    title: 'K8s 상용 서비스 운영 전문가 되기',
+    tags: ['ko', 'tech', 'volatile'],
+  }, // horizon-0 uvs=55 ✓
+  {
+    mandalaId: '669d1909-cb5d-480a-980b-bf376db62174',
+    title: 'Python 코딩테스트 패스하기',
+    tags: ['ko', 'tech'],
+  },
+  {
+    mandalaId: 'cca14d65-5e60-4345-bc83-a98acd25cc94',
+    title: 'Docker와 Kubernetes로 배우는 클라우드 인프라',
+    tags: ['ko', 'tech', 'volatile'],
+  },
+  {
+    mandalaId: '66a097ce-6b04-4232-b626-9cef83807a65',
+    title: 'ETF 투자로 노후 자산 만들기',
+    tags: ['ko', 'finance', 'volatile'],
+  },
+  {
+    mandalaId: '7f72e5d8-bd1c-4821-a7fb-2332ac0b15eb',
+    title: '26년 금융 투자 전문가 되기',
+    tags: ['ko', 'finance', 'volatile'],
+  },
+  {
+    mandalaId: '82d0169f-f4bf-4c88-8cad-92661f6b252a',
+    title: 'Build retirement assets via ETF',
+    tags: ['en', 'finance'],
+  },
+  {
+    mandalaId: '2558166f-7b48-48ec-a599-b0ca76575ab3',
+    title: 'Complete a daily coding challenge',
+    tags: ['en', 'tech'],
+  },
+];
+
+export const GOLDEN_COHORT_IDS: readonly string[] = GOLDEN_COHORT.map((e) => e.mandalaId);

--- a/src/modules/eval-harness/run-harness.ts
+++ b/src/modules/eval-harness/run-harness.ts
@@ -1,0 +1,272 @@
+/**
+ * Phase 3 Eval Harness runner (G2-b) — golden-cohort gc baseline.
+ *
+ * Scores the FIXED golden cohort (golden-cohort.ts) against its mandala center
+ * goal to produce a gc (relevance) distribution, then upserts the headline into
+ * today's search_metrics_daily row. This is the G3 before/after baseline.
+ *
+ * Governance (CLAUDE.md LLM ban):
+ *   - The gc miss-scoring path calls computeCardRelevance = OpenRouter Haiku.
+ *     That runs ONLY as a PROD runtime admin trigger (same class as the shipped
+ *     relevance-backfill worker). CC/dev must NEVER run the Haiku path.
+ *   - `cacheOnly: true` uses ONLY existing relevance_pct (no LLM call) — safe to
+ *     run anywhere, and the way CC verifies the harness end-to-end.
+ *
+ * Cost control (Claude-web feedback):
+ *   - Cache reuse first: a card with a stored relevance_pct is NOT re-scored.
+ *   - Cache MISSES are scored up to `capPerMandala` per mandala (representative
+ *     sample, not exhaustive). Misses beyond the cap are counted as unmeasured.
+ *
+ * Storage: PARTIAL upsert of gc_median / gc_pct_below_65 / coverage only — never
+ * touches the fleet-rollup columns (2-B). `coverage.run_type='golden_cohort'`
+ * tags the provenance so cohort vs fleet numbers never get confused.
+ *
+ * NOTE: the per-cell pool-cosine coverage (the metric that moves with the G3
+ * embedding backfill) is a marked follow-up — `coverage.cosine_coverage=null`
+ * here. This run delivers the gc baseline; cosine coverage lands next.
+ */
+
+import { Prisma } from '@prisma/client';
+
+import { getPrismaClient } from '@/modules/database/client';
+import { getMandalaManager } from '@/modules/mandala/manager';
+import { computeCardRelevance } from '@/modules/relevance/compute-card-relevance';
+import { logger } from '@/utils/logger';
+import { GOLDEN_COHORT, GOLDEN_COHORT_IDS } from './golden-cohort';
+
+const log = logger.child({ module: 'EvalHarness' });
+
+const DEFAULT_CAP_PER_MANDALA = 30;
+const GC_BELOW_THRESHOLD = 65;
+
+export interface HarnessRunOptions {
+  /** true ⇒ only existing relevance_pct used, ZERO Haiku calls (CC-safe verify). */
+  cacheOnly?: boolean;
+  /** Max cache-MISSES scored per mandala (cost bound). Default 30. */
+  capPerMandala?: number;
+}
+
+export interface PerMandalaResult {
+  mandalaId: string;
+  title: string;
+  cards: number;
+  cacheHits: number;
+  scored: number;
+  unmeasured: number;
+  gcMedian: number | null;
+  gcPctBelow65: number | null;
+  error?: string;
+}
+
+export interface HarnessResult {
+  cacheOnly: boolean;
+  capPerMandala: number;
+  cohortSize: number;
+  totalCards: number;
+  cacheHits: number;
+  scored: number;
+  gcN: number;
+  gcMedian: number | null;
+  gcPctBelow65: number | null;
+  perMandala: PerMandalaResult[];
+}
+
+function median(xs: number[]): number | null {
+  if (xs.length === 0) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid]! : (s[mid - 1]! + s[mid]!) / 2;
+}
+
+function pctBelow(xs: number[], threshold: number): number | null {
+  if (xs.length === 0) return null;
+  return +((xs.filter((x) => x < threshold).length / xs.length) * 100).toFixed(1);
+}
+
+function utcMidnightToday(): Date {
+  const d = new Date();
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+interface LoadedCard {
+  title: string;
+  description?: string;
+  cellIndex: number | null;
+  cached: number | null;
+}
+
+/** Run the golden-cohort gc baseline and persist the headline. */
+export async function runGoldenCohortHarness(opts: HarnessRunOptions = {}): Promise<HarnessResult> {
+  const prisma = getPrismaClient();
+  const cacheOnly = opts.cacheOnly ?? false;
+  const capPerMandala = opts.capPerMandala ?? DEFAULT_CAP_PER_MANDALA;
+
+  const allGc: number[] = [];
+  const perMandala: PerMandalaResult[] = [];
+  let totalCards = 0;
+  let totalCacheHits = 0;
+  let totalScored = 0;
+
+  for (const entry of GOLDEN_COHORT) {
+    const mandalaId = entry.mandalaId;
+    const owner = await prisma.user_mandalas.findUnique({
+      where: { id: mandalaId },
+      select: { user_id: true, title: true },
+    });
+    if (!owner) {
+      perMandala.push({
+        mandalaId,
+        title: entry.title,
+        cards: 0,
+        cacheHits: 0,
+        scored: 0,
+        unmeasured: 0,
+        gcMedian: null,
+        gcPctBelow65: null,
+        error: 'mandala_not_found',
+      });
+      continue;
+    }
+    const userId = owner.user_id;
+
+    let centerGoal = '';
+    let cellGoals: string[] = [];
+    try {
+      const mandala = await getMandalaManager().getMandalaById(userId, mandalaId);
+      centerGoal = mandala?.levels[0]?.centerGoal ?? '';
+      cellGoals = mandala?.levels[0]?.subjects ?? [];
+    } catch (err) {
+      log.warn('mandala lookup failed', {
+        mandalaId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const [uvs, ulc] = await Promise.all([
+      prisma.userVideoState.findMany({
+        where: { user_id: userId, mandala_id: mandalaId, cell_index: { gte: 0 } },
+        select: { cell_index: true, relevance_pct: true, video: { select: { title: true } } },
+      }),
+      prisma.user_local_cards.findMany({
+        where: { user_id: userId, mandala_id: mandalaId, cell_index: { gte: 0 } },
+        select: {
+          cell_index: true,
+          relevance_pct: true,
+          title: true,
+          metadata_title: true,
+          metadata_description: true,
+        },
+      }),
+    ]);
+
+    const cards: LoadedCard[] = [
+      ...uvs.map((r) => ({
+        title: r.video?.title ?? '',
+        description: undefined,
+        cellIndex: r.cell_index,
+        cached: r.relevance_pct,
+      })),
+      ...ulc.map((r) => ({
+        title: r.title ?? r.metadata_title ?? '',
+        description: r.metadata_description ?? undefined,
+        cellIndex: r.cell_index,
+        cached: r.relevance_pct,
+      })),
+    ];
+
+    const gc: number[] = [];
+    let cacheHits = 0;
+    let scored = 0;
+    let unmeasured = 0;
+
+    for (const c of cards) {
+      if (c.cached != null) {
+        gc.push(c.cached);
+        cacheHits += 1;
+        continue;
+      }
+      if (cacheOnly || scored >= capPerMandala || !c.title) {
+        unmeasured += 1;
+        continue;
+      }
+      // PROD-ONLY: OpenRouter Haiku. CC/dev never reaches here (cacheOnly=true).
+      const r = await computeCardRelevance({
+        title: c.title,
+        description: c.description,
+        centerGoal,
+        cellGoal: c.cellIndex != null ? cellGoals[c.cellIndex] : undefined,
+      });
+      if (r.ok) {
+        gc.push(r.relevancePct);
+        scored += 1;
+      } else {
+        unmeasured += 1;
+      }
+    }
+
+    totalCards += cards.length;
+    totalCacheHits += cacheHits;
+    totalScored += scored;
+    allGc.push(...gc);
+    perMandala.push({
+      mandalaId,
+      title: owner.title,
+      cards: cards.length,
+      cacheHits,
+      scored,
+      unmeasured,
+      gcMedian: median(gc),
+      gcPctBelow65: pctBelow(gc, GC_BELOW_THRESHOLD),
+    });
+  }
+
+  const gcMedian = median(allGc);
+  const gcPctBelow65 = pctBelow(allGc, GC_BELOW_THRESHOLD);
+
+  const coverage = {
+    run_type: 'golden_cohort',
+    cache_only: cacheOnly,
+    cap_per_mandala: capPerMandala,
+    cohort_ids: [...GOLDEN_COHORT_IDS],
+    total_cards: totalCards,
+    cache_hits: totalCacheHits,
+    scored: totalScored,
+    gc_n: allGc.length,
+    per_mandala: perMandala,
+    cosine_coverage: null, // follow-up: per-cell pool-cosine coverage (G3 metric)
+  } as unknown as Prisma.InputJsonValue;
+
+  const metricDate = utcMidnightToday();
+  // PARTIAL upsert — only gc + coverage. Fleet-rollup (2-B) columns untouched.
+  await prisma.search_metrics_daily.upsert({
+    where: { metric_date: metricDate },
+    create: {
+      metric_date: metricDate,
+      gc_median: gcMedian,
+      gc_pct_below_65: gcPctBelow65,
+      coverage,
+    },
+    update: { gc_median: gcMedian, gc_pct_below_65: gcPctBelow65, coverage },
+  });
+
+  const result: HarnessResult = {
+    cacheOnly,
+    capPerMandala,
+    cohortSize: GOLDEN_COHORT_IDS.length,
+    totalCards,
+    cacheHits: totalCacheHits,
+    scored: totalScored,
+    gcN: allGc.length,
+    gcMedian,
+    gcPctBelow65,
+    perMandala,
+  };
+  log.info('golden-cohort harness run', {
+    cacheOnly,
+    gcMedian,
+    gcN: allGc.length,
+    scored: totalScored,
+    cacheHits: totalCacheHits,
+  });
+  return result;
+}


### PR DESCRIPTION
## What (Observability G2-b)
Admin-triggered **Phase 3 Eval Harness** (design SSOT §7): scores the FIXED golden cohort against its mandala center goal → gc (relevance) distribution → upserts today's `search_metrics_daily` gc columns. This is the **G3 embedding-backfill before/after baseline**.

## How (reuse, no new DDL)
- `golden-cohort.ts` — 10 frozen mandala IDs (horizon-0/M2 core set; `K8S 전문가` uvs=60 & `K8s 상용운영` uvs=55 match the horizon-0 card counts exactly, confirming the set). **Fixed IDs, never name-lookup** — so before/after compares the same cohort. ⚠️ James confirms the set (`GET /admin/eval-harness/cohort`).
- `run-harness.ts` — reuses `computeCardRelevance` (the shipped CP498 scorer) + the relevance-backfill card-loading pattern. **Cache reuse** (stored `relevance_pct` not re-scored) + **cache-misses scored up to `capPerMandala`** (default 30, cost bound). **PARTIAL upsert** of gc/coverage only — fleet-rollup (2-B) columns untouched; `coverage.run_type='golden_cohort'` tags provenance so cohort vs fleet never mix.
- `admin/eval-harness.ts` — `GET /cohort`, `POST /run { cacheOnly?, capPerMandala? }`.

## Governance (LLM ban)
gc miss-scoring = OpenRouter Haiku → **PROD runtime admin trigger only** (same class as the shipped relevance-backfill worker). `cacheOnly=true` uses only stored relevance_pct = **zero LLM** = the CC-safe verify. CC never runs the Haiku path in dev.

## Verified
- BE `tsc --noEmit` = 0 errors; eslint 0 errors. No FE changes.
- Post-deploy: `POST /run {cacheOnly:true}` (no LLM) to verify end-to-end + partial cached-gc baseline.

## Follow-up (marked)
Per-cell pool-cosine coverage (the metric that moves with the G3 embedding backfill) = `coverage.cosine_coverage=null` here; lands next. This PR delivers the gc baseline.

## Done gate
James triggers `POST /admin/eval-harness/run` (full, prod Haiku, aware of scale) → golden-cohort baseline gc distribution + coverage = G3 before/after reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)