### PR TITLE
feat(quality): D-06 — subscriber trust-signal shadow (measure-only)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -388,6 +388,7 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             // D-04-보정 shadow: score async off the response path — trace-only
             // would_* counters, ZERO exposure impact, zero added latency. The
             // 24-48h distribution decides the real threshold (no gut cutoffs).
+            const defByVideoId = new Map(v5Filtered.map((c) => [c.videoId, c.definition]));
             void gateLiveSearchCards(v5Filtered, liveGateCtx)
               .then((g) => {
                 recordTrace({
@@ -404,7 +405,12 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
                     would_drop_subscriber_1000: g.wouldDropSub1000,
                     gc_scores: Array.from(g.gcByVideoId.entries())
                       .filter(([, v]) => v != null)
-                      .map(([id, v]) => ({ id, gc: v, subs: g.subsByVideoId.get(id) ?? null })),
+                      .map(([id, v]) => ({
+                        id,
+                        gc: v,
+                        subs: g.subsByVideoId.get(id) ?? null,
+                        hd: defByVideoId.get(id) ?? null,
+                      })),
                   },
                 });
               })

--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -400,9 +400,11 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
                     cache_hits: g.cacheHits,
                     scored: g.scored,
                     latency_ms: g.latencyMs,
+                    would_drop_subscriber_100: g.wouldDropSub100,
+                    would_drop_subscriber_1000: g.wouldDropSub1000,
                     gc_scores: Array.from(g.gcByVideoId.entries())
                       .filter(([, v]) => v != null)
-                      .map(([id, v]) => ({ id, gc: v })),
+                      .map(([id, v]) => ({ id, gc: v, subs: g.subsByVideoId.get(id) ?? null })),
                   },
                 });
               })

