### PR TITLE
fix(search): add '심화' to W2 tsquery stopwords + make the stopword test suite actually runnable

### DIFF
--- a/docs/handoffs/cosine-recruit-roi-fin26-2026-07-02.md
+++ b/docs/handoffs/cosine-recruit-roi-fin26-2026-07-02.md
@@ -1,0 +1,81 @@
+# cosine-recruit flag ROI package — 26년금융 (2026-07-02)
+
+> Materials only — the flag-on decision is James's gate (`V5_POOL_SERVE_COSINE_RECRUIT`,
+> PR #1051, merged flag-OFF). Measured by CC under Claude-web supervision (CP509 → this
+> session). Method identical to the CP509 benefit map: per-cell cosine top-5 over the
+> ACTIVE pool × Haiku `computeCardRelevance` (center + cellGoal, ko).
+
+## Context
+
+Mandala `7f72e5d8` "26년 금융 투자 전문가 되기" (golden-cohort gc 65, borderline).
+Direct-collect round 1 (this session): 7 cell-aligned queries → 44 unique → classifyQuality
+gate 42 accepted (2 too_long) → `video_pool` (yt_promoted) + Ollama embeddings. YouTube API 0.
+
+Before/after (same measure, cosine top-5 max/median gc per cell): no cell regressed.
+- c5 자격증: max 65 → **92**, median 25 → **78** (new videos rank 1/3/4)
+- c4 암호화폐: max 72 → 72, median 35 → **72** (new videos rank 4/5/8/9/10)
+- c3 대체투자: median 45 → 62
+- others unchanged (c2 92 / c7 78 / c0 72 / c1 65 / c6 72)
+- mandala cell-median aggregate: 58.5 → **72**
+
+## The gap this flag addresses (measured)
+
+gc-good content now EXISTS in the pool for 3 weak cells, but neither serving path picks it up:
+
+| cell | gc-good collected (Haiku) | cosine rank (cell embedding) | tsquery recruit match |
+|------|---------------------------|------------------------------|----------------------|
+| c1 국내주식 기본·기술분석 | 72 (차트 기초) | 13 | 0 (recruit 8건 전부 뉴스성, 콘텐츠 0) |
+| c3 대체투자(부동산·펀드·옵션) | 72, 72 (리츠 입문 ×2) | 40 / 53 | 0 (post-'심화'-fix: honest empty) |
+| c6 리스크·포트폴리오 최적화 | **88**, 78 (리스크관리 9가지 / 포트폴리오) | 33 / 39 | 0 |
+
+- Keyword (tsquery) recruit misses them **structurally** (see below), cosine top-5 misses
+  them because adjacent-generic finance titles sit closer to the cell embedding.
+- A cosine-recruit pass with K beyond top-5 (rank 13–53) + the existing semantic gate
+  (`V5_POOL_SERVE_RELEVANCE_MIN=60`) would admit exactly these (all ≥ 72, gate-passing).
+
+## Expected lift if flag-on (this mandala)
+
+- c1: cell median 45 → ~72 range (candidate gc 72)
+- c6: cell median 72 → ~88 range (candidate gc 88/78)
+- c3: median 62 → ~72 range (candidates gc 72×2)
+- No-regression mechanism: gate 60 rejects any cosine-recruited candidate scoring < 60
+  (proven fail-closed in CP509 canary: poolPassed=0 on gc<60 supply).
+
+## Safety rails (already in code, PR #1051)
+
+- Cost bound: cosine pass capped (recruit cap in pool-serve-fill cosine branch).
+- Accuracy bound: same semantic gate (computeCardRelevance ≥ 60) as keyword recruits —
+  cosine proximity alone cannot serve a card.
+- Rollback: flag-off (`V5_POOL_SERVE_COSINE_RECRUIT=false`), config-only, no code revert.
+
+## Suggested canary scope (materials, not a recommendation)
+
+Single-mandala canary: enable for `7f72e5d8` only (or lowest-traffic window), then re-run
+this same per-cell measure + golden-cohort gc; success = c1/c3/c6 medians move toward the
+candidate gc values with zero regression elsewhere; failure = any cell after < before.
+
+## Structural finding (record for G4 scoping as well)
+
+**Colloquial video titles vs. literary cell-goal tokens do not intersect — tsquery recruit
+is structurally blind to them.** Cell goals use written-register tokens (기본분석, 기술분석,
+대체투자, 최적화); real YouTube learning titles use colloquial phrasing ("차트 보는 법",
+"리츠 투자 입문", "리스크 관리하는 9가지 방법"). Keyword OR-match can only bridge this if
+the title happens to contain the exact token — embeddings bridge it semantically (the gc-good
+candidates above are all cosine-reachable at rank 13–53). Consequences:
+
+1. Collecting more content cannot fix c1/c3/c6 under keyword-only recruit (the gap is the
+   matcher, not supply) — re-collecting titles that parrot cell phrasing would game the
+   embedding metric and was rejected (GATE-DIAG).
+2. The residual W2 noise axis is the mirror image: leftover generic tokens ('심화' — fixed
+   in `99ad1305` on branch `fix/w2-tsquery-stopword-simhwa`, 5/5 jest) pull cross-domain
+   videos INTO cells; measured c3 recruit noise 2 → 0 after the fix.
+3. G4 (serving-quality follow-up) should treat "recruit = lexical, serve-gate = semantic,
+   bridge = embeddings" as the baseline architecture fact when scoping re-rank/recall work.
+
+## Evidence trail
+
+- Collection TSV: session scratchpad `fin26.dedup.tsv` (44 rows, 42 accepted).
+- Probes (read-only, prod container): per-cell cosine top-5 ×2 (before/after), new-video
+  rank probe, real-path tsquery recruit probe (W2 builder from dist), c3 post-fix recruit.
+- Scoring: `computeCardRelevance` (Haiku quick, prod path), 40 + 14 + 1 calls.
+- Branch: `fix/w2-tsquery-stopword-simhwa` @ `99ad1305` (stopword + test-runner fix).

