### PR TITLE
fix(learning): top-bar breadcrumb follows the current video (+ robust fallbacks)

### DIFF
--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -23,6 +23,7 @@ import { LearningShareMenu } from '@/features/learning-share';
 import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import { useRichSummary } from '@/features/video-side-panel/model/useRichSummary';
 import { useHighlightReel, HIGHLIGHT_RELEVANCE_THRESHOLD } from '../model/useHighlightReel';
+import { useMandalaCards } from '../model/useMandalaCards';
 import { FloatingVideoNavigator } from './FloatingVideoNavigator';
 import { PlayerChrome } from './PlayerChrome';
 import {
@@ -71,6 +72,8 @@ function fmtDuration(seconds: number): string {
   return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`;
 }
 
+const YT_ID_RE = /(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\s]+)/;
+
 export function CenterPanel({
   mandalaId,
   videoId,
@@ -106,6 +109,9 @@ export function CenterPanel({
   // [STEP5] floating navigator expand state — breadcrumb/secondary controls
   // yield the top-bar width while the strip is expanded.
   const [navExpanded, setNavExpanded] = useState(false);
+  // Breadcrumb fallback for videos absent from the book (개요 cell / unsummarized).
+  const { cards } = useMandalaCards(mandalaId);
+  const currentCard = cards.find((c) => c.videoUrl.match(YT_ID_RE)?.[1] === videoId);
   const setActiveNoteVideoKey = useLearningStore((s) => s.setActiveNoteVideoKey);
   const noteAutoFollowEnabled = useLearningStore((s) => s.noteAutoFollowEnabled);
   const setNoteAutoFollow = useLearningStore((s) => s.setNoteAutoFollow);
@@ -269,7 +275,9 @@ export function CenterPanel({
   // only changes on book-index clicks (CP445: auto-set once), so navigating to
   // another video left the top-bar chapter stale (user bug report). Player mode
   // derives the chapter containing the playing video; note mode keeps the
-  // reading position (activeSection).
+  // reading position. Videos absent from the book (개요/cell-0 group, or not
+  // yet summarized) fall back to the card's cell index — the breadcrumb must
+  // never just vanish (2nd report: overview videos showed nothing).
   const videoSection = (() => {
     if (!book?.book?.chapters) return null;
     for (const chapter of book.book.chapters) {
@@ -281,8 +289,27 @@ export function CenterPanel({
     }
     return null;
   })();
-  const crumbSection =
-    centerViewMode === 'player' ? (videoSection ?? activeSection) : (activeSection ?? videoSection);
+  const crumb = ((): { label: string; title: string | null } | null => {
+    const fromSection = (s: NonNullable<typeof activeSection>) => ({
+      label: `${t('learning.topicGroup', '주제군')} ${String((s.chapter.ch ?? 0) + 1).padStart(2, '0')}`,
+      title: s.chapter.title,
+    });
+    if (centerViewMode === 'note') {
+      if (activeSection) return fromSection(activeSection);
+      return videoSection ? fromSection(videoSection) : null;
+    }
+    if (videoSection) return fromSection(videoSection);
+    const cell = currentCard?.cellIndex;
+    if (cell === 0) return { label: t('learning.overviewGroup', '개요'), title: null };
+    if (typeof cell === 'number' && cell >= 1) {
+      const chapter = book?.book?.chapters?.find((c) => c.ch === cell - 1);
+      return {
+        label: `${t('learning.topicGroup', '주제군')} ${String(cell).padStart(2, '0')}`,
+        title: chapter?.title ?? null,
+      };
+    }
+    return activeSection ? fromSection(activeSection) : null;
+  })();
 
   const tabs: Array<{
     id: CenterTabId;
@@ -326,14 +353,15 @@ export function CenterPanel({
               onExpandedChange={setNavExpanded}
             />
           )}
-          {!(navExpanded && centerViewMode === 'player') && crumbSection && (
+          {!(navExpanded && centerViewMode === 'player') && crumb && (
             <div className="flex min-w-0 items-center gap-2.5 text-[12.5px] text-[var(--lp-faint)]">
-              <span className="shrink-0 font-semibold text-[var(--lp-accent)]">
-                {t('learning.topicGroup', '주제군')}{' '}
-                {String((crumbSection.chapter.ch ?? 0) + 1).padStart(2, '0')}
-              </span>
-              <span aria-hidden>·</span>
-              <span className="truncate">{crumbSection.chapter.title}</span>
+              <span className="shrink-0 font-semibold text-[var(--lp-accent)]">{crumb.label}</span>
+              {crumb.title && (
+                <>
+                  <span aria-hidden>·</span>
+                  <span className="truncate">{crumb.title}</span>
+                </>
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -24,6 +24,7 @@ import { useMandalaBook } from '@/features/mandala/model/useMandalaBook';
 import { useRichSummary } from '@/features/video-side-panel/model/useRichSummary';
 import { useHighlightReel, HIGHLIGHT_RELEVANCE_THRESHOLD } from '../model/useHighlightReel';
 import { useMandalaCards } from '../model/useMandalaCards';
+import { useMandalaQuery } from '@/features/mandala';
 import { FloatingVideoNavigator } from './FloatingVideoNavigator';
 import { PlayerChrome } from './PlayerChrome';
 import {
@@ -112,6 +113,11 @@ export function CenterPanel({
   // Breadcrumb fallback for videos absent from the book (개요 cell / unsummarized).
   const { cards } = useMandalaCards(mandalaId);
   const currentCard = cards.find((c) => c.videoUrl.match(YT_ID_RE)?.[1] === videoId);
+  // Group titles for the fallback — SAME source as the sidebar TOC's numbered
+  // rows (subjectLabels/subjects), which exist even when the book doesn't.
+  const { mandalaLevels } = useMandalaQuery(mandalaId);
+  const crumbSubjects = mandalaLevels?.root?.subjects ?? [];
+  const crumbSubjectLabels = mandalaLevels?.root?.subjectLabels ?? [];
   const setActiveNoteVideoKey = useLearningStore((s) => s.setActiveNoteVideoKey);
   const noteAutoFollowEnabled = useLearningStore((s) => s.noteAutoFollowEnabled);
   const setNoteAutoFollow = useLearningStore((s) => s.setNoteAutoFollow);
@@ -302,10 +308,14 @@ export function CenterPanel({
     const cell = currentCard?.cellIndex;
     if (cell === 0) return { label: t('learning.overviewGroup', '개요'), title: null };
     if (typeof cell === 'number' && cell >= 1) {
-      const chapter = book?.book?.chapters?.find((c) => c.ch === cell - 1);
+      const groupTitle =
+        crumbSubjectLabels[cell - 1]?.trim() ||
+        crumbSubjects[cell - 1] ||
+        book?.book?.chapters?.find((c) => c.ch === cell - 1)?.title ||
+        null;
       return {
         label: `${t('learning.topicGroup', '주제군')} ${String(cell).padStart(2, '0')}`,
-        title: chapter?.title ?? null,
+        title: groupTitle,
       };
     }
     return activeSection ? fromSection(activeSection) : null;

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -265,6 +265,25 @@ export function CenterPanel({
     return { chapter, section: sec };
   })();
 
+  // [STEP1 fix 2026-07-03] breadcrumb follows the CURRENT VIDEO. activeSectionRef
+  // only changes on book-index clicks (CP445: auto-set once), so navigating to
+  // another video left the top-bar chapter stale (user bug report). Player mode
+  // derives the chapter containing the playing video; note mode keeps the
+  // reading position (activeSection).
+  const videoSection = (() => {
+    if (!book?.book?.chapters) return null;
+    for (const chapter of book.book.chapters) {
+      for (const sec of chapter.sections ?? []) {
+        if ((sec.atoms ?? []).some((a) => a.vid === videoId)) {
+          return { chapter, section: sec };
+        }
+      }
+    }
+    return null;
+  })();
+  const crumbSection =
+    centerViewMode === 'player' ? (videoSection ?? activeSection) : (activeSection ?? videoSection);
+
   const tabs: Array<{
     id: CenterTabId;
     labelKey: string;
@@ -307,14 +326,14 @@ export function CenterPanel({
               onExpandedChange={setNavExpanded}
             />
           )}
-          {!(navExpanded && centerViewMode === 'player') && activeSection && (
+          {!(navExpanded && centerViewMode === 'player') && crumbSection && (
             <div className="flex min-w-0 items-center gap-2.5 text-[12.5px] text-[var(--lp-faint)]">
               <span className="shrink-0 font-semibold text-[var(--lp-accent)]">
                 {t('learning.topicGroup', '주제군')}{' '}
-                {String((activeSection.chapter.ch ?? 0) + 1).padStart(2, '0')}
+                {String((crumbSection.chapter.ch ?? 0) + 1).padStart(2, '0')}
               </span>
               <span aria-hidden>·</span>
-              <span className="truncate">{activeSection.chapter.title}</span>
+              <span className="truncate">{crumbSection.chapter.title}</span>
             </div>
           )}
         </div>

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1920,7 +1920,8 @@
     "relevanceHigh": "High",
     "playingNow": "Playing",
     "nowWatchingVideo": "Now watching",
-    "nowReadingSection": "Now reading"
+    "nowReadingSection": "Now reading",
+    "overviewGroup": "Overview"
   },
   "addCards": {
     "triggerChip": "+ Add Cards",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1928,7 +1928,8 @@
     "relevanceHigh": "높음",
     "playingNow": "재생 중",
     "nowWatchingVideo": "지금 보는 영상",
-    "nowReadingSection": "지금 읽는 구간"
+    "nowReadingSection": "지금 읽는 구간",
+    "overviewGroup": "개요"
   },
   "addCards": {
     "triggerChip": "+ 카드 추가",


### PR DESCRIPTION
## Bug
Top-bar breadcrumb stayed frozen on the last book-index click (activeSectionRef auto-sets once per CP445) — navigating videos left '주제군 03 · …' stale; overview-cell videos showed nothing; some mandalas showed the number without a title.

## Fix (3 reports, one chain)
1. Player mode derives the chapter containing the CURRENT video from book atoms (same match the sidebar uses); note mode keeps the reading position.
2. Videos absent from the book (개요 cell-0 / unsummarized) fall back to the card's cell index — cell 0 → '개요', cell n → '주제군 0n'.
3. Fallback group title comes from mandala subjectLabels/subjects — the SAME source as the sidebar TOC (book chapters are absent/keyed differently on some mandalas).

activeSectionRef semantics untouched (섹션내용 탭·노트 스크롤 동기화 무영향).

## Verification
tsc 0 new (32 baseline) · vitest 491/491 · James verified 3 cases on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)