### PR TITLE
feat(trust): live-search view floor + user_curated blocklist containment (P0)

### DIFF
--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -537,6 +537,19 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           if (!ytFull) return; // youtube_videos row 자체가 없으면 skip
           const v = ytFull.view_count != null ? Number(ytFull.view_count) : 0;
           const quality = v >= 100_000 ? 'gold' : v >= 10_000 ? 'silver' : 'bronze';
+          // P0 trust containment (scam-inflow, 2026-07-03): the Heart stays an
+          // explicit user signal (never rejected from the USER's own mandala),
+          // but a blocklisted title must not enter the shared pool where a
+          // future source expansion could serve it to other users.
+          const { titleHitsBlocklist } = await import(
+            '@/skills/plugins/video-discover/v2/youtube-client'
+          );
+          if (ytFull.title && titleHitsBlocklist(ytFull.title)) {
+            log.info(
+              `like → video_pool ingest SKIPPED (blocklisted title): videoId=${videoId}`
+            );
+            return;
+          }
           const lang = ytFull.title && /[가-힣]/.test(ytFull.title) ? 'ko' : 'en';
           // CP491 step 4 — short gate (demote Shorts at promote).
           const shortGate = await shortGateFields(videoId, ytFull.duration_seconds);

--- a/src/skills/plugins/video-discover/v5/config.ts
+++ b/src/skills/plugins/video-discover/v5/config.ts
@@ -31,6 +31,10 @@ const v5EnvSchema = z.object({
   // Hard wall-clock cap for the whole short-probe phase (shared deadline
   // across all probes). 0 disables the gate. Fail-open past this.
   V5_SHORT_PROBE_DEADLINE_MS: z.coerce.number().int().min(0).max(15000).default(8000),
+  // P0 trust gate (scam-inflow 2026-07-03): live-search candidates below this
+  // view floor — or with UNKNOWN view count — are dropped fail-closed.
+  // 0 (default) = gate off = today's behavior; enable via prod compose.
+  V5_LIVE_VIEW_FLOOR: z.coerce.number().int().min(0).default(0),
   // CP492 — picker mode. 'llm' (default, current behavior) runs the OpenRouter
   // batch picker. 'cell_binning' skips the LLM and round-robins fanout
   // candidates by query cellIndex (9-cell balance + ~1s discover, no garbage
@@ -100,6 +104,8 @@ export interface V5Config {
   dedupHardCap: number;
   shortOverpickFactor: number;
   shortProbeDeadlineMs: number;
+  /** P0 trust gate — live candidates need view_count >= floor (NULL = reject). 0 = off. */
+  liveViewFloor: number;
   pickerMode: 'llm' | 'cell_binning';
   queryGen: 'rule' | 'llm';
   /** CP494 — pool-first backfill gate enabled. */
@@ -137,6 +143,7 @@ export function getV5Config(env: NodeJS.ProcessEnv = process.env): V5Config {
     dedupHardCap: p.V5_DEDUP_HARDCAP,
     shortOverpickFactor: p.V5_SHORT_OVERPICK_FACTOR,
     shortProbeDeadlineMs: p.V5_SHORT_PROBE_DEADLINE_MS,
+    liveViewFloor: p.V5_LIVE_VIEW_FLOOR,
     pickerMode: p.V5_PICKER_MODE,
     queryGen: p.V5_QUERY_GEN,
     poolBackfill: p.V5_POOL_BACKFILL,

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -121,6 +121,7 @@ export interface V5ExecuteResult {
     perQuery: FanoutPerQuery[];
     /** CP491 — Shorts dropped by the post-pick short gate. */
     shortsDropped: number;
+    trustDropped: number;
     /** CP492 Track-1 — query-gen telemetry (mode/model/latency/llmCells/fellBack). */
     queryGen: QueryGenMeta;
     /** CP492 2차 gate — candidates dropped by the off-language script filter. */
@@ -359,6 +360,18 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
   }
   stage.shortMs = Date.now() - tShort0;
 
+  // 6b. P0 trust gate (scam-inflow, 2026-07-03): a 5-view impersonation channel
+  // reached the add-cards candidate list because the live path had NO view
+  // floor. Fail-closed: unknown view count cannot prove trustworthiness.
+  let trustDropped = 0;
+  if (cfg.liveViewFloor > 0) {
+    const beforeTrust = gatedCards.length;
+    gatedCards = gatedCards.filter(
+      (c) => c.viewCount != null && c.viewCount >= cfg.liveViewFloor
+    );
+    trustDropped = beforeTrust - gatedCards.length;
+  }
+
   // 7. Final slice to targetPicks (cards are score-sorted; filter preserved order).
   const finalCards = gatedCards.slice(0, cfg.targetPicks);
 
@@ -404,6 +417,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       durationMs: Date.now() - t0,
       pickerModel: pickerModelStr,
       shortsDropped,
+      trustDropped,
       stageMs: stage,
       abortedBatches,
       pickerTimedOut,
@@ -454,6 +468,7 @@ function emptyResult(args: {
       durationMs: Date.now() - args.t0,
       pickerModel: args.pickerCfg.model,
       shortsDropped: 0,
+      trustDropped: 0,
       stageMs: args.stage,
       abortedBatches: args.abortedBatches,
       pickerTimedOut: args.pickerTimedOut,

--- a/tests/smoke/v5-live-view-floor.test.ts
+++ b/tests/smoke/v5-live-view-floor.test.ts
@@ -1,0 +1,29 @@
+/**
+ * P0 trust gate config (scam-inflow 2026-07-03) — a 5-view impersonation
+ * channel reached the add-cards candidate list because the live path had no
+ * view floor. This pins the flag contract: unset = today's behavior (off).
+ */
+
+import {
+  getV5Config,
+  resetV5ConfigForTest,
+} from '../../src/skills/plugins/video-discover/v5/config';
+
+describe('V5_LIVE_VIEW_FLOOR — trust gate flag contract', () => {
+  beforeEach(() => resetV5ConfigForTest());
+  test('unset → 0 (gate off, todays behavior unchanged)', () => {
+    const cfg = getV5Config({} as NodeJS.ProcessEnv);
+    expect(cfg.liveViewFloor).toBe(0);
+  });
+
+  test('set → coerced numeric floor (fail-closed filter engages)', () => {
+    const cfg = getV5Config({ V5_LIVE_VIEW_FLOOR: '1000' } as unknown as NodeJS.ProcessEnv);
+    expect(cfg.liveViewFloor).toBe(1000);
+  });
+
+  test('negative rejected by schema (floor cannot be below zero)', () => {
+    expect(() =>
+      getV5Config({ V5_LIVE_VIEW_FLOOR: '-5' } as unknown as NodeJS.ProcessEnv)
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Incident (prod, 2026-07-03)
A **3-subscriber impersonation channel's 5-view crypto-scam video** appeared in James's add-cards candidate list and, via a test add, entered video_pool (`user_curated`, bronze) + placement. Full measured chain in the CP509 supervisor thread.

## Root (measured, file:line)
- `classifyQuality` is **sound** (`quality.ts:32-36`: NULL/below-floor reject) — the leak paths bypass it:
  1. **add-cards live search has no view floor** — the v5 gate chain (duration/shorts/blocklist/diversity) never checks views; a 5-view candidate renders.
  2. **user_curated ingest is ungated** (`cards.ts:508+`) — Heart accepts to bronze, no blocklist.
- Exposure containment (verified, unchanged): bronze is NOT served to other users — serving reads gold/silver only (`cache-matcher.ts:103,277`) and pool-serve sources exclude `user_curated` (`pool-serve-fill.ts:69`). Scam footprint in DB = this 1 video.

## Fix (path-differentiated per supervisor verdict)
1. **`V5_LIVE_VIEW_FLOOR`** (default 0 = off = today's behavior): when set, live candidates with `view_count` **NULL or < floor drop fail-closed** after the shorts gate. `trustDropped` in diagnostics. Activation = prod compose (**James gate**; supervisor recommends immediate canary ON at 1000).
2. **user_curated containment**: the Heart is never rejected from the user's own mandala; a **blocklisted title no longer enters the shared pool**.
3. Subscriber-count floor = phase 2 (needs channels.list, separate decision).

## Verification
- Flag-contract smoke 3/3 (tests/smoke, CI-executed) via `resetV5ConfigForTest`.
- Full smoke suite green. `tsc --noEmit` 0.
- Isolation SQL for the 1 scam row is packaged separately (James GO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)