### PR TITLE
feat(collector): W3 goal-driven collection source (popular_goals run type)

### DIFF
--- a/src/skills/plugins/batch-video-collector/__tests__/goal-source.test.ts
+++ b/src/skills/plugins/batch-video-collector/__tests__/goal-source.test.ts
@@ -1,0 +1,45 @@
+import { loadGoalKeywords } from '../sources/goal-source';
+
+type Row = { keyword: string; language: string | null; domain: string | null; freq: number };
+
+function mockDb(rows: Row[]): any {
+  return { $queryRawUnsafe: jest.fn().mockResolvedValue(rows) };
+}
+
+describe('loadGoalKeywords (W3 goal-driven source)', () => {
+  it('maps cell sub-goals to TrendKeyword shape and normalizes score by top freq', async () => {
+    const out = await loadGoalKeywords(
+      mockDb([
+        { keyword: 'ETF 투자로 노후 준비', language: 'ko', domain: 'finance', freq: 4 },
+        { keyword: '쿠버네티스 상용 운영', language: null, domain: null, freq: 2 },
+      ]),
+      10
+    );
+    expect(out[0]).toMatchObject({
+      keyword: 'ETF 투자로 노후 준비',
+      language: 'ko',
+      domain: 'finance',
+      trendSource: 'popular_goals',
+      score: 1,
+    });
+    // null language -> 'ko', null domain -> 'goal', freq 2/4 -> score 0.5
+    expect(out[1]).toMatchObject({ language: 'ko', domain: 'goal', score: 0.5 });
+  });
+
+  it('dedups by (keyword, language) case-insensitively and respects limit', async () => {
+    const rows: Row[] = [
+      { keyword: 'Master algorithm patterns', language: 'ko', domain: null, freq: 3 },
+      { keyword: 'master algorithm patterns', language: 'ko', domain: null, freq: 2 }, // dup
+      { keyword: 'Bond and rate markets', language: 'ko', domain: null, freq: 1 },
+    ];
+    expect((await loadGoalKeywords(mockDb(rows), 10)).length).toBe(2);
+    expect((await loadGoalKeywords(mockDb(rows), 1)).length).toBe(1);
+  });
+
+  it('drops too-short goals and returns empty for no rows', async () => {
+    expect(await loadGoalKeywords(mockDb([]), 10)).toEqual([]);
+    expect(
+      await loadGoalKeywords(mockDb([{ keyword: 'ab', language: 'ko', domain: null, freq: 9 }]), 10)
+    ).toEqual([]);
+  });
+});

--- a/src/skills/plugins/batch-video-collector/executor.ts
+++ b/src/skills/plugins/batch-video-collector/executor.ts
@@ -37,6 +37,7 @@ import {
   BATCH_COLLECTOR_SEARCH_PARALLELISM,
 } from './manifest';
 import { loadTrendKeywords, type TrendKeyword } from './sources/trend-source';
