### PR TITLE
feat(observability): thread videoId/userId onto llm_call_logs (#963)

### DIFF
--- a/src/modules/llm/gemini.ts
+++ b/src/modules/llm/gemini.ts
@@ -80,6 +80,8 @@ export class GeminiGenerationProvider implements GenerationProvider {
       });
     } catch (err) {
       logLLMCall({
+        videoId: options?.videoId,
+        userId: options?.userId,
         module: 'gemini',
         model: this.model,
         latencyMs: Date.now() - startTime,
@@ -92,6 +94,8 @@ export class GeminiGenerationProvider implements GenerationProvider {
     if (!response.ok) {
       const errorBody = await response.text();
       logLLMCall({
+        videoId: options?.videoId,
+        userId: options?.userId,
         module: 'gemini',
         model: this.model,
         latencyMs: Date.now() - startTime,
@@ -109,6 +113,8 @@ export class GeminiGenerationProvider implements GenerationProvider {
     const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
     if (!text) {
       logLLMCall({
+        videoId: options?.videoId,
+        userId: options?.userId,
         module: 'gemini',
         model: this.model,
         inputTokens: data.usageMetadata?.promptTokenCount,
@@ -122,6 +128,8 @@ export class GeminiGenerationProvider implements GenerationProvider {
 
     // Fire-and-forget cost log
     logLLMCall({
+      videoId: options?.videoId,
+      userId: options?.userId,
       module: 'gemini',
       model: this.model,
       inputTokens: data.usageMetadata?.promptTokenCount,

--- a/src/modules/llm/ollama.ts
+++ b/src/modules/llm/ollama.ts
@@ -88,6 +88,8 @@ export class OllamaGenerationProvider implements GenerationProvider {
       });
     } catch (err) {
       logLLMCall({
+        videoId: options?.videoId,
+        userId: options?.userId,
         module: 'ollama',
         model: this.model,
         latencyMs: Date.now() - startTime,
@@ -100,6 +102,8 @@ export class OllamaGenerationProvider implements GenerationProvider {
     if (!response.ok) {
       const errorBody = await response.text();
       logLLMCall({
+        videoId: options?.videoId,
+        userId: options?.userId,
         module: 'ollama',
         model: this.model,
         latencyMs: Date.now() - startTime,
@@ -119,6 +123,8 @@ export class OllamaGenerationProvider implements GenerationProvider {
 
     if (!content) {
       logLLMCall({
+        videoId: options?.videoId,
+        userId: options?.userId,
         module: 'ollama',
         model: this.model,
         inputTokens: data.prompt_eval_count,
@@ -132,6 +138,8 @@ export class OllamaGenerationProvider implements GenerationProvider {
 
     // Fire-and-forget cost log (Ollama = local inference, zero cost)
     logLLMCall({
+      videoId: options?.videoId,
+      userId: options?.userId,
       module: 'ollama',
       model: this.model,
       inputTokens: data.prompt_eval_count,

--- a/src/modules/llm/openrouter.ts
+++ b/src/modules/llm/openrouter.ts
@@ -135,6 +135,8 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
           // Distinguish "external cancel" from internal timeout for clearer logs.
           if (externalSignal?.aborted) {
             logLLMCall({
+              videoId: options?.videoId,
+              userId: options?.userId,
               module: 'openrouter',
               model: this.model,
               latencyMs,
@@ -144,6 +146,8 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
             throw new Error('OpenRouter request cancelled by external signal');
           }
           logLLMCall({
+            videoId: options?.videoId,
+            userId: options?.userId,
             module: 'openrouter',
             model: this.model,
             latencyMs,
@@ -153,6 +157,8 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
           throw new Error(`OpenRouter request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`);
         }
         logLLMCall({
+          videoId: options?.videoId,
+          userId: options?.userId,
           module: 'openrouter',
           model: this.model,
           latencyMs,
@@ -171,6 +177,8 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
       if (!response.ok && isRetryableStatus(response.status) && attempt < OPENROUTER_MAX_RETRIES) {
         const delayMs = retryDelayMs(response.headers?.get?.('retry-after') ?? null, attempt);
         logLLMCall({
+          videoId: options?.videoId,
+          userId: options?.userId,
           module: 'openrouter',
           model: this.model,
           latencyMs: Date.now() - startTime,
@@ -186,6 +194,8 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
     if (!response.ok) {
       const errorBody = await response.text();
       logLLMCall({
+        videoId: options?.videoId,
+        userId: options?.userId,
         module: 'openrouter',
         model: this.model,
         latencyMs: Date.now() - startTime,
@@ -212,6 +222,8 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
     if (!content) {
       const hasReasoning = !!message?.reasoning;
       logLLMCall({
+        videoId: options?.videoId,
+        userId: options?.userId,
         module: 'openrouter',
         model: this.model,
         inputTokens: data.usage?.prompt_tokens,
@@ -229,6 +241,8 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
 
     // Fire-and-forget cost log — errors handled inside logLLMCall
     logLLMCall({
+      videoId: options?.videoId,
+      userId: options?.userId,
       module: 'openrouter',
       model: this.model,
       inputTokens: data.usage?.prompt_tokens,

--- a/src/modules/llm/provider.ts
+++ b/src/modules/llm/provider.ts
@@ -21,6 +21,13 @@ export interface GenerateOptions {
    * Used by race-fallback patterns to discard losers without waiting for them.
    */
   signal?: AbortSignal;
+  /**
+   * Cost-attribution passthrough (#963) — providers copy these onto the
+   * llm_call_logs row so per-video/per-user cost and cache-hit-rate become
+   * measurable. Purely additive: absent = NULL, logging behavior unchanged.
+   */
+  videoId?: string;
+  userId?: string;
 }
 
 export interface GenerationProvider {

--- a/src/modules/relevance/compute-card-relevance.ts
+++ b/src/modules/relevance/compute-card-relevance.ts
@@ -37,6 +37,8 @@ const MAX_TOKENS = 800;
 const TEMPERATURE = 0.2;
 
 export interface CardRelevanceInput {
+  /** #963 — optional cost attribution onto llm_call_logs (absent = NULL). */
+  videoId?: string;
   /** Card title (required — the minimal signal). */
   title: string;
   /** Card description / metadata_description (optional). */
@@ -122,6 +124,7 @@ export async function computeCardRelevance(
       format: 'json',
       temperature: TEMPERATURE,
       maxTokens: MAX_TOKENS,
+      videoId: input.videoId,
     });
   } catch (err) {
     return {

--- a/src/modules/skills/rich-summary-v2-generator.ts
+++ b/src/modules/skills/rich-summary-v2-generator.ts
@@ -196,6 +196,9 @@ export async function generateRichSummaryV2(
         format: 'json',
         temperature: TEMPERATURE,
         maxTokens: richConfig.maxOutputTokens,
+        // #963 — cost attribution onto llm_call_logs
+        videoId: input.videoId,
+        userId: input.userId ?? undefined,
       });
       let parsed: unknown;
       try {

--- a/src/modules/skills/rich-summary.ts
+++ b/src/modules/skills/rich-summary.ts
@@ -187,7 +187,9 @@ export async function enrichRichSummary(
   const generate = (
     prompt: string,
     opts?: { format?: 'json' | 'text'; temperature?: number; maxTokens?: number }
-  ) => generationProvider.generate(prompt, opts);
+  ) =>
+    // #963 — every v1/v2 enrich call carries its video/user for cost attribution
+    generationProvider.generate(prompt, { ...opts, videoId, userId: options.userId });
 
   const transcriptChunk = options.transcript
     ? options.transcript.slice(0, TRANSCRIPT_CHUNK_SIZE)

--- a/tests/smoke/llm-call-log-attribution.test.ts
+++ b/tests/smoke/llm-call-log-attribution.test.ts
@@ -1,0 +1,94 @@
+/**
+ * #963 — llm_call_logs cost attribution.
+ *
+ * Verifies the videoId/userId passthrough lands on the llm_call_logs row
+ * WITHOUT any real LLM call (fetch is mocked — the LLM-API hard rule holds):
+ *   provider.generate(prompt, { videoId, userId })
+ *     → logLLMCall({ videoId, userId })
+ *     → prisma.llm_call_logs.create({ data: { video_id, user_id } })
+ *
+ * Lives in tests/smoke so CI actually executes it (ci.yml testPathPattern).
+ */
+
+const mockLlmLogCreate = jest.fn().mockResolvedValue({});
+
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    llm_call_logs: { create: mockLlmLogCreate },
+  }),
+}));
+
+jest.mock('@/config/index', () => {
+  const actual = jest.requireActual('@/config/index');
+  return {
+    ...actual,
+    config: {
+      ...actual.config,
+      openrouter: { ...actual.config.openrouter, apiKey: 'test-key' },
+    },
+  };
+});
+
+import { OpenRouterGenerationProvider } from '../../src/modules/llm/openrouter';
+import { logLLMCall } from '../../src/modules/llm/call-logger';
+
+const VIDEO = 'vidAttr12345';
+const USER = 'bbbbbbbb-1111-2222-3333-dddddddddddd';
+
+describe('#963 llm_call_logs attribution', () => {
+  beforeEach(() => {
+    mockLlmLogCreate.mockClear();
+  });
+
+  test('logLLMCall persists videoId/userId onto the row', async () => {
+    await logLLMCall({
+      module: 'openrouter',
+      model: 'openrouter/test-model',
+      status: 'success',
+      videoId: VIDEO,
+      userId: USER,
+    });
+    expect(mockLlmLogCreate).toHaveBeenCalledTimes(1);
+    expect(mockLlmLogCreate.mock.calls[0]![0].data).toMatchObject({
+      video_id: VIDEO,
+      user_id: USER,
+    });
+  });
+
+  test('logLLMCall without attribution stays NULL (additive default unchanged)', async () => {
+    await logLLMCall({
+      module: 'openrouter',
+      model: 'openrouter/test-model',
+      status: 'success',
+    });
+    expect(mockLlmLogCreate.mock.calls[0]![0].data).toMatchObject({
+      video_id: null,
+      user_id: null,
+    });
+  });
+
+  test('provider.generate threads videoId/userId through to the log row (success path, fetch mocked)', async () => {
+    const realFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' } }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      }),
+      headers: { get: () => null },
+      text: async () => '',
+    }) as unknown as typeof fetch;
+    try {
+      const provider = new OpenRouterGenerationProvider('openrouter/test-model');
+      await provider.generate('hello', { videoId: VIDEO, userId: USER });
+      // fire-and-forget log write — flush microtasks
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockLlmLogCreate).toHaveBeenCalled();
+      const rows = mockLlmLogCreate.mock.calls.map((c) => c[0].data);
+      expect(rows.some((d) => d.video_id === VIDEO && d.user_id === USER)).toBe(true);
+    } finally {
+      global.fetch = realFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Why
30d prod measurement (tick20): `llm_call_logs.video_id` is NULL across **all** modules (11,274 Haiku + 1,575 Sonnet calls, 0 with video_id) — blocking per-video cost attribution, global v2 cache hit-rate (#963), and pro-gating cost metering.

## What (additive only — no DDL, no behavior change)
- `GenerateOptions` gains optional `videoId`/`userId` (`provider.ts`).
- All **15** `logLLMCall` sites in the three providers (openrouter 7, gemini 4, ollama 4) copy them through — full write-site coverage, verified the DB INSERT is a single chokepoint (`call-logger.ts:48`).
- Video-scoped callers wired: rich-summary v2 generator (Sonnet full path, `input.videoId`), v1/quick path (`enrichRichSummary` param), `computeCardRelevance` (optional input field).
- Non-video callers (mandala-gen, book pipeline, llm-picker) legitimately stay NULL — enumerated, not missed.

## Verification (no real LLM call — hard-rule compliant)
- `tests/smoke/llm-call-log-attribution.test.ts` (CI-executed path): fetch-mocked `generate()` → log row carries `video_id`/`user_id`; absent → stays NULL (additive default). 3/3.
- Full smoke suite: 206 passed. `tsc --noEmit` 0.
- Post-deploy check (step for James): first organic v2 call → `SELECT video_id FROM llm_call_logs WHERE module='openrouter' ORDER BY created_at DESC LIMIT 5` shows non-NULL.

Closes #963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)