--- a/src/modules/inflow-gate/live-search-gate.ts
+++ b/src/modules/inflow-gate/live-search-gate.ts
@@ -40,6 +40,8 @@ export interface LiveGateCandidate {
   audioLanguage: string | null;
   /** D-06 — for the subscriber trust-signal shadow (channels.list batch). */
   channelId?: string | null;
+  /** D-06-b — hd/sd from videos.list contentDetails (free field). */
+  definition?: string | null;
 }
 
 export interface LiveGateContext {

--- a/src/modules/inflow-gate/live-search-gate.ts
+++ b/src/modules/inflow-gate/live-search-gate.ts
@@ -38,6 +38,8 @@ export interface LiveGateCandidate {
   title: string;
   cellIndex: number | null;
   audioLanguage: string | null;
+  /** D-06 — for the subscriber trust-signal shadow (channels.list batch). */
+  channelId?: string | null;
 }
 
 export interface LiveGateContext {
@@ -54,6 +56,10 @@ export interface LiveGateResult<T> {
   exposed: T[];
   /** gc attached per exposed videoId (null = unscored/demoted). */
   gcByVideoId: Map<string, number | null>;
+  /** D-06 subscriber shadow — measurement only, never gates in this module. */
+  subsByVideoId: Map<string, number | null>;
+  wouldDropSub100: number;
+  wouldDropSub1000: number;
   gcDropped: number;
   langDropped: number;
   cacheHits: number;
@@ -204,10 +210,38 @@ export async function gateLiveSearchCards<T extends LiveGateCandidate>(
   pass.sort((a, b) => b.gc - a.gc);
   for (const t of tail) gcByVideoId.set(t.videoId, null);
 
+  // D-06 subscriber shadow — measure-only (channels.list, cached 1h). A
+  // fetch failure leaves the map empty; gaps must never gate.
+  const subsByVideoId = new Map<string, number | null>();
+  let wouldDropSub100 = 0;
+  let wouldDropSub1000 = 0;
+  try {
+    const { fetchChannelStats } = await import('@/modules/youtube/channel-stats');
+    const { resolveVideosApiKeys } =
+      await import('@/skills/plugins/video-discover/v2/youtube-client');
+    const chIds = head.map((c) => c.channelId).filter((x): x is string => !!x);
+    if (chIds.length > 0) {
+      const stats = await fetchChannelStats(chIds, resolveVideosApiKeys(process.env));
+      for (const c of head) {
+        const subs = c.channelId ? (stats.get(c.channelId)?.subscriberCount ?? null) : null;
+        subsByVideoId.set(c.videoId, subs);
+        if (subs != null && subs < 100) wouldDropSub100 += 1;
+        if (subs != null && subs < 1000) wouldDropSub1000 += 1;
+      }
+    }
+  } catch (err) {
+    log.warn(
+      `subscriber shadow failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
   const exposed = [...pass.map((p) => p.c), ...demotedScored, ...tail];
   return {
     exposed,
     gcByVideoId,
+    subsByVideoId,
+    wouldDropSub100,
+    wouldDropSub1000,
     gcDropped,
     langDropped,
     cacheHits,

--- a/src/modules/youtube/channel-stats.ts
+++ b/src/modules/youtube/channel-stats.ts
@@ -1,0 +1,98 @@
+/**
+ * Channel statistics fetcher (D-06 2026-07-03 — trust-axis subscriber shadow).
+ *
+ * James's insight, validated by the floor incident: subscriber count separates
+ * "niche but legit" (MS/AWS official lectures: hundreds of views, hundreds of
+ * thousands of subscribers) from "3-subscriber scam farms" — exactly where the
+ * view-count floor failed. This module only MEASURES (channels.list, 1u/50
+ * channels); gating decisions stay with the shadow-distribution pipeline.
+ *
+ * In-memory TTL cache (1h): channel stats drift slowly, and the shadow path
+ * re-sees the same channels every round — steady-state quota cost ≈ 0.
+ */
+
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'channel-stats' });
+
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const BATCH_SIZE = 50;
+
+export interface ChannelStats {
+  subscriberCount: number | null;
+  videoCount: number | null;
+  publishedAt: string | null;
+}
+
+const cache = new Map<string, { stats: ChannelStats; at: number }>();
+
+export function resetChannelStatsCacheForTest(): void {
+  cache.clear();
+}
+
+/**
+ * Batch-fetch statistics for the given channelIds. Unknown/failed channels
+ * are simply absent from the result map (callers treat missing as null —
+ * measurement gaps must never gate anything).
+ */
+export async function fetchChannelStats(
+  channelIds: string[],
+  apiKeys: string[]
+): Promise<Map<string, ChannelStats>> {
+  const out = new Map<string, ChannelStats>();
+  const now = Date.now();
+  const misses: string[] = [];
+  for (const id of new Set(channelIds)) {
+    const hit = cache.get(id);
+    if (hit && now - hit.at < CACHE_TTL_MS) {
+      out.set(id, hit.stats);
+    } else {
+      misses.push(id);
+    }
+  }
+  if (misses.length === 0 || apiKeys.length === 0) return out;
+
+  for (let i = 0; i < misses.length; i += BATCH_SIZE) {
+    const batch = misses.slice(i, i + BATCH_SIZE);
+    const url =
+      `https://www.googleapis.com/youtube/v3/channels?part=statistics,snippet` +
+      `&id=${batch.join(',')}&key=${apiKeys[0]}`;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        log.warn(`channels.list ${res.status} (batch skipped, stats absent)`);
+        continue;
+      }
+      const json = (await res.json()) as {
+        items?: Array<{
+          id: string;
+          snippet?: { publishedAt?: string };
+          statistics?: {
+            subscriberCount?: string;
+            videoCount?: string;
+            hiddenSubscriberCount?: boolean;
+          };
+        }>;
+      };
+      for (const item of json.items ?? []) {
+        const stats: ChannelStats = {
+          subscriberCount: item.statistics?.hiddenSubscriberCount
+            ? null
+            : item.statistics?.subscriberCount != null
+              ? Number(item.statistics.subscriberCount)
+              : null,
+          videoCount:
+            item.statistics?.videoCount != null ? Number(item.statistics.videoCount) : null,
+          publishedAt: item.snippet?.publishedAt ?? null,
+        };
+        cache.set(item.id, { stats, at: now });
+        out.set(item.id, stats);
+      }
+    } catch (err) {
+      log.warn(
+        `channels.list failed (batch skipped): ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+  return out;
+}

--- a/src/modules/youtube/channel-stats.ts
+++ b/src/modules/youtube/channel-stats.ts
@@ -12,10 +12,11 @@
  */
 
 import { logger } from '@/utils/logger';
+import { MS_PER_HOUR } from '@/utils/time-constants';
 
 const log = logger.child({ module: 'channel-stats' });
 
-const CACHE_TTL_MS = 60 * 60 * 1000;
+const CACHE_TTL_MS = MS_PER_HOUR;
 const BATCH_SIZE = 50;
 
 export interface ChannelStats {

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -75,6 +75,8 @@ export interface V5Card {
   publishedAt: string | null;
   /** D-01 — videos.list snippet.defaultAudioLanguage (free field on the existing 1u call). */
   audioLanguage: string | null;
+  /** D-06-b — videos.list contentDetails.definition (hd/sd, free field). */
+  definition: string | null;
   durationSec: number | null;
   viewCount: number | null;
   cellIndex: number | null;
@@ -597,6 +599,7 @@ function assembleCard(
     '';
   const publishedAt = meta?.snippet?.publishedAt ?? fan?.publishedAt ?? null;
   const audioLanguage = meta?.snippet?.defaultAudioLanguage ?? null;
+  const definition = meta?.contentDetails?.definition ?? null;
   const durationSec = parseIsoDurationSeconds(meta?.contentDetails?.duration);
   const viewCountStr = meta?.statistics?.viewCount;
   const viewCount = viewCountStr ? Number(viewCountStr) : null;
@@ -609,6 +612,7 @@ function assembleCard(
     thumbnailUrl,
     publishedAt,
     audioLanguage,
+    definition,
     durationSec,
     viewCount: Number.isFinite(viewCount) ? viewCount : null,
     cellIndex: fan?.cellIndex ?? null,


### PR DESCRIPTION
D-06 §2: subscriber count as the trust-axis candidate — validated by the floor incident's counter-example (MS/AWS official lectures: hundreds of views but 100k+ subscribers; the scam farms: 0-466 subs). This PR only **measures**: `channels.list` statistics batch (1u/50 channels, 1h cache → steady-state ≈ 0 quota) joins per-video `subs` onto the shadow trace's gc_scores, plus `would_drop_subscriber_100/_1000` parallel counters. The threshold decision comes from the shadow distribution (snapshot 8th axis: scam-vs-legit subscriber separation + MS/AWS-niche pass-through proof). Zero exposure impact; gaps (hidden subs, fetch failure) never gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)