### PR TITLE
fix(config): price qwen3-embedding-8b — close the last live cost_usd gap

### DIFF
--- a/src/config/llm-pricing.ts
+++ b/src/config/llm-pricing.ts
@@ -42,6 +42,13 @@ export const LLM_PRICING: Record<string, LLMPricing> = {
     source: 'simonw/llm-prices (2026-06): $0.14/M in, $0.28/M out',
   },
   // --- OpenRouter: Qwen family (sourced 2026-04-27) ---
+  // iks-embed-fallback path — without this entry every embedding call logged
+  // cost_usd NULL (30d prod: 1,368 token-bearing calls, 100% NULL).
+  'qwen/qwen3-embedding-8b': {
+    inputPerToken: 0.00000001,
+    outputPerToken: 0,
+    source: 'openrouter.ai/api/v1/embeddings/models (2026-07-02): $0.01/M in, $0 out',
+  },
   'qwen/qwen3-30b-a3b': {
     inputPerToken: 0.00000008,
     outputPerToken: 0.00000028,

--- a/tests/smoke/llm-pricing-embedding.test.ts
+++ b/tests/smoke/llm-pricing-embedding.test.ts
@@ -1,0 +1,30 @@
+/**
+ * cost_usd 단가 갭 (v2 비용 묶음) — the iks-embed-fallback model must price.
+ *
+ * 30d prod: module=iks-embed-fallback, model=openrouter/qwen/qwen3-embedding-8b,
+ * 1,368 token-bearing calls with cost_usd 100% NULL — calculateCost returned
+ * null because the model was absent from LLM_PRICING. This pins the entry and
+ * the exact call-logger normalization path (openrouter/ prefix strip).
+ */
+
+import { calculateCost, LLM_PRICING } from '../../src/config/llm-pricing';
+
+describe('llm-pricing — qwen3-embedding-8b entry', () => {
+  test('entry exists with the embeddings-catalog price', () => {
+    const p = LLM_PRICING['qwen/qwen3-embedding-8b'];
+    expect(p).toBeDefined();
+    expect(p!.inputPerToken).toBe(0.00000001);
+    expect(p!.outputPerToken).toBe(0);
+  });
+
+  test('calculateCost prices the PREFIXED model id exactly as call-logger passes it', () => {
+    // call-logger receives entry.model verbatim ('openrouter/qwen/qwen3-embedding-8b');
+    // calculateCost strips the provider prefix before the table lookup.
+    const cost = calculateCost('openrouter/qwen/qwen3-embedding-8b', 1_000_000, 0);
+    expect(cost).toBeCloseTo(0.01, 10); // $0.01 per 1M input tokens
+  });
+
+  test('unknown model still returns null (NULL contract unchanged)', () => {
+    expect(calculateCost('openrouter/some/unknown-model', 100, 100)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why
v2 cost-bundle scoping (30d prod): `iks-embed-fallback` calls (`openrouter/qwen/qwen3-embedding-8b`) logged **1,368 token-bearing rows with cost_usd 100% NULL** — `calculateCost` hits `llm-pricing.ts:145` `return null` because the model was absent from the `LLM_PRICING` SSOT table. This was the only live pricing gap (sonnet-4-6/haiku-4.5/deepseek all covered; the 217 historical Sonnet NULLs predate the table entry).

## What (config-only + smoke)
- One `LLM_PRICING` entry: `qwen/qwen3-embedding-8b` = $0.01/M input, $0 output — sourced per the file-header convention from `openrouter.ai/api/v1/embeddings/models` (fetched 2026-07-02; the chat `/models` catalog does not list embedding models).
- `tests/smoke/llm-pricing-embedding.test.ts` (CI-executed): pins the entry, prices the **prefixed** model id exactly as call-logger passes it (`openrouter/` strip path), and pins the unknown-model NULL contract.

## Verification
- Smoke 3/3, `tsc --noEmit` 0. Pure function — no mocks, no LLM call.
- Post-deploy: next `iks-embed-fallback` call logs non-NULL `cost_usd` (~$0.00001/call at typical sizes).

Part of the v2 cost bundle (with #1066 / #963). Historical NULL backfill (tokens × current price) is possible but deliberately deferred — analyses can exclude pre-entry rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)