### PR TITLE
feat(observability): failure-time quota/ban alert on all-keys-exhausted search.list (G5 step 1)

### DIFF
--- a/src/modules/quota-alert/index.ts
+++ b/src/modules/quota-alert/index.ts
@@ -22,11 +22,12 @@
 import { config } from '@/config/index';
 import { logger } from '@/utils/logger';
 import { transporter } from '@/modules/skills/mailer';
+import { MS_PER_HOUR } from '@/utils/time-constants';
 
 const log = logger.child({ module: 'quota-alert' });
 
 /** Min gap between alert emails (6h) — burst of exhausted calls = 1 mail. */
-export const QUOTA_ALERT_MIN_INTERVAL_MS = 6 * 60 * 60 * 1000;
+export const QUOTA_ALERT_MIN_INTERVAL_MS = 6 * MS_PER_HOUR;
 
 let lastSentAtMs = 0;
 

--- a/src/modules/quota-alert/index.ts
+++ b/src/modules/quota-alert/index.ts
@@ -1,0 +1,92 @@
+/**
+ * G5 — quota/ban FAILURE-time alert (companion to the daily key-COUNT alarm,
+ * queue/handlers/key-alarm.ts Phase 2-A).
+ *
+ * The key-alarm job counts configured keys once a day; it cannot tell the
+ * operator that the pool just DIED. This module fires when the search.list
+ * rotation exhausts ALL keys (every key answered 403/429) — the exact moment
+ * the 8→1 key consolidation makes silent: with one key there is no rotation
+ * left to hide behind, so an unnoticed quota/ban outage becomes user-facing.
+ *
+ * Contract:
+ *   - Inert when OBSERVABILITY_ALERT_EMAIL is unset (same convention as
+ *     key-alarm / search-metrics-report — no new env, unset = today's behavior).
+ *   - Fire-and-forget: never throws, never awaited by the serving path
+ *     (poll/await on this would insert SMTP latency into wizard search —
+ *     CP501 poll-dependency lesson).
+ *   - Throttled in-process: at most one email per QUOTA_ALERT_MIN_INTERVAL_MS
+ *     so a burst of exhausted searches cannot mail-storm the operator.
+ *   - No key VALUES are ever included — counts and error text only.
+ */
+
+import { config } from '@/config/index';
+import { logger } from '@/utils/logger';
+import { transporter } from '@/modules/skills/mailer';
+
+const log = logger.child({ module: 'quota-alert' });
+
+/** Min gap between alert emails (6h) — burst of exhausted calls = 1 mail. */
+export const QUOTA_ALERT_MIN_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+let lastSentAtMs = 0;
+
+/** Test seam — reset the throttle window. */
+export function _resetQuotaAlertThrottleForTest(): void {
+  lastSentAtMs = 0;
+}
+
+export interface QuotaExhaustedInput {
+  /** Which API pool died (e.g. 'search.list'). */
+  api: string;
+  /** How many keys the rotation tried before giving up. */
+  keysTried: number;
+  /** Last provider error message (no key material — API error text only). */
+  lastError: string;
+}
+
+/**
+ * Decide-and-send. Returns what happened so tests can pin the logic:
+ * 'sent' | 'throttled' | 'inert' | 'send_failed'.
+ */
+export async function notifyQuotaExhausted(input: QuotaExhaustedInput): Promise<string> {
+  const to = config.observability.alertEmail;
+  if (!to) {
+    log.warn(
+      `quota-alert: ${input.api} exhausted all ${input.keysTried} key(s) but ` +
+        `OBSERVABILITY_ALERT_EMAIL is unset — email skipped`
+    );
+    return 'inert';
+  }
+  const now = Date.now();
+  if (now - lastSentAtMs < QUOTA_ALERT_MIN_INTERVAL_MS) return 'throttled';
+  lastSentAtMs = now;
+  try {
+    await transporter.sendMail({
+      from: config.gmail.smtpFrom,
+      to,
+      subject: `🔴 Insighta ops: YouTube ${input.api} — ALL ${input.keysTried} key(s) quota-exhausted`,
+      text: [
+        `🔴 Insighta ops alarm — YouTube quota exhausted at failure time`,
+        ``,
+        `API: ${input.api}`,
+        `Keys tried (rotation): ${input.keysTried} — every one answered 403/429.`,
+        `Last provider error: ${input.lastError.slice(0, 300)}`,
+        ``,
+        `User impact: live search fanout returns 0 items until quota resets`,
+        `(midnight PT) or the key/quota is fixed. Pool-serve/cosine paths are`,
+        `unaffected. If this is a single-key setup (post 8→1 consolidation),`,
+        `check the Google Cloud project for a quota bump or a ban notice.`,
+        ``,
+        `(Throttled: at most one of these emails per ${QUOTA_ALERT_MIN_INTERVAL_MS / 3600000}h.`,
+        ` No key values are transmitted.)`,
+      ].join('\n'),
+    });
+    log.info(`quota-alert: email sent to ${to} (api=${input.api}, keys_tried=${input.keysTried})`);
+    return 'sent';
+  } catch (err) {
+    log.warn(
+      `quota-alert: email send failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+    );
+    return 'send_failed';
+  }
+}

--- a/src/skills/plugins/video-discover/v2/youtube-client.ts
+++ b/src/skills/plugins/video-discover/v2/youtube-client.ts
@@ -10,6 +10,7 @@
  */
 
 import { recordTrace } from '@/modules/discover-tracing';
+import { notifyQuotaExhausted } from '@/modules/quota-alert';
 
 const YOUTUBE_API_BASE = 'https://www.googleapis.com/youtube/v3';
 
@@ -345,6 +346,13 @@ export async function searchVideos(opts: SearchOpts): Promise<YouTubeSearchItem[
     // consumed nothing on YouTube's side (quota already 0), so units = 0;
     // we still log the call counter so cost view can see the attempt.
     costUnits: { youtube_calls: keys.length },
+  });
+  // G5 failure-time alert — fire-and-forget (never awaited: SMTP latency must
+  // not sit in the serving path; inert when OBSERVABILITY_ALERT_EMAIL unset).
+  void notifyQuotaExhausted({
+    api: 'search.list',
+    keysTried: keys.length,
+    lastError: lastErr instanceof Error ? lastErr.message : String(lastErr),
   });
   throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
 }

--- a/tests/smoke/quota-alert.test.ts
+++ b/tests/smoke/quota-alert.test.ts
@@ -1,0 +1,65 @@
+/**
+ * G5 quota-alert — failure-time email on all-keys-quota-exhausted.
+ *
+ * Placed in tests/smoke/ deliberately: CI's backend test step runs ONLY
+ * --testPathPattern=tests/smoke (ci.yml:125), so a test outside this dir is
+ * never executed by CI (PR #1055 finding).
+ */
+
+const sendMail = jest.fn();
+const mockConfig = {
+  observability: { alertEmail: '' },
+  gmail: { smtpFrom: 'noreply@insighta.one' },
+};
+
+jest.mock('@/modules/skills/mailer', () => ({ transporter: { sendMail: (...a: unknown[]) => sendMail(...a) } }));
+jest.mock('@/config/index', () => ({ config: mockConfig }));
+jest.mock('@/utils/logger', () => ({
+  logger: { child: () => ({ info: jest.fn(), warn: jest.fn() }) },
+}));
+
+import {
+  notifyQuotaExhausted,
+  _resetQuotaAlertThrottleForTest,
+  QUOTA_ALERT_MIN_INTERVAL_MS,
+} from '@/modules/quota-alert';
+
+const INPUT = { api: 'search.list', keysTried: 8, lastError: 'search.list HTTP 403: quotaExceeded' };
+
+describe('quota-alert — failure-time notify', () => {
+  beforeEach(() => {
+    sendMail.mockReset();
+    sendMail.mockResolvedValue(undefined);
+    mockConfig.observability.alertEmail = '';
+    _resetQuotaAlertThrottleForTest();
+  });
+
+  it('inert when OBSERVABILITY_ALERT_EMAIL is unset (today-behavior default)', async () => {
+    await expect(notifyQuotaExhausted(INPUT)).resolves.toBe('inert');
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it('sends to the configured inbox with counts only (no key values)', async () => {
+    mockConfig.observability.alertEmail = 'admin@insighta.one';
+    await expect(notifyQuotaExhausted(INPUT)).resolves.toBe('sent');
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    const arg = sendMail.mock.calls[0][0] as { to: string; subject: string; text: string };
+    expect(arg.to).toBe('admin@insighta.one');
+    expect(arg.subject).toContain('ALL 8 key(s) quota-exhausted');
+    expect(arg.text).toContain('quotaExceeded');
+  });
+
+  it('throttles a burst — second exhaustion within the window sends nothing', async () => {
+    mockConfig.observability.alertEmail = 'admin@insighta.one';
+    await expect(notifyQuotaExhausted(INPUT)).resolves.toBe('sent');
+    await expect(notifyQuotaExhausted(INPUT)).resolves.toBe('throttled');
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    expect(QUOTA_ALERT_MIN_INTERVAL_MS).toBeGreaterThanOrEqual(60 * 60 * 1000);
+  });
+
+  it('never throws when SMTP fails (fire-and-forget contract)', async () => {
+    mockConfig.observability.alertEmail = 'admin@insighta.one';
+    sendMail.mockRejectedValueOnce(new Error('SMTP down'));
+    await expect(notifyQuotaExhausted(INPUT)).resolves.toBe('send_failed');
+  });
+});


### PR DESCRIPTION
## What

New `src/modules/quota-alert`: when the search.list rotation exhausts **ALL** keys (every key 403/429), email `OBSERVABILITY_ALERT_EMAIL` once (6h in-process throttle). Hooked into the existing `all_keys_quota_exhausted` branch of `searchVideos` as **fire-and-forget** (never awaited — no SMTP latency in the wizard serving path).

- **Inert by default**: `OBSERVABILITY_ALERT_EMAIL` unset = today's behavior, no new env (same convention as key-alarm / metrics-report).
- Complements (does not duplicate) the daily key-COUNT alarm (`queue/handlers/key-alarm.ts`, Phase 2-A): that one says "you have too many keys", this one says "your keys just died".
- No key values in logs or mail — counts + provider error text only.

## Why (G5 8→1 key consolidation, step 1 — supervisor-pinned order)

Scoping measurement (2026-07-02): prod has 8 SEARCH keys; last-7d consumption is only ~72 search.list calls (~1,030u/day) vs a single project's 10,000u/day — **the consolidation bottleneck is not quota, it's the no-notification risk when the single key dies** (today the silent rotation hides key death). So: **alert first, key reduction after.** Removing Secrets `_2.._8` before this alert exists would maximize the unnoticed-outage window.

Sequence: ① this PR → ② merge (James gate) → ③ GH Secrets `YOUTUBE_API_KEY_SEARCH_2..8` removal + key-slot cleanup decision (single `SEARCH` + legacy `YOUTUBE_API_KEY` disposition) — James gate, config-only, rollback = restore Secrets → ④ 7-day consumption re-measure to close.

## Verification ("code exists" ≠ "alert works")

- `tests/smoke/quota-alert.test.ts` **4/4** — inert / sent / throttled / SMTP-fail-no-throw. Placed in `tests/smoke` so CI **actually runs it** (PR #1055 finding: CI runs only `--testPathPattern=tests/smoke`).
- **Real delivery fired from the prod container** with a `[TEST]`-marked simulated-403 mail via the same transporter + recipient: SMTP `250 2.0.0 OK`, messageId `<f5dfdf78-7cb5-994b-342c-a97c3dbfa000@insighta.one>`, delivered to `admin@insighta.one`.
- `tsc --noEmit` 0 errors.
- Post-merge: one end-to-end re-verification of the deployed module path is listed as the ④ close-out step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)