### PR TITLE
fix(tests): repair three TS-drift suites failing at load (never run by CI)

### DIFF
--- a/tests/unit/modules/book-factcheck.test.ts
+++ b/tests/unit/modules/book-factcheck.test.ts
@@ -23,7 +23,6 @@ import {
   factcheckChapterBody,
   buildFactcheckPrompt,
   type FactSentence,
-  type CheckResult,
 } from '../../../src/modules/mandala-book/book-factcheck';
 
 // Minimal mock CSE client (never throws, returns controlled items).

--- a/tests/unit/modules/book-skeleton.test.ts
+++ b/tests/unit/modules/book-skeleton.test.ts
@@ -149,8 +149,8 @@ describe('buildBookJson skeleton mode (gate[2]: cross-cell, ch sequential, intro
     expect(ch.intro).toBe('기초를 다지고 실전으로'); // POPULATED (legacy cell mode = '')
     expect(ch.sections).toHaveLength(2); // both topics, across cells
     // global atom resolution: section 0 ← vidA (cell0), section 1 ← vidB (cell1)
-    expect(ch.sections[0]!.atoms[0]!.vid).toBe('vidA');
-    expect(ch.sections[1]!.atoms[0]!.vid).toBe('vidB');
+    expect(ch.sections[0]!.atoms![0]!.vid).toBe('vidA');
+    expect(ch.sections[1]!.atoms![0]!.vid).toBe('vidB');
   });
 
   it('drops a skeleton chapter whose topic_refs all fail to resolve', () => {

--- a/tests/unit/modules/rec-publisher.test.ts
+++ b/tests/unit/modules/rec-publisher.test.ts
@@ -26,6 +26,8 @@ function makePayload(overrides: Partial<CardPayload> = {}): CardPayload {
     keyword: 'daily routine',
     source: 'auto_recommend',
     recReason: 'tier:gold',
+    publishedAt: null,
+    startSec: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Class
Part of the non-smoke debt repair (G4 item 6): these three suites fail **at suite load** with TS errors because production types moved and CI never runs non-smoke suites (`ci.yml:125`).

## Fixes (code is SSOT — assertions follow current contracts, #1058 method)
- `rec-publisher.test.ts`: `CardPayload` gained required `publishedAt: string | null` (publisher.ts:48) and `startSec: number | null` — the `makePayload` factory now supplies `null` defaults (TS2322).
- `book-skeleton.test.ts`: `Section.atoms` became optional — added non-null assertions on the two asserted paths (TS2532).
- `book-factcheck.test.ts`: removed unused `CheckResult` type import (TS6133).

## Evidence
- Before: 3 suites = load failures, 0 tests run.
- After: **rec-publisher 8/8, book-skeleton + book-factcheck 39/39** (solo runs).
- `tsc --noEmit` 0 errors. Test-only diff (3 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)