### PR TITLE
feat(search): empty-title fail-closed guard for BL-17 (flags default OFF)

### DIFF
--- a/src/modules/search/algorithm-resolver.ts
+++ b/src/modules/search/algorithm-resolver.ts
@@ -139,6 +139,7 @@ function materialize(id: string, parametersJson: unknown): ResolvedAlgorithm {
     V3_ENABLE_ZERO_HIT_RETRY: asStr(j['enableZeroHitRetry']),
     V3_ENABLE_USER_CURATED_INGEST: asStr(j['enableUserCuratedIngest']),
     V3_EMPTY_TITLE_GATE_SHADOW: asStr(j['emptyTitleGateShadow']),
+    V3_EMPTY_TITLE_GATE: asStr(j['emptyTitleGate']),
   };
 
   const parsed = v3EnvSchema.safeParse(envLike);
@@ -174,6 +175,7 @@ function materialize(id: string, parametersJson: unknown): ResolvedAlgorithm {
     enableZeroHitRetry: d['V3_ENABLE_ZERO_HIT_RETRY'] as boolean,
     enableUserCuratedIngest: d['V3_ENABLE_USER_CURATED_INGEST'] as boolean,
     emptyTitleGateShadow: d['V3_EMPTY_TITLE_GATE_SHADOW'] as boolean,
+    emptyTitleGate: d['V3_EMPTY_TITLE_GATE'] as boolean,
   };
 
   return { id, parameters: cfg };

--- a/src/modules/search/algorithm-resolver.ts
+++ b/src/modules/search/algorithm-resolver.ts
@@ -138,6 +138,7 @@ function materialize(id: string, parametersJson: unknown): ResolvedAlgorithm {
     V3_ENABLE_SIGNAL_EXCLUDE: asStr(j['enableSignalExclude']),
     V3_ENABLE_ZERO_HIT_RETRY: asStr(j['enableZeroHitRetry']),
     V3_ENABLE_USER_CURATED_INGEST: asStr(j['enableUserCuratedIngest']),
+    V3_EMPTY_TITLE_GATE_SHADOW: asStr(j['emptyTitleGateShadow']),
   };
 
   const parsed = v3EnvSchema.safeParse(envLike);
@@ -172,6 +173,7 @@ function materialize(id: string, parametersJson: unknown): ResolvedAlgorithm {
     enableSignalExclude: d['V3_ENABLE_SIGNAL_EXCLUDE'] as boolean,
     enableZeroHitRetry: d['V3_ENABLE_ZERO_HIT_RETRY'] as boolean,
     enableUserCuratedIngest: d['V3_ENABLE_USER_CURATED_INGEST'] as boolean,
+    emptyTitleGateShadow: d['V3_EMPTY_TITLE_GATE_SHADOW'] as boolean,
   };
 
   return { id, parameters: cfg };

--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -43,6 +43,7 @@ describe('loadV3Config', () => {
       enableSignalExclude: true,
       enableZeroHitRetry: true,
       enableUserCuratedIngest: true,
+      emptyTitleGateShadow: false, // R4 shadow guard default (2026-07-04, BL-17)
     });
   });
 
@@ -121,6 +122,7 @@ describe('loadV3Config', () => {
       enableSignalExclude: true,
       enableZeroHitRetry: true,
       enableUserCuratedIngest: true,
+      emptyTitleGateShadow: false, // R4 shadow guard default (2026-07-04, BL-17)
     });
   });
 
@@ -272,5 +274,18 @@ describe('loadV3Config', () => {
     expect(loadV3Config({ V3_TIER2_OVERFETCH: 'false' }).tier2Overfetch).toBe(false);
     // Empty string → booleanFlag treats as false (matches other flags' contract)
     expect(loadV3Config({ V3_TIER2_OVERFETCH: '' }).tier2Overfetch).toBe(false);
+  });
+
+  test('V3_EMPTY_TITLE_GATE_SHADOW defaults false (unset = no-op); explicit true opts in (R4, BL-17)', () => {
+    // Default: shadow guard OFF — mandala-filter.ts never classifies.
+    expect(loadV3Config({}).emptyTitleGateShadow).toBe(false);
+    // Explicit opt-in.
+    expect(loadV3Config({ V3_EMPTY_TITLE_GATE_SHADOW: 'true' }).emptyTitleGateShadow).toBe(true);
+    expect(loadV3Config({ V3_EMPTY_TITLE_GATE_SHADOW: '  TRUE  ' }).emptyTitleGateShadow).toBe(
+      true
+    );
+    // Explicit false / empty / unset all collapse to default false.
+    expect(loadV3Config({ V3_EMPTY_TITLE_GATE_SHADOW: 'false' }).emptyTitleGateShadow).toBe(false);
+    expect(loadV3Config({ V3_EMPTY_TITLE_GATE_SHADOW: '' }).emptyTitleGateShadow).toBe(false);
   });
 });