+import { loadGoalKeywords } from './sources/goal-source';
 import { classifyQuality, type QualityTier } from './quality';
 import {
   searchVideos,
@@ -61,6 +62,10 @@ const log = logger.child({ module: 'batch-video-collector' });
 
 const DESC_SNIPPET_LEN = 200;
 const DEFAULT_RUN_TYPE = 'daily_trend';
+/** W3 — goal-driven run type: keywords come from user mandala cell sub-goals
+ *  (goal-source) instead of trend_signals. Set BATCH_COLLECTOR_RUN_TYPE to this
+ *  to collect for the topics users actually asked for. */
+const GOAL_RUN_TYPE = 'popular_goals';
 
 interface HydratedState {
   apiKeys: string[];
@@ -160,12 +165,20 @@ export const executor: SkillExecutor = {
     let quotaExhausted = false;
 
     try {
-      // 2. Load trend keywords
-      const keywords = await loadTrendKeywords(db, state.limit, { offset: state.offset });
+      // 2. Load keywords — trend signals (Source A) or, for the goal-driven
+      //    run type (W3), user mandala cell sub-goals (Source B). Same shape,
+      //    so the search → gate → embed → upsert flow below is unchanged.
+      const keywords =
+        state.runType === GOAL_RUN_TYPE
+          ? await loadGoalKeywords(db, state.limit)
+          : await loadTrendKeywords(db, state.limit, { offset: state.offset });
       if (keywords.length === 0) {
         await finalizeRun(db, run.id, {
           status: 'failed',
-          error: 'No trend keywords available (trend_signals empty or all expired)',
+          error:
+            state.runType === GOAL_RUN_TYPE
+              ? 'No goal keywords available (no mandala cell sub-goals)'
+              : 'No trend keywords available (trend_signals empty or all expired)',
           queriesExecuted: 0,
           videosFound: 0,
           videosNew: 0,

--- a/src/skills/plugins/batch-video-collector/sources/goal-source.ts
+++ b/src/skills/plugins/batch-video-collector/sources/goal-source.ts
@@ -1,0 +1,84 @@
+/**
+ * batch-video-collector — Source B: goal keywords (W3, goal-driven collection).
+ *
+ * WHY: the pool is filled by Source A (trend keywords), so a user-goal topic
+ * that isn't currently trending — middle-school English grammar, Kubernetes,
+ * coding-challenge prep — never gets collected, and those mandalas stay
+ * content-starved (measured 2026-07-02: grammar 1 pool video, k8s 15, vs
+ * finance 673; gc tracks topic coverage). This source turns the actual user
+ * mandala CELL SUB-GOALS into collection queries, so we go get the content
+ * users are asking for. Ordered by frequency (popular goals first) so the
+ * daily quota lands on the goals the most mandalas share.
+ *
+ * Returns the SAME `TrendKeyword` shape as Source A, so the executor's
+ * search → quality-gate → embed → upsert flow is reused unchanged; only the
+ * keyword source differs (run_type='popular_goals' → this loader).
+ */
+
+import type { PrismaClient } from '@prisma/client';
+
+import { logger } from '@/utils/logger';
+import type { TrendKeyword } from './trend-source';
+
+const log = logger.child({ module: 'batch-video-collector/goal-source' });
+
+const DEFAULT_DOMAIN = 'goal';
+const DEFAULT_LANGUAGE = 'ko';
+const MIN_GOAL_LEN = 3;
+
+interface GoalRow {
+  keyword: string;
+  language: string | null;
+  domain: string | null;
+  freq: number | bigint;
+}
+
+/**
+ * Load up to `limit` distinct user cell sub-goals as collection keywords,
+ * ordered by how many cells share the goal (popular first). Deduped by
+ * (keyword, language). `score` is the share-frequency normalized to [0, 1].
+ */
+export async function loadGoalKeywords(db: PrismaClient, limit: number): Promise<TrendKeyword[]> {
+  // Over-fetch for dedup headroom, cap the DB work.
+  const fetchCount = Math.max(limit * 3, 50);
+  // mandala_embeddings.mandala_id is TEXT; user_mandalas.id is UUID → cast.
+  const rows = await db.$queryRawUnsafe<GoalRow[]>(`
+    SELECT
+      me.sub_goal AS keyword,
+      min(um.language) AS language,
+      min(um.domain) AS domain,
+      count(*)::int AS freq
+    FROM mandala_embeddings me
+    JOIN user_mandalas um ON um.id::text = me.mandala_id
+    WHERE me.level = 1
+      AND me.sub_goal IS NOT NULL
+      AND length(trim(me.sub_goal)) > ${MIN_GOAL_LEN}
+    GROUP BY me.sub_goal
+    ORDER BY freq DESC
+    LIMIT ${fetchCount}
+  `);
+
+  const maxFreq = rows.length > 0 ? Number(rows[0]!.freq) : 1;
+  const seen = new Set<string>();
+  const out: TrendKeyword[] = [];
+  for (const r of rows) {
+    const keyword = r.keyword.trim();
+    const language = r.language?.trim() || DEFAULT_LANGUAGE;
+    const key = `${language}::${keyword.toLowerCase()}`;
+    if (keyword.length <= MIN_GOAL_LEN || seen.has(key)) continue;
+    seen.add(key);
+    out.push({
+      keyword,
+      language,
+      domain: r.domain?.trim() || DEFAULT_DOMAIN,
+      trendSource: 'popular_goals',
+      score: maxFreq > 0 ? Number(r.freq) / maxFreq : 0,
+    });
+    if (out.length >= limit) break;
+  }
+
+  log.info(
+    `loaded ${out.length} goal keywords (from ${rows.length} raw cell-goals, limit ${limit})`
+  );
+  return out;
+}


### PR DESCRIPTION
## W3 — goal-driven collection (the root-cause fix for content-starved mandalas)

**Code only. Merging is safe (adds an unused run type); RUNNING it spends YouTube quota = James decision.**

### Root cause (measured this session)
The pool is filled ONLY by trend keywords (Source A). A user-goal topic that isn't trending — English grammar, Kubernetes, coding-challenge prep — never gets collected, so those mandalas stay content-starved. Measured: grammar **1** pool video, k8s **15**, vs finance **673** — and gc (search quality) tracks topic coverage. This is *the* root cause behind the weak mandalas; W2 (precision) + supply (backfill/flip) don't fix a topic the pool simply lacks.

### Change
- **goal-source.ts** `loadGoalKeywords(db, limit)` — distinct level-1 cell sub-goals, ordered by share-frequency (popular first), deduped `(keyword, language)`, returned in the SAME `TrendKeyword` shape as Source A. Query validated read-only on prod (returns real goals: ETF / networking / deploy-monitoring / …).
- **executor.ts** — `run_type='popular_goals'` → `loadGoalKeywords`; else `loadTrendKeywords`. The search → quality-gate → embed → upsert flow is **reused unchanged**.
- **goal-source.test.ts** — jest unit tests (shape map / score normalize / dedup / limit / short-drop / empty).

### Scope / safety
- Code only, **no run**. Trend collection path is untouched (default run type unchanged).
- Running = set `BATCH_COLLECTOR_RUN_TYPE=popular_goals` + trigger the collector. That spends `search.list` quota (~ up to the distinct-goal count) → **James's decision on scale/quota/priority** (recommend: start small, deficit-cell / most-popular goals first).
- tsc clean. Unit test mirrors the passing trend-source test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)