### PR TITLE
fix(cards): honest date labels — stop disguising added-date as publish date

### DIFF
--- a/frontend/src/__tests__/format-card-date-label.test.ts
+++ b/frontend/src/__tests__/format-card-date-label.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { formatCardDateLabel } from '@/shared/lib/format-date';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('formatCardDateLabel — honest publish-vs-added labels', () => {
+  it('renders the publish date plainly when present', () => {
+    const twoMonthsAgo = new Date(Date.now() - 61 * DAY);
+    expect(formatCardDateLabel(twoMonthsAgo, new Date())).toBe('2 months ago');
+  });
+
+  it('marks the createdAt fallback as "added …" — never disguised as a publish date', () => {
+    const threeDaysAgo = new Date(Date.now() - 3 * DAY);
+    expect(formatCardDateLabel(null, threeDaysAgo)).toBe('added 3 days ago');
+  });
+
+  it('returns null when neither date exists (slot stays empty)', () => {
+    expect(formatCardDateLabel(null, null)).toBeNull();
+  });
+});

--- a/frontend/src/shared/lib/format-date.ts
+++ b/frontend/src/shared/lib/format-date.ts
@@ -32,3 +32,21 @@ export function formatRelativeDate(date: Date | string | null | undefined): stri
   if (years === 1) return '1 year ago';
   return `${years} years ago`;
 }
+
+/**
+ * Honest card date label (#published_at contamination fix).
+ * - publishedAt present  → "N months ago"        (actual YouTube publish date)
+ * - publishedAt missing  → "added N days ago"    (when the card was added —
+ *   NEVER disguised as a publish date; prior code fell back silently and a
+ *   contaminated/absent publish date rendered as a fake "2 months ago")
+ * - neither              → null (slot stays empty)
+ */
+export function formatCardDateLabel(
+  publishedAt: Date | string | null | undefined,
+  createdAt: Date | string | null | undefined
+): string | null {
+  const published = formatRelativeDate(publishedAt);
+  if (published) return published;
+  const added = formatRelativeDate(createdAt);
+  return added ? `added ${added}` : null;
+}

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -19,7 +19,7 @@ import {
   handleThumbnailError,
   handleThumbnailLoad,
 } from '@/shared/lib/image-utils';
-import { formatRelativeDate } from '@/shared/lib/format-date';
+import { formatCardDateLabel } from '@/shared/lib/format-date';
 import { formatDuration, formatViewCount } from '@/shared/lib/format-number';
 import { decodeHtmlEntities } from '@/shared/lib/decode-html-entities';
 import { ScrollableChipRow } from '@/shared/ui/scrollable-chip-row';
@@ -387,8 +387,10 @@ export function InsightCardItemV2({
   // briefly and then a real date like "4 weeks ago" 1s later — a
   // jarring swap that erodes trust in the data. With `null`, the slot
   // simply stays empty until the next refetch lands the real value.
+  // Honest label: a missing publish date must not masquerade as one —
+  // the createdAt fallback is rendered as "added N days ago" instead.
   const relDate = metadataComplete
-    ? formatRelativeDate(ytMeta.publishedAt ?? card.createdAt?.toISOString())
+    ? formatCardDateLabel(ytMeta.publishedAt, card.createdAt)
     : null;
   const hasNote = !!card.userNote?.trim();
   // CP475+ blockquote source priority (user-confirmed 2026-05-20):

--- a/src/skills/plugins/trend-collector/sources/youtube.ts
+++ b/src/skills/plugins/trend-collector/sources/youtube.ts
@@ -17,7 +17,7 @@ export interface TrendingVideo {
   channelId: string;
   channelTitle: string;
   categoryId: string;
-  publishedAt: string;
+  publishedAt: string | null;
   /** parseInt(item.statistics.viewCount). 0 if statistics omitted. */
   viewCount: number;
   /** parseInt(item.statistics.likeCount). null if hidden. */
@@ -125,7 +125,10 @@ function normalizeItem(item: YouTubeVideoItem, fallbackCategory: string): Trendi
     channelId: item.snippet?.channelId ?? '',
     channelTitle: item.snippet?.channelTitle ?? '',
     categoryId: item.snippet?.categoryId ?? fallbackCategory,
-    publishedAt: item.snippet?.publishedAt ?? new Date().toISOString(),
+    // No publish date from the API ⇒ store nothing — a collection-time stamp
+    // masquerading as a publish date is exactly the contamination class found
+    // on 781 prod rows (2026-07-02 measurement).
+    publishedAt: item.snippet?.publishedAt ?? null,
     viewCount: viewCountStr ? parseInt(viewCountStr, 10) || 0 : 0,
     likeCount: likeCountStr ? parseInt(likeCountStr, 10) || 0 : null,
   };


### PR DESCRIPTION
## What James caught (prod screen, 2026-07-02)
A card showing **"2 months ago"** on a 2-year-old video with 93 views. Measured root (read-only prod):
- **781 `youtube_videos` rows** carry a collection-time `published_at` stamp — batch-identical timestamps down to the millisecond (2026-04-25 cluster, 30-row batches), `view_count` NULL. The FE renders the contaminated value faithfully.
- Distribution: NOT_IN_POOL 504 / v2_promoted 258 / batch_trend 17 / user_playlist 2. `video_pool` itself: 0 contaminated — the stamp came in through a bulk ingest payload (Mac Mini collector era, 4/26-28 inserts).
- Independent second leg: when `publishedAt` is absent the FE silently falls back to `card.createdAt` **disguised as a publish date** (InsightCardItemV2.tsx:391).

## Fix (code only — data repair is a separate James-gated decision)
1. `formatCardDateLabel` (shared/lib/format-date.ts): publish date renders plainly; createdAt fallback renders as **"added N days ago"**; neither → null (slot empty). 3-case vitest.
2. `InsightCardItemV2.tsx:391` uses the helper — no silent disguise.
3. `trend-collector/sources/youtube.ts:128`: the **only in-repo now()-fallback** for publishedAt removed (`?? null`) — same contamination class, still reachable via the watchdog workflow. Local type widened to `string | null` (no external consumers — verified).

## Verification
- FE vitest **481/481** (incl. new 3), `vite build` OK, BE+FE targeted tsc 0 on touched files.
- Honest note: browser-runtime check NOT performed in this session (label-only pure-function change; runtime confirmation = James screen after deploy). 
- Remaining exposure note: Mac Mini collector (external repo) payload is the suspected origin of the 4/25 batch — needs its own fix there (listed as follow-up material).

## Data repair options (James GO, separate)
- **A**: NULL-out the 781 contaminated `published_at` (+ keep view_count NULL) — API 0, removes the lie; cards show "added …" labels.
- **B**: videos.list backfill — ~16 calls (50/batch) restores REAL publish dates + view counts, also closing the view-floor fail-open. Cost: 16 quota units (0.16% daily).

🤖 Generated with [Claude Code](https://claude.com/claude-code)