### PR TITLE
fix(add-cards): hover frames use hq (480x360) variants — gray-blob fix

### DIFF
--- a/frontend/src/__tests__/hover-frame-thumbnail.test.tsx
+++ b/frontend/src/__tests__/hover-frame-thumbnail.test.tsx
@@ -32,13 +32,13 @@ describe('HoverFrameThumbnail', () => {
     expect(getImg(container).src).toBe(THUMB);
     // After delay: frame 1.
     act(() => vi.advanceTimersByTime(150));
-    expect(getImg(container).src).toContain('/vi/abc123/1.jpg');
+    expect(getImg(container).src).toContain('/vi/abc123/hq1.jpg');
     // After one interval: frame 2.
     act(() => vi.advanceTimersByTime(700));
-    expect(getImg(container).src).toContain('/vi/abc123/2.jpg');
+    expect(getImg(container).src).toContain('/vi/abc123/hq2.jpg');
     // Wraps 3 → 1.
     act(() => vi.advanceTimersByTime(1400));
-    expect(getImg(container).src).toContain('/vi/abc123/1.jpg');
+    expect(getImg(container).src).toContain('/vi/abc123/hq1.jpg');
   });
 
   it('snaps back to the original thumbnail when deactivated', () => {
@@ -47,7 +47,7 @@ describe('HoverFrameThumbnail', () => {
       <HoverFrameThumbnail videoId="abc123" thumbnail={THUMB} active={true} />
     );
     act(() => vi.advanceTimersByTime(1100)); // 300 delay + 800 → one interval passed = frame 2
-    expect(getImg(container).src).toContain('/2.jpg');
+    expect(getImg(container).src).toContain('/hq2.jpg');
     rerender(<HoverFrameThumbnail videoId="abc123" thumbnail={THUMB} active={false} />);
     expect(getImg(container).src).toBe(THUMB);
   });

--- a/frontend/src/shared/ui/hover-frame-thumbnail.tsx
+++ b/frontend/src/shared/ui/hover-frame-thumbnail.tsx
@@ -15,8 +15,13 @@ import { handleThumbnailError, handleThumbnailLoad } from '@/shared/lib/image-ut
 const HOVER_START_DELAY_MS = 300;
 /** Per-frame dwell time. */
 const FRAME_INTERVAL_MS = 700;
-/** YouTube official still-frame indices (1=early, 2=mid, 3=late). */
-const FRAME_INDICES = [1, 2, 3] as const;
+/**
+ * YouTube official still-frame variants (1=early, 2=mid, 3=late).
+ * `hq` prefix = 480×360 (~10-22KB measured). The bare `1.jpg` variants are
+ * 120×90 — upscaled into a card they look like a blurry gray blob
+ * (prod-reported 2026-07-02, measured root cause).
+ */
+const FRAME_FILES = ['hq1.jpg', 'hq2.jpg', 'hq3.jpg'] as const;
 
 interface Props {
   videoId: string | null | undefined;
@@ -39,7 +44,7 @@ export function HoverFrameThumbnail({ videoId, thumbnail, active, className }: P
       setFrame(0);
       cursor = 0;
       intervalId = setInterval(() => {
-        cursor = (cursor + 1) % FRAME_INDICES.length;
+        cursor = (cursor + 1) % FRAME_FILES.length;
         setFrame(cursor);
       }, FRAME_INTERVAL_MS);
     }, HOVER_START_DELAY_MS);
@@ -52,9 +57,7 @@ export function HoverFrameThumbnail({ videoId, thumbnail, active, className }: P
   }, [active, videoId]);
 
   const src =
-    frame >= 0 && videoId
-      ? `https://i.ytimg.com/vi/${videoId}/${FRAME_INDICES[frame]}.jpg`
-      : thumbnail;
+    frame >= 0 && videoId ? `https://i.ytimg.com/vi/${videoId}/${FRAME_FILES[frame]}` : thumbnail;
 
   return (
     <img


### PR DESCRIPTION
## Summary
Prod-reported (#1048 follow-up): hovering an add-cards candidate showed a **blurry gray box** instead of a preview.

**Measured root cause**: the bare `1|2|3.jpg` frame variants are **120×90** (~3-4KB) — upscaled into the card they look like a gray blob. The `hq1|hq2|hq3.jpg` variants are **480×360** (~10-22KB measured on 2 videos), same official i.ytimg URLs, still 1/100 the weight of an iframe.

One-line swap + test assertions. vitest 4/4, tsc 0.

## Rollback
Revert — or revert #1048 entirely if the feature still underwhelms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)