### PR TITLE
feat(learning): video-view center column redesign — chapters tab + floating video navigator

### DIFF
--- a/frontend/src/__tests__/relevance-level.test.ts
+++ b/frontend/src/__tests__/relevance-level.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import {
+  relevanceLevel,
+  relevanceBars,
+  relevanceCssVar,
+  RELEVANCE_HIGH_MIN,
+  RELEVANCE_MID_MIN,
+} from '@/pages/learning/lib/relevance-level';
+
+describe('relevanceLevel', () => {
+  it('maps boundaries to tiers (>=80 high / >=50 mid / <50 low)', () => {
+    expect(relevanceLevel(100)).toBe('high');
+    expect(relevanceLevel(RELEVANCE_HIGH_MIN)).toBe('high');
+    expect(relevanceLevel(RELEVANCE_HIGH_MIN - 1)).toBe('mid');
+    expect(relevanceLevel(RELEVANCE_MID_MIN)).toBe('mid');
+    expect(relevanceLevel(RELEVANCE_MID_MIN - 1)).toBe('low');
+    expect(relevanceLevel(0)).toBe('low');
+  });
+
+  it('lights 3/2/1 meter bars by tier', () => {
+    expect(relevanceBars('high')).toBe(3);
+    expect(relevanceBars('mid')).toBe(2);
+    expect(relevanceBars('low')).toBe(1);
+  });
+
+  it('resolves the token var per tier', () => {
+    expect(relevanceCssVar('high')).toBe('var(--lp-rel-high)');
+    expect(relevanceCssVar('mid')).toBe('var(--lp-rel-mid)');
+    expect(relevanceCssVar('low')).toBe('var(--lp-rel-low)');
+  });
+});

