### PR TITLE
feat(search): W2 retrieval precision — drop generic-filler tokens from per-cell tsquery

### DIFF
--- a/src/skills/plugins/video-discover/__tests__/v3-tsquery-stopword.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v3-tsquery-stopword.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildTsqueryString } from '../v3/tsquery-builder';
+
+/**
+ * W2 retrieval precision — buildTsqueryString drops generic-filler tokens so an
+ * OR-tsquery no longer pulls cross-domain videos into a topical cell.
+ */
+describe('buildTsqueryString — W2 generic-filler stopwords', () => {
+  it('drops generic filler, keeps topical nouns', () => {
+    const q = buildTsqueryString('해외주식 시장 분석 글로벌 기업 투자 역량 강화');
+    const toks = q.split(' | ');
+    // topical nouns kept
+    expect(toks).toContain('해외주식');
+    expect(toks).toContain('투자');
+    expect(toks).toContain('글로벌');
+    // generic filler dropped
+    expect(toks).not.toContain('분석');
+    expect(toks).not.toContain('강화');
+  });
+
+  it('empty-guard: an all-generic cell keeps its original tokens (recall never 0)', () => {
+    // every token is a stopword — must NOT collapse to empty tsquery
+    const q = buildTsqueryString('학습 관리 전략 강화');
+    expect(q.length).toBeGreaterThan(0);
+    expect(q.split(' | ')).toContain('학습');
+  });
+
+  it('still de-duplicates and returns OR-joined tokens', () => {
+    const q = buildTsqueryString('쿠버네티스 쿠버네티스 배포');
+    expect(q).toBe('쿠버네티스 | 배포');
+  });
+
+  it('returns empty string for token-less input (unchanged contract)', () => {
+    expect(buildTsqueryString('   ')).toBe('');
+  });
+});

--- a/src/skills/plugins/video-discover/v3/hybrid-rerank.ts
+++ b/src/skills/plugins/video-discover/v3/hybrid-rerank.ts
@@ -41,6 +41,7 @@ import { config } from '@/config/index';
 import { getPrismaClient } from '@/modules/database/client';
 import { logger } from '@/utils/logger';
 import { recordTrace } from '@/modules/discover-tracing';
+import { buildTsqueryString } from './tsquery-builder';
 import {
   rerank,
   CohereRerankConfigError,
@@ -308,22 +309,9 @@ export async function tsvectorKeywordCandidates(
   }
 }
 