--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -44,6 +44,7 @@ describe('loadV3Config', () => {
       enableZeroHitRetry: true,
       enableUserCuratedIngest: true,
       emptyTitleGateShadow: false, // R4 shadow guard default (2026-07-04, BL-17)
+      emptyTitleGate: false, // R4 enforce default (2026-07-04, BL-17)
     });
   });
 
@@ -123,6 +124,7 @@ describe('loadV3Config', () => {
       enableZeroHitRetry: true,
       enableUserCuratedIngest: true,
       emptyTitleGateShadow: false, // R4 shadow guard default (2026-07-04, BL-17)
+      emptyTitleGate: false, // R4 enforce default (2026-07-04, BL-17)
     });
   });
 
@@ -287,5 +289,25 @@ describe('loadV3Config', () => {
     // Explicit false / empty / unset all collapse to default false.
     expect(loadV3Config({ V3_EMPTY_TITLE_GATE_SHADOW: 'false' }).emptyTitleGateShadow).toBe(false);
     expect(loadV3Config({ V3_EMPTY_TITLE_GATE_SHADOW: '' }).emptyTitleGateShadow).toBe(false);
+  });
+
+  test('V3_EMPTY_TITLE_GATE (enforce) defaults false (unset = no-op); explicit true opts in (R4, BL-17)', () => {
+    // Default: enforce OFF — mandala-filter.ts never actually drops.
+    expect(loadV3Config({}).emptyTitleGate).toBe(false);
+    // Explicit opt-in.
+    expect(loadV3Config({ V3_EMPTY_TITLE_GATE: 'true' }).emptyTitleGate).toBe(true);
+    expect(loadV3Config({ V3_EMPTY_TITLE_GATE: '  TRUE  ' }).emptyTitleGate).toBe(true);
+    // Explicit false / empty / unset all collapse to default false.
+    expect(loadV3Config({ V3_EMPTY_TITLE_GATE: 'false' }).emptyTitleGate).toBe(false);
+    expect(loadV3Config({ V3_EMPTY_TITLE_GATE: '' }).emptyTitleGate).toBe(false);
+    // Independent from the shadow flag — enabling one does not flip the other.
+    expect(
+      loadV3Config({ V3_EMPTY_TITLE_GATE: 'true', V3_EMPTY_TITLE_GATE_SHADOW: 'false' })
+        .emptyTitleGate
+    ).toBe(true);
+    expect(
+      loadV3Config({ V3_EMPTY_TITLE_GATE: 'true', V3_EMPTY_TITLE_GATE_SHADOW: 'false' })
+        .emptyTitleGateShadow
+    ).toBe(false);
   });
 });

