### PR TITLE
revert(compose): V5_LIVE_VIEW_FLOOR 1000 → 0 (canary rollback, user-verified regression)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -103,9 +103,9 @@ services:
       # Revert: delete both lines → code defaults 30 / 120.
       - V5_TARGET_PICKS=60
       - V5_DEDUP_HARDCAP=180
-      # P0 trust gate canary (night delegation 2026-07-03): live-search view
-      # floor, NULL views = reject fail-closed. Rollback = delete this line.
-      - V5_LIVE_VIEW_FLOOR=1000
+      # P0 trust canary ROLLED BACK 2026-07-03 morning: floor=1000 gutted niche
+      # relevance (user-verified regression). Channel blocklist still guards scam.
+      - V5_LIVE_VIEW_FLOOR=0
       # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
       # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
       # a cell with ≥3 pool candidates drops its live search.list query → quota


### PR DESCRIPTION
**P0 canary rollback.** The overnight `V5_LIVE_VIEW_FLOOR=1000` canary caused a user-verified relevance regression on niche mandalas the next morning (relevant low-view lectures cut; only generic high-view items survive — funnel measured in trace: raw 305 → cards 13 with offLang 105 dropped). Prod compose already hot-rolled to 0 (printenv verified); this syncs the repo SSOT so the next deploy doesn't re-arm it. Channel blocklist (the actual scam guard) remains active — the two seed scam channels stay blocked.

Follow-ups (separate): observability wiring for trustDropped/channelBlockedDropped in add_cards.end trace mapping; re-tuning proposal (e.g. floor 100~300 or per-topic) with data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)