### PR TITLE
feat(add-cards): hover preview — official YouTube still-frame cycle (no iframe)

### DIFF
--- a/frontend/src/__tests__/hover-frame-thumbnail.test.tsx
+++ b/frontend/src/__tests__/hover-frame-thumbnail.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * HoverFrameThumbnail — hover starts the official-still-frame cycle after a
+ * delay; leaving snaps back to the original thumbnail (no iframe, by design).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { HoverFrameThumbnail } from '@/shared/ui/hover-frame-thumbnail';
+
+const THUMB = 'https://i.ytimg.com/vi/abc123/hqdefault.jpg';
+
+const getImg = (container: HTMLElement) => container.querySelector('img') as HTMLImageElement;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('HoverFrameThumbnail', () => {
+  it('shows the original thumbnail when inactive', () => {
+    const { container } = render(
+      <HoverFrameThumbnail videoId="abc123" thumbnail={THUMB} active={false} />
+    );
+    expect(getImg(container).src).toBe(THUMB);
+  });
+
+  it('starts cycling frames only after the hover delay, then advances', () => {
+    vi.useFakeTimers();
+    const { container } = render(
+      <HoverFrameThumbnail videoId="abc123" thumbnail={THUMB} active={true} />
+    );
+    // Before the delay: still the original (incidental sweep protection).
+    act(() => vi.advanceTimersByTime(200));
+    expect(getImg(container).src).toBe(THUMB);
+    // After delay: frame 1.
+    act(() => vi.advanceTimersByTime(150));
+    expect(getImg(container).src).toContain('/vi/abc123/1.jpg');
+    // After one interval: frame 2.
+    act(() => vi.advanceTimersByTime(700));
+    expect(getImg(container).src).toContain('/vi/abc123/2.jpg');
+    // Wraps 3 → 1.
+    act(() => vi.advanceTimersByTime(1400));
+    expect(getImg(container).src).toContain('/vi/abc123/1.jpg');
+  });
+
+  it('snaps back to the original thumbnail when deactivated', () => {
+    vi.useFakeTimers();
+    const { container, rerender } = render(
+      <HoverFrameThumbnail videoId="abc123" thumbnail={THUMB} active={true} />
+    );
+    act(() => vi.advanceTimersByTime(1100)); // 300 delay + 800 → one interval passed = frame 2
+    expect(getImg(container).src).toContain('/2.jpg');
+    rerender(<HoverFrameThumbnail videoId="abc123" thumbnail={THUMB} active={false} />);
+    expect(getImg(container).src).toBe(THUMB);
+  });
+
+  it('never cycles without a videoId', () => {
+    vi.useFakeTimers();
+    const { container } = render(
+      <HoverFrameThumbnail videoId={null} thumbnail={THUMB} active={true} />
+    );
+    act(() => vi.advanceTimersByTime(3000));
+    expect(getImg(container).src).toBe(THUMB);
+  });
+});

