### PR TITLE
feat(quality): T2 — ON전략 A gc rank-demote mode (flag OFF, no serving change)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -384,6 +384,46 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           if (liveGateCfg.mode === 'on' && v5Filtered.length > 0) {
             liveGate = await gateLiveSearchCards(v5Filtered, liveGateCtx);
             v5Exposed = liveGate.exposed;
+          } else if (liveGateCfg.mode === 'rank' && v5Filtered.length > 0) {
+            // ON전략 A: order by CACHED gc (no blocking, nothing hidden), then
+            // fire the shadow scoring async to populate the cache for the next
+            // round. First search = pick order (+0ms); re-search = gc-ordered.
+            const { orderByCachedGc } = await import('@/modules/inflow-gate/live-search-gate');
+            const ranked = await orderByCachedGc(v5Filtered, mandalaId).catch(() => null);
+            if (ranked) v5Exposed = ranked.ordered;
+            const defByVideoId = new Map(v5Filtered.map((c) => [c.videoId, c.definition]));
+            void gateLiveSearchCards(v5Filtered, liveGateCtx)
+              .then((g) => {
+                recordTrace({
+                  step: 'live_gate.shadow',
+                  status: 'ok',
+                  response: {
+                    mode: 'rank',
+                    would_gc_dropped: g.gcDropped,
+                    would_lang_dropped: g.langDropped,
+                    lang_dropped_items: g.langDroppedItems,
+                    would_demoted: g.demoted,
+                    cache_hits: g.cacheHits,
+                    scored: g.scored,
+                    latency_ms: g.latencyMs,
+                    would_drop_subscriber_100: g.wouldDropSub100,
+                    would_drop_subscriber_1000: g.wouldDropSub1000,
+                    gc_scores: Array.from(g.gcByVideoId.entries())
+                      .filter(([, v]) => v != null)
+                      .map(([id, v]) => ({
+                        id,
+                        gc: v,
+                        subs: g.subsByVideoId.get(id) ?? null,
+                        hd: defByVideoId.get(id) ?? null,
+                      })),
+                  },
+                });
+              })
+              .catch((err) => {
+                log.warn(
+                  `live_gate rank-shadow failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+                );
+              });
           } else if (liveGateCfg.mode === 'shadow' && v5Filtered.length > 0) {
             // D-04-보정 shadow: score async off the response path — trace-only
             // would_* counters, ZERO exposure impact, zero added latency. The

--- a/src/config/live-search-gate.ts
+++ b/src/config/live-search-gate.ts
@@ -37,7 +37,7 @@ export const liveSearchGateEnvSchema = z.object({
   LIVE_SEARCH_GC_MIN: z.coerce.number().int().min(0).max(100).default(60),
 });
 
-export type LiveSearchGateMode = 'off' | 'shadow' | 'on';
+export type LiveSearchGateMode = 'off' | 'shadow' | 'rank' | 'on';
 
 export interface LiveSearchGateConfig {
   mode: LiveSearchGateMode;

--- a/src/modules/inflow-gate/live-search-gate.ts
+++ b/src/modules/inflow-gate/live-search-gate.ts
@@ -87,6 +87,39 @@ export function audioLanguageMismatch(audioLanguage: string | null, target: 'ko'
 }
 
 /**
+ * ON전략 A (rank-demote, 2026-07-03) — order candidates by CACHED gc without
+ * scoring or hiding. First search of a mandala has no cache → pick order
+ * preserved (supply-first, +0ms). Re-search benefits from the cache the async
+ * shadow scoring populated. Nothing is hidden; below-min items sink, they do
+ * not disappear (floor-incident lesson: empty screen worse than low relevance).
+ * No-flicker by construction: each round is one response ordered at request
+ * time; the async scoring of THIS round only improves the NEXT round.
+ */
+export async function orderByCachedGc<T extends LiveGateCandidate>(
+  candidates: T[],
+  mandalaId: string
+): Promise<{ ordered: T[]; cacheOrderedCount: number }> {
+  if (candidates.length === 0) return { ordered: candidates, cacheOrderedCount: 0 };
+  const prisma = getPrismaClient();
+  const rows = await prisma.video_mandala_relevance
+    .findMany({
+      where: { mandala_id: mandalaId, video_id: { in: candidates.map((c) => c.videoId) } },
+      select: { video_id: true, relevance_pct: true },
+    })
+    .catch(() => [] as Array<{ video_id: string; relevance_pct: number }>);
+  const gcById = new Map(rows.map((r) => [r.video_id, r.relevance_pct]));
+  // Stable sort: cached-gc desc first, uncached keep original pick order (after).
+  const withIdx = candidates.map((c, i) => ({ c, i, gc: gcById.get(c.videoId) ?? null }));
+  withIdx.sort((a, b) => {
+    if (a.gc == null && b.gc == null) return a.i - b.i; // both uncached: pick order
+    if (a.gc == null) return 1; // uncached sinks below cached
+    if (b.gc == null) return -1;
+    return b.gc - a.gc; // both cached: gc desc
+  });
+  return { ordered: withIdx.map((x) => x.c), cacheOrderedCount: gcById.size };
+}
+
+/**
  * Gate the exposed slice: language check on ALL candidates (free), then gc
  * scoring on the top-N slice only (cache-first, one bounded Haiku wave).
  * Never throws; a total scorer outage demotes everything instead of hiding.

--- a/tests/smoke/live-search-gate.test.ts
+++ b/tests/smoke/live-search-gate.test.ts
@@ -106,3 +106,39 @@ describe('gateLiveSearchCards', () => {
     expect(r.langDroppedItems).toEqual([{ videoId: 'a', audioLang: 'ar', target: 'ko' }]);
   });
 });
+
+describe('orderByCachedGc (ON전략 A rank-demote)', () => {
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
+
+  test('orders by cached gc desc; uncached keep pick order below cached (no-flicker)', async () => {
+    const { orderByCachedGc } = await import('../../src/modules/inflow-gate/live-search-gate');
+    mockFindMany.mockResolvedValue([
+      { video_id: 'b', relevance_pct: 90 },
+      { video_id: 'a', relevance_pct: 50 },
+    ]);
+    const items = [card('a'), card('b'), card('c'), card('d')]; // c,d uncached
+    const r = await orderByCachedGc(items, '00000000-0000-0000-0000-000000000000');
+    // cached first (b90, a50) then uncached in original pick order (c, d)
+    expect(r.ordered.map((x) => x.videoId)).toEqual(['b', 'a', 'c', 'd']);
+    expect(r.cacheOrderedCount).toBe(2);
+  });
+
+  test('no cache = pick order preserved (first search supply-first, +0ms)', async () => {
+    const { orderByCachedGc } = await import('../../src/modules/inflow-gate/live-search-gate');
+    mockFindMany.mockResolvedValue([]);
+    const items = [card('a'), card('b'), card('c')];
+    const r = await orderByCachedGc(items, '00000000-0000-0000-0000-000000000000');
+    expect(r.ordered.map((x) => x.videoId)).toEqual(['a', 'b', 'c']);
+    expect(r.cacheOrderedCount).toBe(0);
+  });
+
+  test('cache read failure falls back to pick order (nothing hidden — floor lesson)', async () => {
+    const { orderByCachedGc } = await import('../../src/modules/inflow-gate/live-search-gate');
+    mockFindMany.mockRejectedValue(new Error('db down'));
+    const items = [card('a'), card('b')];
+    const r = await orderByCachedGc(items, '00000000-0000-0000-0000-000000000000');
+    expect(r.ordered.map((x) => x.videoId)).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
**ON전략 A** (supervisor-confirmed): the blocking gc gate was rejected (p95 5.5s = churn). gc becomes a RANKING signal — below-min items sink, never hidden (floor lesson). `LIVE_SEARCH_GC_GATE` gains `rank`: order by CACHED gc (+0ms, no scoring), first-search = pick order (supply-first), re-search = gc-ordered. No-flicker by construction (each round ordered once at request; async scoring only improves the next round). Cache failure → pick-order fallback (nothing hidden). Flag stays **OFF** — zero serving change until James GO (flag→rank on 2 canary mandalas). Smoke 9/9 (order/no-cache/fallback), tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)