### PR TITLE
feat(pool-serve): cosine recruit pass — serve embedded supply that keyword misses

### DIFF
--- a/src/config/pool-serve.ts
+++ b/src/config/pool-serve.ts
@@ -44,6 +44,16 @@ export const poolServeEnvSchema = z.object({
    *  Default ON — same-bundle lever (James 2026-06-11: no partial-state
    *  exposure; per-cell ONE search.list call cap lives in the worker). */
   V5_POOL_SERVE_LIVE_FALLBACK: boolFlag.default(true as unknown as string),
+  /** Add a SECOND (cosine) recruit pass alongside keyword — surfaces pool
+   *  supply whose title doesn't literally match the cell goal. Also broadens
+   *  this handler's recruit sources to include yt_promoted (direct-collected
+   *  content). Precision still owned by the gc-gate. Default OFF. */
+  V5_POOL_SERVE_COSINE_RECRUIT: boolFlag.default(false as unknown as string),
+  /** Cosine DISTANCE cap for the cosine recruit (1 - similarity). Bounds
+   *  Haiku cost on abstract goals (noisy neighbours); NOT a precision knob. */
+  V5_POOL_SERVE_COSINE_DIST_MAX: z.coerce.number().min(0).max(1).default(0.45),
+  /** Max cosine candidates recruited per cell. */
+  V5_POOL_SERVE_COSINE_K: z.coerce.number().int().min(1).max(50).default(10),
 });
 
 export interface PoolServeConfig {
@@ -54,6 +64,9 @@ export interface PoolServeConfig {
   candidatesLimit: number;
   concurrency: number;
   liveFallback: boolean;
+  cosineRecruit: boolean;
+  cosineDistMax: number;
+  cosineK: number;
 }
 
 const DEFAULTS: PoolServeConfig = {
@@ -64,6 +77,9 @@ const DEFAULTS: PoolServeConfig = {
   candidatesLimit: 12,
   concurrency: 2,
   liveFallback: true,
+  cosineRecruit: false,
+  cosineDistMax: 0.45,
+  cosineK: 10,
 };
 
 export function loadPoolServeConfig(env: NodeJS.ProcessEnv = process.env): PoolServeConfig {
@@ -75,6 +91,9 @@ export function loadPoolServeConfig(env: NodeJS.ProcessEnv = process.env): PoolS
     V5_POOL_SERVE_CANDIDATES_LIMIT: env['V5_POOL_SERVE_CANDIDATES_LIMIT'],
     V5_POOL_SERVE_CONCURRENCY: env['V5_POOL_SERVE_CONCURRENCY'],
     V5_POOL_SERVE_LIVE_FALLBACK: env['V5_POOL_SERVE_LIVE_FALLBACK'],
+    V5_POOL_SERVE_COSINE_RECRUIT: env['V5_POOL_SERVE_COSINE_RECRUIT'],
+    V5_POOL_SERVE_COSINE_DIST_MAX: env['V5_POOL_SERVE_COSINE_DIST_MAX'],
+    V5_POOL_SERVE_COSINE_K: env['V5_POOL_SERVE_COSINE_K'],
   });
   if (!parsed.success) return DEFAULTS;
   return {
@@ -85,5 +104,8 @@ export function loadPoolServeConfig(env: NodeJS.ProcessEnv = process.env): PoolS
     candidatesLimit: parsed.data.V5_POOL_SERVE_CANDIDATES_LIMIT,
     concurrency: parsed.data.V5_POOL_SERVE_CONCURRENCY,
     liveFallback: parsed.data.V5_POOL_SERVE_LIVE_FALLBACK,
+    cosineRecruit: parsed.data.V5_POOL_SERVE_COSINE_RECRUIT,
+    cosineDistMax: parsed.data.V5_POOL_SERVE_COSINE_DIST_MAX,
+    cosineK: parsed.data.V5_POOL_SERVE_COSINE_K,
   };
 }

--- a/src/modules/queue/handlers/pool-serve-fill.ts
+++ b/src/modules/queue/handlers/pool-serve-fill.ts
@@ -33,7 +33,10 @@ import { computeCardRelevance } from '@/modules/relevance/compute-card-relevance
 import { getPrismaClient } from '@/modules/database/client';
 import { loadPoolServeConfig } from '@/config/pool-serve';
 import { loadRelevanceRubricConfig } from '@/config/relevance-rubric';
-import { tsvectorKeywordCandidatesPerCell } from '@/skills/plugins/video-discover/v3/hybrid-rerank';
+import {
+  tsvectorKeywordCandidatesPerCell,
+  cosinePoolCandidatesPerCell,
+} from '@/skills/plugins/video-discover/v3/hybrid-rerank';
 import {
   resolveSearchApiKeys,
   resolveVideosApiKeys,
@@ -308,12 +311,30 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
     };
 
     // ── 1차 POOL ──────────────────────────────────────────────────────────