--- a/frontend/src/shared/ui/hover-frame-thumbnail.tsx
+++ b/frontend/src/shared/ui/hover-frame-thumbnail.tsx
@@ -1,0 +1,79 @@
+/**
+ * HoverFrameThumbnail — lightweight YouTube hover preview (NOT an iframe).
+ *
+ * While `active`, cycles through YouTube's official per-video still frames
+ * (i.ytimg.com/vi/{id}/1.jpg → 2.jpg → 3.jpg ≈ early/mid/late scenes,
+ * ~10-20KB each) to give a "moving preview" feel; on leave it snaps back to
+ * the original thumbnail. Chosen over an iframe player on purpose: a real
+ * player costs ~2-3MB JS + stream buffering per hover — wrong for a panel
+ * the user sweep-scans (design decision, 2026-07-02).
+ */
+import { useEffect, useState } from 'react';
+import { handleThumbnailError, handleThumbnailLoad } from '@/shared/lib/image-utils';
+
+/** Delay before the cycle starts — avoids firing on incidental sweeps. */
+const HOVER_START_DELAY_MS = 300;
+/** Per-frame dwell time. */
+const FRAME_INTERVAL_MS = 700;
+/** YouTube official still-frame indices (1=early, 2=mid, 3=late). */
+const FRAME_INDICES = [1, 2, 3] as const;
+
+interface Props {
+  videoId: string | null | undefined;
+  thumbnail: string;
+  active: boolean;
+  className?: string;
+}
+
+export function HoverFrameThumbnail({ videoId, thumbnail, active, className }: Props) {
+  // -1 = original thumbnail; 0..2 = FRAME_INDICES cursor.
+  const [frame, setFrame] = useState(-1);
+
+  useEffect(() => {
+    if (!active || !videoId) {
+      setFrame(-1);
+      return;
+    }
+    let cursor = 0;
+    const start = setTimeout(() => {
+      setFrame(0);
+      cursor = 0;
+      intervalId = setInterval(() => {
+        cursor = (cursor + 1) % FRAME_INDICES.length;
+        setFrame(cursor);
+      }, FRAME_INTERVAL_MS);
+    }, HOVER_START_DELAY_MS);
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+    return () => {
+      clearTimeout(start);
+      if (intervalId) clearInterval(intervalId);
+      setFrame(-1);
+    };
+  }, [active, videoId]);
+
+  const src =
+    frame >= 0 && videoId
+      ? `https://i.ytimg.com/vi/${videoId}/${FRAME_INDICES[frame]}.jpg`
+      : thumbnail;
+
+  return (
+    <img
+      src={src}
+      alt=""
+      className={className}
+      loading="lazy"
+      decoding="async"
+      // A missing frame variant falls back to the original thumbnail
+      // (official URLs, but stay defensive) — reuses the shared handler
+      // only for the base thumbnail path.
+      onError={(e) => {
+        if (frame >= 0) {
+          (e.currentTarget as HTMLImageElement).src = thumbnail;
+        } else {
+          handleThumbnailError(e);
+        }
+      }}
+      onLoad={handleThumbnailLoad}
+    />
+  );
+}

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
@@ -24,7 +24,7 @@ import { cn } from '@/shared/lib/utils';
 import { decodeHtmlEntities } from '@/shared/lib/decode-html-entities';
 import { formatRelativeDate } from '@/shared/lib/format-date';
 import { formatDuration, formatViewCount } from '@/shared/lib/format-number';
-import { handleThumbnailError, handleThumbnailLoad } from '@/shared/lib/image-utils';
+import { HoverFrameThumbnail } from '@/shared/ui/hover-frame-thumbnail';
 import type { AddCardCandidate } from '../model/useAddCards';
 import type { AddCardsRound } from '../lib/persistence';
 
@@ -201,6 +201,9 @@ function CardItem({
   onPick: (videoId: string, title: string) => void;
 }) {
   const { t } = useTranslation();
+  // Hover frame-cycle preview (YouTube-like feel, image-only — see
+  // shared/ui/hover-frame-thumbnail.tsx for the iframe-vs-frames decision).
+  const [hovered, setHovered] = useState(false);
   // CP480+ — picked cards are now clickable to unpick (idempotent
   // toggle). Only mid-flight requests are disabled.
   const disabled = isPickPending;
@@ -224,6 +227,8 @@ function CardItem({
           onPick(card.videoId, card.title);
         }
       }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       className={cn(
         'group relative rounded-md overflow-hidden border bg-card transition-colors',
         'border-transparent',
@@ -234,15 +239,11 @@ function CardItem({
     >
       <div className="relative aspect-video bg-muted">
         {card.thumbnail && (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={card.thumbnail}
-            alt=""
+          <HoverFrameThumbnail
+            videoId={card.videoId}
+            thumbnail={card.thumbnail}
+            active={hovered}
             className="h-full w-full object-cover"
-            loading="lazy"
-            decoding="async"
-            onError={handleThumbnailError}
-            onLoad={handleThumbnailLoad}
           />
         )}
 


### PR DESCRIPTION
## Summary
YouTube-like hover preview on add-cards candidates, James-requested. On hover (300ms sweep guard) the thumbnail cycles YouTube's **official** per-video still frames (`i.ytimg.com/vi/{id}/1|2|3.jpg`, ~10-20KB each) every 700ms; mouse-out snaps back.

**Deliberately NOT an iframe player** (design decision): a real player = ~2-3MB JS + stream buffering per hover — wrong for a sweep-scanned panel of ephemeral candidates. Frames cost <50KB total, zero API quota, official URLs.

- `shared/ui/hover-frame-thumbnail.tsx` — reusable (dashboard grid can adopt later)
- `AddCardsList` CandidateCard wiring
- 4 unit tests (delay guard / cycle+wrap / snap-back / no-videoId)

## Verification
FE tsc 0 / lint 0 / vitest **476/476** (+4). Dev browser: panel opens clean, console 0 errors (live candidate hover requires a search fetch — skipped in dev to avoid burning YouTube quota; prod verify on next real panel use).

## Rollback
Single revert — additive component + one call-site swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)