### PR TITLE
fix(search): fail-open non-linguistic audio codes (zxx/und/mul/mis) — lang gate T1 false-positive

### DIFF
--- a/src/modules/inflow-gate/live-search-gate.ts
+++ b/src/modules/inflow-gate/live-search-gate.ts
@@ -73,14 +73,26 @@ export interface LiveGateResult<T> {
 }
 
 /**
- * Audio-language mismatch: null passes (fail-open); primary subtag must be
- * the target language or English (en content is globally acceptable per the
- * CP492 off-language gate contract: ko ∪ en survives on ko mandalas).
+ * ISO 639 codes that denote NO determinate spoken language — not a language
+ * mismatch. YouTube frequently mis-tags Korean/English speech as `zxx` (T1
+ * 2026-07-03: 3/3 dropped ETF videos were Korean but tagged zxx). Treating
+ * these as a mismatch drops legit content, so they fail-open like null:
+ *   zxx = no linguistic content, und = undetermined, mul = multiple,
+ *   mis = uncoded. (Determinate mismatches like `ar` / `ja` still drop.)
+ */
+const NON_LINGUISTIC_AUDIO = new Set(['zxx', 'und', 'mul', 'mis']);
+
+/**
+ * Audio-language mismatch: null / non-linguistic codes pass (fail-open);
+ * a determinate primary subtag must be the target language or English (en
+ * content is globally acceptable per the CP492 off-language gate contract:
+ * ko ∪ en survives on ko mandalas).
  */
 export function audioLanguageMismatch(audioLanguage: string | null, target: 'ko' | 'en'): boolean {
   if (!audioLanguage) return false;
   const primary = audioLanguage.trim().toLowerCase().split(/[-_]/)[0];
   if (!primary) return false;
+  if (NON_LINGUISTIC_AUDIO.has(primary)) return false;
   if (primary === 'en') return false;
   if (target === 'ko' && primary === 'ko') return false;
   return true;

--- a/tests/smoke/live-search-gate.test.ts
+++ b/tests/smoke/live-search-gate.test.ts
@@ -52,6 +52,19 @@ describe('audioLanguageMismatch', () => {
     expect(audioLanguageMismatch('ko-KR', 'en')).toBe(true);
     expect(audioLanguageMismatch('th', 'ko')).toBe(true);
   });
+  test('non-linguistic ISO 639 codes fail-open — zxx/und/mul/mis are not a language mismatch (T1 2026-07-03)', () => {
+    // YouTube mis-tags Korean ETF videos as zxx; must not drop them.
+    expect(audioLanguageMismatch('zxx', 'ko')).toBe(false);
+    expect(audioLanguageMismatch('zxx', 'en')).toBe(false);
+    expect(audioLanguageMismatch('und', 'ko')).toBe(false);
+    expect(audioLanguageMismatch('mul', 'ko')).toBe(false);
+    expect(audioLanguageMismatch('mis', 'en')).toBe(false);
+  });
+  test('regression: zxx pass does NOT open determinate mismatches — ar still drops', () => {
+    expect(audioLanguageMismatch('ar', 'ko')).toBe(true);
+    expect(audioLanguageMismatch('ja', 'ko')).toBe(true);
+    expect(audioLanguageMismatch('ja', 'en')).toBe(true);
+  });
 });
 
 describe('gateLiveSearchCards', () => {


### PR DESCRIPTION
**T1 language-axis verification (James search → read-only shadow trace).** The audio-language gate dropped **3/3 legit Korean ETF videos** (mandala 'ETF 투자로 노후 자산 만들기') because YouTube mis-tagged them `defaultAudioLanguage='zxx'` (ISO 639 'no linguistic content'). The gate fail-opens `null` but treated `zxx` as 'not ko/en' → drop → killed legit Korean content.

`zxx/und/mul/mis` are **not** a language mismatch (no-content / undetermined / multiple / uncoded). audioLanguage is an unreliable signal — per the CP509 dominant principle, hard-cutting a single unreliable signal kills legit niche.

**Fix**: `NON_LINGUISTIC_AUDIO` set fails open like null; determinate mismatches (`ar`/`ja` on ko/en mandala) still drop. Robust beyond zxx-only (supervisor condition 2) to preempt the same drop recurring under `und`/`mul`.

**Tests** (4 pass): zxx/und/mul/mis fail-open + regression that ar/ja still drop.
**Verify** = live re-logging after deploy (James re-search → langDropped shows 0 special-code drops, only true mismatches). No LLM call. Merge = James gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)