### PR TITLE
feat(search): global search BE — /api/v1/search across cards/mandalas/notes/v2 (PR-1)

### DIFF
--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -97,6 +97,61 @@ export interface BillingSubscriptionMeResponse {
   subscription: BillingSubscriptionSummary | null;
 }
 
+// Global Search (⌘K palette) — mirrors src/modules/search/global-search.ts
+export interface GlobalSearchCardHit {
+  kind: 'video' | 'local';
+  id: string;
+  title: string | null;
+  channelTitle: string | null;
+  thumbnailUrl: string | null;
+  url: string | null;
+  videoId: string | null;
+  note: string | null;
+  mandalaId: string | null;
+  cellIndex: number | null;
+  createdAt: string;
+}
+
+export interface GlobalSearchMandalaHit {
+  id: string;
+  title: string | null;
+  centerLabel: string | null;
+  createdAt: string;
+}
+
+export interface GlobalSearchNoteHit {
+  id: string;
+  mandalaId: string;
+  mandalaTitle: string | null;
+  snippet: string;
+  updatedAt: string;
+}
+
+export interface GlobalSearchSummaryHit {
+  videoId: string;
+  oneLiner: string;
+  videoTitle: string | null;
+  mandalaId: string | null;
+}
+
+export interface GlobalSearchGroup<T> {
+  items: T[];
+  total: number;
+  /** true = the group missed its server-side time budget (incomplete). */
+  partial: boolean;
+}
+
+export interface GlobalSearchResponse {
+  query: string;
+  groups: {
+    cards: GlobalSearchGroup<GlobalSearchCardHit>;
+    mandalas: GlobalSearchGroup<GlobalSearchMandalaHit>;
+    notes: GlobalSearchGroup<GlobalSearchNoteHit>;
+    summaries: GlobalSearchGroup<GlobalSearchSummaryHit>;
+  };
+  tookMs: number;
+}
+
 export interface VideoRichSummaryChapter {
   start_sec: number;
   title: string;
@@ -980,6 +1035,20 @@ class ApiClient {
     return this.request<void>(`/playlists/${id}/resume`, {
       method: 'PATCH',
     });
+  }
+
+  // ========================================
+  // Global Search (⌘K palette)
+  // ========================================
+
+  /**
+   * Unified user-data search — cards / mandalas / notes / v2 summaries.
+   * BE: GET /api/v1/search (src/api/routes/search.ts). All groups are
+   * user-scoped server-side. Consumed by the ⌘K CommandPalette (PR-2).
+   */
+  async searchAll(q: string, limitPerGroup?: number): Promise<GlobalSearchResponse> {
+    const limitParam = limitPerGroup ? `&limit=${limitPerGroup}` : '';
+    return this.request<GlobalSearchResponse>(`/search?q=${encodeURIComponent(q)}${limitParam}`);
   }
 
   // ========================================

--- a/prisma/migrations/global-search/001_pg_trgm_indexes.sql
+++ b/prisma/migrations/global-search/001_pg_trgm_indexes.sql
@@ -1,0 +1,18 @@
+-- Global search (⌘K) Phase 1 — trigram indexes for ILIKE substring search.
+-- Idempotent: safe to re-run (IF NOT EXISTS everywhere).
+-- Measured need (2026-07-02, prod, worst-case term): cards group 927ms,
+-- summaries group 1688ms on seq scans — GIN trgm brings both to ms range.
+-- Design: docs/design/global-search-cmdk-2026-07-02.md §3.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- cards group: user_video_states JOIN youtube_videos(title, channel_title)
+CREATE INDEX IF NOT EXISTS idx_yv_title_trgm
+  ON youtube_videos USING gin (title gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_yv_channel_title_trgm
+  ON youtube_videos USING gin (channel_title gin_trgm_ops);
+
+-- summaries group: video_rich_summaries.one_liner (Phase 1 = one_liner only)
+CREATE INDEX IF NOT EXISTS idx_vrs_one_liner_trgm
+  ON video_rich_summaries USING gin (one_liner gin_trgm_ops);

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -164,6 +164,11 @@ APPLY_FILES=(
   # CREATE TABLE/INDEX IF NOT EXISTS + NOTIFY pgrst — idempotent. Inert until the
   # rollup job (daily boss.schedule) writes a row.
   "prisma/migrations/search-metrics/001_create_search_metrics_daily.sql"
+  # Global search (⌘K) Phase 1 — pg_trgm + 3 GIN trigram indexes for ILIKE
+  # substring search (yv.title / yv.channel_title / vrs.one_liner). CREATE
+  # EXTENSION/INDEX IF NOT EXISTS — fully idempotent. Perf-only (no schema
+  # change); inert until /api/v1/search is called.
+  "prisma/migrations/global-search/001_pg_trgm_indexes.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "

--- a/src/api/routes/search.ts
+++ b/src/api/routes/search.ts
@@ -1,0 +1,57 @@
+/**
+ * Global Search API — GET /api/v1/search?q=&limit=
+ *
+ * Unified user-data search for the ⌘K palette (cards / mandalas / notes /
+ * v2 summaries). Auth required; every group query is user-scoped inside
+ * src/modules/search/global-search.ts (R3 — no cross-user leak).
+ *
+ * Design: docs/design/global-search-cmdk-2026-07-02.md
+ */
+import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
+import {
+  globalSearch,
+  SEARCH_GROUP_LIMIT_DEFAULT,
+  SEARCH_GROUP_LIMIT_MAX,
+} from '../../modules/search/global-search';
+import { logger } from '../../utils/logger';
+
+function getUserId(request: FastifyRequest, reply: FastifyReply): string | null {
+  if (!request.user || !('userId' in request.user)) {
+    reply.status(401).send({ error: 'Unauthorized' });
+    return null;
+  }
+  return (request.user as { userId: string }).userId;
+}
+
+export const searchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+  fastify.get<{ Querystring: { q?: string; limit?: string } }>(
+    '/',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const userId = getUserId(request, reply);
+      if (!userId) return;
+
+      const q = (request.query.q ?? '').trim();
+      if (q.length === 0) {
+        return reply.status(400).send({ error: 'Query parameter "q" is required' });
+      }
+
+      const parsedLimit = Number.parseInt(request.query.limit ?? '', 10);
+      const limitPerGroup = Number.isFinite(parsedLimit)
+        ? Math.min(Math.max(parsedLimit, 1), SEARCH_GROUP_LIMIT_MAX)
+        : SEARCH_GROUP_LIMIT_DEFAULT;
+
+      try {
+        const result = await globalSearch(userId, q, { limitPerGroup });
+        return reply.send(result);
+      } catch (err) {
+        logger.error('[search] global search failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return reply.status(500).send({ error: 'Search failed' });
+      }
+    }
+  );
+
+  done();
+};

--- a/src/api/routes/search.ts
+++ b/src/api/routes/search.ts
@@ -17,7 +17,7 @@ import { logger } from '../../utils/logger';
 
 function getUserId(request: FastifyRequest, reply: FastifyReply): string | null {
   if (!request.user || !('userId' in request.user)) {
-    reply.status(401).send({ error: 'Unauthorized' });
+    void reply.status(401).send({ error: 'Unauthorized' });
     return null;
   }
   return (request.user as { userId: string }).userId;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -18,6 +18,7 @@ import { quotaRoutes } from './routes/quota';
 import { mandalaRoutes } from './routes/mandalas';
 import { imageRoutes } from './routes/images';
 import { ontologyRoutes } from './routes/ontology';
+import { searchRoutes } from './routes/search';
 import { llmRoutes } from './routes/llm';
 import { adminRoutes } from './routes/admin';
 import { subscriptionRoutes } from './routes/subscriptions';
@@ -306,6 +307,9 @@ export async function buildServer() {
 
       // Register ontology routes (GraphRAG knowledge graph)
       await instance.register(ontologyRoutes, { prefix: '/ontology' });
+
+      // Register global search routes (⌘K palette — cards/mandalas/notes/summaries)
+      await instance.register(searchRoutes, { prefix: '/search' });
 
       // Register LLM provider routes (status, health)
       await instance.register(llmRoutes, { prefix: '/llm' });

--- a/src/modules/search/global-search.ts
+++ b/src/modules/search/global-search.ts
@@ -1,0 +1,387 @@
+/**
+ * Global Search — unified user-data search behind the ⌘K palette (Phase 1).
+ *
+ * Four groups run in parallel, ALL scoped to the requesting user (R3):
+ *   cards     — user_video_states JOIN youtube_videos (99.6% of placed cards)
+ *               + user_local_cards (manual/link/file cards + memos)
+ *   mandalas  — user_mandalas title + user_mandala_levels goal/labels/subjects
+ *   notes     — note_documents.content_json (TipTap doc → extracted text snippet)
+ *   summaries — video_rich_summaries.one_liner (v2; user-cards join. core body = Phase 2)
+ *
+ * Design: docs/design/global-search-cmdk-2026-07-02.md
+ * Perf: worst-case measured 2026-07-02 (see design §3) — pg_trgm GIN indexes
+ * (prisma/migrations/global-search/001) keep cards/summaries in the ms range.
+ */
+import { Prisma } from '@prisma/client';
+import { getPrismaClient } from '../database/client';
+import { logger } from '../../utils/logger';
+
+export const SEARCH_GROUP_LIMIT_DEFAULT = 5;
+export const SEARCH_GROUP_LIMIT_MAX = 20;
+/** Per-group budget; a late group returns empty + partial:true (honest partial). */
+export const SEARCH_GROUP_TIMEOUT_MS = 800;
+export const SEARCH_SNIPPET_RADIUS = 60;
+const SEARCH_QUERY_MAX_LEN = 100;
+
+export interface CardHit {
+  kind: 'video' | 'local';
+  id: string;
+  title: string | null;
+  channelTitle: string | null;
+  thumbnailUrl: string | null;
+  url: string | null;
+  videoId: string | null;
+  note: string | null;
+  mandalaId: string | null;
+  cellIndex: number | null;
+  createdAt: string;
+}
+
+export interface MandalaHit {
+  id: string;
+  title: string | null;
+  centerLabel: string | null;
+  createdAt: string;
+}
+
+export interface NoteHit {
+  id: string;
+  mandalaId: string;
+  mandalaTitle: string | null;
+  snippet: string;
+  updatedAt: string;
+}
+
+export interface SummaryHit {
+  videoId: string;
+  oneLiner: string;
+  videoTitle: string | null;
+  mandalaId: string | null;
+}
+
+export interface SearchGroup<T> {
+  items: T[];
+  total: number;
+  /** true = the group missed its time budget; items/total are incomplete. */
+  partial: boolean;
+}
+
+export interface GlobalSearchResult {
+  query: string;
+  groups: {
+    cards: SearchGroup<CardHit>;
+    mandalas: SearchGroup<MandalaHit>;
+    notes: SearchGroup<NoteHit>;
+    summaries: SearchGroup<SummaryHit>;
+  };
+  tookMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested)
+// ---------------------------------------------------------------------------
+
+/** Escape LIKE/ILIKE metacharacters so user input matches literally. */
+export function escapeLikePattern(raw: string): string {
+  return raw.replace(/[\\%_]/g, (m) => `\\${m}`);
+}
+
+/** Depth-first text extraction from a TipTap/ProseMirror JSON doc. */
+export function extractTiptapText(node: unknown): string {
+  if (node == null || typeof node !== 'object') return '';
+  const n = node as { text?: unknown; content?: unknown };
+  const parts: string[] = [];
+  if (typeof n.text === 'string') parts.push(n.text);
+  if (Array.isArray(n.content)) {
+    for (const child of n.content) parts.push(extractTiptapText(child));
+  }
+  return parts.join(' ');
+}
+
+/** Case-insensitive snippet around the first query hit (±radius chars). */
+export function makeSnippet(text: string, query: string, radius = SEARCH_SNIPPET_RADIUS): string {
+  const compact = text.replace(/\s+/g, ' ').trim();
+  const idx = compact.toLowerCase().indexOf(query.toLowerCase());
+  if (idx < 0) return compact.slice(0, radius * 2);
+  const start = Math.max(0, idx - radius);
+  const end = Math.min(compact.length, idx + query.length + radius);
+  return `${start > 0 ? '…' : ''}${compact.slice(start, end)}${end < compact.length ? '…' : ''}`;
+}
+
+/** Merge the two card sources: title matches first, then recency; cap at limit. */
+export function mergeCardHits(hits: CardHit[], query: string, limit: number): CardHit[] {
+  const q = query.toLowerCase();
+  const titleMatch = (h: CardHit) => ((h.title ?? '').toLowerCase().includes(q) ? 0 : 1);
+  return [...hits]
+    .sort((a, b) => titleMatch(a) - titleMatch(b) || b.createdAt.localeCompare(a.createdAt))
+    .slice(0, limit);
+}
+
+/** Resolve a group promise against the time budget; late = empty + partial. */
+export async function withGroupTimeout<T>(
+  work: Promise<SearchGroup<T>>,
+  timeoutMs = SEARCH_GROUP_TIMEOUT_MS
+): Promise<SearchGroup<T>> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const late = new Promise<SearchGroup<T>>((resolve) => {
+    timer = setTimeout(() => resolve({ items: [], total: 0, partial: true }), timeoutMs);
+  });
+  try {
+    return await Promise.race([work, late]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Group queries (parameterized via Prisma.sql — never string-interpolated)
+// ---------------------------------------------------------------------------
+
+async function searchCards(userId: string, pattern: string, query: string, limit: number) {
+  const prisma = getPrismaClient();
+  const [videoRows, videoCount, localRows, localCount] = await Promise.all([
+    prisma.$queryRaw<
+      Array<{
+        id: string;
+        video_id: string | null;
+        title: string | null;
+        channel_title: string | null;
+        thumbnail_url: string | null;
+        user_note: string | null;
+        mandala_id: string | null;
+        cell_index: number | null;
+        created_at: Date;
+      }>
+    >(Prisma.sql`
+      SELECT s.id, v.youtube_video_id AS video_id, v.title, v.channel_title,
+             v.thumbnail_url, s.user_note, s.mandala_id, s.cell_index, s.created_at
+      FROM user_video_states s
+      JOIN youtube_videos v ON v.id = s.video_id
+      WHERE s.user_id = ${userId}::uuid
+        AND (v.title ILIKE ${pattern} OR v.channel_title ILIKE ${pattern} OR s.user_note ILIKE ${pattern})
+      ORDER BY (v.title ILIKE ${pattern}) DESC, s.created_at DESC
+      LIMIT ${limit}`),
+    prisma.$queryRaw<Array<{ n: number }>>(Prisma.sql`
+      SELECT count(*)::int AS n
+      FROM user_video_states s
+      JOIN youtube_videos v ON v.id = s.video_id
+      WHERE s.user_id = ${userId}::uuid
+        AND (v.title ILIKE ${pattern} OR v.channel_title ILIKE ${pattern} OR s.user_note ILIKE ${pattern})`),
+    prisma.$queryRaw<
+      Array<{
+        id: string;
+        title: string | null;
+        user_note: string | null;
+        url: string | null;
+        thumbnail: string | null;
+        video_id: string | null;
+        mandala_id: string | null;
+        cell_index: number | null;
+        created_at: Date;
+      }>
+    >(Prisma.sql`
+      SELECT id, title, user_note, url, thumbnail, video_id, mandala_id, cell_index, created_at
+      FROM user_local_cards
+      WHERE user_id = ${userId}::uuid
+        AND (title ILIKE ${pattern} OR user_note ILIKE ${pattern} OR url ILIKE ${pattern}
+             OR metadata_title ILIKE ${pattern} OR metadata_description ILIKE ${pattern})
+      ORDER BY (title ILIKE ${pattern}) DESC, created_at DESC
+      LIMIT ${limit}`),
+    prisma.$queryRaw<Array<{ n: number }>>(Prisma.sql`
+      SELECT count(*)::int AS n
+      FROM user_local_cards
+      WHERE user_id = ${userId}::uuid
+        AND (title ILIKE ${pattern} OR user_note ILIKE ${pattern} OR url ILIKE ${pattern}
+             OR metadata_title ILIKE ${pattern} OR metadata_description ILIKE ${pattern})`),
+  ]);
+
+  const hits: CardHit[] = [
+    ...videoRows.map((r) => ({
+      kind: 'video' as const,
+      id: r.id,
+      title: r.title,
+      channelTitle: r.channel_title,
+      thumbnailUrl: r.thumbnail_url,
+      url: null,
+      videoId: r.video_id,
+      note: r.user_note,
+      mandalaId: r.mandala_id,
+      cellIndex: r.cell_index,
+      createdAt: r.created_at.toISOString(),
+    })),
+    ...localRows.map((r) => ({
+      kind: 'local' as const,
+      id: r.id,
+      title: r.title,
+      channelTitle: null,
+      thumbnailUrl: r.thumbnail,
+      url: r.url,
+      videoId: r.video_id,
+      note: r.user_note,
+      mandalaId: r.mandala_id,
+      cellIndex: r.cell_index,
+      createdAt: r.created_at.toISOString(),
+    })),
+  ];
+
+  return {
+    items: mergeCardHits(hits, query, limit),
+    total: (videoCount[0]?.n ?? 0) + (localCount[0]?.n ?? 0),
+    partial: false,
+  };
+}
+
+async function searchMandalas(userId: string, pattern: string, limit: number) {
+  const prisma = getPrismaClient();
+  const cellMatch = Prisma.sql`EXISTS (
+    SELECT 1 FROM user_mandala_levels l
+    WHERE l.mandala_id = m.id
+      AND (l.center_goal ILIKE ${pattern} OR l.center_label ILIKE ${pattern}
+           OR array_to_string(l.subjects, ' ') ILIKE ${pattern}
+           OR array_to_string(l.subject_labels, ' ') ILIKE ${pattern}))`;
+  const [rows, count] = await Promise.all([
+    prisma.$queryRaw<
+      Array<{ id: string; title: string | null; center_label: string | null; created_at: Date }>
+    >(Prisma.sql`
+      SELECT m.id, m.title,
+             (SELECT l.center_label FROM user_mandala_levels l
+              WHERE l.mandala_id = m.id AND l.depth = 0 LIMIT 1) AS center_label,
+             m.created_at
+      FROM user_mandalas m
+      WHERE m.user_id = ${userId}::uuid AND (m.title ILIKE ${pattern} OR ${cellMatch})
+      ORDER BY (m.title ILIKE ${pattern}) DESC, m.created_at DESC
+      LIMIT ${limit}`),
+    prisma.$queryRaw<Array<{ n: number }>>(Prisma.sql`
+      SELECT count(*)::int AS n
+      FROM user_mandalas m
+      WHERE m.user_id = ${userId}::uuid AND (m.title ILIKE ${pattern} OR ${cellMatch})`),
+  ]);
+  const items: MandalaHit[] = rows.map((r) => ({
+    id: r.id,
+    title: r.title,
+    centerLabel: r.center_label,
+    createdAt: r.created_at.toISOString(),
+  }));
+  return { items, total: count[0]?.n ?? 0, partial: false };
+}
+
+async function searchNotes(userId: string, pattern: string, query: string, limit: number) {
+  const prisma = getPrismaClient();
+  const [rows, count] = await Promise.all([
+    prisma.$queryRaw<
+      Array<{
+        id: string;
+        mandala_id: string;
+        mandala_title: string | null;
+        content_json: unknown;
+        updated_at: Date;
+      }>
+    >(Prisma.sql`
+      SELECT n.id, n.mandala_id, m.title AS mandala_title, n.content_json, n.updated_at
+      FROM note_documents n
+      LEFT JOIN user_mandalas m ON m.id = n.mandala_id
+      WHERE n.user_id = ${userId}::uuid AND n.content_json::text ILIKE ${pattern}
+      ORDER BY n.updated_at DESC
+      LIMIT ${limit}`),
+    prisma.$queryRaw<Array<{ n: number }>>(Prisma.sql`
+      SELECT count(*)::int AS n
+      FROM note_documents n
+      WHERE n.user_id = ${userId}::uuid AND n.content_json::text ILIKE ${pattern}`),
+  ]);
+  const items: NoteHit[] = rows.map((r) => ({
+    id: r.id,
+    mandalaId: r.mandala_id,
+    mandalaTitle: r.mandala_title,
+    snippet: makeSnippet(extractTiptapText(r.content_json), query),
+    updatedAt: r.updated_at.toISOString(),
+  }));
+  return { items, total: count[0]?.n ?? 0, partial: false };
+}
+
+async function searchSummaries(userId: string, pattern: string, limit: number) {
+  const prisma = getPrismaClient();
+  const [rows, count] = await Promise.all([
+    prisma.$queryRaw<
+      Array<{
+        video_id: string;
+        one_liner: string;
+        video_title: string | null;
+        mandala_id: string | null;
+      }>
+    >(Prisma.sql`
+      SELECT DISTINCT ON (vrs.video_id)
+             vrs.video_id, vrs.one_liner, v.title AS video_title, s.mandala_id
+      FROM video_rich_summaries vrs
+      JOIN youtube_videos v ON v.youtube_video_id = vrs.video_id
+      JOIN user_video_states s ON s.video_id = v.id AND s.user_id = ${userId}::uuid
+      WHERE vrs.one_liner ILIKE ${pattern}
+      ORDER BY vrs.video_id, s.created_at DESC
+      LIMIT ${limit}`),
+    prisma.$queryRaw<Array<{ n: number }>>(Prisma.sql`
+      SELECT count(DISTINCT vrs.video_id)::int AS n
+      FROM video_rich_summaries vrs
+      JOIN youtube_videos v ON v.youtube_video_id = vrs.video_id
+      JOIN user_video_states s ON s.video_id = v.id AND s.user_id = ${userId}::uuid
+      WHERE vrs.one_liner ILIKE ${pattern}`),
+  ]);
+  const items: SummaryHit[] = rows.map((r) => ({
+    videoId: r.video_id,
+    oneLiner: r.one_liner,
+    videoTitle: r.video_title,
+    mandalaId: r.mandala_id,
+  }));
+  return { items, total: count[0]?.n ?? 0, partial: false };
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+const EMPTY_GROUP = { items: [], total: 0, partial: false } as const;
+
+export async function globalSearch(
+  userId: string,
+  rawQuery: string,
+  options: { limitPerGroup?: number } = {}
+): Promise<GlobalSearchResult> {
+  const started = Date.now();
+  const query = rawQuery.trim().slice(0, SEARCH_QUERY_MAX_LEN);
+  const limit = Math.min(
+    Math.max(options.limitPerGroup ?? SEARCH_GROUP_LIMIT_DEFAULT, 1),
+    SEARCH_GROUP_LIMIT_MAX
+  );
+
+  if (query.length === 0) {
+    return {
+      query,
+      groups: {
+        cards: { ...EMPTY_GROUP, items: [] },
+        mandalas: { ...EMPTY_GROUP, items: [] },
+        notes: { ...EMPTY_GROUP, items: [] },
+        summaries: { ...EMPTY_GROUP, items: [] },
+      },
+      tookMs: Date.now() - started,
+    };
+  }
+
+  const pattern = `%${escapeLikePattern(query)}%`;
+  const guarded = <T>(work: Promise<SearchGroup<T>>, group: string): Promise<SearchGroup<T>> =>
+    withGroupTimeout(
+      work.catch((err) => {
+        logger.warn('[global-search] group query failed (degraded)', {
+          group,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return { items: [] as T[], total: 0, partial: true };
+      })
+    );
+
+  const [cards, mandalas, notes, summaries] = await Promise.all([
+    guarded(searchCards(userId, pattern, query, limit), 'cards'),
+    guarded(searchMandalas(userId, pattern, limit), 'mandalas'),
+    guarded(searchNotes(userId, pattern, query, limit), 'notes'),
+    guarded(searchSummaries(userId, pattern, limit), 'summaries'),
+  ]);
+
+  return { query, groups: { cards, mandalas, notes, summaries }, tookMs: Date.now() - started };
+}

--- a/tests/unit/modules/global-search.test.ts
+++ b/tests/unit/modules/global-search.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Global search (⌘K) Phase 1 — pure helper unit tests.
+ * DB-hitting group queries are covered by the prod verification step
+ * (design doc §4); these tests pin the injectable/pure surface.
+ */
+import {
+  escapeLikePattern,
+  extractTiptapText,
+  makeSnippet,
+  mergeCardHits,
+  withGroupTimeout,
+  globalSearch,
+  type CardHit,
+} from '../../../src/modules/search/global-search';
+
+const cardHit = (over: Partial<CardHit>): CardHit => ({
+  kind: 'video',
+  id: 'id',
+  title: null,
+  channelTitle: null,
+  thumbnailUrl: null,
+  url: null,
+  videoId: null,
+  note: null,
+  mandalaId: null,
+  cellIndex: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  ...over,
+});
+
+describe('escapeLikePattern', () => {
+  it('escapes %, _ and backslash so user input matches literally', () => {
+    expect(escapeLikePattern('100%_done\\x')).toBe('100\\%\\_done\\\\x');
+  });
+
+  it('leaves plain korean/english text untouched', () => {
+    expect(escapeLikePattern('수동태 grammar')).toBe('수동태 grammar');
+  });
+});
+
+describe('extractTiptapText', () => {
+  it('walks nested TipTap doc collecting text nodes in order', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        { type: 'heading', content: [{ type: 'text', text: '수동태 정리' }] },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'be동사 +' },
+            { type: 'text', text: '과거분사' },
+          ],
+        },
+      ],
+    };
+    expect(extractTiptapText(doc)).toContain('수동태 정리');
+    expect(extractTiptapText(doc)).toContain('과거분사');
+  });
+
+  it('returns empty string for null/primitive input', () => {
+    expect(extractTiptapText(null)).toBe('');
+    expect(extractTiptapText('raw')).toBe('');
+  });
+});
+
+describe('makeSnippet', () => {
+  it('centers the snippet on the first case-insensitive hit with ellipses', () => {
+    const text = `${'a'.repeat(200)} 수동태 핵심 정리 ${'b'.repeat(200)}`;
+    const snip = makeSnippet(text, '수동태', 20);
+    expect(snip).toContain('수동태');
+    expect(snip.startsWith('…')).toBe(true);
+    expect(snip.endsWith('…')).toBe(true);
+    expect(snip.length).toBeLessThan(80);
+  });
+
+  it('falls back to a head slice when the query is not present', () => {
+    expect(makeSnippet('short text', 'absent', 30)).toBe('short text');
+  });
+});
+
+describe('mergeCardHits', () => {
+  it('ranks title matches above note-only matches, then by recency, capped at limit', () => {
+    const hits = [
+      cardHit({ id: 'note-only', note: '수동태 메모', createdAt: '2026-06-30T00:00:00.000Z' }),
+      cardHit({ id: 'title-old', title: '수동태 개념', createdAt: '2026-01-02T00:00:00.000Z' }),
+      cardHit({ id: 'title-new', title: '수동태 끝내기', createdAt: '2026-06-01T00:00:00.000Z' }),
+    ];
+    const merged = mergeCardHits(hits, '수동태', 2);
+    expect(merged.map((h) => h.id)).toEqual(['title-new', 'title-old']);
+  });
+});
+
+describe('withGroupTimeout', () => {
+  it('returns the group result when it beats the budget', async () => {
+    const group = Promise.resolve({ items: [1], total: 1, partial: false });
+    await expect(withGroupTimeout(group, 200)).resolves.toEqual({
+      items: [1],
+      total: 1,
+      partial: false,
+    });
+  });
+
+  it('yields empty + partial:true when the group misses the budget', async () => {
+    const never = new Promise<{ items: number[]; total: number; partial: boolean }>(() => {});
+    await expect(withGroupTimeout(never, 20)).resolves.toEqual({
+      items: [],
+      total: 0,
+      partial: true,
+    });
+  });
+});
+
+describe('globalSearch — empty query guard', () => {
+  it('returns all-empty groups without touching the DB when q trims to empty', async () => {
+    const result = await globalSearch('00000000-0000-0000-0000-000000000000', '   ');
+    expect(result.groups.cards).toEqual({ items: [], total: 0, partial: false });
+    expect(result.groups.mandalas.items).toEqual([]);
+    expect(result.groups.notes.items).toEqual([]);
+    expect(result.groups.summaries.items).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 1 of the global ⌘K search (design: `docs/design/global-search-cmdk-2026-07-02.md`). BE only — the CommandPalette UI lands in PR-2.

**Root cause fixed**: the existing search (`local-cards?action=search`) covers `user_local_cards` only — **0.4% of placed cards** (measured 28 vs 7,587 on prod); wizard-placed cards live in `user_video_states` and were invisible. Measured symptom: visible cards "수동태"=7 on screen, search returned 0.

## What's included
- `src/modules/search/global-search.ts` — four groups in parallel, **all user-scoped (R3)**: cards (uvs+yv AND ulc), mandalas (+levels goal/labels/subjects), notes (TipTap text extraction + snippet), v2 summaries (one_liner, user-cards join). Parameterized SQL + ILIKE escaping; per-group 800ms budget with honest `partial` flag.
- `src/api/routes/search.ts` — authenticated `GET /api/v1/search?q=&limit=`.
- `prisma/migrations/global-search/001_pg_trgm_indexes.sql` (+ allowlist) — pg_trgm + 3 GIN trigram indexes. Measured seq scans on worst-case term: cards 927ms / summaries 1688ms → ms-range with indexes. Idempotent.
- FE `api-client.searchAll()` + response types (covered by URL contract test; no UI yet).
- 10 unit tests (escape / tiptap walk / snippet / merge-rank / timeout / empty-guard).

## Verification
| Gate | Result |
|---|---|
| BE tsc / jest | 0 errors / 10/10 |
| FE tsc / vitest / contract | 0 / 468/468 / 15/15 |
| Local DDL | applied to local supabase, `pg_trgm` + 3 indexes confirmed |
| Local e2e (direct, local DB) | "영어" 42ms cards=18 mandalas=7 v2=1; injection pattern → 0 rows; random-uuid isolation → 0/0/0/0 |
| Dev smoke | endpoint registered, unauthenticated → 401 |

Note: local isolation probe initially "leaked" 58 mandalas — investigated: the probe uuid collided with the local seed user `system-templates@insighta.one` (2,000 mandalas); re-verified with a random uuid → clean isolation.

## Rollback
Endpoint is additive (no FE caller in prod until PR-2); indexes are perf-only. Single revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)