### PR TITLE
fix(tests): manual logger mock — close the suite-load failure class (5 suites)

### DIFF
--- a/src/skills/plugins/iks-scorer/__tests__/executor.test.ts
+++ b/src/skills/plugins/iks-scorer/__tests__/executor.test.ts
@@ -37,15 +37,9 @@ jest.mock('@/modules/database', () => ({
   }),
 }));
 
-jest.mock('@/utils/logger', () => ({
-  logger: {
-    child: () => ({
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-    }),
-  },
-}));
+// Manual mock (src/utils/__mocks__/logger.ts) — full export surface,
+// survives module-scope top-level logger calls in imported prod code.
+jest.mock('@/utils/logger');
 
 import { executor } from '../executor';
 import type { PreflightContext, ExecuteContext } from '@/skills/_shared/types';

--- a/src/skills/plugins/trend-collector/__tests__/executor.execute.test.ts
+++ b/src/skills/plugins/trend-collector/__tests__/executor.execute.test.ts
@@ -34,15 +34,9 @@ jest.mock('@/modules/database', () => ({
   }),
 }));
 
-jest.mock('@/utils/logger', () => ({
-  logger: {
-    child: () => ({
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-    }),
-  },
-}));
+// Manual mock (src/utils/__mocks__/logger.ts) — full export surface,
+// survives module-scope top-level logger calls in imported prod code.
+jest.mock('@/utils/logger');
 
 import { executor } from '../executor';
 import { TREND_COLLECTOR_SOURCE_LLM, TREND_COLLECTOR_SOURCE_SUGGEST } from '../manifest';

--- a/src/skills/plugins/video-discover/__tests__/executor.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/executor.test.ts
@@ -36,15 +36,9 @@ jest.mock('@/modules/database', () => ({
   }),
 }));
 
-jest.mock('@/utils/logger', () => ({
-  logger: {
-    child: () => ({
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-    }),
-  },
-}));
+// Manual mock (src/utils/__mocks__/logger.ts) — full export surface,
+// survives module-scope top-level logger calls in imported prod code.
+jest.mock('@/utils/logger');
 
 import {
   executor,

--- a/src/skills/plugins/video-discover/__tests__/v5-search-trace.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v5-search-trace.test.ts
@@ -22,6 +22,9 @@ jest.mock('@/config/index', () => ({
       },
       discoverTracing: { enabled: false },
       app: { isDevelopment: false, isProduction: false, isTest: true },
+      // mailer.ts creates its transporter at module scope from config.gmail —
+      // the import chain reaches it, so the mock must provide the block.
+      gmail: { smtpHost: 'localhost', smtpPort: 587, smtpFrom: 'test@test.local' },
     };
   },
 }));

--- a/src/skills/plugins/video-discover/v3/__tests__/executor-semantic-rerank.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/executor-semantic-rerank.test.ts
@@ -24,16 +24,9 @@ jest.mock('@/modules/database', () => ({
   getPrismaClient: () => ({ $queryRaw: jest.fn() }),
 }));
 
-jest.mock('@/utils/logger', () => ({
-  logger: {
-    child: () => ({
-      debug: jest.fn(),
-      warn: jest.fn(),
-      info: jest.fn(),
-      error: jest.fn(),
-    }),
-  },
-}));
+// Manual mock (src/utils/__mocks__/logger.ts) — full export surface,
+// survives module-scope top-level logger calls in imported prod code.
+jest.mock('@/utils/logger');
 
 // Config module mocked so we can toggle the flag without touching process.env.
 jest.mock('../config', () => ({

--- a/src/skills/plugins/video-discover/v3/__tests__/executor-whitelist-gate.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/executor-whitelist-gate.test.ts
@@ -25,16 +25,9 @@ jest.mock('@/modules/database', () => ({
   getPrismaClient: () => ({ $queryRaw: jest.fn() }),
 }));
 
-jest.mock('@/utils/logger', () => ({
-  logger: {
-    child: () => ({
-      debug: jest.fn(),
-      warn: jest.fn(),
-      info: jest.fn(),
-      error: jest.fn(),
-    }),
-  },
-}));
+// Manual mock (src/utils/__mocks__/logger.ts) — full export surface,
+// survives module-scope top-level logger calls in imported prod code.
+jest.mock('@/utils/logger');
 
 jest.mock('../config', () => ({
   v3Config: {

--- a/src/utils/__mocks__/logger.ts
+++ b/src/utils/__mocks__/logger.ts
@@ -1,0 +1,31 @@
+/**
+ * Manual mock for '@/utils/logger' (jest picks this up on jest.mock('@/utils/logger')).
+ *
+ * Mirrors the real module's full export surface. Production modules call
+ * top-level logger.info/warn at import time (e.g. modules/database Prisma
+ * init) — hand-rolled child-only partial mocks throw at suite load, which
+ * silently broke 5 non-smoke suites that CI never runs.
+ */
+const childLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+export const logger: any = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  child: jest.fn(() => childLogger),
+};
+
+export function createLogger(_context: string) {
+  return childLogger;
+}
+
+export const logQuotaUsage = jest.fn();
+export const logSyncOperation = jest.fn();
+
+export default logger;


### PR DESCRIPTION
## Class being closed
G4 scoping follow-up (supervisor-directed): of 23 non-smoke failing suites, 10 fail **at suite load**. The dominant sub-class (5 suites) is one drift: tests mock `@/utils/logger` as **child-only**, while production code later added **top-level** `logger.info` at module scope (`src/modules/database/index.ts:69` Prisma init) — every import chain that reaches it throws `TypeError: logger.info is not a function` before a single test runs. CI never executes non-smoke suites (`ci.yml:125`), so this rotted silently.

## Fix (test-only, production untouched)
- `src/utils/__mocks__/logger.ts` — jest manual mock mirroring the real export surface (top-level `info/warn/error/debug`, `child()`, `createLogger`, `logQuotaUsage`, `logSyncOperation`, default). The module-scope logging pattern in prod code is respected, not changed.
- The 5 suites drop their inline factories for one-line `jest.mock('@/utils/logger')`: iks-scorer/executor, trend-collector/executor.execute, video-discover/executor, v3/executor-semantic-rerank, v3/executor-whitelist-gate.
- `v5-search-trace`: its config mock gains the `gmail` block — `mailer.ts:12` builds a transporter from `config.gmail` at module scope via the import chain (`undefined.smtpHost`).

## Evidence
- Before: 6 suites = 6 load failures (0 tests run).
- After: **5 suites fully green**; combined run 87 tests / 76 pass.
- `tsc --noEmit` 0 errors.
- Honest note: `video-discover/__tests__/executor.test.ts` now **loads** but exposes 11 pre-existing legacy runtime drifts (Fix2/Fix3/CP360-era assertions) the load failure was masking — deliberately out of scope here, tracked in the runtime-debt bucket (G4 item 6 material).

🤖 Generated with [Claude Code](https://claude.com/claude-code)