### PR TITLE
feat(moderation): channel blocklist — bar impersonation channels from every discovery surface

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2482,3 +2482,19 @@ model video_figure_snapshots {
   @@index([expires_at], map: "idx_vfs_expires")
   @@schema("public")
 }
+
+/// P0 scam-inflow (2026-07-03): channels barred from every discovery surface
+/// (live search, pool recruit, user_curated ingest, placement chokepoint).
+/// Raw SQL DDL: prisma/migrations/channel-blocklist/001_create_channel_blocklist.sql
+model channel_blocklist {
+  id           String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  channel_id   String?  @db.VarChar(64)
+  channel_name String?  @db.VarChar(200)
+  reason       String
+  created_by   String?  @db.VarChar(100)
+  created_at   DateTime @default(now()) @db.Timestamptz(6)
+
+  @@index([channel_id])
+  @@index([channel_name])
+  @@schema("public")
+}

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -169,6 +169,7 @@ APPLY_FILES=(
   # EXTENSION/INDEX IF NOT EXISTS — fully idempotent. Perf-only (no schema
   # change); inert until /api/v1/search is called.
   "prisma/migrations/global-search/001_pg_trgm_indexes.sql"
+  "prisma/migrations/channel-blocklist/001_create_channel_blocklist.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "

--- a/src/api/routes/admin/channel-blocklist.ts
+++ b/src/api/routes/admin/channel-blocklist.ts
@@ -1,0 +1,63 @@
+/**
+ * Admin registry for the channel blocklist (P0 scam-inflow, 2026-07-03).
+ * List / add / remove. Every mutation is admin-gated and logged.
+ */
+
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import { getPrismaClient } from '@/modules/database/client';
+import { resetChannelBlocklistCacheForTest } from '@/modules/moderation/channel-blocklist';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'admin-channel-blocklist' });
+
+const AddSchema = z
+  .object({
+    channelId: z.string().max(64).optional(),
+    channelName: z.string().max(200).optional(),
+    reason: z.string().min(3),
+  })
+  .refine((v) => v.channelId || v.channelName, {
+    message: 'channelId or channelName required',
+  });
+
+export async function adminChannelBlocklistRoutes(fastify: FastifyInstance) {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  // GET /api/v1/admin/channel-blocklist
+  fastify.get('/', adminAuth, async (_req: FastifyRequest, reply: FastifyReply) => {
+    const rows = await getPrismaClient().channel_blocklist.findMany({
+      orderBy: { created_at: 'desc' },
+    });
+    return reply.send({ entries: rows });
+  });
+
+  // POST /api/v1/admin/channel-blocklist
+  fastify.post('/', adminAuth, async (req: FastifyRequest, reply: FastifyReply) => {
+    const body = AddSchema.parse(req.body);
+    const userId = (req as unknown as { userId?: string }).userId ?? null;
+    const row = await getPrismaClient().channel_blocklist.create({
+      data: {
+        channel_id: body.channelId ?? null,
+        channel_name: body.channelName ?? null,
+        reason: body.reason,
+        created_by: userId,
+      },
+    });
+    // Blocks must take effect promptly — drop the 60s snapshot.
+    resetChannelBlocklistCacheForTest();
+    log.info(
+      `channel blocklisted: id=${body.channelId ?? '-'} name=${body.channelName ?? '-'} by=${userId ?? '-'}`
+    );
+    return reply.code(201).send({ entry: row });
+  });
+
+  // DELETE /api/v1/admin/channel-blocklist/:id
+  fastify.delete('/:id', adminAuth, async (req: FastifyRequest, reply: FastifyReply) => {
+    const { id } = req.params as { id: string };
+    await getPrismaClient().channel_blocklist.delete({ where: { id } });
+    resetChannelBlocklistCacheForTest();
+    log.info(`channel blocklist entry removed: ${id}`);
+    return reply.send({ ok: true });
+  });
+}

--- a/src/api/routes/admin/index.ts
+++ b/src/api/routes/admin/index.ts
@@ -5,6 +5,7 @@ import { adminUserRoutes } from './users';
 import { adminStatsRoutes } from './stats';
 import { adminPromotionRoutes } from './promotions';
 import { adminAuditRoutes } from './audit';
+import { adminChannelBlocklistRoutes } from './channel-blocklist';
 import { adminRedemptionRoutes, adminBulkRoutes } from './redemption';
 // Stripe scaffold moved to payments.legacy.ts on 2026-05-13 (superseded by
 // Lemon Squeezy under /api/v1/billing/*). See payments.legacy.ts header.