--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1304,7 +1304,6 @@ html.dark .lemonsqueezy-loader {
   --lp-accent-tint: rgba(201,163,106,0.06);
   --lp-accent-border: rgba(201,163,106,0.30);
   --lp-hover-tint: rgba(255,255,255,0.025);
-  --lp-player-shadow: 0 30px 80px rgba(0,0,0,0.65), 0 0 90px rgba(201,163,106,0.06);
   --lp-avatar-grad: linear-gradient(135deg,#6d3a8f,#2a1840);
   --lp-avatar-fg: #e9d6f5;
   --lp-tab-active-fg: #15171c;

--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1277,6 +1277,38 @@ html.dark .lemonsqueezy-loader {
   --nm-callout-warning-border: rgba(210,160,90,0.30);
   --nm-callout-warning-accent: #d8a85f;
 
+  /* [VIDEO-VIEW] — center-column video view tokens (mockup video-view.html exact
+     values, CP510). Literals live here only; components reference var(--lp-*). */
+  --lp-bg-0: #08090b;
+  --lp-bg-1: #15171d;
+  --lp-accent: #c9a36a;
+  --lp-rel-high: #7fb69a;
+  --lp-rel-mid: #c9a36a;
+  --lp-rel-low: #76746e;
+  --lp-meter-off: rgba(255,255,255,0.13);
+  --lp-strong: #f3f1ec;
+  --lp-text: #cdcbc5;
+  --lp-body: #e8e6e1;
+  --lp-desc: #8d8b86;
+  --lp-dim: #86847f;
+  --lp-faint: #6f6d68;
+  --lp-mute: #56544f;
+  --lp-num: #4f4d49;
+  --lp-surface: #101216;
+  --lp-surface-2: #16181d;
+  --lp-line-8: rgba(255,255,255,0.08);
+  --lp-line-7: rgba(255,255,255,0.07);
+  --lp-line-6: rgba(255,255,255,0.06);
+  --lp-toggle-active-bg: #e8e6e1;
+  --lp-toggle-active-fg: #1a1b1e;
+  --lp-accent-tint: rgba(201,163,106,0.06);
+  --lp-accent-border: rgba(201,163,106,0.30);
+  --lp-hover-tint: rgba(255,255,255,0.025);
+  --lp-player-shadow: 0 30px 80px rgba(0,0,0,0.65), 0 0 90px rgba(201,163,106,0.06);
+  --lp-avatar-grad: linear-gradient(135deg,#6d3a8f,#2a1840);
+  --lp-avatar-fg: #e9d6f5;
+  --lp-tab-active-fg: #15171c;
+
   background: #0e0f10;
 }
 

--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1308,17 +1308,8 @@ html.dark .lemonsqueezy-loader {
   --lp-avatar-grad: linear-gradient(135deg,#6d3a8f,#2a1840);
   --lp-avatar-fg: #e9d6f5;
   --lp-tab-active-fg: #15171c;
-  /* player chrome (mockup ③ overlay) */
-  --lp-chrome-glass: rgba(15,12,18,0.5);
-  --lp-chrome-glass-shadow: 0 10px 36px rgba(0,0,0,0.55);
-  --lp-chip-bg: rgba(12,10,15,0.62);
-  --lp-chip-fg: #f3e8d4;
-  --lp-controls-grad: linear-gradient(transparent, rgba(8,6,10,0.82));
-  --lp-tip-bg: rgba(14,12,17,0.94);
-  --lp-tip-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  /* relevance-curve overlay (the only custom element on the native player) */
   --lp-head-glow: 0 0 8px rgba(201,163,106,0.85), 0 1px 3px rgba(0,0,0,0.6);
-  --lp-seg-track: rgba(255,255,255,0.18);
-  --lp-seg-track-high: rgba(127,182,154,0.30);
   --lp-curve-neutral: #ffffff;
 
   background: #0e0f10;

--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1308,6 +1308,18 @@ html.dark .lemonsqueezy-loader {
   --lp-avatar-grad: linear-gradient(135deg,#6d3a8f,#2a1840);
   --lp-avatar-fg: #e9d6f5;
   --lp-tab-active-fg: #15171c;
+  /* player chrome (mockup ③ overlay) */
+  --lp-chrome-glass: rgba(15,12,18,0.5);
+  --lp-chrome-glass-shadow: 0 10px 36px rgba(0,0,0,0.55);
+  --lp-chip-bg: rgba(12,10,15,0.62);
+  --lp-chip-fg: #f3e8d4;
+  --lp-controls-grad: linear-gradient(transparent, rgba(8,6,10,0.82));
+  --lp-tip-bg: rgba(14,12,17,0.94);
+  --lp-tip-shadow: 0 8px 24px rgba(0,0,0,0.5);
+  --lp-head-glow: 0 0 8px rgba(201,163,106,0.85), 0 1px 3px rgba(0,0,0,0.6);
+  --lp-seg-track: rgba(255,255,255,0.18);
+  --lp-seg-track-high: rgba(127,182,154,0.30);
+  --lp-curve-neutral: #ffffff;
 
   background: #0e0f10;
 }

--- a/frontend/src/features/video-side-panel/ui/PanelVideoPlayer.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelVideoPlayer.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { getYouTubeVideoId, loadYouTubeAPI } from '@/widgets/video-player/model/youtube-api';
 import type { YTPlayer } from '@/widgets/video-player/model/youtube-api';
 import { handleThumbnailError, handleThumbnailLoad } from '@/shared/lib/image-utils';
+import { cn } from '@/shared/lib/utils';
 
 export type PanelPlayerState = 'playing' | 'paused' | 'buffering' | 'ended' | 'unstarted' | 'cued';
 
@@ -29,6 +30,9 @@ export interface PanelVideoPlayerProps {
   onPlayStateChange?: (isPlaying: boolean) => void;
   /** Called every ~1s with current player time/state/duration for chatbot context. */
   onTimeUpdate?: (time: number, state: PanelPlayerState, duration: number) => void;
+  /** Fill the parent width (16:9, no vh caps) — learning video-view column
+   *  owns the sizing. Default false keeps the legacy 49.5vh side-panel cap. */
+  fill?: boolean;
 }
 
 const YT_STATE_MAP: Record<number, PanelPlayerState> = {
@@ -49,6 +53,7 @@ export function PanelVideoPlayer({
   onUserPlayed,
   onPlayStateChange,
   onTimeUpdate,
+  fill = false,
 }: PanelVideoPlayerProps) {
   const youtubeId = getYouTubeVideoId(videoUrl);
   const internalPlayerRef = useRef<YTPlayer | null>(null);
@@ -230,15 +235,23 @@ export function PanelVideoPlayer({
 
   return (
     <div
-      className="relative mx-auto w-full shrink-0 overflow-hidden rounded-lg bg-black"
+      className={cn(
+        'relative mx-auto w-full shrink-0 overflow-hidden bg-black',
+        !fill && 'rounded-lg'
+      )}
       // CP445.x — max-height 49.5vh (55vh 에서 10% 축소, 사용자 spec). 하단
       // 탭 콘텐츠 영역 추가 확보. aspect-ratio 16:9 유지 + max-width 도 비례
-      // cap (16/9 보존 + 가운데).
-      style={{
-        aspectRatio: '16/9',
-        maxHeight: '49.5vh',
-        maxWidth: 'calc(49.5vh * 16 / 9)',
-      }}
+      // cap (16/9 보존 + 가운데). fill=true (learning video-view) 는 부모
+      // 880px 컬럼이 사이징 소유 — vh cap 없이 16:9 풀폭.
+      style={
+        fill
+          ? { aspectRatio: '16/9' }
+          : {
+              aspectRatio: '16/9',
+              maxHeight: '49.5vh',
+              maxWidth: 'calc(49.5vh * 16 / 9)',
+            }
+      }
     >
       <iframe
         ref={iframeRef}
@@ -266,7 +279,11 @@ export function PanelVideoPlayer({
           />
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="flex h-14 w-14 items-center justify-center rounded-full bg-black/60">
-              <svg viewBox="0 0 24 24" className="h-7 w-7 translate-x-0.5 fill-white" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                className="h-7 w-7 translate-x-0.5 fill-white"
+                aria-hidden="true"
+              >
                 <path d="M8 5v14l11-7z" />
               </svg>
             </div>

--- a/frontend/src/features/video-side-panel/ui/PanelVideoPlayer.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelVideoPlayer.tsx
@@ -11,7 +11,6 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { getYouTubeVideoId, loadYouTubeAPI } from '@/widgets/video-player/model/youtube-api';
 import type { YTPlayer } from '@/widgets/video-player/model/youtube-api';
 import { handleThumbnailError, handleThumbnailLoad } from '@/shared/lib/image-utils';
-import { cn } from '@/shared/lib/utils';
 
 export type PanelPlayerState = 'playing' | 'paused' | 'buffering' | 'ended' | 'unstarted' | 'cued';
 
@@ -30,9 +29,6 @@ export interface PanelVideoPlayerProps {
   onPlayStateChange?: (isPlaying: boolean) => void;
   /** Called every ~1s with current player time/state/duration for chatbot context. */
   onTimeUpdate?: (time: number, state: PanelPlayerState, duration: number) => void;
-  /** Fill the parent width (16:9, no vh caps) — learning video-view column
-   *  owns the sizing. Default false keeps the legacy 49.5vh side-panel cap. */
-  fill?: boolean;
 }
 
 const YT_STATE_MAP: Record<number, PanelPlayerState> = {
@@ -53,7 +49,6 @@ export function PanelVideoPlayer({
   onUserPlayed,
   onPlayStateChange,
   onTimeUpdate,
-  fill = false,
 }: PanelVideoPlayerProps) {
   const youtubeId = getYouTubeVideoId(videoUrl);
   const internalPlayerRef = useRef<YTPlayer | null>(null);
@@ -68,7 +63,6 @@ export function PanelVideoPlayer({
   const initialAutoplayRef = useRef(shouldAutoplay);
   const initialStartTimeRef = useRef(startTime);
   const initialYoutubeIdRef = useRef(youtubeId);
-  const initialFillRef = useRef(fill);
 
   // Poster facade — the videoId whose sharp poster overlay is shown (null =
   // hidden). YouTube's NATIVE cued/paused iframe poster is low-res/blurry; we
@@ -230,31 +224,21 @@ export function PanelVideoPlayer({
   // can't reach the new iframe → second-card "stays paused" bug.
   const initialStart = initialStartTimeRef.current;
   const initialYoutubeId = initialYoutubeIdRef.current;
-  // fill (learning video-view) keeps the NATIVE YT chrome (user decision) —
-  // PlayerChrome only overlays the relevance curve above it.
   const embedSrc = initialYoutubeId
     ? `https://www.youtube.com/embed/${initialYoutubeId}?autoplay=${initialAutoplayRef.current ? 1 : 0}&rel=0&modestbranding=1&enablejsapi=1${initialStart ? `&start=${Math.floor(initialStart)}` : ''}`
     : '';
 
   return (
     <div
-      className={cn(
-        'relative mx-auto w-full shrink-0 overflow-hidden bg-black',
-        !fill && 'rounded-lg'
-      )}
+      className="relative mx-auto w-full shrink-0 overflow-hidden rounded-lg bg-black"
       // CP445.x — max-height 49.5vh (55vh 에서 10% 축소, 사용자 spec). 하단
       // 탭 콘텐츠 영역 추가 확보. aspect-ratio 16:9 유지 + max-width 도 비례
-      // cap (16/9 보존 + 가운데). fill=true (learning video-view) 는 부모
-      // 880px 컬럼이 사이징 소유 — vh cap 없이 16:9 풀폭.
-      style={
-        fill
-          ? { aspectRatio: '16/9' }
-          : {
-              aspectRatio: '16/9',
-              maxHeight: '49.5vh',
-              maxWidth: 'calc(49.5vh * 16 / 9)',
-            }
-      }
+      // cap (16/9 보존 + 가운데).
+      style={{
+        aspectRatio: '16/9',
+        maxHeight: '49.5vh',
+        maxWidth: 'calc(49.5vh * 16 / 9)',
+      }}
     >
       <iframe
         ref={iframeRef}
@@ -282,11 +266,7 @@ export function PanelVideoPlayer({
           />
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="flex h-14 w-14 items-center justify-center rounded-full bg-black/60">
-              <svg
-                viewBox="0 0 24 24"
-                className="h-7 w-7 translate-x-0.5 fill-white"
-                aria-hidden="true"
-              >
+              <svg viewBox="0 0 24 24" className="h-7 w-7 translate-x-0.5 fill-white" aria-hidden="true">
                 <path d="M8 5v14l11-7z" />
               </svg>
             </div>

--- a/frontend/src/features/video-side-panel/ui/PanelVideoPlayer.tsx
+++ b/frontend/src/features/video-side-panel/ui/PanelVideoPlayer.tsx
@@ -68,6 +68,7 @@ export function PanelVideoPlayer({
   const initialAutoplayRef = useRef(shouldAutoplay);
   const initialStartTimeRef = useRef(startTime);
   const initialYoutubeIdRef = useRef(youtubeId);
+  const initialFillRef = useRef(fill);
 
   // Poster facade — the videoId whose sharp poster overlay is shown (null =
   // hidden). YouTube's NATIVE cued/paused iframe poster is low-res/blurry; we
@@ -229,6 +230,8 @@ export function PanelVideoPlayer({
   // can't reach the new iframe → second-card "stays paused" bug.
   const initialStart = initialStartTimeRef.current;
   const initialYoutubeId = initialYoutubeIdRef.current;
+  // fill (learning video-view) keeps the NATIVE YT chrome (user decision) —
+  // PlayerChrome only overlays the relevance curve above it.
   const embedSrc = initialYoutubeId
     ? `https://www.youtube.com/embed/${initialYoutubeId}?autoplay=${initialAutoplayRef.current ? 1 : 0}&rel=0&modestbranding=1&enablejsapi=1${initialStart ? `&start=${Math.floor(initialStart)}` : ''}`
     : '';

--- a/frontend/src/pages/learning/lib/relevance-level.ts
+++ b/frontend/src/pages/learning/lib/relevance-level.ts
@@ -1,0 +1,25 @@
+/**
+ * Relevance tier mapping for the video-view chapter UI (mockup spec).
+ * high >= 80 aligns with HIGHLIGHT_RELEVANCE_THRESHOLD (useHighlightReel).
+ */
+
+export type RelevanceLevel = 'high' | 'mid' | 'low';
+
+export const RELEVANCE_HIGH_MIN = 80;
+export const RELEVANCE_MID_MIN = 50;
+
+export function relevanceLevel(pct: number): RelevanceLevel {
+  if (pct >= RELEVANCE_HIGH_MIN) return 'high';
+  if (pct >= RELEVANCE_MID_MIN) return 'mid';
+  return 'low';
+}
+
+/** CSS var name per level — tokens defined under `.note-mode` in index.css. */
+export function relevanceCssVar(level: RelevanceLevel): string {
+  return `var(--lp-rel-${level})`;
+}
+
+/** Meter bar count lit per level (3-bar ascending signal meter). */
+export function relevanceBars(level: RelevanceLevel): number {
+  return level === 'high' ? 3 : level === 'mid' ? 2 : 1;
+}

--- a/frontend/src/pages/learning/lib/time-format.ts
+++ b/frontend/src/pages/learning/lib/time-format.ts
@@ -1,0 +1,5 @@
+/** Mockup chapter/player time format — unpadded minutes ("0:00", "12:07"). */
+export function fmtChapterTime(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds));
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
+}

--- a/frontend/src/pages/learning/model/useLearningStore.ts
+++ b/frontend/src/pages/learning/model/useLearningStore.ts
@@ -1,27 +1,6 @@
 import { create } from 'zustand';
 
-const LS_KEY_VIDEO_STRIP_ENABLED = 'insighta.learning.videoStripEnabled';
-
-function readVideoStripEnabled(): boolean {
-  if (typeof window === 'undefined') return true;
-  try {
-    const v = window.localStorage.getItem(LS_KEY_VIDEO_STRIP_ENABLED);
-    return v === null ? true : v === 'true';
-  } catch {
-    return true;
-  }
-}
-
-function writeVideoStripEnabled(enabled: boolean): void {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(LS_KEY_VIDEO_STRIP_ENABLED, enabled ? 'true' : 'false');
-  } catch {
-    /* localStorage disabled — silently degrade to in-memory only */
-  }
-}
-
-export type CenterTab = 'summary' | 'section';
+export type CenterTab = 'chapters' | 'summary' | 'section';
 
 export type CenterViewMode = 'player' | 'note';
 
@@ -57,11 +36,6 @@ interface LearningState {
    *  first VideoBlock click, false on note-mode exit / edit-mode enter /
    *  mandala change. Spec: "명시적 재생 액티비티 only". */
   noteAutoFollowEnabled: boolean;
-  /** Hover-slide video thumbnail strip on player wrapper. User can dismiss
-   *  via X on the strip; restore via icon in left sidebar header. Persisted
-   *  to localStorage so the choice survives reloads. */
-  videoStripEnabled: boolean;
-
   setCurrentVideo: (videoId: string) => void;
   setActiveTab: (tab: 'ai-summary' | 'notes') => void;
   setSelectedCell: (cellIndex: number | null) => void;
@@ -70,7 +44,6 @@ interface LearningState {
   setActiveSection: (ref: ActiveSectionRef | null) => void;
   setActiveNoteVideoKey: (key: number | null) => void;
   setNoteAutoFollow: (enabled: boolean) => void;
-  setVideoStripEnabled: (enabled: boolean) => void;
 
   setActiveRegion: (region: ActiveRegion) => void;
   setPlayerState: (time: number, state: PlayerState, duration: number) => void;
@@ -81,7 +54,7 @@ export const useLearningStore = create<LearningState>((set) => ({
   currentVideoId: null,
   activeTab: 'ai-summary',
   selectedCellIndex: null,
-  centerTab: 'summary',
+  centerTab: 'chapters',
   centerViewMode: 'player',
   activeSectionRef: null,
 
@@ -94,7 +67,6 @@ export const useLearningStore = create<LearningState>((set) => ({
   noteSelectionText: null,
   activeNoteVideoKey: null,
   noteAutoFollowEnabled: false,
-  videoStripEnabled: readVideoStripEnabled(),
 
   setCurrentVideo: (videoId) => set({ currentVideoId: videoId }),
   setActiveTab: (tab) => set({ activeTab: tab }),
@@ -104,10 +76,6 @@ export const useLearningStore = create<LearningState>((set) => ({
   setActiveSection: (ref) => set({ activeSectionRef: ref }),
   setActiveNoteVideoKey: (key) => set({ activeNoteVideoKey: key }),
   setNoteAutoFollow: (enabled) => set({ noteAutoFollowEnabled: enabled }),
-  setVideoStripEnabled: (enabled) => {
-    writeVideoStripEnabled(enabled);
-    set({ videoStripEnabled: enabled });
-  },
 
   setActiveRegion: (region) => set({ activeRegion: region, lastInteractionTs: Date.now() }),
   setPlayerState: (time, state, duration) =>

--- a/frontend/src/pages/learning/ui/-legacy/VideoStrip.tsx
+++ b/frontend/src/pages/learning/ui/-legacy/VideoStrip.tsx
@@ -1,7 +1,11 @@
+/**
+ * @deprecated [VIDEO-VIEW] Replaced by FloatingVideoNavigator (click-to-expand
+ * strip in CenterPanel's top bar). Kept per no-component-deletion rule.
+ */
 import { useRef, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useMandalaCards } from '../model/useMandalaCards';
+import { useMandalaCards } from '../../model/useMandalaCards';
 import { cn } from '@/shared/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -25,6 +25,8 @@ import { useRichSummary } from '@/features/video-side-panel/model/useRichSummary
 import { useHighlightReel, HIGHLIGHT_RELEVANCE_THRESHOLD } from '../model/useHighlightReel';
 import { useMandalaCards } from '../model/useMandalaCards';
 import { FloatingVideoNavigator } from './FloatingVideoNavigator';
+import { PlayerChrome } from './PlayerChrome';
+import { fmtChapterTime } from '../lib/time-format';
 import {
   relevanceLevel,
   relevanceCssVar,
@@ -65,13 +67,12 @@ function formatMMSS(seconds: number): string {
   return `${mm.toString().padStart(2, '0')}:${ss.toString().padStart(2, '0')}`;
 }
 
-/** Mockup chapter time format — unpadded minutes ("0:00", "12:00"). */
-function fmtChapterTime(seconds: number): string {
-  const total = Math.max(0, Math.floor(seconds));
-  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
-}
-
 const YT_ID_RE = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\s]+)/;
+
+// [R1] Fixed-player layout: the whole fixed zone (meta/player/tabs) and the
+// scrolling panel zone share this width so everything stays edge-aligned with
+// the player, which is height-capped at 49.5vh (CP445 spec). +80px = px-10.
+const ALIGNED_MAX_WIDTH = 'min(880px, calc(49.5vh * 16 / 9 + 80px))';
 
 export function CenterPanel({
   mandalaId,
@@ -385,101 +386,106 @@ export function CenterPanel({
         </div>
       </div>
 
-      {/* Player — kept MOUNTED in note mode (CP442 mount-preserve), hidden via CSS.
-          The wrapper now lives inside the scrolling 880px column below, so in note
-          mode we render it here hidden to preserve the iframe instance. */}
+      {/* [R1] FIXED zone — meta header + player + tabs are pinned; only the
+          panel contents below scroll. Player kept MOUNTED in note mode
+          (CP442 mount-preserve), hidden via CSS. */}
+      <div
+        className={cn('mx-auto w-full shrink-0 px-10 pt-2', centerViewMode === 'note' && 'hidden')}
+        style={{ maxWidth: ALIGNED_MAX_WIDTH }}
+      >
+        {/* Video meta header (mockup ②) */}
+        <div className="mb-3 flex items-center gap-[13px]">
+          <div
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-[15px] text-[var(--lp-avatar-fg)]"
+            style={{ background: 'var(--lp-avatar-grad)' }}
+            aria-hidden
+          >
+            {(currentCard?.title ?? 'Y').slice(0, 1)}
+          </div>
+          <div className="min-w-0">
+            <div className="truncate text-[17px] font-semibold leading-[1.35] tracking-[-0.01em] text-[var(--lp-strong)]">
+              {currentCard?.title ?? t('learning.videoFallbackTitle', '영상')}
+            </div>
+            <div className="mt-0.5 text-[12.5px] text-[var(--lp-faint)]">
+              YouTube{playerDurationSec > 0 ? ` · ${fmtChapterTime(playerDurationSec)}` : ''}
+            </div>
+          </div>
+        </div>
+
+        {/* Player hero frame (mockup ③) — group/player drives the hover chrome */}
+        <div
+          className="group/player relative overflow-hidden rounded-2xl border border-[var(--lp-line-8)] bg-black"
+          style={{ boxShadow: 'var(--lp-player-shadow)' }}
+          onMouseEnter={() => setActiveRegion('player')}
+        >
+          <PanelVideoPlayer
+            videoUrl={videoUrl}
+            playerRef={playerRef}
+            shouldAutoplay={shouldAutoplay}
+            onUserPlayed={onUserPlayed}
+            onPlayStateChange={onPlayStateChange}
+            onTimeUpdate={setPlayerState}
+            startTime={startTime}
+            fill
+          />
+          <PlayerChrome sections={chapterSections} />
+        </div>
+
+        {/* Tab switch row (mockup ④) — segment tabs + relevance legend */}
+        <div className="flex flex-wrap items-center justify-between gap-3 pb-2 pt-4">
+          <div className="flex gap-1 rounded-[10px] border border-[var(--lp-line-7)] bg-[var(--lp-surface)] p-1">
+            {tabs.map(({ id, labelKey, fallback, icon: Icon }) => (
+              <button
+                key={id}
+                onClick={() => setCenterTab(id)}
+                className={cn(
+                  'flex items-center gap-[7px] rounded-[7px] px-4 py-2 text-[13.5px] font-semibold transition-colors',
+                  centerTab === id
+                    ? 'bg-[var(--lp-toggle-active-bg)] text-[var(--lp-tab-active-fg)]'
+                    : 'text-[var(--lp-dim)] hover:text-[var(--lp-strong)]'
+                )}
+              >
+                <Icon className="h-[15px] w-[15px]" />
+                {t(labelKey, fallback)}
+              </button>
+            ))}
+          </div>
+          {chapterSections.length > 0 && (
+            <div className="flex items-center gap-[13px] text-[11.5px] text-[var(--lp-faint)]">
+              <div className="flex items-center gap-[9px]">
+                <span className="text-[10px] font-semibold tracking-[0.06em] text-[var(--lp-mute)]">
+                  {t('learning.relevanceLabel', '관련도')}
+                </span>
+                <span className="text-[10.5px] text-[var(--lp-mute)]">
+                  {t('learning.relevanceLow', '낮음')}
+                </span>
+                <RelevanceMeter level="low" />
+                <RelevanceMeter level="mid" />
+                <RelevanceMeter level="high" />
+                <span className="text-[10.5px] text-[var(--lp-mute)]">
+                  {t('learning.relevanceHigh', '높음')}
+                </span>
+              </div>
+              <span className="h-[11px] w-px bg-white/10" aria-hidden />
+              <span>
+                {t('learning.chaptersCount', '{{count}}개 챕터', {
+                  count: chapterSections.length,
+                })}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* [R1] SCROLL zone — only the tab-panel contents scroll (video fixed). */}
       <div
         className="flex-1 overflow-y-auto scrollbar-pro"
         onMouseEnter={() => setActiveRegion('book-index')}
       >
         <div
-          className={cn(
-            'mx-auto w-full max-w-[880px] px-10 pb-[120px] pt-[18px]',
-            centerViewMode === 'note' && 'hidden'
-          )}
+          className={cn('mx-auto w-full px-10 pb-16 pt-1', centerViewMode === 'note' && 'hidden')}
+          style={{ maxWidth: ALIGNED_MAX_WIDTH }}
         >
-          {/* Video meta header (mockup ②) */}
-          <div className="mb-[18px] flex items-center gap-[13px]">
-            <div
-              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-[15px] text-[var(--lp-avatar-fg)]"
-              style={{ background: 'var(--lp-avatar-grad)' }}
-              aria-hidden
-            >
-              {(currentCard?.title ?? 'Y').slice(0, 1)}
-            </div>
-            <div className="min-w-0">
-              <div className="truncate text-[17px] font-semibold leading-[1.35] tracking-[-0.01em] text-[var(--lp-strong)]">
-                {currentCard?.title ?? t('learning.videoFallbackTitle', '영상')}
-              </div>
-              <div className="mt-0.5 text-[12.5px] text-[var(--lp-faint)]">
-                YouTube{playerDurationSec > 0 ? ` · ${fmtChapterTime(playerDurationSec)}` : ''}
-              </div>
-            </div>
-          </div>
-
-          {/* Player hero frame (mockup ③ outer frame; custom chrome = Phase 4) */}
-          <div
-            className="overflow-hidden rounded-2xl border border-[var(--lp-line-8)] bg-black"
-            style={{ boxShadow: 'var(--lp-player-shadow)' }}
-            onMouseEnter={() => setActiveRegion('player')}
-          >
-            <PanelVideoPlayer
-              videoUrl={videoUrl}
-              playerRef={playerRef}
-              shouldAutoplay={shouldAutoplay}
-              onUserPlayed={onUserPlayed}
-              onPlayStateChange={onPlayStateChange}
-              onTimeUpdate={setPlayerState}
-              startTime={startTime}
-              fill
-            />
-          </div>
-
-          {/* Tab switch row (mockup ④) — segment tabs + relevance legend */}
-          <div className="mb-1.5 mt-[30px] flex flex-wrap items-center justify-between gap-3">
-            <div className="flex gap-1 rounded-[10px] border border-[var(--lp-line-7)] bg-[var(--lp-surface)] p-1">
-              {tabs.map(({ id, labelKey, fallback, icon: Icon }) => (
-                <button
-                  key={id}
-                  onClick={() => setCenterTab(id)}
-                  className={cn(
-                    'flex items-center gap-[7px] rounded-[7px] px-4 py-2 text-[13.5px] font-semibold transition-colors',
-                    centerTab === id
-                      ? 'bg-[var(--lp-toggle-active-bg)] text-[var(--lp-tab-active-fg)]'
-                      : 'text-[var(--lp-dim)] hover:text-[var(--lp-strong)]'
-                  )}
-                >
-                  <Icon className="h-[15px] w-[15px]" />
-                  {t(labelKey, fallback)}
-                </button>
-              ))}
-            </div>
-            {chapterSections.length > 0 && (
-              <div className="flex items-center gap-[13px] text-[11.5px] text-[var(--lp-faint)]">
-                <div className="flex items-center gap-[9px]">
-                  <span className="text-[10px] font-semibold tracking-[0.06em] text-[var(--lp-mute)]">
-                    {t('learning.relevanceLabel', '관련도')}
-                  </span>
-                  <span className="text-[10.5px] text-[var(--lp-mute)]">
-                    {t('learning.relevanceLow', '낮음')}
-                  </span>
-                  <RelevanceMeter level="low" />
-                  <RelevanceMeter level="mid" />
-                  <RelevanceMeter level="high" />
-                  <span className="text-[10.5px] text-[var(--lp-mute)]">
-                    {t('learning.relevanceHigh', '높음')}
-                  </span>
-                </div>
-                <span className="h-[11px] w-px bg-white/10" aria-hidden />
-                <span>
-                  {t('learning.chaptersCount', '{{count}}개 챕터', {
-                    count: chapterSections.length,
-                  })}
-                </span>
-              </div>
-            )}
-          </div>
-
           {/* Panels */}
           {centerTab === 'chapters' && (
             <ChapterList

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -71,8 +71,10 @@ const YT_ID_RE = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\s]+)/;
 
 // [R1] Fixed-player layout: the whole fixed zone (meta/player/tabs) and the
 // scrolling panel zone share this width so everything stays edge-aligned with
-// the player, which is height-capped at 49.5vh (CP445 spec). +80px = px-10.
-const ALIGNED_MAX_WIDTH = 'min(880px, calc(49.5vh * 16 / 9 + 80px))';
+// the player, which keeps its own original cap (49.5vh, CP445 spec). +32px
+// = px-4 — matches the pre-redesign horizontal gutter so the player renders
+// at the exact same size as before (user report: unintended shrink).
+const ALIGNED_MAX_WIDTH = 'min(880px, calc(49.5vh * 16 / 9 + 32px))';
 
 export function CenterPanel({
   mandalaId,
@@ -390,7 +392,7 @@ export function CenterPanel({
           panel contents below scroll. Player kept MOUNTED in note mode
           (CP442 mount-preserve), hidden via CSS. */}
       <div
-        className={cn('mx-auto w-full shrink-0 px-10 pt-2', centerViewMode === 'note' && 'hidden')}
+        className={cn('mx-auto w-full shrink-0 px-4 pt-2', centerViewMode === 'note' && 'hidden')}
         style={{ maxWidth: ALIGNED_MAX_WIDTH }}
       >
         {/* Video meta header (mockup ②) */}
@@ -485,7 +487,7 @@ export function CenterPanel({
         onMouseEnter={() => setActiveRegion('book-index')}
       >
         <div
-          className={cn('mx-auto w-full px-10 pb-16 pt-1', centerViewMode === 'note' && 'hidden')}
+          className={cn('mx-auto w-full px-4 pb-16 pt-1', centerViewMode === 'note' && 'hidden')}
           style={{ maxWidth: ALIGNED_MAX_WIDTH }}
         >
           {/* Panels */}

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -6,6 +6,7 @@ import {
   Sparkles,
   Zap,
   BookText,
+  List,
   Play,
   BookOpen,
   Pencil,
@@ -22,13 +23,25 @@ import { LearningShareMenu } from '@/features/learning-share';
 import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import { useRichSummary } from '@/features/video-side-panel/model/useRichSummary';
 import { useHighlightReel, HIGHLIGHT_RELEVANCE_THRESHOLD } from '../model/useHighlightReel';
+import { useMandalaCards } from '../model/useMandalaCards';
+import { FloatingVideoNavigator } from './FloatingVideoNavigator';
+import {
+  relevanceLevel,
+  relevanceCssVar,
+  relevanceBars,
+  type RelevanceLevel,
+} from '../lib/relevance-level';
 import { useLearningStore } from '@/pages/learning/model/useLearningStore';
 import { useNoteDocument } from '@/pages/learning/model/useNoteDocument';
 import { useNoteAutoFollow } from '@/pages/learning/model/useNoteAutoFollow';
 import { exportToMarkdown, exportToHtml } from '@/pages/learning/lib/note-export';
 import { cn } from '@/shared/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
-import type { MandalaBookChapter, MandalaBookSection } from '@/shared/lib/api-client';
+import type {
+  MandalaBookChapter,
+  MandalaBookSection,
+  VideoRichSummarySection,
+} from '@/shared/lib/api-client';
 import type { Editor } from '@tiptap/react';
 import type { TiptapDoc } from '@/features/video-side-panel/lib/note-parser';
 import type { YTPlayer } from '@/widgets/video-player/model/youtube-api';
@@ -41,11 +54,9 @@ interface CenterPanelProps {
   onUserPlayed?: () => void;
   onPlayStateChange?: (isPlaying: boolean) => void;
   startTime?: number;
-  onPlayerHoverIn?: () => void;
-  onPlayerHoverOut?: () => void;
 }
 
-type CenterTabId = 'summary' | 'section';
+type CenterTabId = 'chapters' | 'summary' | 'section';
 
 function formatMMSS(seconds: number): string {
   const total = Math.max(0, Math.round(seconds));
@@ -53,6 +64,14 @@ function formatMMSS(seconds: number): string {
   const ss = total % 60;
   return `${mm.toString().padStart(2, '0')}:${ss.toString().padStart(2, '0')}`;
 }
+
+/** Mockup chapter time format — unpadded minutes ("0:00", "12:00"). */
+function fmtChapterTime(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds));
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
+}
+
+const YT_ID_RE = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\s]+)/;
 
 export function CenterPanel({
   mandalaId,
@@ -62,8 +81,6 @@ export function CenterPanel({
   onUserPlayed,
   onPlayStateChange,
   startTime,
-  onPlayerHoverIn,
-  onPlayerHoverOut,
 }: CenterPanelProps) {
   const { t } = useTranslation();
   const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
@@ -86,10 +103,17 @@ export function CenterPanel({
   // scroll-to effect below doesn't re-scroll (which would fight free scrolling).
   const scrollSpyRef = useRef<string | null>(null);
   const setPlayerState = useLearningStore((s) => s.setPlayerState);
-  const { book } = useMandalaBook(mandalaId);
+  const setCenterViewMode = useLearningStore((s) => s.setCenterViewMode);
+  const playerDurationSec = useLearningStore((s) => s.playerDurationSec);
+  const { book, isLoading: bookLoading } = useMandalaBook(mandalaId);
   const setActiveNoteVideoKey = useLearningStore((s) => s.setActiveNoteVideoKey);
   const noteAutoFollowEnabled = useLearningStore((s) => s.noteAutoFollowEnabled);
   const setNoteAutoFollow = useLearningStore((s) => s.setNoteAutoFollow);
+  // Video meta header (mockup ②) — title from the mandala card set.
+  const { cards } = useMandalaCards(mandalaId);
+  const currentCard = cards.find((c) => c.videoUrl.match(YT_ID_RE)?.[1] === videoId);
+  // Floating navigator expand state — breadcrumb hides while expanded.
+  const [navExpanded, setNavExpanded] = useState(false);
 
   // CP445.x — VideoBlock owns its click → inline YouTube iframe (autoplay)
   // via Zustand `activeNoteVideoKey`. No external player.seekTo needed.
@@ -252,66 +276,66 @@ export function CenterPanel({
     fallback: string;
     icon: typeof Sparkles;
   }> = [
+    { id: 'chapters', labelKey: 'learning.tabChapters', fallback: '챕터', icon: List },
     { id: 'summary', labelKey: 'learning.tabSummary', fallback: 'AI 요약', icon: Sparkles },
     { id: 'section', labelKey: 'learning.tabSection', fallback: '섹션 내용', icon: BookText },
   ];
 
-  return (
-    <div className="flex flex-1 min-w-0 flex-col overflow-hidden pl-4 pr-3 pt-[5px]">
-      <div
-        className={cn('mt-2 shrink-0', centerViewMode === 'note' && 'hidden')}
-        onMouseEnter={() => {
-          setActiveRegion('player');
-          onPlayerHoverIn?.();
-        }}
-        onMouseLeave={() => onPlayerHoverOut?.()}
-      >
-        <PanelVideoPlayer
-          videoUrl={videoUrl}
-          playerRef={playerRef}
-          shouldAutoplay={shouldAutoplay}
-          onUserPlayed={onUserPlayed}
-          onPlayStateChange={onPlayStateChange}
-          onTimeUpdate={setPlayerState}
-          startTime={startTime}
-        />
-      </div>
+  // Chapters = v2 segment sections (same source as the highlight reel).
+  const chapterSections = (highlightSections ?? [])
+    .filter((s) => s.to_sec > s.from_sec)
+    .slice()
+    .sort((a, b) => a.from_sec - b.from_sec);
 
-      {centerViewMode === 'player' && (
-        // CP445 B2 — ViewModeToggle moved to LearningPage toprow (tb-right).
-        // This row holds only the [AI 요약][섹션 내용] tabs and is hidden in
-        // note mode (toprow toggle covers the mode switch).
-        // CP445.x — tabs / 본문 wrapper 의 가로폭 = 영상 (49.5vh*16/9) 동일
-        // mx-auto. 영상 ↔ AI요약/섹션 좌우 시각 정렬 일치.
-        <div
-          className="mx-auto w-full shrink-0"
-          style={{ maxWidth: 'calc(49.5vh * 16 / 9)' }}
-          onMouseEnter={() => setActiveRegion('book-index')}
-        >
-          <div className="flex items-center justify-between">
-            <div className="flex">
-              {tabs.map(({ id, labelKey, fallback, icon: Icon }) => (
-                <button
-                  key={id}
-                  onClick={() => setCenterTab(id)}
-                  className={cn(
-                    'flex items-center gap-1.5 py-2.5 px-3 text-[12px] transition-colors border-b-2',
-                    centerTab === id
-                      ? 'border-primary text-foreground font-semibold'
-                      : 'border-transparent text-muted-foreground font-normal hover:text-foreground'
-                  )}
-                >
-                  <Icon className="h-3.5 w-3.5" />
-                  {t(labelKey, fallback)}
-                </button>
-              ))}
+  const handleModeChange = (mode: 'player' | 'note') => {
+    if (mode === 'note' && !bookLoading && !book) {
+      toast(t('learning.noteNotReady', '노트가 아직 생성되지 않았어요'));
+      return;
+    }
+    setCenterViewMode(mode);
+  };
+
+  return (
+    <div
+      className="flex min-w-0 flex-1 flex-col overflow-hidden"
+      // [VIDEO-VIEW] mockup center bg — subtle top glow over near-black.
+      style={{
+        background: 'radial-gradient(110% 60% at 50% 0%, var(--lp-bg-1) 0%, var(--lp-bg-0) 55%)',
+      }}
+    >
+      {/* Top bar (mockup ①) — navigator + breadcrumb left, ⚡/share/mode-toggle
+          right. Rendered in BOTH modes: single home of the mode toggle. */}
+      <div className="flex h-[60px] shrink-0 items-center justify-between gap-3 px-8">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          {centerViewMode === 'player' && (
+            <FloatingVideoNavigator
+              mandalaId={mandalaId}
+              currentVideoId={videoId}
+              expanded={navExpanded}
+              onExpandedChange={setNavExpanded}
+            />
+          )}
+          {!(navExpanded && centerViewMode === 'player') && activeSection && (
+            <div className="flex min-w-0 items-center gap-2.5 text-[12.5px] text-[var(--lp-faint)]">
+              <span className="shrink-0 font-semibold text-[var(--lp-accent)]">
+                {t('learning.topicGroup', '주제군')}{' '}
+                {String((activeSection.chapter.ch ?? 0) + 1).padStart(2, '0')}
+              </span>
+              <span aria-hidden>·</span>
+              <span className="truncate">{activeSection.chapter.title}</span>
             </div>
-            <div className="flex items-center gap-2">
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {/* While the navigator strip is expanded, yield width to it — hide the
+              secondary reel/share cluster (mode toggle stays). */}
+          {centerViewMode === 'player' && !navExpanded && (
+            <>
               {highlightReel.enabled && (
                 <span
                   className={cn(
                     'text-[11px] tabular-nums font-medium transition-colors',
-                    highlightReel.active ? 'text-white/90' : 'text-white/60'
+                    highlightReel.active ? 'text-[var(--lp-strong)]' : 'text-[var(--lp-dim)]'
                   )}
                   aria-live="polite"
                 >
@@ -328,14 +352,14 @@ export function CenterPanel({
                     disabled={!highlightReel.enabled}
                     aria-label={t('learning.highlightReel')}
                     className={cn(
-                      'inline-flex items-center justify-center w-8 h-8 rounded-full transition-colors',
+                      'inline-flex h-8 w-8 items-center justify-center rounded-full transition-colors',
                       highlightReel.active
-                        ? 'text-white/90 hover:bg-white/10'
-                        : 'text-white hover:bg-white/10',
+                        ? 'text-[var(--lp-strong)] hover:bg-white/10'
+                        : 'text-[var(--lp-dim)] hover:bg-white/10 hover:text-[var(--lp-strong)]',
                       !highlightReel.enabled && 'opacity-40 cursor-not-allowed'
                     )}
                   >
-                    <Zap className="h-5 w-5" aria-hidden="true" />
+                    <Zap className="h-[18px] w-[18px]" aria-hidden="true" />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom" className="text-[12px] max-w-[280px]">
@@ -350,16 +374,143 @@ export function CenterPanel({
                         })}
                 </TooltipContent>
               </Tooltip>
-              <LearningShareMenu mandalaId={mandalaId} videoId={videoId} />
-            </div>
-          </div>
+            </>
+          )}
+          {!navExpanded && <LearningShareMenu mandalaId={mandalaId} videoId={videoId} />}
+          <ViewModeToggle
+            mode={centerViewMode}
+            noteDisabled={!bookLoading && !book}
+            onChange={handleModeChange}
+          />
         </div>
-      )}
+      </div>
 
+      {/* Player — kept MOUNTED in note mode (CP442 mount-preserve), hidden via CSS.
+          The wrapper now lives inside the scrolling 880px column below, so in note
+          mode we render it here hidden to preserve the iframe instance. */}
       <div
         className="flex-1 overflow-y-auto scrollbar-pro"
         onMouseEnter={() => setActiveRegion('book-index')}
       >
+        <div
+          className={cn(
+            'mx-auto w-full max-w-[880px] px-10 pb-[120px] pt-[18px]',
+            centerViewMode === 'note' && 'hidden'
+          )}
+        >
+          {/* Video meta header (mockup ②) */}
+          <div className="mb-[18px] flex items-center gap-[13px]">
+            <div
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-[15px] text-[var(--lp-avatar-fg)]"
+              style={{ background: 'var(--lp-avatar-grad)' }}
+              aria-hidden
+            >
+              {(currentCard?.title ?? 'Y').slice(0, 1)}
+            </div>
+            <div className="min-w-0">
+              <div className="truncate text-[17px] font-semibold leading-[1.35] tracking-[-0.01em] text-[var(--lp-strong)]">
+                {currentCard?.title ?? t('learning.videoFallbackTitle', '영상')}
+              </div>
+              <div className="mt-0.5 text-[12.5px] text-[var(--lp-faint)]">
+                YouTube{playerDurationSec > 0 ? ` · ${fmtChapterTime(playerDurationSec)}` : ''}
+              </div>
+            </div>
+          </div>
+
+          {/* Player hero frame (mockup ③ outer frame; custom chrome = Phase 4) */}
+          <div
+            className="overflow-hidden rounded-2xl border border-[var(--lp-line-8)] bg-black"
+            style={{ boxShadow: 'var(--lp-player-shadow)' }}
+            onMouseEnter={() => setActiveRegion('player')}
+          >
+            <PanelVideoPlayer
+              videoUrl={videoUrl}
+              playerRef={playerRef}
+              shouldAutoplay={shouldAutoplay}
+              onUserPlayed={onUserPlayed}
+              onPlayStateChange={onPlayStateChange}
+              onTimeUpdate={setPlayerState}
+              startTime={startTime}
+              fill
+            />
+          </div>
+
+          {/* Tab switch row (mockup ④) — segment tabs + relevance legend */}
+          <div className="mb-1.5 mt-[30px] flex flex-wrap items-center justify-between gap-3">
+            <div className="flex gap-1 rounded-[10px] border border-[var(--lp-line-7)] bg-[var(--lp-surface)] p-1">
+              {tabs.map(({ id, labelKey, fallback, icon: Icon }) => (
+                <button
+                  key={id}
+                  onClick={() => setCenterTab(id)}
+                  className={cn(
+                    'flex items-center gap-[7px] rounded-[7px] px-4 py-2 text-[13.5px] font-semibold transition-colors',
+                    centerTab === id
+                      ? 'bg-[var(--lp-toggle-active-bg)] text-[var(--lp-tab-active-fg)]'
+                      : 'text-[var(--lp-dim)] hover:text-[var(--lp-strong)]'
+                  )}
+                >
+                  <Icon className="h-[15px] w-[15px]" />
+                  {t(labelKey, fallback)}
+                </button>
+              ))}
+            </div>
+            {chapterSections.length > 0 && (
+              <div className="flex items-center gap-[13px] text-[11.5px] text-[var(--lp-faint)]">
+                <div className="flex items-center gap-[9px]">
+                  <span className="text-[10px] font-semibold tracking-[0.06em] text-[var(--lp-mute)]">
+                    {t('learning.relevanceLabel', '관련도')}
+                  </span>
+                  <span className="text-[10.5px] text-[var(--lp-mute)]">
+                    {t('learning.relevanceLow', '낮음')}
+                  </span>
+                  <RelevanceMeter level="low" />
+                  <RelevanceMeter level="mid" />
+                  <RelevanceMeter level="high" />
+                  <span className="text-[10.5px] text-[var(--lp-mute)]">
+                    {t('learning.relevanceHigh', '높음')}
+                  </span>
+                </div>
+                <span className="h-[11px] w-px bg-white/10" aria-hidden />
+                <span>
+                  {t('learning.chaptersCount', '{{count}}개 챕터', {
+                    count: chapterSections.length,
+                  })}
+                </span>
+              </div>
+            )}
+          </div>
+
+          {/* Panels */}
+          {centerTab === 'chapters' && (
+            <ChapterList
+              sections={chapterSections}
+              playerRef={playerRef}
+              onUserPlayed={onUserPlayed}
+              onGoSummary={() => setCenterTab('summary')}
+            />
+          )}
+          {centerTab === 'summary' && (
+            <div data-onboarding="ai-summary" className="mt-[18px]">
+              <PanelAISummary videoSummary={undefined} videoUrl={videoUrl} />
+            </div>
+          )}
+          {centerTab === 'section' && (
+            <div className="mt-[18px]">
+              {activeSection ? (
+                <SectionContentView
+                  chapter={activeSection.chapter}
+                  section={activeSection.section}
+                  mandalaId={mandalaId}
+                />
+              ) : (
+                <div className="text-[12px] text-muted-foreground">
+                  {t('learning.noActiveSection', '좌측 북인덱스에서 섹션을 선택하세요.')}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
         {centerViewMode === 'note' ? (
           <>
             {/* §1④ PR2 — "준비 중": when the book is still filling (v2 pending),
@@ -405,33 +556,160 @@ export function CenterPanel({
               hasBook={Boolean(book?.book?.chapters?.length)}
             />
           </>
-        ) : (
-          // CP445.x — 본문 영역 max-width = 영상 (49.5vh*16/9) 동일 + mx-auto
-          // 좌우 정렬. 영상 ↔ AI요약/섹션 시각 일관성.
-          <div
-            className="mx-auto w-full p-4"
-            style={{ maxWidth: 'min(calc(49.5vh * 16 / 9), 760px)' }}
-          >
-            {centerTab === 'summary' && (
-              <div data-onboarding="ai-summary">
-                <PanelAISummary videoSummary={undefined} videoUrl={videoUrl} />
-              </div>
-            )}
-            {centerTab === 'section' &&
-              (activeSection ? (
-                <SectionContentView
-                  chapter={activeSection.chapter}
-                  section={activeSection.section}
-                  mandalaId={mandalaId}
-                />
-              ) : (
-                <div className="text-[12px] text-muted-foreground">
-                  {t('learning.noActiveSection', '좌측 북인덱스에서 섹션을 선택하세요.')}
-                </div>
-              ))}
-          </div>
-        )}
+        ) : null}
       </div>
+    </div>
+  );
+}
+
+/** 3-bar ascending signal meter — wordless relevance indicator (mockup ⑤). */
+function RelevanceMeter({ level }: { level: RelevanceLevel }) {
+  const lit = relevanceBars(level);
+  const color = relevanceCssVar(level);
+  return (
+    <span className="inline-flex h-[11px] items-end gap-[2.5px]" aria-hidden>
+      {[5, 8, 11].map((h, k) => (
+        <span
+          key={h}
+          className="w-[3px] rounded-[1px]"
+          style={{ height: h, background: k < lit ? color : 'var(--lp-meter-off)' }}
+        />
+      ))}
+    </span>
+  );
+}
+
+/** Chapter list (mockup ⑤) — v2 segment sections with time range, relevance
+ *  edge/meter, hover-expand description, click-to-seek. Subscribes to player
+ *  time HERE so the 1s tick re-renders only this list. */
+function ChapterList({
+  sections,
+  playerRef,
+  onUserPlayed,
+  onGoSummary,
+}: {
+  sections: VideoRichSummarySection[];
+  playerRef: React.MutableRefObject<YTPlayer | null>;
+  onUserPlayed?: () => void;
+  onGoSummary: () => void;
+}) {
+  const { t } = useTranslation();
+  const playerTimeSec = useLearningStore((s) => s.playerTimeSec);
+  const playerState = useLearningStore((s) => s.playerState);
+
+  if (sections.length === 0) {
+    return (
+      <div className="mt-6 rounded-xl border border-[var(--lp-line-6)] bg-[var(--lp-surface)] px-5 py-6 text-center">
+        <p className="text-[13px] leading-[1.6] text-[var(--lp-dim)]">
+          {t(
+            'learning.chaptersEmpty',
+            '챕터 정보가 아직 준비되지 않았어요. AI 요약이 생성되면 챕터가 나타납니다.'
+          )}
+        </p>
+        <button
+          type="button"
+          onClick={onGoSummary}
+          className="mt-3 rounded-md border border-[var(--lp-line-8)] px-3 py-1.5 text-[12px] text-[var(--lp-text)] transition-colors hover:bg-[var(--lp-hover-tint)]"
+        >
+          {t('learning.tabSummary', 'AI 요약')}
+        </button>
+      </div>
+    );
+  }
+
+  const activeIdx = sections.findIndex(
+    (s) => playerTimeSec >= s.from_sec && playerTimeSec < s.to_sec
+  );
+
+  return (
+    <div className="mt-3.5 flex flex-col">
+      {sections.map((s, i) => {
+        const level = typeof s.relevance_pct === 'number' ? relevanceLevel(s.relevance_pct) : null;
+        const color = level ? relevanceCssVar(level) : 'var(--lp-meter-off)';
+        const active = i === activeIdx;
+        const playing = active && playerState === 'playing';
+        return (
+          <button
+            key={`${s.from_sec}-${i}`}
+            type="button"
+            onClick={() => {
+              try {
+                playerRef.current?.seekTo(s.from_sec, true);
+                playerRef.current?.playVideo?.();
+                onUserPlayed?.();
+              } catch {
+                // player not ready
+              }
+            }}
+            className={cn(
+              'group relative flex w-full gap-4 rounded-xl border px-4 py-3.5 pl-[18px] text-left transition-colors',
+              active
+                ? 'border-[var(--lp-accent-border)] bg-[var(--lp-accent-tint)]'
+                : 'border-transparent hover:bg-[var(--lp-hover-tint)]'
+            )}
+          >
+            <span
+              className="absolute bottom-3.5 left-0 top-3.5 w-[3px] rounded-[3px] transition-opacity"
+              style={{ background: color, opacity: active ? 1 : 0.55 }}
+              aria-hidden
+            />
+            <span
+              className={cn(
+                'w-[88px] shrink-0 pt-px text-[13px] font-semibold tabular-nums tracking-[0.01em]',
+                active ? 'text-[var(--lp-accent)]' : 'text-[var(--lp-dim)]'
+              )}
+            >
+              {fmtChapterTime(s.from_sec)}–{fmtChapterTime(s.to_sec)}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="flex items-center gap-[9px]">
+                <span
+                  className={cn(
+                    'text-[11px] font-bold tabular-nums',
+                    active ? 'text-[var(--lp-accent)]' : 'text-[var(--lp-num)]'
+                  )}
+                >
+                  {String(i + 1).padStart(2, '0')}
+                </span>
+                <span
+                  className={cn(
+                    'text-[15px] font-semibold leading-[1.4] tracking-[-0.01em]',
+                    active ? 'text-[var(--lp-strong)]' : 'text-[var(--lp-text)]'
+                  )}
+                >
+                  {s.title}
+                </span>
+                {playing && (
+                  <span className="flex shrink-0 items-center gap-[5px] whitespace-nowrap text-[10.5px] font-semibold text-[var(--lp-accent)]">
+                    <span
+                      className="h-[5px] w-[5px] rounded-full bg-[var(--lp-accent)]"
+                      aria-hidden
+                    />
+                    {t('learning.playingNow', '재생 중')}
+                  </span>
+                )}
+              </span>
+              {s.summary && (
+                <span
+                  className={cn(
+                    'block overflow-hidden text-[13.5px] leading-[1.65] text-[var(--lp-desc)] transition-all duration-300',
+                    active
+                      ? 'mt-[7px] max-h-[60px] opacity-100'
+                      : 'mt-0 max-h-0 opacity-0 group-hover:mt-[7px] group-hover:max-h-[60px] group-hover:opacity-100'
+                  )}
+                >
+                  {s.summary}
+                </span>
+              )}
+            </span>
+            {level && (
+              <span className="shrink-0 self-center pt-px">
+                <RelevanceMeter level={level} />
+              </span>
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -522,7 +800,9 @@ export function ViewModeToggle({
     { id: 'note', labelKey: 'learning.viewModeNote', Icon: BookOpen },
   ];
   return (
-    <div className="flex items-center gap-0.5 self-center rounded-md border border-border bg-secondary/30 p-0.5">
+    // [VIDEO-VIEW] mockup skin — dark pill container, active item flips to a
+    // light chip with dark text.
+    <div className="flex shrink-0 items-center rounded-[9px] border border-[var(--lp-line-8)] bg-[var(--lp-surface-2)] p-[3px]">
       {items.map(({ id, labelKey, Icon }) => {
         const dimmed = id === 'note' && noteDisabled;
         return (
@@ -530,10 +810,10 @@ export function ViewModeToggle({
             key={id}
             onClick={() => onChange(id)}
             className={cn(
-              'flex items-center gap-1 rounded px-2 py-1 text-[12px] transition-colors',
+              'flex items-center gap-1.5 rounded-[7px] px-[13px] py-1.5 text-[13px] transition-colors',
               mode === id
-                ? 'bg-background text-foreground font-semibold shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
+                ? 'bg-[var(--lp-toggle-active-bg)] font-semibold text-[var(--lp-toggle-active-fg)]'
+                : 'text-[var(--lp-dim)] hover:text-[var(--lp-strong)]',
               dimmed && 'opacity-50'
             )}
             aria-pressed={mode === id}

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -412,10 +412,13 @@ export function CenterPanel({
           </div>
         </div>
 
-        {/* Player hero frame (mockup ③) — group/player drives the hover chrome */}
+        {/* Player — ORIGINAL PanelVideoPlayer untouched (user decision after a
+            regression: native YT menus stay exactly as before). The relevance
+            curve overlay is the only custom element; the wrapper mirrors the
+            player's own size cap so the overlay hugs the video box exactly. */}
         <div
-          className="group/player relative overflow-hidden rounded-2xl border border-[var(--lp-line-8)] bg-black"
-          style={{ boxShadow: 'var(--lp-player-shadow)' }}
+          className="group/player relative mx-auto w-full"
+          style={{ maxWidth: 'calc(49.5vh * 16 / 9)' }}
           onMouseEnter={() => setActiveRegion('player')}
         >
           <PanelVideoPlayer
@@ -426,7 +429,6 @@ export function CenterPanel({
             onPlayStateChange={onPlayStateChange}
             onTimeUpdate={setPlayerState}
             startTime={startTime}
-            fill
           />
           <PlayerChrome sections={chapterSections} />
         </div>

--- a/frontend/src/pages/learning/ui/FloatingVideoNavigator.tsx
+++ b/frontend/src/pages/learning/ui/FloatingVideoNavigator.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ChevronLeft, ChevronRight, GalleryHorizontalEnd, X } from 'lucide-react';
+import { useMandalaCards } from '../model/useMandalaCards';
+import { cn } from '@/shared/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
+
+/**
+ * Floating video navigator (video-view mockup track) — collapsed: a round
+ * pill button with the current position badge; click expands a horizontal
+ * thumbnail strip for prev/next hops + rough position. Hover on a thumb
+ * shows a LARGE thumbnail preview so neighbors are visually identifiable.
+ * Click-to-expand by design: player hover is reserved for the scrubber,
+ * and hover-in-hover (strip + preview tooltip) would misfire on trackpads.
+ */
+
+interface FloatingVideoNavigatorProps {
+  mandalaId: string;
+  currentVideoId: string;
+  /** Controlled expand state — parent hides the breadcrumb while expanded. */
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+}
+
+const SCROLL_AMOUNT = 240;
+const YT_ID_RE = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\s]+)/;
+
+export function FloatingVideoNavigator({
+  mandalaId,
+  currentVideoId,
+  expanded,
+  onExpandedChange,
+}: FloatingVideoNavigatorProps) {
+  const navigate = useNavigate();
+  const { cards } = useMandalaCards(mandalaId);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const videos = cards
+    .map((c) => ({ ...c, ytId: c.videoUrl.match(YT_ID_RE)?.[1] ?? null }))
+    .filter((c) => c.ytId);
+  const currentIdx = videos.findIndex((v) => v.ytId === currentVideoId);
+
+  // Outside-close uses `click` (not mousedown) — CP443: avoids races with
+  // TipTap / dnd-kit pointerdown paths.
+  useEffect(() => {
+    if (!expanded) return;
+    function onClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onExpandedChange(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onExpandedChange(false);
+    }
+    // Defer attach one tick — the expanding click's own bubble would otherwise
+    // hit document with the (now-unmounted) collapsed button as target →
+    // contains() false → instant re-collapse.
+    const timerId = window.setTimeout(() => {
+      document.addEventListener('click', onClick);
+    }, 0);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      window.clearTimeout(timerId);
+      document.removeEventListener('click', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [expanded, onExpandedChange]);
+
+  // Center the active thumb when the strip opens or the video changes.
+  useEffect(() => {
+    if (!expanded) return;
+    const activeEl = scrollRef.current?.querySelector('[data-active="true"]');
+    activeEl?.scrollIntoView({ inline: 'center', block: 'nearest' });
+  }, [expanded, currentVideoId]);
+
+  const scroll = useCallback((direction: 'left' | 'right') => {
+    scrollRef.current?.scrollBy({
+      left: direction === 'left' ? -SCROLL_AMOUNT : SCROLL_AMOUNT,
+      behavior: 'smooth',
+    });
+  }, []);
+
+  if (videos.length <= 1) return null;
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => onExpandedChange(true)}
+        aria-expanded={false}
+        aria-label="영상 네비게이터 열기"
+        className="flex h-9 shrink-0 items-center gap-2 rounded-full border border-[var(--lp-line-8)] bg-[var(--lp-surface-2)] pl-2.5 pr-3 text-[var(--lp-dim)] transition-colors hover:text-[var(--lp-strong)]"
+      >
+        <GalleryHorizontalEnd className="h-4 w-4" aria-hidden />
+        <span className="text-[11.5px] font-semibold tabular-nums">
+          {currentIdx >= 0 ? currentIdx + 1 : 1}/{videos.length}
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex h-11 min-w-0 flex-1 items-center gap-1 rounded-[10px] border border-[var(--lp-line-8)] bg-[var(--lp-surface-2)] px-1.5"
+    >
+      <button
+        type="button"
+        onClick={() => onExpandedChange(false)}
+        aria-label="영상 네비게이터 닫기"
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[var(--lp-dim)] transition-colors hover:text-[var(--lp-strong)]"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={() => scroll('left')}
+        aria-label="이전 썸네일"
+        className="flex h-7 w-5 shrink-0 items-center justify-center text-[var(--lp-dim)] transition-colors hover:text-[var(--lp-strong)]"
+      >
+        <ChevronLeft className="h-3.5 w-3.5" />
+      </button>
+      <div
+        ref={scrollRef}
+        className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto scrollbar-none py-1"
+      >
+        {videos.map((v) => {
+          const isActive = v.ytId === currentVideoId;
+          return (
+            <Tooltip key={v.id} delayDuration={150}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  data-active={isActive}
+                  onClick={() => {
+                    if (!isActive) navigate(`/learning/${mandalaId}/${v.ytId}`);
+                  }}
+                  className={cn(
+                    'relative h-8 w-[57px] shrink-0 overflow-hidden rounded-[5px] bg-[var(--lp-surface)] transition-opacity',
+                    isActive ? 'ring-2 ring-[var(--lp-accent)]' : 'opacity-60 hover:opacity-100'
+                  )}
+                >
+                  {v.thumbnail ? (
+                    <img src={v.thumbnail} alt="" className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="h-full w-full bg-[var(--lp-surface)]" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              {/* Large preview — big enough to actually identify prev/next videos */}
+              <TooltipContent side="bottom" className="max-w-none p-1.5">
+                <div className="w-[240px]">
+                  {v.thumbnail && (
+                    <img
+                      src={v.thumbnail}
+                      alt=""
+                      className="h-[135px] w-[240px] rounded-[6px] object-cover"
+                    />
+                  )}
+                  <p className="mt-1.5 line-clamp-2 px-0.5 pb-0.5 text-[12px] leading-[1.4]">
+                    {v.title}
+                  </p>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={() => scroll('right')}
+        aria-label="다음 썸네일"
+        className="flex h-7 w-5 shrink-0 items-center justify-center text-[var(--lp-dim)] transition-colors hover:text-[var(--lp-strong)]"
+      >
+        <ChevronRight className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/learning/ui/LearningPage.tsx
+++ b/frontend/src/pages/learning/ui/LearningPage.tsx
@@ -1,11 +1,9 @@
 import { markOnboardingTask } from '@/features/onboarding';
 import { useRef, useCallback, useState, useLayoutEffect, useEffect } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
-import { VideoStrip } from './VideoStrip';
 import { CenterPanel } from './CenterPanel';
 import { RightPanel } from './RightPanel';
 import { useLearningStore } from '@/pages/learning/model/useLearningStore';
-import { cn } from '@/shared/lib/utils';
 import type { YTPlayer } from '@/widgets/video-player/model/youtube-api';
 
 export default function LearningPage() {
@@ -32,8 +30,6 @@ export default function LearningPage() {
   }, [videoId]);
 
   const centerViewMode = useLearningStore((s) => s.centerViewMode);
-  const videoStripEnabled = useLearningStore((s) => s.videoStripEnabled);
-  const [stripVisible, setStripVisible] = useState(false);
 
   // CP438+1: ?t=N query param drives in-page seek. When the user clicks
   // an atom timestamp link in the sidebar/panel, the same-video case
@@ -91,30 +87,12 @@ export default function LearningPage() {
 
   return (
     <div className="flex h-full overflow-hidden">
-      {/* 좌측 column = VideoStrip + CenterPanel (둘 다 px-10 → player 와
-          좌우 polo align). RightPanel 은 별도 column. */}
-      <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
-        {/* VideoStrip slide-on-hover. Trigger = player wrapper only (via
-            onPlayerHoverIn/Out from CenterPanel). Strip itself also
-            stays visible while hovered so the user can click a thumb.
-            Toggle (ON/OFF) lives in the left sidebar header. */}
-        {videoStripEnabled && (
-          <div
-            onMouseEnter={() => setStripVisible(true)}
-            onMouseLeave={() => setStripVisible(false)}
-            className={cn(
-              'absolute left-0 right-0 top-0 z-20 pl-4 pr-3 pt-[5px]',
-              'bg-[hsl(var(--bg-base))]/95 backdrop-blur-sm',
-              'transition-transform duration-300 ease-out',
-              stripVisible
-                ? 'translate-y-0 pointer-events-auto'
-                : '-translate-y-full pointer-events-none',
-              centerViewMode === 'note' && 'hidden'
-            )}
-          >
-            <VideoStrip mandalaId={mandalaId!} currentVideoId={videoId!} />
-          </div>
-        )}
+      {/* [VIDEO-VIEW] center column — min-w floor so shrinking the browser
+          never crushes it into vertical text (sidebar auto-collapse in
+          AppShell frees width first; below the floor the page clips). The
+          old hover-slide VideoStrip is replaced by FloatingVideoNavigator
+          inside CenterPanel's top bar. */}
+      <div className="relative flex min-w-[380px] flex-1 flex-col overflow-hidden">
         <CenterPanel
           mandalaId={mandalaId!}
           videoId={videoId!}
@@ -126,8 +104,6 @@ export default function LearningPage() {
           onUserPlayed={handleUserPlayed}
           onPlayStateChange={handlePlayStateChange}
           startTime={startTime}
-          onPlayerHoverIn={() => setStripVisible(true)}
-          onPlayerHoverOut={() => setStripVisible(false)}
         />
       </div>
       <RightPanel mandalaId={mandalaId!} videoId={videoId!} playerRef={playerRef} />

--- a/frontend/src/pages/learning/ui/PlayerChrome.tsx
+++ b/frontend/src/pages/learning/ui/PlayerChrome.tsx
@@ -1,19 +1,16 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { useLearningStore } from '../model/useLearningStore';
-import { relevanceLevel, relevanceCssVar, type RelevanceLevel } from '../lib/relevance-level';
+import { relevanceLevel, type RelevanceLevel } from '../lib/relevance-level';
 import type { VideoRichSummarySection } from '@/shared/lib/api-client';
 
 /**
- * Relevance overlay for the NATIVE YouTube player (user decision: keep the
- * YT navigator/menus; overlay only). Two pointer-events-none layers inside a
- * `group/player relative` frame around the iframe:
- *  - now-chip (top-left, current chapter) — hides on hover so it never
- *    clashes with YT's own hover title bar;
- *  - relevance curve — appears WITH the native controls on hover, sitting
- *    just above the YT progress bar so both read as one navigator. High/mid/
- *    low chapters are color-coded with a wide amplitude, played portion is
- *    tinted gold, and a playhead dot tracks the curve.
- * All interaction (seek/scrub/menus) stays native — nothing here is clickable.
+ * Relevance curve overlay for the NATIVE YouTube player (user decision: the
+ * curve is the ONLY custom element — every menu/control stays YouTube's).
+ * A single pointer-events-none layer inside a `group/player relative` frame:
+ * the curve appears WITH the native controls on hover, parked just above the
+ * YT progress bar so both read as one navigator. High/mid/low chapters are
+ * color-coded with a wide amplitude, the played portion is tinted gold, and
+ * a playhead dot tracks the curve. Nothing here is clickable.
  */
 
 interface PlayerChromeProps {
@@ -75,15 +72,6 @@ export function PlayerChrome({ sections }: PlayerChromeProps) {
     playerDurationSec > 0 ? playerDurationSec : (chapters[chapters.length - 1]?.to_sec ?? 0);
   const progress = duration > 0 ? Math.min(1, Math.max(0, playerTimeSec / duration)) : 0;
 
-  const activeIdx = (() => {
-    for (let i = 0; i < chapters.length; i++) {
-      const c = chapters[i]!;
-      if (playerTimeSec >= c.from_sec && playerTimeSec < c.to_sec) return i;
-    }
-    return chapters.length - 1;
-  })();
-  const activeChapter = chapters[activeIdx];
-
   // Curve geometry (mockup renderRelCurve): one smooth curve; chapter
   // boundaries punched out by a clip; per-level color-coded stroke.
   const curve = useMemo(() => {
@@ -143,27 +131,6 @@ export function PlayerChrome({ sections }: PlayerChromeProps) {
   return (
     // z-20 — must sit above PanelVideoPlayer's poster facade (z-10).
     <div className="pointer-events-none absolute inset-0 z-20" aria-hidden>
-      {/* Now-chip — current chapter; yields to YT's own hover title bar. */}
-      {activeChapter && (
-        <div
-          className="absolute left-[18px] top-4 z-[5] flex max-w-[62%] items-center gap-[9px] rounded-[10px] py-[7px] pl-[13px] pr-[9px] text-[12.5px] font-semibold transition-opacity duration-200 group-hover/player:opacity-0"
-          style={{
-            background: 'var(--lp-chip-bg)',
-            backdropFilter: 'blur(7px)',
-            color: 'var(--lp-chip-fg)',
-          }}
-        >
-          <span
-            className="h-[7px] w-[7px] shrink-0 rounded-full"
-            style={{ background: relevanceCssVar(levelOf(activeChapter)) }}
-          />
-          <span className="min-w-0 truncate">{activeChapter.title}</span>
-          <span className="shrink-0 border-l border-white/15 pl-[9px] text-[11px] font-semibold tabular-nums text-white/50">
-            {String(activeIdx + 1).padStart(2, '0')} / {String(chapters.length).padStart(2, '0')}
-          </span>
-        </div>
-      )}
-
       {/* Relevance curve — fades in WITH the native controls (hover), parked
           just above the YT progress bar so the two read as one navigator. */}
       <div className="absolute bottom-[52px] left-3 right-3 h-[56px] opacity-0 transition-opacity duration-200 group-hover/player:opacity-100">

--- a/frontend/src/pages/learning/ui/PlayerChrome.tsx
+++ b/frontend/src/pages/learning/ui/PlayerChrome.tsx
@@ -126,7 +126,13 @@ export function PlayerChrome({ sections }: PlayerChromeProps) {
     head.style.top = `${(pt.y / CURVE_H) * H}px`;
   }, [progress, curve]);
 
-  if (!curve) return null;
+  // Coverage gate — segments must actually map the video. A 65-min video
+  // whose chapters cover only the first ~7 min would render as a squiggle
+  // crammed into the left edge + a long flat line (user bug report): worse
+  // than no curve. Hide unless the data spans ≥90% of the real duration.
+  const coverage =
+    duration > 0 && chapters.length ? chapters[chapters.length - 1]!.to_sec / duration : 0;
+  if (!curve || coverage < 0.9) return null;
 
   return (
     // z-20 — must sit above PanelVideoPlayer's poster facade (z-10).

--- a/frontend/src/pages/learning/ui/PlayerChrome.tsx
+++ b/frontend/src/pages/learning/ui/PlayerChrome.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useLearningStore } from '../model/useLearningStore';
+import { relevanceLevel, relevanceCssVar, type RelevanceLevel } from '../lib/relevance-level';
+import type { VideoRichSummarySection } from '@/shared/lib/api-client';
+
+/**
+ * Relevance overlay for the NATIVE YouTube player (user decision: keep the
+ * YT navigator/menus; overlay only). Two pointer-events-none layers inside a
+ * `group/player relative` frame around the iframe:
+ *  - now-chip (top-left, current chapter) — hides on hover so it never
+ *    clashes with YT's own hover title bar;
+ *  - relevance curve — appears WITH the native controls on hover, sitting
+ *    just above the YT progress bar so both read as one navigator. High/mid/
+ *    low chapters are color-coded with a wide amplitude, played portion is
+ *    tinted gold, and a playhead dot tracks the curve.
+ * All interaction (seek/scrub/menus) stays native — nothing here is clickable.
+ */
+
+interface PlayerChromeProps {
+  sections: VideoRichSummarySection[];
+}
+
+const CURVE_W = 1000;
+const CURVE_H = 100;
+const BASE_Y = 92;
+const GAP = 7;
+// Wide amplitude (user directive: mockup's 26/48/66 read as a wobbly line).
+const Y_FOR: Record<RelevanceLevel, number> = { high: 14, mid: 52, low: 84 };
+
+interface Pt {
+  x: number;
+  y: number;
+}
+
+/** Catmull-Rom → cubic bézier path (mockup buildPath, verbatim math). */
+function buildPath(pts: Pt[]): string {
+  if (pts.length < 2) return '';
+  const d = [`M${pts[0]!.x.toFixed(1)},${pts[0]!.y.toFixed(1)}`];
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i]!;
+    const p1 = pts[i]!;
+    const p2 = pts[i + 1]!;
+    const p3 = pts[i + 2] ?? pts[i + 1]!;
+    const c1x = p1.x + (p2.x - p0.x) / 6;
+    const c1y = p1.y + (p2.y - p0.y) / 6;
+    const c2x = p2.x - (p3.x - p1.x) / 6;
+    const c2y = p2.y - (p3.y - p1.y) / 6;
+    d.push(
+      `C${c1x.toFixed(1)},${c1y.toFixed(1)} ${c2x.toFixed(1)},${c2y.toFixed(1)} ${p2.x.toFixed(1)},${p2.y.toFixed(1)}`
+    );
+  }
+  return d.join(' ');
+}
+
+function levelOf(s: VideoRichSummarySection): RelevanceLevel {
+  return typeof s.relevance_pct === 'number' ? relevanceLevel(s.relevance_pct) : 'low';
+}
+
+export function PlayerChrome({ sections }: PlayerChromeProps) {
+  const playerTimeSec = useLearningStore((s) => s.playerTimeSec);
+  const playerDurationSec = useLearningStore((s) => s.playerDurationSec);
+
+  const basePathRef = useRef<SVGPathElement>(null);
+  const headRef = useRef<HTMLDivElement>(null);
+
+  const chapters = useMemo(
+    () =>
+      sections
+        .filter((s) => s.to_sec > s.from_sec)
+        .slice()
+        .sort((a, b) => a.from_sec - b.from_sec),
+    [sections]
+  );
+  const duration =
+    playerDurationSec > 0 ? playerDurationSec : (chapters[chapters.length - 1]?.to_sec ?? 0);
+  const progress = duration > 0 ? Math.min(1, Math.max(0, playerTimeSec / duration)) : 0;
+
+  const activeIdx = (() => {
+    for (let i = 0; i < chapters.length; i++) {
+      const c = chapters[i]!;
+      if (playerTimeSec >= c.from_sec && playerTimeSec < c.to_sec) return i;
+    }
+    return chapters.length - 1;
+  })();
+  const activeChapter = chapters[activeIdx];
+
+  // Curve geometry (mockup renderRelCurve): one smooth curve; chapter
+  // boundaries punched out by a clip; per-level color-coded stroke.
+  const curve = useMemo(() => {
+    if (!chapters.length || duration <= 0) return null;
+    const pts: Pt[] = [{ x: 0, y: BASE_Y }];
+    for (const c of chapters) {
+      pts.push({ x: ((c.from_sec + c.to_sec) / 2 / duration) * CURVE_W, y: Y_FOR[levelOf(c)] });
+    }
+    pts.push({ x: CURVE_W, y: BASE_Y });
+    const lineD = buildPath(pts);
+    const gapRects = chapters.map((c, i) => {
+      const x0 = i === 0 ? 0 : (c.from_sec / duration) * CURVE_W + GAP / 2;
+      const x1 = i === chapters.length - 1 ? CURVE_W : (c.to_sec / duration) * CURVE_W - GAP / 2;
+      return { x: x0, w: Math.max(0, x1 - x0) };
+    });
+    // Per-level color coding — high green / mid gold / low dim (user directive:
+    // relevance must be identifiable from the curve alone).
+    const gradStops = chapters.flatMap((c) => {
+      const level = levelOf(c);
+      const color = level === 'low' ? 'var(--lp-curve-neutral)' : `var(--lp-rel-${level})`;
+      const op = level === 'high' ? 0.95 : level === 'mid' ? 0.75 : 0.35;
+      return [
+        { off: (c.from_sec / duration) * 100, color, op },
+        { off: (c.to_sec / duration) * 100, color, op },
+      ];
+    });
+    return { lineD, gapRects, gradStops };
+  }, [chapters, duration]);
+
+  // Playhead — walk the base path to the x of current progress (mockup paint).
+  useEffect(() => {
+    const base = basePathRef.current;
+    const head = headRef.current;
+    if (!base || !head || !curve) return;
+    const svg = base.ownerSVGElement;
+    if (!svg || typeof base.getTotalLength !== 'function') return;
+    const W = svg.clientWidth;
+    const H = svg.clientHeight;
+    if (!W || !H) return;
+    const targetX = progress * CURVE_W;
+    const total = base.getTotalLength();
+    let lo = 0;
+    let hi = total;
+    let pt = base.getPointAtLength(0);
+    for (let k = 0; k < 20; k++) {
+      const mid = (lo + hi) / 2;
+      pt = base.getPointAtLength(mid);
+      if (pt.x < targetX) lo = mid;
+      else hi = mid;
+    }
+    head.style.left = `${progress * W}px`;
+    head.style.top = `${(pt.y / CURVE_H) * H}px`;
+  }, [progress, curve]);
+
+  if (!curve) return null;
+
+  return (
+    // z-20 — must sit above PanelVideoPlayer's poster facade (z-10).
+    <div className="pointer-events-none absolute inset-0 z-20" aria-hidden>
+      {/* Now-chip — current chapter; yields to YT's own hover title bar. */}
+      {activeChapter && (
+        <div
+          className="absolute left-[18px] top-4 z-[5] flex max-w-[62%] items-center gap-[9px] rounded-[10px] py-[7px] pl-[13px] pr-[9px] text-[12.5px] font-semibold transition-opacity duration-200 group-hover/player:opacity-0"
+          style={{
+            background: 'var(--lp-chip-bg)',
+            backdropFilter: 'blur(7px)',
+            color: 'var(--lp-chip-fg)',
+          }}
+        >
+          <span
+            className="h-[7px] w-[7px] shrink-0 rounded-full"
+            style={{ background: relevanceCssVar(levelOf(activeChapter)) }}
+          />
+          <span className="min-w-0 truncate">{activeChapter.title}</span>
+          <span className="shrink-0 border-l border-white/15 pl-[9px] text-[11px] font-semibold tabular-nums text-white/50">
+            {String(activeIdx + 1).padStart(2, '0')} / {String(chapters.length).padStart(2, '0')}
+          </span>
+        </div>
+      )}
+
+      {/* Relevance curve — fades in WITH the native controls (hover), parked
+          just above the YT progress bar so the two read as one navigator. */}
+      <div className="absolute bottom-[52px] left-3 right-3 h-[56px] opacity-0 transition-opacity duration-200 group-hover/player:opacity-100">
+        <svg
+          width="100%"
+          height="56"
+          viewBox={`0 0 ${CURVE_W} ${CURVE_H}`}
+          preserveAspectRatio="none"
+          className="block h-full w-full overflow-visible"
+        >
+          <defs>
+            <clipPath id="lpRelProgClip">
+              <rect x="0" y="0" width={progress * CURVE_W} height={CURVE_H} />
+            </clipPath>
+            <clipPath id="lpGapClip">
+              {curve.gapRects.map((g, i) => (
+                <rect key={i} x={g.x} y="0" width={g.w} height={CURVE_H} />
+              ))}
+            </clipPath>
+            <linearGradient
+              id="lpRelStroke"
+              gradientUnits="userSpaceOnUse"
+              x1="0"
+              y1="0"
+              x2={CURVE_W}
+              y2="0"
+            >
+              {curve.gradStops.map((s, i) => (
+                <stop
+                  key={i}
+                  offset={`${s.off.toFixed(2)}%`}
+                  style={{ stopColor: s.color, stopOpacity: s.op }}
+                />
+              ))}
+            </linearGradient>
+          </defs>
+          <g clipPath="url(#lpGapClip)">
+            <path
+              ref={basePathRef}
+              d={curve.lineD}
+              fill="none"
+              stroke="url(#lpRelStroke)"
+              strokeWidth={3}
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+            />
+            {/* var() doesn't resolve in SVG presentation attributes — style it. */}
+            <path
+              d={curve.lineD}
+              fill="none"
+              style={{ stroke: 'var(--lp-accent)' }}
+              strokeWidth={3.5}
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+              clipPath="url(#lpRelProgClip)"
+            />
+          </g>
+        </svg>
+        <div
+          ref={headRef}
+          className="absolute h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white"
+          style={{ boxShadow: 'var(--lp-head-glow)' }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/learning/ui/RightPanel.tsx
+++ b/frontend/src/pages/learning/ui/RightPanel.tsx
@@ -26,6 +26,7 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
   const [activeTab, setActiveTab] = useState<RightTab>('chatbot');
   const setActiveRegion = useLearningStore((s) => s.setActiveRegion);
   const setNoteContext = useLearningStore((s) => s.setNoteContext);
+  const centerViewMode = useLearningStore((s) => s.centerViewMode);
   const activeSectionRef = useLearningStore((s) => s.activeSectionRef);
   const { cards } = useMandalaCards(mandalaId);
   const { book } = useMandalaBook(mandalaId);
@@ -108,8 +109,27 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
       className="flex w-[400px] shrink-0 flex-col border-l border-sidebar-border/40 pl-5 pr-5"
       onMouseEnter={() => setActiveRegion(activeTab === 'notes' ? 'notes' : 'chat')}
     >
-      {/* [VIDEO-VIEW] — ViewModeToggle moved to CenterPanel's top bar (mockup ①);
-          this panel starts directly with its own tabs. */}
+      {/* [VIDEO-VIEW R2] Context zone — same 60px rhythm as the center top bar.
+          Names WHICH book-index scope the memo/chatbot below applies to:
+          player mode = the current video (영상용 book-index item), note mode =
+          the section being read (노트용 book-index 구간). */}
+      <div className="flex h-[60px] shrink-0 items-center border-b border-sidebar-border/40 px-1 text-[12px] text-muted-foreground/60">
+        <span className="shrink-0">
+          {centerViewMode === 'note'
+            ? t('learning.nowReadingSection', '지금 읽는 구간')
+            : t('learning.nowWatchingVideo', '지금 보는 영상')}
+        </span>
+        <span className="shrink-0 px-1.5" aria-hidden>
+          ·
+        </span>
+        <span className="min-w-0 truncate text-foreground/75">
+          {(centerViewMode === 'note'
+            ? (activeSectionTitle ?? currentCard?.title)
+            : currentCard?.title) ?? '—'}
+        </span>
+      </div>
+
+      {/* ViewModeToggle moved to CenterPanel's top bar (mockup ①). */}
       <div className="flex shrink-0">
         {tabs.map(({ id, labelKey, icon: Icon }) => (
           <button
@@ -164,12 +184,7 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
           activeTab !== 'chatbot' && 'hidden'
         )}
       >
-        {activeSectionTitle && (
-          // §redesign — chat context (시안 chat-ctx): "지금 읽는 구간 · {제목}".
-          <div className="shrink-0 border-b border-white/[0.06] px-1 pb-2.5 pt-0.5 text-[12px] text-muted-foreground/70">
-            지금 읽는 구간 · <span className="text-muted-foreground">{activeSectionTitle}</span>
-          </div>
-        )}
+        {/* [R2] chat-ctx line superseded by the top context zone above. */}
         <div className="relative min-h-0 flex-1 overflow-hidden">
           <ChatAssistant
             key={videoId}

--- a/frontend/src/pages/learning/ui/RightPanel.tsx
+++ b/frontend/src/pages/learning/ui/RightPanel.tsx
@@ -1,12 +1,11 @@
 import { markOnboardingTask } from '@/features/onboarding';
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { NotebookPen, Bot, MoreHorizontal } from 'lucide-react';
+import { NotebookPen, Bot } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/shared/lib/utils';
 import { PanelNoteEditor } from '@/features/video-side-panel/ui/PanelNoteEditor';
 import { ChatAssistant } from './ChatAssistant';
-import { ViewModeToggle } from './CenterPanel';
 import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import { useMandalaCards } from '../model/useMandalaCards';
 import { useLearningStore } from '../model/useLearningStore';
@@ -27,11 +26,9 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
   const [activeTab, setActiveTab] = useState<RightTab>('chatbot');
   const setActiveRegion = useLearningStore((s) => s.setActiveRegion);
   const setNoteContext = useLearningStore((s) => s.setNoteContext);
-  const centerViewMode = useLearningStore((s) => s.centerViewMode);
-  const setCenterViewMode = useLearningStore((s) => s.setCenterViewMode);
   const activeSectionRef = useLearningStore((s) => s.activeSectionRef);
   const { cards } = useMandalaCards(mandalaId);
-  const { book, isLoading: bookLoading } = useMandalaBook(mandalaId);
+  const { book } = useMandalaBook(mandalaId);
   // §redesign — "지금 읽는 구간" context for the chatbot header (시안 chat-ctx).
   const activeSectionTitle = (() => {
     if (!activeSectionRef || !book?.book?.chapters) return null;
@@ -111,31 +108,8 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
       className="flex w-[400px] shrink-0 flex-col border-l border-sidebar-border/40 pl-5 pr-5"
       onMouseEnter={() => setActiveRegion(activeTab === 'notes' ? 'notes' : 'chat')}
     >
-      {/* CP445 (사용자 directive) — ViewModeToggle + [⋯] 우측 사이드바 상단
-          고정. 영상/노트 모드 전환 시 위치 변동 없음 (toggle 의 단일 home). */}
-      <div className="flex shrink-0 items-center justify-between py-2 pr-3">
-        <ViewModeToggle
-          mode={centerViewMode}
-          noteDisabled={!bookLoading && !book}
-          onChange={(mode) => {
-            if (mode === 'note' && !bookLoading && !book) {
-              toast(t('learning.noteNotReady', '노트가 아직 생성되지 않았어요'));
-              return;
-            }
-            setCenterViewMode(mode);
-          }}
-        />
-        <button
-          type="button"
-          aria-label="More"
-          className="rounded p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
-          onClick={() => {
-            /* CP445 D8 — placeholder, no-op (별 PR) */
-          }}
-        >
-          <MoreHorizontal className="h-3.5 w-3.5" />
-        </button>
-      </div>
+      {/* [VIDEO-VIEW] — ViewModeToggle moved to CenterPanel's top bar (mockup ①);
+          this panel starts directly with its own tabs. */}
       <div className="flex shrink-0">
         {tabs.map(({ id, labelKey, icon: Icon }) => (
           <button

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1918,7 +1918,9 @@
     "relevanceHigh": "High",
     "playingNow": "Playing",
     "topicGroup": "Group",
-    "videoFallbackTitle": "Video"
+    "videoFallbackTitle": "Video",
+    "nowWatchingVideo": "Now watching",
+    "nowReadingSection": "Now reading"
   },
   "addCards": {
     "triggerChip": "+ Add Cards",

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1910,7 +1910,15 @@
     "downloadHtml": "Download HTML",
     "restoreOriginal": "Restore original",
     "viewModePlayer": "Video",
-    "viewModeNote": "Note"
+    "viewModeNote": "Note",
+    "tabChapters": "Chapters",
+    "chaptersCount": "{{count}} chapters",
+    "chaptersEmpty": "Chapters are not ready yet. They will appear once the AI summary is generated.",
+    "relevanceLow": "Low",
+    "relevanceHigh": "High",
+    "playingNow": "Playing",
+    "topicGroup": "Group",
+    "videoFallbackTitle": "Video"
   },
   "addCards": {
     "triggerChip": "+ Add Cards",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1926,7 +1926,9 @@
     "relevanceHigh": "높음",
     "playingNow": "재생 중",
     "topicGroup": "주제군",
-    "videoFallbackTitle": "영상"
+    "videoFallbackTitle": "영상",
+    "nowWatchingVideo": "지금 보는 영상",
+    "nowReadingSection": "지금 읽는 구간"
   },
   "addCards": {
     "triggerChip": "+ 카드 추가",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1918,7 +1918,15 @@
     "downloadHtml": "HTML 다운로드",
     "restoreOriginal": "원본 복원",
     "viewModePlayer": "영상",
-    "viewModeNote": "노트"
+    "viewModeNote": "노트",
+    "tabChapters": "챕터",
+    "chaptersCount": "{{count}}개 챕터",
+    "chaptersEmpty": "챕터 정보가 아직 준비되지 않았어요. AI 요약이 생성되면 챕터가 나타납니다.",
+    "relevanceLow": "낮음",
+    "relevanceHigh": "높음",
+    "playingNow": "재생 중",
+    "topicGroup": "주제군",
+    "videoFallbackTitle": "영상"
   },
   "addCards": {
     "triggerChip": "+ 카드 추가",

--- a/frontend/src/widgets/app-shell/ui/AppShell.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { DndContext } from '@dnd-kit/core';
 import { useTranslation } from 'react-i18next';
@@ -83,7 +83,36 @@ export function AppShell({ children }: AppShellProps) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(getInitialCollapsed);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
 
+  // [VIDEO-VIEW] responsive guard — on /learning, fixed sidebar(320) +
+  // RightPanel(400) crush the center column below ~1280px viewport. Auto-
+  // collapse the sidebar to the icon rail there; a manual toggle while
+  // narrow overrides for the session, and widening restores the persisted
+  // preference untouched.
+  const isLearningRoute = location.pathname.startsWith('/learning');
+  const [narrowLearning, setNarrowLearning] = useState(false);
+  const [narrowOverride, setNarrowOverride] = useState<boolean | null>(null);
+  useEffect(() => {
+    if (!isLearningRoute) {
+      setNarrowLearning(false);
+      return;
+    }
+    const mq = window.matchMedia('(max-width: 1279px)');
+    const sync = () => setNarrowLearning(mq.matches);
+    sync();
+    mq.addEventListener('change', sync);
+    return () => mq.removeEventListener('change', sync);
+  }, [isLearningRoute]);
+  useEffect(() => {
+    if (!narrowLearning) setNarrowOverride(null);
+  }, [narrowLearning]);
+  const effectiveCollapsed = narrowLearning ? (narrowOverride ?? true) : sidebarCollapsed;
+
   const handleToggleCollapse = useCallback(() => {
+    if (narrowLearning) {
+      // Session-only override — don't persist an auto-collapse as preference.
+      setNarrowOverride((prev) => !(prev ?? true));
+      return;
+    }
     setSidebarCollapsed((prev) => {
       const next = !prev;
       try {
@@ -93,7 +122,7 @@ export function AppShell({ children }: AppShellProps) {
       }
       return next;
     });
-  }, []);
+  }, [narrowLearning]);
 
   // Public pages (landing, login, etc.) render their own header — skip AppShell chrome
   if (!isLoggedIn) {
@@ -122,7 +151,7 @@ export function AppShell({ children }: AppShellProps) {
         <div className="flex-1 flex overflow-hidden">
           {showSidebar && (
             <Sidebar
-              collapsed={isSettingsRoute ? false : sidebarCollapsed}
+              collapsed={isSettingsRoute ? false : effectiveCollapsed}
               onToggleCollapse={handleToggleCollapse}
               onNavigateHome={onNavigateHome ?? undefined}
               minimapData={minimapData ?? undefined}

--- a/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { BookOpen, ChevronsDownUp, ChevronsUpDown, PanelTop } from 'lucide-react';
+import { BookOpen, ChevronsDownUp, ChevronsUpDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useMandalaQuery } from '@/features/mandala';
 import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
@@ -40,8 +40,6 @@ export function SidebarLearningSection({
   const activeSectionRef = useLearningStore((s) => s.activeSectionRef);
   const setActiveRegion = useLearningStore((s) => s.setActiveRegion);
   const centerViewMode = useLearningStore((s) => s.centerViewMode);
-  const videoStripEnabled = useLearningStore((s) => s.videoStripEnabled);
-  const setVideoStripEnabled = useLearningStore((s) => s.setVideoStripEnabled);
   // CP445.x — multi-chapter expand state. `null` = default (모두 펼침).
   // 사용자가 individual/all 토글 시 explicit Set 으로 전환.
   const [expandedIdxs, setExpandedIdxs] = useState<Set<number> | null>(null);
@@ -298,27 +296,8 @@ export function SidebarLearningSection({
             })()}
           </div>
           <div className="mt-0.5 flex shrink-0 items-center gap-0.5">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={() => setVideoStripEnabled(!videoStripEnabled)}
-                  aria-label={videoStripEnabled ? '동영상 썸네일 바 끄기' : '동영상 썸네일 바 켜기'}
-                  aria-pressed={videoStripEnabled}
-                  className={cn(
-                    'rounded p-1 transition-colors hover:bg-sidebar-accent/40',
-                    videoStripEnabled
-                      ? 'text-sidebar-foreground/85 hover:text-sidebar-foreground'
-                      : 'text-sidebar-foreground/35 hover:text-sidebar-foreground/85'
-                  )}
-                >
-                  <PanelTop className="h-3.5 w-3.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="text-[12px]">
-                {videoStripEnabled ? '동영상 썸네일 바 끄기' : '동영상 썸네일 바 켜기'}
-              </TooltipContent>
-            </Tooltip>
+            {/* [VIDEO-VIEW] — strip ON/OFF toggle retired; the floating
+                navigator button in CenterPanel's top bar replaces it. */}
             {/* CP445.x — 전체 펼침/접힘 토글. default = 모두 펼침. */}
             {totalChapters > 0 && (
               <Tooltip>
@@ -446,7 +425,9 @@ export function SidebarLearningSection({
                         <span
                           className={cn(
                             'shrink-0 font-mono text-[11px] tabular-nums transition-colors',
-                            chapterActive ? 'text-sidebar-foreground/80' : 'text-sidebar-foreground/35'
+                            chapterActive
+                              ? 'text-sidebar-foreground/80'
+                              : 'text-sidebar-foreground/35'
                           )}
                         >
                           {String(idx + 1).padStart(2, '0')}


### PR DESCRIPTION
## Summary

Learning-page center column redesign per the approved `video-view.html` mockup (Phase 1+2 of 4). All visual values are measured mockup literals, centralized as `--lp-*` tokens in `index.css` (no literals in components).

### Phase 1 — center column skeleton
- **Top bar (h60, both modes)**: chapter breadcrumb + highlight-reel/share + **[video|note] mode toggle moved here from RightPanel** (mockup skin: dark pill, light active chip)
- **Video meta header**: channel-initial avatar + title + duration
- **880px centered scroll column** with radial top-glow background
- **Segment tabs `[챕터|AI 요약|섹션 내용]`** replacing underline tabs (mockup has 2 tabs; the existing 섹션 내용 tab is KEPT pending explicit removal decision)
- **Chapters tab (new)**: v2 `segments.sections` → time range, relevance edge bar + 3-bar meter (+ legend, ≥80 high / 50–79 mid / <50 low, aligned with `HIGHLIGHT_RELEVANCE_THRESHOLD`), hover-expand summary, click-to-seek, live "재생 중" chip; empty state when no segments
- `PanelVideoPlayer` gains an opt-in `fill` prop (16:9 full-width); the VideoSidePanel consumer keeps the legacy 49.5vh cap untouched
- **Responsive fix (user report)**: below 1280px on /learning the fixed sidebar(320)+RightPanel(400) crushed the center column into vertical text → sidebar auto-collapses to the icon rail (manual toggle overrides for the session; persisted preference untouched) + center column `min-w` floor

### Phase 2 — floating video navigator
- Collapsed round pill (position badge `3/12`) in the top bar left; **click** expands a thumbnail strip up to the mode toggle (secondary controls yield width while expanded)
- Hover on a thumb = **large 240×135 preview + title** tooltip (identify prev/next at a glance)
- Click-to-expand by design: player hover stays reserved for the (Phase 4) relevance scrubber; hover-in-hover misfires on trackpads; ESC/outside-click closes (deferred-attach guard against same-click self-close)
- Replaces the hover-slide VideoStrip (moved to `-legacy/`, `@deprecated`) + retires the sidebar strip ON/OFF toggle and its store field/localStorage key

## Verification
- FE deep typecheck (`tsc -p tsconfig.app.json`): **0 new errors** (32 pre-existing baseline)
- vitest **481/481** (new `relevance-level` unit test included)
- vite build PASS; `/verify` PASS marker written
- Real-browser E2E on dev: chapters render/seek/playing-chip, navigator expand/tooltip/outside-close, note-mode toggle parity (incl. "note not ready" toast), narrow-window auto-collapse (853px) + wide restore (1568px), computed styles match mockup tokens

## Out of scope (next phases)
- Phase 3: AI summary tab redesign (feature card/tags/action items/concepts)
- Phase 4: custom player chrome (now-chip, segmented scrubber, hover relevance curve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)