--- a/src/skills/plugins/video-discover/__tests__/v3-tsquery-stopword.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v3-tsquery-stopword.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from 'vitest';
-
 import { buildTsqueryString } from '../v3/tsquery-builder';
 
 /**
@@ -24,6 +22,14 @@ describe('buildTsqueryString — W2 generic-filler stopwords', () => {
     const q = buildTsqueryString('학습 관리 전략 강화');
     expect(q.length).toBeGreaterThan(0);
     expect(q.split(' | ')).toContain('학습');
+  });
+
+  it("drops '심화' — matched cross-domain videos (알고리즘 심화/명상 심화) in a 대체투자 cell", () => {
+    const q = buildTsqueryString('대체투자(부동산·펀드·옵션) 심화 학습');
+    const toks = q.split(' | ');
+    expect(toks).toContain('대체투자');
+    expect(toks).not.toContain('심화');
+    expect(toks).not.toContain('학습');
   });
 
   it('still de-duplicates and returns OR-joined tokens', () => {

--- a/src/skills/plugins/video-discover/v3/tsquery-builder.ts
+++ b/src/skills/plugins/video-discover/v3/tsquery-builder.ts
@@ -30,6 +30,7 @@ export const TSQUERY_GENERIC_STOPWORDS = new Set<string>([
   '확보',
   '준비',
   '개선',
+  '심화',
   '설계',
   '설정',
   '문제',


### PR DESCRIPTION
## What

1. **Add `'심화'` to `TSQUERY_GENERIC_STOPWORDS`** (W2 generic-filler list, #1044 follow-up).
2. **Fix the stopword test suite so it can actually run**: it imported from `'vitest'`, which is not installed at the repo root — the jest runner fails the suite at module resolution. Dropped the import (jest provides `describe/it/expect` as globals, same as every sibling test in `src/skills/**/__tests__`). Added a `'심화'` regression case. **5/5 pass under jest** (was: suite failed to load).
3. **ROI package doc** for the `V5_POOL_SERVE_COSINE_RECRUIT` gate decision: `docs/handoffs/cosine-recruit-roi-fin26-2026-07-02.md` (measured c1/c3/c6 gap table, expected lift, safety rails, single-mandala canary scope).

## Why (measured, 26년금융 mandala 7f72e5d8)

Real-path recruit probe (W2 builder from prod dist, LATERAL top-8, v2+yt_promoted gold/silver) on cell c3 `대체투자(부동산·펀드·옵션) 심화 학습`: the residual generic token `심화` OR-matched **cross-domain videos** — "중간바보도 배우는 알고리즘 5강 - 심화 연습문제" and "[불안해소 심화 Ver.] 두려움 불안 극복 명상" — into a finance cell. Same failure mode #1044 fixed for 학습/강화/분석.

**Post-fix re-probe (read-only sim with the new tsquery `대체투자 | 부동산·펀드·옵션`): recruit noise 2 → 0.** Honest empty — serving falls back to live/cosine paths; the gate would have rejected these anyway, this removes the wasted recruit.

## Full enumeration (per supervisor directive — "CI green ≠ tests ran" family, 2nd occurrence after CP507 FE type-gate no-op)

- `grep -rln "from 'vitest'"` over jest scope (`tests/` + `src/skills/`): the #1044 file was the **only** offender; **0 remaining** after this PR.
- **Root cause of silent pass — CI's backend test step is `npx jest --testPathPattern=tests/smoke` (ci.yml:125)**, so it runs **38** of the 220 jest-scope test files. `src/skills/**/__tests__` (34 files, incl. this suite) and `tests/` outside smoke (148 files) never run in CI. The vitest import could not surface. → Widening the CI test gate is a separate decision (runtime/env cost), flagged here as a finding, not changed in this PR.

## Verification

- `npx jest src/skills/plugins/video-discover/__tests__/v3-tsquery-stopword.test.ts` → **5 passed / 5** (suite previously failed to load with `TS2307: Cannot find module 'vitest'`).
- Serving-path change is token-filter only; empty-guard (all-generic cell keeps original tokens) unchanged.

## Gates

Merge = James gate. Related pending gates: 26년금융 c4/c5 screen verification + cosine-recruit single-mandala canary decision (see ROI doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)