### PR TITLE
feat(search): global ⌘K CommandPalette — centered modal on all routes (PR-2)

### DIFF
--- a/frontend/src/__tests__/command-palette.test.tsx
+++ b/frontend/src/__tests__/command-palette.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * ⌘K CommandPalette smoke — open/close, quick actions, grouped results,
+ * and the SearchBar-no-longer-owns-⌘K regression.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import fs from 'fs';
+import path from 'path';
+import { CommandPalette } from '@/widgets/command-palette';
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('react-router-dom')>();
+  return { ...mod, useNavigate: () => navigateMock };
+});
+
+vi.mock('@/features/auth/model/useAuth', () => ({
+  useAuth: () => ({ isLoggedIn: true, isTokenReady: true }),
+}));
+
+const searchAllMock = vi.fn();
+vi.mock('@/shared/lib/api-client', () => ({
+  apiClient: { searchAll: (...args: unknown[]) => searchAllMock(...args) },
+}));
+
+function renderPalette() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <CommandPalette />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const openPalette = () => fireEvent.keyDown(document, { key: 'k', metaKey: true });
+
+beforeEach(() => {
+  navigateMock.mockReset();
+  searchAllMock.mockReset();
+});
+
+describe('CommandPalette', () => {
+  it('opens on Cmd+K and shows quick actions when input is empty', async () => {
+    renderPalette();
+    expect(screen.queryByRole('combobox')).toBeNull();
+    openPalette();
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeTruthy());
+    expect(screen.getByText('새 만다라')).toBeTruthy();
+    expect(screen.getByText('템플릿 찾기')).toBeTruthy();
+  });
+
+  it('quick action navigates to the wizard and closes', async () => {
+    renderPalette();
+    openPalette();
+    await waitFor(() => expect(screen.getByText('새 만다라')).toBeTruthy());
+    fireEvent.click(screen.getByText('새 만다라'));
+    expect(navigateMock).toHaveBeenCalledWith('/mandalas/new');
+    await waitFor(() => expect(screen.queryByRole('combobox')).toBeNull());
+  });
+
+  it('typed query renders grouped results from searchAll', async () => {
+    searchAllMock.mockResolvedValue({
+      query: '수동태',
+      groups: {
+        cards: {
+          items: [
+            {
+              kind: 'video',
+              id: 'uvs-1',
+              title: '수동태 개념끝',
+              channelTitle: '채널A',
+              thumbnailUrl: null,
+              url: null,
+              videoId: 'vid1',
+              note: null,
+              mandalaId: 'm-1',
+              cellIndex: 2,
+              createdAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+          total: 7,
+          partial: false,
+        },
+        mandalas: { items: [], total: 0, partial: false },
+        notes: { items: [], total: 0, partial: false },
+        summaries: { items: [], total: 0, partial: false },
+      },
+      tookMs: 42,
+    });
+    renderPalette();
+    openPalette();
+    await waitFor(() => expect(screen.getByRole('combobox')).toBeTruthy());
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '수동태' } });
+    // debounce(300ms) + query resolve
+    await waitFor(() => expect(screen.getByText('수동태 개념끝')).toBeTruthy(), {
+      timeout: 2000,
+    });
+    expect(searchAllMock).toHaveBeenCalledWith('수동태', 5);
+    expect(screen.getByText('카드')).toBeTruthy();
+  });
+
+  it('REGRESSION: SearchBar no longer binds its own ⌘K listener', () => {
+    const src = fs.readFileSync(
+      path.resolve(__dirname, '../features/search/ui/SearchBar.tsx'),
+      'utf-8'
+    );
+    expect(src).not.toMatch(/metaKey.*key === 'k'/);
+  });
+});

