### PR TITLE
chore(compose): enforce V3_EMPTY_TITLE_GATE=on (BL-17 canary)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -519,6 +519,15 @@ services:
       # Rollback: append ,batch_trend — but expect 45-100s Tier 1.
       - V3_TIER1_SOURCES=v2_promoted
       - V3_SEMANTIC_MIN_COSINE=0.5
+      # BL-17 (2026-07-04) — fail-closed empty-title guard. SCRUB (YouTube ToS
+      # 30d metadata wipe, is_active-agnostic) + /like zombie upsert leave ~691
+      # live v2_promoted rows with title=''; their empty-string embedding
+      # silently passes the semantic center-gate. ON → mandala-filter drops
+      # blank/whitespace-title candidates before scoring (fail-closed: a gate
+      # can't evaluate a blank title, so reject not admit). Measured blast:
+      # 14/88 cells touched, 2 newly-sparse (7→2, 4→2), 0 newly-empty.
+      # Rollback: remove line → code default off (DEFAULT_EMPTY_TITLE_GATE=false).
+      - V3_EMPTY_TITLE_GATE=on
       # CP457+ — per-step request/response capture for video-discovery
       # (LLM prompts, YouTube search, Cohere rerank, embeddings, results).
       # Writes to public.video_discover_traces (TTL 7d). Fire-and-forget;


### PR DESCRIPTION
Canary flip of the empty-title fail-closed guard (code merged flag-off in #1099).

`V3_EMPTY_TITLE_GATE=on` → `mandala-filter` drops blank/whitespace-title candidates before scoring, restoring the semantic center-gate that empty-string embeddings silently bypassed.

**Measured blast (read-only prod shadow):** 691 zombie rows dropped from serving; 14/88 cells touched; 2 newly-sparse (7→2, 4→2); 0 newly-empty. Immediately rollbackable (remove the line → code default off).

Post-deploy verification = prod screenshots of 영어/기타 baseline mandalas + the 2 sparse cells (supervisor Done gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)