@@ -48,6 +49,7 @@ export async function adminRoutes(fastify: FastifyInstance) {
   await fastify.register(adminRedemptionRoutes, { prefix: '/promotions' });
   await fastify.register(adminBulkRoutes, { prefix: '/users/bulk' });
   await fastify.register(adminAuditRoutes, { prefix: '/audit-log' });
+  await fastify.register(adminChannelBlocklistRoutes, { prefix: '/channel-blocklist' });
   await fastify.register(adminAnalyticsRoutes, { prefix: '/analytics' });
   await fastify.register(adminContentRoutes, { prefix: '/content' });
   await fastify.register(adminReportRoutes, { prefix: '/reports' });

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -547,6 +547,17 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             log.info(`like → video_pool ingest SKIPPED (blocklisted title): videoId=${videoId}`);
             return;
           }
+          // Channel-level block (P0 scam-inflow): an impersonation channel is
+          // barred from the shared pool even when its title looks innocent.
+          const { isChannelBlocked } = await import(
+            '@/modules/moderation/channel-blocklist'
+          );
+          if (await isChannelBlocked(ytFull.channel_id, ytFull.channel_title)) {
+            log.info(
+              `like → video_pool ingest SKIPPED (blocklisted channel): videoId=${videoId}`
+            );
+            return;
+          }
           const lang = ytFull.title && /[가-힣]/.test(ytFull.title) ? 'ko' : 'en';
           // CP491 step 4 — short gate (demote Shorts at promote).
           const shortGate = await shortGateFields(videoId, ytFull.duration_seconds);

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -549,13 +549,9 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           }
           // Channel-level block (P0 scam-inflow): an impersonation channel is
           // barred from the shared pool even when its title looks innocent.
-          const { isChannelBlocked } = await import(
-            '@/modules/moderation/channel-blocklist'
-          );
+          const { isChannelBlocked } = await import('@/modules/moderation/channel-blocklist');
           if (await isChannelBlocked(ytFull.channel_id, ytFull.channel_title)) {
-            log.info(
-              `like → video_pool ingest SKIPPED (blocklisted channel): videoId=${videoId}`
-            );
+            log.info(`like → video_pool ingest SKIPPED (blocklisted channel): videoId=${videoId}`);
             return;
           }
           const lang = ytFull.title && /[가-힣]/.test(ytFull.title) ? 'ko' : 'en';

