### PR TITLE
style: prettier formatting for the P0 trust-gate hunks (unblocks main deploy)

### DIFF
--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -541,13 +541,10 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           // explicit user signal (never rejected from the USER's own mandala),
           // but a blocklisted title must not enter the shared pool where a
           // future source expansion could serve it to other users.
-          const { titleHitsBlocklist } = await import(
-            '@/skills/plugins/video-discover/v2/youtube-client'
-          );
+          const { titleHitsBlocklist } =
+            await import('@/skills/plugins/video-discover/v2/youtube-client');
           if (ytFull.title && titleHitsBlocklist(ytFull.title)) {
-            log.info(
-              `like → video_pool ingest SKIPPED (blocklisted title): videoId=${videoId}`
-            );
+            log.info(`like → video_pool ingest SKIPPED (blocklisted title): videoId=${videoId}`);
             return;
           }
           const lang = ytFull.title && /[가-힣]/.test(ytFull.title) ? 'ko' : 'en';

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -366,9 +366,7 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
   let trustDropped = 0;
   if (cfg.liveViewFloor > 0) {
     const beforeTrust = gatedCards.length;
-    gatedCards = gatedCards.filter(
-      (c) => c.viewCount != null && c.viewCount >= cfg.liveViewFloor
-    );
+    gatedCards = gatedCards.filter((c) => c.viewCount != null && c.viewCount >= cfg.liveViewFloor);
     trustDropped = beforeTrust - gatedCards.length;
   }
 


### PR DESCRIPTION
Main-branch deploy Lint gate failed on 3 prettier violations from the #1070/#1071 hunks (committed with --no-verify), skipping the entire 15-PR wave's deploy (prod unharmed — previous image, health 200). Formatting only, zero behavior change. Night-delegation scope: unblocks the wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)