-/**
- * Build a Postgres `to_tsquery('simple', …)` OR-string from free text.
- * Mirrors the inline tokenization of tsvectorKeywordCandidates (lines ~172-178)
- * deliberately, so the legacy v3 path stays byte-identical (no shared-refactor
- * risk on that function). Returns '' when no usable token remains.
- */
-function buildTsqueryString(text: string): string {
-  const tokens = text
-    .split(/[\s,/.;()[\]{}!?"'`~&|<>:*+\-=]+/)
-    .map((t) => t.trim())
-    .filter((t) => t.length > 0)
-    .map((t) => t.replace(/[':!&|()<>*]/g, ''))
-    .filter((t) => t.length > 0)
-    .filter((t, i, arr) => arr.indexOf(t) === i);
-  return tokens.join(' | ');
-}
+// buildTsqueryString + the W2 generic-filler stopword set live in the pure
+// ./tsquery-builder module (unit-testable in isolation without this file's
+// `@/` import chain). Imported at the top of this module.
 
 /**
  * CP494 안 A (per-cell tsquery) — video_pool match WITHOUT the global top-N

--- a/src/skills/plugins/video-discover/v3/tsquery-builder.ts
+++ b/src/skills/plugins/video-discover/v3/tsquery-builder.ts
@@ -1,0 +1,73 @@
+/**
+ * Per-cell `to_tsquery('simple', …)` builder + W2 generic-filler stopwords.
+ *
+ * Extracted from hybrid-rerank.ts as a PURE module (no `@/` imports) so the
+ * tokenizer + stopword list are unit-testable in isolation.
+ *
+ * W2 precision (2026-07-02): the stopword set is the empirically top-frequency
+ * NON-topic tokens across all mandala cell goals (each appears in ~1.5–9% of
+ * ~2,430 cells). An OR-tsquery that includes these matches cross-domain videos
+ * (e.g. a "강화" self-help clip pulled into a "해외주식 … 역량 강화" finance
+ * cell), diluting recruit precision. Dropping them tightens the query to
+ * topical nouns — with a guard so a generic-only cell never empties to 0 recall.
+ */
+
+export const TSQUERY_GENERIC_STOPWORDS = new Set<string>([
+  '학습',
+  '관리',
+  '전략',
+  '구축',
+  '분석',
+  '최적화',
+  '수립',
+  '능력',
+  '위한',
+  '습득',
+  '기초',
+  '강화',
+  '계획',
+  '이해',
+  '확보',
+  '준비',
+  '개선',
+  '설계',
+  '설정',
+  '문제',
+  '목표',
+  '정리',
+  '유지',
+  '핵심',
+  '구성',
+  '통한',
+  '활용',
+  '기법',
+  '방법',
+  '마스터',
+  '완성',
+  '실천',
+  '도전',
+  '과정',
+  '단계',
+  '달성',
+  '되기',
+  '전문가',
+]);
+
+/**
+ * Build a Postgres `to_tsquery('simple', …)` OR-string from free text.
+ * Tokenization mirrors the inline logic of tsvectorKeywordCandidates
+ * (hybrid-rerank ~172-178). Returns '' when no usable token remains.
+ */
+export function buildTsqueryString(text: string): string {
+  const tokens = text
+    .split(/[\s,/.;()[\]{}!?"'`~&|<>:*+\-=]+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0)
+    .map((t) => t.replace(/[':!&|()<>*]/g, ''))
+    .filter((t) => t.length > 0)
+    .filter((t, i, arr) => arr.indexOf(t) === i);
+  // W2 precision: drop generic-filler tokens. Guard — if a cell's tokens are
+  // ALL generic, keep the original set so recall never collapses to empty.
+  const topical = tokens.filter((t) => !TSQUERY_GENERIC_STOPWORDS.has(t));
+  return (topical.length > 0 ? topical : tokens).join(' | ');
+}


### PR DESCRIPTION
## W2 (retrieval precision) — first prescription, quota-0, serving-algo only

**DO NOT MERGE until James golden-cohort gc verify.** CC-coded per Claude-web design-approval; Claude-web reviews diff, James verifies effect.

### Root cause (measured this session)
Pool recruitment = keyword tsquery (`buildTsqueryString` OR-joins all cell-goal tokens). Generic-filler tokens (`학습/관리/전략/분석/강화/…`, each in 1.5–9% of ~2,430 cells) match cross-domain videos — e.g. a `강화` self-help clip pulled into a `해외주식 … 역량 강화` finance cell. Measured: 26년금융 ~43% of top candidates off-topic, gc stuck at 62 despite **673 finance videos** in the servable pool. Correlation across cohort: fewer topical videos → lower gc.

### Fix
Extract `buildTsqueryString` + an **empirical** generic-filler stopword set into a pure `./tsquery-builder` module; drop stopwords before the OR-join.
- **Guard**: if a cell's tokens are ALL generic, keep the original set → recall never collapses to empty (no self-starvation for generic-only cells).
- Stopword set = top-frequency NON-topic tokens measured across all 2,430 cell goals.

### Scope / safety
- **quota-0**, serving-path algorithm only. No new data, no collector change, no schema.
- Pure module = unit-testable; `hybrid-rerank` imports it (was inline), no behavior change beyond the filter.
- 4 unit tests pass (drop / keep-topical / empty-guard / dedup). `tsc --noEmit` clean.

### Verify (James, before merge)
Golden-cohort gc re-measure, **bidirectional**:
1. Content-rich mandalas (26년금융) gc **up** (cross-domain noise down).
2. **No** mandala recall crashes to 0 (esp. content-sparse ones — the guard should prevent this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)