### PR TITLE
fix(chatbot): probe-gate CopilotKit mount to retry the intermittent runtime-info 400 (BL-10)

### DIFF
--- a/frontend/src/__tests__/smoke/chat-runtime-probe.test.ts
+++ b/frontend/src/__tests__/smoke/chat-runtime-probe.test.ts
@@ -1,0 +1,60 @@
+// BL-10 (2026-07-03) — the CopilotKit runtime-info probe gates the chat mount
+// so the intermittent yoga 400 ("empty payload" race) self-heals instead of
+// hanging. These cover the three states: immediate ready, recover-after-retry,
+// and exhausted → failed.
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { useChatRuntimeProbe } from '@/pages/learning/ui/ChatAssistant';
+
+const HEADERS = { Authorization: 'Bearer test-token' };
+
+describe('useChatRuntimeProbe (BL-10 runtime-info retry gate)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test('200 on first probe → ready (no hang, no retry needed)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useChatRuntimeProbe(HEADERS));
+    await waitFor(() => expect(result.current.state).toBe('ready'));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/chat/info',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  test('400 then 200 → recovers to ready (the intermittent race self-heals)', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useChatRuntimeProbe(HEADERS));
+    // let the first (failed) attempt resolve, then advance past the backoff.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(result.current.state).toBe('ready');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('persistent failure → failed after max attempts (manual retry offered)', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useChatRuntimeProbe(HEADERS));
+    // 5 attempts with 400/800/1600/3200ms backoffs — advance well past total.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(result.current.state).toBe('failed');
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+});

--- a/frontend/src/pages/learning/ui/ChatAssistant.tsx
+++ b/frontend/src/pages/learning/ui/ChatAssistant.tsx
@@ -2,7 +2,7 @@
 // direct use by tests; React-refresh's only-export-components rule flags
 // non-component exports in a component file, so we disable it here.
 /* eslint-disable react-refresh/only-export-components */
-import { useMemo, useEffect, useRef, useCallback } from 'react';
+import { useMemo, useEffect, useRef, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CopilotKit, useCopilotReadable, useCopilotChat } from '@copilotkit/react-core';
 import { CopilotChat } from '@copilotkit/react-ui';
@@ -524,7 +524,70 @@ function ChatPanel({
   );
 }
 
