### PR TITLE
feat(learning): video-view STEPs 3-7 — chapters tab, floating navigator, relevance curve, right-panel balance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,13 @@
 
 ## Hard Rules
 
+### 🚨 짧은 시간 반복 서버(API) 호출 절대 금지 — "닭질" 금지 (절대 규칙, LEVEL-3, 2026-07-03 YouTube embed 차단 사고)
+- **동일 외부 서버/API(YouTube, LLM, DB, 로그인, 서드파티 전부)에 짧은 간격 반복 호출·반복 로드 절대 금지.** 어뷰즈 감지 → 서킷/락/계정·세션 블락 유발. 블락은 코드 버그와 달리 **시간으로만 풀리는 손실**이라 비용이 비대칭적으로 크다.
+- **2-strike 룰**: 같은 대상에 같은 액션 2회 실패 시 3회째 금지 — 중단하고 접근법을 전환 (전환 시 "직전 방법 X N회 실패 → Y로 전환" 1줄 명시 의무).
+- 재시도가 꼭 필요하면 exponential backoff + 최대 2회 + **근본 원인 가설 변경 동반**. 무가설 재시도 = 위반.
+- **진단/검증 루프도 동일**: 브라우저 자동화로 외부 리소스(YouTube embed 등)를 반복 로드하는 것도 API 호출 반복과 같은 위반.
+- 근거: 2026-07-03 자동화 검증 중 localhost에서 YouTube embed 수십 회 반복 로드 → YouTube가 해당 파티션 embed 차단 → dev 영상 재생 불능(TTL 대기 외 해제 불가). 과거 동일 계열: OpenRouter 서킷, DB 락, 계정 블락. 상세: `memory/feedback_no_repeated_hammering.md`.
+
 ### 🚨 LLM API 호출 금지 (예외 없음, 2026-04-15 재정 손실 사고)
 - **Anthropic API 직접 호출 금지** (Messages, Batch 모두)
 - **OpenRouter API 호출 금지**

--- a/frontend/src/__tests__/relevance-level.test.ts
+++ b/frontend/src/__tests__/relevance-level.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import {
+  relevanceLevel,
+  relevanceBars,
+  relevanceCssVar,
+  RELEVANCE_HIGH_MIN,
+  RELEVANCE_MID_MIN,
+} from '@/pages/learning/lib/relevance-level';
+
+describe('relevanceLevel', () => {
+  it('maps boundaries to tiers (>=80 high / >=50 mid / <50 low)', () => {
+    expect(relevanceLevel(100)).toBe('high');
+    expect(relevanceLevel(RELEVANCE_HIGH_MIN)).toBe('high');
+    expect(relevanceLevel(RELEVANCE_HIGH_MIN - 1)).toBe('mid');
+    expect(relevanceLevel(RELEVANCE_MID_MIN)).toBe('mid');
+    expect(relevanceLevel(RELEVANCE_MID_MIN - 1)).toBe('low');
+    expect(relevanceLevel(0)).toBe('low');
+  });
+
+  it('lights 3/2/1 meter bars by tier', () => {
+    expect(relevanceBars('high')).toBe(3);
+    expect(relevanceBars('mid')).toBe(2);
+    expect(relevanceBars('low')).toBe(1);
+  });
+
+  it('resolves the token var per tier', () => {
+    expect(relevanceCssVar('high')).toBe('var(--lp-rel-high)');
+    expect(relevanceCssVar('mid')).toBe('var(--lp-rel-mid)');
+    expect(relevanceCssVar('low')).toBe('var(--lp-rel-low)');
+  });
+});

--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1289,6 +1289,22 @@ html.dark .lemonsqueezy-loader {
   --lp-toggle-active-fg: #1a1b1e;
   --lp-avatar-grad: linear-gradient(135deg,#6d3a8f,#2a1840);
   --lp-avatar-fg: #e9d6f5;
+  /* [VIDEO-VIEW STEP3] — chapters tab + relevance meter tokens */
+  --lp-rel-high: #7fb69a;
+  --lp-rel-mid: #c9a36a;
+  --lp-rel-low: #76746e;
+  --lp-meter-off: rgba(255,255,255,0.13);
+  --lp-surface: #101216;
+  --lp-line-7: rgba(255,255,255,0.07);
+  --lp-line-6: rgba(255,255,255,0.06);
+  --lp-tab-active-fg: #15171c;
+  --lp-text: #cdcbc5;
+  --lp-num: #4f4d49;
+  --lp-desc: #8d8b86;
+  --lp-mute: #56544f;
+  --lp-accent-tint: rgba(201,163,106,0.06);
+  --lp-accent-border: rgba(201,163,106,0.30);
+  --lp-hover-tint: rgba(255,255,255,0.025);
 
   background: #0e0f10;
 }

--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -1305,6 +1305,9 @@ html.dark .lemonsqueezy-loader {
   --lp-accent-tint: rgba(201,163,106,0.06);
   --lp-accent-border: rgba(201,163,106,0.30);
   --lp-hover-tint: rgba(255,255,255,0.025);
+  /* relevance-curve overlay (the only custom element on the native player) */
+  --lp-head-glow: 0 0 8px rgba(201,163,106,0.85), 0 1px 3px rgba(0,0,0,0.6);
+  --lp-curve-neutral: #ffffff;
 
   background: #0e0f10;
 }

--- a/frontend/src/pages/learning/lib/relevance-level.ts
+++ b/frontend/src/pages/learning/lib/relevance-level.ts
@@ -1,0 +1,25 @@
+/**
+ * Relevance tier mapping for the video-view chapter UI (mockup spec).
+ * high >= 80 aligns with HIGHLIGHT_RELEVANCE_THRESHOLD (useHighlightReel).
+ */
+
+export type RelevanceLevel = 'high' | 'mid' | 'low';
+
+export const RELEVANCE_HIGH_MIN = 80;
+export const RELEVANCE_MID_MIN = 50;
+
+export function relevanceLevel(pct: number): RelevanceLevel {
+  if (pct >= RELEVANCE_HIGH_MIN) return 'high';
+  if (pct >= RELEVANCE_MID_MIN) return 'mid';
+  return 'low';
+}
+
+/** CSS var name per level — tokens defined under `.note-mode` in index.css. */
+export function relevanceCssVar(level: RelevanceLevel): string {
+  return `var(--lp-rel-${level})`;
+}
+
+/** Meter bar count lit per level (3-bar ascending signal meter). */
+export function relevanceBars(level: RelevanceLevel): number {
+  return level === 'high' ? 3 : level === 'mid' ? 2 : 1;
+}

--- a/frontend/src/pages/learning/lib/toc-label.ts
+++ b/frontend/src/pages/learning/lib/toc-label.ts
@@ -1,0 +1,9 @@
+/**
+ * CP505 — shared short label for TOC-style displays. Book chapter/section and
+ * video titles run 60-84 chars; take the lead clause (before the first colon /
+ * em-dash / middle-dot). Used by the left sidebar TOC and the right-panel
+ * context zone so both show the SAME short label.
+ */
+export function tocShortLabel(title: string): string {
+  return title.split(/[:：—–·|]/)[0]?.trim() || title;
+}

--- a/frontend/src/pages/learning/model/useLearningStore.ts
+++ b/frontend/src/pages/learning/model/useLearningStore.ts
@@ -1,26 +1,5 @@
 import { create } from 'zustand';
 
-const LS_KEY_VIDEO_STRIP_ENABLED = 'insighta.learning.videoStripEnabled';
-
-function readVideoStripEnabled(): boolean {
-  if (typeof window === 'undefined') return true;
-  try {
-    const v = window.localStorage.getItem(LS_KEY_VIDEO_STRIP_ENABLED);
-    return v === null ? true : v === 'true';
-  } catch {
-    return true;
-  }
-}
-
-function writeVideoStripEnabled(enabled: boolean): void {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(LS_KEY_VIDEO_STRIP_ENABLED, enabled ? 'true' : 'false');
-  } catch {
-    /* localStorage disabled — silently degrade to in-memory only */
-  }
-}
-
 export type CenterTab = 'chapters' | 'summary' | 'section';
 
 export type CenterViewMode = 'player' | 'note';
