### PR TITLE
fix(add-cards): round summary displayed 1yr for a 2yr search — dedupe publish-bucket mapping

### DIFF
--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1989,7 +1989,9 @@
       "nth": "Round {{n}} (more)",
       "foundCount": "{{count}} new",
       "tablist": "Search rounds",
-      "activePanel": "Active round results"
+      "activePanel": "Active round results",
+      "pub2y": "Past 2 years",
+      "pub3y": "Past 3 years"
     }
   },
   "onboarding": {

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1997,7 +1997,9 @@
       "nth": "{{n}}차 추가 검색",
       "foundCount": "{{count}}개 발견",
       "tablist": "검색 라운드",
-      "activePanel": "선택한 라운드 결과"
+      "activePanel": "선택한 라운드 결과",
+      "pub2y": "지난 2년",
+      "pub3y": "지난 3년"
     }
   },
   "onboarding": {

--- a/frontend/src/widgets/add-cards-panel/lib/published-bucket.test.ts
+++ b/frontend/src/widgets/add-cards-panel/lib/published-bucket.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { isoToPublishedBucket, MS_PER_DAY } from './published-bucket';
+
+const NOW = Date.parse('2026-07-03T00:00:00.000Z');
+const daysAgo = (d: number) => new Date(NOW - d * MS_PER_DAY).toISOString();
+
+describe('isoToPublishedBucket — shared publish-period mapping', () => {
+  it('maps each preset ISO back to its own bucket (round-trip)', () => {
+    expect(isoToPublishedBucket(daysAgo(7), NOW)).toBe('7');
+    expect(isoToPublishedBucket(daysAgo(30), NOW)).toBe('30');
+    expect(isoToPublishedBucket(daysAgo(180), NOW)).toBe('180');
+    expect(isoToPublishedBucket(daysAgo(365), NOW)).toBe('365');
+    // the 2026-07-03 defect: 730d rendered as the 365 bucket ("지난 1년")
+    expect(isoToPublishedBucket(daysAgo(730), NOW)).toBe('730');
+    expect(isoToPublishedBucket(daysAgo(1095), NOW)).toBe('1095');
+  });
+
+  it('boundary days fall into the nearest preset', () => {
+    expect(isoToPublishedBucket(daysAgo(366), NOW)).toBe('365');
+    expect(isoToPublishedBucket(daysAgo(367), NOW)).toBe('730');
+    expect(isoToPublishedBucket(daysAgo(731), NOW)).toBe('730');
+    expect(isoToPublishedBucket(daysAgo(732), NOW)).toBe('1095');
+    expect(isoToPublishedBucket(daysAgo(4000), NOW)).toBe('1095');
+  });
+
+  it('invalid ISO → empty bucket (any time)', () => {
+    expect(isoToPublishedBucket('not-a-date', NOW)).toBe('');
+  });
+});

--- a/frontend/src/widgets/add-cards-panel/lib/published-bucket.ts
+++ b/frontend/src/widgets/add-cards-panel/lib/published-bucket.ts
@@ -1,0 +1,35 @@
+/**
+ * Single source for the publish-period bucket mapping (2026-07-03).
+ *
+ * Two divergent copies existed — AddCardsFilters.isoToDaysBucket (chip
+ * selection state) and an inline mapping in AddCardsList's round summary.
+ * The summary copy topped out at "지난 1년", so a 2yr search was DISPLAYED
+ * as 1yr (user report). Both callers now share this table.
+ */
+
+export const MS_PER_DAY = 86_400_000;
+
+/** Chip values of PUBLISHED_PRESETS (days as string; '' = any time). */
+export type PublishedBucket = '' | '7' | '30' | '180' | '365' | '730' | '1095';
+
+/** Bucket upper bounds carry +1..+15d slack so an ISO produced by
+ *  `daysAgoIso(N)` still lands in bucket N after clock skew / a stale
+ *  snapshot being re-rendered days later. */
+const BUCKET_MAX_DAYS: ReadonlyArray<[number, PublishedBucket]> = [
+  [8, '7'],
+  [31, '30'],
+  [181, '180'],
+  [366, '365'],
+  [731, '730'],
+  [Infinity, '1095'],
+];
+
+export function isoToPublishedBucket(iso: string, nowMs: number = Date.now()): PublishedBucket {
+  const ts = Date.parse(iso);
+  if (!Number.isFinite(ts)) return '';
+  const days = Math.round((nowMs - ts) / MS_PER_DAY);
+  for (const [max, bucket] of BUCKET_MAX_DAYS) {
+    if (days <= max) return bucket;
+  }
+  return '1095';
+}

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsFilters.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsFilters.tsx
@@ -12,9 +12,8 @@
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/shared/lib/utils';
 import { useAddCardsPanelStore } from '../model/useAddCardsPanelStore';
+import { isoToPublishedBucket, MS_PER_DAY } from '../lib/published-bucket';
 import type { DurationBucket } from '../model/useAddCards';
-
-const MS_PER_DAY = 86_400_000;
 
 type FacetPreset<V extends string> = {
   value: V;
@@ -50,18 +49,6 @@ const PUBLISHED_PRESETS: ReadonlyArray<FacetPreset<string>> = [
 
 function daysAgoIso(days: number): string {
   return new Date(Date.now() - days * MS_PER_DAY).toISOString();
-}
-
-function isoToDaysBucket(iso: string): string {
-  const ts = Date.parse(iso);
-  if (!Number.isFinite(ts)) return '';
-  const days = Math.round((Date.now() - ts) / MS_PER_DAY);
-  if (days <= 8) return '7';
-  if (days <= 31) return '30';
-  if (days <= 181) return '180';
-  if (days <= 366) return '365';
-  if (days <= 731) return '730';
-  return '1095';
 }
 
 interface ChipRowProps<V extends string> {
@@ -122,7 +109,9 @@ export function AddCardsFilters({
 
   const minViewsValue = filters.minViewCount != null ? String(filters.minViewCount) : '';
   const durationValue: '' | DurationBucket = filters.durationBucket ?? '';
-  const publishedDaysValue = filters.publishedAfter ? isoToDaysBucket(filters.publishedAfter) : '';
+  const publishedDaysValue = filters.publishedAfter
+    ? isoToPublishedBucket(filters.publishedAfter)
+    : '';
 
   // i18n wrapper around defaultLabel — translation falls back to defaultLabel.
   const tr = (preset: FacetPreset<string>): string =>

--- a/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
+++ b/frontend/src/widgets/add-cards-panel/ui/AddCardsList.tsx
@@ -26,6 +26,7 @@ import { formatRelativeDate } from '@/shared/lib/format-date';
 import { formatDuration, formatViewCount } from '@/shared/lib/format-number';
 import { handleThumbnailError, handleThumbnailLoad } from '@/shared/lib/image-utils';
 import type { AddCardCandidate } from '../model/useAddCards';
+import { isoToPublishedBucket } from '../lib/published-bucket';
 import type { AddCardsRound } from '../lib/persistence';
 
 interface AddCardsListProps {
@@ -252,16 +253,18 @@ function formatRoundFilters(
     if (map[filters.durationBucket]) parts.push(map[filters.durationBucket]);
   }
   if (filters.publishedAfter) {
-    const days = Math.round((Date.now() - new Date(filters.publishedAfter).getTime()) / 86_400_000);
-    const label =
-      days <= 8
-        ? t('addCards.round.pubWeek', '지난 1주')
-        : days <= 32
-          ? t('addCards.round.pubMonth', '지난 1개월')
-          : days <= 190
-            ? t('addCards.round.pubHalf', '지난 6개월')
-            : t('addCards.round.pubYear', '지난 1년');
-    parts.push(label);
+    // 2026-07-03 — shared bucket mapping (was a divergent inline copy that
+    // topped out at 1yr, so a 2yr search DISPLAYED as "지난 1년").
+    const labelByBucket: Record<string, string> = {
+      '7': t('addCards.round.pubWeek', '지난 1주'),
+      '30': t('addCards.round.pubMonth', '지난 1개월'),
+      '180': t('addCards.round.pubHalf', '지난 6개월'),
+      '365': t('addCards.round.pubYear', '지난 1년'),
+      '730': t('addCards.round.pub2y', '지난 2년'),
+      '1095': t('addCards.round.pub3y', '지난 3년'),
+    };
+    const bucket = isoToPublishedBucket(filters.publishedAfter);
+    if (labelByBucket[bucket]) parts.push(labelByBucket[bucket]);
   }
   if (filters.difficulty) parts.push(filters.difficulty);
   if (filters.keywords?.length) parts.push(filters.keywords.map((k) => `"${k}"`).join(' '));


### PR DESCRIPTION
## Symptom
User searched with 게시기간 = **지난 2년**; the round tab's applied-filter chip showed **지난 1년** (screenshot, 2026-07-03).

## Diagnosis
The search itself WAS 2yr — request & round snapshot carry the raw ISO and BE filters by it. Display-only defect: `AddCardsList`'s round-summary renderer had its own inline ISO→label mapping whose fallback was '지난 1년' for anything >190d. The 2yr/3yr PR (#1079) extended only `AddCardsFilters.isoToDaysBucket` — a fragmentary fix that missed the second copy (violates the CLAUDE.md same-pattern-sweep rule; sweep now done: exactly 2 copies existed).

## Fix
- `lib/published-bucket.ts` — single shared bucket table; both callers import it (inline copies deleted)
- Round summary renders 지난 2년/지난 3년 (+ ko/en i18n)
- Boundary tests incl. the defect case (730d must map to the 730 bucket, not 365)

Display-only; no search/persistence behavior change. Rollback = single-file revert.

## Verification
tsc 0 new (32 baseline) · vitest 491/491 (+3) · build PASS · smoke 200. Existing round chips recompute from stored ISO → correct label immediately after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)