### PR TITLE
polish(search): palette chrome + unified sidebar trigger (PR-3)

### DIFF
--- a/frontend/src/features/explore/ui/ExploreCard.tsx
+++ b/frontend/src/features/explore/ui/ExploreCard.tsx
@@ -1,5 +1,6 @@
 import { MessageSquare, Pencil, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/shared/ui/tooltip';
 import type { MandalaDomain } from '@/shared/config/domain-colors';
 import { DOMAIN_STYLES, domainCssVars, getDomainLabel } from '@/shared/config/domain-colors';
 
@@ -225,14 +226,22 @@ export function ExploreCard({
         ))}
       </div>
 
-      {/* Title (BOTTOM, line-clamp-2 강제 — `<h4>` 사용 (이전 `<span block>` 은 line-clamp 의 display:-webkit-box 를 덮어써서 영문 5줄 풀어짐)). title attribute = native browser tooltip showing full text on hover. */}
-      <h4
-        className="line-clamp-2 text-[14px] font-semibold leading-snug tracking-tight mb-3 break-keep"
-        style={{ color: 'hsl(var(--foreground))' }}
-        title={title}
-      >
-        {title}
-      </h4>
+      {/* Title (BOTTOM) — short display (centerLabel when present, else 1-line
+          clamp of the full goal); hover = custom Radix tooltip with the FULL
+          original text (user request: 짧은 레이블 + 원문 툴팁, native title 금지). */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <h4
+            className={`${centerLabel ? 'line-clamp-1' : 'line-clamp-2'} text-[14px] font-semibold leading-snug tracking-tight mb-3 break-keep`}
+            style={{ color: 'hsl(var(--foreground))' }}
+          >
+            {centerLabel ?? title}
+          </h4>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-[320px] text-xs leading-snug">
+          {title}
+        </TooltipContent>
+      </Tooltip>
 
       {/* Footer (mockup v6 — Heart/Copy meta retired; left = N people started, right = preview CTA). Owner-aware label branching is Step 2B. */}
       <div className="flex items-center justify-between text-[11.5px]">

--- a/frontend/src/features/explore/ui/ExploreExpandModal.tsx
+++ b/frontend/src/features/explore/ui/ExploreExpandModal.tsx
@@ -8,6 +8,8 @@ import { DOMAIN_STYLES, domainCssVars, getDomainLabel } from '@/shared/config/do
 interface MandalaLevel {
   centerGoal: string;
   subjects: string[];
+  /** Short display labels for the 8 action items (depth-1 subject_labels). */
+  subjectLabels?: string[];
 }
 
 interface Props {

--- a/frontend/src/pages/explore/ui/ExplorePage.tsx
+++ b/frontend/src/pages/explore/ui/ExplorePage.tsx
@@ -91,7 +91,11 @@ export default function ExplorePage() {
           const subs = levels
             .filter((l) => l.depth === 1)
             .sort((a, b) => a.position - b.position)
-            .map((l) => ({ centerGoal: l.centerGoal, subjects: l.subjects }));
+            .map((l) => ({
+              centerGoal: l.centerGoal,
+              subjects: l.subjects,
+              subjectLabels: l.subjectLabels,
+            }));
 
           setModal((prev) => ({
             ...prev,

--- a/frontend/src/pages/index/ui/IndexPage.tsx
+++ b/frontend/src/pages/index/ui/IndexPage.tsx
@@ -31,7 +31,8 @@ import { useMandalaQuery, useMandalaList } from '@/features/mandala';
 import { useMandalaStore } from '@/stores/mandalaStore';
 import { youtubeSyncKeys } from '@/features/youtube-sync/model/useYouTubeSync';
 import { localCardsKeys } from '@/features/card-management/model/useLocalCards';
-import { useSearchCards, SearchBar } from '@/features/search';
+import { useSearchCards } from '@/features/search';
+import { CommandPaletteTrigger } from '@/widgets/command-palette';
 import { useMandalaNavigation } from '../model/useMandalaNavigation';
 import { useLayoutPreferences } from '../model/useLayoutPreferences';
 import { useCardOrchestrator } from '../model/useCardOrchestrator';
@@ -931,36 +932,9 @@ function AuthenticatedApp() {
     setNewlySyncedCountByMandala(cards.newlySyncedCountByMandala);
   }, [cards.newlySyncedCountByMandala, setNewlySyncedCountByMandala]);
 
-  // searchBar — useMemo with primitive deps only
-  const searchBarMemo = useMemo(
-    () => (
-      <SearchBar
-        value={search.searchTerm}
-        onChange={search.setSearchTerm}
-        onClear={search.clearSearch}
-        isLoading={search.isLoading}
-        resultCount={search.total}
-        filteredCount={search.filteredCount}
-        isSearchActive={search.isSearchActive}
-        sourceFilter={search.sourceFilter}
-        onSourceFilterChange={search.setSourceFilter}
-        onArrowDown={() => search.moveHighlight('down')}
-        onArrowUp={() => search.moveHighlight('up')}
-        onEnter={() => {
-          const card = search.getHighlightedCard();
-          if (card) handleCardClick(card);
-        }}
-      />
-    ),
-    [
-      search.searchTerm,
-      search.isLoading,
-      search.total,
-      search.filteredCount,
-      search.isSearchActive,
-      search.sourceFilter,
-    ] // eslint-disable-line react-hooks/exhaustive-deps
-  );
+  // Sidebar search — a trigger that opens the global ⌘K palette (ONE search
+  // experience; the legacy inline SearchBar/ulc-only path is retired here).
+  const searchBarMemo = useMemo(() => <CommandPaletteTrigger />, []);
 
   useEffect(() => {
     setSearchBarElement(searchBarMemo);
@@ -1013,25 +987,9 @@ function AuthenticatedApp() {
                     : ''
                 }`}
               >
-                {/* Mobile search bar (hidden on md+, shown in header instead) */}
+                {/* Mobile search trigger (hidden on md+, shown in header instead) */}
                 <div className="md:hidden mb-3">
-                  <SearchBar
-                    value={search.searchTerm}
-                    onChange={search.setSearchTerm}
-                    onClear={search.clearSearch}
-                    isLoading={search.isLoading}
-                    resultCount={search.total}
-                    filteredCount={search.filteredCount}
-                    isSearchActive={search.isSearchActive}
-                    sourceFilter={search.sourceFilter}
-                    onSourceFilterChange={search.setSourceFilter}
-                    onArrowDown={() => search.moveHighlight('down')}
-                    onArrowUp={() => search.moveHighlight('up')}
-                    onEnter={() => {
-                      const card = search.getHighlightedCard();
-                      if (card) handleCardClick(card);
-                    }}
-                  />
+                  <CommandPaletteTrigger />
                 </div>
                 {layout.viewMode === 'insights' ? (
                   <InsightsView

--- a/frontend/src/pages/templates/ui/TemplatesPage.tsx
+++ b/frontend/src/pages/templates/ui/TemplatesPage.tsx
@@ -90,7 +90,11 @@ export default function TemplatesPage() {
         const subs = levels
           .filter((l) => l.depth === 1)
           .sort((a, b) => a.position - b.position)
-          .map((l) => ({ centerGoal: l.centerGoal, subjects: l.subjects }));
+          .map((l) => ({
+            centerGoal: l.centerGoal,
+            subjects: l.subjects,
+            subjectLabels: l.subjectLabels,
+          }));
 
         setModal((prev) => ({
           ...prev,

--- a/frontend/src/widgets/app-shell/ui/SidebarTopSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarTopSection.tsx
@@ -3,8 +3,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { CirclePlus, ChevronDown, ChevronUp, Compass, PanelLeft, Search } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from '@/shared/ui/popover';
-import { Dialog, DialogContent } from '@/shared/ui/dialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
+import { openCommandPalette } from '@/widgets/command-palette';
 import { SidebarSkillPanel } from '@/widgets/sidebar-skill-panel';
 import { useMandalaStore } from '@/stores/mandalaStore';
 
@@ -24,8 +24,7 @@ export function SidebarTopSection({
   const { t } = useTranslation();
   const navigate = useNavigate();
   const selectedMandalaId = useMandalaStore((s) => s.selectedMandalaId);
-  // CP441 — collapsed search opens a centered modal (ChatGPT pattern).
-  const [searchDialogOpen, setSearchDialogOpen] = useState(false);
+  // Collapsed search icon opens the global ⌘K CommandPalette (one search UX).
   // CP446 — expanded "more" Popover uses controlled open state so the chevron
   // can toggle (ChevronDown ↔ ChevronUp).
   const [moreOpen, setMoreOpen] = useState(false);
@@ -98,26 +97,21 @@ export function SidebarTopSection({
         </Tooltip>
 
         {searchBarElement && (
-          <>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={() => setSearchDialogOpen(true)}
-                  aria-label={t('sidebar.searchPlaceholder', '검색 (⌘K)')}
-                  className={iconBtn}
-                >
-                  <Search className="w-5 h-5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="right" sideOffset={8}>
-                {t('sidebar.searchPlaceholder', '검색 (⌘K)')}
-              </TooltipContent>
-            </Tooltip>
-            <Dialog open={searchDialogOpen} onOpenChange={setSearchDialogOpen}>
-              <DialogContent className="max-w-xl p-4">{searchBarElement}</DialogContent>
-            </Dialog>
-          </>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={openCommandPalette}
+                aria-label={t('sidebar.searchPlaceholder', '검색 (⌘K)')}
+                className={iconBtn}
+              >
+                <Search className="w-5 h-5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right" sideOffset={8}>
+              {t('sidebar.searchPlaceholder', '검색 (⌘K)')}
+            </TooltipContent>
+          </Tooltip>
         )}
 
         <Popover>

--- a/frontend/src/widgets/command-palette/index.ts
+++ b/frontend/src/widgets/command-palette/index.ts
@@ -1,1 +1,3 @@
 export { CommandPalette } from './ui/CommandPalette';
+export { CommandPaletteTrigger } from './ui/CommandPaletteTrigger';
+export { openCommandPalette } from './model/palette-controller';

--- a/frontend/src/widgets/command-palette/model/palette-controller.ts
+++ b/frontend/src/widgets/command-palette/model/palette-controller.ts
@@ -1,0 +1,17 @@
+/**
+ * Module-level open-controller for the ⌘K CommandPalette — lets any surface
+ * (sidebar trigger, collapsed icon) open the palette without prop drilling.
+ * Same module-level-ref pattern as shellStore.dndHandlersRef.
+ */
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+export function openCommandPalette(): void {
+  listeners.forEach((l) => l());
+}
+
+export function subscribePaletteOpen(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/frontend/src/widgets/command-palette/ui/CommandPalette.tsx
+++ b/frontend/src/widgets/command-palette/ui/CommandPalette.tsx
@@ -253,7 +253,8 @@ export function CommandPalette() {
       <DialogContent
         // Palette chrome — elevated popover surface, larger radius, deep shadow,
         // built-in dialog X hidden ([&>button]:hidden targets the direct child).
-        className="max-w-xl p-0 gap-0 overflow-hidden top-[18%] translate-y-0 rounded-xl border-border/40 bg-popover shadow-2xl [&>button]:hidden"
+        // Width matched to the claude.ai ⌘K reference (~768px measured).
+        className="max-w-3xl p-0 gap-0 overflow-hidden top-[18%] translate-y-0 rounded-xl border-border/40 bg-popover shadow-2xl [&>button]:hidden"
         aria-describedby={undefined}
       >
         <DialogTitle className="sr-only">{t('palette.title', '검색 및 빠른 작업')}</DialogTitle>
@@ -281,7 +282,11 @@ export function CommandPalette() {
         </div>
 
         {/* Rows */}
-        <div ref={listRef} className="max-h-[50vh] overflow-y-auto py-1.5" role="listbox">
+        <div
+          ref={listRef}
+          className="max-h-[50vh] overflow-y-auto py-1.5 scrollbar-pro"
+          role="listbox"
+        >
           {rows.length === 0 && isActive && !isLoading && (
             <div className="px-4 py-8 text-center text-sm text-muted-foreground">
               {t('palette.empty', '결과가 없습니다')}

--- a/frontend/src/widgets/command-palette/ui/CommandPalette.tsx
+++ b/frontend/src/widgets/command-palette/ui/CommandPalette.tsx
@@ -35,6 +35,7 @@ import type {
   GlobalSearchSummaryHit,
 } from '@/shared/lib/api-client';
 import { useGlobalSearch } from '../model/useGlobalSearch';
+import { subscribePaletteOpen } from '../model/palette-controller';
 
 /** One flat keyboard-navigable row (quick action or search hit). */
 interface PaletteRow {
@@ -75,6 +76,9 @@ export function CommandPalette() {
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
   }, [isLoggedIn]);
+
+  // External open requests (sidebar trigger / collapsed icon).
+  useEffect(() => subscribePaletteOpen(() => setOpen(true)), []);
 
   // Reset transient state whenever the palette closes.
   useEffect(() => {
@@ -247,13 +251,16 @@ export function CommandPalette() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent
-        className="max-w-xl p-0 gap-0 overflow-hidden top-[20%] translate-y-0"
+        // Palette chrome — elevated popover surface, larger radius, deep shadow,
+        // built-in dialog X hidden ([&>button]:hidden targets the direct child).
+        className="max-w-xl p-0 gap-0 overflow-hidden top-[18%] translate-y-0 rounded-xl border-border/40 bg-popover shadow-2xl [&>button]:hidden"
         aria-describedby={undefined}
       >
         <DialogTitle className="sr-only">{t('palette.title', '검색 및 빠른 작업')}</DialogTitle>
 
-        {/* Input row */}
-        <div className="flex items-center gap-2 px-4 h-12 border-b border-border/50">
+        {/* Input row — seamless (no inner box); the global input:focus-visible
+            ring (app/styles/index.css:328) is suppressed for the palette. */}
+        <div className="flex items-center gap-2.5 px-4 h-[52px] border-b border-border/40">
           <Search className="w-4 h-4 shrink-0 text-muted-foreground" aria-hidden="true" />
           <input
             autoFocus
@@ -265,7 +272,7 @@ export function CommandPalette() {
             }}
             onKeyDown={handleKeyDown}
             placeholder={t('palette.placeholder', '카드, 만다라, 노트, 요약 검색…')}
-            className="flex-1 h-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+            className="flex-1 h-full bg-transparent text-[15px] text-foreground placeholder:text-muted-foreground focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
             role="combobox"
             aria-expanded={rows.length > 0}
             aria-haspopup="listbox"
@@ -327,11 +334,29 @@ export function CommandPalette() {
           })}
         </div>
 
-        {/* Footer hints */}
-        <div className="flex items-center gap-3 px-4 h-9 border-t border-border/50 text-[11px] text-muted-foreground">
-          <span>↑↓ {t('palette.hintSelect', '선택')}</span>
-          <span>↵ {t('palette.hintOpen', '이동')}</span>
-          <span>esc {t('palette.hintClose', '닫기')}</span>
+        {/* Footer hints — keycap chips (claude.ai reference) */}
+        <div className="flex items-center gap-4 px-4 h-10 border-t border-border/40 text-[11px] text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <kbd className="px-1 py-0.5 min-w-[18px] text-center rounded border border-border/50 bg-muted/40 text-[10px] font-mono leading-none">
+              ↑
+            </kbd>
+            <kbd className="px-1 py-0.5 min-w-[18px] text-center rounded border border-border/50 bg-muted/40 text-[10px] font-mono leading-none">
+              ↓
+            </kbd>
+            {t('palette.hintSelect', '선택')}
+          </span>
+          <span className="flex items-center gap-1.5">
+            <kbd className="px-1 py-0.5 min-w-[18px] text-center rounded border border-border/50 bg-muted/40 text-[10px] font-mono leading-none">
+              ↵
+            </kbd>
+            {t('palette.hintOpen', '이동')}
+          </span>
+          <span className="flex items-center gap-1.5">
+            <kbd className="px-1.5 py-0.5 rounded border border-border/50 bg-muted/40 text-[10px] font-mono leading-none">
+              esc
+            </kbd>
+            {t('palette.hintClose', '닫기')}
+          </span>
         </div>
       </DialogContent>
     </Dialog>

--- a/frontend/src/widgets/command-palette/ui/CommandPalette.tsx
+++ b/frontend/src/widgets/command-palette/ui/CommandPalette.tsx
@@ -152,7 +152,9 @@ export function CommandPalette() {
           title: t('palette.actionTemplates', '템플릿 찾기'),
           icon: <Compass className="w-4 h-4" />,
           run: () => {
-            navigate('/templates');
+            // Same destination as the sidebar 템플릿 찾기 menu (in-app explore,
+            // NOT the /templates marketing page) — user-reported mismatch.
+            navigate('/explore');
             close();
           },
         }

--- a/frontend/src/widgets/command-palette/ui/CommandPaletteTrigger.tsx
+++ b/frontend/src/widgets/command-palette/ui/CommandPaletteTrigger.tsx
@@ -1,0 +1,26 @@
+/**
+ * Sidebar search trigger — an input-look button that opens the ⌘K palette.
+ * Replaces the legacy inline SearchBar (ulc-only search) so there is ONE
+ * consistent search experience (claude.ai pattern).
+ */
+import { Search } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { openCommandPalette } from '../model/palette-controller';
+
+export function CommandPaletteTrigger() {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      onClick={openCommandPalette}
+      className="w-full h-9 flex items-center gap-2 pl-2 pr-2 rounded-md bg-sidebar-foreground/[0.06] text-[13px] text-muted-foreground hover:bg-sidebar-foreground/[0.1] transition-colors duration-150"
+      aria-label={t('palette.title', '검색 및 빠른 작업')}
+    >
+      <Search className="w-4 h-4 shrink-0" aria-hidden="true" />
+      <span className="flex-1 text-left truncate">{t('search.placeholder', '카드 검색...')}</span>
+      <kbd className="shrink-0 px-1.5 py-0.5 rounded border border-border/50 bg-muted/40 text-[10px] font-mono leading-none">
+        ⌘K
+      </kbd>
+    </button>
+  );
+}

--- a/frontend/src/widgets/mandala-full-preview/ui/MandalaFullPreview.tsx
+++ b/frontend/src/widgets/mandala-full-preview/ui/MandalaFullPreview.tsx
@@ -12,12 +12,15 @@
  */
 
 import { useState } from 'react';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/shared/ui/tooltip';
 import type { MandalaDomain } from '@/shared/config/domain-colors';
 import { DOMAIN_STYLES } from '@/shared/config/domain-colors';
 
 interface MandalaLevel {
   centerGoal: string;
   subjects: string[];
+  /** Short display labels for the 8 action items (depth-1 subject_labels). */
+  subjectLabels?: string[];
 }
 
 interface Props {
@@ -141,8 +144,10 @@ function buildCells(
           let fullBlockCells: string[];
 
           if (sub) {
-            blockCells = [...sub.subjects.slice(0, 4), subLabelName, ...sub.subjects.slice(4)];
-            // sub-center 자리 = subGoalName (full), ring 1+ = sub.subjects (이미 full)
+            // Action items: short labels when the level provides them, full text otherwise.
+            const subDisplay = sub.subjectLabels?.length === 8 ? sub.subjectLabels : sub.subjects;
+            blockCells = [...subDisplay.slice(0, 4), subLabelName, ...subDisplay.slice(4)];
+            // sub-center 자리 = subGoalName (full), ring 1+ = sub.subjects (원본 full)
             fullBlockCells = [...sub.subjects.slice(0, 4), subGoalName, ...sub.subjects.slice(4)];
           } else {
             blockCells = ['', '', '', '', subLabelName, '', '', '', ''];
@@ -421,7 +426,9 @@ export function MandalaFullPreview({
             ? { background: 'hsl(var(--muted) / 0.4)', opacity: 1, zIndex: 5, position: 'relative' }
             : {};
 
-          return (
+          // Custom Radix tooltip (NOT native title) showing the full original
+          // text whenever the displayed label differs from it.
+          const cellEl = (
             <div
               key={i}
               className={getCellClass(cell)}
@@ -432,7 +439,6 @@ export function MandalaFullPreview({
                 ...flyStyle,
                 ...hoverLinkStyle,
               }}
-              title={cell.goal}
               onClick={() => handleCellClick(cell)}
               onMouseEnter={() =>
                 cell.blockIdx !== -1 ? setHoveredBlock(cell.blockIdx) : undefined
@@ -442,6 +448,25 @@ export function MandalaFullPreview({
               {cell.text}
             </div>
           );
+          // Tooltip when the display differs from the original OR the original
+          // is long enough that the tiny cell clips it (labels for depth-1
+          // action items are absent fleet-wide today — 8/17,852 measured —
+          // so the length branch is what fires for ring cells until a label
+          // backfill lands).
+          const CLIP_LIKELY_LEN = 12;
+          if (cell.goal && (cell.goal !== cell.text || cell.goal.length >= CLIP_LIKELY_LEN)) {
+            return (
+              <Tooltip key={i}>
+                <TooltipTrigger asChild>{cellEl}</TooltipTrigger>
+                {/* z-[300]: the explore modal overlay sits at z-[200]; the shared
+                    TooltipContent default z-50 would render BEHIND it. */}
+                <TooltipContent side="top" className="z-[300] max-w-[280px] text-xs leading-snug">
+                  {cell.goal}
+                </TooltipContent>
+              </Tooltip>
+            );
+          }
+          return cellEl;
         })}
       </div>
     </div>


### PR DESCRIPTION
## Summary
Design feedback round on the shipped ⌘K palette (#1045), James-reported:

1. **"배경이 촌스럽다"** → elevated popover surface, `rounded-xl`, deep shadow, built-in dialog X hidden, seamless input row (no inner box).
2. **"보라색 하이라이트 제거"** → root-caused to the global `input:focus-visible` rule (`app/styles/index.css:328`, `ring-primary/50`); suppressed on the palette input only (global rule untouched).
3. **"아이콘 개선 (claude.ai 참조)"** → footer hints as keycap `<kbd>` chips (↑ ↓ / ↵ / esc).
4. **"인라인 검색과 일관성"** → legacy inline SearchBar (the ulc-only R1 bug surface) retired from IndexPage; sidebar search = `CommandPaletteTrigger` (input-look button + ⌘K keycap) opening the palette; collapsed sidebar search icon opens it too (module-level `palette-controller`, same pattern as `dndHandlersRef`). ONE search experience.

## Verification
- Dev browser: trigger click + ⌘K both open the restyled palette; no purple ring; keycap footer renders; consistency confirmed.
- FE tsc 0 / lint 0 / vitest **472/472** / vite build OK.

## Rollback
Single revert (SearchBar component itself untouched — only its IndexPage usage swapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)