@@ -57,11 +36,6 @@ interface LearningState {
    *  first VideoBlock click, false on note-mode exit / edit-mode enter /
    *  mandala change. Spec: "명시적 재생 액티비티 only". */
   noteAutoFollowEnabled: boolean;
-  /** Hover-slide video thumbnail strip on player wrapper. User can dismiss
-   *  via X on the strip; restore via icon in left sidebar header. Persisted
-   *  to localStorage so the choice survives reloads. */
-  videoStripEnabled: boolean;
-
   setCurrentVideo: (videoId: string) => void;
   setActiveTab: (tab: 'ai-summary' | 'notes') => void;
   setSelectedCell: (cellIndex: number | null) => void;
@@ -70,7 +44,6 @@ interface LearningState {
   setActiveSection: (ref: ActiveSectionRef | null) => void;
   setActiveNoteVideoKey: (key: number | null) => void;
   setNoteAutoFollow: (enabled: boolean) => void;
-  setVideoStripEnabled: (enabled: boolean) => void;
 
   setActiveRegion: (region: ActiveRegion) => void;
   setPlayerState: (time: number, state: PlayerState, duration: number) => void;
@@ -94,7 +67,6 @@ export const useLearningStore = create<LearningState>((set) => ({
   noteSelectionText: null,
   activeNoteVideoKey: null,
   noteAutoFollowEnabled: false,
-  videoStripEnabled: readVideoStripEnabled(),
 
   setCurrentVideo: (videoId) => set({ currentVideoId: videoId }),
   setActiveTab: (tab) => set({ activeTab: tab }),
@@ -104,10 +76,6 @@ export const useLearningStore = create<LearningState>((set) => ({
   setActiveSection: (ref) => set({ activeSectionRef: ref }),
   setActiveNoteVideoKey: (key) => set({ activeNoteVideoKey: key }),
   setNoteAutoFollow: (enabled) => set({ noteAutoFollowEnabled: enabled }),
-  setVideoStripEnabled: (enabled) => {
-    writeVideoStripEnabled(enabled);
-    set({ videoStripEnabled: enabled });
-  },
 
   setActiveRegion: (region) => set({ activeRegion: region, lastInteractionTs: Date.now() }),
   setPlayerState: (time, state, duration) =>

--- a/frontend/src/pages/learning/model/useLearningStore.ts
+++ b/frontend/src/pages/learning/model/useLearningStore.ts
@@ -21,7 +21,7 @@ function writeVideoStripEnabled(enabled: boolean): void {
   }
 }
 
-export type CenterTab = 'summary' | 'section';
+export type CenterTab = 'chapters' | 'summary' | 'section';
 
 export type CenterViewMode = 'player' | 'note';
 
@@ -81,7 +81,7 @@ export const useLearningStore = create<LearningState>((set) => ({
   currentVideoId: null,
   activeTab: 'ai-summary',
   selectedCellIndex: null,
-  centerTab: 'summary',
+  centerTab: 'chapters',
   centerViewMode: 'player',
   activeSectionRef: null,
 

--- a/frontend/src/pages/learning/ui/-legacy/VideoStrip.tsx
+++ b/frontend/src/pages/learning/ui/-legacy/VideoStrip.tsx
@@ -1,7 +1,11 @@
+/**
+ * @deprecated [VIDEO-VIEW] Replaced by FloatingVideoNavigator (click-to-expand
+ * strip in CenterPanel's top bar). Kept per no-component-deletion rule.
+ */
 import { useRef, useCallback, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useMandalaCards } from '../model/useMandalaCards';
+import { useMandalaCards } from '../../model/useMandalaCards';
 import { cn } from '@/shared/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
 

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -6,6 +6,7 @@ import {
   Sparkles,
   Zap,
   BookText,
+  List,
   Play,
   BookOpen,
   Pencil,
@@ -23,13 +24,23 @@ import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import { useRichSummary } from '@/features/video-side-panel/model/useRichSummary';
 import { useHighlightReel, HIGHLIGHT_RELEVANCE_THRESHOLD } from '../model/useHighlightReel';
 import { useMandalaCards } from '../model/useMandalaCards';
+import {
+  relevanceLevel,
+  relevanceCssVar,
+  relevanceBars,
+  type RelevanceLevel,
+} from '../lib/relevance-level';
 import { useLearningStore } from '@/pages/learning/model/useLearningStore';
 import { useNoteDocument } from '@/pages/learning/model/useNoteDocument';
 import { useNoteAutoFollow } from '@/pages/learning/model/useNoteAutoFollow';
 import { exportToMarkdown, exportToHtml } from '@/pages/learning/lib/note-export';
 import { cn } from '@/shared/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
-import type { MandalaBookChapter, MandalaBookSection } from '@/shared/lib/api-client';
+import type {
+  MandalaBookChapter,
+  MandalaBookSection,
+  VideoRichSummarySection,
+} from '@/shared/lib/api-client';
 import type { Editor } from '@tiptap/react';
 import type { TiptapDoc } from '@/features/video-side-panel/lib/note-parser';
 import type { YTPlayer } from '@/widgets/video-player/model/youtube-api';
@@ -46,7 +57,7 @@ interface CenterPanelProps {
   onPlayerHoverOut?: () => void;
 }
 
-type CenterTabId = 'summary' | 'section';
+type CenterTabId = 'chapters' | 'summary' | 'section';
 
 function formatMMSS(seconds: number): string {
   const total = Math.max(0, Math.round(seconds));
@@ -266,9 +277,16 @@ export function CenterPanel({
     fallback: string;
     icon: typeof Sparkles;
   }> = [
+    { id: 'chapters', labelKey: 'learning.tabChapters', fallback: '챕터', icon: List },
     { id: 'summary', labelKey: 'learning.tabSummary', fallback: 'AI 요약', icon: Sparkles },
     { id: 'section', labelKey: 'learning.tabSection', fallback: '섹션 내용', icon: BookText },
   ];
+
+  // [STEP3] Chapters = v2 segment sections (same data the highlight reel uses).
+  const chapterSections = (highlightSections ?? [])
+    .filter((s) => s.to_sec > s.from_sec)
+    .slice()
+    .sort((a, b) => a.from_sec - b.from_sec);
 
   // [STEP1] mode switch now lives in the center top bar (single home);
   // the note-not-ready guard moves here with it (was RightPanel's).
@@ -409,23 +427,50 @@ export function CenterPanel({
           style={{ maxWidth: 'calc(49.5vh * 16 / 9)' }}
           onMouseEnter={() => setActiveRegion('book-index')}
         >
-          {/* [STEP1] highlight-reel/share cluster moved to the top bar. */}
-          <div className="flex items-center">
-            {tabs.map(({ id, labelKey, fallback, icon: Icon }) => (
-              <button
-                key={id}
-                onClick={() => setCenterTab(id)}
-                className={cn(
-                  'flex items-center gap-1.5 py-2.5 px-3 text-[12px] transition-colors border-b-2',
-                  centerTab === id
-                    ? 'border-primary text-foreground font-semibold'
-                    : 'border-transparent text-muted-foreground font-normal hover:text-foreground'
-                )}
-              >
-                <Icon className="h-3.5 w-3.5" />
-                {t(labelKey, fallback)}
-              </button>
-            ))}
+          {/* [STEP3] mockup segment tabs + relevance legend (highlight-reel/
+              share cluster lives in the top bar since STEP1). */}
+          <div className="flex flex-wrap items-center justify-between gap-3 pb-1 pt-2.5">
+            <div className="flex gap-1 rounded-[10px] border border-[var(--lp-line-7)] bg-[var(--lp-surface)] p-1">
+              {tabs.map(({ id, labelKey, fallback, icon: Icon }) => (
+                <button
+                  key={id}
+                  onClick={() => setCenterTab(id)}
+                  className={cn(
+                    'flex items-center gap-[7px] rounded-[7px] px-3.5 py-1.5 text-[13px] font-semibold transition-colors',
+                    centerTab === id
+                      ? 'bg-[var(--lp-toggle-active-bg)] text-[var(--lp-tab-active-fg)]'
+                      : 'text-[var(--lp-dim)] hover:text-[var(--lp-strong)]'
+                  )}
+                >
+                  <Icon className="h-[15px] w-[15px]" />
+                  {t(labelKey, fallback)}
+                </button>
+              ))}
+            </div>
+            {chapterSections.length > 0 && (
+              <div className="flex items-center gap-[13px] text-[11.5px] text-[var(--lp-faint)]">
+                <div className="flex items-center gap-[9px]">
+                  <span className="text-[10px] font-semibold tracking-[0.06em] text-[var(--lp-mute)]">
+                    {t('learning.relevanceLabel', '관련도')}
+                  </span>
+                  <span className="text-[10.5px] text-[var(--lp-mute)]">
+                    {t('learning.relevanceLow', '낮음')}
+                  </span>
+                  <RelevanceMeter level="low" />
+                  <RelevanceMeter level="mid" />
+                  <RelevanceMeter level="high" />
+                  <span className="text-[10.5px] text-[var(--lp-mute)]">
+                    {t('learning.relevanceHigh', '높음')}
+                  </span>
+                </div>
+                <span className="h-[11px] w-px bg-white/10" aria-hidden />
+                <span>
+                  {t('learning.chaptersCount', '{{count}}개 챕터', {
+                    count: chapterSections.length,
+                  })}
+                </span>
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -486,6 +531,14 @@ export function CenterPanel({
             className="mx-auto w-full p-4"
             style={{ maxWidth: 'min(calc(49.5vh * 16 / 9), 760px)' }}
           >
+            {centerTab === 'chapters' && (
+              <ChapterList
+                sections={chapterSections}
+                playerRef={playerRef}
+                onUserPlayed={onUserPlayed}
+                onGoSummary={() => setCenterTab('summary')}
+              />
+            )}
             {centerTab === 'summary' && (
               <div data-onboarding="ai-summary">
                 <PanelAISummary videoSummary={undefined} videoUrl={videoUrl} />
@@ -506,6 +559,158 @@ export function CenterPanel({
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+/** [STEP3] 3-bar ascending signal meter — wordless relevance indicator. */
+function RelevanceMeter({ level }: { level: RelevanceLevel }) {
+  const lit = relevanceBars(level);
+  const color = relevanceCssVar(level);
+  return (
+    <span className="inline-flex h-[11px] items-end gap-[2.5px]" aria-hidden>
+      {[5, 8, 11].map((h, k) => (
+        <span
+          key={h}
+          className="w-[3px] rounded-[1px]"
+          style={{ height: h, background: k < lit ? color : 'var(--lp-meter-off)' }}
+        />
+      ))}
+    </span>
+  );
+}
+
+/** [STEP3] Chapter list — v2 segment sections with time range, relevance edge
+ *  bar + meter, hover-expand description, click-to-seek, live "재생 중" chip.
+ *  Subscribes to player time HERE so the 1s tick re-renders only this list. */
+function ChapterList({
+  sections,
+  playerRef,
+  onUserPlayed,
+  onGoSummary,
+}: {
+  sections: VideoRichSummarySection[];
+  playerRef: React.MutableRefObject<YTPlayer | null>;
+  onUserPlayed?: () => void;
+  onGoSummary: () => void;
+}) {
+  const { t } = useTranslation();
+  const playerTimeSec = useLearningStore((s) => s.playerTimeSec);
+  const playerState = useLearningStore((s) => s.playerState);
+
+  if (sections.length === 0) {
+    return (
+      <div className="mt-2 rounded-xl border border-[var(--lp-line-6)] bg-[var(--lp-surface)] px-5 py-6 text-center">
+        <p className="text-[13px] leading-[1.6] text-[var(--lp-dim)]">
+          {t(
+            'learning.chaptersEmpty',
+            '챕터 정보가 아직 준비되지 않았어요. AI 요약이 생성되면 챕터가 나타납니다.'
+          )}
+        </p>
+        <button
+          type="button"
+          onClick={onGoSummary}
+          className="mt-3 rounded-md border border-[var(--lp-line-8)] px-3 py-1.5 text-[12px] text-[var(--lp-text)] transition-colors hover:bg-[var(--lp-hover-tint)]"
+        >
+          {t('learning.tabSummary', 'AI 요약')}
+        </button>
+      </div>
+    );
+  }
+
+  const activeIdx = sections.findIndex(
+    (s) => playerTimeSec >= s.from_sec && playerTimeSec < s.to_sec
+  );
+
+  return (
+    <div className="flex flex-col">
+      {sections.map((s, i) => {
+        const level = typeof s.relevance_pct === 'number' ? relevanceLevel(s.relevance_pct) : null;
+        const color = level ? relevanceCssVar(level) : 'var(--lp-meter-off)';
+        const active = i === activeIdx;
+        const playing = active && playerState === 'playing';
+        return (
+          <button
+            key={`${s.from_sec}-${i}`}
+            type="button"
+            onClick={() => {
+              try {
+                playerRef.current?.seekTo(s.from_sec, true);
+                playerRef.current?.playVideo?.();
+                onUserPlayed?.();
+              } catch {
+                // player not ready
+              }
+            }}
+            className={cn(
+              'group relative flex w-full gap-4 rounded-xl border px-4 py-3.5 pl-[18px] text-left transition-colors',
+              active
+                ? 'border-[var(--lp-accent-border)] bg-[var(--lp-accent-tint)]'
+                : 'border-transparent hover:bg-[var(--lp-hover-tint)]'
+            )}
+          >
+            <span
+              className="absolute bottom-3.5 left-0 top-3.5 w-[3px] rounded-[3px] transition-opacity"
+              style={{ background: color, opacity: active ? 1 : 0.55 }}
+              aria-hidden
+            />
+            <span
+              className={cn(
+                'w-[88px] shrink-0 pt-px text-[13px] font-semibold tabular-nums tracking-[0.01em]',
+                active ? 'text-[var(--lp-accent)]' : 'text-[var(--lp-dim)]'
+              )}
+            >
+              {fmtDuration(s.from_sec)}–{fmtDuration(s.to_sec)}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="flex items-center gap-[9px]">
+                <span
+                  className={cn(
+                    'text-[11px] font-bold tabular-nums',
+                    active ? 'text-[var(--lp-accent)]' : 'text-[var(--lp-num)]'
+                  )}
+                >
+                  {String(i + 1).padStart(2, '0')}
+                </span>
+                <span
+                  className={cn(
+                    'text-[15px] font-semibold leading-[1.4] tracking-[-0.01em]',
+                    active ? 'text-[var(--lp-strong)]' : 'text-[var(--lp-text)]'
+                  )}
+                >
+                  {s.title}
+                </span>
+                {playing && (
+                  <span className="flex shrink-0 items-center gap-[5px] whitespace-nowrap text-[10.5px] font-semibold text-[var(--lp-accent)]">
+                    <span
+                      className="h-[5px] w-[5px] rounded-full bg-[var(--lp-accent)]"
+                      aria-hidden
+                    />
+                    {t('learning.playingNow', '재생 중')}
+                  </span>
+                )}
+              </span>
+              {s.summary && (
+                <span
+                  className={cn(
+                    'block overflow-hidden text-[13.5px] leading-[1.65] text-[var(--lp-desc)] transition-all duration-300',
+                    active
+                      ? 'mt-[7px] max-h-[60px] opacity-100'
+                      : 'mt-0 max-h-0 opacity-0 group-hover:mt-[7px] group-hover:max-h-[60px] group-hover:opacity-100'
+                  )}
+                >
+                  {s.summary}
+                </span>
+              )}
+            </span>
+            {level && (
+              <span className="shrink-0 self-center pt-px">
+                <RelevanceMeter level={level} />
+              </span>
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -23,7 +23,7 @@ import { LearningShareMenu } from '@/features/learning-share';
 import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import { useRichSummary } from '@/features/video-side-panel/model/useRichSummary';
 import { useHighlightReel, HIGHLIGHT_RELEVANCE_THRESHOLD } from '../model/useHighlightReel';
-import { useMandalaCards } from '../model/useMandalaCards';
+import { FloatingVideoNavigator } from './FloatingVideoNavigator';
 import {
   relevanceLevel,
   relevanceCssVar,
@@ -53,8 +53,6 @@ interface CenterPanelProps {
   onUserPlayed?: () => void;
   onPlayStateChange?: (isPlaying: boolean) => void;
   startTime?: number;
-  onPlayerHoverIn?: () => void;
-  onPlayerHoverOut?: () => void;
 }
 
 type CenterTabId = 'chapters' | 'summary' | 'section';
@@ -72,8 +70,6 @@ function fmtDuration(seconds: number): string {
   return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
 }
 
-const YT_ID_RE = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\s]+)/;
-
 export function CenterPanel({
   mandalaId,
   videoId,
@@ -82,8 +78,6 @@ export function CenterPanel({
   onUserPlayed,
   onPlayStateChange,
   startTime,
-  onPlayerHoverIn,
-  onPlayerHoverOut,
 }: CenterPanelProps) {
   const { t } = useTranslation();
   const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
@@ -107,11 +101,10 @@ export function CenterPanel({
   const scrollSpyRef = useRef<string | null>(null);
   const setPlayerState = useLearningStore((s) => s.setPlayerState);
   const setCenterViewMode = useLearningStore((s) => s.setCenterViewMode);
-  const playerDurationSec = useLearningStore((s) => s.playerDurationSec);
   const { book, isLoading: bookLoading } = useMandalaBook(mandalaId);
-  // [STEP1] video meta header — title from the mandala card set.
-  const { cards } = useMandalaCards(mandalaId);
-  const currentCard = cards.find((c) => c.videoUrl.match(YT_ID_RE)?.[1] === videoId);
+  // [STEP5] floating navigator expand state — breadcrumb/secondary controls
+  // yield the top-bar width while the strip is expanded.
+  const [navExpanded, setNavExpanded] = useState(false);
   const setActiveNoteVideoKey = useLearningStore((s) => s.setActiveNoteVideoKey);
   const noteAutoFollowEnabled = useLearningStore((s) => s.noteAutoFollowEnabled);
   const setNoteAutoFollow = useLearningStore((s) => s.setNoteAutoFollow);
@@ -303,20 +296,29 @@ export function CenterPanel({
       {/* [STEP1] Top bar (mockup ①) — breadcrumb left; highlight-reel/share +
           [영상|노트] toggle right. Rendered in BOTH modes (toggle's single home). */}
       <div className="flex h-[52px] shrink-0 items-center justify-between gap-3 px-1">
-        <div className="flex min-w-0 flex-1 items-center gap-2.5 text-[12.5px] text-[var(--lp-faint)]">
-          {activeSection && (
-            <>
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          {/* [STEP5] floating thumbnail navigator — collapsed pill / expanded strip */}
+          {centerViewMode === 'player' && (
+            <FloatingVideoNavigator
+              mandalaId={mandalaId}
+              currentVideoId={videoId}
+              expanded={navExpanded}
+              onExpandedChange={setNavExpanded}
+            />
+          )}
+          {!(navExpanded && centerViewMode === 'player') && activeSection && (
+            <div className="flex min-w-0 items-center gap-2.5 text-[12.5px] text-[var(--lp-faint)]">
               <span className="shrink-0 font-semibold text-[var(--lp-accent)]">
                 {t('learning.topicGroup', '주제군')}{' '}
                 {String((activeSection.chapter.ch ?? 0) + 1).padStart(2, '0')}
               </span>
               <span aria-hidden>·</span>
               <span className="truncate">{activeSection.chapter.title}</span>
-            </>
+            </div>
           )}
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          {centerViewMode === 'player' && (
+          {centerViewMode === 'player' && !navExpanded && (
             <>
               {highlightReel.enabled && (
                 <span
@@ -363,7 +365,7 @@ export function CenterPanel({
               </Tooltip>
             </>
           )}
-          <LearningShareMenu mandalaId={mandalaId} videoId={videoId} />
+          {!navExpanded && <LearningShareMenu mandalaId={mandalaId} videoId={videoId} />}
           <ViewModeToggle
             mode={centerViewMode}
             noteDisabled={!bookLoading && !book}
@@ -372,38 +374,11 @@ export function CenterPanel({
         </div>
       </div>
 
-      {/* [STEP1] Video meta header (mockup ②) — channel-initial avatar + title
-          + duration. Width-aligned with the player (CP445 pattern). */}
-      <div
-        className={cn('mx-auto w-full shrink-0', centerViewMode === 'note' && 'hidden')}
-        style={{ maxWidth: 'calc(49.5vh * 16 / 9)' }}
-      >
-        <div className="mb-1 flex items-center gap-[13px]">
-          <div
-            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-[15px] text-[var(--lp-avatar-fg)]"
-            style={{ background: 'var(--lp-avatar-grad)' }}
-            aria-hidden
-          >
-            {(currentCard?.title ?? 'Y').slice(0, 1)}
-          </div>
-          <div className="min-w-0">
-            <div className="truncate text-[17px] font-semibold leading-[1.35] tracking-[-0.01em] text-[var(--lp-strong)]">
-              {currentCard?.title ?? t('learning.videoFallbackTitle', '영상')}
-            </div>
-            <div className="mt-0.5 text-[12.5px] text-[var(--lp-faint)]">
-              YouTube{playerDurationSec > 0 ? ` · ${fmtDuration(playerDurationSec)}` : ''}
-            </div>
-          </div>
-        </div>
-      </div>
-
+      {/* [STEP5] meta header removed (user: 유튜브 자체 제목과 중복, 공간 비효율).
+          Video title lives in the navigator tooltip / YT hover title / left TOC. */}
       <div
         className={cn('mt-2 shrink-0', centerViewMode === 'note' && 'hidden')}
-        onMouseEnter={() => {
-          setActiveRegion('player');
-          onPlayerHoverIn?.();
-        }}
-        onMouseLeave={() => onPlayerHoverOut?.()}
+        onMouseEnter={() => setActiveRegion('player')}
       >
         <PanelVideoPlayer
           videoUrl={videoUrl}

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -24,6 +24,7 @@ import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import { useRichSummary } from '@/features/video-side-panel/model/useRichSummary';
 import { useHighlightReel, HIGHLIGHT_RELEVANCE_THRESHOLD } from '../model/useHighlightReel';
 import { FloatingVideoNavigator } from './FloatingVideoNavigator';
+import { PlayerChrome } from './PlayerChrome';
 import {
   relevanceLevel,
   relevanceCssVar,
@@ -375,9 +376,15 @@ export function CenterPanel({
       </div>
 
       {/* [STEP5] meta header removed (user: 유튜브 자체 제목과 중복, 공간 비효율).
-          Video title lives in the navigator tooltip / YT hover title / left TOC. */}
+          [STEP6] group/player wrapper mirrors the player's own size cap so the
+          relevance-curve overlay hugs the video box exactly; the player itself
+          (native YT chrome) is untouched. */}
       <div
-        className={cn('mt-2 shrink-0', centerViewMode === 'note' && 'hidden')}
+        className={cn(
+          'group/player relative mx-auto mt-2 w-full shrink-0',
+          centerViewMode === 'note' && 'hidden'
+        )}
+        style={{ maxWidth: 'calc(49.5vh * 16 / 9)' }}
         onMouseEnter={() => setActiveRegion('player')}
       >
         <PanelVideoPlayer
@@ -389,6 +396,7 @@ export function CenterPanel({
           onTimeUpdate={setPlayerState}
           startTime={startTime}
         />
+        <PlayerChrome sections={chapterSections} />
       </div>
 
       {centerViewMode === 'player' && (

--- a/frontend/src/pages/learning/ui/FloatingVideoNavigator.tsx
+++ b/frontend/src/pages/learning/ui/FloatingVideoNavigator.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ChevronLeft, ChevronRight, GalleryHorizontalEnd, X } from 'lucide-react';
+import { useMandalaCards } from '../model/useMandalaCards';
+import { cn } from '@/shared/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/tooltip';
+
+/**
+ * Floating video navigator (video-view mockup track) — collapsed: a round
+ * pill button with the current position badge; click expands a horizontal
+ * thumbnail strip for prev/next hops + rough position. Hover on a thumb
+ * shows a LARGE thumbnail preview so neighbors are visually identifiable.
+ * Click-to-expand by design: player hover is reserved for the scrubber,
+ * and hover-in-hover (strip + preview tooltip) would misfire on trackpads.
+ */
+
+interface FloatingVideoNavigatorProps {
+  mandalaId: string;
+  currentVideoId: string;
+  /** Controlled expand state — parent hides the breadcrumb while expanded. */
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+}
+
+const SCROLL_AMOUNT = 240;
+const YT_ID_RE = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\s]+)/;
+
+export function FloatingVideoNavigator({
+  mandalaId,
+  currentVideoId,
+  expanded,
+  onExpandedChange,
+}: FloatingVideoNavigatorProps) {
+  const navigate = useNavigate();
+  const { cards } = useMandalaCards(mandalaId);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const videos = cards
+    .map((c) => ({ ...c, ytId: c.videoUrl.match(YT_ID_RE)?.[1] ?? null }))
+    .filter((c) => c.ytId);
+  const currentIdx = videos.findIndex((v) => v.ytId === currentVideoId);
+
+  // Outside-close uses `click` (not mousedown) — CP443: avoids races with
+  // TipTap / dnd-kit pointerdown paths.
+  useEffect(() => {
+    if (!expanded) return;
+    function onClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onExpandedChange(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onExpandedChange(false);
+    }
+    // Defer attach one tick — the expanding click's own bubble would otherwise
+    // hit document with the (now-unmounted) collapsed button as target →
+    // contains() false → instant re-collapse.
+    const timerId = window.setTimeout(() => {
+      document.addEventListener('click', onClick);
+    }, 0);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      window.clearTimeout(timerId);
+      document.removeEventListener('click', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [expanded, onExpandedChange]);
+
+  // Center the active thumb when the strip opens or the video changes.
+  useEffect(() => {
+    if (!expanded) return;
+    const activeEl = scrollRef.current?.querySelector('[data-active="true"]');
+    activeEl?.scrollIntoView({ inline: 'center', block: 'nearest' });
+  }, [expanded, currentVideoId]);
+
+  const scroll = useCallback((direction: 'left' | 'right') => {
+    scrollRef.current?.scrollBy({
+      left: direction === 'left' ? -SCROLL_AMOUNT : SCROLL_AMOUNT,
+      behavior: 'smooth',
+    });
+  }, []);
+
+  if (videos.length <= 1) return null;
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => onExpandedChange(true)}
+        aria-expanded={false}
+        aria-label="영상 네비게이터 열기"
+        className="flex h-9 shrink-0 items-center gap-2 rounded-full border border-[var(--lp-line-8)] bg-[var(--lp-surface-2)] pl-2.5 pr-3 text-[var(--lp-dim)] transition-colors hover:text-[var(--lp-strong)]"
+      >
+        <GalleryHorizontalEnd className="h-4 w-4" aria-hidden />
+        <span className="text-[11.5px] font-semibold tabular-nums">
+          {currentIdx >= 0 ? currentIdx + 1 : 1}/{videos.length}
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex h-11 min-w-0 flex-1 items-center gap-1 rounded-[10px] border border-[var(--lp-line-8)] bg-[var(--lp-surface-2)] px-1.5"
+    >
+      <button
+        type="button"
+        onClick={() => onExpandedChange(false)}
+        aria-label="영상 네비게이터 닫기"
+        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[var(--lp-dim)] transition-colors hover:text-[var(--lp-strong)]"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={() => scroll('left')}
+        aria-label="이전 썸네일"
+        className="flex h-7 w-5 shrink-0 items-center justify-center text-[var(--lp-dim)] transition-colors hover:text-[var(--lp-strong)]"
+      >
+        <ChevronLeft className="h-3.5 w-3.5" />
+      </button>
+      <div
+        ref={scrollRef}
+        className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto scrollbar-none py-1"
+      >
+        {videos.map((v) => {
+          const isActive = v.ytId === currentVideoId;
+          return (
+            <Tooltip key={v.id} delayDuration={150}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  data-active={isActive}
+                  onClick={() => {
+                    if (!isActive) navigate(`/learning/${mandalaId}/${v.ytId}`);
+                  }}
+                  className={cn(
+                    'relative h-8 w-[57px] shrink-0 overflow-hidden rounded-[5px] bg-[var(--lp-surface)] transition-opacity',
+                    isActive ? 'ring-2 ring-[var(--lp-accent)]' : 'opacity-60 hover:opacity-100'
+                  )}
+                >
+                  {v.thumbnail ? (
+                    <img src={v.thumbnail} alt="" className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="h-full w-full bg-[var(--lp-surface)]" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              {/* Large preview — big enough to actually identify prev/next videos */}
+              <TooltipContent side="bottom" className="max-w-none p-1.5">
+                <div className="w-[240px]">
+                  {v.thumbnail && (
+                    <img
+                      src={v.thumbnail}
+                      alt=""
+                      className="h-[135px] w-[240px] rounded-[6px] object-cover"
+                    />
+                  )}
+                  <p className="mt-1.5 line-clamp-2 px-0.5 pb-0.5 text-[12px] leading-[1.4]">
+                    {v.title}
+                  </p>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={() => scroll('right')}
+        aria-label="다음 썸네일"
+        className="flex h-7 w-5 shrink-0 items-center justify-center text-[var(--lp-dim)] transition-colors hover:text-[var(--lp-strong)]"
+      >
+        <ChevronRight className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/learning/ui/LearningPage.tsx
+++ b/frontend/src/pages/learning/ui/LearningPage.tsx
@@ -1,11 +1,9 @@
 import { markOnboardingTask } from '@/features/onboarding';
 import { useRef, useCallback, useState, useLayoutEffect, useEffect } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
-import { VideoStrip } from './VideoStrip';
 import { CenterPanel } from './CenterPanel';
 import { RightPanel } from './RightPanel';
 import { useLearningStore } from '@/pages/learning/model/useLearningStore';
-import { cn } from '@/shared/lib/utils';
 import type { YTPlayer } from '@/widgets/video-player/model/youtube-api';
 
 export default function LearningPage() {
@@ -32,8 +30,6 @@ export default function LearningPage() {
   }, [videoId]);
 
   const centerViewMode = useLearningStore((s) => s.centerViewMode);
-  const videoStripEnabled = useLearningStore((s) => s.videoStripEnabled);
-  const [stripVisible, setStripVisible] = useState(false);
 
   // CP438+1: ?t=N query param drives in-page seek. When the user clicks
   // an atom timestamp link in the sidebar/panel, the same-video case
@@ -91,30 +87,9 @@ export default function LearningPage() {
 
   return (
     <div className="flex h-full overflow-hidden">
-      {/* 좌측 column = VideoStrip + CenterPanel (둘 다 px-10 → player 와
-          좌우 polo align). RightPanel 은 별도 column. */}
+      {/* [STEP5] The hover-slide VideoStrip is replaced by the click-to-expand
+          FloatingVideoNavigator inside CenterPanel's top bar. */}
       <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
-        {/* VideoStrip slide-on-hover. Trigger = player wrapper only (via
-            onPlayerHoverIn/Out from CenterPanel). Strip itself also
-            stays visible while hovered so the user can click a thumb.
-            Toggle (ON/OFF) lives in the left sidebar header. */}
-        {videoStripEnabled && (
-          <div
-            onMouseEnter={() => setStripVisible(true)}
-            onMouseLeave={() => setStripVisible(false)}
-            className={cn(
-              'absolute left-0 right-0 top-0 z-20 pl-4 pr-3 pt-[5px]',
-              'bg-[hsl(var(--bg-base))]/95 backdrop-blur-sm',
-              'transition-transform duration-300 ease-out',
-              stripVisible
-                ? 'translate-y-0 pointer-events-auto'
-                : '-translate-y-full pointer-events-none',
-              centerViewMode === 'note' && 'hidden'
-            )}
-          >
-            <VideoStrip mandalaId={mandalaId!} currentVideoId={videoId!} />
-          </div>
-        )}
         <CenterPanel
           mandalaId={mandalaId!}
           videoId={videoId!}
@@ -126,8 +101,6 @@ export default function LearningPage() {
           onUserPlayed={handleUserPlayed}
           onPlayStateChange={handlePlayStateChange}
           startTime={startTime}
-          onPlayerHoverIn={() => setStripVisible(true)}
-          onPlayerHoverOut={() => setStripVisible(false)}
         />
       </div>
       <RightPanel mandalaId={mandalaId!} videoId={videoId!} playerRef={playerRef} />

--- a/frontend/src/pages/learning/ui/LearningPage.tsx
+++ b/frontend/src/pages/learning/ui/LearningPage.tsx
@@ -89,7 +89,9 @@ export default function LearningPage() {
     <div className="flex h-full overflow-hidden">
       {/* [STEP5] The hover-slide VideoStrip is replaced by the click-to-expand
           FloatingVideoNavigator inside CenterPanel's top bar. */}
-      <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+      {/* min-w floor — shrinking the browser must not crush the center column
+          into vertical text (sidebar auto-collapse frees width first). */}
+      <div className="relative flex min-w-[380px] flex-1 flex-col overflow-hidden">
         <CenterPanel
           mandalaId={mandalaId!}
           videoId={videoId!}

--- a/frontend/src/pages/learning/ui/PlayerChrome.tsx
+++ b/frontend/src/pages/learning/ui/PlayerChrome.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useLearningStore } from '../model/useLearningStore';
+import { relevanceLevel, type RelevanceLevel } from '../lib/relevance-level';
+import type { VideoRichSummarySection } from '@/shared/lib/api-client';
+
+/**
+ * Relevance curve overlay for the NATIVE YouTube player (user decision: the
+ * curve is the ONLY custom element — every menu/control stays YouTube's).
+ * A single pointer-events-none layer inside a `group/player relative` frame:
+ * the curve appears WITH the native controls on hover, parked just above the
+ * YT progress bar so both read as one navigator. High/mid/low chapters are
+ * color-coded with a wide amplitude, the played portion is tinted gold, and
+ * a playhead dot tracks the curve. Nothing here is clickable.
+ */
+
+interface PlayerChromeProps {
+  sections: VideoRichSummarySection[];
+}
+
+const CURVE_W = 1000;
+const CURVE_H = 100;
+const BASE_Y = 92;
+const GAP = 7;
+// Wide amplitude (user directive: mockup's 26/48/66 read as a wobbly line).
+const Y_FOR: Record<RelevanceLevel, number> = { high: 14, mid: 52, low: 84 };
+
+interface Pt {
+  x: number;
+  y: number;
+}
+
+/** Catmull-Rom → cubic bézier path (mockup buildPath, verbatim math). */
+function buildPath(pts: Pt[]): string {
+  if (pts.length < 2) return '';
+  const d = [`M${pts[0]!.x.toFixed(1)},${pts[0]!.y.toFixed(1)}`];
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i]!;
+    const p1 = pts[i]!;
+    const p2 = pts[i + 1]!;
+    const p3 = pts[i + 2] ?? pts[i + 1]!;
+    const c1x = p1.x + (p2.x - p0.x) / 6;
+    const c1y = p1.y + (p2.y - p0.y) / 6;
+    const c2x = p2.x - (p3.x - p1.x) / 6;
+    const c2y = p2.y - (p3.y - p1.y) / 6;
+    d.push(
+      `C${c1x.toFixed(1)},${c1y.toFixed(1)} ${c2x.toFixed(1)},${c2y.toFixed(1)} ${p2.x.toFixed(1)},${p2.y.toFixed(1)}`
+    );
+  }
+  return d.join(' ');
+}
+
+function levelOf(s: VideoRichSummarySection): RelevanceLevel {
+  return typeof s.relevance_pct === 'number' ? relevanceLevel(s.relevance_pct) : 'low';
+}
+
+export function PlayerChrome({ sections }: PlayerChromeProps) {
+  const playerTimeSec = useLearningStore((s) => s.playerTimeSec);
+  const playerDurationSec = useLearningStore((s) => s.playerDurationSec);
+
+  const basePathRef = useRef<SVGPathElement>(null);
+  const headRef = useRef<HTMLDivElement>(null);
+
+  const chapters = useMemo(
+    () =>
+      sections
+        .filter((s) => s.to_sec > s.from_sec)
+        .slice()
+        .sort((a, b) => a.from_sec - b.from_sec),
+    [sections]
+  );
+  const duration =
+    playerDurationSec > 0 ? playerDurationSec : (chapters[chapters.length - 1]?.to_sec ?? 0);
+  const progress = duration > 0 ? Math.min(1, Math.max(0, playerTimeSec / duration)) : 0;
+
+  // Curve geometry (mockup renderRelCurve): one smooth curve; chapter
+  // boundaries punched out by a clip; per-level color-coded stroke.
+  const curve = useMemo(() => {
+    if (!chapters.length || duration <= 0) return null;
+    const pts: Pt[] = [{ x: 0, y: BASE_Y }];
+    for (const c of chapters) {
+      pts.push({ x: ((c.from_sec + c.to_sec) / 2 / duration) * CURVE_W, y: Y_FOR[levelOf(c)] });
+    }
+    pts.push({ x: CURVE_W, y: BASE_Y });
+    const lineD = buildPath(pts);
+    const gapRects = chapters.map((c, i) => {
+      const x0 = i === 0 ? 0 : (c.from_sec / duration) * CURVE_W + GAP / 2;
+      const x1 = i === chapters.length - 1 ? CURVE_W : (c.to_sec / duration) * CURVE_W - GAP / 2;
+      return { x: x0, w: Math.max(0, x1 - x0) };
+    });
+    // Per-level color coding — high green / mid gold / low dim (user directive:
+    // relevance must be identifiable from the curve alone).
+    const gradStops = chapters.flatMap((c) => {
+      const level = levelOf(c);
+      const color = level === 'low' ? 'var(--lp-curve-neutral)' : `var(--lp-rel-${level})`;
+      const op = level === 'high' ? 0.95 : level === 'mid' ? 0.75 : 0.35;
+      return [
+        { off: (c.from_sec / duration) * 100, color, op },
+        { off: (c.to_sec / duration) * 100, color, op },
+      ];
+    });
+    return { lineD, gapRects, gradStops };
+  }, [chapters, duration]);
+
+  // Playhead — walk the base path to the x of current progress (mockup paint).
+  useEffect(() => {
+    const base = basePathRef.current;
+    const head = headRef.current;
+    if (!base || !head || !curve) return;
+    const svg = base.ownerSVGElement;
+    if (!svg || typeof base.getTotalLength !== 'function') return;
+    const W = svg.clientWidth;
+    const H = svg.clientHeight;
+    if (!W || !H) return;
+    const targetX = progress * CURVE_W;
+    const total = base.getTotalLength();
+    let lo = 0;
+    let hi = total;
+    let pt = base.getPointAtLength(0);
+    for (let k = 0; k < 20; k++) {
+      const mid = (lo + hi) / 2;
+      pt = base.getPointAtLength(mid);
+      if (pt.x < targetX) lo = mid;
+      else hi = mid;
+    }
+    head.style.left = `${progress * W}px`;
+    head.style.top = `${(pt.y / CURVE_H) * H}px`;
+  }, [progress, curve]);
+
+  // Coverage gate — segments must actually map the video. A 65-min video
+  // whose chapters cover only the first ~7 min would render as a squiggle
+  // crammed into the left edge + a long flat line (user bug report): worse
+  // than no curve. Hide unless the data spans ≥90% of the real duration.
+  const coverage =
+    duration > 0 && chapters.length ? chapters[chapters.length - 1]!.to_sec / duration : 0;
+  if (!curve || coverage < 0.9) return null;
+
+  return (
+    // z-20 — must sit above PanelVideoPlayer's poster facade (z-10).
+    <div className="pointer-events-none absolute inset-0 z-20" aria-hidden>
+      {/* Relevance curve — fades in WITH the native controls (hover), parked
+          just above the YT progress bar so the two read as one navigator. */}
+      <div className="absolute bottom-[52px] left-3 right-3 h-[56px] opacity-0 transition-opacity duration-200 group-hover/player:opacity-100">
+        <svg
+          width="100%"
+          height="56"
+          viewBox={`0 0 ${CURVE_W} ${CURVE_H}`}
+          preserveAspectRatio="none"
+          className="block h-full w-full overflow-visible"
+        >
+          <defs>
+            <clipPath id="lpRelProgClip">
+              <rect x="0" y="0" width={progress * CURVE_W} height={CURVE_H} />
+            </clipPath>
+            <clipPath id="lpGapClip">
+              {curve.gapRects.map((g, i) => (
+                <rect key={i} x={g.x} y="0" width={g.w} height={CURVE_H} />
+              ))}
+            </clipPath>
+            <linearGradient
+              id="lpRelStroke"
+              gradientUnits="userSpaceOnUse"
+              x1="0"
+              y1="0"
+              x2={CURVE_W}
+              y2="0"
+            >
+              {curve.gradStops.map((s, i) => (
+                <stop
+                  key={i}
+                  offset={`${s.off.toFixed(2)}%`}
+                  style={{ stopColor: s.color, stopOpacity: s.op }}
+                />
+              ))}
+            </linearGradient>
+          </defs>
+          <g clipPath="url(#lpGapClip)">
+            <path
+              ref={basePathRef}
+              d={curve.lineD}
+              fill="none"
+              stroke="url(#lpRelStroke)"
+              strokeWidth={3}
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+            />
+            {/* var() doesn't resolve in SVG presentation attributes — style it. */}
+            <path
+              d={curve.lineD}
+              fill="none"
+              style={{ stroke: 'var(--lp-accent)' }}
+              strokeWidth={3.5}
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+              clipPath="url(#lpRelProgClip)"
+            />
+          </g>
+        </svg>
+        <div
+          ref={headRef}
+          className="absolute h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white"
+          style={{ boxShadow: 'var(--lp-head-glow)' }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/learning/ui/RightPanel.tsx
+++ b/frontend/src/pages/learning/ui/RightPanel.tsx
@@ -8,6 +8,8 @@ import { PanelNoteEditor } from '@/features/video-side-panel/ui/PanelNoteEditor'
 import { ChatAssistant } from './ChatAssistant';
 import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import { useMandalaCards } from '../model/useMandalaCards';
+import { useV2Summaries } from '@/features/card-management/model/useV2Summaries';
+import { tocShortLabel } from '../lib/toc-label';
 import { useLearningStore } from '../model/useLearningStore';
 import { apiClient } from '@/shared/lib/api-client';
 import type { YTPlayer } from '@/widgets/video-player/model/youtube-api';
@@ -43,6 +45,19 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
   });
 
   const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
+
+  // [STEP7b] context-zone label = same short label the left book index shows:
+  // v2 tocLabel first, lead-clause of the title as fallback.
+  const { summariesByVideoId } = useV2Summaries(videoId ? [videoId] : []);
+  const v2ForVideo = summariesByVideoId.get(videoId);
+  const videoLabel =
+    v2ForVideo?.tocLabel?.trim() || (currentCard?.title ? tocShortLabel(currentCard.title) : null);
+  const contextLabel =
+    (centerViewMode === 'note'
+      ? activeSectionTitle
+        ? tocShortLabel(activeSectionTitle)
+        : videoLabel
+      : videoLabel) ?? '—';
 
   const [richNote, setRichNote] = useState<TiptapDoc | null>(null);
   const [noteLoaded, setNoteLoaded] = useState(false);
@@ -122,11 +137,9 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
         <span className="shrink-0 px-1.5" aria-hidden>
           ·
         </span>
-        <span className="min-w-0 truncate text-foreground/75">
-          {(centerViewMode === 'note'
-            ? (activeSectionTitle ?? currentCard?.title)
-            : currentCard?.title) ?? '—'}
-        </span>
+        {/* [STEP7b] SAME short label as the left book index (v2 tocLabel →
+            lead-clause fallback) — not the full rambling title (user). */}
+        <span className="min-w-0 truncate text-foreground/75">{contextLabel}</span>
       </div>
 
       <div className="flex shrink-0">

--- a/frontend/src/pages/learning/ui/RightPanel.tsx
+++ b/frontend/src/pages/learning/ui/RightPanel.tsx
@@ -26,6 +26,7 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
   const [activeTab, setActiveTab] = useState<RightTab>('chatbot');
   const setActiveRegion = useLearningStore((s) => s.setActiveRegion);
   const setNoteContext = useLearningStore((s) => s.setNoteContext);
+  const centerViewMode = useLearningStore((s) => s.centerViewMode);
   const activeSectionRef = useLearningStore((s) => s.activeSectionRef);
   const { cards } = useMandalaCards(mandalaId);
   const { book } = useMandalaBook(mandalaId);
@@ -108,8 +109,26 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
       className="flex w-[400px] shrink-0 flex-col border-l border-sidebar-border/40 pl-5 pr-5"
       onMouseEnter={() => setActiveRegion(activeTab === 'notes' ? 'notes' : 'chat')}
     >
-      {/* [STEP1] ViewModeToggle moved to CenterPanel's top bar (single home);
-          this panel starts directly with its own tabs. */}
+      {/* [STEP7] Context zone — same 52px rhythm as the center top bar (left
+          sidebar has its own header block, so all three columns align). Names
+          WHICH scope the memo/chatbot below applies to: player mode = current
+          video, note mode = the section being read. */}
+      <div className="flex h-[52px] shrink-0 items-center border-b border-sidebar-border/40 px-1 text-[12px] text-muted-foreground/60">
+        <span className="shrink-0">
+          {centerViewMode === 'note'
+            ? t('learning.nowReadingSection', '지금 읽는 구간')
+            : t('learning.nowWatchingVideo', '지금 보는 영상')}
+        </span>
+        <span className="shrink-0 px-1.5" aria-hidden>
+          ·
+        </span>
+        <span className="min-w-0 truncate text-foreground/75">
+          {(centerViewMode === 'note'
+            ? (activeSectionTitle ?? currentCard?.title)
+            : currentCard?.title) ?? '—'}
+        </span>
+      </div>
+
       <div className="flex shrink-0">
         {tabs.map(({ id, labelKey, icon: Icon }) => (
           <button
@@ -164,12 +183,7 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
           activeTab !== 'chatbot' && 'hidden'
         )}
       >
-        {activeSectionTitle && (
-          // §redesign — chat context (시안 chat-ctx): "지금 읽는 구간 · {제목}".
-          <div className="shrink-0 border-b border-white/[0.06] px-1 pb-2.5 pt-0.5 text-[12px] text-muted-foreground/70">
-            지금 읽는 구간 · <span className="text-muted-foreground">{activeSectionTitle}</span>
-          </div>
-        )}
+        {/* [STEP7] chat-ctx line superseded by the top context zone. */}
         <div className="relative min-h-0 flex-1 overflow-hidden">
           <ChatAssistant
             key={videoId}

--- a/frontend/src/pages/learning/ui/RightPanel.tsx
+++ b/frontend/src/pages/learning/ui/RightPanel.tsx
@@ -121,7 +121,10 @@ export function RightPanel({ mandalaId, videoId, playerRef }: RightPanelProps) {
       // (Sidebar.tsx: border-sidebar-border/40) so both panel seams are identical.
       // Previous border-white/[0.06] read heavier/cruder than the left edge.
       data-onboarding="learn-panel"
-      className="flex w-[400px] shrink-0 flex-col border-l border-sidebar-border/40 pl-5 pr-5"
+      // pt-[5px] mirrors CenterPanel's root offset so the context zone's text
+      // line + bottom divider land on the SAME y as the center top bar (and
+      // the left sidebar's first row) — measured alignment, not eyeballed.
+      className="flex w-[400px] shrink-0 flex-col border-l border-sidebar-border/40 pl-5 pr-5 pt-[5px]"
       onMouseEnter={() => setActiveRegion(activeTab === 'notes' ? 'notes' : 'chat')}
     >
       {/* [STEP7] Context zone — same 52px rhythm as the center top bar (left

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1918,7 +1918,9 @@
     "chaptersEmpty": "Chapters are not ready yet. They will appear once the AI summary is generated.",
     "relevanceLow": "Low",
     "relevanceHigh": "High",
-    "playingNow": "Playing"
+    "playingNow": "Playing",
+    "nowWatchingVideo": "Now watching",
+    "nowReadingSection": "Now reading"
   },
   "addCards": {
     "triggerChip": "+ Add Cards",

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1912,7 +1912,13 @@
     "viewModePlayer": "Video",
     "viewModeNote": "Note",
     "topicGroup": "Group",
-    "videoFallbackTitle": "Video"
+    "videoFallbackTitle": "Video",
+    "tabChapters": "Chapters",
+    "chaptersCount": "{{count}} chapters",
+    "chaptersEmpty": "Chapters are not ready yet. They will appear once the AI summary is generated.",
+    "relevanceLow": "Low",
+    "relevanceHigh": "High",
+    "playingNow": "Playing"
   },
   "addCards": {
     "triggerChip": "+ Add Cards",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1920,7 +1920,13 @@
     "viewModePlayer": "영상",
     "viewModeNote": "노트",
     "topicGroup": "주제군",
-    "videoFallbackTitle": "영상"
+    "videoFallbackTitle": "영상",
+    "tabChapters": "챕터",
+    "chaptersCount": "{{count}}개 챕터",
+    "chaptersEmpty": "챕터 정보가 아직 준비되지 않았어요. AI 요약이 생성되면 챕터가 나타납니다.",
+    "relevanceLow": "낮음",
+    "relevanceHigh": "높음",
+    "playingNow": "재생 중"
   },
   "addCards": {
     "triggerChip": "+ 카드 추가",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1926,7 +1926,9 @@
     "chaptersEmpty": "챕터 정보가 아직 준비되지 않았어요. AI 요약이 생성되면 챕터가 나타납니다.",
     "relevanceLow": "낮음",
     "relevanceHigh": "높음",
-    "playingNow": "재생 중"
+    "playingNow": "재생 중",
+    "nowWatchingVideo": "지금 보는 영상",
+    "nowReadingSection": "지금 읽는 구간"
   },
   "addCards": {
     "triggerChip": "+ 카드 추가",

--- a/frontend/src/widgets/app-shell/ui/AppShell.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { DndContext } from '@dnd-kit/core';
 import { useTranslation } from 'react-i18next';
@@ -83,7 +83,36 @@ export function AppShell({ children }: AppShellProps) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(getInitialCollapsed);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
 
+  // [VIDEO-VIEW responsive] — on /learning, fixed sidebar(320) + RightPanel
+  // (400) crush the center column below ~1280px viewport (tabs wrap to
+  // vertical text). Auto-collapse the sidebar to the icon rail there; a
+  // manual toggle while narrow overrides for the session, and widening
+  // restores the persisted preference untouched.
+  const isLearningRoute = location.pathname.startsWith('/learning');
+  const [narrowLearning, setNarrowLearning] = useState(false);
+  const [narrowOverride, setNarrowOverride] = useState<boolean | null>(null);
+  useEffect(() => {
+    if (!isLearningRoute) {
+      setNarrowLearning(false);
+      return;
+    }
+    const mq = window.matchMedia('(max-width: 1279px)');
+    const sync = () => setNarrowLearning(mq.matches);
+    sync();
+    mq.addEventListener('change', sync);
+    return () => mq.removeEventListener('change', sync);
+  }, [isLearningRoute]);
+  useEffect(() => {
+    if (!narrowLearning) setNarrowOverride(null);
+  }, [narrowLearning]);
+  const effectiveCollapsed = narrowLearning ? (narrowOverride ?? true) : sidebarCollapsed;
+
   const handleToggleCollapse = useCallback(() => {
+    if (narrowLearning) {
+      // Session-only override — don't persist an auto-collapse as preference.
+      setNarrowOverride((prev) => !(prev ?? true));
+      return;
+    }
     setSidebarCollapsed((prev) => {
       const next = !prev;
       try {
@@ -93,7 +122,7 @@ export function AppShell({ children }: AppShellProps) {
       }
       return next;
     });
-  }, []);
+  }, [narrowLearning]);
 
   // Public pages (landing, login, etc.) render their own header — skip AppShell chrome
   if (!isLoggedIn) {
@@ -122,7 +151,7 @@ export function AppShell({ children }: AppShellProps) {
         <div className="flex-1 flex overflow-hidden">
           {showSidebar && (
             <Sidebar
-              collapsed={isSettingsRoute ? false : sidebarCollapsed}
+              collapsed={isSettingsRoute ? false : effectiveCollapsed}
               onToggleCollapse={handleToggleCollapse}
               onNavigateHome={onNavigateHome ?? undefined}
               minimapData={minimapData ?? undefined}

--- a/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { BookOpen, ChevronsDownUp, ChevronsUpDown, PanelTop } from 'lucide-react';
+import { BookOpen, ChevronsDownUp, ChevronsUpDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useMandalaQuery } from '@/features/mandala';
 import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
@@ -40,8 +40,6 @@ export function SidebarLearningSection({
   const activeSectionRef = useLearningStore((s) => s.activeSectionRef);
   const setActiveRegion = useLearningStore((s) => s.setActiveRegion);
   const centerViewMode = useLearningStore((s) => s.centerViewMode);
-  const videoStripEnabled = useLearningStore((s) => s.videoStripEnabled);
-  const setVideoStripEnabled = useLearningStore((s) => s.setVideoStripEnabled);
   // CP445.x — multi-chapter expand state. `null` = default (모두 펼침).
   // 사용자가 individual/all 토글 시 explicit Set 으로 전환.
   const [expandedIdxs, setExpandedIdxs] = useState<Set<number> | null>(null);
@@ -298,27 +296,8 @@ export function SidebarLearningSection({
             })()}
           </div>
           <div className="mt-0.5 flex shrink-0 items-center gap-0.5">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={() => setVideoStripEnabled(!videoStripEnabled)}
-                  aria-label={videoStripEnabled ? '동영상 썸네일 바 끄기' : '동영상 썸네일 바 켜기'}
-                  aria-pressed={videoStripEnabled}
-                  className={cn(
-                    'rounded p-1 transition-colors hover:bg-sidebar-accent/40',
-                    videoStripEnabled
-                      ? 'text-sidebar-foreground/85 hover:text-sidebar-foreground'
-                      : 'text-sidebar-foreground/35 hover:text-sidebar-foreground/85'
-                  )}
-                >
-                  <PanelTop className="h-3.5 w-3.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="text-[12px]">
-                {videoStripEnabled ? '동영상 썸네일 바 끄기' : '동영상 썸네일 바 켜기'}
-              </TooltipContent>
-            </Tooltip>
+            {/* [STEP5] strip ON/OFF toggle retired — the floating navigator
+                button in CenterPanel's top bar replaces it. */}
             {/* CP445.x — 전체 펼침/접힘 토글. default = 모두 펼침. */}
             {totalChapters > 0 && (
               <Tooltip>
@@ -446,7 +425,9 @@ export function SidebarLearningSection({
                         <span
                           className={cn(
                             'shrink-0 font-mono text-[11px] tabular-nums transition-colors',
-                            chapterActive ? 'text-sidebar-foreground/80' : 'text-sidebar-foreground/35'
+                            chapterActive
+                              ? 'text-sidebar-foreground/80'
+                              : 'text-sidebar-foreground/35'
                           )}
                         >
                           {String(idx + 1).padStart(2, '0')}

--- a/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
+++ b/frontend/src/widgets/app-shell/ui/SidebarLearningSection.tsx
@@ -19,15 +19,9 @@ interface SidebarLearningSectionProps {
   collapsed: boolean;
 }
 
-/**
- * CP505 — sidebar TOC short label (chapter + topic, shared). Book chapter/topic
- * titles run 60-84 chars and wrap or ellipsis-truncate ("…"). Take the lead clause
- * (before the first colon / em-dash / middle-dot) as a short label. Sidebar-only —
- * the note BODY heading keeps the full title; `truncate` stays as a 1-line backstop.
- */
-function tocShortLabel(title: string): string {
-  return title.split(/[:：—–·]/)[0]?.trim() || title;
-}
+// CP505 short label — moved to a shared lib so the right-panel context zone
+// shows the SAME label as this TOC. `truncate` stays as a 1-line backstop.
+import { tocShortLabel } from '@/pages/learning/lib/toc-label';
 
 export function SidebarLearningSection({
   mandalaId,


### PR DESCRIPTION
## What (one line per feature)

1. **Chapters tab (new default)** — v2 segment sections as rows: time range, relevance edge bar + 3-bar meter, hover-expand summary, click-to-seek, live '재생 중' chip; honest empty state without segments.
2. **Segment-pill tab row** + relevance legend ('N개 챕터') on the right.
3. **Floating thumbnail navigator** — collapsed pill (8/17 badge) in the top bar; click expands a thumbnail strip (gold ring = current, large 240x135 hover preview, ESC/outside closes). Replaces the hover-slide VideoStrip (-legacy) + sidebar ON/OFF toggle.
4. **Video meta header removed** (duplicates the video's own title; user).
5. **Right-panel context zone** — same 52px rhythm as the center top bar; shows the SAME short label as the left book index ('지금 보는 영상/읽는 구간 · <tocLabel>'); measured 3-column top alignment (5→57 y, aligned:true).
6. **Responsive** — below 1280px the sidebar auto-collapses to the icon rail (manual override per session) + center min-w floor.
7. **Relevance curve overlay** — hover-synced, pointer-events-none, per-level colors + gold played tint + playhead, hides when segments cover <90% of the video. Native YouTube player untouched (component diff 0 vs main).
8. **CLAUDE.md Hard Rule** — no short-interval repeated server/API calls (2-strike approach-switch), after the YouTube embed block incident.

## Verification
- FE deep typecheck 0 new errors (32 baseline) · vitest 481/481 · build PASS
- Browser screen test on dev: 3-column alignment measured (aligned:true), chapters render, navigator expand/close, curve on hover, short context label — all confirmed
- Player component byte-identical to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)