-    const recruits = await tsvectorKeywordCandidatesPerCell(
+    const keywordRecruits = await tsvectorKeywordCandidatesPerCell(
       [{ cellIndex: p.cellIndex, query: p.cellQuery }],
       [...seen],
       cfg.candidatesLimit,
       POOL_SOURCES
     );
+    // Optional COSINE recruit pass (flag-gated): surfaces pool supply whose
+    // TITLE doesn't literally match the cell goal (keyword misses it). Broadens
+    // sources to include yt_promoted (direct-collected). Merged keyword-first,
+    // deduped; the gc-gate below still owns precision (cosine noise is rejected).
+    let recruits = keywordRecruits;
+    if (cfg.cosineRecruit) {
+      const kwIds = new Set(keywordRecruits.map((c) => c.videoId));
+      const cosineRecruits = await cosinePoolCandidatesPerCell(
+        p.mandalaId,
+        [p.cellIndex],
+        p.language,
+        [...seen, ...keywordRecruits.map((c) => c.videoId)],
+        cfg.cosineK,
+        [...POOL_SOURCES, 'yt_promoted'],
+        cfg.cosineDistMax
+      );
+      recruits = [...keywordRecruits, ...cosineRecruits.filter((c) => !kwIds.has(c.videoId))];
+    }
     result.recruited = recruits.length;
     const passed: PassedCandidate[] = [];
     await gate(

--- a/src/skills/plugins/video-discover/v3/hybrid-rerank.ts
+++ b/src/skills/plugins/video-discover/v3/hybrid-rerank.ts
@@ -150,6 +150,128 @@ export interface KeywordCandidate {
 }
 
 /**
+ * Per-cell COSINE recruit from video_pool (pool-serve, flag-gated).
+ *
+ * Complements the keyword (tsvector) recruit: keyword matches a cell only when
+ * a pool video's TITLE literally shares the cell-goal tokens, so semantically-
+ * relevant supply whose title uses different words (measured: 문장구조 cell vs
+ * 구문독해 videos) is never recruited. This ranks pool videos by cosine to the
+ * cell's stored embedding (mandala_embeddings.sub_goal_index, no re-embed).
+ *
+ * Precision is NOT owned here — the caller's gc-gate still decides. `distMax`
+ * only bounds Haiku cost (abstract goals pull noisy neighbours; the gate rejects
+ * them). Reuses the matchFromVideoPool CTE shape (eligible-first for pgvector
+ * perf, CP458). rec_score = cosine similarity (1 - distance).
+ */
+export async function cosinePoolCandidatesPerCell(
+  mandalaId: string,
+  cellIndices: ReadonlyArray<number>,
+  language: string,
+  excludeVideoIds: ReadonlyArray<string>,
+  perCellLimit: number,
+  sources: ReadonlyArray<string>,
+  distMax: number
+): Promise<KeywordCandidate[]> {
+  if (cellIndices.length === 0) return [];
+  const t0 = Date.now();
+  try {
+    const prisma = getPrismaClient();
+    const exclude = excludeVideoIds.length > 0 ? excludeVideoIds : [''];
+    const rows = await prisma.$queryRaw<
+      Array<{
+        cell_index: number;
+        video_id: string;
+        title: string;
+        description: string | null;
+        channel_name: string | null;
+        channel_id: string | null;
+        thumbnail_url: string | null;
+        view_count: bigint | null;
+        like_count: bigint | null;
+        duration_seconds: number | null;
+        published_at: Date | null;
+        dist: number;
+      }>
+    >(Prisma.sql`
+      WITH eligible AS (
+        SELECT video_id, title, description, channel_name, channel_id,
+               thumbnail_url, view_count, like_count, duration_seconds, published_at
+        FROM public.video_pool
+        WHERE is_active = true
+          AND language = ${language}
+          AND quality_tier IN ('gold', 'silver')
+          AND source = ANY(${sources}::text[])
+          AND video_id <> ALL(${exclude}::text[])
+      ),
+      cell_embs AS (
+        SELECT sub_goal_index AS cell_index, embedding
+        FROM public.mandala_embeddings
+        WHERE mandala_id = ${mandalaId}
+          AND level = 1
+          AND sub_goal_index = ANY(${[...cellIndices]}::int[])
+          AND embedding IS NOT NULL
+      ),
+      scored AS (
+        SELECT e.video_id, e.title, e.description, e.channel_name, e.channel_id,
+               e.thumbnail_url, e.view_count, e.like_count, e.duration_seconds,
+               e.published_at, ce.cell_index,
+               (vpe.embedding <=> ce.embedding) AS dist
+        FROM eligible e
+        JOIN public.video_pool_embeddings vpe ON vpe.video_id = e.video_id
+        CROSS JOIN cell_embs ce
+      ),
+      ranked AS (
+        SELECT s.*, ROW_NUMBER() OVER (
+          PARTITION BY s.cell_index ORDER BY s.dist ASC
+        ) AS rn
+        FROM scored s
+        WHERE s.dist <= ${distMax}
+      )
+      SELECT cell_index, video_id, title, description, channel_name, channel_id,
+             thumbnail_url, view_count, like_count, duration_seconds, published_at, dist
+      FROM ranked
+      WHERE rn <= ${perCellLimit}
+    `);
+
+    const out: KeywordCandidate[] = rows.map((r) => ({
+      videoId: r.video_id,
+      title: r.title,
+      description: r.description,
+      channelName: r.channel_name,
+      channelId: r.channel_id,
+      thumbnail: r.thumbnail_url,
+      viewCount: r.view_count != null ? Number(r.view_count) : null,
+      likeCount: r.like_count != null ? Number(r.like_count) : null,
+      durationSec: r.duration_seconds,
+      publishedAt: r.published_at,
+      cellIndex: r.cell_index,
+      rec_score: 1 - Number(r.dist),
+    }));
+
+    recordTrace({
+      step: 'hybrid_rerank.cosine_per_cell',
+      status: 'ok',
+      request: {
+        mandalaId,
+        cells: [...cellIndices],
+        sources: [...sources],
+        perCellLimit,
+        distMax,
+        exclude_count: excludeVideoIds.length,
+      },
+      response: { sql_row_count: rows.length },
+      latencyMs: Date.now() - t0,
+    });
+    return out;
+  } catch (err) {
+    log.warn('per-cell cosine pool recruit failed (non-fatal)', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+/**
  * video_pool tsvector keyword search by centerGoal ONLY.
  * subGoals are used for cell-assignment (argmax token-overlap), never for
  * the tsquery itself — including subGoal tokens caused cross-domain noise

--- a/tests/unit/config/pool-serve-cosine.test.ts
+++ b/tests/unit/config/pool-serve-cosine.test.ts
@@ -1,0 +1,28 @@
+import { loadPoolServeConfig } from '@/config/pool-serve';
+
+describe('loadPoolServeConfig — cosine recruit flags', () => {
+  it('defaults cosine recruit OFF with safe params (no behavior change)', () => {
+    const cfg = loadPoolServeConfig({} as NodeJS.ProcessEnv);
+    expect(cfg.cosineRecruit).toBe(false);
+    expect(cfg.cosineDistMax).toBe(0.45);
+    expect(cfg.cosineK).toBe(10);
+  });
+
+  it('parses the cosine flags from env when set', () => {
+    const cfg = loadPoolServeConfig({
+      V5_POOL_SERVE_COSINE_RECRUIT: 'true',
+      V5_POOL_SERVE_COSINE_DIST_MAX: '0.4',
+      V5_POOL_SERVE_COSINE_K: '8',
+    } as unknown as NodeJS.ProcessEnv);
+    expect(cfg.cosineRecruit).toBe(true);
+    expect(cfg.cosineDistMax).toBe(0.4);
+    expect(cfg.cosineK).toBe(8);
+  });
+
+  it('keeps the keyword-recruit defaults untouched', () => {
+    const cfg = loadPoolServeConfig({ V5_POOL_SERVE_COSINE_RECRUIT: 'true' } as unknown as NodeJS.ProcessEnv);
+    expect(cfg.relevanceMin).toBe(60);
+    expect(cfg.minPerCell).toBe(3);
+    expect(cfg.candidatesLimit).toBe(12);
+  });
+});


### PR DESCRIPTION
## The last search-quality lever (flag-gated, default OFF)

pool-serve-fill recruits by **tsvector keyword only** — a pool video whose title doesn't literally share the cell-goal tokens is never recruited, even when it's a strong semantic match. Measured: 영문법 문장구조 cell keyword-recruits **0**, but cosine top-3 → **gc 85/82/72** (all pass the 60 gate); 오류패턴 cell → **gc 72/92/72**. Embedded supply (direct-collected grammar/coding) sits unservable via this deficit-fill path.

### Change
- **cosinePoolCandidatesPerCell** (hybrid-rerank): ranks pool videos by cosine to the cell's stored `mandala_embeddings` (no re-embed), reusing the `matchFromVideoPool` eligible-first CTE (pgvector perf). `distMax` caps Haiku cost, **not** precision.
- **pool-serve-fill**: flag-gated SECOND pass — cosine recruit from `[v2_promoted, yt_promoted]` → merge keyword-first, dedupe → the **existing gc-gate still decides**.
- **config**: `V5_POOL_SERVE_COSINE_RECRUIT` (default OFF), `_COSINE_DIST_MAX=0.45`, `_COSINE_K=10`.

### Safe by construction
Precision is owned by the gc-gate (≥60), not cosine distance. Cosine pulls noisy neighbours on abstract goals, but measured gc 0/5/25/45 noise **all fail the 60 gate**; only 65-92 pass. `distMax` bounds cost only. Default OFF = zero behavior change; rollback = flip env (revert-free).

### Verify plan (Claude-web's 3 careful checks, before flag-on Done)
1. **gate robustness** — with cosine-recruit ON, the noisy abstract cell (c7) must serve only gc≥60 (gate rejects the interleaved noise). live K=10, not the top-8 sim.
2. **Haiku cost bound** — cos cap + K=10 bounds scoring calls vs keyword-only; deficit-cell-only trigger.
3. **blast radius** — keyword-sufficient cells unchanged by flag-on (flag off vs on gc compare).

Done = golden-cohort gc, no mandala regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)