### PR TITLE
feat(quality): arm wizard inflow-gate shadow (INFLOW_GATE_ENABLED, CUT off)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -110,6 +110,10 @@ services:
       # distribution collection (would_drop keys), zero exposure impact.
       # Blocking mode requires supervisor-verified thresholds first.
       - LIVE_SEARCH_GC_GATE=shadow
+      # D-04 §4-2 wizard shadow (supervisor-approved after CUT=false zero-
+      # impact proof, wizard-precompute.ts:179): judge scores + traces
+      # would_cut, slots untouched. CUT stays off until the canary gate.
+      - INFLOW_GATE_ENABLED=true
       # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
       # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
       # a cell with ≥3 pool candidates drops its live search.list query → quota


### PR DESCRIPTION
D-04 §4-2 second surface (reissue of #1084 — self-squash conflict after #1082 landed; cherry-picked onto main). The existing inflow gate's stage 1 IS shadow semantics — supervisor-approved after the zero-impact proof (slots mutated only inside `if(gateCfg.cut)`, wizard-precompute.ts:179; CUT off = exposure/order/count untouched, off the consume SLO, fail-open). Arms `INFLOW_GATE_ENABLED=true` in repo compose (SSOT); CUT stays off until the canary gate. Traces = `inflow_gate.would_cut` rows joining the add-cards `live_gate.shadow` rows for the 24-48h snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)