### PR TITLE
feat(quality): arm wizard inflow-gate shadow (INFLOW_GATE_ENABLED, CUT off)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -106,9 +106,10 @@ services:
       # P0 trust canary ROLLED BACK 2026-07-03 morning: floor=1000 gutted niche
       # relevance (user-verified regression). Channel blocklist still guards scam.
       - V5_LIVE_VIEW_FLOOR=0
-      # D-01 (2026-07-03): live-search exposure gate — relevance (Haiku,
-      # cache-first, top-20 slice) + audio-language. Rollback = delete lines.
-      - LIVE_SEARCH_GC_GATE=true
+      # D-04-보정 (2026-07-03): live-search gate SHADOW — async trace-only
+      # distribution collection (would_drop keys), zero exposure impact.
+      # Blocking mode requires supervisor-verified thresholds first.
+      - LIVE_SEARCH_GC_GATE=shadow
       # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
       # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
       # a cell with ≥3 pool candidates drops its live search.list query → quota

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -106,6 +106,9 @@ services:
       # P0 trust canary ROLLED BACK 2026-07-03 morning: floor=1000 gutted niche
       # relevance (user-verified regression). Channel blocklist still guards scam.
       - V5_LIVE_VIEW_FLOOR=0
+      # D-01 (2026-07-03): live-search exposure gate — relevance (Haiku,
+      # cache-first, top-20 slice) + audio-language. Rollback = delete lines.
+      - LIVE_SEARCH_GC_GATE=true
       # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
       # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
       # a cell with ≥3 pool candidates drops its live search.list query → quota

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -110,6 +110,10 @@ services:
       # distribution collection (would_drop keys), zero exposure impact.
       # Blocking mode requires supervisor-verified thresholds first.
       - LIVE_SEARCH_GC_GATE=shadow
+      # D-04 §4-2 wizard shadow (supervisor-approved after CUT=false zero-
+      # impact proof, wizard-precompute.ts:179): judge scores + traces
+      # would_cut, slots untouched. CUT stays off until the canary gate.
+      - INFLOW_GATE_ENABLED=true
       # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
       # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
       # a cell with ≥3 pool candidates drops its live search.list query → quota

--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -31,6 +31,8 @@
 import { FastifyPluginCallback } from 'fastify';
 import { getPrismaClient } from '@/modules/database';
 import { logger } from '@/utils/logger';
+import { loadLiveSearchGateConfig } from '@/config/live-search-gate';
+import { gateLiveSearchCards } from '@/modules/inflow-gate/live-search-gate';
 import { getMandalaManager } from '@/modules/mandala/manager';
 import { resolveAlgorithm } from '@/modules/search/algorithm-resolver';
 import { getExcludedVideoIds } from '@/modules/exclude/excluded-videos';
@@ -363,7 +365,27 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             return true;
           });
 