--- a/frontend/src/features/search/ui/SearchBar.tsx
+++ b/frontend/src/features/search/ui/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useCallback } from 'react';
 import { Search, X, Loader2, Youtube, Link2, FileText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { SourceFilter } from '../model/useSearchCards';
@@ -65,17 +65,8 @@ export function SearchBar({
     [onClear, onArrowDown, onArrowUp, onEnter]
   );
 
-  // Cmd/Ctrl+K to focus search
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-        e.preventDefault();
-        inputRef.current?.focus();
-      }
-    };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, []);
+  // ⌘K is owned by the global CommandPalette (widgets/command-palette) —
+  // the old focus-binding here was removed to avoid double firing.
 
   const handleFilterClick = useCallback(
     (filter: SourceFilter) => {
@@ -94,7 +85,7 @@ export function SearchBar({
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder={t('search.placeholder', 'Search cards... (⌘K)')}
+          placeholder={t('search.placeholder', 'Search cards...')}
           className="w-full h-9 pl-9 pr-9 rounded-md border-0 bg-sidebar-foreground/[0.06] text-sm text-foreground/80 placeholder:text-[13px] placeholder:text-muted-foreground focus:outline focus:outline-[1.5px] focus:outline-sidebar-border/60 focus:text-foreground transition-colors duration-150"
           role="combobox"
           aria-expanded={isSearchActive}

--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -328,6 +328,23 @@ function AuthenticatedApp() {
     }
   }, [highlightedCard]);
 
+  // 5d. ⌘K palette cross-route handoff — scroll + ring the requested card once
+  // it renders (re-runs as displayCards stream in after the mandala switch).
+  const pendingCardHighlight = useMandalaStore((s) => s.pendingCardHighlight);
+  const setPendingCardHighlight = useMandalaStore((s) => s.setPendingCardHighlight);
+  useEffect(() => {
+    if (!pendingCardHighlight) return;
+    const el = document.querySelector(`[data-card-id="${pendingCardHighlight.cardId}"]`);
+    if (!el) return; // cards still loading — effect re-fires on displayCards change
+    el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    el.classList.add('ring-2', 'ring-primary', 'ring-offset-1');
+    const timer = setTimeout(() => {
+      el.classList.remove('ring-2', 'ring-primary', 'ring-offset-1');
+      setPendingCardHighlight(null);
+    }, 2500);
+    return () => clearTimeout(timer);
+  }, [pendingCardHighlight, cards.displayCards, setPendingCardHighlight]);
+
   // 6. Video modal
   const modal = useVideoModal(cards.allMandalaCards, cards.scratchPadCards);
   const isSidePanelOpen = useVideoPanelStore((s) => s.isOpen);

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -669,7 +669,7 @@
     "selectSectorDesc": "Choose a sector from the pills above to assign cards."
   },
   "search": {
-    "placeholder": "Search cards... (⌘K)",
+    "placeholder": "Search cards...",
     "clear": "Clear search",
     "noResults": "No results found",
     "resultCount": "{{count}} results",
@@ -678,6 +678,23 @@
     "filterYouTube": "YouTube",
     "filterLink": "Links",
     "filterFile": "Files"
+  },
+  "palette": {
+    "title": "Search and quick actions",
+    "placeholder": "Search cards, mandalas, notes, summaries…",
+    "actionNewMandala": "New mandala",
+    "actionTemplates": "Find templates",
+    "groupActions": "Quick actions",
+    "groupCards": "Cards",
+    "groupMandalas": "Mandalas",
+    "groupNotes": "Notes",
+    "groupSummaries": "Summaries",
+    "untitled": "(untitled)",
+    "noteFallback": "Note",
+    "empty": "No results",
+    "hintSelect": "select",
+    "hintOpen": "open",
+    "hintClose": "close"
   },
   "help": {
     "title": "Help & Support",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -677,7 +677,7 @@
     "selectSectorDesc": "카드를 배치할 섹터를 먼저 선택해주세요."
   },
   "search": {
-    "placeholder": "카드 검색... (⌘K)",
+    "placeholder": "카드 검색...",
     "clear": "검색 지우기",
     "noResults": "결과 없음",
     "resultCount": "{{count}}건",
@@ -686,6 +686,23 @@
     "filterYouTube": "YouTube",
     "filterLink": "링크",
     "filterFile": "파일"
+  },
+  "palette": {
+    "title": "검색 및 빠른 작업",
+    "placeholder": "카드, 만다라, 노트, 요약 검색…",
+    "actionNewMandala": "새 만다라",
+    "actionTemplates": "템플릿 찾기",
+    "groupActions": "빠른 작업",
+    "groupCards": "카드",
+    "groupMandalas": "만다라",
+    "groupNotes": "노트",
+    "groupSummaries": "요약",
+    "untitled": "(제목 없음)",
+    "noteFallback": "노트",
+    "empty": "결과가 없습니다",
+    "hintSelect": "선택",
+    "hintOpen": "이동",
+    "hintClose": "닫기"
   },
   "help": {
     "title": "도움말 및 지원",

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -97,6 +97,61 @@ export interface BillingSubscriptionMeResponse {
   subscription: BillingSubscriptionSummary | null;
 }
 
+// Global Search (⌘K palette) — mirrors src/modules/search/global-search.ts
+export interface GlobalSearchCardHit {
+  kind: 'video' | 'local';
+  id: string;
+  title: string | null;
+  channelTitle: string | null;
+  thumbnailUrl: string | null;
+  url: string | null;
+  videoId: string | null;
+  note: string | null;
+  mandalaId: string | null;
+  cellIndex: number | null;
+  createdAt: string;
+}
+
+export interface GlobalSearchMandalaHit {
+  id: string;
+  title: string | null;
+  centerLabel: string | null;
+  createdAt: string;
+}
+
+export interface GlobalSearchNoteHit {
+  id: string;
+  mandalaId: string;
+  mandalaTitle: string | null;
+  snippet: string;
+  updatedAt: string;
+}
+
+export interface GlobalSearchSummaryHit {
+  videoId: string;
+  oneLiner: string;
+  videoTitle: string | null;
+  mandalaId: string | null;
+}
+
+export interface GlobalSearchGroup<T> {
+  items: T[];
+  total: number;
+  /** true = the group missed its server-side time budget (incomplete). */
+  partial: boolean;
+}
+
+export interface GlobalSearchResponse {
+  query: string;
+  groups: {
+    cards: GlobalSearchGroup<GlobalSearchCardHit>;
+    mandalas: GlobalSearchGroup<GlobalSearchMandalaHit>;
+    notes: GlobalSearchGroup<GlobalSearchNoteHit>;
+    summaries: GlobalSearchGroup<GlobalSearchSummaryHit>;
+  };
+  tookMs: number;
+}
+
 export interface VideoRichSummaryChapter {
   start_sec: number;
   title: string;
@@ -980,6 +1035,20 @@ class ApiClient {
     return this.request<void>(`/playlists/${id}/resume`, {
       method: 'PATCH',
     });
+  }
+
+  // ========================================
+  // Global Search (⌘K palette)
+  // ========================================
+
+  /**
+   * Unified user-data search — cards / mandalas / notes / v2 summaries.
+   * BE: GET /api/v1/search (src/api/routes/search.ts). All groups are
+   * user-scoped server-side. Consumed by the ⌘K CommandPalette (PR-2).
+   */
+  async searchAll(q: string, limitPerGroup?: number): Promise<GlobalSearchResponse> {
+    const limitParam = limitPerGroup ? `&limit=${limitPerGroup}` : '';
+    return this.request<GlobalSearchResponse>(`/search?q=${encodeURIComponent(q)}${limitParam}`);
   }
 
   // ========================================

--- a/frontend/src/stores/mandalaStore.ts
+++ b/frontend/src/stores/mandalaStore.ts
@@ -44,7 +44,10 @@ interface MandalaUIStore {
   justCreatedMandalaId: string | null;
   pendingMandala: PendingMandala | null;
   lastOptimisticTitle: { id: string; title: string } | null;
+  /** ⌘K palette → cross-route card highlight handoff (transient — NOT persisted). */
+  pendingCardHighlight: { cardId: string; videoId: string | null } | null;
   selectMandala: (id: string | null) => void;
+  setPendingCardHighlight: (v: { cardId: string; videoId: string | null } | null) => void;
   setNavigation: (mandalaId: string, patch: Partial<MandalaNavigationState>) => void;
   clearNavigation: (mandalaId: string) => void;
   getNavigation: (mandalaId: string | null | undefined) => MandalaNavigationState;
@@ -61,6 +64,7 @@ const INITIAL_STATE = {
   justCreatedMandalaId: null,
   pendingMandala: null,
   lastOptimisticTitle: null,
+  pendingCardHighlight: null as { cardId: string; videoId: string | null } | null,
 };
 
 export const useMandalaStore = create<MandalaUIStore>()(
@@ -68,6 +72,7 @@ export const useMandalaStore = create<MandalaUIStore>()(
     (set, get) => ({
       ...INITIAL_STATE,
       selectMandala: (id) => set({ selectedMandalaId: id }),
+      setPendingCardHighlight: (v) => set({ pendingCardHighlight: v }),
       setNavigation: (mandalaId, patch) =>
         set((state) => ({
           navigationByMandala: {

--- a/frontend/src/widgets/app-shell/ui/AppShell.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppShell.tsx
@@ -4,6 +4,7 @@ import { DndContext } from '@dnd-kit/core';
 import { useTranslation } from 'react-i18next';
 import { Sidebar } from './Sidebar';
 import { MobileDrawer } from './MobileDrawer';
+import { CommandPalette } from '@/widgets/command-palette';
 import { useShellStore, dndHandlersRef } from '@/stores/shellStore';
 import { useAuth } from '@/features/auth/model/useAuth';
 import { useDndSensors, pointerWithinThenClosest } from '@/shared/lib/dnd';
@@ -140,6 +141,9 @@ export function AppShell({ children }: AppShellProps) {
           onOpenChange={setMobileDrawerOpen}
           onNavigateHome={onNavigateHome ?? undefined}
         />
+
+        {/* ⌘K global search — works on every authenticated route (incl. no-sidebar ones) */}
+        <CommandPalette />
       </div>
     </DndContext>
   );

--- a/frontend/src/widgets/command-palette/index.ts
+++ b/frontend/src/widgets/command-palette/index.ts
@@ -1,0 +1,1 @@
+export { CommandPalette } from './ui/CommandPalette';

--- a/frontend/src/widgets/command-palette/model/useGlobalSearch.ts
+++ b/frontend/src/widgets/command-palette/model/useGlobalSearch.ts
@@ -1,0 +1,39 @@
+/**
+ * ⌘K palette search hook — debounced call to GET /api/v1/search (PR-1 BE).
+ * Server does all scoping/ranking; this hook only debounces + caches.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { apiClient, type GlobalSearchResponse } from '@/shared/lib/api-client';
+import { useAuth } from '@/features/auth/model/useAuth';
+import { useDebounce } from '@/shared/lib/useDebounce';
+
+const PALETTE_DEBOUNCE_MS = 300;
+const PALETTE_GROUP_LIMIT = 5;
+const PALETTE_STALE_MS = 30_000;
+
+export const globalSearchKeys = {
+  all: ['global-search'] as const,
+  query: (q: string) => [...globalSearchKeys.all, q] as const,
+};
+
+export function useGlobalSearch(rawTerm: string, enabled: boolean) {
+  const { isLoggedIn, isTokenReady } = useAuth();
+  const term = rawTerm.trim();
+  const debounced = useDebounce(term, PALETTE_DEBOUNCE_MS);
+  const active = debounced.length > 0;
+
+  const query = useQuery<GlobalSearchResponse>({
+    queryKey: globalSearchKeys.query(debounced),
+    queryFn: () => apiClient.searchAll(debounced, PALETTE_GROUP_LIMIT),
+    enabled: enabled && isLoggedIn && isTokenReady && active,
+    staleTime: PALETTE_STALE_MS,
+    placeholderData: (prev) => prev,
+  });
+
+  return {
+    data: query.data ?? null,
+    isLoading: query.isFetching && active,
+    isActive: active,
+    error: query.error,
+  };
+}

--- a/frontend/src/widgets/command-palette/ui/CommandPalette.tsx
+++ b/frontend/src/widgets/command-palette/ui/CommandPalette.tsx
@@ -1,0 +1,339 @@
+/**
+ * ⌘K Command Palette — centered global search modal (design:
+ * docs/design/global-search-cmdk-2026-07-02.md §4, claude.ai ⌘K reference).
+ *
+ * - Global Cmd/Ctrl+K opens it on ANY route (mounted at AppShell level).
+ * - Empty input → Quick actions (새 만다라 / 템플릿 찾기).
+ * - Typed input → grouped results (cards / mandalas / notes / summaries)
+ *   from GET /api/v1/search; groups report honest totals + partial flags.
+ * - ↑↓ move / ↵ run / esc close; footer shows the hints.
+ * - Card hits navigate to the dashboard, switch mandala and hand off a
+ *   highlight request via mandalaStore.pendingCardHighlight (Q3).
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import {
+  Search,
+  Loader2,
+  Plus,
+  Compass,
+  SquarePlay,
+  Grid3X3,
+  NotebookText,
+  Sparkles,
+  CornerDownLeft,
+} from 'lucide-react';
+import { Dialog, DialogContent, DialogTitle } from '@/shared/ui/dialog';
+import { cn } from '@/shared/lib/utils';
+import { useAuth } from '@/features/auth/model/useAuth';
+import { useMandalaStore } from '@/stores/mandalaStore';
+import type {
+  GlobalSearchCardHit,
+  GlobalSearchMandalaHit,
+  GlobalSearchNoteHit,
+  GlobalSearchSummaryHit,
+} from '@/shared/lib/api-client';
+import { useGlobalSearch } from '../model/useGlobalSearch';
+
+/** One flat keyboard-navigable row (quick action or search hit). */
+interface PaletteRow {
+  key: string;
+  group: 'actions' | 'cards' | 'mandalas' | 'notes' | 'summaries';
+  title: string;
+  subtitle?: string | null;
+  icon: React.ReactNode;
+  run: () => void;
+}
+
+const INPUT_MAX_LEN = 100;
+
+export function CommandPalette() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { isLoggedIn } = useAuth();
+  const selectMandala = useMandalaStore((s) => s.selectMandala);
+  const setPendingCardHighlight = useMandalaStore((s) => s.setPendingCardHighlight);
+
+  const [open, setOpen] = useState(false);
+  const [term, setTerm] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const { data, isLoading, isActive } = useGlobalSearch(term, open);
+
+  // Global hotkey — palette owns Cmd/Ctrl+K app-wide (SearchBar's old
+  // focus-binding was removed in this PR to avoid double firing).
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isLoggedIn]);
+
+  // Reset transient state whenever the palette closes.
+  useEffect(() => {
+    if (!open) {
+      setTerm('');
+      setActiveIndex(0);
+    }
+  }, [open]);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  const goCard = useCallback(
+    (hit: GlobalSearchCardHit) => {
+      if (hit.mandalaId) selectMandala(hit.mandalaId);
+      setPendingCardHighlight({ cardId: hit.id, videoId: hit.videoId });
+      navigate('/');
+      close();
+    },
+    [selectMandala, setPendingCardHighlight, navigate, close]
+  );
+
+  const goMandala = useCallback(
+    (hit: GlobalSearchMandalaHit) => {
+      selectMandala(hit.id);
+      navigate('/');
+      close();
+    },
+    [selectMandala, navigate, close]
+  );
+
+  const goNote = useCallback(
+    (hit: GlobalSearchNoteHit) => {
+      // /learning route requires a videoId — Phase 1 lands on the mandala.
+      selectMandala(hit.mandalaId);
+      navigate('/');
+      close();
+    },
+    [selectMandala, navigate, close]
+  );
+
+  const goSummary = useCallback(
+    (hit: GlobalSearchSummaryHit) => {
+      if (hit.mandalaId) {
+        navigate(`/learning/${hit.mandalaId}/${hit.videoId}`);
+      } else {
+        navigate('/');
+      }
+      close();
+    },
+    [navigate, close]
+  );
+
+  // Flat, ordered row list drives both rendering and ↑↓ navigation.
+  const rows = useMemo<PaletteRow[]>(() => {
+    const out: PaletteRow[] = [];
+    if (!isActive) {
+      out.push(
+        {
+          key: 'qa-new-mandala',
+          group: 'actions',
+          title: t('palette.actionNewMandala', '새 만다라'),
+          icon: <Plus className="w-4 h-4" />,
+          run: () => {
+            navigate('/mandalas/new');
+            close();
+          },
+        },
+        {
+          key: 'qa-templates',
+          group: 'actions',
+          title: t('palette.actionTemplates', '템플릿 찾기'),
+          icon: <Compass className="w-4 h-4" />,
+          run: () => {
+            navigate('/templates');
+            close();
+          },
+        }
+      );
+      return out;
+    }
+    const g = data?.groups;
+    for (const hit of g?.cards.items ?? []) {
+      out.push({
+        key: `card-${hit.kind}-${hit.id}`,
+        group: 'cards',
+        title: hit.title ?? t('palette.untitled', '(제목 없음)'),
+        subtitle: hit.channelTitle ?? hit.note ?? hit.url,
+        icon: <SquarePlay className="w-4 h-4" />,
+        run: () => goCard(hit),
+      });
+    }
+    for (const hit of g?.mandalas.items ?? []) {
+      out.push({
+        key: `mandala-${hit.id}`,
+        group: 'mandalas',
+        title: hit.centerLabel ?? hit.title ?? t('palette.untitled', '(제목 없음)'),
+        subtitle: hit.centerLabel ? hit.title : null,
+        icon: <Grid3X3 className="w-4 h-4" />,
+        run: () => goMandala(hit),
+      });
+    }
+    for (const hit of g?.notes.items ?? []) {
+      out.push({
+        key: `note-${hit.id}`,
+        group: 'notes',
+        title: hit.mandalaTitle ?? t('palette.noteFallback', '노트'),
+        subtitle: hit.snippet,
+        icon: <NotebookText className="w-4 h-4" />,
+        run: () => goNote(hit),
+      });
+    }
+    for (const hit of g?.summaries.items ?? []) {
+      out.push({
+        key: `summary-${hit.videoId}`,
+        group: 'summaries',
+        title: hit.videoTitle ?? t('palette.untitled', '(제목 없음)'),
+        subtitle: hit.oneLiner,
+        icon: <Sparkles className="w-4 h-4" />,
+        run: () => goSummary(hit),
+      });
+    }
+    return out;
+  }, [isActive, data, t, navigate, close, goCard, goMandala, goNote, goSummary]);
+
+  // Clamp the cursor when the row set changes.
+  useEffect(() => {
+    setActiveIndex((prev) => Math.min(prev, Math.max(rows.length - 1, 0)));
+  }, [rows.length]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveIndex((p) => (rows.length === 0 ? 0 : (p + 1) % rows.length));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIndex((p) => (rows.length === 0 ? 0 : (p - 1 + rows.length) % rows.length));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        rows[activeIndex]?.run();
+      }
+    },
+    [rows, activeIndex]
+  );
+
+  // Keep the active row visible while arrowing through a long list.
+  useEffect(() => {
+    const el = listRef.current?.querySelector(`[data-palette-index="${activeIndex}"]`);
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex]);
+
+  const groupLabel: Record<PaletteRow['group'], string> = {
+    actions: t('palette.groupActions', '빠른 작업'),
+    cards: t('palette.groupCards', '카드'),
+    mandalas: t('palette.groupMandalas', '만다라'),
+    notes: t('palette.groupNotes', '노트'),
+    summaries: t('palette.groupSummaries', '요약'),
+  };
+  const groupTotal: Partial<Record<PaletteRow['group'], number>> = {
+    cards: data?.groups.cards.total,
+    mandalas: data?.groups.mandalas.total,
+    notes: data?.groups.notes.total,
+    summaries: data?.groups.summaries.total,
+  };
+
+  if (!isLoggedIn) return null;
+
+  let lastGroup: PaletteRow['group'] | null = null;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent
+        className="max-w-xl p-0 gap-0 overflow-hidden top-[20%] translate-y-0"
+        aria-describedby={undefined}
+      >
+        <DialogTitle className="sr-only">{t('palette.title', '검색 및 빠른 작업')}</DialogTitle>
+
+        {/* Input row */}
+        <div className="flex items-center gap-2 px-4 h-12 border-b border-border/50">
+          <Search className="w-4 h-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <input
+            autoFocus
+            value={term}
+            maxLength={INPUT_MAX_LEN}
+            onChange={(e) => {
+              setTerm(e.target.value);
+              setActiveIndex(0);
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder={t('palette.placeholder', '카드, 만다라, 노트, 요약 검색…')}
+            className="flex-1 h-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+            role="combobox"
+            aria-expanded={rows.length > 0}
+            aria-haspopup="listbox"
+          />
+          {isLoading && <Loader2 className="w-4 h-4 shrink-0 text-muted-foreground animate-spin" />}
+        </div>
+
+        {/* Rows */}
+        <div ref={listRef} className="max-h-[50vh] overflow-y-auto py-1.5" role="listbox">
+          {rows.length === 0 && isActive && !isLoading && (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              {t('palette.empty', '결과가 없습니다')}
+            </div>
+          )}
+          {rows.map((row, i) => {
+            const showHeader = row.group !== lastGroup;
+            lastGroup = row.group;
+            const total = groupTotal[row.group];
+            return (
+              <div key={row.key}>
+                {showHeader && (
+                  <div className="px-4 pt-2 pb-1 text-[11px] font-medium text-muted-foreground flex items-center gap-1.5">
+                    {groupLabel[row.group]}
+                    {typeof total === 'number' && total > 0 && (
+                      <span className="opacity-60">{total}</span>
+                    )}
+                  </div>
+                )}
+                <button
+                  type="button"
+                  data-palette-index={i}
+                  onClick={row.run}
+                  onMouseEnter={() => setActiveIndex(i)}
+                  className={cn(
+                    'w-full flex items-center gap-2.5 px-4 py-2 text-left text-sm transition-colors',
+                    i === activeIndex ? 'bg-accent text-accent-foreground' : 'text-foreground/85'
+                  )}
+                  role="option"
+                  aria-selected={i === activeIndex}
+                >
+                  <span className="shrink-0 text-muted-foreground">{row.icon}</span>
+                  <span className="flex-1 min-w-0">
+                    <span className="block truncate">{row.title}</span>
+                    {row.subtitle && (
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {row.subtitle}
+                      </span>
+                    )}
+                  </span>
+                  {i === activeIndex && (
+                    <CornerDownLeft
+                      className="w-3.5 h-3.5 shrink-0 text-muted-foreground"
+                      aria-hidden="true"
+                    />
+                  )}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer hints */}
+        <div className="flex items-center gap-3 px-4 h-9 border-t border-border/50 text-[11px] text-muted-foreground">
+          <span>↑↓ {t('palette.hintSelect', '선택')}</span>
+          <span>↵ {t('palette.hintOpen', '이동')}</span>
+          <span>esc {t('palette.hintClose', '닫기')}</span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/prisma/migrations/global-search/001_pg_trgm_indexes.sql
+++ b/prisma/migrations/global-search/001_pg_trgm_indexes.sql
@@ -1,0 +1,18 @@
+-- Global search (⌘K) Phase 1 — trigram indexes for ILIKE substring search.
+-- Idempotent: safe to re-run (IF NOT EXISTS everywhere).
+-- Measured need (2026-07-02, prod, worst-case term): cards group 927ms,
+-- summaries group 1688ms on seq scans — GIN trgm brings both to ms range.
+-- Design: docs/design/global-search-cmdk-2026-07-02.md §3.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- cards group: user_video_states JOIN youtube_videos(title, channel_title)
+CREATE INDEX IF NOT EXISTS idx_yv_title_trgm
+  ON youtube_videos USING gin (title gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_yv_channel_title_trgm
+  ON youtube_videos USING gin (channel_title gin_trgm_ops);
+
+-- summaries group: video_rich_summaries.one_liner (Phase 1 = one_liner only)
+CREATE INDEX IF NOT EXISTS idx_vrs_one_liner_trgm
+  ON video_rich_summaries USING gin (one_liner gin_trgm_ops);

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -164,6 +164,11 @@ APPLY_FILES=(
   # CREATE TABLE/INDEX IF NOT EXISTS + NOTIFY pgrst — idempotent. Inert until the
   # rollup job (daily boss.schedule) writes a row.
   "prisma/migrations/search-metrics/001_create_search_metrics_daily.sql"
+  # Global search (⌘K) Phase 1 — pg_trgm + 3 GIN trigram indexes for ILIKE
+  # substring search (yv.title / yv.channel_title / vrs.one_liner). CREATE
+  # EXTENSION/INDEX IF NOT EXISTS — fully idempotent. Perf-only (no schema
+  # change); inert until /api/v1/search is called.
+  "prisma/migrations/global-search/001_pg_trgm_indexes.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "

--- a/src/api/routes/search.ts
+++ b/src/api/routes/search.ts
@@ -1,0 +1,57 @@
+/**
+ * Global Search API — GET /api/v1/search?q=&limit=
+ *
+ * Unified user-data search for the ⌘K palette (cards / mandalas / notes /
+ * v2 summaries). Auth required; every group query is user-scoped inside
+ * src/modules/search/global-search.ts (R3 — no cross-user leak).
+ *
+ * Design: docs/design/global-search-cmdk-2026-07-02.md
+ */
+import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
+import {
+  globalSearch,
+  SEARCH_GROUP_LIMIT_DEFAULT,
+  SEARCH_GROUP_LIMIT_MAX,
+} from '../../modules/search/global-search';
+import { logger } from '../../utils/logger';
+
+function getUserId(request: FastifyRequest, reply: FastifyReply): string | null {
+  if (!request.user || !('userId' in request.user)) {
+    reply.status(401).send({ error: 'Unauthorized' });
+    return null;
+  }
+  return (request.user as { userId: string }).userId;
+}
+
+export const searchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+  fastify.get<{ Querystring: { q?: string; limit?: string } }>(
+    '/',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const userId = getUserId(request, reply);
+      if (!userId) return;
+
+      const q = (request.query.q ?? '').trim();
+      if (q.length === 0) {
+        return reply.status(400).send({ error: 'Query parameter "q" is required' });
+      }
+
+      const parsedLimit = Number.parseInt(request.query.limit ?? '', 10);
+      const limitPerGroup = Number.isFinite(parsedLimit)
+        ? Math.min(Math.max(parsedLimit, 1), SEARCH_GROUP_LIMIT_MAX)
+        : SEARCH_GROUP_LIMIT_DEFAULT;
+
+      try {
+        const result = await globalSearch(userId, q, { limitPerGroup });
+        return reply.send(result);
+      } catch (err) {
+        logger.error('[search] global search failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return reply.status(500).send({ error: 'Search failed' });
+      }
+    }
+  );
+
+  done();
+};

--- a/src/api/routes/search.ts
+++ b/src/api/routes/search.ts
@@ -17,7 +17,7 @@ import { logger } from '../../utils/logger';
 
 function getUserId(request: FastifyRequest, reply: FastifyReply): string | null {
   if (!request.user || !('userId' in request.user)) {
-    reply.status(401).send({ error: 'Unauthorized' });
+    void reply.status(401).send({ error: 'Unauthorized' });
     return null;
   }
   return (request.user as { userId: string }).userId;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -18,6 +18,7 @@ import { quotaRoutes } from './routes/quota';
 import { mandalaRoutes } from './routes/mandalas';
 import { imageRoutes } from './routes/images';
 import { ontologyRoutes } from './routes/ontology';
+import { searchRoutes } from './routes/search';
 import { llmRoutes } from './routes/llm';
 import { adminRoutes } from './routes/admin';
 import { subscriptionRoutes } from './routes/subscriptions';
@@ -306,6 +307,9 @@ export async function buildServer() {
 
       // Register ontology routes (GraphRAG knowledge graph)
       await instance.register(ontologyRoutes, { prefix: '/ontology' });
+
+      // Register global search routes (⌘K palette — cards/mandalas/notes/summaries)
+      await instance.register(searchRoutes, { prefix: '/search' });
 
       // Register LLM provider routes (status, health)
       await instance.register(llmRoutes, { prefix: '/llm' });

--- a/src/modules/search/global-search.ts
+++ b/src/modules/search/global-search.ts
@@ -1,0 +1,387 @@
+/**
+ * Global Search — unified user-data search behind the ⌘K palette (Phase 1).
+ *
+ * Four groups run in parallel, ALL scoped to the requesting user (R3):
+ *   cards     — user_video_states JOIN youtube_videos (99.6% of placed cards)
+ *               + user_local_cards (manual/link/file cards + memos)
+ *   mandalas  — user_mandalas title + user_mandala_levels goal/labels/subjects
+ *   notes     — note_documents.content_json (TipTap doc → extracted text snippet)
+ *   summaries — video_rich_summaries.one_liner (v2; user-cards join. core body = Phase 2)
+ *
+ * Design: docs/design/global-search-cmdk-2026-07-02.md
+ * Perf: worst-case measured 2026-07-02 (see design §3) — pg_trgm GIN indexes
+ * (prisma/migrations/global-search/001) keep cards/summaries in the ms range.
+ */
+import { Prisma } from '@prisma/client';
+import { getPrismaClient } from '../database/client';
+import { logger } from '../../utils/logger';
+
+export const SEARCH_GROUP_LIMIT_DEFAULT = 5;
+export const SEARCH_GROUP_LIMIT_MAX = 20;
+/** Per-group budget; a late group returns empty + partial:true (honest partial). */
+export const SEARCH_GROUP_TIMEOUT_MS = 800;
+export const SEARCH_SNIPPET_RADIUS = 60;
+const SEARCH_QUERY_MAX_LEN = 100;
+
+export interface CardHit {
+  kind: 'video' | 'local';
+  id: string;
+  title: string | null;
+  channelTitle: string | null;
+  thumbnailUrl: string | null;
+  url: string | null;
+  videoId: string | null;
+  note: string | null;
+  mandalaId: string | null;
+  cellIndex: number | null;
+  createdAt: string;
+}
+
+export interface MandalaHit {
+  id: string;
+  title: string | null;
+  centerLabel: string | null;
+  createdAt: string;
+}
+
+export interface NoteHit {
+  id: string;
+  mandalaId: string;
+  mandalaTitle: string | null;
+  snippet: string;
+  updatedAt: string;
+}
+
+export interface SummaryHit {
+  videoId: string;
+  oneLiner: string;
+  videoTitle: string | null;
+  mandalaId: string | null;
+}
+
+export interface SearchGroup<T> {
+  items: T[];
+  total: number;
+  /** true = the group missed its time budget; items/total are incomplete. */
+  partial: boolean;
+}
+
+export interface GlobalSearchResult {
+  query: string;
+  groups: {
+    cards: SearchGroup<CardHit>;
+    mandalas: SearchGroup<MandalaHit>;
+    notes: SearchGroup<NoteHit>;
+    summaries: SearchGroup<SummaryHit>;
+  };
+  tookMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested)
+// ---------------------------------------------------------------------------
+
+/** Escape LIKE/ILIKE metacharacters so user input matches literally. */
+export function escapeLikePattern(raw: string): string {
+  return raw.replace(/[\\%_]/g, (m) => `\\${m}`);
+}
+
+/** Depth-first text extraction from a TipTap/ProseMirror JSON doc. */
+export function extractTiptapText(node: unknown): string {
+  if (node == null || typeof node !== 'object') return '';
+  const n = node as { text?: unknown; content?: unknown };
+  const parts: string[] = [];
+  if (typeof n.text === 'string') parts.push(n.text);
+  if (Array.isArray(n.content)) {
+    for (const child of n.content) parts.push(extractTiptapText(child));
+  }
+  return parts.join(' ');
+}
+
+/** Case-insensitive snippet around the first query hit (±radius chars). */
+export function makeSnippet(text: string, query: string, radius = SEARCH_SNIPPET_RADIUS): string {
+  const compact = text.replace(/\s+/g, ' ').trim();
+  const idx = compact.toLowerCase().indexOf(query.toLowerCase());
+  if (idx < 0) return compact.slice(0, radius * 2);
+  const start = Math.max(0, idx - radius);
+  const end = Math.min(compact.length, idx + query.length + radius);
+  return `${start > 0 ? '…' : ''}${compact.slice(start, end)}${end < compact.length ? '…' : ''}`;
+}
+
+/** Merge the two card sources: title matches first, then recency; cap at limit. */
+export function mergeCardHits(hits: CardHit[], query: string, limit: number): CardHit[] {
+  const q = query.toLowerCase();
+  const titleMatch = (h: CardHit) => ((h.title ?? '').toLowerCase().includes(q) ? 0 : 1);
+  return [...hits]
+    .sort((a, b) => titleMatch(a) - titleMatch(b) || b.createdAt.localeCompare(a.createdAt))
+    .slice(0, limit);
+}
+
+/** Resolve a group promise against the time budget; late = empty + partial. */
+export async function withGroupTimeout<T>(
+  work: Promise<SearchGroup<T>>,
+  timeoutMs = SEARCH_GROUP_TIMEOUT_MS
+): Promise<SearchGroup<T>> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const late = new Promise<SearchGroup<T>>((resolve) => {
+    timer = setTimeout(() => resolve({ items: [], total: 0, partial: true }), timeoutMs);
+  });
+  try {
+    return await Promise.race([work, late]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Group queries (parameterized via Prisma.sql — never string-interpolated)
+// ---------------------------------------------------------------------------
+
+async function searchCards(userId: string, pattern: string, query: string, limit: number) {
+  const prisma = getPrismaClient();
+  const [videoRows, videoCount, localRows, localCount] = await Promise.all([
+    prisma.$queryRaw<
+      Array<{
+        id: string;
+        video_id: string | null;
+        title: string | null;
+        channel_title: string | null;
+        thumbnail_url: string | null;
+        user_note: string | null;
+        mandala_id: string | null;
+        cell_index: number | null;
+        created_at: Date;
+      }>
+    >(Prisma.sql`
+      SELECT s.id, v.youtube_video_id AS video_id, v.title, v.channel_title,
+             v.thumbnail_url, s.user_note, s.mandala_id, s.cell_index, s.created_at
+      FROM user_video_states s
+      JOIN youtube_videos v ON v.id = s.video_id
+      WHERE s.user_id = ${userId}::uuid
+        AND (v.title ILIKE ${pattern} OR v.channel_title ILIKE ${pattern} OR s.user_note ILIKE ${pattern})
+      ORDER BY (v.title ILIKE ${pattern}) DESC, s.created_at DESC
+      LIMIT ${limit}`),
+    prisma.$queryRaw<Array<{ n: number }>>(Prisma.sql`
+      SELECT count(*)::int AS n
+      FROM user_video_states s
+      JOIN youtube_videos v ON v.id = s.video_id
+      WHERE s.user_id = ${userId}::uuid
+        AND (v.title ILIKE ${pattern} OR v.channel_title ILIKE ${pattern} OR s.user_note ILIKE ${pattern})`),
+    prisma.$queryRaw<
+      Array<{
+        id: string;
+        title: string | null;
+        user_note: string | null;
+        url: string | null;
+        thumbnail: string | null;
+        video_id: string | null;
+        mandala_id: string | null;
+        cell_index: number | null;
+        created_at: Date;
+      }>
+    >(Prisma.sql`
+      SELECT id, title, user_note, url, thumbnail, video_id, mandala_id, cell_index, created_at
+      FROM user_local_cards
+      WHERE user_id = ${userId}::uuid
+        AND (title ILIKE ${pattern} OR user_note ILIKE ${pattern} OR url ILIKE ${pattern}
+             OR metadata_title ILIKE ${pattern} OR metadata_description ILIKE ${pattern})
+      ORDER BY (title ILIKE ${pattern}) DESC, created_at DESC
+      LIMIT ${limit}`),
+    prisma.$queryRaw<Array<{ n: number }>>(Prisma.sql`
+      SELECT count(*)::int AS n
+      FROM user_local_cards
+      WHERE user_id = ${userId}::uuid
+        AND (title ILIKE ${pattern} OR user_note ILIKE ${pattern} OR url ILIKE ${pattern}
+             OR metadata_title ILIKE ${pattern} OR metadata_description ILIKE ${pattern})`),
+  ]);
+
+  const hits: CardHit[] = [
+    ...videoRows.map((r) => ({
+      kind: 'video' as const,
+      id: r.id,
+      title: r.title,
+      channelTitle: r.channel_title,
+      thumbnailUrl: r.thumbnail_url,
+      url: null,
+      videoId: r.video_id,
+      note: r.user_note,
+      mandalaId: r.mandala_id,
+      cellIndex: r.cell_index,
+      createdAt: r.created_at.toISOString(),
+    })),
+    ...localRows.map((r) => ({
+      kind: 'local' as const,
+      id: r.id,
+      title: r.title,
+      channelTitle: null,
+      thumbnailUrl: r.thumbnail,
+      url: r.url,
+      videoId: r.video_id,
+      note: r.user_note,
+      mandalaId: r.mandala_id,
+      cellIndex: r.cell_index,
+      createdAt: r.created_at.toISOString(),
+    })),
+  ];
+
+  return {
+    items: mergeCardHits(hits, query, limit),
+    total: (videoCount[0]?.n ?? 0) + (localCount[0]?.n ?? 0),
+    partial: false,
+  };
+}
+
+async function searchMandalas(userId: string, pattern: string, limit: number) {
+  const prisma = getPrismaClient();
+  const cellMatch = Prisma.sql`EXISTS (
+    SELECT 1 FROM user_mandala_levels l
+    WHERE l.mandala_id = m.id
+      AND (l.center_goal ILIKE ${pattern} OR l.center_label ILIKE ${pattern}
+           OR array_to_string(l.subjects, ' ') ILIKE ${pattern}
+           OR array_to_string(l.subject_labels, ' ') ILIKE ${pattern}))`;
+  const [rows, count] = await Promise.all([
+    prisma.$queryRaw<
+      Array<{ id: string; title: string | null; center_label: string | null; created_at: Date }>
+    >(Prisma.sql`
+      SELECT m.id, m.title,
+             (SELECT l.center_label FROM user_mandala_levels l
+              WHERE l.mandala_id = m.id AND l.depth = 0 LIMIT 1) AS center_label,
+             m.created_at
+      FROM user_mandalas m
+      WHERE m.user_id = ${userId}::uuid AND (m.title ILIKE ${pattern} OR ${cellMatch})
+      ORDER BY (m.title ILIKE ${pattern}) DESC, m.created_at DESC
+      LIMIT ${limit}`),
+    prisma.$queryRaw<Array<{ n: number }>>(Prisma.sql`
+      SELECT count(*)::int AS n
+      FROM user_mandalas m
+      WHERE m.user_id = ${userId}::uuid AND (m.title ILIKE ${pattern} OR ${cellMatch})`),
+  ]);
+  const items: MandalaHit[] = rows.map((r) => ({
+    id: r.id,
+    title: r.title,
+    centerLabel: r.center_label,
+    createdAt: r.created_at.toISOString(),
+  }));
+  return { items, total: count[0]?.n ?? 0, partial: false };
+}
+
+async function searchNotes(userId: string, pattern: string, query: string, limit: number) {
+  const prisma = getPrismaClient();
+  const [rows, count] = await Promise.all([
+    prisma.$queryRaw<
+      Array<{
+        id: string;
+        mandala_id: string;
+        mandala_title: string | null;
+        content_json: unknown;
+        updated_at: Date;
+      }>
+    >(Prisma.sql`
+      SELECT n.id, n.mandala_id, m.title AS mandala_title, n.content_json, n.updated_at
+      FROM note_documents n
+      LEFT JOIN user_mandalas m ON m.id = n.mandala_id
+      WHERE n.user_id = ${userId}::uuid AND n.content_json::text ILIKE ${pattern}
+      ORDER BY n.updated_at DESC
+      LIMIT ${limit}`),
+    prisma.$queryRaw<Array<{ n: number }>>(Prisma.sql`
+      SELECT count(*)::int AS n
+      FROM note_documents n
+      WHERE n.user_id = ${userId}::uuid AND n.content_json::text ILIKE ${pattern}`),
+  ]);
+  const items: NoteHit[] = rows.map((r) => ({
+    id: r.id,
+    mandalaId: r.mandala_id,
+    mandalaTitle: r.mandala_title,
+    snippet: makeSnippet(extractTiptapText(r.content_json), query),
+    updatedAt: r.updated_at.toISOString(),
+  }));
+  return { items, total: count[0]?.n ?? 0, partial: false };
+}
+
+async function searchSummaries(userId: string, pattern: string, limit: number) {
+  const prisma = getPrismaClient();
+  const [rows, count] = await Promise.all([
+    prisma.$queryRaw<
+      Array<{
+        video_id: string;
+        one_liner: string;
+        video_title: string | null;
+        mandala_id: string | null;
+      }>
+    >(Prisma.sql`
+      SELECT DISTINCT ON (vrs.video_id)
+             vrs.video_id, vrs.one_liner, v.title AS video_title, s.mandala_id
+      FROM video_rich_summaries vrs
+      JOIN youtube_videos v ON v.youtube_video_id = vrs.video_id
+      JOIN user_video_states s ON s.video_id = v.id AND s.user_id = ${userId}::uuid
+      WHERE vrs.one_liner ILIKE ${pattern}
+      ORDER BY vrs.video_id, s.created_at DESC
+      LIMIT ${limit}`),
+    prisma.$queryRaw<Array<{ n: number }>>(Prisma.sql`
+      SELECT count(DISTINCT vrs.video_id)::int AS n
+      FROM video_rich_summaries vrs
+      JOIN youtube_videos v ON v.youtube_video_id = vrs.video_id
+      JOIN user_video_states s ON s.video_id = v.id AND s.user_id = ${userId}::uuid
+      WHERE vrs.one_liner ILIKE ${pattern}`),
+  ]);
+  const items: SummaryHit[] = rows.map((r) => ({
+    videoId: r.video_id,
+    oneLiner: r.one_liner,
+    videoTitle: r.video_title,
+    mandalaId: r.mandala_id,
+  }));
+  return { items, total: count[0]?.n ?? 0, partial: false };
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+const EMPTY_GROUP = { items: [], total: 0, partial: false } as const;
+
+export async function globalSearch(
+  userId: string,
+  rawQuery: string,
+  options: { limitPerGroup?: number } = {}
+): Promise<GlobalSearchResult> {
+  const started = Date.now();
+  const query = rawQuery.trim().slice(0, SEARCH_QUERY_MAX_LEN);
+  const limit = Math.min(
+    Math.max(options.limitPerGroup ?? SEARCH_GROUP_LIMIT_DEFAULT, 1),
+    SEARCH_GROUP_LIMIT_MAX
+  );
+
+  if (query.length === 0) {
+    return {
+      query,
+      groups: {
+        cards: { ...EMPTY_GROUP, items: [] },
+        mandalas: { ...EMPTY_GROUP, items: [] },
+        notes: { ...EMPTY_GROUP, items: [] },
+        summaries: { ...EMPTY_GROUP, items: [] },
+      },
+      tookMs: Date.now() - started,
+    };
+  }
+
+  const pattern = `%${escapeLikePattern(query)}%`;
+  const guarded = <T>(work: Promise<SearchGroup<T>>, group: string): Promise<SearchGroup<T>> =>
+    withGroupTimeout(
+      work.catch((err) => {
+        logger.warn('[global-search] group query failed (degraded)', {
+          group,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return { items: [] as T[], total: 0, partial: true };
+      })
+    );
+
+  const [cards, mandalas, notes, summaries] = await Promise.all([
+    guarded(searchCards(userId, pattern, query, limit), 'cards'),
+    guarded(searchMandalas(userId, pattern, limit), 'mandalas'),
+    guarded(searchNotes(userId, pattern, query, limit), 'notes'),
+    guarded(searchSummaries(userId, pattern, limit), 'summaries'),
+  ]);
+
+  return { query, groups: { cards, mandalas, notes, summaries }, tookMs: Date.now() - started };
+}

--- a/tests/unit/modules/global-search.test.ts
+++ b/tests/unit/modules/global-search.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Global search (⌘K) Phase 1 — pure helper unit tests.
+ * DB-hitting group queries are covered by the prod verification step
+ * (design doc §4); these tests pin the injectable/pure surface.
+ */
+import {
+  escapeLikePattern,
+  extractTiptapText,
+  makeSnippet,
+  mergeCardHits,
+  withGroupTimeout,
+  globalSearch,
+  type CardHit,
+} from '../../../src/modules/search/global-search';
+
+const cardHit = (over: Partial<CardHit>): CardHit => ({
+  kind: 'video',
+  id: 'id',
+  title: null,
+  channelTitle: null,
+  thumbnailUrl: null,
+  url: null,
+  videoId: null,
+  note: null,
+  mandalaId: null,
+  cellIndex: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  ...over,
+});
+
+describe('escapeLikePattern', () => {
+  it('escapes %, _ and backslash so user input matches literally', () => {
+    expect(escapeLikePattern('100%_done\\x')).toBe('100\\%\\_done\\\\x');
+  });
+
+  it('leaves plain korean/english text untouched', () => {
+    expect(escapeLikePattern('수동태 grammar')).toBe('수동태 grammar');
+  });
+});
+
+describe('extractTiptapText', () => {
+  it('walks nested TipTap doc collecting text nodes in order', () => {
+    const doc = {
+      type: 'doc',
+      content: [
+        { type: 'heading', content: [{ type: 'text', text: '수동태 정리' }] },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'be동사 +' },
+            { type: 'text', text: '과거분사' },
+          ],
+        },
+      ],
+    };
+    expect(extractTiptapText(doc)).toContain('수동태 정리');
+    expect(extractTiptapText(doc)).toContain('과거분사');
+  });
+
+  it('returns empty string for null/primitive input', () => {
+    expect(extractTiptapText(null)).toBe('');
+    expect(extractTiptapText('raw')).toBe('');
+  });
+});
+
+describe('makeSnippet', () => {
+  it('centers the snippet on the first case-insensitive hit with ellipses', () => {
+    const text = `${'a'.repeat(200)} 수동태 핵심 정리 ${'b'.repeat(200)}`;
+    const snip = makeSnippet(text, '수동태', 20);
+    expect(snip).toContain('수동태');
+    expect(snip.startsWith('…')).toBe(true);
+    expect(snip.endsWith('…')).toBe(true);
+    expect(snip.length).toBeLessThan(80);
+  });
+
+  it('falls back to a head slice when the query is not present', () => {
+    expect(makeSnippet('short text', 'absent', 30)).toBe('short text');
+  });
+});
+
+describe('mergeCardHits', () => {
+  it('ranks title matches above note-only matches, then by recency, capped at limit', () => {
+    const hits = [
+      cardHit({ id: 'note-only', note: '수동태 메모', createdAt: '2026-06-30T00:00:00.000Z' }),
+      cardHit({ id: 'title-old', title: '수동태 개념', createdAt: '2026-01-02T00:00:00.000Z' }),
+      cardHit({ id: 'title-new', title: '수동태 끝내기', createdAt: '2026-06-01T00:00:00.000Z' }),
+    ];
+    const merged = mergeCardHits(hits, '수동태', 2);
+    expect(merged.map((h) => h.id)).toEqual(['title-new', 'title-old']);
+  });
+});
+
+describe('withGroupTimeout', () => {
+  it('returns the group result when it beats the budget', async () => {
+    const group = Promise.resolve({ items: [1], total: 1, partial: false });
+    await expect(withGroupTimeout(group, 200)).resolves.toEqual({
+      items: [1],
+      total: 1,
+      partial: false,
+    });
+  });
+
+  it('yields empty + partial:true when the group misses the budget', async () => {
+    const never = new Promise<{ items: number[]; total: number; partial: boolean }>(() => {});
+    await expect(withGroupTimeout(never, 20)).resolves.toEqual({
+      items: [],
+      total: 0,
+      partial: true,
+    });
+  });
+});
+
+describe('globalSearch — empty query guard', () => {
+  it('returns all-empty groups without touching the DB when q trims to empty', async () => {
+    const result = await globalSearch('00000000-0000-0000-0000-000000000000', '   ');
+    expect(result.groups.cards).toEqual({ items: [], total: 0, partial: false });
+    expect(result.groups.mandalas.items).toEqual([]);
+    expect(result.groups.notes.items).toEqual([]);
+    expect(result.groups.summaries.items).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
PR-2 of the global search track (design: `docs/design/global-search-cmdk-2026-07-02.md`; BE = #1043). Centered ⌘K command palette, claude.ai reference layout.

- **widgets/command-palette** (NEW): Radix Dialog modal — input → Quick actions (new mandala / find templates) when empty → grouped results (cards / mandalas / notes / summaries) with per-group totals + honest partial flags → footer keyboard hints. ↑↓/↵/esc navigation.
- **AppShell mount**: Cmd/Ctrl+K now works on EVERY authenticated route (was an IndexPage-only inline focus binding). DndContext hierarchy untouched (dnd smoke green).
- **SearchBar**: old ⌘K listener removed (palette owns the hotkey); inline sidebar search behavior unchanged; stale "(⌘K)" placeholder hint dropped (ko/en).
- **Navigation (Q3)**: card hit → switch mandala + `pendingCardHighlight` handoff (transient store field, non-persisted) → IndexPage scrolls + rings the card. Summary hit → `/learning/:mandalaId/:videoId` deep link. Note hit → mandala (learning deep-link needs videoId — Phase 2).

## Verification
| Gate | Result |
|---|---|
| FE tsc / vitest / build | 0 / **472/472** (incl. dnd smoke + 4 new palette cases) / OK |
| Browser (dev, real DB) | palette opens on the **learning route**; "영어" → cards 18 / mandalas 7 rendered (API 200); card click → mandala switched + card scrolled into view; console 0 errors |
| Contract | searchAll already covered by api-url-contract (PR-1) |

## Rollback
Single revert — palette unmount restores previous behavior; inline search untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)