--- a/src/modules/mandala/place-auto-added-cards.ts
+++ b/src/modules/mandala/place-auto-added-cards.ts
@@ -85,6 +85,21 @@ export async function placeAutoAddedCards(
 ): Promise<PlaceResult> {
   if (candidates.length === 0) return { inserted: 0 };
 
+  // Channel blocklist (P0 scam-inflow 2026-07-03) — placement is the single
+  // chokepoint every auto-add path funnels through, so a blocked channel can
+  // never be placed regardless of which recruit path surfaced it.
+  const { filterBlockedChannels } = await import('@/modules/moderation/channel-blocklist');
+  const chGate = await filterBlockedChannels(candidates, (c) => ({
+    channelName: c.channelTitle,
+  }));
+  if (chGate.blockedCount > 0) {
+    logger.info(
+      `placeAutoAddedCards: ${chGate.blockedCount} candidate(s) dropped by channel blocklist (cell=${cellIndex})`
+    );
+  }
+  candidates = chGate.kept;
+  if (candidates.length === 0) return { inserted: 0 };
+
   // Dedup: skip videos already linked to this user's uvs — otherwise the
   // unique(user_id, videoId) constraint turns the insert into a silent UPDATE
   // (apparent-add without a fresh row). User-touched cards are filtered here so

--- a/src/modules/moderation/channel-blocklist.ts
+++ b/src/modules/moderation/channel-blocklist.ts
@@ -1,0 +1,86 @@
+/**
+ * Channel blocklist (P0 scam-inflow, 2026-07-03).
+ *
+ * A 3-subscriber impersonation channel's 5-view crypto-scam video reached the
+ * add-cards candidate list. Title blocklists cannot catch channel-level abuse,
+ * so this bars channels from EVERY discovery surface:
+ *   - v5 live search candidates (executor)
+ *   - pool recruit / cosine match (SQL-side callers use isChannelBlocked on rows)
+ *   - user_curated ingest (Heart → pool)
+ *   - placement chokepoint (place-auto-added-cards)
+ *
+ * Matching: channel_id when present, exact channel_name otherwise — the two
+ * seed scam channels shipped with channel_id NULL, so name matching is not
+ * optional. In-memory cache (60s TTL) keeps the hot path DB-free; a stale
+ * entry only delays a NEW block by up to a minute.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'channel-blocklist' });
+
+const CACHE_TTL_MS = 60_000;
+
+interface BlocklistSnapshot {
+  ids: Set<string>;
+  names: Set<string>;
+  loadedAt: number;
+}
+
+let cache: BlocklistSnapshot | null = null;
+
+export function resetChannelBlocklistCacheForTest(): void {
+  cache = null;
+}
+
+async function loadSnapshot(): Promise<BlocklistSnapshot> {
+  const now = Date.now();
+  if (cache && now - cache.loadedAt < CACHE_TTL_MS) return cache;
+  try {
+    const rows = await getPrismaClient().channel_blocklist.findMany({
+      select: { channel_id: true, channel_name: true },
+    });
+    cache = {
+      ids: new Set(rows.map((r) => r.channel_id).filter((x): x is string => !!x)),
+      names: new Set(rows.map((r) => r.channel_name).filter((x): x is string => !!x)),
+      loadedAt: now,
+    };
+  } catch (err) {
+    // Fail-open on infra errors: an unreadable blocklist must not take the
+    // whole discovery pipeline down. Log loudly; keep last snapshot if any.
+    log.error('channel_blocklist load failed (serving continues with last snapshot)', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    if (!cache) cache = { ids: new Set(), names: new Set(), loadedAt: now };
+  }
+  return cache;
+}
+
+/** True when the channel is barred from discovery surfaces. */
+export async function isChannelBlocked(
+  channelId: string | null | undefined,
+  channelName: string | null | undefined
+): Promise<boolean> {
+  if (!channelId && !channelName) return false;
+  const snap = await loadSnapshot();
+  if (channelId && snap.ids.has(channelId)) return true;
+  if (channelName && snap.names.has(channelName)) return true;
+  return false;
+}
+
+/** Bulk variant for candidate arrays — one snapshot load per call. */
+export async function filterBlockedChannels<T>(
+  items: T[],
+  pick: (item: T) => { channelId?: string | null; channelName?: string | null }
+): Promise<{ kept: T[]; blockedCount: number }> {
+  if (items.length === 0) return { kept: items, blockedCount: 0 };
+  const snap = await loadSnapshot();
+  const kept = items.filter((it) => {
+    const { channelId, channelName } = pick(it);
+    if (channelId && snap.ids.has(channelId)) return false;
+    if (channelName && snap.names.has(channelName)) return false;
+    return true;
+  });
+  return { kept, blockedCount: items.length - kept.length };
+}

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -122,6 +122,7 @@ export interface V5ExecuteResult {
     /** CP491 — Shorts dropped by the post-pick short gate. */
     shortsDropped: number;
     trustDropped: number;
+    channelBlockedDropped: number;
     /** CP492 Track-1 — query-gen telemetry (mode/model/latency/llmCells/fellBack). */
     queryGen: QueryGenMeta;
     /** CP492 2차 gate — candidates dropped by the off-language script filter. */
@@ -333,15 +334,26 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
   // (YouTube cap; >=180s short-circuits with no HTTP). A single shared
   // AbortController deadline bounds TOTAL wall-clock regardless of probe
   // count/waves; probes still in-flight at the deadline fail open (kept).
+  // 6a-pre. Channel blocklist (P0 scam-inflow 2026-07-03): impersonation
+  // channels are barred from every discovery surface — filtered before the
+  // shorts probe so blocked channels never consume probe budget.
+  const { filterBlockedChannels } = await import('@/modules/moderation/channel-blocklist');
+  const chFiltered = await filterBlockedChannels(cards, (c) => ({
+    channelId: c.channelId,
+    channelName: c.channelTitle,
+  }));
+  const channelBlockedDropped = chFiltered.blockedCount;
+  const allowedCards = chFiltered.kept;
+
   const tShort0 = Date.now();
   let shortsDropped = 0;
-  let gatedCards = cards;
-  if (cfg.shortProbeDeadlineMs > 0 && cards.length > 0) {
+  let gatedCards = allowedCards;
+  if (cfg.shortProbeDeadlineMs > 0 && allowedCards.length > 0) {
     const shortCtl = new AbortController();
     const shortTimer = setTimeout(() => shortCtl.abort(), cfg.shortProbeDeadlineMs);
     try {
       const shortFlags = await Promise.all(
-        cards.map(async (c) => {
+        allowedCards.map(async (c) => {
           if (c.durationSec != null && c.durationSec >= SHORT_MAX_DURATION_SEC) return false;
           // E-final (CP500+) — known sub-180s dropped on inflow without probing;
           // learning content under 3 min lacks depth. Only unknown duration probes.
@@ -352,8 +364,8 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
           return isShort;
         })
       );
-      gatedCards = cards.filter((_, i) => !shortFlags[i]);
-      shortsDropped = cards.length - gatedCards.length;
+      gatedCards = allowedCards.filter((_, i) => !shortFlags[i]);
+      shortsDropped = allowedCards.length - gatedCards.length;
     } finally {
       clearTimeout(shortTimer);
     }
@@ -416,6 +428,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       pickerModel: pickerModelStr,
       shortsDropped,
       trustDropped,
+      channelBlockedDropped,
       stageMs: stage,
       abortedBatches,
       pickerTimedOut,
@@ -467,6 +480,7 @@ function emptyResult(args: {
       pickerModel: args.pickerCfg.model,
       shortsDropped: 0,
       trustDropped: 0,
+      channelBlockedDropped: 0,
       stageMs: args.stage,
       abortedBatches: args.abortedBatches,
       pickerTimedOut: args.pickerTimedOut,

--- a/tests/smoke/channel-blocklist.test.ts
+++ b/tests/smoke/channel-blocklist.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Channel blocklist (P0 scam-inflow 2026-07-03) — matching + cache contract.
+ * The two seed scam channels shipped with channel_id NULL, so name matching
+ * is load-bearing, not a fallback nicety.
+ */
+
+const mockFindMany = jest.fn();
+
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    channel_blocklist: { findMany: mockFindMany },
+  }),
+}));
+
+import {
+  isChannelBlocked,
+  filterBlockedChannels,
+  resetChannelBlocklistCacheForTest,
+} from '../../src/modules/moderation/channel-blocklist';
+
+describe('channel-blocklist', () => {
+  beforeEach(() => {
+    resetChannelBlocklistCacheForTest();
+    mockFindMany.mockReset();
+    mockFindMany.mockResolvedValue([
+      { channel_id: 'UC_scam', channel_name: null },
+      { channel_id: null, channel_name: '체인분석가' },
+    ]);
+  });
+
+  test('blocks by channel_id', async () => {
+    expect(await isChannelBlocked('UC_scam', null)).toBe(true);
+  });
+
+  test('blocks by exact channel_name when id is absent (seed scam case)', async () => {
+    expect(await isChannelBlocked(null, '체인분석가')).toBe(true);
+  });
+
+  test('passes unlisted channels; neither field = pass', async () => {
+    expect(await isChannelBlocked('UC_ok', '정상채널')).toBe(false);
+    expect(await isChannelBlocked(null, null)).toBe(false);
+  });
+
+  test('filterBlockedChannels drops blocked and counts them (one snapshot load)', async () => {
+    const items = [
+      { id: 1, ch: 'UC_scam', name: null as string | null },
+      { id: 2, ch: null as string | null, name: '체인분석가' },
+      { id: 3, ch: 'UC_ok', name: '정상채널' },
+    ];
+    const r = await filterBlockedChannels(items, (i) => ({
+      channelId: i.ch,
+      channelName: i.name,
+    }));
+    expect(r.kept.map((i) => i.id)).toEqual([3]);
+    expect(r.blockedCount).toBe(2);
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+  });
+
+  test('fail-open on DB error — discovery keeps serving with empty snapshot', async () => {
+    mockFindMany.mockRejectedValueOnce(new Error('db down'));
+    expect(await isChannelBlocked('UC_scam', null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Night-execution item 5 (James delegation, supervisor spec)
Channel-level abuse cannot be caught by title blocklists — the scam video's title read as a normal learning summary. This bars channels from **every discovery surface**, matching `channel_id` when present and **exact `channel_name` otherwise** (both seed scam channels shipped with `channel_id` NULL).

## Surfaces
1. **v5 live search** — candidates filtered before the shorts probe (blocked channels never consume probe budget); `channelBlockedDropped` in diagnostics.
2. **user_curated ingest** — next to the #1071 title check; the Heart is still honored on the user's own mandala, but a blocked channel never enters the shared pool.
3. **Placement chokepoint** (`place-auto-added-cards`) — every auto-add path funnels through it (CP500+ chokepoint principle): a blocked channel can never be placed regardless of recruit path.
4. **Admin registry** — `GET/POST/DELETE /api/v1/admin/channel-blocklist` (admin-gated; mutations bust the 60s snapshot).

## Storage & safety
- `channel_blocklist` table — **raw idempotent DDL** (`prisma/migrations/channel-blocklist/001`) registered in the `apply-custom-sql.sh` allowlist **in this same PR** (CP499+ LEVEL-3 rule; deploy pipeline applies it).
- Rollback: `DROP TABLE` line in the DDL header; code is inert with an empty table.
- Fail-open on infra error with a loud log — an unreadable blocklist must not take discovery down.

## Verification
- Smoke 5/5: id-match / name-match (seed case) / pass-through / bulk filter+count / fail-open. Full smoke suite green. `tsc --noEmit` 0.
- Seeding of the two scam channels (체인분석가, 크립토전략랩) = isolation step (prod SQL, recorded in the night ledger with rollback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)