### PR TITLE
chore(compose): V5_LIVE_VIEW_FLOOR=1000 canary — repo compose is the SSOT

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -103,6 +103,9 @@ services:
       # Revert: delete both lines → code defaults 30 / 120.
       - V5_TARGET_PICKS=60
       - V5_DEDUP_HARDCAP=180
+      # P0 trust gate canary (night delegation 2026-07-03): live-search view
+      # floor, NULL views = reject fail-closed. Rollback = delete this line.
+      - V5_LIVE_VIEW_FLOOR=1000
       # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
       # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
       # a cell with ≥3 pool candidates drops its live search.list query → quota


### PR DESCRIPTION
Night-delegation Step 3 set the trust-gate floor directly on the EC2 compose file; the #1075 deploy overwrote it (deploy.yml copies the repo compose to EC2). Per the CP500++ rule the toggle SSOT is the **repo** compose — this line makes the canary survive every deploy. Gate semantics: live-search candidates with NULL or <1000 views drop fail-closed (code shipped in #1071, default-off without this env). Rollback = delete the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)