+// BL-10 (2026-07-03) — the CopilotKit runtime endpoint is served by a raw
+// graphql-yoga handler whose `req.pause()→await→resume()` window can lose the
+// body and reply 400 ("empty payload"), intermittently (~2/10h) even on a warm
+// server — not just cold-start. CopilotKit's own runtime-info fetch does NOT
+// retry, so a single 400 hangs the chat until a manual refresh. This probe
+// gates the CopilotKit mount: it retries GET /api/v1/chat/info with backoff
+// until it 200s, so CopilotKit only mounts against a working endpoint and the
+// rare race self-heals with no visible hang.
+const RUNTIME_INFO_URL = '/api/v1/chat/info';
+const RUNTIME_PROBE_MAX_ATTEMPTS = 5;
+const RUNTIME_PROBE_BASE_DELAY_MS = 400;
+
+type RuntimeProbeState = 'probing' | 'ready' | 'failed';
+
+export function useChatRuntimeProbe(headers: Record<string, string>): {
+  state: RuntimeProbeState;
+  attemptKey: number;
+  retry: () => void;
+} {
+  const [state, setState] = useState<RuntimeProbeState>('probing');
+  // Bumped on manual retry AND used as CopilotKit's remount key so a recovered
+  // probe re-initialises the provider cleanly.
+  const [attemptKey, setAttemptKey] = useState(0);
+  const authHeader = headers.Authorization ?? '';
+
+  useEffect(() => {
+    let cancelled = false;
+    setState('probing');
+    const probe = async () => {
+      for (let attempt = 0; attempt < RUNTIME_PROBE_MAX_ATTEMPTS; attempt++) {
+        if (cancelled) return;
+        try {
+          const res = await fetch(RUNTIME_INFO_URL, {
+            method: 'GET',
+            headers: authHeader ? { Authorization: authHeader } : undefined,
+          });
+          if (res.ok) {
+            if (!cancelled) setState('ready');
+            return;
+          }
+        } catch {
+          // network hiccup — treated the same as a non-ok response, retried.
+        }
+        // Exponential backoff before the NEXT attempt (400/800/1600/3200ms);
+        // no wait after the last attempt — we fail immediately once exhausted.
+        if (attempt < RUNTIME_PROBE_MAX_ATTEMPTS - 1) {
+          const delay = RUNTIME_PROBE_BASE_DELAY_MS * 2 ** attempt;
+          await new Promise((r) => setTimeout(r, delay));
+        }
+      }
+      if (!cancelled) setState('failed');
+    };
+    void probe();
+    return () => {
+      cancelled = true;
+    };
+  }, [authHeader, attemptKey]);
+
+  const retry = useCallback(() => setAttemptKey((k) => k + 1), []);
+  return { state, attemptKey, retry };
+}
+
 export function ChatAssistant({ mandalaId, videoId, onSeek }: ChatAssistantProps) {
+  const { t } = useTranslation();
   // CP475+6 — Bug 2 fix: chat history preserved across tab switches (chatbot ↔
   // notes) within the same videoId.
   //
@@ -540,9 +603,32 @@ export function ChatAssistant({ mandalaId, videoId, onSeek }: ChatAssistantProps
   // and the runtime rebuilds — but for ordinary tab navigation it stays put.
   const token = apiClient.getAccessToken();
   const headers = useMemo(() => (token ? { Authorization: `Bearer ${token}` } : {}), [token]);
+  const { state: probeState, attemptKey, retry } = useChatRuntimeProbe(headers);
+
+  if (probeState !== 'ready') {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-muted-foreground">
+        {probeState === 'probing' ? (
+          <span>{t('chat.connecting', '챗봇 연결 중…')}</span>
+        ) : (
+          <>
+            <span>{t('chat.connectFailed', '챗봇 연결에 실패했습니다.')}</span>
+            <button
+              type="button"
+              onClick={retry}
+              className="rounded-md border border-border px-3 py-1.5 text-foreground hover:bg-accent"
+            >
+              {t('chat.retry', '다시 시도')}
+            </button>
+          </>
+        )}
+      </div>
+    );
+  }
 
   return (
     <CopilotKit
+      key={attemptKey}
       runtimeUrl="/api/v1/chat"
       showDevConsole={false}
       enableInspector={false}


### PR DESCRIPTION
**BL-10 real fix — warm-up (#1095) was NOT enough.** Prod re-check (James, 20:03:29) shows GET /api/v1/chat/info still 400 on a **WARM** container (RestartCount=0, warm-up log present). BE log: CopilotKit Runtime WARN 'Request stream consumed with no available body; sending empty payload' — the raw graphql-yoga handler's `req.pause()→await→resume()` window loses the body and 400s **intermittently (~2/10h)**, not only at cold-start. CopilotKit's runtime-info fetch does not retry → a single 400 hangs the chat until manual refresh.

_(Honest correction: the earlier '0 chat/info 400' PASS was wrong — yoga runs on the raw `server.on('request')` handler and bypasses Fastify's res logger, so those 400s were invisible in the checked log source.)_

**Fix (α — FE client resilience):** `useChatRuntimeProbe` gates the CopilotKit mount. It retries GET /api/v1/chat/info with exponential backoff (400/800/1600/3200ms, 5 attempts) until 200, then mounts CopilotKit against a working endpoint (keyed for clean re-init). The rare race self-heals with a 'connecting' placeholder instead of a silent hang; persistent failure shows a manual retry button.

**Tests** (3): 200→ready, 400-then-200→recovers, persistent→failed. /verify PASS (tsc 0, vitest 494/494, build, route smoke).

**⚠️ Done gate = PROD multi-reproduction (browser), NOT logs**: post-deploy, 10+ chatbot entries on jkim0420 with hang=0 AND ≥1 captured '400→auto-recover' network sequence. β (BE root race) is a separate track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)