--- a/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
@@ -912,3 +912,134 @@ describe('applyMandalaFilterWithStats — empty-title shadow guard (R4, enforce=
     expect(on.stats.wouldRejectEmptyTitle).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// R4 empty-title ENFORCE (2026-07-04, BL-17) — real reject, code-path-only.
+// V3_EMPTY_TITLE_GATE stays OFF in prod until a separate flip decision; this
+// suite proves the drop path is correct while the flag defaults false.
+// ---------------------------------------------------------------------------
+
+describe('applyMandalaFilterWithStats — empty-title ENFORCE gate (R4, code-path only)', () => {
+  const input = {
+    centerGoal: '1달 일일 루틴으로 전문가되기',
+    subGoals: [
+      '전문 분야 선정 및 학습 계획 수립',
+      '매일 집중 학습 시간 확보 및 루틴화',
+      '실무 프로젝트 진행 및 포트폴리오 구축',
+      '전문 커뮤니티 참여 및 네트워킹',
+      '월간 집중 전문화',
+      '지식 체계화 및 아웃풋 생산',
+      '피드백 수집 및 개선 사이클',
+      '일일 진도 추적 및 동기 유지',
+    ],
+    language: 'ko' as const,
+    centerGateMode: 'semantic' as const,
+    centerEmbedding: [1, 0.2, 0, 0, 0, 0, 0, 0],
+    subGoalEmbeddings: [
+      [1, 0.2, 0, 0, 0, 0, 0, 0],
+      [0, 0, 1, 0, 0, 0, 0, 0],
+      [0, 0, 0, 1, 0, 0, 0, 0],
+      [0, 0, 0, 0, 1, 0, 0, 0],
+      [0, 0, 0, 0, 0, 1, 0, 0],
+      [0, 0, 0, 0, 0, 0, 1, 0],
+      [0, 0, 0, 0, 0, 0, 0, 1],
+      [0, 0, 1, 1, 0, 0, 0, 0],
+    ],
+  };
+  const staleVec = [0.95, 0.25, 0, 0, 0, 0, 0, 0];
+  const blankTitleCandidate = cand('zombie1', '', 'stale description', null);
+  const whitespaceTitleCandidate = cand('zombie2', '   ', '', null);
+  const normalCandidate = cand('p1', '하루 습관 형성하는 법', '', null);
+  const embeddings = new Map([
+    ['zombie1', staleVec],
+    ['zombie2', staleVec],
+    ['p1', staleVec],
+  ]);
+
+  test('both flags OFF (default) — byte-identical to pre-R4 baseline', () => {
+    const withoutFlags = applyMandalaFilterWithStats(
+      [blankTitleCandidate, whitespaceTitleCandidate, normalCandidate],
+      { ...input, candidateEmbeddings: embeddings }
+    );
+    const withExplicitFalse = applyMandalaFilterWithStats(
+      [blankTitleCandidate, whitespaceTitleCandidate, normalCandidate],
+      {
+        ...input,
+        candidateEmbeddings: embeddings,
+        emptyTitleGateShadow: false,
+        emptyTitleGate: false,
+      }
+    );
+    const flatten = (m: ReturnType<typeof applyMandalaFilterWithStats>['byCell']) =>
+      Array.from(m.values())
+        .flat()
+        .map((a) => ({ id: a.candidate.videoId, score: a.score, cellIndex: a.cellIndex }));
+    expect(flatten(withoutFlags.byCell)).toEqual(flatten(withExplicitFalse.byCell));
+    expect(withoutFlags.stats.wouldRejectEmptyTitle).toBe(0);
+    expect(withoutFlags.stats.droppedByEmptyTitle).toBe(0);
+    // Both zombies still admitted — gate never fires without the flags.
+    const allIds = flatten(withoutFlags.byCell).map((a) => a.id);
+    expect(allIds).toEqual(expect.arrayContaining(['zombie1', 'zombie2', 'p1']));
+  });
+
+  test('SHADOW ON only, ENFORCE OFF — count only, batch unchanged (regression guard)', () => {
+    const shadowOnly = applyMandalaFilterWithStats(
+      [blankTitleCandidate, whitespaceTitleCandidate, normalCandidate],
+      { ...input, candidateEmbeddings: embeddings, emptyTitleGateShadow: true }
+    );
+    expect(shadowOnly.stats.wouldRejectEmptyTitle).toBe(2);
+    expect(shadowOnly.stats.droppedByEmptyTitle).toBe(0);
+    const flat = Array.from(shadowOnly.byCell.values()).flat();
+    const ids = flat.map((a) => a.candidate.videoId);
+    // No enforcement — all three candidates still present.
+    expect(ids).toEqual(expect.arrayContaining(['zombie1', 'zombie2', 'p1']));
+    expect(ids).toHaveLength(3);
+  });
+
+  test("ENFORCE ON — blank title ('') actually dropped", () => {
+    const { byCell, stats } = applyMandalaFilterWithStats([blankTitleCandidate], {
+      ...input,
+      candidateEmbeddings: embeddings,
+      emptyTitleGate: true,
+    });
+    expect(stats.droppedByEmptyTitle).toBe(1);
+    const flat = Array.from(byCell.values()).flat();
+    expect(flat.some((a) => a.candidate.videoId === 'zombie1')).toBe(false);
+  });
+
+  test('ENFORCE ON — whitespace-only title also actually dropped', () => {
+    const { byCell, stats } = applyMandalaFilterWithStats([whitespaceTitleCandidate], {
+      ...input,
+      candidateEmbeddings: embeddings,
+      emptyTitleGate: true,
+    });
+    expect(stats.droppedByEmptyTitle).toBe(1);
+    const flat = Array.from(byCell.values()).flat();
+    expect(flat.some((a) => a.candidate.videoId === 'zombie2')).toBe(false);
+  });
+
+  test('ENFORCE ON — normal title survives (0 over-rejection) + drop count exact', () => {
+    const { byCell, stats } = applyMandalaFilterWithStats(
+      [blankTitleCandidate, whitespaceTitleCandidate, normalCandidate],
+      { ...input, candidateEmbeddings: embeddings, emptyTitleGate: true }
+    );
+    expect(stats.droppedByEmptyTitle).toBe(2);
+    const flat = Array.from(byCell.values()).flat();
+    const ids = flat.map((a) => a.candidate.videoId);
+    expect(ids).toEqual(['p1']);
+    expect(stats.output).toBe(1);
+  });
+
+  test('ENFORCE ON with SHADOW also ON — both counters fire consistently, still 1 real drop', () => {
+    const { byCell, stats } = applyMandalaFilterWithStats([blankTitleCandidate, normalCandidate], {
+      ...input,
+      candidateEmbeddings: embeddings,
+      emptyTitleGate: true,
+      emptyTitleGateShadow: true,
+    });
+    expect(stats.wouldRejectEmptyTitle).toBe(1);
+    expect(stats.droppedByEmptyTitle).toBe(1);
+    const flat = Array.from(byCell.values()).flat();
+    expect(flat.map((a) => a.candidate.videoId)).toEqual(['p1']);
+  });
+});

--- a/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/mandala-filter.test.ts
@@ -780,3 +780,135 @@ describe('applyMandalaFilter — semantic cell assignment via subGoalEmbeddings'
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// R4 empty-title shadow guard (2026-07-04, BL-17) — classify only, enforce = 0
+// ---------------------------------------------------------------------------
+
+describe('applyMandalaFilterWithStats — empty-title shadow guard (R4, enforce=0)', () => {
+  // Mirrors the prod bug: a Tier 1 candidate whose video_pool row title was
+  // SCRUBbed to '' but whose stale embedding still clears the semantic
+  // cosine gate (candidateEmbeddings keyed by videoId, independent of the
+  // current title text).
+  const input = {
+    centerGoal: '1달 일일 루틴으로 전문가되기',
+    subGoals: [
+      '전문 분야 선정 및 학습 계획 수립',
+      '매일 집중 학습 시간 확보 및 루틴화',
+      '실무 프로젝트 진행 및 포트폴리오 구축',
+      '전문 커뮤니티 참여 및 네트워킹',
+      '월간 집중 전문화',
+      '지식 체계화 및 아웃풋 생산',
+      '피드백 수집 및 개선 사이클',
+      '일일 진도 추적 및 동기 유지',
+    ],
+    language: 'ko' as const,
+    centerGateMode: 'semantic' as const,
+    centerEmbedding: [1, 0.2, 0, 0, 0, 0, 0, 0],
+    // Semantic cell assignment too (mirrors prod Tier 1: cell routing also
+    // runs on embeddings, not title text) — cell 0 axis-aligned with the
+    // stale embedding below so the candidate clears BOTH gates on cosine
+    // alone, exactly like the prod zombie row.
+    subGoalEmbeddings: [
+      [1, 0.2, 0, 0, 0, 0, 0, 0],
+      [0, 0, 1, 0, 0, 0, 0, 0],
+      [0, 0, 0, 1, 0, 0, 0, 0],
+      [0, 0, 0, 0, 1, 0, 0, 0],
+      [0, 0, 0, 0, 0, 1, 0, 0],
+      [0, 0, 0, 0, 0, 0, 1, 0],
+      [0, 0, 0, 0, 0, 0, 0, 1],
+      [0, 0, 1, 1, 0, 0, 0, 0],
+    ],
+  };
+  // High-cosine stale embedding — mirrors the prod cosine-recruit that let
+  // a blank-title zombie row through the semantic gate.
+  const staleVec = [0.95, 0.25, 0, 0, 0, 0, 0, 0];
+  const blankTitleCandidate = cand('zombie1', '', 'stale description', null);
+  const whitespaceTitleCandidate = cand('zombie2', '   ', '', null);
+  const normalCandidate = cand('p1', '하루 습관 형성하는 법', '', null);
+
+  test('flag OFF (default/unset) — wouldRejectEmptyTitle stays 0 even with a blank-title candidate', () => {
+    const { stats } = applyMandalaFilterWithStats([blankTitleCandidate], {
+      ...input,
+      candidateEmbeddings: new Map([['zombie1', staleVec]]),
+      // emptyTitleGateShadow intentionally omitted
+    });
+    expect(stats.wouldRejectEmptyTitle).toBe(0);
+  });
+
+  test("flag ON — blank title ('') classified as would-reject, but still admitted (enforce=0)", () => {
+    const { byCell, stats } = applyMandalaFilterWithStats([blankTitleCandidate], {
+      ...input,
+      candidateEmbeddings: new Map([['zombie1', staleVec]]),
+      emptyTitleGateShadow: true,
+    });
+    expect(stats.wouldRejectEmptyTitle).toBe(1);
+    // Classification only — the candidate must still be admitted exactly
+    // as it would be without the flag (stale embedding clears the gate).
+    const flat = Array.from(byCell.values()).flat();
+    expect(flat.some((a) => a.candidate.videoId === 'zombie1')).toBe(true);
+  });
+
+  test('flag ON — whitespace-only title also classified as would-reject', () => {
+    const { stats } = applyMandalaFilterWithStats([whitespaceTitleCandidate], {
+      ...input,
+      candidateEmbeddings: new Map([['zombie2', staleVec]]),
+      emptyTitleGateShadow: true,
+    });
+    expect(stats.wouldRejectEmptyTitle).toBe(1);
+  });
+
+  test('flag ON — normal non-empty title never counted (no over-flagging)', () => {
+    const { stats } = applyMandalaFilterWithStats([normalCandidate], {
+      ...input,
+      candidateEmbeddings: new Map([['p1', staleVec]]),
+      emptyTitleGateShadow: true,
+    });
+    expect(stats.wouldRejectEmptyTitle).toBe(0);
+  });
+
+  test('flag ON — mixed batch counts only the blank-title candidates', () => {
+    const { stats } = applyMandalaFilterWithStats(
+      [blankTitleCandidate, whitespaceTitleCandidate, normalCandidate],
+      {
+        ...input,
+        candidateEmbeddings: new Map([
+          ['zombie1', staleVec],
+          ['zombie2', staleVec],
+          ['p1', staleVec],
+        ]),
+        emptyTitleGateShadow: true,
+      }
+    );
+    expect(stats.wouldRejectEmptyTitle).toBe(2);
+  });
+
+  test('enforce=0 invariant — byCell output is byte-identical whether the flag is on or off', () => {
+    const candidates = [blankTitleCandidate, normalCandidate];
+    const embeddings = new Map([
+      ['zombie1', staleVec],
+      ['p1', staleVec],
+    ]);
+    const off = applyMandalaFilterWithStats(candidates, {
+      ...input,
+      candidateEmbeddings: embeddings,
+      emptyTitleGateShadow: false,
+    });
+    const on = applyMandalaFilterWithStats(candidates, {
+      ...input,
+      candidateEmbeddings: embeddings,
+      emptyTitleGateShadow: true,
+    });
+    const flatOff = Array.from(off.byCell.values())
+      .flat()
+      .map((a) => ({ id: a.candidate.videoId, score: a.score, cellIndex: a.cellIndex }));
+    const flatOn = Array.from(on.byCell.values())
+      .flat()
+      .map((a) => ({ id: a.candidate.videoId, score: a.score, cellIndex: a.cellIndex }));
+    expect(flatOn).toEqual(flatOff);
+    expect(off.stats.output).toBe(on.stats.output);
+    // Only the instrumentation counter differs.
+    expect(off.stats.wouldRejectEmptyTitle).toBe(0);
+    expect(on.stats.wouldRejectEmptyTitle).toBe(1);
+  });
+});

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -285,6 +285,22 @@ const semanticMaxCandidates = z
   )
   .transform((v) => v ?? DEFAULT_SEMANTIC_MAX_CANDIDATES);
 
+/**
+ * R4 shadow guard kill switch (2026-07-04, BL-17).
+ *
+ * When `true`, `applyMandalaFilterWithStats` classifies blank/whitespace-
+ * only title candidates as `stats.wouldRejectEmptyTitle` WITHOUT dropping
+ * them — read-only instrumentation for measuring blast radius before any
+ * enforcement decision. Default `false` (unset = no-op): the classification
+ * branch never runs and `byCell` output is bit-identical to pre-R4
+ * behavior regardless of this flag's value (enforce = 0, always).
+ *
+ * See `mandala-filter.ts::MandalaFilterInput.emptyTitleGateShadow` for the
+ * root-cause writeup (stale Tier 1 embeddings surviving a title SCRUB).
+ * Rollback: unset the env var — no code change required.
+ */
+export const DEFAULT_EMPTY_TITLE_GATE_SHADOW = false;
+
 export const v3EnvSchema = z.object({
   V3_ENABLE_TIER1_CACHE: booleanFlag.optional().default(false as unknown as string),
   V3_RECENCY_WEIGHT: clampedUnit,
@@ -312,6 +328,7 @@ export const v3EnvSchema = z.object({
   V3_ENABLE_SIGNAL_EXCLUDE: booleanFlag.optional().default(true as unknown as string),
   V3_ENABLE_ZERO_HIT_RETRY: booleanFlag.optional().default(true as unknown as string),
   V3_ENABLE_USER_CURATED_INGEST: booleanFlag.optional().default(true as unknown as string),
+  V3_EMPTY_TITLE_GATE_SHADOW: booleanFlag.optional().default(false as unknown as string),
 });
 
 export interface V3Config {
@@ -361,6 +378,12 @@ export interface V3Config {
    * false, Heart only records signals + pins; pool unchanged (pre-CP488).
    */
   enableUserCuratedIngest: boolean;
+  /**
+   * R4 shadow guard (2026-07-04, BL-17) — see `DEFAULT_EMPTY_TITLE_GATE_SHADOW`
+   * for the full writeup. Default false = no-op (classification skipped,
+   * `mandala-filter.ts` stats.wouldRejectEmptyTitle stays 0).
+   */
+  emptyTitleGateShadow: boolean;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -388,6 +411,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_ENABLE_SIGNAL_EXCLUDE: env['V3_ENABLE_SIGNAL_EXCLUDE'],
     V3_ENABLE_ZERO_HIT_RETRY: env['V3_ENABLE_ZERO_HIT_RETRY'],
     V3_ENABLE_USER_CURATED_INGEST: env['V3_ENABLE_USER_CURATED_INGEST'],
+    V3_EMPTY_TITLE_GATE_SHADOW: env['V3_EMPTY_TITLE_GATE_SHADOW'],
   });
   if (!parsed.success) {
     return {
@@ -414,6 +438,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       enableSignalExclude: true,
       enableZeroHitRetry: true,
       enableUserCuratedIngest: true,
+      emptyTitleGateShadow: DEFAULT_EMPTY_TITLE_GATE_SHADOW,
     };
   }
   return {
@@ -440,6 +465,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     enableSignalExclude: parsed.data.V3_ENABLE_SIGNAL_EXCLUDE,
     enableZeroHitRetry: parsed.data.V3_ENABLE_ZERO_HIT_RETRY,
     enableUserCuratedIngest: parsed.data.V3_ENABLE_USER_CURATED_INGEST,
+    emptyTitleGateShadow: parsed.data.V3_EMPTY_TITLE_GATE_SHADOW,
   };
 }
 

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -301,6 +301,22 @@ const semanticMaxCandidates = z
  */
 export const DEFAULT_EMPTY_TITLE_GATE_SHADOW = false;
 
+/**
+ * R4 enforce kill switch (2026-07-04, BL-17).
+ *
+ * When `true`, `applyMandalaFilterWithStats` actually drops (real
+ * `continue`) blank/whitespace-only title candidates instead of only
+ * counting them — separate from `V3_EMPTY_TITLE_GATE_SHADOW` above, so
+ * shadow-only measurement runs are unaffected by shipping this switch.
+ * Default `false` (unset = no-op): pre-R4 behavior is bit-identical.
+ *
+ * This PR ships the code path only — flag stays OFF until a separate,
+ * explicit flip decision (James gate) based on the R4 shadow-measurement
+ * data (blast-radius: sparse/empty-cell counts). Rollback: unset the env
+ * var — no code change required.
+ */
+export const DEFAULT_EMPTY_TITLE_GATE = false;
+
 export const v3EnvSchema = z.object({
   V3_ENABLE_TIER1_CACHE: booleanFlag.optional().default(false as unknown as string),
   V3_RECENCY_WEIGHT: clampedUnit,
@@ -329,6 +345,7 @@ export const v3EnvSchema = z.object({
   V3_ENABLE_ZERO_HIT_RETRY: booleanFlag.optional().default(true as unknown as string),
   V3_ENABLE_USER_CURATED_INGEST: booleanFlag.optional().default(true as unknown as string),
   V3_EMPTY_TITLE_GATE_SHADOW: booleanFlag.optional().default(false as unknown as string),
+  V3_EMPTY_TITLE_GATE: booleanFlag.optional().default(false as unknown as string),
 });
 
 export interface V3Config {
@@ -384,6 +401,13 @@ export interface V3Config {
    * `mandala-filter.ts` stats.wouldRejectEmptyTitle stays 0).
    */
   emptyTitleGateShadow: boolean;
+  /**
+   * R4 enforce (2026-07-04, BL-17) — see `DEFAULT_EMPTY_TITLE_GATE` for the
+   * full writeup. Default false = no-op (real drop skipped,
+   * `mandala-filter.ts` stats.droppedByEmptyTitle stays 0). Separate kill
+   * switch from `emptyTitleGateShadow` above.
+   */
+  emptyTitleGate: boolean;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -412,6 +436,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_ENABLE_ZERO_HIT_RETRY: env['V3_ENABLE_ZERO_HIT_RETRY'],
     V3_ENABLE_USER_CURATED_INGEST: env['V3_ENABLE_USER_CURATED_INGEST'],
     V3_EMPTY_TITLE_GATE_SHADOW: env['V3_EMPTY_TITLE_GATE_SHADOW'],
+    V3_EMPTY_TITLE_GATE: env['V3_EMPTY_TITLE_GATE'],
   });
   if (!parsed.success) {
     return {
@@ -439,6 +464,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       enableZeroHitRetry: true,
       enableUserCuratedIngest: true,
       emptyTitleGateShadow: DEFAULT_EMPTY_TITLE_GATE_SHADOW,
+      emptyTitleGate: DEFAULT_EMPTY_TITLE_GATE,
     };
   }
   return {
@@ -466,6 +492,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     enableZeroHitRetry: parsed.data.V3_ENABLE_ZERO_HIT_RETRY,
     enableUserCuratedIngest: parsed.data.V3_ENABLE_USER_CURATED_INGEST,
     emptyTitleGateShadow: parsed.data.V3_EMPTY_TITLE_GATE_SHADOW,
+    emptyTitleGate: parsed.data.V3_EMPTY_TITLE_GATE,
   };
 }
 

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -480,6 +480,7 @@ async function executeImpl(
             semanticMinCosine: v3Config.semanticMinCosine,
             subGoalEmbeddings: state.subGoalEmbeddings,
             emptyTitleGateShadow: v3Config.emptyTitleGateShadow,
+            emptyTitleGate: v3Config.emptyTitleGate,
           });
           const keptIds = new Set<string>();
           for (const assignments of byCell.values()) {
@@ -1221,6 +1222,7 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
       semanticMinCosine: v3Config.semanticMinCosine,
       subGoalEmbeddings: input.state.subGoalEmbeddings,
       emptyTitleGateShadow: v3Config.emptyTitleGateShadow,
+      emptyTitleGate: v3Config.emptyTitleGate,
     });
     debug.timing.mandalaFilterMs = Date.now() - tMandalaFilterStart;
 
