### PR TITLE
fix(tests): five small runtime-drift suites follow current contracts

### DIFF
--- a/src/skills/plugins/video-discover/__tests__/v2-youtube-client.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v2-youtube-client.test.ts
@@ -210,7 +210,10 @@ describe('searchVideos — key rotation on 403 quota', () => {
     expect(urls[1]).toContain('key=KEY2');
   });
 
-  test('does NOT rotate on non-quota 403 (e.g., referer blocked)', async () => {
+  // 282ac58b "fix(v3): unified hybrid pipeline": isQuotaError now treats ALL
+  // search.list 403/429 as rotatable (youtube-client.ts:208) — the prior
+  // quota|exceeded-only match left referer-blocked/429 keys stuck on first try.
+  test('rotates on non-quota 403 too (e.g., referer blocked) — all 403/429 rotate', async () => {
     let call = 0;
     const fetchFn = (async () => {
       call++;
@@ -226,8 +229,8 @@ describe('searchVideos — key rotation on 403 quota', () => {
     await expect(searchVideos({ query: 'x', apiKey: ['KEY1', 'KEY2'], fetchFn })).rejects.toThrow(
       /referer/
     );
-    // Only one call — did not rotate
-    expect(call).toBe(1);
+    // Both keys tried — referer-blocked 403 rotates instead of failing fast
+    expect(call).toBe(2);
   });
 
   test('throws if all keys quota-exhausted', async () => {

--- a/tests/unit/modules/chatbot-rag/prompt-builder.test.ts
+++ b/tests/unit/modules/chatbot-rag/prompt-builder.test.ts
@@ -378,8 +378,11 @@ describe('LAYER_BLOCKS shape', () => {
   });
 
   it('LAYER_BLOCKS_FALLBACK substitutes T for A-D blocks', () => {
-    expect(LAYER_BLOCKS_FALLBACK.video).toEqual(['T', 'U', 'H']);
-    expect(LAYER_BLOCKS_FALLBACK['video-time']).toEqual(['T', 'F', 'U', 'H']);
+    // CP477+15 (#742 b1ce8350): fallback layers gained structural blocks E/I/J/N
+    // and block order is now U → mandala → book → cards → note → video
+    // (prompt-builder.ts:239 LAYER_BLOCKS_FALLBACK).
+    expect(LAYER_BLOCKS_FALLBACK.video).toEqual(['U', 'E', 'I', 'J', 'N', 'T', 'H']);
+    expect(LAYER_BLOCKS_FALLBACK['video-time']).toEqual(['U', 'E', 'I', 'J', 'N', 'T', 'F', 'H']);
     for (const blocks of Object.values(LAYER_BLOCKS_FALLBACK)) {
       // Fallback layers must never carry the v2-grounded A-D blocks.
       expect(blocks).not.toContain('A');
@@ -426,14 +429,15 @@ describe('buildQwenSystemPrompt — full stack assembly', () => {
     expect(idxPersona).toBe(0);
     expect(idxRole).toBeGreaterThan(idxPersona);
     expect(idxExtended).toBeGreaterThan(idxRole);
-    // Per LAYER_BLOCKS.note = ['A','B','C','D','F','G','U','H'], A precedes
-    // F, G, U, H — and E is NOT in the note layer (mandala block only attaches
-    // to mandala/cell layers).
-    expect(idxA).toBeGreaterThan(idxExtended);
-    expect(idxE).toBe(-1);
+    // CP477+15 (#742 b1ce8350): LAYER_BLOCKS.note =
+    // ['U','E','I','J','N','A','B','C','D','F','G','H'] (prompt-builder.ts:230)
+    // — E now attaches to every mandala-scoped layer, and blocks render in
+    // user → mandala → video → state → note → RAG order.
+    expect(idxU).toBeGreaterThan(idxExtended);
+    expect(idxE).toBeGreaterThan(idxU);
+    expect(idxA).toBeGreaterThan(idxE);
     expect(idxF).toBeGreaterThan(idxA);
     expect(idxG).toBeGreaterThan(idxF);
-    expect(idxU).toBeGreaterThan(idxG);
-    expect(idxH).toBeGreaterThan(idxU);
+    expect(idxH).toBeGreaterThan(idxG);
   });
 });

--- a/tests/unit/modules/queue-handlers.test.ts
+++ b/tests/unit/modules/queue-handlers.test.ts
@@ -33,6 +33,15 @@ jest.mock('../../../src/config', () => ({
     // CP498: enrich-rich-summary (PR2) + enrich-relevance-quick (PR3b) workers
     // read these at registration.
     queue: { richSummaryConcurrency: 4, relevanceBackfillConcurrency: 4 },
+    // CP457+: discover-tracing/index.ts reads config.discoverTracing.enabled at
+    // module scope (line 37), imported transitively via v2/youtube-client.
+    discoverTracing: { enabled: false },
+    // Observability Phase 1/2 (#1037): searchTrace read by pool-serve-fill /
+    // search-metrics-rollup; observability + gmail read by key-alarm/report handlers.
+    searchTrace: { enabled: false },
+    poolMaintenance: { enabled: false },
+    observability: { keyAlarmMaxKeys: 8, alertEmail: 'test@example.com' },
+    gmail: { smtpFrom: 'test@example.com' },
   },
 }));
 
@@ -205,13 +214,16 @@ describe('initJobQueue integration', () => {
     const { initJobQueue } = require('../../../src/modules/queue');
     await initJobQueue();
 
-    // Should register all 7 workers: enrich-video, batch-scan,
-    // enrich-rich-summary, batch-video-collector, pool-maintenance,
-    // enrich-relevance-quick (CP498 PR3b), mandala-actions-fill (W1' CP499+).
-    expect(mockBossInstance.work).toHaveBeenCalledTimes(7);
+    // Should register all 15 workers per src/modules/queue/index.ts:57-71:
+    // enrich-video, batch-scan, enrich-rich-summary, batch-video-collector,
+    // pool-maintenance, enrich-relevance-quick, pool-serve-fill,
+    // mandala-actions-fill, mandala-book-fill, translate-mandala-bulk,
+    // segment-relevance-fill, deck-build, note-cv-enrich, key-alarm (#1037),
+    // search-metrics-rollup (#1037).
+    expect(mockBossInstance.work).toHaveBeenCalledTimes(15);
 
-    // Should schedule batch-scan
-    expect(mockBossInstance.schedule).toHaveBeenCalledTimes(1);
+    // Should schedule batch-scan + key-alarm + search-metrics-rollup (#1037).
+    expect(mockBossInstance.schedule).toHaveBeenCalledTimes(3);
     expect(mockBossInstance.schedule).toHaveBeenCalledWith(
       'batch-scan',
       '*/30 * * * *',

--- a/tests/unit/modules/snapshot-get-or-extract.test.ts
+++ b/tests/unit/modules/snapshot-get-or-extract.test.ts
@@ -108,10 +108,13 @@ describe('get-or-extract', () => {
     expect(figs).toEqual([]); // no fabricated figures
 
     // Sentinels upserted for ts=5 and ts=6 to prevent future re-extraction.
+    // CP505 (#1011 f32d0161): upsertSentinel params follow the SQL column order
+    // (get-or-extract.ts:90) — $1 videoId, $2 tsSec, $3 kind, $4 status, $5 source.
     expect(mockExec).toHaveBeenCalledTimes(2);
     const firstCall = mockExec.mock.calls[0]!;
-    expect(firstCall[2]).toBe('__none__'); // kind param is the sentinel marker
-    expect(firstCall[4]).toBe('negative-cache'); // source param
+    expect(firstCall[2]).toBe(5); // ts_sec param
+    expect(firstCall[3]).toBe('__none__'); // kind param is the sentinel marker
+    expect(firstCall[5]).toBe('negative-cache'); // source param
   });
 
   it('(d) negative-cache sentinel within window prevents re-extraction', async () => {
@@ -173,8 +176,10 @@ describe('get-or-extract', () => {
 
     expect(mockExtract).toHaveBeenCalledWith(VID, [500]); // only the miss
     // One sentinel for ts=500 (no extracted figure covered it).
+    // CP505 (#1011 f32d0161): sentinel kind is param $3 (get-or-extract.ts:90).
     expect(mockExec).toHaveBeenCalledTimes(1);
-    expect(mockExec.mock.calls[0]![2]).toBe('__none__');
+    expect(mockExec.mock.calls[0]![2]).toBe(500); // ts_sec param
+    expect(mockExec.mock.calls[0]![3]).toBe('__none__');
     expect(figs).toHaveLength(1); // only the cached ts=10 row
     expect(figs[0]!.tsSec).toBe(10);
   });

--- a/tests/unit/skills/rich-summary-v2.test.ts
+++ b/tests/unit/skills/rich-summary-v2.test.ts
@@ -189,10 +189,18 @@ describe('scoreCompleteness', () => {
     expect(r.score).toBeLessThan(PASS_THRESHOLD);
   });
 
-  test('fails when one_liner exceeds 20 chars', () => {
+  // CP504 (#973 ada0294f): one_liner length cap relaxed in scoreCompleteness —
+  // scored on non-emptiness only (rich-summary-v2-prompt.ts:731); the short-label
+  // constraint moved to optional toc_label. Long one_liner no longer penalized.
+  test('one_liner over 20 chars no longer penalized; empty one_liner fails', () => {
     const s = validSummary();
     s.core.one_liner = '가'.repeat(ONE_LINER_MAX_LEN + 1);
-    const r = scoreCompleteness(s);
+    let r = scoreCompleteness(s);
+    expect(r.score).toBe(1);
+    expect(r.reasons.some((x) => x.includes('one_liner'))).toBe(false);
+
+    s.core.one_liner = '';
+    r = scoreCompleteness(s);
     expect(r.score).toBeLessThan(1);
     expect(r.reasons.some((x) => x.includes('one_liner'))).toBe(true);
   });


### PR DESCRIPTION
## Class
Runtime assertion drifts in non-smoke suites (never run by CI). Every change traced to an explicit intentional commit — none flagged as code regression.

- rich-summary-v2: one_liner length cap relaxed (#973 ada0294f) — long no longer penalized
- chatbot-rag/prompt-builder: LAYER_BLOCKS/FALLBACK reshaped (#742 b1ce8350)
- snapshot-get-or-extract: negative-cache sentinel param order (#1011 f32d0161)
- v2-youtube-client: isQuotaError now rotates on ALL 403/429 (282ac58b, explicit commit message)
- queue-handlers: 7→15 workers + 3 schedules (#1037) + config-mock shape (discover-tracing module-scope read)

Solo runs: 82/82 across the 5 suites. Test-only diff (5 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)