### PR TITLE
feat(supply): G3 W1③ — enable yt_promoted supply bridge (SUPPLY_YT_BRIDGE_ENABLED)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -155,6 +155,14 @@ services:
       # Rollback = flip BOTH back (false / delete line) + redeploy, no revert.
       - V5_KO_EN_TITLE_DROP=true
       - V5_POOL_SERVE=true
+      # G3 W1③ supply bridge — serve the backfilled yt_promoted rows.
+      # W1① backfill embedded 7,015 yt_promoted (gold/silver, classifyQuality —
+      # same gate as v2_promoted, NOT batch_trend). Measured: cohort cos>=0.5
+      # servable candidates jump v2_promoted-only 228 -> +11,320 yt_promoted.
+      # This flip adds 'yt_promoted' to v5 poolSources (config.ts:150) so the
+      # backfill's +87% coverage reaches serving. Rollback = false + redeploy
+      # (revert-free) if golden-cohort gc_median drops below 73 (baseline 76).
+      - SUPPLY_YT_BRIDGE_ENABLED=true
       # CP500+ diversity guard (UX 원칙 2 다양성 축, James-approved 2026-06-12).
       # Same-channel series episodes collapse to the latest one (measured:
       # Basphere "[Kubernetes 6주 코스]" 5-1/5-2/6-2 all placed on cca14d65);


### PR DESCRIPTION
## What
Enable `SUPPLY_YT_BRIDGE_ENABLED=true` in prod compose → adds `yt_promoted` to v5 `poolSources` (config.ts:150), so the **W1① backfilled 7,015 yt_promoted rows become servable**.

## Why (measured, read-only)
- W1① backfill embedded 7,015 yt_promoted (qwen3-embedding:8b) → golden-cohort cos≥0.5 coverage **+87%** (11,356 → 21,221).
- That coverage is **nearly all in yt_promoted, invisible to serving**: current `poolSources` is `v2_promoted`-only.
- flip-preview (80 cohort cells, cos≥0.5 servable by source): **v2_promoted 228 / yt_promoted +11,320 / other 1,396**. Flip = 228 → 11,548 servable (~50×), 78/80 cells newly servable from yt_promoted.

## Safety
- `yt_promoted` admission = `classifyQuality` gold/silver — **same gate as `v2_promoted`**, NOT the `batch_trend` trend source. Anti-noise preserved.
- **Flag-gated, revert-free**: rollback = `SUPPLY_YT_BRIDGE_ENABLED=false` + redeploy.
- Also re-activates the promote write (youtube_videos → yt_promoted, quota-0 Mac Mini, immediate-embed).

## Done gate (post-deploy, James)
1. New add-cards → Search-Trace Explorer shows yt_promoted candidates entering.
2. Golden-cohort `gc_median` stays **≥73** (baseline 76, −3 tolerance).
3. No per-mandala gc crash (baseline: 9 mandalas gc72–80, daily-coding-en gc35 outlier).
- gc dilution below 73 → **immediate rollback**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)