@@ -2046,6 +2048,7 @@ async function runDiscoverEphemeralImpl(
           candidateEmbeddings,
           semanticMinCosine: v3Config.semanticMinCosine,
           emptyTitleGateShadow: v3Config.emptyTitleGateShadow,
+          emptyTitleGate: v3Config.emptyTitleGate,
         });
         const slotById = new Map(allSlots.map((s) => [s.videoId, s]));
         const flattened: AssembledSlot[] = [];

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -479,6 +479,7 @@ async function executeImpl(
             candidateEmbeddings,
             semanticMinCosine: v3Config.semanticMinCosine,
             subGoalEmbeddings: state.subGoalEmbeddings,
+            emptyTitleGateShadow: v3Config.emptyTitleGateShadow,
           });
           const keptIds = new Set<string>();
           for (const assignments of byCell.values()) {
@@ -1219,6 +1220,7 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
       candidateEmbeddings,
       semanticMinCosine: v3Config.semanticMinCosine,
       subGoalEmbeddings: input.state.subGoalEmbeddings,
+      emptyTitleGateShadow: v3Config.emptyTitleGateShadow,
     });
     debug.timing.mandalaFilterMs = Date.now() - tMandalaFilterStart;
 
@@ -2043,6 +2045,7 @@ async function runDiscoverEphemeralImpl(
           centerEmbedding,
           candidateEmbeddings,
           semanticMinCosine: v3Config.semanticMinCosine,
+          emptyTitleGateShadow: v3Config.emptyTitleGateShadow,
         });
         const slotById = new Map(allSlots.map((s) => [s.videoId, s]));
         const flattened: AssembledSlot[] = [];

