### PR TITLE
feat(add-cards): panel UX round — 3-col, sticky tabs, per-round filters, scoped reset

### DIFF
--- a/frontend/src/widgets/add-cards-panel/lib/persistence.ts
+++ b/frontend/src/widgets/add-cards-panel/lib/persistence.ts
@@ -25,10 +25,25 @@ const MAX_SURFACED_VIDEO_IDS = 5000;
 const MAX_ROUNDS = 12;
 const SESSION_PICKS_PREFIX = 'addCards:sessionPicks:';
 
+/** Snapshot of the search options a round was created with — drives the
+ *  per-round filter summary under the round tabs (James request 2026-07-02:
+ *  "칩을 선택하면 적용된 필터옵션이 각 보여져야"). */
+export interface AddCardsRoundFilters {
+  language?: 'ko' | 'en';
+  keywords?: string[];
+  minViewCount?: number;
+  durationBucket?: string;
+  publishedAfter?: string;
+  difficulty?: string;
+}
+
 export interface AddCardsRound {
   id: string;
   at: string; // ISO
   cards: AddCardCandidate[];
+  /** Absent on rounds created before 2026-07-02 (no snapshot stored) —
+   *  the summary line simply doesn't render for those. */
+  filters?: AddCardsRoundFilters;
 }
 
 /** Persisted "this session" picks per mandala. Survives panel close/reopen

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
@@ -43,6 +43,10 @@ interface AddCardsListProps {
   pickedSet: ReadonlySet<string>;
   isPickPending: boolean;
   onPick: (videoId: string, title: string) => void;
+  /** Controlled active tab (lifted to the panel so 초기화 can scope to the
+   *  selected round). When omitted, the list self-manages (test back-compat). */
+  activeRoundId?: string | null;
+  onActiveRoundChange?: (id: string) => void;
 }
 
 export function AddCardsList({
@@ -55,6 +59,8 @@ export function AddCardsList({
   pickedSet,
   isPickPending,
   onPick,
+  activeRoundId: controlledActiveId,
+  onActiveRoundChange,
 }: AddCardsListProps) {
   const { t } = useTranslation();
   const totalCards = rounds.reduce((n, r) => n + r.cards.length, 0);
@@ -62,11 +68,14 @@ export function AddCardsList({
   // Active tab follows the NEWEST round: initial mount and every newly
   // prepended round auto-activate rounds[0] (the user just searched — show
   // them their result); manual tab clicks win until the next new round.
+  // Controlled from the panel when the props are provided (초기화 scoping).
   const newestRoundId = rounds[0]?.id ?? null;
-  const [activeRoundId, setActiveRoundId] = useState<string | null>(newestRoundId);
+  const [localActiveId, setLocalActiveId] = useState<string | null>(newestRoundId);
   useEffect(() => {
-    setActiveRoundId(newestRoundId);
+    setLocalActiveId(newestRoundId);
   }, [newestRoundId]);
+  const activeRoundId = controlledActiveId !== undefined ? controlledActiveId : localActiveId;
+  const setActiveRoundId = onActiveRoundChange ?? setLocalActiveId;
   const activeRound = rounds.find((r) => r.id === activeRoundId) ?? rounds[0] ?? null;
 
   if (isLoading) {
@@ -127,40 +136,67 @@ export function AddCardsList({
 
   return (
     <div className="flex flex-col">
-      <div
-        role="tablist"
-        aria-label={t('addCards.round.tablist', 'Search rounds')}
-        className="flex items-center gap-1.5 px-5 pt-3 pb-1 sm:px-6 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-      >
-        {rounds.map((round, idx) => {
-          const roundNumber = totalRounds - idx;
-          const label =
-            roundNumber === 1
-              ? t('addCards.round.first', 'Round 1')
-              : t('addCards.round.nth', 'Round {{n}} (more)', { n: roundNumber });
-          const isActive = round.id === activeRoundId;
-          return (
-            <button
-              key={round.id}
-              type="button"
-              role="tab"
-              aria-selected={isActive}
-              aria-controls={`add-cards-round-${round.id}`}
-              onClick={() => setActiveRoundId(round.id)}
-              className={cn(
-                'shrink-0 inline-flex items-center gap-1 h-7 rounded-full border px-3 text-[11.5px] font-medium transition-colors',
-                isActive
-                  ? 'bg-foreground text-background border-foreground'
-                  : 'bg-transparent text-foreground/80 border-border/50 hover:border-border hover:bg-foreground/[0.04]'
-              )}
-            >
-              {label}
-              <span className={cn('text-[10.5px]', isActive ? 'opacity-70' : 'opacity-50')}>
-                ({round.cards.length})
+      {/* Sticky tab strip — stays pinned while the results scroll under it
+          (2026-07-02 James: 칩이 스크롤에 말려 올라감). bg matches the panel
+          surface so cards never bleed through. */}
+      <div className="sticky top-0 z-20 bg-background/95 backdrop-blur-sm border-b border-border/30">
+        <div
+          role="tablist"
+          aria-label={t('addCards.round.tablist', 'Search rounds')}
+          className="flex items-center gap-1.5 px-5 pt-3 pb-2 sm:px-6 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        >
+          {rounds.map((round, idx) => {
+            const roundNumber = totalRounds - idx;
+            const label =
+              roundNumber === 1
+                ? t('addCards.round.first', 'Round 1')
+                : t('addCards.round.nth', 'Round {{n}} (more)', { n: roundNumber });
+            const isActive = round.id === activeRoundId;
+            // Picked count per round (2026-07-02 James: 선택 수 병기).
+            const pickedInRound = round.cards.reduce(
+              (n, c) => n + (pickedSet.has(c.videoId) ? 1 : 0),
+              0
+            );
+            return (
+              <button
+                key={round.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                aria-controls={`add-cards-round-${round.id}`}
+                onClick={() => setActiveRoundId(round.id)}
+                className={cn(
+                  'shrink-0 inline-flex items-center gap-1 h-7 rounded-full border px-3 text-[11.5px] font-medium transition-colors',
+                  isActive
+                    ? 'bg-foreground text-background border-foreground'
+                    : 'bg-transparent text-foreground/80 border-border/50 hover:border-border hover:bg-foreground/[0.04]'
+                )}
+              >
+                {label}
+                <span className={cn('text-[10.5px]', isActive ? 'opacity-70' : 'opacity-50')}>
+                  {pickedInRound > 0
+                    ? `(${pickedInRound}/${round.cards.length})`
+                    : `(${round.cards.length})`}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        {/* Applied-filter summary for the ACTIVE round (rounds searched after
+            2026-07-02 carry a snapshot; older rounds show date only). */}
+        {activeRound && (
+          <div className="flex items-center flex-wrap gap-x-2 gap-y-0.5 px-5 pb-2 sm:px-6 text-[11px] text-muted-foreground">
+            <span className="opacity-70">{formatRelativeDate(activeRound.at)}</span>
+            {formatRoundFilters(activeRound.filters, t).map((part) => (
+              <span
+                key={part}
+                className="inline-flex items-center rounded border border-border/40 bg-foreground/[0.03] px-1.5 py-px"
+              >
+                {part}
               </span>
-            </button>
-          );
-        })}
+            ))}
+          </div>
+        )}
       </div>
       {activeRound && (
         <section
@@ -169,10 +205,7 @@ export function AddCardsList({
           role="tabpanel"
           aria-label={t('addCards.round.activePanel', 'Active round results')}
         >
-          <div className="px-5 pt-1 sm:px-6 text-[11px] text-muted-foreground">
-            {formatRelativeDate(activeRound.at)}
-          </div>
-          <ul className="grid grid-cols-2 gap-3 px-5 py-3 sm:px-6">
+          <ul className="grid grid-cols-2 md:grid-cols-3 gap-3 px-5 py-3 sm:px-6">
             {activeRound.cards.map((card) => (
               <CardItem
                 key={card.videoId}
@@ -187,6 +220,52 @@ export function AddCardsList({
       )}
     </div>
   );
+}
+
+/** Human-readable parts for a round's applied-filter snapshot. Only
+ *  non-default options render; snapshot-less (old) rounds return []. */
+function formatRoundFilters(
+  filters: AddCardsRound['filters'],
+  t: ReturnType<typeof useTranslation>['t']
+): string[] {
+  if (!filters) return [];
+  const parts: string[] = [];
+  if (filters.language)
+    parts.push(
+      filters.language === 'en'
+        ? t('addCards.round.filterEn', 'English')
+        : t('addCards.round.filterKo', '한국어')
+    );
+  if (filters.minViewCount) {
+    const v = filters.minViewCount;
+    const label =
+      v >= 1_000_000 ? '100만+' : v >= 100_000 ? '10만+' : v >= 10_000 ? '1만+' : '1천+';
+    parts.push(t('addCards.round.filterViews', '{{label}} 조회수', { label }));
+  }
+  if (filters.durationBucket) {
+    const map: Record<string, string> = {
+      short: t('addCards.round.durShort', '10분 미만'),
+      medium: t('addCards.round.durMedium', '10–30분'),
+      long: t('addCards.round.durLong', '30–60분'),
+      xlong: t('addCards.round.durXlong', '60분 이상'),
+    };
+    if (map[filters.durationBucket]) parts.push(map[filters.durationBucket]);
+  }
+  if (filters.publishedAfter) {
+    const days = Math.round((Date.now() - new Date(filters.publishedAfter).getTime()) / 86_400_000);
+    const label =
+      days <= 8
+        ? t('addCards.round.pubWeek', '지난 1주')
+        : days <= 32
+          ? t('addCards.round.pubMonth', '지난 1개월')
+          : days <= 190
+            ? t('addCards.round.pubHalf', '지난 6개월')
+            : t('addCards.round.pubYear', '지난 1년');
+    parts.push(label);
+  }
+  if (filters.difficulty) parts.push(filters.difficulty);
+  if (filters.keywords?.length) parts.push(filters.keywords.map((k) => `"${k}"`).join(' '));
+  return parts;
 }
 
 function CardItem({
@@ -267,27 +346,35 @@ function CardItem({
           </div>
         )}
 
-        {/* Picked overlay — post-click dim + center check. */}
+        {/* Picked overlay — SINGLE control (2026-07-02 James: 두 버튼 분리가
+            어색 → 통합). Default = "추가됨" check; hovering the card morphs
+            the SAME center badge into the unpick affordance. Colors stay
+            neutral (no red — user directive). */}
         {isPicked && (
           <>
             <div
               className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/55 backdrop-blur-[2px] gap-1"
               aria-hidden="true"
             >
-              <span className="flex items-center justify-center w-9 h-9 rounded-full bg-emerald-500 shadow-lg">
-                <Check className="w-5 h-5 text-white" strokeWidth={3} />
+              {/* Default state — added */}
+              <span className="flex flex-col items-center gap-1 group-hover:hidden">
+                <span className="flex items-center justify-center w-9 h-9 rounded-full bg-emerald-500 shadow-lg">
+                  <Check className="w-5 h-5 text-white" strokeWidth={3} />
+                </span>
+                <span className="text-[10.5px] font-semibold text-white tracking-wide">
+                  {t('addCards.actions.picked', 'Picked')}
+                </span>
               </span>
-              <span className="text-[10.5px] font-semibold text-white tracking-wide">
-                {t('addCards.actions.picked', 'Picked')}
+              {/* Hover state — same spot becomes the unpick control */}
+              <span className="hidden flex-col items-center gap-1 group-hover:flex">
+                <span className="flex items-center justify-center w-9 h-9 rounded-full border-2 border-white/80 bg-black/30">
+                  <X className="w-5 h-5 text-white/90" strokeWidth={2.6} />
+                </span>
+                <span className="text-[10.5px] font-semibold text-white/90 tracking-wide">
+                  {t('addCards.actions.unpick', 'Remove from mandala')}
+                </span>
               </span>
             </div>
-
-            <span
-              className="absolute top-1 right-1 z-20 inline-flex items-center justify-center h-6 w-6 rounded-full bg-black/60 text-white shadow-md transition-colors group-hover:bg-white/25"
-              aria-hidden="true"
-            >
-              <X className="w-3.5 h-3.5" strokeWidth={2.6} />
-            </span>
 
             <span
               className="absolute bottom-1 right-1 z-10 w-6 h-6 flex items-center justify-center opacity-100"

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsPanel.tsx
@@ -28,7 +28,8 @@ import { AddCardsFilters } from './AddCardsFilters';
 import { TargetLevelChips } from './TargetLevelChips';
 import { AddCardsList } from './AddCardsList';
 
-const PANEL_WIDTH_CLASS = 'w-full md:w-[58vw] md:max-w-[936px]';
+// 2026-07-02 James: wider panel so the candidate grid fits 3 columns.
+const PANEL_WIDTH_CLASS = 'w-full md:w-[66vw] md:max-w-[1120px]';
 const CLOSE_ANIMATION_MS = 200;
 const SCROLL_COLLAPSE_THRESHOLD_PX = 32;
 
@@ -66,6 +67,15 @@ export function AddCardsPanel() {
   // directive #785 "재검색 결과 1 - 재검색 결과 2 - …" cumulative model).
   const [rounds, setRounds] = useState<AddCardsRound[]>([]);
   const [surfacedVideoIds, setSurfacedVideoIds] = useState<string[]>([]);
+  // Active round tab — lifted here (was AddCardsList-local) so 초기화 can
+  // scope to the SELECTED round only (2026-07-02 James: 전체 삭제는 불합리).
+  const [activeRoundId, setActiveRoundId] = useState<string | null>(null);
+  const newestRoundId = rounds[0]?.id ?? null;
+  useEffect(() => {
+    setActiveRoundId(newestRoundId);
+  }, [newestRoundId]);
+  // Options snapshot for the in-flight search (attached to its round on success).
+  const lastSearchSnapshotRef = useRef<AddCardsRound['filters']>(undefined);
 
   useEffect(() => {
     if (!open || !mandalaId) return;
@@ -93,7 +103,12 @@ export function AddCardsPanel() {
     const freshIds = freshCards.map((c) => c.videoId);
     setRounds((prev) => {
       const next: AddCardsRound[] = [
-        { id: data.roundId, at: data.roundAt, cards: freshCards },
+        {
+          id: data.roundId,
+          at: data.roundAt,
+          cards: freshCards,
+          filters: lastSearchSnapshotRef.current,
+        },
         ...prev,
       ];
       const nextSurfaced = mergeSurfacedVideoIds(surfacedVideoIds, freshIds);
@@ -370,6 +385,16 @@ export function AddCardsPanel() {
     if (!mandalaId) return;
     const keywords =
       targetLevel && targetLevel !== 'standard' ? [...extraKeywords, targetLevel] : extraKeywords;
+    // Snapshot the options this search runs with — attached to the resulting
+    // round so its tab can show the applied filters (2026-07-02).
+    lastSearchSnapshotRef.current = {
+      language: searchLanguage,
+      keywords: extraKeywords.length > 0 ? [...extraKeywords] : undefined,
+      minViewCount: filters.minViewCount,
+      durationBucket: filters.durationBucket,
+      publishedAfter: filters.publishedAfter,
+      difficulty: targetLevel && targetLevel !== 'standard' ? targetLevel : undefined,
+    };
     mutation.mutate({
       mandalaId,
       extraKeywords: keywords,
@@ -391,23 +416,27 @@ export function AddCardsPanel() {
     surfaced: string[];
   } | null>(null);
 
-  // Toggle: results visible → click clears all rounds; empty → click searches.
-  // Surfaced history is preserved across the toggle.
+  // 초기화 scopes to the ACTIVE round tab only (2026-07-02 James: clearing
+  // every round was 불합리 — "선택된 칩만 초기화"). Picks are dropped only for
+  // cards that exist EXCLUSIVELY in the removed round. The undo snapshot
+  // still captures the full prior state.
   const resetResults = useCallback(() => {
-    if (rounds.length > 0) {
-      setResetHistory({ rounds, picks: Array.from(localPicks), surfaced: surfacedVideoIds });
+    if (rounds.length === 0) return;
+    setResetHistory({ rounds, picks: Array.from(localPicks), surfaced: surfacedVideoIds });
+    const target = rounds.find((r) => r.id === activeRoundId) ?? rounds[0];
+    const nextRounds = rounds.filter((r) => r.id !== target.id);
+    const remainingIds = new Set(nextRounds.flatMap((r) => r.cards.map((c) => c.videoId)));
+    setRounds(nextRounds);
+    setLocalPicks((prev) => new Set(Array.from(prev).filter((id) => remainingIds.has(id))));
+    if (mandalaId) saveAddCardsState(mandalaId, nextRounds, surfacedVideoIds);
+    if (nextRounds.length === 0) {
+      mutation.reset();
+      // Re-expand the input zone so the user can pick filters / type a new
+      // keyword (bug report 2026-05-21 — collapsed header left no way back).
+      setInputCollapsed(false);
+      if (mandalaId) clearSessionPicks(mandalaId);
     }
-    mutation.reset();
-    setRounds([]);
-    setLocalPicks(new Set());
-    // Re-expand the input zone so the user can pick filters / type a new
-    // keyword. Without this, if 초기화 was clicked while the auto-collapse
-    // (scroll-driven) was active, the header ChevronUp/Down toggle goes
-    // away with the results — leaving no way to expand the input again
-    // without closing the panel. (Bug report 2026-05-21.)
-    setInputCollapsed(false);
-    if (mandalaId) clearSessionPicks(mandalaId);
-  }, [mutation, mandalaId, rounds, localPicks, surfacedVideoIds]);
+  }, [mutation, mandalaId, rounds, localPicks, surfacedVideoIds, activeRoundId]);
 
   // Restore the snapshot captured at the most recent 초기화 click.
   const restorePrevious = useCallback(() => {
@@ -696,6 +725,8 @@ export function AddCardsPanel() {
               pickedSet={pickedSet}
               isPickPending={like.isPending || unlike.isPending}
               onPick={handlePick}
+              activeRoundId={activeRoundId}
+              onActiveRoundChange={setActiveRoundId}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
Six James-requested add-cards panel improvements (2026-07-02):

1. **Wider panel + 3-column grid** — `58vw/936px → 66vw/1120px`, `grid-cols-2 → md:grid-cols-3`.
2. **Sticky round tabs** — tab strip + filter summary pinned while results scroll (was scrolling away).
3. **Per-round applied filters** — each new round stores an options snapshot (language / views / duration / period / difficulty / keywords) rendered as chips under the active tab. Pre-existing rounds have no snapshot → date only (honest limit).
4. **Picked count on chips** — `(3/57)` when any picked, `(57)` otherwise.
5. **Single pick control** — center "추가됨" badge morphs into the unpick affordance (X + 추가 취소) on hover; separate top-right X removed. Neutral colors (no red, per directive).
6. **Scoped 초기화** — clears the ACTIVE round only; picks drop only for cards exclusive to that round; undo snapshot unchanged; clearing the last round = legacy full reset.

## Verification (browser, zero quota)
Injected a localStorage fixture (2 rounds / 42 cards / 3 picks — **cleaned up after**, per directive) and verified all six in dev: 3-col render, tabs+filters pinned through deep scroll, filter chips (`English · 1만+ 조회수 · 10–30분 · 지난 1년 · 심화 · "수동태" "기출"`), `(2/18)`/`(1/24)` counts, hover morph to 추가 취소, reset removed only the active round (39→23 header count matched).

Gates: FE tsc 0 / vitest **472/472** / vite build OK.

## Rollback
Single revert — panel-scoped; persistence change is an optional field (backward/forward compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)