-          const cards: AddCardCandidate[] = v5Filtered.map((c) => ({
+          // D-01 (2026-07-03) — live-search exposure gate: relevance (shared
+          // Haiku scorer, cache-first) + audio-language on the exposed slice.
+          // Trust axis intentionally absent (floor-canary incident). Flag-off
+          // = legacy passthrough.
+          const liveGateCfg = loadLiveSearchGateConfig(process.env);
+          let liveGate: Awaited<
+            ReturnType<typeof gateLiveSearchCards<(typeof v5Filtered)[number]>>
+          > | null = null;
+          let v5Exposed = v5Filtered;
+          if (liveGateCfg.enabled && v5Filtered.length > 0) {
+            liveGate = await gateLiveSearchCards(v5Filtered, {
+              mandalaId,
+              centerGoal,
+              subGoals,
+              language: language === 'en' ? 'en' : 'ko',
+              cfg: liveGateCfg,
+            });
+            v5Exposed = liveGate.exposed;
+          }
+
+          const cards: AddCardCandidate[] = v5Exposed.map((c) => ({
             videoId: c.videoId,
             title: c.title,
             channel: c.channelTitle,
@@ -525,6 +547,12 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               // diagnosed blind because these two were missing from the trace.
               v5_trust_dropped: v5Result.diagnostics.trustDropped,
               v5_channel_blocked_dropped: v5Result.diagnostics.channelBlockedDropped,
+              // D-01 — live exposure gate counters (gc = shared Haiku scorer).
+              live_gate_gc_dropped: liveGate?.gcDropped ?? null,
+              live_gate_lang_dropped: liveGate?.langDropped ?? null,
+              live_gate_cache_hits: liveGate?.cacheHits ?? null,
+              live_gate_scored: liveGate?.scored ?? null,
+              live_gate_latency_ms: liveGate?.latencyMs ?? null,
               // CP489 Phase 6 — emit returned videoIds so the Search Journey
               // Ledger can join per-round trace rows ↔ card_interactions
               // deterministically (no timestamp-window fuzziness). Bounded

--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -520,6 +520,11 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               v5_per_query: v5Result.diagnostics.perQuery,
               // CP491 — Shorts dropped by the post-pick short gate (before→after observability).
               v5_shorts_dropped: v5Result.diagnostics.shortsDropped,
+              // P0 trust gate (2026-07-03) — candidates dropped by the live view
+              // floor and the channel blocklist. The floor canary rollback was
+              // diagnosed blind because these two were missing from the trace.
+              v5_trust_dropped: v5Result.diagnostics.trustDropped,
+              v5_channel_blocked_dropped: v5Result.diagnostics.channelBlockedDropped,
               // CP489 Phase 6 — emit returned videoIds so the Search Journey
               // Ledger can join per-round trace rows ↔ card_interactions
               // deterministically (no timestamp-window fuzziness). Bounded

--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -374,15 +374,43 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             ReturnType<typeof gateLiveSearchCards<(typeof v5Filtered)[number]>>
           > | null = null;
           let v5Exposed = v5Filtered;
-          if (liveGateCfg.enabled && v5Filtered.length > 0) {
-            liveGate = await gateLiveSearchCards(v5Filtered, {
-              mandalaId,
-              centerGoal,
-              subGoals,
-              language: language === 'en' ? 'en' : 'ko',
-              cfg: liveGateCfg,
-            });
+          const liveGateCtx = {
+            mandalaId,
+            centerGoal,
+            subGoals,
+            language: (language === 'en' ? 'en' : 'ko') as 'ko' | 'en',
+            cfg: liveGateCfg,
+          };
+          if (liveGateCfg.mode === 'on' && v5Filtered.length > 0) {
+            liveGate = await gateLiveSearchCards(v5Filtered, liveGateCtx);
             v5Exposed = liveGate.exposed;
+          } else if (liveGateCfg.mode === 'shadow' && v5Filtered.length > 0) {
+            // D-04-보정 shadow: score async off the response path — trace-only
+            // would_* counters, ZERO exposure impact, zero added latency. The
+            // 24-48h distribution decides the real threshold (no gut cutoffs).
+            void gateLiveSearchCards(v5Filtered, liveGateCtx)
+              .then((g) => {
+                recordTrace({
+                  step: 'live_gate.shadow',
+                  status: 'ok',
+                  response: {
+                    would_gc_dropped: g.gcDropped,
+                    would_lang_dropped: g.langDropped,
+                    would_demoted: g.demoted,
+                    cache_hits: g.cacheHits,
+                    scored: g.scored,
+                    latency_ms: g.latencyMs,
+                    gc_scores: Array.from(g.gcByVideoId.entries())
+                      .filter(([, v]) => v != null)
+                      .map(([id, v]) => ({ id, gc: v })),
+                  },
+                });
+              })
+              .catch((err) => {
+                log.warn(
+                  `live_gate shadow failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+                );
+              });
           }
 
           const cards: AddCardCandidate[] = v5Exposed.map((c) => ({

--- a/src/config/live-search-gate.ts
+++ b/src/config/live-search-gate.ts
@@ -14,14 +14,21 @@
 
 import { z } from 'zod';
 
-const boolFlag = z.preprocess((v) => {
-  if (v == null || v === '') return false;
-  const s = String(v).trim().toLowerCase();
-  return s === 'true' || s === '1' || s === 'yes';
-}, z.boolean());
+// D-04-보정 tri-state: off (legacy) / shadow (score async, trace-only, zero
+// exposure impact) / on (blocking gate). Legacy "true" maps to on.
+const gateMode = z.preprocess(
+  (v) => {
+    if (v == null || v === '') return 'off';
+    const s = String(v).trim().toLowerCase();
+    if (s === 'shadow') return 'shadow';
+    if (s === 'on' || s === 'true' || s === '1' || s === 'yes') return 'on';
+    return 'off';
+  },
+  z.enum(['off', 'shadow', 'on'])
+);
 
 export const liveSearchGateEnvSchema = z.object({
-  LIVE_SEARCH_GC_GATE: boolFlag.default(false as unknown as string),
+  LIVE_SEARCH_GC_GATE: gateMode.default('off' as never),
   /** Exposed slice scored per round; tail beyond this is demoted, not scored. */
   LIVE_SEARCH_GC_TOP_N: z.coerce.number().int().min(1).max(100).default(20),
   /** Haiku scoring concurrency (single wave when >= TOP_N keeps p95 low). */
@@ -30,8 +37,10 @@ export const liveSearchGateEnvSchema = z.object({
   LIVE_SEARCH_GC_MIN: z.coerce.number().int().min(0).max(100).default(60),
 });
 
+export type LiveSearchGateMode = 'off' | 'shadow' | 'on';
+
 export interface LiveSearchGateConfig {
-  enabled: boolean;
+  mode: LiveSearchGateMode;
   topN: number;
   burst: number;
   relevanceMin: number;
@@ -47,10 +56,10 @@ export function loadLiveSearchGateConfig(
     LIVE_SEARCH_GC_MIN: env['LIVE_SEARCH_GC_MIN'],
   });
   if (!parsed.success) {
-    return { enabled: false, topN: 20, burst: 20, relevanceMin: 60 };
+    return { mode: 'off', topN: 20, burst: 20, relevanceMin: 60 };
   }
   return {
-    enabled: parsed.data.LIVE_SEARCH_GC_GATE,
+    mode: parsed.data.LIVE_SEARCH_GC_GATE,
     topN: parsed.data.LIVE_SEARCH_GC_TOP_N,
     burst: parsed.data.LIVE_SEARCH_GC_BURST,
     relevanceMin: parsed.data.LIVE_SEARCH_GC_MIN,

--- a/src/config/live-search-gate.ts
+++ b/src/config/live-search-gate.ts
@@ -1,0 +1,58 @@
+/**
+ * Live-search gate config (D-01 2026-07-03 — add-cards quality wiring).
+ *
+ * The add-cards live path (v5) exposes candidates with NO relevance or
+ * language-audio judge — the floor-canary incident proved a trust-only gate
+ * kills niche topics, so this gate wires the RELEVANCE axis (shared Haiku
+ * scorer, gc<min = hidden) plus an AUDIO-LANGUAGE check (defaultAudioLanguage
+ * from the existing videos.list call) onto the EXPOSED slice only (top-N by
+ * pick score; the tail is never scored, it is demoted below scored results).
+ *
+ * Default OFF (unset = legacy, no gate). Rollback = flip env, no code revert.
+ * Single-sourced in docker-compose.prod.yml environment per CONFIG-SSOT.
+ */
+
+import { z } from 'zod';
+
+const boolFlag = z.preprocess((v) => {
+  if (v == null || v === '') return false;
+  const s = String(v).trim().toLowerCase();
+  return s === 'true' || s === '1' || s === 'yes';
+}, z.boolean());
+
+export const liveSearchGateEnvSchema = z.object({
+  LIVE_SEARCH_GC_GATE: boolFlag.default(false as unknown as string),
+  /** Exposed slice scored per round; tail beyond this is demoted, not scored. */
+  LIVE_SEARCH_GC_TOP_N: z.coerce.number().int().min(1).max(100).default(20),
+  /** Haiku scoring concurrency (single wave when >= TOP_N keeps p95 low). */
+  LIVE_SEARCH_GC_BURST: z.coerce.number().int().min(1).max(50).default(20),
+  /** Candidates scoring below this are hidden from the exposed results. */
+  LIVE_SEARCH_GC_MIN: z.coerce.number().int().min(0).max(100).default(60),
+});
+
+export interface LiveSearchGateConfig {
+  enabled: boolean;
+  topN: number;
+  burst: number;
+  relevanceMin: number;
+}
+
+export function loadLiveSearchGateConfig(
+  env: NodeJS.ProcessEnv = process.env
+): LiveSearchGateConfig {
+  const parsed = liveSearchGateEnvSchema.safeParse({
+    LIVE_SEARCH_GC_GATE: env['LIVE_SEARCH_GC_GATE'],
+    LIVE_SEARCH_GC_TOP_N: env['LIVE_SEARCH_GC_TOP_N'],
+    LIVE_SEARCH_GC_BURST: env['LIVE_SEARCH_GC_BURST'],
+    LIVE_SEARCH_GC_MIN: env['LIVE_SEARCH_GC_MIN'],
+  });
+  if (!parsed.success) {
+    return { enabled: false, topN: 20, burst: 20, relevanceMin: 60 };
+  }
+  return {
+    enabled: parsed.data.LIVE_SEARCH_GC_GATE,
+    topN: parsed.data.LIVE_SEARCH_GC_TOP_N,
+    burst: parsed.data.LIVE_SEARCH_GC_BURST,
+    relevanceMin: parsed.data.LIVE_SEARCH_GC_MIN,
+  };
+}

--- a/src/modules/inflow-gate/live-search-gate.ts
+++ b/src/modules/inflow-gate/live-search-gate.ts
@@ -1,0 +1,218 @@
+/**
+ * Live-search exposure gate (D-01 2026-07-03 — add-cards quality wiring).
+ *
+ * Wires the RELEVANCE axis (shared Haiku scorer via computeCardRelevance)
+ * plus an AUDIO-LANGUAGE check onto the add-cards exposed slice. The trust
+ * (view floor) axis is deliberately ABSENT: the 2026-07-03 floor-canary
+ * incident proved view count alone kills niche topics (84% of a niche
+ * mandala's relevant candidates sat under 1000 views, incl. official
+ * Microsoft/AWS lectures). Channel blocklist stays wired upstream in v5.
+ *
+ * Cost/latency contract (measure-first):
+ *  - Only the top-N exposed slice (pick-score order) is scored — never the
+ *    raw fanout. The tail past top-N is DEMOTED below scored results, not
+ *    scored and not hidden.
+ *  - Scores are cached in video_mandala_relevance; a re-search is a cache
+ *    hit = zero cost + idempotent ordering.
+ *  - Scoring failure/timeout DEMOTES (never hides) — an empty panel is
+ *    worse than a low-confidence tail (floor-incident lesson).
+ *
+ * Language rule (audio wins over title script): defaultAudioLanguage from
+ * the existing videos.list snippet (free field, no extra quota). null =
+ * pass (fail-open). A clear mismatch with the mandala's target language
+ * (e.g. Arabic audio on an en mandala — the script-invisible case the
+ * title filter cannot catch) hides the candidate.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { computeCardRelevance } from '@/modules/relevance/compute-card-relevance';
+import { loadRelevanceRubricConfig } from '@/config/relevance-rubric';
+import type { LiveSearchGateConfig } from '@/config/live-search-gate';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'live-search-gate' });
+
+/** Minimal candidate shape the gate needs (v5 card is a structural superset). */
+export interface LiveGateCandidate {
+  videoId: string;
+  title: string;
+  cellIndex: number | null;
+  audioLanguage: string | null;
+}
+
+export interface LiveGateContext {
+  mandalaId: string;
+  centerGoal: string;
+  /** Per-cell sub-goals; cellGoal = subGoals[cellIndex]. */
+  subGoals: string[];
+  language: 'ko' | 'en';
+  cfg: LiveSearchGateConfig;
+}
+
+export interface LiveGateResult<T> {
+  /** Exposed candidates: scored-pass first (gc desc), then demoted tail. */
+  exposed: T[];
+  /** gc attached per exposed videoId (null = unscored/demoted). */
+  gcByVideoId: Map<string, number | null>;
+  gcDropped: number;
+  langDropped: number;
+  cacheHits: number;
+  scored: number;
+  demoted: number;
+  latencyMs: number;
+}
+
+/**
+ * Audio-language mismatch: null passes (fail-open); primary subtag must be
+ * the target language or English (en content is globally acceptable per the
+ * CP492 off-language gate contract: ko ∪ en survives on ko mandalas).
+ */
+export function audioLanguageMismatch(audioLanguage: string | null, target: 'ko' | 'en'): boolean {
+  if (!audioLanguage) return false;
+  const primary = audioLanguage.trim().toLowerCase().split(/[-_]/)[0];
+  if (!primary) return false;
+  if (primary === 'en') return false;
+  if (target === 'ko' && primary === 'ko') return false;
+  return true;
+}
+
+/**
+ * Gate the exposed slice: language check on ALL candidates (free), then gc
+ * scoring on the top-N slice only (cache-first, one bounded Haiku wave).
+ * Never throws; a total scorer outage demotes everything instead of hiding.
+ */
+export async function gateLiveSearchCards<T extends LiveGateCandidate>(
+  candidates: T[],
+  ctx: LiveGateContext
+): Promise<LiveGateResult<T>> {
+  const t0 = Date.now();
+  const prisma = getPrismaClient();
+  const rubric = loadRelevanceRubricConfig().enabled;
+  const gcByVideoId = new Map<string, number | null>();
+
+  // 1. Audio-language gate — free, applies to every candidate.
+  let langDropped = 0;
+  const langOk = candidates.filter((c) => {
+    if (audioLanguageMismatch(c.audioLanguage, ctx.language)) {
+      langDropped += 1;
+      return false;
+    }
+    return true;
+  });
+
+  // 2. gc gate on the exposed top-N slice only.
+  const head = langOk.slice(0, ctx.cfg.topN);
+  const tail = langOk.slice(ctx.cfg.topN);
+
+  // 2a. Cache read (one query for the whole slice).
+  let cacheHits = 0;
+  const cachedByIdRaw = head.length
+    ? await prisma.video_mandala_relevance
+        .findMany({
+          where: {
+            mandala_id: ctx.mandalaId,
+            video_id: { in: head.map((c) => c.videoId) },
+          },
+          select: { video_id: true, relevance_pct: true, detail: true },
+        })
+        .catch((err: unknown) => {
+          log.warn(
+            `live-search gate cache read failed (scoring all): ${err instanceof Error ? err.message : String(err)}`
+          );
+          return [] as Array<{ video_id: string; relevance_pct: number; detail: unknown }>;
+        })
+    : [];
+  const cachedById = new Map(cachedByIdRaw.map((r) => [r.video_id, r]));
+
+  // 2b. Score misses in bounded bursts (single wave when burst >= topN).
+  const scoredEntries: Array<{ c: T; gc: number | null }> = [];
+  let scored = 0;
+  const misses: T[] = [];
+  for (const c of head) {
+    const hit = cachedById.get(c.videoId);
+    if (hit) {
+      cacheHits += 1;
+      const detail = hit.detail as { goalContributionPct?: number } | null;
+      const gc =
+        rubric && detail?.goalContributionPct != null
+          ? detail.goalContributionPct
+          : hit.relevance_pct;
+      scoredEntries.push({ c, gc });
+    } else {
+      misses.push(c);
+    }
+  }
+
+  for (let i = 0; i < misses.length; i += ctx.cfg.burst) {
+    const burst = misses.slice(i, i + ctx.cfg.burst);
+    const verdicts = await Promise.all(
+      burst.map(async (c) => {
+        const cellGoal = c.cellIndex != null ? ctx.subGoals[c.cellIndex] : undefined;
+        const r = await computeCardRelevance({
+          title: c.title,
+          description: '',
+          centerGoal: ctx.centerGoal,
+          cellGoal,
+          language: ctx.language,
+          ...(rubric ? { rubric: true } : {}),
+        });
+        if (!r.ok) return { c, gc: null as number | null, detail: null };
+        return { c, gc: r.relevancePct, detail: r.detail ?? null };
+      })
+    );
+    for (const v of verdicts) {
+      scored += 1;
+      if (v.gc != null) {
+        // Cache write — a re-search becomes a free cache hit (idempotency).
+        const detailJson = v.detail ? JSON.stringify(v.detail) : null;
+        await prisma.$executeRaw`
+            INSERT INTO video_mandala_relevance (video_id, mandala_id, relevance_pct, detail)
+            VALUES (${v.c.videoId}, ${ctx.mandalaId}::uuid, ${v.gc}, ${detailJson}::jsonb)
+            ON CONFLICT (video_id, mandala_id)
+            DO UPDATE SET relevance_pct = EXCLUDED.relevance_pct, detail = EXCLUDED.detail`.catch(
+          (err: unknown) => {
+            log.warn(
+              `live-search gate cache write failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        );
+        const detail = v.detail as { goalContributionPct?: number } | null;
+        const gc =
+          rubric && detail?.goalContributionPct != null ? detail.goalContributionPct : v.gc;
+        scoredEntries.push({ c: v.c, gc });
+      } else {
+        // Scoring failure — DEMOTE, never hide (floor-incident lesson).
+        scoredEntries.push({ c: v.c, gc: null });
+      }
+    }
+  }
+
+  // 3. Partition + order: pass (gc desc) → failed-open demoted → unscored tail.
+  const pass: Array<{ c: T; gc: number }> = [];
+  const demotedScored: T[] = [];
+  let gcDropped = 0;
+  for (const e of scoredEntries) {
+    if (e.gc == null) {
+      demotedScored.push(e.c);
+    } else if (e.gc >= ctx.cfg.relevanceMin) {
+      pass.push({ c: e.c, gc: e.gc });
+    } else {
+      gcDropped += 1;
+    }
+    gcByVideoId.set(e.c.videoId, e.gc);
+  }
+  pass.sort((a, b) => b.gc - a.gc);
+  for (const t of tail) gcByVideoId.set(t.videoId, null);
+
+  const exposed = [...pass.map((p) => p.c), ...demotedScored, ...tail];
+  return {
+    exposed,
+    gcByVideoId,
+    gcDropped,
+    langDropped,
+    cacheHits,
+    scored,
+    demoted: demotedScored.length + tail.length,
+    latencyMs: Date.now() - t0,
+  };
+}

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -73,6 +73,8 @@ export interface V5Card {
   channelId: string;
   thumbnailUrl: string;
   publishedAt: string | null;
+  /** D-01 — videos.list snippet.defaultAudioLanguage (free field on the existing 1u call). */
+  audioLanguage: string | null;
   durationSec: number | null;
   viewCount: number | null;
   cellIndex: number | null;
@@ -594,6 +596,7 @@ function assembleCard(
     fan?.thumbnailUrl ??
     '';
   const publishedAt = meta?.snippet?.publishedAt ?? fan?.publishedAt ?? null;
+  const audioLanguage = meta?.snippet?.defaultAudioLanguage ?? null;
   const durationSec = parseIsoDurationSeconds(meta?.contentDetails?.duration);
   const viewCountStr = meta?.statistics?.viewCount;
   const viewCount = viewCountStr ? Number(viewCountStr) : null;
@@ -605,6 +608,7 @@ function assembleCard(
     channelId,
     thumbnailUrl,
     publishedAt,
+    audioLanguage,
     durationSec,
     viewCount: Number.isFinite(viewCount) ? viewCount : null,
     cellIndex: fan?.cellIndex ?? null,

--- a/tests/smoke/live-search-gate.test.ts
+++ b/tests/smoke/live-search-gate.test.ts
@@ -26,7 +26,7 @@ import {
   audioLanguageMismatch,
 } from '../../src/modules/inflow-gate/live-search-gate';
 
-const CFG = { enabled: true, topN: 3, burst: 3, relevanceMin: 60 };
+const CFG = { mode: 'on' as const, topN: 3, burst: 3, relevanceMin: 60 };
 const CTX = {
   mandalaId: '00000000-0000-0000-0000-000000000000',
   centerGoal: '머신러닝 마스터',

--- a/tests/smoke/live-search-gate.test.ts
+++ b/tests/smoke/live-search-gate.test.ts
@@ -1,0 +1,106 @@
+/**
+ * D-01 live-search exposure gate — partition/cache/demotion contract.
+ * Floor-incident lessons under test: scoring failure DEMOTES (never hides),
+ * tail past top-N is demoted unscored, audio mismatch hides (null passes).
+ */
+
+const mockFindMany = jest.fn();
+const mockExecuteRaw = jest.fn();
+const mockCompute = jest.fn();
+
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    video_mandala_relevance: { findMany: mockFindMany },
+    $executeRaw: (...args: unknown[]) => mockExecuteRaw(...args),
+  }),
+}));
+jest.mock('@/modules/relevance/compute-card-relevance', () => ({
+  computeCardRelevance: (...args: unknown[]) => mockCompute(...args),
+}));
+jest.mock('@/config/relevance-rubric', () => ({
+  loadRelevanceRubricConfig: () => ({ enabled: false }),
+}));
+
+import {
+  gateLiveSearchCards,
+  audioLanguageMismatch,
+} from '../../src/modules/inflow-gate/live-search-gate';
+
+const CFG = { enabled: true, topN: 3, burst: 3, relevanceMin: 60 };
+const CTX = {
+  mandalaId: '00000000-0000-0000-0000-000000000000',
+  centerGoal: '머신러닝 마스터',
+  subGoals: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'],
+  language: 'ko' as const,
+  cfg: CFG,
+};
+const card = (id: string, audio: string | null = null) => ({
+  videoId: id,
+  title: `title-${id}`,
+  cellIndex: 0,
+  audioLanguage: audio,
+});
+
+describe('audioLanguageMismatch', () => {
+  test('null passes (fail-open); en passes everywhere', () => {
+    expect(audioLanguageMismatch(null, 'ko')).toBe(false);
+    expect(audioLanguageMismatch('en-US', 'ko')).toBe(false);
+    expect(audioLanguageMismatch('en', 'en')).toBe(false);
+  });
+  test('clear mismatch hides — Arabic audio on en mandala (script-invisible case)', () => {
+    expect(audioLanguageMismatch('ar', 'en')).toBe(true);
+    expect(audioLanguageMismatch('ko-KR', 'en')).toBe(true);
+    expect(audioLanguageMismatch('th', 'ko')).toBe(true);
+  });
+});
+
+describe('gateLiveSearchCards', () => {
+  beforeEach(() => {
+    mockFindMany.mockReset().mockResolvedValue([]);
+    mockExecuteRaw.mockReset().mockResolvedValue(1);
+    mockCompute.mockReset();
+  });
+
+  test('pass sorted by gc desc; below-min hidden; tail demoted unscored', async () => {
+    mockCompute
+      .mockResolvedValueOnce({ ok: true, relevancePct: 70 })
+      .mockResolvedValueOnce({ ok: true, relevancePct: 40 })
+      .mockResolvedValueOnce({ ok: true, relevancePct: 90 });
+    const cards = [card('a'), card('b'), card('c'), card('tail1'), card('tail2')];
+    const r = await gateLiveSearchCards(cards, CTX);
+    expect(r.exposed.map((c) => c.videoId)).toEqual(['c', 'a', 'tail1', 'tail2']);
+    expect(r.gcDropped).toBe(1);
+    expect(r.demoted).toBe(2);
+    expect(mockCompute).toHaveBeenCalledTimes(3);
+  });
+
+  test('scoring failure demotes, never hides (floor-incident lesson)', async () => {
+    mockCompute
+      .mockResolvedValueOnce({ ok: true, relevancePct: 80 })
+      .mockResolvedValueOnce({ ok: false, reason: 'provider_error: timeout' })
+      .mockResolvedValueOnce({ ok: true, relevancePct: 75 });
+    const r = await gateLiveSearchCards([card('a'), card('b'), card('c')], CTX);
+    expect(r.exposed.map((c) => c.videoId)).toEqual(['a', 'c', 'b']);
+    expect(r.gcDropped).toBe(0);
+  });
+
+  test('cache hit skips scoring and costs nothing', async () => {
+    mockFindMany.mockResolvedValue([
+      { video_id: 'a', relevance_pct: 85, detail: null },
+      { video_id: 'b', relevance_pct: 30, detail: null },
+    ]);
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 65 });
+    const r = await gateLiveSearchCards([card('a'), card('b'), card('c')], CTX);
+    expect(r.cacheHits).toBe(2);
+    expect(mockCompute).toHaveBeenCalledTimes(1);
+    expect(r.exposed.map((c) => c.videoId)).toEqual(['a', 'c']);
+    expect(r.gcDropped).toBe(1);
+  });
+
+  test('audio mismatch hides before scoring', async () => {
+    mockCompute.mockResolvedValue({ ok: true, relevancePct: 99 });
+    const r = await gateLiveSearchCards([card('a', 'ar'), card('b', 'ko')], CTX);
+    expect(r.langDropped).toBe(1);
+    expect(r.exposed.map((c) => c.videoId)).toEqual(['b']);
+  });
+});


### PR DESCRIPTION
D-04 §4-2 second surface: the existing inflow gate's stage 1 IS shadow semantics — supervisor-approved after the zero-impact proof (slots mutated only inside `if(gateCfg.cut)`, wizard-precompute.ts:179; CUT off = exposure/order/count untouched, off the consume SLO, fail-open at every level). Arms `INFLOW_GATE_ENABLED=true` in the repo compose (SSOT); `INFLOW_GATE_CUT` stays off until the canary gate (James GO). Traces land as `inflow_gate.would_cut` rows — joins the add-cards `live_gate.shadow` rows for the 24-48h distribution snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)