### PR TITLE
fix(tests): three complex runtime-drift suites (upsert-slots, mandala-routes, wizard-precompute)

### DIFF
--- a/src/skills/plugins/video-discover/__tests__/v3-upsert-slots.test.ts
+++ b/src/skills/plugins/video-discover/__tests__/v3-upsert-slots.test.ts
@@ -114,6 +114,9 @@ jest.mock('@/skills/plugins/video-discover/v2/youtube-client', () => ({
   titleIndicatesShorts: jest.fn().mockReturnValue(false),
   titleHitsBlocklist: jest.fn().mockReturnValue(false),
   resolveSearchApiKeys: jest.fn().mockReturnValue(['test-api-key']),
+  // Added after this mock was written (videos.list key split) — executor.ts:577
+  // calls it at execute time, so a missing mock fails all tests in the suite.
+  resolveVideosApiKeys: jest.fn().mockReturnValue(['test-videos-key']),
 }));
 
 // ─── LLM keyword builder — return one search query per cell ──────────────────

--- a/tests/unit/api/mandala-routes.test.ts
+++ b/tests/unit/api/mandala-routes.test.ts
@@ -85,6 +85,15 @@ const mockEnqueueDeckBuild = jest.fn().mockResolvedValue('deck-job-1');
 jest.mock('../../../src/modules/queue/handlers/deck-build', () => ({
   enqueueDeckBuild: (...a: unknown[]) => mockEnqueueDeckBuild(...a),
 }));
+// ④ /quota daily-limit block reads prisma directly ($queryRaw super-admin
+// check + user_mandalas.count) — added after this suite was written.
+// The route imports getPrismaClient from modules/database/client (mandalas.ts:11).
+jest.mock('../../../src/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    $queryRaw: jest.fn().mockResolvedValue([{ is_super_admin: false }]),
+    user_mandalas: { count: jest.fn().mockResolvedValue(0) },
+  }),
+}));
 
 import { mandalaRoutes } from '../../../src/api/routes/mandalas';
 
@@ -354,6 +363,8 @@ describe('Mandala API Routes', () => {
       const res = await app.inject({
         method: 'GET',
         url: `${PREFIX}/explore`,
+        // /explore requires auth since #666 (onRequest: [fastify.authenticate])
+        headers: authHeaders(),
       });
 
       expect(res.statusCode).toBe(200);
@@ -364,6 +375,7 @@ describe('Mandala API Routes', () => {
       const res = await app.inject({
         method: 'GET',
         url: `${PREFIX}/explore?page=0`,
+        headers: authHeaders(),
       });
 
       expect(res.statusCode).toBe(400);
@@ -380,6 +392,7 @@ describe('Mandala API Routes', () => {
       const res = await app.inject({
         method: 'GET',
         url: `${PREFIX}/explore?page=2&limit=5&domain=tech&sort=popular&source=template`,
+        headers: authHeaders(),
       });
 
       expect(res.statusCode).toBe(200);

--- a/tests/unit/modules/wizard-precompute.test.ts
+++ b/tests/unit/modules/wizard-precompute.test.ts
@@ -70,6 +70,24 @@ jest.mock('@/config/wizard-precompute', () => ({
   loadWizardPrecomputeConfig: mockLoadConfig,
 }));
 
+// #1037 added fire-and-forget observability calls (trail log + placed-not-in
+// reclassify) into startPrecompute/consume — unmocked they hit real config/DB
+// at module scope, flipping the happy path to status=failed.
+jest.mock('@/modules/search-trace', () => ({
+  writeSearchTrace: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/skills/plugins/video-discover/v5/trace-candidates', () => ({
+  reclassifyPlacedNotIn: jest.fn().mockResolvedValue(undefined),
+}));
+// discover-tracing is dynamically imported in the consume path; its real
+// recordTrace writes through the (mocked) prisma client's $executeRaw and
+// inflates the INSERT call count the tests assert on.
+jest.mock('@/modules/discover-tracing', () => ({
+  withTraceContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  recordTrace: jest.fn(),
+  getTraceContext: jest.fn(() => null),
+}));
+
 jest.mock('@/utils/logger', () => ({
   logger: {
     child: () => ({
@@ -152,6 +170,9 @@ describe('wizard-precompute — startPrecompute', () => {
       tier2_matches: 2,
       duration_ms: 1234,
       debug: { timing: { totalMs: 1234 } },
+      // v5 contract: diagnostics is always present (wizard-adapter.ts:52 reads
+      // it unguarded); #1037 trail log reads optional fields off it.
+      diagnostics: {},
     };
     mockCreate.mockResolvedValueOnce({});
     mockUpdate.mockResolvedValue({});
@@ -348,12 +369,14 @@ describe('wizard-precompute — consumePrecompute', () => {
     const elapsed = Date.now() - t0;
     expect(r.consumed).toBe(false);
     expect(r.reason).toBe('not-done');
-    // Should give up within ~1s (POLL_BUDGET_MS=1000). Lower bound allows
-    // for the polling interval (250ms) to catch the budget-exhausted state
-    // on its next tick. Upper bound guards against budget creep.
-    expect(elapsed).toBeGreaterThanOrEqual(800);
-    expect(elapsed).toBeLessThan(1500);
-  }, 5_000);
+    // Should give up within ~6s (POLL_BUDGET_MS=6_000 since #666 — the CP436
+    // 1s budget was raised with the settle-window work). Lower bound allows
+    // for the polling interval (250ms); upper bound guards budget creep.
+    // NOTE: the jest timeout MUST exceed the budget — a timed-out test leaks
+    // its still-running poll loop into the next test's mocks (double INSERT).
+    expect(elapsed).toBeGreaterThanOrEqual(5800);
+    expect(elapsed).toBeLessThan(7500);
+  }, 10_000);
 
   test('status=running → done within budget → consume succeeds', async () => {
     // First read: running. Subsequent reads: done.


### PR DESCRIPTION
## Fixes (each verified against code history)
- **v3-upsert-slots** (was 4/4 failing): youtube-client mock gained `resolveVideosApiKeys` — the videos.list key-split fn is called at execute time (v3/executor.ts:577); missing mock failed the whole suite. **4/4**
- **mandala-routes** (was 4 failing): /explore requires auth since #666 → authHeaders on 3 injects; /quota's daily-limit block ($queryRaw super-admin + user_mandalas.count, mandalas.ts:680+) needs a database/client mock (route imports it at mandalas.ts:11). **57/57**
- **wizard-precompute** (was 3 failing): #1037 observability imports mocked (search-trace / trace-candidates / discover-tracing); v5 fixture gains the always-present `diagnostics` (wizard-adapter.ts:52 reads it unguarded); poll test updated to the #666 `POLL_BUDGET_MS=6s` contract. Root-cause note: the old 5s jest timeout was BELOW the 6s budget — the timed-out test leaked its live poll loop into the next test's mocks, which produced a phantom duplicate INSERT. **21/21**

Test-only diff (3 files). Part of the G4-item-6 non-smoke debt repair track (#1058 #1060 #1061 #1062 siblings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)