### PR TITLE
feat(observability): log language-dropped item detail (L2 canary blocker)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -397,6 +397,7 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
                   response: {
                     would_gc_dropped: g.gcDropped,
                     would_lang_dropped: g.langDropped,
+                    lang_dropped_items: g.langDroppedItems,
                     would_demoted: g.demoted,
                     cache_hits: g.cacheHits,
                     scored: g.scored,

--- a/src/modules/inflow-gate/live-search-gate.ts
+++ b/src/modules/inflow-gate/live-search-gate.ts
@@ -64,6 +64,8 @@ export interface LiveGateResult<T> {
   wouldDropSub1000: number;
   gcDropped: number;
   langDropped: number;
+  /** L2 canary blocker — per-item audio labels of the language-dropped candidates. */
+  langDroppedItems: Array<{ videoId: string; audioLang: string | null; target: 'ko' | 'en' }>;
   cacheHits: number;
   scored: number;
   demoted: number;
@@ -100,9 +102,22 @@ export async function gateLiveSearchCards<T extends LiveGateCandidate>(
 
   // 1. Audio-language gate — free, applies to every candidate.
   let langDropped = 0;
+  const langDroppedItems: Array<{
+    videoId: string;
+    audioLang: string | null;
+    target: 'ko' | 'en';
+  }> = [];
   const langOk = candidates.filter((c) => {
     if (audioLanguageMismatch(c.audioLanguage, ctx.language)) {
       langDropped += 1;
+      // L2 canary blocker (2026-07-03): log the dropped item's audio label so
+      // "correctly dropped (真 off-lang)" vs "false positive (legit en mislabeled)"
+      // can be eyeballed before the lang axis is armed. count alone is not enough.
+      langDroppedItems.push({
+        videoId: c.videoId,
+        audioLang: c.audioLanguage,
+        target: ctx.language,
+      });
       return false;
     }
     return true;
@@ -246,6 +261,7 @@ export async function gateLiveSearchCards<T extends LiveGateCandidate>(
     wouldDropSub1000,
     gcDropped,
     langDropped,
+    langDroppedItems,
     cacheHits,
     scored,
     demoted: demotedScored.length + tail.length,

--- a/tests/smoke/live-search-gate.test.ts
+++ b/tests/smoke/live-search-gate.test.ts
@@ -97,10 +97,12 @@ describe('gateLiveSearchCards', () => {
     expect(r.gcDropped).toBe(1);
   });
 
-  test('audio mismatch hides before scoring', async () => {
+  test('audio mismatch hides before scoring + logs the dropped item detail', async () => {
     mockCompute.mockResolvedValue({ ok: true, relevancePct: 99 });
     const r = await gateLiveSearchCards([card('a', 'ar'), card('b', 'ko')], CTX);
     expect(r.langDropped).toBe(1);
     expect(r.exposed.map((c) => c.videoId)).toEqual(['b']);
+    // L2 canary blocker — dropped-item audio label logged for false-positive eyeball
+    expect(r.langDroppedItems).toEqual([{ videoId: 'a', audioLang: 'ar', target: 'ko' }]);
   });
 });


### PR DESCRIPTION
L2 판정: the lang axis is a **canary blocker** until we can verify the audio-language gate drops correctly vs false-positives (legit en mislabeled) — the shadow trace recorded only a count. This is the direct follow-up to the Arabic-audio-on-Latin-title problem. Adds `langDroppedItems` (videoId + audioLang + target) to `live_gate.shadow`, so the next naturally-occurring drops can be eyeballed for false-positive rate before the lang axis is armed. Measure-only; zero gate behavior change. Smoke 6/6, tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)