--- a/src/skills/plugins/video-discover/v3/mandala-filter.ts
+++ b/src/skills/plugins/video-discover/v3/mandala-filter.ts
@@ -166,6 +166,18 @@ export interface MandalaFilterInput {
    * pre-R4 behavior. Gated by `V3_EMPTY_TITLE_GATE_SHADOW` (see v3/config.ts).
    */
   emptyTitleGateShadow?: boolean;
+  /**
+   * R4 enforce (2026-07-04, BL-17) — actually REJECT blank/whitespace-only
+   * title candidates (real `continue`/drop), independent of
+   * `emptyTitleGateShadow` above. See that field's JSDoc for the root-cause
+   * writeup (stale Tier 1 embeddings surviving a title SCRUB).
+   *
+   * Defaults to `false` (unset = no-op): pre-R4 behavior is bit-identical
+   * when omitted. Gated by `V3_EMPTY_TITLE_GATE` (see v3/config.ts) — a
+   * separate kill switch from the shadow-instrumentation flag so shadow-only
+   * measurement runs stay non-invasive even after this code path ships.
+   */
+  emptyTitleGate?: boolean;
 }
 
 export interface ScoreWeights {
@@ -235,6 +247,12 @@ export interface MandalaFilterStats {
    * `input.emptyTitleGateShadow` is false/omitted (default).
    */
   wouldRejectEmptyTitle: number;
+  /**
+   * R4 enforce (2026-07-04, BL-17) — count of candidates ACTUALLY dropped
+   * because their `title` was blank/whitespace-only. Only non-zero when
+   * `input.emptyTitleGate` is true; always 0 otherwise (default — no-op).
+   */
+  droppedByEmptyTitle: number;
 }
 
 export function applyMandalaFilter<T extends FilterCandidate>(
@@ -303,6 +321,7 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
     droppedByJaccardBelowThreshold: 0,
     droppedByCellScoreBelowThreshold: 0,
     wouldRejectEmptyTitle: 0,
+    droppedByEmptyTitle: 0,
     centerTokens: [...centerTokens],
     subGoalTokenCounts: subGoalTokens.map((s) => s.size),
     passedByFocusTag: 0,
@@ -321,6 +340,14 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
     // below, so byCell output is byte-identical regardless of the flag.
     if (input.emptyTitleGateShadow && isBlankTitle(c.title)) {
       stats.wouldRejectEmptyTitle++;
+    }
+
+    // R4 enforce (2026-07-04, BL-17) — real reject. Independent kill switch
+    // from the shadow flag above; a candidate the gate cannot evaluate
+    // (blank title = no text signal) should be dropped, not admitted.
+    if (input.emptyTitleGate && isBlankTitle(c.title)) {
+      stats.droppedByEmptyTitle++;
+      continue;
     }
 
     const titleTokens = tokenize(c.title, input.language);

--- a/src/skills/plugins/video-discover/v3/mandala-filter.ts
+++ b/src/skills/plugins/video-discover/v3/mandala-filter.ts
@@ -146,6 +146,26 @@ export interface MandalaFilterInput {
    * get bit-identical lexical behavior (backward compatible).
    */
   subGoalEmbeddings?: ReadonlyArray<ReadonlyArray<number>>;
+  /**
+   * R4 shadow guard (2026-07-04, BL-17) — classify blank/whitespace-only
+   * title candidates as "would-reject: empty_title" in `MandalaFilterStats`
+   * WITHOUT dropping them (enforce = 0, byte-identical output either way).
+   *
+   * Root cause: Tier 1 (video_pool cache) matches candidates by stored
+   * `video_pool_embeddings`, which stay populated even after the pool row's
+   * `title` is scrubbed to '' by the SCRUB path (pool-maintenance.ts) or
+   * left unrepaired by the `/like` upsert (cards.ts). The stale embedding
+   * still clears the semantic cosine gate because that gate never inspects
+   * `title` text directly in `'semantic'` mode — it compares
+   * `candidateEmbeddings` vectors, so an empty-title candidate can pass
+   * with a high score. A gate that cannot evaluate a candidate (blank
+   * title = nothing to admit on) should reject, not admit.
+   *
+   * Defaults to `false` (unset = no-op): when omitted, `stats.wouldRejectEmptyTitle`
+   * stays 0 and no candidate is inspected for this — bit-identical to
+   * pre-R4 behavior. Gated by `V3_EMPTY_TITLE_GATE_SHADOW` (see v3/config.ts).
+   */
+  emptyTitleGateShadow?: boolean;
 }
 
 export interface ScoreWeights {
@@ -207,6 +227,14 @@ export interface MandalaFilterStats {
   };
   /** Which mode was applied this run. Useful for prod A/B logs. */
   centerGateMode?: CenterGateMode;
+  /**
+   * R4 shadow guard (2026-07-04, BL-17) — count of candidates with a
+   * blank/whitespace-only `title` that WOULD be rejected if the empty-title
+   * gate were enforced. Classification only — these candidates are still
+   * scored and admitted exactly as before. Always 0 when
+   * `input.emptyTitleGateShadow` is false/omitted (default).
+   */
+  wouldRejectEmptyTitle: number;
 }
 
 export function applyMandalaFilter<T extends FilterCandidate>(
@@ -274,6 +302,7 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
     droppedByCenterGate: 0,
     droppedByJaccardBelowThreshold: 0,
     droppedByCellScoreBelowThreshold: 0,
+    wouldRejectEmptyTitle: 0,
     centerTokens: [...centerTokens],
     subGoalTokenCounts: subGoalTokens.map((s) => s.size),
     passedByFocusTag: 0,
@@ -287,6 +316,13 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
   };
 
   for (const c of candidates) {
+    // R4 shadow guard (2026-07-04, BL-17) — classify only, never drop.
+    // enforce = 0: this branch never affects `continue`/gate decisions
+    // below, so byCell output is byte-identical regardless of the flag.
+    if (input.emptyTitleGateShadow && isBlankTitle(c.title)) {
+      stats.wouldRejectEmptyTitle++;
+    }
+
     const titleTokens = tokenize(c.title, input.language);
     // Center score per mode:
     //   substring — legacy, token-level substring overlap
@@ -409,6 +445,17 @@ export function applyMandalaFilterWithStats<T extends FilterCandidate>(
     list.sort((a, b) => b.score - a.score);
   }
   return { byCell, stats };
+}
+
+/**
+ * R4 shadow guard (2026-07-04, BL-17) — true when `title` is missing, empty,
+ * or contains only whitespace. Such a candidate carries no evaluable text
+ * signal for the lexical gates and, in `'semantic'` mode, may still clear
+ * the cosine gate on a stale pre-scrub embedding (see
+ * `MandalaFilterInput.emptyTitleGateShadow` JSDoc for the full root cause).
+ */
+function isBlankTitle(title: string | null | undefined): boolean {
+  return !title || title.trim().length === 0;
 }
 
 /**


### PR DESCRIPTION
## What
Restores the CP455 domain center-gate against **empty-title zombie pool rows** that silently bypass it (root of BL-17 off-topic contamination).

Two flags, **both default OFF (unset = no-op, byte-identical serving)**:
- `V3_EMPTY_TITLE_GATE_SHADOW` — classify-only (would-reject counter, no drop).
- `V3_EMPTY_TITLE_GATE` — enforce (actually drops empty/whitespace-title candidates).

Single instrumentation point: `mandala-filter.ts::applyMandalaFilterWithStats` (covers all 3 serving routes: Tier1, Tier1+2, ephemeral wizard).

## Why (measured, origin/main SSOT)
- v3 Tier1 embedding-cosine matches the drifted sub-goal embedding → pulls **691 live `v2_promoted` gold/silver rows whose `title=''`** (scrubbed by ToS 30-day `pool-maintenance` + `/like` zombie bug). Empty title → empty-string embedding → cosine-judged instead of rejected = silent domain-gate bypass.
- Read-only prod shadow measurement: **691 would-reject, 0 false positives** (all `length(title)=0`), enforce impact = **14/88 cells touched, 2 newly-sparse (7→2, 4→2), 0 newly-empty.**

## Blast
- Merge/deploy: flags OFF → **zero behavior change** (canary step 1).
- Enforce flip (`V3_EMPTY_TITLE_GATE=on` in prod compose) is a **separate, explicit step**, immediately rollbackable.

## Tests
`tsc --noEmit` clean; `jest .../video-discover/v3` → 8 suites / 121 tests pass (+7 new, 0 regressions), incl. byte-identical-when-off invariant + enforce over-rejection=0.

Data-layer root fixes (SCRUB `is_active` guard + `/like` title recovery) = separate follow-up track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)