### PR TITLE
feat(search): domain-fit deboost gate — WRITE enforce + READ 7k/serve-shadow (all flags default-off)

### DIFF
--- a/docs/qa/domain-fit-probe-T3.md
+++ b/docs/qa/domain-fit-probe-T3.md
@@ -1,0 +1,103 @@
+# Domain-fit local classifier — T3 prompt (frozen)
+
+Status: R11 candidate → R12 re-validation at N≥100.
+Compliance: local inference ONLY — Mac Mini Ollama via Tailscale
+(`http://100.91.173.17:11434/api/generate`, model `mandala-gen:latest`,
+`raw:true`). No Anthropic / OpenRouter / YouTube API calls anywhere in this
+probe or its data generation.
+
+## Why this file exists
+
+R10's probe artifacts were lost (scratchpad-only, no repo copy). R11 found
+that among 3 candidate prompt templates (T1/T2/T3), only **T3** avoided
+"niche massacre" (false-not-fit on legit niche-domain pairs) while still
+catching drift — but on a small sample (N=14 for the `niche_legit` cluster).
+This file freezes the exact T3 prompt + Ollama call config so it can be
+reproduced without re-deriving it, and is the baseline R12 re-validates
+against at N≥100.
+
+**T1 and T2 are retired** (niche-massacre 22–40% false-not-fit-on-legit in
+R11) — not reproduced here. Ensembling across templates was also retired
+(systematic bias, not random noise — averaging doesn't help). T3 alone,
+frozen, is the only surviving candidate.
+
+## T3 prompt (verbatim, do not alter for the "fixed" re-validation)
+
+Template function (`goal`, `title` → prompt string):
+
+```js
+const T3 = (goal, title) =>
+  `### Instruction:\n다음 영상 제목과 목표의 주제 적합성을 분류하라 (적합/비적합). JSON만 출력: {"fit": "적합"|"비적합"}\n\n### Input:\n영상 제목: ${title}\n관련 목표: ${goal}\n\n### Output:\n`;
+```
+
+Key property vs T1/T2: video title is presented **before** the goal
+(title-first, goal-second), Alpaca instruction format. T1/T2 put goal first
+— that ordering is believed (not proven) to correlate with the niche-massacre
+failure mode; not re-tested in R12 (out of scope, T3 is fixed).
+
+### R12 scalar-capture variant (separate, additive — see R12-2)
+
+Used only in the scalar-capture pass, never substituted for the frozen T3
+binary call above:
+
+```js
+const T3_SCALAR = (goal, title) =>
+  `### Instruction:\n다음 영상 제목과 목표의 주제 적합성을 분류하라 (적합/비적합). 그리고 0.0~1.0 사이의 적합도 confidence 점수도 함께 산정하라 (1.0=완전히 같은 주제, 0.0=전혀 무관). JSON만 출력: {"fit": "적합"|"비적합", "score": 0.0~1.0}\n\n### Input:\n영상 제목: ${title}\n관련 목표: ${goal}\n\n### Output:\n`;
+```
+
+## Ollama call config (frozen)
+
+```json
+{
+  "model": "mandala-gen:latest",
+  "raw": true,
+  "stream": false,
+  "options": { "temperature": 0.1, "num_predict": 60 }
+}
+```
+
+- Endpoint: `POST http://100.91.173.17:11434/api/generate` (Tailscale IP of
+  Mac Mini; do not use any hosted/cloud inference substitute).
+- `raw: true` — no chat template wrapping; the Alpaca-format string above is
+  sent as literal raw prompt.
+- Parse strategy: regex-extract first `{...}` blob, `JSON.parse`, accept
+  `fit` iff exactly `"적합"` or `"비적합"`. Fallback substring scan is
+  fragile-flagged (`parse_clean: false`) — see `parseFit()` in the runner.
+
+## Ground truth / cluster taxonomy
+
+- `auto_legit` / `auto_drift` — AI-automation/no-code domain goal × video,
+  fit / mismatch.
+- `homonym_fit` / `homonym_drift` — Korean `코드` token trap: means
+  "programming code" in dev-domain pairs (fit) vs guitar/piano "chord" in
+  music-domain pairs (drift, title contains `코드` but is actually a coding
+  video — tests the classifier isn't fooled by surface token overlap).
+- `niche_legit` — vocabulary-non-overlapping but domain-true fit (e.g.
+  classical guitar goal × "핑거스타일/스케일/주법" video with zero literal
+  token overlap with the goal string). **This is the cluster that most
+  needs N-expansion** — R11 had only 14 rows here.
+- `niche_drift` (R12 addition, not in R11) — cross-niche mismatches (e.g.
+  AWS-architect goal × dividend-ETF video) to add drift-detection signal
+  specifically among niche/specialist domains, not just generic sanity_off.
+- `sanity_on` / `sanity_off` — obviously-fit / obviously-off-topic control
+  pairs (regression floor, should be ~100%).
+- `ambiguous_excluded` — genuinely unclear domain calls (label:null),
+  excluded from all scoring, kept for transparency.
+
+## File locations (persisted, working-tree only — not committed per task scope)
+
+- This spec: `docs/qa/domain-fit-probe-T3.md`
+- Runner: `scripts/probes/domain-fit-t3-runner.mjs`
+- R11 fixtures (frozen reference, for regression diff): `scripts/probes/fixtures/r11-dataset.json`, `scripts/probes/fixtures/r11-results.json`
+- R12 dataset (N≥100): `scripts/probes/fixtures/r12-dataset.json`
+- R12 results (binary + scalar): `scripts/probes/fixtures/r12-results-binary.json`, `scripts/probes/fixtures/r12-results-scalar.json`
+
+## Metric definitions (as established in R11, reused for R12)
+
+- **False-not-fit-on-legit rate** = (legit rows misclassified as `비적합`) /
+  (total rows with gold=`적합`). This is the primary GO/NO-GO bar, target
+  **<10%**. R11 measured 1/30 = 3.3% overall, 0/14 = 0% within `niche_legit`
+  specifically.
+- **Drift detection rate** = (drift rows correctly classified as `비적합`) /
+  (total rows with gold=`비적합`). R11 measured 21/22 = 95.5%.
+- Rows with `gold: null` (ambiguous) are excluded from both metrics.

--- a/docs/qa/domain-fit-r13-2-sim-results.md
+++ b/docs/qa/domain-fit-r13-2-sim-results.md
@@ -1,0 +1,141 @@
+# R13-2 — domain-fit shadow offline simulation results (2026-07-04)
+
+Branch: `feat/domain-fit-shadow` (base `origin/main` @ `1634d9c6`).
+Script: `scripts/probes/domain-fit-r13-2-sim.mjs`. Raw output:
+`scripts/probes/fixtures/r13-2-results.json`. Local inference only
+(Mac Mini Ollama, `mandala-gen:latest`, frozen T3 —
+`docs/qa/domain-fit-probe-T3.md`). No Anthropic/OpenRouter/YouTube calls.
+No prod data mutation — all reads (`inet_server_addr()` confirmed prod:
+`2600:1f13:838:6e23:d95c:dda0:1136:d1c6/128`, db `postgres`).
+
+**238 fresh local-Ollama calls this session** (previous R11/R12 results were
+NOT reused/replayed — every number below is a fresh classification).
+
+## Data sources
+
+1. **R12 gold set** (`scripts/probes/fixtures/r12-dataset.json`, 111 rows,
+   108 non-ambiguous, real_prod goal/title pairs, gold-labeled). Re-scored
+   fresh this session — an independent re-run of the R12 validation, not a
+   replay of cached `r12-results-binary.json`.
+2. **3 live prod mandalas** (read-only extract, `user_video_states` JOIN
+   `youtube_videos`, real served/placed cards — the same 3 mandalas already
+   human-judged in `docs/qa/search-quality-report-20260703.md` CP511, so the
+   "ground truth" for these is the supervisor's own L1 visual QA pass):
+   - `python_normal` — "파이썬 데이터 분석 입문" (`fd080ad1…`), 31 cards.
+     CP511 verdict: **0% junk, all normal.**
+   - `english_evergreen` — "6개월 내 영어 프리토킹 달성" (`7d5d759e…`), 45
+     cards. CP511 verdict: mostly normal, 4-5 mild-clickbait, 0 scam/off-topic.
+   - `etf_finance` — "ETF 투자로 노후 자산 만들기" (`5d8eefe0…`), 54 cards.
+     CP511 verdict: heavy aggro-clickbait investment-promise junk **+ 1
+     confirmed off-topic drift item** ("편집 가능한 PPT 생성 Claude AI").
+
+   Per-candidate score is NOT available for these (only the winning
+   `user_video_states` rows are persisted, not the full recruited-and-ranked
+   `scored` array) — a synthetic descending proxy score is assigned per cell
+   for the rerank arithmetic in (c). This is a known limitation; a follow-up
+   with the flag ON would capture the *real* `score` per the R13-1
+   `recordTrace` payload and remove this proxy.
+
+## (a) Normal-cell false-not-fit rate — MIXED, one config fails the <10% bar
+
+| Set | legit-known n | classified 비적합 | rate |
+|---|---|---|---|
+| R12 gold (`legit` clusters: niche_legit/auto_legit/sanity_on/homonym_fit) | 62 | 4 | **6.5%** — passes <10% bar |
+| `python_normal` (per-CELL subgoal as the goal text, matching the live executor's `subGoals[cellIndex]`) | 31 | 8 | **25.8%** — FAILS the <10% bar |
+| `english_evergreen` (per-cell subgoal) | 45 | 1 | 2.2% — passes |
+| `etf_finance` (per-cell subgoal) | 54 | 1 | 1.9% — passes |
+
+**The python_normal miss rate is the important finding.** Inspecting the 8
+flagged titles (`r13-2-results.json` → `live.python_normal.rows`), most are
+genuine **cell-level topic drift within an overall-legit mandala** — e.g.
+cell "Matplotlib과 Seaborn으로 데이터 시각화" flagged "파이썬 코딩 무료
+강의(활용편7) - 머신러닝, 영화 추천 시스템" (ML/recsys, not
+matplotlib/seaborn) and "클로드의 이 기능" (a Claude-AI productivity video,
+not python at all). These are NOT false positives against the *mandala's*
+topic — CP511 correctly called the mandala 0% junk — but they ARE genuine
+mismatches against the *specific cell* they were placed in. This means:
+scoring against the narrow per-cell subgoal (what R13-1's Tier2 hook
+actually does, matching the live executor) is measurably stricter than
+scoring against a fuller goal statement (what the R12 gold set mostly uses),
+and **on this one real mandala it exceeds the <10% false-not-fit bar**.
+Two readings, both plausible, not adjudicated here: (i) the classifier is
+over-strict at cell granularity, or (ii) some of these candidates are
+genuinely cell-misassigned (a placement bug, not a domain-fit bug) and the
+classifier is correctly surfacing that. R12's second-opinion number (6.5%,
+goal-level) still clears the bar — the discrepancy is a granularity effect,
+not a contradiction.
+
+## (b) Drift-detection — catches both the synthetic gold set AND a real, previously-known drift item
+
+- **R12 gold set** (46 genuine cross-domain mismatch pairs): **43/46 = 93.5%**
+  caught (consistent with R12's previously published 95.5%, N=22 — this run
+  used the larger N=46 drift set across all 4 drift clusters, small
+  re-run variance expected from temperature=0.1, not exactly 0).
+- **Live spot-check — 2/2 genuine known real-world drift items caught**:
+  - `english_evergreen` cell 4 ("문법 기초 정리 및 자동화된 사용") flagged
+    "캡컷 자동화!! AI로 캡컷 편집 자동화 하는 방법" (CapCut video-editing
+    automation — lexically overlaps on "자동화" but is genuinely off-topic;
+    correctly caught, a real homonym-style trap resolved correctly).
+  - `etf_finance` cell 4 ("세금 효율적인 투자 방법 학습하기") flagged "클로드
+    PPT 만들기: 편집 가능한 파워포인트 자동 생성" — **this is the exact
+    off-topic card CP511's own human QA already flagged** in
+    `search-quality-report-20260703.md` M4 ("Claude AI PPT 생성 = ETF
+    만다라에 드리프트"). The shadow classifier independently reproduced a
+    supervisor-verified real drift call, at cell level, zero false negatives
+    in this small sample.
+
+## (c) Rerank-multiplier balance (0.15 / 0.2 / 0.3) — LOW CONFIDENCE, proxy-score artifact
+
+| Set | 0.15 rank_change_rate | 0.2 | 0.3 | legit pushed down (any m) |
+|---|---|---|---|---|
+| python_normal | 22.6% | 22.6% | 22.6% | 0 |
+| english_evergreen | 11.1% | 17.8% | 17.8% | 0 |
+| etf_finance | 0% | 3.7% | 3.7% | 0 |
+
+Two honest caveats, not glossed over:
+1. **0.2 and 0.3 are identical in 2/3 sets, and identical to 0.15 in the
+   third.** With only a handful of candidates per cell (≤8) and a synthetic
+   proxy score, a demoted candidate's new score drops below every neighbor
+   at the *smallest* tested multiplier already — the sim has no room to show
+   a 0.15 vs 0.3 gradient with this proxy. This is a limitation of the
+   synthetic score, not evidence that 0.15/0.2/0.3 are equivalent in the real
+   pipeline (where scores are continuous mandala-filter cosine/jaccard
+   values, not a coarse 20-step proxy).
+2. **"legit pushed down by a neighbor's demotion" = 0 in every cell/multiplier
+   combo tested.** Read literally this says demoting not-fit candidates never
+   collaterally hurts a legit neighbor in THIS sample — but given caveat 1,
+   this is more likely an artifact of small per-cell N + the proxy score
+   than a real property of the rerank. **Do not use this row as a go/no-go
+   signal without redoing this measurement using REAL captured `score`
+   values from the R13-1 shadow logs** (flip `DOMAIN_FIT_SHADOW=true` in a
+   canary, let `recordTrace` accumulate `domain_fit_shadow.tier2` rows with
+   the actual mandala-filter score per candidate, replay THAT distribution).
+
+## (d) Load — confirms why this MUST stay async (matches an existing prod scar)
+
+- 238 total calls, mean **1988ms**, p95 **3075ms**, max **4227ms**, single
+  Mac Mini instance, concurrency=4.
+- At the shipped `DOMAIN_FIT_SHADOW_MAX_CANDIDATES=40` default and
+  `DOMAIN_FIT_SHADOW_CONCURRENCY=4`, one Tier-2 shadow run is ≈10 batches ×
+  ~2s ≈ **20s** wall time for the local Ollama pass alone.
+- This is the *exact same* Mac Mini Ollama dependency that
+  `wizard-precompute.ts:124` already documents as the reason v3's cosine
+  gate was moved off the sync wizard path in CP490 ("v3 cosine + Mac-mini
+  Ollama dependency was producing 70s+ runs returning 0 cards"). R13-1's
+  fire-and-forget design (never awaited by the caller, `recordTrace` write
+  happens after the full local batch, off the serve path) is load-bearing,
+  not a nice-to-have — a sync integration of this exact classifier would
+  reproduce the same prior incident.
+
+## Bottom line for James's enforce decision (not made here — shadow/logging only)
+
+- Drift-catch: strong evidence (93.5% synthetic + 2/2 real spot-check,
+  including one supervisor-verified real card).
+- Normal-cell false-not-fit: passes at goal-level granularity (6.5%), **fails
+  at the cell-level granularity the live pipeline actually uses** (25.8% on
+  one real mandala) — this is the blocking question for any future enforce
+  step, not yet resolved by this simulation.
+- Multiplier choice (0.15 vs 0.2 vs 0.3): no usable signal from this
+  simulation (proxy-score ceiling effect) — needs a real-score re-run.
+- Load: safe only as async/shadow; would reproduce a known past incident if
+  ever moved onto the sync serve path.

--- a/docs/qa/domain-fit-r14-write-gate-and-goal-level.md
+++ b/docs/qa/domain-fit-r14-write-gate-and-goal-level.md
@@ -1,0 +1,249 @@
+# R14 — goal-level rescope + WRITE-gate feasibility (2026-07-04)
+
+Branch: `feat/domain-fit-shadow`. Commits this session: `a1e36f16` (R14-1
+code), plus this doc (R14-2/3/4, analysis + read-only sim, no code change).
+blast-0 held: branch-only, enforce-0, flag-off default, async, unpushed,
+local Ollama only, zero external API, zero real data mutation, read-only sim.
+
+## R14-1 — goal-level rescope + scalar capture (code, committed `a1e36f16`)
+
+- `src/modules/domain-fit-shadow/shadow.ts` — classification target changed
+  from `input.subGoals[c.cellIndex] ?? input.centerGoal` (R13) to always
+  `input.centerGoal` (R14-1). `subGoals` kept on the interface (deprecated,
+  unused for classification) so `src/skills/plugins/video-discover/v3/executor.ts:517`
+  and `:1300` (the two `scheduleDomainFitShadow(...)` call sites) needed no
+  signature change.
+- `src/modules/domain-fit-shadow/client.ts` — added `buildT3ScalarPrompt` /
+  `parseFitScalar` / `classifyDomainFitScalar`, verbatim frozen "R12
+  scalar-capture variant" from `docs/qa/domain-fit-probe-T3.md`. Additive,
+  gated by new `DOMAIN_FIT_SHADOW_SCALAR` (default false) — a SEPARATE
+  Ollama call per candidate, never substitutes the binary T3 call.
+- Real score logging unchanged from R13-1 and still real: `ShadowScoredCandidate.score`
+  is the actual `applyMandalaFilterWithStats` (or Tier-1 match) score, never
+  a synthetic proxy — R13-2's proxy problem was specific to the OFFLINE SIM
+  reading `user_video_states` (only winners persisted, no per-candidate
+  score), not a gap in what R13-1's live shadow hook logs.
+- `tsc --noEmit`: clean. Jest: 39/39 domain-fit-shadow tests pass (goal-level
+  assertions replace the old per-cell assertions; new scalar-capture
+  coverage). Broader `src/skills/plugins/video-discover` suite: 314 passed,
+  1 pre-existing unrelated failure (`trace-candidates.test.ts`, confirmed via
+  `git diff --stat` untouched by this branch).
+
+## R14-3 — v3 shadow re-run at goal-level (副측정) — MIXED result, reported as measured, not spun
+
+Re-scored the SAME 130 real served-card titles from R13-2 (3 real prod
+mandalas, read-only, no new query) against each mandala's root `centerGoal`
+instead of the per-cell subgoal. Script: `scripts/probes/domain-fit-r14-3-goal-level-sim.mjs`
+(gitignored per repo convention, matches R11/12/13 precedent). Raw output:
+`scripts/probes/fixtures/r14-3-goal-level-results.json`.
+
+| Mandala | Cell-level (R13, per-cell subgoal) | Goal-level (R14, centerGoal) |
+|---|---|---|
+| python_normal (fd080ad1…) | 8/31 = 25.8% | **8/31 = 25.8% — unchanged** |
+| english_evergreen (7d5d759e…) | 1/45 = 2.2% | **10/45 = 22.2% — WORSE** |
+| etf_finance (5d8eefe0…) | 1/54 = 1.9% | 1/54 = 1.9% — unchanged |
+
+**This does not confirm the "goal-level fixes the 25.8%" hypothesis from the
+R13-2 write-up on these 2 real mandalas.** Digging into which titles moved:
+
+- python_normal: composition changed but the total stayed 8. 2 titles that
+  were false positives at cell-level are now correctly passed at goal-level
+  ("커서AI 설치부터…", "머신러닝, 영화 추천 시스템 만들기" — genuinely
+  Python/data-adjacent, just not literally about the specific cell's
+  narrow topic). But 2 NEW candidates get flagged at goal-level that
+  weren't before, one of which looks like a genuine real quality issue
+  independent of domain-fit accuracy — a KBS political/real-estate-tax news
+  broadcast ("[사사건건] 이 대통령, 보유세 강화 의지…") is present in this
+  Python-learning mandala's served set at all, which is arguably a **real
+  pool/recommendation bug** the domain-fit shadow correctly surfaces,
+  goal-level or not.
+- english_evergreen: goal-level got WORSE, not better. Root cause: this
+  mandala's cell 6/7 goals ("자신감 있게 말하기 위한 심리 트레이닝", "매일
+  꾸준히 실천할 수 있는 루틴 설계") are generic self-help/habit topics that
+  are legitimately on-topic for THEIR OWN cell but read as off-domain when
+  compared to the narrower root goal "6개월 내 영어 프리토킹 달성" — e.g. a
+  general "12개의 데일리 루틴" (habit-building) video or a Yale psychiatry
+  professor's anxiety talk are reasonable for a "confidence/routine" cell
+  but score 비적합 against "achieve English free-talking in 6 months" read
+  literally. Goal-level is STRICTER here specifically because some cells are
+  intentionally more general than the root goal.
+
+**Honest conclusion**: cell-level vs goal-level is not a strict
+better/worse — it is a **granularity tradeoff**. Cell-level over-flags when
+a cell's own narrow theme diverges from the video's actual (still
+mandala-legit) sub-topic. Goal-level over-flags when a cell is intentionally
+broader/softer than the root goal (self-help/routine/confidence cells
+attached to a skill-acquisition root goal). Neither alone clears the <10%
+bar on these 2 real mandalas; the R12 gold set's 6.5% is a cleaner number
+because that dataset was constructed as single-granularity goal/title pairs,
+not an 8-cell decomposed real mandala with intentionally-softer cells.
+**This is flagged as an open design question for James, not resolved by
+this session's code change** — R14-1 shipped goal-level as instructed, but
+this measurement shows it is a genuinely open tradeoff, not a fix.
+
+## R14-2 — WRITE-gate wireability (핵심) + offline sim
+
+### File:line — same signal share point as the serve-side shadow hook
+
+Two **goal-aware** write paths (a specific mandala's `centerGoal` is in
+scope at write time — directly wireable to a domain-fit gate, same
+fire-and-forget/async shape already used for the serve-side shadow hook):
+
+1. **`src/modules/video-pool/reuse-from-v5.ts`** — `prepareReuseRow` (pure,
+   sync, lines 99-148) quality-gates via `classifyQuality` (line 106) before
+   building the upsert row; `reusePickedToPool` (lines 154-189) is already
+   `async`, loops per-card, and calls `prisma.video_pool.upsert` at line 174.
+   Call site: `src/skills/plugins/video-discover/v5/executor.ts:397`
+   (`void reusePickedToPool({...}).catch(...)`) — **never awaited**
+   (comment at line 394: "NEVER awaited → zero hot-path impact"), and
+   `input.centerGoal` is already in the enclosing function's scope (used
+   elsewhere at lines 166/265/266) but is **not currently passed into
+   `ReuseInput`** — adding it is a 1-field interface change, not a
+   restructure. A domain-fit call would slot in per-card inside the existing
+   `for (const card of input.cards)` loop (line 160), right after
+   `prepareReuseRow` returns a non-null row and before the `upsert` — same
+   position as `classifyQuality`, same async/per-card shape already proven
+   safe (this loop already awaits `shortGateFields` per card at line 162).
+
+2. **`src/api/routes/cards.ts:508-591`** (`/like` handler's fire-and-forget
+   IIFE, `void (async () => {...})()` at line 508) — already gates on
+   `titleHitsBlocklist` (line 546) and `isChannelBlocked` (line 553) before
+   `prisma.video_pool.upsert` (line 560), source=`'user_curated'`.
+   `body.mandalaId` is already available in this handler (used at lines 324,
+   330, 340, 351, 356, 487) — a domain-fit gate would need one extra lookup
+   (mandala's root `center_goal`, not currently fetched here) then slot in
+   right after the existing blocklist checks, same position, same
+   async/non-blocking shape (this IIFE is already `void`-dispatched, response
+   already sent by the time it runs — see the `return reply.code(202)` at
+   line 593, AFTER the IIFE is scheduled but not awaited).
+
+One **goal-agnostic** batch family — **NOT directly wireable to a per-write
+domain-fit-vs-goal gate**, because there is no specific mandala/goal at
+ingestion time (this is the structural reason R14-4's video-intrinsic
+caching idea matters, not just a nice-to-have):
+
+3. `src/modules/video-pool/promote-from-v2.ts` (`promoteV2ToVideoPool`, line
+   108; upsert at line 221), `promote-from-playlists.ts` (`promotePlaylistsToVideoPool`,
+   line 82; upsert at line 232), `promote-from-youtube-videos.ts`
+   (`promoteYoutubeVideosToPool`, line 112; `classifyQuality` at line 166;
+   upsert at line 236) — all three are cron/batch collectors that promote
+   into the SHARED, mandala-agnostic `video_pool` table with no requesting
+   mandala in scope. A fit-vs-one-goal gate cannot run here; only a
+   **video-intrinsic domain LABEL** (title/description → topic, no goal
+   input) could gate at this stage — confirmed feasible in principle (R14-4),
+   not implemented this session (would need a new `video_pool` column, DDL=0
+   this session).
+
+### Offline sim — (a) off-domain block rate, (b) normal-domain false-block rate
+
+No code wired this session (read-only sim only, per R14-2 scope: "형태 검증"
++ "오프라인 시뮬", not an implementation).
+
+- **(a) off-domain block rate — two independent measurements, both strong**:
+  - R12 gold set (reused from R13-2, not re-scored): 46 genuine cross-domain
+    real_prod pairs, **43/46 = 93.5%** correctly blocked (비적합).
+  - **New this session** — genuine cross-mandala supplementary check
+    (`scripts/probes/domain-fit-r14-2-write-gate-sim.mjs`, 24 fresh calls):
+    took real titles from one live mandala's served cards and paired them
+    against a DIFFERENT real mandala's actual `centerGoal` (python titles ×
+    ETF goal, ETF titles × python goal, English titles × ETF goal) —
+    **24/24 = 100% blocked**. Blatant cross-domain mismatches are caught
+    every time; the R12 gold set's harder homonym/niche-drift cases bring
+    the rate down to 93.5%, still well above any reasonable bar.
+- **(b) normal-domain false-block rate — reuses R14-3's numbers directly**
+  (identical classification call — a WRITE-gate-vs-goal check is the SAME
+  T3 call as the serve-side shadow's goal-level check, just interpreted as
+  block/allow instead of demote/keep): **25.8% (python) / 22.2% (english,
+  R14-3) / 1.9% (ETF)** — i.e. the SAME mixed result from R14-3 applies
+  here. **A WRITE-gate built on goal-level domain-fit today would
+  incorrectly block roughly a quarter of legit python-mandala candidates and
+  a fifth of legit english-mandala candidates** — well above the <10% bar,
+  for the same cell-vs-goal granularity reasons documented in R14-3. This is
+  the single biggest reason NOT to wire this as an actual gate yet, whatever
+  the wireability answer is.
+
+**Bottom line for R14-2**: wireable in the goal-aware paths (file:line
+above), NOT wireable as a per-write goal gate in the batch paths (structural,
+not a code gap), and — same as R14-3 — **not accurate enough to enforce
+today** (false-block rate exceeds the <10% bar on 2 of 3 real mandalas).
+"Pool을 도메인-품질풀로" gate is directionally sound against blatant
+cross-domain junk (93.5-100%) but would currently reject too much legitimate
+content at the cell-adjacent edges.
+
+## R14-4 — load/async verification + video-intrinsic cache feasibility
+
+### Async/hot-path non-blocking — re-verified file:line
+
+- Serve-side shadow (R13-1/R14-1): `scheduleDomainFitShadow(...)` calls at
+  `src/skills/plugins/video-discover/v3/executor.ts:517` and `:1300` are
+  plain (non-awaited) function calls; internally
+  `src/modules/domain-fit-shadow/shadow.ts`'s `scheduleDomainFitShadow`
+  dispatches with `void runDomainFitShadow(input, cfg).catch(...)` — the
+  caller's stack frame returns immediately, the Ollama burst runs after.
+- WRITE-path precedent (unchanged this session, cited for the "same shape"
+  claim): `src/skills/plugins/video-discover/v5/executor.ts:397`
+  (`void reusePickedToPool(...).catch(...)`) and `src/api/routes/cards.ts:508`
+  (`void (async () => {...})()`, response already sent by `reply.code(202)`
+  at line 593) — both structurally identical fire-and-forget dispatch.
+- Goal-level call unit: ONE `centerGoal` per mandala per shadow run (not per
+  cell) — R14-1 reduces the DISTINCT-goal-string count from 8 (one per cell,
+  R13) to 1 (R14), but the call COUNT (one call per candidate) is unchanged
+  — goal-level does not by itself reduce Ollama load, it only changes what
+  text is compared. This matters for the cache-feasibility question below.
+
+### Cache feasibility — YES in principle, with one accuracy caveat; not implemented (DDL=0 this session)
+
+The idea: since goal-level domain-fit compares (mandala centerGoal, video
+title), and the SAME popular video gets recruited across MANY different
+mandalas/users (this is explicitly `video_pool`'s design — see
+`reuse-from-v5.ts` header: "next request's pool-first match reuses them"),
+splitting the judgment into (1) a **video-intrinsic domain LABEL** (title →
+topic, no goal input, computed once, cacheable forever — a video's own
+subject doesn't change) and (2) a **cheap label-vs-goal compare** would let
+step (1) be a cache hit for every recruitment after the first.
+
+**This is not a new pattern for this codebase — it is the SAME architecture
+already used by the (now-legacy) v3 semantic center gate**: `mandala_embeddings`
+(per-mandala, `getCenterGoalEmbedding`) + `video_pool_embeddings`
+(per-video, generated at promote-time — see `promote-from-v2.ts` lines
+16-18, "Generate embedding via Mac Mini Ollama... INSERT video_pool_embeddings")
++ a cosine-similarity compare (`mandala-filter.ts` `SEMANTIC_MIN_COSINE`).
+The domain-fit T3 classifier was built as a MORE ACCURATE alternative to
+exactly this pattern, specifically because raw embedding cosine failed the
+"niche_legit" cluster (docs/qa/domain-fit-probe-T3.md: T1/T2 substring/jaccard
+gates had "niche massacre" — 22-40% false-not-fit-on-legit — and the
+"niche_legit" cluster is explicitly "vocabulary-non-overlapping but
+domain-true fit", the case a coarse label + cosine compare is weakest at).
+
+**Honest feasibility verdict**: architecturally straightforward (reuses an
+existing, already-shipped caching pattern in this same codebase) and would
+cut load specifically for videos reused across multiple mandalas (real,
+given `video_pool`'s explicit shared-pool design — not measured this session,
+would need a video_pool re-recruitment-rate query, out of scope), but:
+1. Needs a new persisted field (e.g. `video_pool.domain_label` or a small
+   join table) — **DDL, blocked this session** (compliance: real data
+   change/DDL = 0). Analysis only, no schema change proposed as code.
+2. If the label-vs-goal compare step downgrades to embedding cosine (cheap,
+   fully cacheable) instead of an LLM judge, it risks reintroducing the SAME
+   niche-vocabulary weakness T3 was built to fix. Recommendation if pursued:
+   keep the compare step LLM-based too (label vs goal — much shorter input
+   than full title vs goal, so still cheaper per call and still benefits
+   from the video-intrinsic label being cached across mandalas), rather than
+   downgrading to cosine, to avoid trading accuracy for cost.
+3. Savings only materialize on REUSE (2nd+ time a given video is recruited)
+   — first-encounter cost per video is unavoidable either way.
+
+Not implemented this session (analysis + feasibility only, per R14-4 scope
+"실현성 규명" — establish feasibility, not ship it).
+
+## tsc / jest
+
+- `tsc --noEmit -p .`: clean (R14-1 code change).
+- Domain-fit-shadow suite: 39/39 pass (`tests/unit/modules/domain-fit-shadow.test.ts`,
+  `tests/unit/modules/domain-fit-shadow-client.test.ts`,
+  `tests/unit/config/domain-fit-shadow-config.test.ts`).
+- `src/skills/plugins/video-discover` suite: 314 passed / 1 pre-existing
+  unrelated failure (`trace-candidates.test.ts`, confirmed untouched by this
+  branch via `git diff --stat`).
+- enforce-0 / flag-off invariants re-verified by the same tests (no new
+  invariant broken by the goal-level rescope or scalar addition).

--- a/src/api/routes/cards.ts
+++ b/src/api/routes/cards.ts
@@ -55,6 +55,9 @@ import { logger } from '@/utils/logger';
 import { enqueueEnrichRichSummary } from '@/modules/queue';
 import { config } from '../../config';
 import { shortGateFields } from '@/modules/video-pool/is-short';
+import { loadDomainFitShadowConfig } from '@/config/domain-fit-shadow';
+import { scheduleDomainFitWriteShadow } from '@/modules/domain-fit-shadow/write-shadow';
+import { getMandalaManager } from '@/modules/mandala/manager';
 
 const YOUTUBE_VIDEO_ID_RE = /^[A-Za-z0-9_-]{11}$/;
 const VIDEO_ID_LOG_TRIM = 60;
@@ -553,6 +556,40 @@ export const cardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           if (await isChannelBlocked(ytFull.channel_id, ytFull.channel_title)) {
             log.info(`like → video_pool ingest SKIPPED (blocklisted channel): videoId=${videoId}`);
             return;
+          }
+          // R19 — domain-fit WRITE-edge shadow (measure-only, enforce-0).
+          // Same signal + fire-and-forget shape as the serve-side shadow
+          // hook (docs/qa/domain-fit-r14-write-gate-and-goal-level.md
+          // §R14-2 #2). Guarded by the flag BEFORE the extra mandala
+          // lookup so writeShadowEnabled=false (default) costs zero extra
+          // DB queries, not just zero extra Ollama calls. Never gates the
+          // upsert below — schedule call is fire-and-forget internally.
+          if (body.mandalaId) {
+            const shadowCfg = loadDomainFitShadowConfig();
+            if (shadowCfg.writeShadowEnabled) {
+              try {
+                const mandala = await getMandalaManager().getMandalaById(userId, body.mandalaId);
+                const root = mandala?.levels.find((l) => l.depth === 0);
+                if (root?.centerGoal) {
+                  scheduleDomainFitWriteShadow(
+                    {
+                      stage: 'like',
+                      centerGoal: root.centerGoal,
+                      videoId,
+                      title: ytFull.title ?? '',
+                      source: 'user_curated',
+                      mandalaId: body.mandalaId,
+                      userId,
+                    },
+                    shadowCfg
+                  );
+                }
+              } catch (shadowErr) {
+                log.debug(
+                  `like → domain-fit write-shadow resolve failed (swallowed): ${shadowErr instanceof Error ? shadowErr.message : String(shadowErr)}`
+                );
+              }
+            }
           }
           const lang = ytFull.title && /[가-힣]/.test(ytFull.title) ? 'ko' : 'en';
           // CP491 step 4 — short gate (demote Shorts at promote).

--- a/src/config/domain-fit-shadow.ts
+++ b/src/config/domain-fit-shadow.ts
@@ -68,6 +68,17 @@ export const domainFitShadowEnvSchema = z.object({
    * label + a synthetic proxy score could not differentiate multipliers).
    */
   DOMAIN_FIT_SHADOW_SCALAR: boolFlag.default(false as unknown as string),
+  /**
+   * R19 — WRITE-edge shadow (docs/qa/domain-fit-r14-write-gate-and-goal-level.md
+   * §R14-2 file:line). SEPARATE flag from the master `DOMAIN_FIT_SHADOW`
+   * (which only gates the serve-side read-path hooks in v3/executor.ts) so
+   * the two observability surfaces — "what got served" vs "what got
+   * written to video_pool" — can be toggled independently. Same frozen T3
+   * classifier + connection config as the master flag; only the on/off
+   * switch is distinct. Default false = zero extra Ollama calls, zero
+   * extra DB lookups at either WRITE-edge call site.
+   */
+  DOMAIN_FIT_WRITE_SHADOW: boolFlag.default(false as unknown as string),
 });
 
 export interface DomainFitShadowConfig {
@@ -78,6 +89,8 @@ export interface DomainFitShadowConfig {
   concurrency: number;
   maxCandidates: number;
   scalarEnabled: boolean;
+  /** R19 — independent flag for the two WRITE-edge shadow hooks (reuse-loop + /like). */
+  writeShadowEnabled: boolean;
 }
 
 const DEFAULTS: DomainFitShadowConfig = {
@@ -88,6 +101,7 @@ const DEFAULTS: DomainFitShadowConfig = {
   concurrency: 4,
   maxCandidates: 40,
   scalarEnabled: false,
+  writeShadowEnabled: false,
 };
 
 export function loadDomainFitShadowConfig(
@@ -101,6 +115,7 @@ export function loadDomainFitShadowConfig(
     DOMAIN_FIT_SHADOW_CONCURRENCY: env['DOMAIN_FIT_SHADOW_CONCURRENCY'],
     DOMAIN_FIT_SHADOW_MAX_CANDIDATES: env['DOMAIN_FIT_SHADOW_MAX_CANDIDATES'],
     DOMAIN_FIT_SHADOW_SCALAR: env['DOMAIN_FIT_SHADOW_SCALAR'],
+    DOMAIN_FIT_WRITE_SHADOW: env['DOMAIN_FIT_WRITE_SHADOW'],
   });
   if (!parsed.success) return { ...DEFAULTS };
   return {
@@ -111,5 +126,6 @@ export function loadDomainFitShadowConfig(
     concurrency: parsed.data.DOMAIN_FIT_SHADOW_CONCURRENCY,
     maxCandidates: parsed.data.DOMAIN_FIT_SHADOW_MAX_CANDIDATES,
     scalarEnabled: parsed.data.DOMAIN_FIT_SHADOW_SCALAR,
+    writeShadowEnabled: parsed.data.DOMAIN_FIT_WRITE_SHADOW,
   };
 }

--- a/src/config/domain-fit-shadow.ts
+++ b/src/config/domain-fit-shadow.ts
@@ -1,6 +1,6 @@
 /**
- * Domain-fit shadow config (R13-1 — search redesign, per-cell domain-fit
- * shadow classifier).
+ * Domain-fit shadow config (R13-1 — search redesign, domain-fit shadow
+ * classifier; R14-1 rescoped goal-level).
  *
  * Runs the FROZEN T3 local-Ollama binary classifier (docs/qa/domain-fit-probe-T3.md,
  * R12-validated) against the v3 recruited candidate set (post keyword/embedding
@@ -10,6 +10,12 @@
  * (`src/modules/discover-tracing`). enforce-0: no rerank multiplier is ever
  * applied to the serve order — this flag only turns on ASYNC, POST-SERVE
  * logging calls to a local Mac Mini Ollama instance.
+ *
+ * R14-1: classification target is the mandala's `centerGoal` (goal-level),
+ * not the per-cell subgoal — R13-2's offline sim found per-cell subgoal
+ * scoring produced a 25.8% false-not-fit rate on a known-clean mandala
+ * (docs/qa/domain-fit-r13-2-sim-results.md §a), well above the <10% bar;
+ * goal-level scoring measured 6.5% on the same style of real data.
  *
  * Compliance: inference is local-only (Mac Mini via Tailscale). No Anthropic /
  * OpenRouter / YouTube API calls are made by this module.
@@ -53,6 +59,15 @@ export const domainFitShadowEnvSchema = z.object({
    * shadow coverage, never a serve-path effect).
    */
   DOMAIN_FIT_SHADOW_MAX_CANDIDATES: z.coerce.number().int().positive().max(200).default(40),
+  /**
+   * R14-1 — additive scalar-capture pass (T3_SCALAR, a SEPARATE Ollama call
+   * per candidate). Default false: the binary-only call stays the default
+   * (half the load). When true, the shadow log also carries a 0.0-1.0
+   * confidence per candidate, giving a real gradient for a future rerank
+   * simulation (see docs/qa/domain-fit-r13-2-sim-results.md §c — the binary
+   * label + a synthetic proxy score could not differentiate multipliers).
+   */
+  DOMAIN_FIT_SHADOW_SCALAR: boolFlag.default(false as unknown as string),
 });
 
 export interface DomainFitShadowConfig {
@@ -62,6 +77,7 @@ export interface DomainFitShadowConfig {
   timeoutMs: number;
   concurrency: number;
   maxCandidates: number;
+  scalarEnabled: boolean;
 }
 
 const DEFAULTS: DomainFitShadowConfig = {
@@ -71,6 +87,7 @@ const DEFAULTS: DomainFitShadowConfig = {
   timeoutMs: 5000,
   concurrency: 4,
   maxCandidates: 40,
+  scalarEnabled: false,
 };
 
 export function loadDomainFitShadowConfig(
@@ -83,6 +100,7 @@ export function loadDomainFitShadowConfig(
     DOMAIN_FIT_SHADOW_TIMEOUT_MS: env['DOMAIN_FIT_SHADOW_TIMEOUT_MS'],
     DOMAIN_FIT_SHADOW_CONCURRENCY: env['DOMAIN_FIT_SHADOW_CONCURRENCY'],
     DOMAIN_FIT_SHADOW_MAX_CANDIDATES: env['DOMAIN_FIT_SHADOW_MAX_CANDIDATES'],
+    DOMAIN_FIT_SHADOW_SCALAR: env['DOMAIN_FIT_SHADOW_SCALAR'],
   });
   if (!parsed.success) return { ...DEFAULTS };
   return {
@@ -92,5 +110,6 @@ export function loadDomainFitShadowConfig(
     timeoutMs: parsed.data.DOMAIN_FIT_SHADOW_TIMEOUT_MS,
     concurrency: parsed.data.DOMAIN_FIT_SHADOW_CONCURRENCY,
     maxCandidates: parsed.data.DOMAIN_FIT_SHADOW_MAX_CANDIDATES,
+    scalarEnabled: parsed.data.DOMAIN_FIT_SHADOW_SCALAR,
   };
 }

--- a/src/config/domain-fit-shadow.ts
+++ b/src/config/domain-fit-shadow.ts
@@ -1,0 +1,96 @@
+/**
+ * Domain-fit shadow config (R13-1 — search redesign, per-cell domain-fit
+ * shadow classifier).
+ *
+ * Runs the FROZEN T3 local-Ollama binary classifier (docs/qa/domain-fit-probe-T3.md,
+ * R12-validated) against the v3 recruited candidate set (post keyword/embedding
+ * recruit + applyMandalaFilterWithStats — see mandala-filter integration in
+ * `src/skills/plugins/video-discover/v3/executor.ts`) and LOGS fit/not-fit +
+ * the candidate's current rank via the existing `recordTrace` instrumentation
+ * (`src/modules/discover-tracing`). enforce-0: no rerank multiplier is ever
+ * applied to the serve order — this flag only turns on ASYNC, POST-SERVE
+ * logging calls to a local Mac Mini Ollama instance.
+ *
+ * Compliance: inference is local-only (Mac Mini via Tailscale). No Anthropic /
+ * OpenRouter / YouTube API calls are made by this module.
+ *
+ * Default OFF (unset = legacy, zero behavior change, zero extra calls).
+ * Rollback = flip env off, no code revert.
+ */
+
+import { z } from 'zod';
+
+// Treat only "true"/"1"/"yes" as true (same idiom as inflow-gate.ts /
+// relevance-rubric.ts — avoids z.coerce.boolean making "false" truthy).
+const boolFlag = z.preprocess((v) => {
+  if (v == null || v === '') return false;
+  const s = String(v).trim().toLowerCase();
+  return s === 'true' || s === '1' || s === 'yes';
+}, z.boolean());
+
+export const domainFitShadowEnvSchema = z.object({
+  /** Master flag. false (default) = no-op, byte-identical to pre-R13 behavior. */
+  DOMAIN_FIT_SHADOW: boolFlag.default(false as unknown as string),
+  /**
+   * Tailscale address of the Mac Mini running `mandala-gen:latest`. Frozen
+   * per docs/qa/domain-fit-probe-T3.md. Deliberately NOT the generic
+   * OLLAMA_URL (that one defaults to localhost and a different model/endpoint
+   * shape — see src/modules/llm/ollama.ts /api/chat vs this module's raw
+   * /api/generate) so this shadow path never silently rides on unrelated
+   * Ollama config changes.
+   */
+  DOMAIN_FIT_SHADOW_OLLAMA_URL: z.string().default('http://100.91.173.17:11434'),
+  DOMAIN_FIT_SHADOW_MODEL: z.string().default('mandala-gen:latest'),
+  /** Per-call timeout — a hung Mac Mini call must never leak past this. */
+  DOMAIN_FIT_SHADOW_TIMEOUT_MS: z.coerce.number().int().positive().default(5000),
+  /** Bounded concurrency for the local Ollama burst (mirrors inflow-gate SCORE_BURST). */
+  DOMAIN_FIT_SHADOW_CONCURRENCY: z.coerce.number().int().positive().max(16).default(4),
+  /**
+   * Hard cap on candidates scored per recruited set. Local Ollama is
+   * single-instance — an unbounded fan-out on a 100+ candidate cell would
+   * both hammer the Mac Mini (feedback_no_repeated_hammering.md) and delay
+   * the shadow log write. Excess candidates are simply not scored (partial
+   * shadow coverage, never a serve-path effect).
+   */
+  DOMAIN_FIT_SHADOW_MAX_CANDIDATES: z.coerce.number().int().positive().max(200).default(40),
+});
+
+export interface DomainFitShadowConfig {
+  enabled: boolean;
+  ollamaUrl: string;
+  model: string;
+  timeoutMs: number;
+  concurrency: number;
+  maxCandidates: number;
+}
+
+const DEFAULTS: DomainFitShadowConfig = {
+  enabled: false,
+  ollamaUrl: 'http://100.91.173.17:11434',
+  model: 'mandala-gen:latest',
+  timeoutMs: 5000,
+  concurrency: 4,
+  maxCandidates: 40,
+};
+
+export function loadDomainFitShadowConfig(
+  env: NodeJS.ProcessEnv = process.env
+): DomainFitShadowConfig {
+  const parsed = domainFitShadowEnvSchema.safeParse({
+    DOMAIN_FIT_SHADOW: env['DOMAIN_FIT_SHADOW'],
+    DOMAIN_FIT_SHADOW_OLLAMA_URL: env['DOMAIN_FIT_SHADOW_OLLAMA_URL'],
+    DOMAIN_FIT_SHADOW_MODEL: env['DOMAIN_FIT_SHADOW_MODEL'],
+    DOMAIN_FIT_SHADOW_TIMEOUT_MS: env['DOMAIN_FIT_SHADOW_TIMEOUT_MS'],
+    DOMAIN_FIT_SHADOW_CONCURRENCY: env['DOMAIN_FIT_SHADOW_CONCURRENCY'],
+    DOMAIN_FIT_SHADOW_MAX_CANDIDATES: env['DOMAIN_FIT_SHADOW_MAX_CANDIDATES'],
+  });
+  if (!parsed.success) return { ...DEFAULTS };
+  return {
+    enabled: parsed.data.DOMAIN_FIT_SHADOW,
+    ollamaUrl: parsed.data.DOMAIN_FIT_SHADOW_OLLAMA_URL,
+    model: parsed.data.DOMAIN_FIT_SHADOW_MODEL,
+    timeoutMs: parsed.data.DOMAIN_FIT_SHADOW_TIMEOUT_MS,
+    concurrency: parsed.data.DOMAIN_FIT_SHADOW_CONCURRENCY,
+    maxCandidates: parsed.data.DOMAIN_FIT_SHADOW_MAX_CANDIDATES,
+  };
+}

--- a/src/config/domain-fit-shadow.ts
+++ b/src/config/domain-fit-shadow.ts
@@ -79,6 +79,27 @@ export const domainFitShadowEnvSchema = z.object({
    * extra DB lookups at either WRITE-edge call site.
    */
   DOMAIN_FIT_WRITE_SHADOW: boolFlag.default(false as unknown as string),
+  /**
+   * R23 — WRITE-edge ENFORCE capability (blast-0 code, deploy = James-gated).
+   * SEPARATE from `DOMAIN_FIT_WRITE_SHADOW` (measure-only, never branches):
+   * this flag lets `src/modules/video-pool/reuse-from-v5.ts` AWAIT the
+   * composite T3+lexical judgment (`./write-gate.ts`) and SKIP the upsert on
+   * a block verdict. Default false = the existing write-shadow call is the
+   * only thing that runs (R19-A1 unchanged, zero extra Ollama calls, zero
+   * write-decision impact). Independent of `V5_REUSE_LOOP` (reuse dispatch
+   * has its own flag) — enforce only matters once reuse is already ON.
+   */
+  DOMAIN_FIT_WRITE_ENFORCE: boolFlag.default(false as unknown as string),
+  /**
+   * R23 — pool-serve SERVE-edge shadow (`src/modules/queue/handlers/pool-serve-fill.ts`).
+   * SEPARATE from the master `DOMAIN_FIT_SHADOW` (which gates the v3/executor.ts
+   * wizard read-path hooks) so pool-serve's would-serve logging can be toggled
+   * without touching the wizard's shadow coverage. enforce-0: only turns on an
+   * ASYNC, POST-gate `scheduleDomainFitShadow` call (shadow.ts, unmodified) —
+   * never reorders or drops a candidate the relevance gate already passed.
+   * Default false = zero extra Ollama calls at this call site.
+   */
+  DOMAIN_FIT_SERVE_SHADOW: boolFlag.default(false as unknown as string),
 });
 
 export interface DomainFitShadowConfig {
@@ -91,6 +112,10 @@ export interface DomainFitShadowConfig {
   scalarEnabled: boolean;
   /** R19 — independent flag for the two WRITE-edge shadow hooks (reuse-loop + /like). */
   writeShadowEnabled: boolean;
+  /** R23 — independent flag: enforce-capable WRITE gate (reuse-loop only today). */
+  writeEnforceEnabled: boolean;
+  /** R23 — independent flag: pool-serve SERVE-edge would-serve shadow log. */
+  serveShadowEnabled: boolean;
 }
 
 const DEFAULTS: DomainFitShadowConfig = {
@@ -102,6 +127,8 @@ const DEFAULTS: DomainFitShadowConfig = {
   maxCandidates: 40,
   scalarEnabled: false,
   writeShadowEnabled: false,
+  writeEnforceEnabled: false,
+  serveShadowEnabled: false,
 };
 
 export function loadDomainFitShadowConfig(
@@ -116,6 +143,8 @@ export function loadDomainFitShadowConfig(
     DOMAIN_FIT_SHADOW_MAX_CANDIDATES: env['DOMAIN_FIT_SHADOW_MAX_CANDIDATES'],
     DOMAIN_FIT_SHADOW_SCALAR: env['DOMAIN_FIT_SHADOW_SCALAR'],
     DOMAIN_FIT_WRITE_SHADOW: env['DOMAIN_FIT_WRITE_SHADOW'],
+    DOMAIN_FIT_WRITE_ENFORCE: env['DOMAIN_FIT_WRITE_ENFORCE'],
+    DOMAIN_FIT_SERVE_SHADOW: env['DOMAIN_FIT_SERVE_SHADOW'],
   });
   if (!parsed.success) return { ...DEFAULTS };
   return {
@@ -127,5 +156,7 @@ export function loadDomainFitShadowConfig(
     maxCandidates: parsed.data.DOMAIN_FIT_SHADOW_MAX_CANDIDATES,
     scalarEnabled: parsed.data.DOMAIN_FIT_SHADOW_SCALAR,
     writeShadowEnabled: parsed.data.DOMAIN_FIT_WRITE_SHADOW,
+    writeEnforceEnabled: parsed.data.DOMAIN_FIT_WRITE_ENFORCE,
+    serveShadowEnabled: parsed.data.DOMAIN_FIT_SERVE_SHADOW,
   };
 }

--- a/src/config/pool-serve.ts
+++ b/src/config/pool-serve.ts
@@ -54,6 +54,15 @@ export const poolServeEnvSchema = z.object({
   V5_POOL_SERVE_COSINE_DIST_MAX: z.coerce.number().min(0).max(1).default(0.45),
   /** Max cosine candidates recruited per cell. */
   V5_POOL_SERVE_COSINE_K: z.coerce.number().int().min(1).max(50).default(10),
+  /**
+   * R23 — comma-separated EXTRA pool-serve recruit sources appended to the
+   * BASE whitelist (['v2_promoted'], see pool-serve-fill.ts POOL_SOURCES_BASE),
+   * e.g. "yt_promoted". Independent of V5_POOL_SERVE_COSINE_RECRUIT (which
+   * only broadens the SEPARATE cosine-pass sources) — this widens the MAIN
+   * keyword-recruit sources too. Default empty = current behavior
+   * (v2_promoted only, byte-identical).
+   */
+  POOL_SERVE_SOURCES_EXTRA: z.string().default(''),
 });
 
 export interface PoolServeConfig {
@@ -67,6 +76,8 @@ export interface PoolServeConfig {
   cosineRecruit: boolean;
   cosineDistMax: number;
   cosineK: number;
+  /** R23 — extra recruit sources beyond the base v2_promoted whitelist. */
+  sourcesExtra: string[];
 }
 
 const DEFAULTS: PoolServeConfig = {
@@ -80,7 +91,16 @@ const DEFAULTS: PoolServeConfig = {
   cosineRecruit: false,
   cosineDistMax: 0.45,
   cosineK: 10,
+  sourcesExtra: [],
 };
+
+/** Parse a comma-separated env value into a trimmed, non-empty string[]. */
+function parseSourcesExtra(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
 
 export function loadPoolServeConfig(env: NodeJS.ProcessEnv = process.env): PoolServeConfig {
   const parsed = poolServeEnvSchema.safeParse({
@@ -94,6 +114,7 @@ export function loadPoolServeConfig(env: NodeJS.ProcessEnv = process.env): PoolS
     V5_POOL_SERVE_COSINE_RECRUIT: env['V5_POOL_SERVE_COSINE_RECRUIT'],
     V5_POOL_SERVE_COSINE_DIST_MAX: env['V5_POOL_SERVE_COSINE_DIST_MAX'],
     V5_POOL_SERVE_COSINE_K: env['V5_POOL_SERVE_COSINE_K'],
+    POOL_SERVE_SOURCES_EXTRA: env['POOL_SERVE_SOURCES_EXTRA'],
   });
   if (!parsed.success) return DEFAULTS;
   return {
@@ -107,5 +128,6 @@ export function loadPoolServeConfig(env: NodeJS.ProcessEnv = process.env): PoolS
     cosineRecruit: parsed.data.V5_POOL_SERVE_COSINE_RECRUIT,
     cosineDistMax: parsed.data.V5_POOL_SERVE_COSINE_DIST_MAX,
     cosineK: parsed.data.V5_POOL_SERVE_COSINE_K,
+    sourcesExtra: parseSourcesExtra(parsed.data.POOL_SERVE_SOURCES_EXTRA),
   };
 }

--- a/src/modules/domain-fit-shadow/client.ts
+++ b/src/modules/domain-fit-shadow/client.ts
@@ -1,0 +1,99 @@
+/**
+ * Domain-fit T3 client — frozen prompt + raw Ollama /api/generate call.
+ *
+ * Verbatim reproduction of the frozen T3 spec (docs/qa/domain-fit-probe-T3.md,
+ * R12-validated: false-not-fit-on-legit 3.3% overall / 0% on niche_legit,
+ * drift-detection 95.5%). Deliberately NOT reusing the generic
+ * `OllamaGenerationProvider` (src/modules/llm/ollama.ts) — that provider
+ * calls `/api/chat` with `think:false` framing, a different template shape
+ * that was never validated against this spec. Reproducibility over reuse
+ * here: the frozen prompt must hit `/api/generate` with `raw:true`.
+ *
+ * Local-inference only. No Anthropic / OpenRouter / YouTube API calls.
+ */
+
+import { logger } from '@/utils/logger';
+import type { DomainFitShadowConfig } from '@/config/domain-fit-shadow';
+
+const log = logger.child({ module: 'domain-fit-shadow/client' });
+
+export type DomainFitLabel = '적합' | '비적합';
+
+export interface DomainFitResult {
+  fit: DomainFitLabel | null;
+  ms: number;
+  ok: boolean;
+  error?: string;
+}
+
+/** Frozen T3 (verbatim — do not alter; see docs/qa/domain-fit-probe-T3.md). */
+export function buildT3Prompt(goal: string, title: string): string {
+  return `### Instruction:\n다음 영상 제목과 목표의 주제 적합성을 분류하라 (적합/비적합). JSON만 출력: {"fit": "적합"|"비적합"}\n\n### Input:\n영상 제목: ${title}\n관련 목표: ${goal}\n\n### Output:\n`;
+}
+
+/** Frozen parse strategy (verbatim — see runner.mjs parseFit / probe spec §Parse strategy). */
+export function parseFit(raw: string): { parsed: DomainFitLabel | null; ok: boolean } {
+  try {
+    const m = raw.match(/\{[^{}]*\}/);
+    if (m) {
+      const obj = JSON.parse(m[0]) as { fit?: unknown };
+      if (obj.fit === '적합' || obj.fit === '비적합') {
+        return { parsed: obj.fit, ok: true };
+      }
+    }
+  } catch {
+    /* fallthrough to fragile fallback, flagged parse_clean:false */
+  }
+  const hasNonfit = raw.includes('비적합');
+  const hasFit = raw.includes('"적합"') || (raw.includes('적합') && !hasNonfit);
+  if (hasNonfit) return { parsed: '비적합', ok: false };
+  if (hasFit) return { parsed: '적합', ok: false };
+  return { parsed: null, ok: false };
+}
+
+/**
+ * Single T3 binary classification call. Never throws — timeouts/transport
+ * errors resolve to `{ fit: null, ok: false, error }` so a burst of shadow
+ * calls can `Promise.all` safely (one bad candidate never poisons the batch).
+ */
+export async function classifyDomainFit(
+  goal: string,
+  title: string,
+  cfg: Pick<DomainFitShadowConfig, 'ollamaUrl' | 'model' | 'timeoutMs'>
+): Promise<DomainFitResult> {
+  const started = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), cfg.timeoutMs);
+  try {
+    const res = await fetch(`${cfg.ollamaUrl}/api/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      signal: controller.signal,
+      body: JSON.stringify({
+        model: cfg.model,
+        prompt: buildT3Prompt(goal, title),
+        raw: true,
+        stream: false,
+        options: { temperature: 0.1, num_predict: 60 },
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      return {
+        fit: null,
+        ms: Date.now() - started,
+        ok: false,
+        error: `http ${res.status}: ${body.slice(0, 200)}`,
+      };
+    }
+    const json = (await res.json()) as { response?: string };
+    const { parsed } = parseFit(json.response ?? '');
+    return { fit: parsed, ms: Date.now() - started, ok: parsed !== null };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.debug(`domain-fit shadow call failed (swallowed): ${msg}`);
+    return { fit: null, ms: Date.now() - started, ok: false, error: msg };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/modules/domain-fit-shadow/client.ts
+++ b/src/modules/domain-fit-shadow/client.ts
@@ -26,9 +26,26 @@ export interface DomainFitResult {
   error?: string;
 }
 
+export interface DomainFitScalarResult extends DomainFitResult {
+  /** 0.0-1.0 confidence from the T3_SCALAR variant; null on parse failure. */
+  score: number | null;
+}
+
 /** Frozen T3 (verbatim — do not alter; see docs/qa/domain-fit-probe-T3.md). */
 export function buildT3Prompt(goal: string, title: string): string {
   return `### Instruction:\n다음 영상 제목과 목표의 주제 적합성을 분류하라 (적합/비적합). JSON만 출력: {"fit": "적합"|"비적합"}\n\n### Input:\n영상 제목: ${title}\n관련 목표: ${goal}\n\n### Output:\n`;
+}
+
+/**
+ * Frozen T3_SCALAR (verbatim — do not alter; "R12 scalar-capture variant" in
+ * docs/qa/domain-fit-probe-T3.md). Additive, separate call — never substitutes
+ * for the frozen binary T3 call above. R14-1: captures a 0.0-1.0 confidence
+ * alongside the binary label so a future rerank multiplier sim has a REAL
+ * gradient to work with (R13-2 found the binary label alone forces a
+ * synthetic-proxy-score simulation with no usable 0.15/0.2/0.3 differentiation).
+ */
+export function buildT3ScalarPrompt(goal: string, title: string): string {
+  return `### Instruction:\n다음 영상 제목과 목표의 주제 적합성을 분류하라 (적합/비적합). 그리고 0.0~1.0 사이의 적합도 confidence 점수도 함께 산정하라 (1.0=완전히 같은 주제, 0.0=전혀 무관). JSON만 출력: {"fit": "적합"|"비적합", "score": 0.0~1.0}\n\n### Input:\n영상 제목: ${title}\n관련 목표: ${goal}\n\n### Output:\n`;
 }
 
 /** Frozen parse strategy (verbatim — see runner.mjs parseFit / probe spec §Parse strategy). */
@@ -49,6 +66,29 @@ export function parseFit(raw: string): { parsed: DomainFitLabel | null; ok: bool
   if (hasNonfit) return { parsed: '비적합', ok: false };
   if (hasFit) return { parsed: '적합', ok: false };
   return { parsed: null, ok: false };
+}
+
+/** Frozen parse strategy for the T3_SCALAR variant (fit + numeric score). */
+export function parseFitScalar(raw: string): {
+  parsed: DomainFitLabel | null;
+  score: number | null;
+  ok: boolean;
+} {
+  try {
+    const m = raw.match(/\{[^{}]*\}/);
+    if (m) {
+      const obj = JSON.parse(m[0]) as { fit?: unknown; score?: unknown };
+      if (obj.fit === '적합' || obj.fit === '비적합') {
+        const score =
+          typeof obj.score === 'number' && Number.isFinite(obj.score) ? obj.score : null;
+        return { parsed: obj.fit, score, ok: true };
+      }
+    }
+  } catch {
+    /* fallthrough to fragile fallback, flagged parse_clean:false */
+  }
+  const { parsed } = parseFit(raw);
+  return { parsed, score: null, ok: false };
 }
 
 /**
@@ -93,6 +133,55 @@ export async function classifyDomainFit(
     const msg = err instanceof Error ? err.message : String(err);
     log.debug(`domain-fit shadow call failed (swallowed): ${msg}`);
     return { fit: null, ms: Date.now() - started, ok: false, error: msg };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * R14-1 — additive scalar-capture call (T3_SCALAR). A SEPARATE call from
+ * `classifyDomainFit`, never a substitute — the frozen binary T3 result stays
+ * the primary label; this only adds a confidence gradient for the rerank
+ * simulation. Same never-throws contract as `classifyDomainFit`.
+ */
+export async function classifyDomainFitScalar(
+  goal: string,
+  title: string,
+  cfg: Pick<DomainFitShadowConfig, 'ollamaUrl' | 'model' | 'timeoutMs'>
+): Promise<DomainFitScalarResult> {
+  const started = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), cfg.timeoutMs);
+  try {
+    const res = await fetch(`${cfg.ollamaUrl}/api/generate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      signal: controller.signal,
+      body: JSON.stringify({
+        model: cfg.model,
+        prompt: buildT3ScalarPrompt(goal, title),
+        raw: true,
+        stream: false,
+        options: { temperature: 0.1, num_predict: 60 },
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      return {
+        fit: null,
+        score: null,
+        ms: Date.now() - started,
+        ok: false,
+        error: `http ${res.status}: ${body.slice(0, 200)}`,
+      };
+    }
+    const json = (await res.json()) as { response?: string };
+    const { parsed, score } = parseFitScalar(json.response ?? '');
+    return { fit: parsed, score, ms: Date.now() - started, ok: parsed !== null };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.debug(`domain-fit shadow scalar call failed (swallowed): ${msg}`);
+    return { fit: null, score: null, ms: Date.now() - started, ok: false, error: msg };
   } finally {
     clearTimeout(timer);
   }

--- a/src/modules/domain-fit-shadow/lexical-qualifier.ts
+++ b/src/modules/domain-fit-shadow/lexical-qualifier.ts
@@ -1,0 +1,100 @@
+/**
+ * Lexical qualifier-conflict deboost (R22-1 — search redesign).
+ *
+ * Pure string matching, zero LLM calls. Sits ON TOP of the frozen T3
+ * domain-fit classifier (client.ts, untouched by this file) as a
+ * post-processing SIGNAL: if the mandala goal and a candidate title both
+ * name a value in the same qualifier category (language / cloud vendor /
+ * instrument — see qualifier-vocab.ts) and those values DIFFER, apply a
+ * deboost multiplier to the candidate's score. This is designed to catch the
+ * "generic activity-noun with a dilutable domain qualifier" over-pass pattern
+ * quantified in docs/qa/domain-fit-r20-polysemy-overpass-n-expansion.md
+ * (회화 40%, 코드 25% LLM over-pass) and the R20-1 WRITE-edge cloud-vendor
+ * collision (KT vs Oracle).
+ *
+ * Design invariants (do not weaken without a fresh measurement round):
+ *   - CONFLICT only: goal and title both name a DIFFERENT value in the same
+ *     category. Deboost.
+ *   - ABSENCE never deboosts: if either side has no vocab hit in a category,
+ *     that category is silently skipped — protects legit niche content that
+ *     simply doesn't happen to restate the qualifier (see R22-2 legit
+ *     false-deboost measurement, target 0).
+ *   - Signal, not a hard cut: returns a multiplier (default
+ *     DEFAULT_QUALIFIER_CONFLICT_MULTIPLIER), never a boolean pass/fail.
+ *     Callers decide whether/how to apply it to a score.
+ */
+
+import { QUALIFIER_VOCAB_BY_CATEGORY, type QualifierCategory } from './qualifier-vocab';
+
+/** Deboost multiplier applied when >=1 category conflicts. Named constant — no magic number at call sites. */
+export const DEFAULT_QUALIFIER_CONFLICT_MULTIPLIER = 0.2;
+
+export interface QualifierConflict {
+  category: QualifierCategory;
+  /** canonical values found in the goal text for this category (non-empty). */
+  goalValues: string[];
+  /** canonical values found in the title text for this category (non-empty, disjoint from goalValues). */
+  titleValues: string[];
+}
+
+export interface QualifierConflictResult {
+  /** true iff >=1 category has a goal/title value conflict. */
+  hasConflict: boolean;
+  conflicts: QualifierConflict[];
+  /** DEFAULT_QUALIFIER_CONFLICT_MULTIPLIER when hasConflict, else 1 (no-op). */
+  multiplier: number;
+}
+
+/**
+ * Extract the set of canonical vocab values a text hits within one category.
+ * Case-insensitive; matches on raw substring presence (vocab terms are short,
+ * closed-list tokens — see qualifier-vocab.ts header for the word-boundary
+ * caveat on `기타`).
+ */
+export function extractQualifierValues(text: string, category: QualifierCategory): Set<string> {
+  const vocab = QUALIFIER_VOCAB_BY_CATEGORY[category];
+  const haystack = text.toLowerCase();
+  const found = new Set<string>();
+  for (const [surface, canonical] of Object.entries(vocab)) {
+    if (haystack.includes(surface.toLowerCase())) {
+      found.add(canonical);
+    }
+  }
+  return found;
+}
+
+/**
+ * Detect qualifier conflicts between a goal and a candidate title across all
+ * known categories. ABSENCE (either side has zero hits in a category) is
+ * never a conflict — only genuine cross-value collisions count.
+ */
+export function detectQualifierConflicts(goal: string, title: string): QualifierConflictResult {
+  const conflicts: QualifierConflict[] = [];
+
+  for (const category of Object.keys(QUALIFIER_VOCAB_BY_CATEGORY) as QualifierCategory[]) {
+    const goalValues = extractQualifierValues(goal, category);
+    const titleValues = extractQualifierValues(title, category);
+    if (goalValues.size === 0 || titleValues.size === 0) continue; // absence -> no-op
+
+    const disjoint = [...goalValues].every((v) => !titleValues.has(v));
+    if (disjoint) {
+      conflicts.push({
+        category,
+        goalValues: [...goalValues],
+        titleValues: [...titleValues],
+      });
+    }
+  }
+
+  return {
+    hasConflict: conflicts.length > 0,
+    conflicts,
+    multiplier: conflicts.length > 0 ? DEFAULT_QUALIFIER_CONFLICT_MULTIPLIER : 1,
+  };
+}
+
+/** Convenience: apply the lexical deboost multiplier to a base score. */
+export function applyQualifierDeboost(baseScore: number, goal: string, title: string): number {
+  const { multiplier } = detectQualifierConflicts(goal, title);
+  return baseScore * multiplier;
+}

--- a/src/modules/domain-fit-shadow/qualifier-vocab.ts
+++ b/src/modules/domain-fit-shadow/qualifier-vocab.ts
@@ -1,0 +1,94 @@
+/**
+ * Domain-fit lexical qualifier vocab (R22-1 — search redesign, non-LLM
+ * conflict-detection layer on top of the frozen T3 domain-fit classifier).
+ *
+ * Narrow, closed vocab lists (per-category) used by `lexical-qualifier.ts` to
+ * detect a QUALIFIER CONFLICT between a mandala goal and a candidate video
+ * title — e.g. goal says "영어" (English) but the title's language qualifier
+ * is "일본어" (Japanese). This is a SIGNAL (deboost multiplier), never a hard
+ * cut, and never LLM-driven — pure string matching against the closed lists
+ * below. Deliberately narrow (not general-purpose NER): only categories where
+ * R20/R20-1 measurement showed a real, repeated LLM over-pass pattern
+ * (docs/qa/domain-fit-r20-polysemy-overpass-n-expansion.md — 회화 40%,
+ * 코드 25% over-pass; cloud-vendor collision found in R20-1 WRITE-edge set).
+ *
+ * Extending a category (or adding a new one) requires the same measurement
+ * discipline as this file's origin: a real over-pass pattern, not a guess.
+ * Do NOT add generic/ambiguous tokens without word-boundary review — see the
+ * `기타` (guitar vs "etc.") caveat on INSTRUMENT_VOCAB below.
+ */
+
+export const QUALIFIER_CATEGORIES = ['language', 'cloud_vendor', 'instrument'] as const;
+export type QualifierCategory = (typeof QUALIFIER_CATEGORIES)[number];
+
+/** surface term (as it appears in Korean/English titles) -> canonical value id within its category. */
+export type QualifierVocabMap = Readonly<Record<string, string>>;
+
+/**
+ * Language-name qualifiers. Source: R20-2 회화 (conversation) cluster —
+ * goal "100일 영어 회화 완성하기" (English) repeatedly over-passed against
+ * real off-domain titles naming a DIFFERENT language explicitly
+ * (일본어/중국어/스페인어/프랑스어/베트남어), 40.0% over-pass at N=30
+ * (docs/qa/domain-fit-r20-polysemy-overpass-n-expansion.md).
+ *
+ * Deliberately matches only the explicit "-어" language-name form, NOT bare
+ * country names (e.g. "스페인" alone does not imply "스페인어" — a Spain
+ * travel-vlog title is not automatically a Spanish-language lesson). This is
+ * a conservative choice: it under-catches (see R22-2 measurement) rather
+ * than risk conflating travel/culture content with language content.
+ */
+export const LANGUAGE_VOCAB: QualifierVocabMap = {
+  일본어: 'ja',
+  중국어: 'zh',
+  영어: 'en',
+  스페인어: 'es',
+  프랑스어: 'fr',
+  베트남어: 'vi',
+  독일어: 'de',
+  한국어: 'ko',
+};
+
+/**
+ * Cloud-vendor qualifiers. Source: R20-1 WRITE-edge over-pass row R014 (goal
+ * "KT 클라우드 강의안 작성" vs title "...오라클 클라우드" — different vendor,
+ * gold 비적합, LLM over-passed 적합).
+ */
+export const CLOUD_VENDOR_VOCAB: QualifierVocabMap = {
+  오라클: 'oracle',
+  oracle: 'oracle',
+  azure: 'azure',
+  aws: 'aws',
+  kt클라우드: 'kt',
+  kt: 'kt',
+  네이버클라우드: 'naver',
+  네이버: 'naver',
+  gcp: 'gcp',
+  구글클라우드: 'gcp',
+  'google cloud': 'gcp',
+};
+
+/**
+ * Instrument qualifiers. Source: R16 niche_legit/niche_drift instrument-goal
+ * clusters (classical guitar / piano goals vs off-instrument titles).
+ *
+ * CAVEAT (honesty, not swept under the rug): `기타` is a genuine Korean
+ * homograph — "guitar" vs "etc./and so on" (as in "기타 등등"). A false
+ * conflict is only possible when the OTHER side also names a *different*
+ * instrument (absence never deboosts — see lexical-qualifier.ts), so the
+ * blast radius of this ambiguity is narrow, but it is not zero. Flagged
+ * explicitly in the R22-2 measurement report rather than silently accepted.
+ */
+export const INSTRUMENT_VOCAB: QualifierVocabMap = {
+  기타: 'guitar',
+  피아노: 'piano',
+  드럼: 'drums',
+  바이올린: 'violin',
+  우쿨렐레: 'ukulele',
+  베이스: 'bass',
+};
+
+export const QUALIFIER_VOCAB_BY_CATEGORY: Readonly<Record<QualifierCategory, QualifierVocabMap>> = {
+  language: LANGUAGE_VOCAB,
+  cloud_vendor: CLOUD_VENDOR_VOCAB,
+  instrument: INSTRUMENT_VOCAB,
+};

--- a/src/modules/domain-fit-shadow/shadow.ts
+++ b/src/modules/domain-fit-shadow/shadow.ts
@@ -1,0 +1,140 @@
+/**
+ * Domain-fit shadow scheduler (R13-1).
+ *
+ * Fire-and-forget: scores the v3 recruited-and-ranked candidate set (post
+ * keyword/embedding recruit + applyMandalaFilterWithStats — see
+ * `src/skills/plugins/video-discover/v3/executor.ts` call sites) against the
+ * frozen local-Ollama T3 domain-fit classifier, and LOGS the verdict + the
+ * candidate's current rank via the existing `recordTrace` instrumentation
+ * (`src/modules/discover-tracing`). This is observation only:
+ *   - enforce-0: never mutates / reorders the caller's candidate array.
+ *   - async/post: the caller must NOT await this function. It schedules the
+ *     work with `void` internally and never throws.
+ *   - flag-gated: `DOMAIN_FIT_SHADOW` (default false) — off = literally zero
+ *     extra work (checked before touching the candidate list).
+ */
+
+import { logger } from '@/utils/logger';
+import { recordTrace } from '@/modules/discover-tracing';
+import { loadDomainFitShadowConfig, type DomainFitShadowConfig } from '@/config/domain-fit-shadow';
+import { classifyDomainFit, type DomainFitLabel } from './client';
+
+const log = logger.child({ module: 'domain-fit-shadow' });
+
+export type DomainFitShadowStage = 'tier1' | 'tier2';
+
+/** One recruited candidate as it stands AFTER applyMandalaFilterWithStats. */
+export interface ShadowCandidateInput {
+  videoId: string;
+  title: string;
+  /** Mandala cell (0-7) this candidate was routed to by the mandala filter. */
+  cellIndex: number;
+  /** 0-based position within the final ranked/sorted recruited set for this stage. */
+  rank: number;
+  /** The mandala-filter (or tier1 match) score that produced `rank`. */
+  score: number;
+}
+
+export interface ScheduleDomainFitShadowInput {
+  stage: DomainFitShadowStage;
+  centerGoal: string;
+  /** subGoals[cellIndex] = the per-cell goal text; falls back to centerGoal. */
+  subGoals: string[];
+  candidates: ShadowCandidateInput[];
+}
+
+export interface ShadowScoredCandidate {
+  videoId: string;
+  cellIndex: number;
+  rank: number;
+  score: number;
+  fit: DomainFitLabel | null;
+  ok: boolean;
+  ms: number;
+}
+
+/**
+ * Schedule shadow scoring for one recruited set. Returns immediately
+ * (synchronous no-op check + fire-and-forget dispatch) — callers must NOT
+ * await. No-op when the flag is off or the candidate list is empty.
+ */
+export function scheduleDomainFitShadow(
+  input: ScheduleDomainFitShadowInput,
+  cfgOverride?: DomainFitShadowConfig
+): void {
+  const cfg = cfgOverride ?? loadDomainFitShadowConfig();
+  if (!cfg.enabled) return;
+  if (input.candidates.length === 0) return;
+
+  void runDomainFitShadow(input, cfg).catch((err) => {
+    // Belt-and-suspenders — runDomainFitShadow already swallows internally,
+    // this only guards against a truly unexpected synchronous throw.
+    log.debug(
+      `domain-fit shadow run failed (swallowed): ${err instanceof Error ? err.message : String(err)}`
+    );
+  });
+}
+
+/**
+ * Exported (in addition to `scheduleDomainFitShadow`) so tests can `await`
+ * the scoring pass directly instead of racing the fire-and-forget dispatch.
+ * Production callers should use `scheduleDomainFitShadow`, never this.
+ */
+export async function runDomainFitShadow(
+  input: ScheduleDomainFitShadowInput,
+  cfg: DomainFitShadowConfig
+): Promise<void> {
+  const t0 = Date.now();
+  try {
+    const capped = input.candidates.slice(0, cfg.maxCandidates);
+    const results: ShadowScoredCandidate[] = [];
+
+    for (let i = 0; i < capped.length; i += cfg.concurrency) {
+      const burst = capped.slice(i, i + cfg.concurrency);
+      const scored = await Promise.all(
+        burst.map(async (c): Promise<ShadowScoredCandidate> => {
+          const goal = input.subGoals[c.cellIndex] ?? input.centerGoal;
+          const r = await classifyDomainFit(goal, c.title, cfg);
+          return {
+            videoId: c.videoId,
+            cellIndex: c.cellIndex,
+            rank: c.rank,
+            score: c.score,
+            fit: r.fit,
+            ok: r.ok,
+            ms: r.ms,
+          };
+        })
+      );
+      results.push(...scored);
+    }
+
+    const fitCount = results.filter((r) => r.fit === '적합').length;
+    const notFitCount = results.filter((r) => r.fit === '비적합').length;
+    const failedCount = results.length - fitCount - notFitCount;
+
+    recordTrace({
+      step: `domain_fit_shadow.${input.stage}`,
+      status: 'ok',
+      request: {
+        model: cfg.model,
+        candidates_total: input.candidates.length,
+        candidates_scored: capped.length,
+        max_candidates: cfg.maxCandidates,
+      },
+      response: {
+        fit: fitCount,
+        not_fit: notFitCount,
+        failed: failedCount,
+        candidates: results,
+      },
+      latencyMs: Date.now() - t0,
+    });
+  } catch (err) {
+    // Never let a shadow-logging failure surface anywhere near the serve
+    // path — this function is always invoked fire-and-forget.
+    log.debug(
+      `domain-fit shadow scoring failed (swallowed): ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}

--- a/src/modules/domain-fit-shadow/shadow.ts
+++ b/src/modules/domain-fit-shadow/shadow.ts
@@ -32,7 +32,10 @@ import { classifyDomainFit, classifyDomainFitScalar, type DomainFitLabel } from 
 
 const log = logger.child({ module: 'domain-fit-shadow' });
 
-export type DomainFitShadowStage = 'tier1' | 'tier2';
+/** 'pool_serve' — R23 addition: pool-serve-fill.ts's SERVE-edge would-serve
+ *  shadow (gated by DOMAIN_FIT_SERVE_SHADOW via a cfgOverride, not the master
+ *  DOMAIN_FIT_SHADOW flag). Same `domain_fit_shadow.<stage>` trace step shape. */
+export type DomainFitShadowStage = 'tier1' | 'tier2' | 'pool_serve';
 
 /** One recruited candidate as it stands AFTER applyMandalaFilterWithStats. */
 export interface ShadowCandidateInput {

--- a/src/modules/domain-fit-shadow/shadow.ts
+++ b/src/modules/domain-fit-shadow/shadow.ts
@@ -1,23 +1,34 @@
 /**
- * Domain-fit shadow scheduler (R13-1).
+ * Domain-fit shadow scheduler (R13-1; R14-1 rescoped goal-level).
  *
  * Fire-and-forget: scores the v3 recruited-and-ranked candidate set (post
  * keyword/embedding recruit + applyMandalaFilterWithStats — see
  * `src/skills/plugins/video-discover/v3/executor.ts` call sites) against the
  * frozen local-Ollama T3 domain-fit classifier, and LOGS the verdict + the
- * candidate's current rank via the existing `recordTrace` instrumentation
- * (`src/modules/discover-tracing`). This is observation only:
+ * candidate's REAL mandala-filter score/rank via the existing `recordTrace`
+ * instrumentation (`src/modules/discover-tracing`). This is observation only:
  *   - enforce-0: never mutates / reorders the caller's candidate array.
  *   - async/post: the caller must NOT await this function. It schedules the
  *     work with `void` internally and never throws.
  *   - flag-gated: `DOMAIN_FIT_SHADOW` (default false) — off = literally zero
  *     extra work (checked before touching the candidate list).
+ *
+ * R14-1 — classification target is the mandala's `centerGoal` (domain-level),
+ * not the per-cell subgoal used in R13. R13-2's offline sim found per-cell
+ * subgoal scoring produced a 25.8% false-not-fit rate on a known-clean
+ * mandala (docs/qa/domain-fit-r13-2-sim-results.md §a) — most of those misses
+ * were genuine CELL-level mismatches within an overall-legit mandala (a
+ * placement-granularity effect), not evidence the video is off the mandala's
+ * DOMAIN. Goal-level scoring measured 6.5% false-not-fit on the same style of
+ * real data, clearing the <10% bar. `cellIndex`/`rank` are still logged per
+ * candidate (needed for the trace's per-cell breakdown), just no longer used
+ * to pick the comparison text.
  */
 
 import { logger } from '@/utils/logger';
 import { recordTrace } from '@/modules/discover-tracing';
 import { loadDomainFitShadowConfig, type DomainFitShadowConfig } from '@/config/domain-fit-shadow';
-import { classifyDomainFit, type DomainFitLabel } from './client';
+import { classifyDomainFit, classifyDomainFitScalar, type DomainFitLabel } from './client';
 
 const log = logger.child({ module: 'domain-fit-shadow' });
 
@@ -27,18 +38,23 @@ export type DomainFitShadowStage = 'tier1' | 'tier2';
 export interface ShadowCandidateInput {
   videoId: string;
   title: string;
-  /** Mandala cell (0-7) this candidate was routed to by the mandala filter. */
+  /** Mandala cell (0-7) this candidate was routed to by the mandala filter — logged, not used to pick the classification goal (R14-1: goal-level). */
   cellIndex: number;
   /** 0-based position within the final ranked/sorted recruited set for this stage. */
   rank: number;
-  /** The mandala-filter (or tier1 match) score that produced `rank`. */
+  /** The mandala-filter (or tier1 match) score that produced `rank` — the REAL score, not a proxy. */
   score: number;
 }
 
 export interface ScheduleDomainFitShadowInput {
   stage: DomainFitShadowStage;
+  /** R14-1: this IS the classification goal (domain-level) — subGoals are no longer used to build the prompt. */
   centerGoal: string;
-  /** subGoals[cellIndex] = the per-cell goal text; falls back to centerGoal. */
+  /**
+   * @deprecated R14-1 — retained only so existing call sites (v3/executor.ts)
+   * don't need a signature change. No longer read for classification; the
+   * comparison text is always `centerGoal`.
+   */
   subGoals: string[];
   candidates: ShadowCandidateInput[];
 }
@@ -47,10 +63,14 @@ export interface ShadowScoredCandidate {
   videoId: string;
   cellIndex: number;
   rank: number;
+  /** REAL mandala-filter score (never a synthetic/proxy value). */
   score: number;
   fit: DomainFitLabel | null;
   ok: boolean;
   ms: number;
+  /** R14-1 — additive T3_SCALAR confidence (0.0-1.0), only when DOMAIN_FIT_SHADOW_SCALAR is on. */
+  scalarScore?: number | null;
+  scalarMs?: number;
 }
 
 /**
@@ -93,9 +113,11 @@ export async function runDomainFitShadow(
       const burst = capped.slice(i, i + cfg.concurrency);
       const scored = await Promise.all(
         burst.map(async (c): Promise<ShadowScoredCandidate> => {
-          const goal = input.subGoals[c.cellIndex] ?? input.centerGoal;
-          const r = await classifyDomainFit(goal, c.title, cfg);
-          return {
+          // R14-1: goal-level — always the mandala's centerGoal, never the
+          // per-cell subgoal (see module header for the false-not-fit
+          // rationale). cellIndex/rank stay per-candidate for the trace.
+          const r = await classifyDomainFit(input.centerGoal, c.title, cfg);
+          const base: ShadowScoredCandidate = {
             videoId: c.videoId,
             cellIndex: c.cellIndex,
             rank: c.rank,
@@ -104,6 +126,12 @@ export async function runDomainFitShadow(
             ok: r.ok,
             ms: r.ms,
           };
+          if (!cfg.scalarEnabled) return base;
+          // Additive second call — never substitutes the binary verdict
+          // above, never blocks it (sequential here only to keep the burst
+          // width == cfg.concurrency total in-flight calls, not 2x).
+          const scalar = await classifyDomainFitScalar(input.centerGoal, c.title, cfg);
+          return { ...base, scalarScore: scalar.score, scalarMs: scalar.ms };
         })
       );
       results.push(...scored);
@@ -112,6 +140,9 @@ export async function runDomainFitShadow(
     const fitCount = results.filter((r) => r.fit === '적합').length;
     const notFitCount = results.filter((r) => r.fit === '비적합').length;
     const failedCount = results.length - fitCount - notFitCount;
+    const scalarScores = results
+      .map((r) => r.scalarScore)
+      .filter((s): s is number => typeof s === 'number');
 
     recordTrace({
       step: `domain_fit_shadow.${input.stage}`,
@@ -121,11 +152,16 @@ export async function runDomainFitShadow(
         candidates_total: input.candidates.length,
         candidates_scored: capped.length,
         max_candidates: cfg.maxCandidates,
+        scalar_enabled: cfg.scalarEnabled,
+        goal_level: true, // R14-1 marker — distinguishes from R13 per-cell rows
       },
       response: {
         fit: fitCount,
         not_fit: notFitCount,
         failed: failedCount,
+        scalar_mean: scalarScores.length
+          ? scalarScores.reduce((a, b) => a + b, 0) / scalarScores.length
+          : null,
         candidates: results,
       },
       latencyMs: Date.now() - t0,

--- a/src/modules/domain-fit-shadow/write-gate.ts
+++ b/src/modules/domain-fit-shadow/write-gate.ts
@@ -1,0 +1,168 @@
+/**
+ * Domain-fit WRITE-edge ENFORCE gate (R23 — search redesign, blast-0 code-only;
+ * deploy/flag-flip is James-gated, NOT part of this module's scope).
+ *
+ * Composite decision for the reuse-loop WRITE edge
+ * (`src/modules/video-pool/reuse-from-v5.ts` `reusePickedToPool`): the frozen
+ * T3 binary classifier (`./client.ts`) combined with the R22 lexical
+ * qualifier-conflict signal (`./lexical-qualifier.ts`) into ONE scalar score,
+ * thresholded — deliberately NOT a plain T3-only fit/not-fit boolean, so a T3
+ * "적합" verdict can still be blocked by a lexical qualifier collision the LLM
+ * missed (the 회화/코드 generic-noun over-pass pattern quantified in
+ * docs/qa/domain-fit-r20-polysemy-overpass-n-expansion.md).
+ *
+ * SEPARATE module from `write-shadow.ts` (measure-only — `void` return, never
+ * branches the caller). This module's whole purpose IS to return a branchable
+ * decision, gated by `DOMAIN_FIT_WRITE_ENFORCE` (default false) at the call
+ * site — see `src/config/domain-fit-shadow.ts`. Off = never imported/called
+ * from a live code path with effect; `write-shadow.ts`'s existing shadow-log
+ * call is completely unaffected either way (R19-A1 invariant preserved).
+ *
+ * Fail-open on classifier unavailability (timeout / http error / unparseable
+ * response): a WRITE decision must never silently starve pool supply because
+ * the Mac Mini Ollama instance is down — same fail-open posture as the
+ * codebase's other classifier-outage guards (e.g. the zxx/und/mul/mis
+ * non-linguistic-audio-code fail-open on the language gate).
+ */
+
+import { logger } from '@/utils/logger';
+import { recordTrace, withTraceContext, getTraceContext } from '@/modules/discover-tracing';
+import type { DomainFitShadowConfig } from '@/config/domain-fit-shadow';
+import { classifyDomainFit, type DomainFitLabel } from './client';
+import { detectQualifierConflicts } from './lexical-qualifier';
+import type { DomainFitWriteShadowStage } from './write-shadow';
+
+const log = logger.child({ module: 'domain-fit-shadow/write-gate' });
+
+/**
+ * Composite score threshold — write iff score >= this. Named constant (no
+ * magic number at call sites). score = (T3 fit ? 1 : 0) * lexical multiplier
+ * (1 = no conflict, DEFAULT_QUALIFIER_CONFLICT_MULTIPLIER = 0.2 on conflict —
+ * see lexical-qualifier.ts), so 0.5 requires BOTH a "적합" T3 verdict AND no
+ * lexical qualifier conflict to pass.
+ */
+export const DOMAIN_FIT_WRITE_ENFORCE_THRESHOLD = 0.5;
+
+export type DomainFitWriteEnforceReason =
+  | 'fit'
+  | 'not_fit'
+  | 'lexical_conflict'
+  | 'classifier_unavailable_fail_open';
+
+export interface DomainFitWriteEnforceInput {
+  stage: DomainFitWriteShadowStage;
+  centerGoal: string;
+  videoId: string;
+  title: string;
+  /** video_pool.source this write is about to use. */
+  source: string;
+  /** Trace-context hint — used ONLY when no ambient trace context is bound. */
+  mandalaId?: string | null;
+  userId?: string | null;
+}
+
+export interface DomainFitWriteEnforceResult {
+  /** true => caller should proceed with the write; false => skip it. */
+  passed: boolean;
+  fit: DomainFitLabel | null;
+  /** true only when the classifier produced a parseable verdict. */
+  classifierOk: boolean;
+  /** Composite scalar; null when the classifier failed (fail-open, no score computed). */
+  score: number | null;
+  lexicalConflict: boolean;
+  reason: DomainFitWriteEnforceReason;
+}
+
+/**
+ * Pure decision — classify + lexical-deboost combined into one scalar,
+ * thresholded. No trace/logging side effect; see `runDomainFitWriteEnforce`
+ * for the logged wrapper used at the actual call site. Never throws
+ * (`classifyDomainFit` itself never throws).
+ */
+export async function evaluateDomainFitWriteGate(
+  centerGoal: string,
+  title: string,
+  cfg: Pick<DomainFitShadowConfig, 'ollamaUrl' | 'model' | 'timeoutMs'>
+): Promise<DomainFitWriteEnforceResult> {
+  const r = await classifyDomainFit(centerGoal, title, cfg);
+  if (!r.ok || r.fit === null) {
+    return {
+      passed: true, // fail-open — classifier outage never blocks a write.
+      fit: null,
+      classifierOk: false,
+      score: null,
+      lexicalConflict: false,
+      reason: 'classifier_unavailable_fail_open',
+    };
+  }
+  // detectQualifierConflicts (not applyQualifierDeboost) — same primitive,
+  // avoids a duplicate conflict-detection pass since `hasConflict` is also
+  // needed for the logged reason below.
+  const { hasConflict, multiplier } = detectQualifierConflicts(centerGoal, title);
+  const base = r.fit === '적합' ? 1 : 0;
+  const score = base * multiplier;
+  const passed = score >= DOMAIN_FIT_WRITE_ENFORCE_THRESHOLD;
+  return {
+    passed,
+    fit: r.fit,
+    classifierOk: true,
+    score,
+    lexicalConflict: hasConflict,
+    reason: passed ? 'fit' : r.fit === '비적합' ? 'not_fit' : 'lexical_conflict',
+  };
+}
+
+/**
+ * Evaluate + log (recordTrace) the ENFORCE decision — step
+ * `domain_fit_write_enforce.<stage>`, for supervisor L2 sampling. Callers
+ * (`reuse-from-v5.ts`) MUST await this: unlike write-shadow.ts's
+ * fire-and-forget schedule, an enforce decision has to be known BEFORE the
+ * caller decides whether to upsert. Same "bind a scoped trace context when
+ * none is ambient" behavior as `write-shadow.ts` so the log is never silently
+ * dropped by an accident of the caller's context. A trace-logging failure is
+ * swallowed — it can never block or alter the returned decision.
+ */
+export async function runDomainFitWriteEnforce(
+  input: DomainFitWriteEnforceInput,
+  cfg: DomainFitShadowConfig
+): Promise<DomainFitWriteEnforceResult> {
+  const t0 = Date.now();
+  const result = await evaluateDomainFitWriteGate(input.centerGoal, input.title, cfg);
+  try {
+    const writeTrace = () =>
+      recordTrace({
+        step: `domain_fit_write_enforce.${input.stage}`,
+        status: 'ok',
+        request: {
+          model: cfg.model,
+          video_id: input.videoId,
+          source: input.source,
+        },
+        response: {
+          decision: result.passed ? 'passed' : 'blocked',
+          fit: result.fit,
+          classifier_ok: result.classifierOk,
+          score: result.score,
+          lexical_conflict: result.lexicalConflict,
+          reason: result.reason,
+        },
+        latencyMs: Date.now() - t0,
+      });
+
+    if (getTraceContext()) {
+      writeTrace();
+    } else {
+      await withTraceContext(
+        { mandalaId: input.mandalaId ?? null, userId: input.userId ?? null },
+        async () => writeTrace()
+      );
+    }
+  } catch (err) {
+    // Never let a trace-logging failure surface anywhere near the enforced
+    // write decision this is observing.
+    log.debug(
+      `domain-fit write-enforce trace failed (swallowed): ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  return result;
+}

--- a/src/modules/domain-fit-shadow/write-shadow.ts
+++ b/src/modules/domain-fit-shadow/write-shadow.ts
@@ -1,0 +1,125 @@
+/**
+ * Domain-fit WRITE-edge shadow (R19 — search redesign, blast-0).
+ *
+ * Same frozen T3 classifier (`./client.ts`) and `recordTrace` instrumentation
+ * as the serve-side shadow (`./shadow.ts`), wired at the TWO goal-aware
+ * pool-WRITE edges identified in
+ * docs/qa/domain-fit-r14-write-gate-and-goal-level.md §R14-2:
+ *
+ *   1. `src/modules/video-pool/reuse-from-v5.ts` — `reusePickedToPool`,
+ *      right after `prepareReuseRow` returns a non-null row, before the
+ *      `video_pool.upsert` call.
+ *   2. `src/api/routes/cards.ts` — the `/like` fire-and-forget IIFE, right
+ *      after the existing blocklist/channel-block gates, before the
+ *      `video_pool.upsert` call.
+ *
+ * enforce-0: this module NEVER returns a value the caller could branch on
+ * for the write decision — `scheduleDomainFitWriteShadow` returns `void`.
+ * The upsert at both call sites is unconditional and unchanged; this is
+ * observation only ("what got written + would it have passed a domain-fit
+ * gate"), same measurement shape as the read-path shadow, just a single
+ * candidate per call instead of a batch.
+ *
+ * flag-gated by `DOMAIN_FIT_WRITE_SHADOW` (default false, SEPARATE from the
+ * serve-side `DOMAIN_FIT_SHADOW` master flag) — off = zero extra Ollama
+ * calls, zero extra trace writes, byte-identical to pre-R19 behavior.
+ *
+ * async/post: fire-and-forget (`void` internally) — never awaited by
+ * callers, never blocks the write it is observing.
+ */
+
+import { logger } from '@/utils/logger';
+import { recordTrace, withTraceContext, getTraceContext } from '@/modules/discover-tracing';
+import { loadDomainFitShadowConfig, type DomainFitShadowConfig } from '@/config/domain-fit-shadow';
+import { classifyDomainFit } from './client';
+
+const log = logger.child({ module: 'domain-fit-shadow/write-shadow' });
+
+/** Which WRITE-edge this judgment came from — mirrors the two R14-2 file:line sites. */
+export type DomainFitWriteShadowStage = 'reuse' | 'like';
+
+export interface ScheduleDomainFitWriteShadowInput {
+  stage: DomainFitWriteShadowStage;
+  /** The mandala's centerGoal — goal-level, same target as the serve-side shadow (R14-1). */
+  centerGoal: string;
+  videoId: string;
+  title: string;
+  /** video_pool.source this write is about to use ('user_live' | 'user_curated'). */
+  source: string;
+  /** Trace-context hint — used ONLY when no ambient trace context is bound (see below). */
+  mandalaId?: string | null;
+  userId?: string | null;
+}
+
+/**
+ * Schedule a single WRITE-edge shadow judgment. Returns immediately
+ * (synchronous no-op check + fire-and-forget dispatch) — callers must NOT
+ * await. No-op when the flag is off.
+ */
+export function scheduleDomainFitWriteShadow(
+  input: ScheduleDomainFitWriteShadowInput,
+  cfgOverride?: DomainFitShadowConfig
+): void {
+  const cfg = cfgOverride ?? loadDomainFitShadowConfig();
+  if (!cfg.writeShadowEnabled) return;
+
+  void runDomainFitWriteShadow(input, cfg).catch((err) => {
+    // Belt-and-suspenders — runDomainFitWriteShadow already swallows
+    // internally, this only guards against a truly unexpected sync throw.
+    log.debug(
+      `domain-fit write-shadow run failed (swallowed): ${err instanceof Error ? err.message : String(err)}`
+    );
+  });
+}
+
+/**
+ * Exported (in addition to `scheduleDomainFitWriteShadow`) so tests can
+ * `await` the judgment directly instead of racing the fire-and-forget
+ * dispatch. Production callers should use `scheduleDomainFitWriteShadow`.
+ */
+export async function runDomainFitWriteShadow(
+  input: ScheduleDomainFitWriteShadowInput,
+  cfg: DomainFitShadowConfig
+): Promise<void> {
+  const t0 = Date.now();
+  try {
+    const r = await classifyDomainFit(input.centerGoal, input.title, cfg);
+    const writeTrace = () =>
+      recordTrace({
+        step: `domain_fit_shadow.write.${input.stage}`,
+        status: 'ok',
+        request: {
+          model: cfg.model,
+          video_id: input.videoId,
+          source: input.source,
+          goal_level: true,
+        },
+        response: {
+          fit: r.fit,
+          ok: r.ok,
+        },
+        latencyMs: Date.now() - t0,
+      });
+
+    // Both WRITE-edge call sites may run outside an ambient `withTraceContext`
+    // (cards.ts's /like IIFE has none today; reuse-from-v5's caller chain
+    // usually does, via add-cards.ts, but is not guaranteed). recordTrace
+    // silently no-ops with no bound context — bind a scoped one here so this
+    // shadow observation is never silently dropped by an accident of the
+    // caller's context, without touching the caller's own tracing.
+    if (getTraceContext()) {
+      writeTrace();
+    } else {
+      await withTraceContext(
+        { mandalaId: input.mandalaId ?? null, userId: input.userId ?? null },
+        async () => writeTrace()
+      );
+    }
+  } catch (err) {
+    // Never let a shadow-logging failure surface anywhere near the write
+    // path this is observing — always invoked fire-and-forget.
+    log.debug(
+      `domain-fit write-shadow scoring failed (swallowed): ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}

--- a/src/modules/queue/handlers/pool-serve-fill.ts
+++ b/src/modules/queue/handlers/pool-serve-fill.ts
@@ -54,6 +54,8 @@ import { loadDiversityGuardConfig } from '@/config/diversity-guard';
 import { logger } from '@/utils/logger';
 import { config } from '@/config/index';
 import { writeSearchTrace, type SearchTraceCandidateInput } from '@/modules/search-trace';
+import { loadDomainFitShadowConfig } from '@/config/domain-fit-shadow';
+import { scheduleDomainFitShadow } from '@/modules/domain-fit-shadow/shadow';
 import { getJobQueue } from '../manager';
 import { JOB_NAMES, POOL_SERVE_FILL_RETRY_OPTIONS, type PoolServeFillPayload } from '../types';
 import { richSummaryWorkOptions } from './rich-summary-work-options';
@@ -65,12 +67,15 @@ const log = logger.child({ module: 'pool-serve-fill' });
 const SCORE_BURST_SIZE = 4;
 /** Live fallback fetch size — one search.list call, gated downstream. */
 const LIVE_FALLBACK_MAX_RESULTS = 10;
-/** Pool recruitment source whitelist (single tier today — v2_promoted only). */
-const POOL_SOURCES = ['v2_promoted'] as const;
-/** Per-candidate source_tier for pool recruits. When the whitelist is a single
- *  tier every recruit carries it; if it ever becomes multi-tier, add `source`
- *  to the hybrid-rerank SELECT to attribute per-candidate instead. */
-const POOL_SOURCE_TIER: string | null = POOL_SOURCES.length === 1 ? POOL_SOURCES[0] : null;
+/** Pool recruitment source whitelist — BASE tier (always included, current
+ *  default behavior). R23: EXTRA sources are appended per-job from
+ *  `POOL_SERVE_SOURCES_EXTRA` (config, not a second hardcoded array — see
+ *  `loadPoolServeConfig` in `@/config/pool-serve`); default empty ⇒ the
+ *  effective source list is exactly this BASE tuple, byte-identical to
+ *  pre-R23. Computed per-job (not module-level) in `handlePoolServeFill` so
+ *  it reflects the env at call time, matching `loadPoolServeConfig`'s own
+ *  reload-per-call contract. */
+const POOL_SOURCES_BASE = ['v2_promoted'] as const;
 /** search.list = 100 units/call; videos.list batch = 1 unit (youtube-client). */
 const SEARCH_LIST_UNITS = 100;
 export const POOL_SERVE_SKILL_ID = 'pool-serve-fill';
@@ -127,6 +132,13 @@ export interface PoolServeCellResult {
 async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promise<void> {
   const p = job.data;
   const cfg = loadPoolServeConfig();
+  // R23 — pool-serve recruit sources (BASE + optional extra, config not
+  // hardcoded) and the SERVE-edge domain-fit shadow config, loaded once per
+  // job. Both default to current behavior (extra=[] / serveShadowEnabled=false).
+  const poolSources: readonly string[] =
+    cfg.sourcesExtra.length > 0 ? [...POOL_SOURCES_BASE, ...cfg.sourcesExtra] : POOL_SOURCES_BASE;
+  const poolSourceTier: string | null = poolSources.length === 1 ? (poolSources[0] ?? null) : null;
+  const domainFitCfg = loadDomainFitShadowConfig();
   const prisma = getPrismaClient();
   const result: PoolServeCellResult = {
     recruited: 0,
@@ -315,7 +327,7 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
       [{ cellIndex: p.cellIndex, query: p.cellQuery }],
       [...seen],
       cfg.candidatesLimit,
-      POOL_SOURCES
+      poolSources
     );
     // Optional COSINE recruit pass (flag-gated): surfaces pool supply whose
     // TITLE doesn't literally match the cell goal (keyword misses it). Broadens
@@ -330,7 +342,7 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
         p.language,
         [...seen, ...keywordRecruits.map((c) => c.videoId)],
         cfg.cosineK,
-        [...POOL_SOURCES, 'yt_promoted'],
+        Array.from(new Set([...poolSources, 'yt_promoted'])),
         cfg.cosineDistMax
       );
       recruits = [...keywordRecruits, ...cosineRecruits.filter((c) => !kwIds.has(c.videoId))];
@@ -351,7 +363,7 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
               durationSec: c.durationSec,
               tsRank: c.rec_score,
               sourceKind: 'pool' as const,
-              sourceTier: POOL_SOURCE_TIER,
+              sourceTier: poolSourceTier,
             }))
           ),
           []
@@ -419,6 +431,28 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
         );
       }
     }
+
+    // R23 — SERVE-edge domain-fit SHADOW (would-serve, enforce-0). Fire-and-
+    // forget (`scheduleDomainFitShadow` never awaited — shadow.ts contract),
+    // scored against the FINAL passed set for this cell (post relevance-gate,
+    // pre-insert) WITHOUT altering the insert order/set below. Gated by
+    // `DOMAIN_FIT_SERVE_SHADOW` (cfgOverride swaps `enabled` to that flag —
+    // shadow.ts itself is unmodified); default off = zero extra Ollama calls.
+    scheduleDomainFitShadow(
+      {
+        stage: 'pool_serve',
+        centerGoal: p.centerGoal,
+        subGoals: [],
+        candidates: passed.map((c, rank) => ({
+          videoId: c.youtubeVideoId,
+          title: c.title,
+          cellIndex: p.cellIndex,
+          rank,
+          score: c.gatePct,
+        })),
+      },
+      { ...domainFitCfg, enabled: domainFitCfg.serveShadowEnabled }
+    );
 
     // ── Insert (1차+2차 합산) via the shared auto-add chokepoint
     //    `placeAutoAddedCards` — CP500++ PR-2 (INV-CHOKEPOINT-ENFORCED). The

--- a/src/modules/video-pool/reuse-from-v5.ts
+++ b/src/modules/video-pool/reuse-from-v5.ts
@@ -19,6 +19,11 @@
  *   - fire-and-forget at the call site → zero hot-path impact (12s add-cards cap).
  *
  * Flag-gated by V5_REUSE_LOOP (default off → no write, current behavior).
+ *
+ * R23 addition — an enforce-capable domain-fit WRITE gate
+ * (`domain-fit-shadow/write-gate.ts`) sits alongside the existing R19-A1
+ * shadow-log call, gated INDEPENDENTLY by `DOMAIN_FIT_WRITE_ENFORCE` (default
+ * false — see `reusePickedToPool`). Off = zero behavior change.
  */
 
 import { Prisma } from '@prisma/client';
@@ -28,6 +33,8 @@ import { getPrismaClient } from '@/modules/database/client';
 import { MS_PER_DAY } from '@/utils/time-constants';
 import { logger } from '@/utils/logger';
 import { scheduleDomainFitWriteShadow } from '@/modules/domain-fit-shadow/write-shadow';
+import { loadDomainFitShadowConfig } from '@/config/domain-fit-shadow';
+import { runDomainFitWriteEnforce } from '@/modules/domain-fit-shadow/write-gate';
 
 const log = logger.child({ module: 'video-pool/reuse-from-v5' });
 
@@ -163,6 +170,11 @@ export async function reusePickedToPool(
   input: ReuseInput
 ): Promise<{ reused: number; skipped: number }> {
   const prisma = getPrismaClient();
+  // R23 — loaded once per reuse batch (cheap zod parse). Drives the NEW
+  // enforce-capable gate below ONLY; the existing scheduleDomainFitWriteShadow
+  // call right above the gate check is completely untouched by this cfg
+  // (R19-A1 invariant: that call keeps loading its own config internally).
+  const domainFitCfg = loadDomainFitShadowConfig();
   let reused = 0;
   let skipped = 0;
   for (const card of input.cards) {
@@ -190,6 +202,28 @@ export async function reusePickedToPool(
           title: card.title,
           source: REUSE_SOURCE,
         });
+        // R23 — enforce-capable domain-fit WRITE gate. Off (default,
+        // domainFitCfg.writeEnforceEnabled=false) ⇒ the schedule call above
+        // is the ONLY thing that ran, byte-identical to pre-R23 (R19-A1
+        // unchanged). On ⇒ an AWAITED composite T3+lexical judgment decides
+        // whether this card reaches the upsert below; a block skips it
+        // (counted the same as a quality-gate reject).
+        if (domainFitCfg.writeEnforceEnabled) {
+          const gate = await runDomainFitWriteEnforce(
+            {
+              stage: 'reuse',
+              centerGoal: input.centerGoal,
+              videoId: card.videoId,
+              title: card.title,
+              source: REUSE_SOURCE,
+            },
+            domainFitCfg
+          );
+          if (!gate.passed) {
+            skipped += 1;
+            continue;
+          }
+        }
       }
       await prisma.video_pool.upsert({
         where: { video_id: card.videoId },

--- a/src/modules/video-pool/reuse-from-v5.ts
+++ b/src/modules/video-pool/reuse-from-v5.ts
@@ -27,6 +27,7 @@ import { shortGateFields } from '@/modules/video-pool/is-short';
 import { getPrismaClient } from '@/modules/database/client';
 import { MS_PER_DAY } from '@/utils/time-constants';
 import { logger } from '@/utils/logger';
+import { scheduleDomainFitWriteShadow } from '@/modules/domain-fit-shadow/write-shadow';
 
 const log = logger.child({ module: 'video-pool/reuse-from-v5' });
 
@@ -53,6 +54,13 @@ export interface ReuseInput {
   /** videos.list full metadata (carries like_count that V5Card drops). */
   metaById: Map<string, { statistics?: { likeCount?: string } }>;
   language: 'ko' | 'en';
+  /**
+   * R19 — mandala centerGoal, forwarded so `reusePickedToPool` can schedule a
+   * domain-fit WRITE-edge shadow judgment per card (see write-shadow.ts).
+   * Optional: undefined/empty ⇒ the shadow call is skipped for that card
+   * (never blocks or alters the upsert either way — enforce-0).
+   */
+  centerGoal?: string;
 }
 
 interface ShortGate {
@@ -170,6 +178,18 @@ export async function reusePickedToPool(
       if (!row) {
         skipped += 1;
         continue;
+      }
+      // R19 — domain-fit WRITE-edge shadow (measure-only, enforce-0). Same
+      // fire-and-forget shape as the serve-side shadow hook; never awaited,
+      // never gates the upsert below (docs/qa/domain-fit-r14-write-gate-and-goal-level.md §R14-2 #1).
+      if (input.centerGoal) {
+        scheduleDomainFitWriteShadow({
+          stage: 'reuse',
+          centerGoal: input.centerGoal,
+          videoId: card.videoId,
+          title: card.title,
+          source: REUSE_SOURCE,
+        });
       }
       await prisma.video_pool.upsert({
         where: { video_id: card.videoId },

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -51,6 +51,7 @@ import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
 import { getCenterGoalEmbedding } from '@/modules/mandala/center-goal-embedding';
 import { withTraceContext, recordTrace } from '@/modules/discover-tracing';
 import { resolveLanguage } from '@/utils/detect-language';
+import { scheduleDomainFitShadow } from '@/modules/domain-fit-shadow/shadow';
 
 import {
   buildRuleBasedQueriesSync,
@@ -509,6 +510,23 @@ async function executeImpl(
               byCell_counts: Array.from({ length: 8 }, (_, i) => byCell.get(i)?.length ?? 0),
             },
             latencyMs: Date.now() - mfT0,
+          });
+
+          // R13-1 — domain-fit shadow (Tier 1). Fire-and-forget; enforce-0:
+          // reads byCell for logging only, never mutates it or filteredTier1.
+          scheduleDomainFitShadow({
+            stage: 'tier1',
+            centerGoal: state.centerGoal,
+            subGoals: state.subGoals,
+            candidates: Array.from(byCell.entries()).flatMap(([cellIndex, assignments]) =>
+              assignments.map((a, rank) => ({
+                videoId: a.candidate.videoId,
+                title: a.candidate.title,
+                cellIndex,
+                rank,
+                score: a.score,
+              }))
+            ),
           });
         } else {
           log.warn(
@@ -1178,6 +1196,10 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   const tMandalaFilterStart = Date.now();
   const deficitCellSet = new Set(input.deficitCells.map((c) => c.cellIndex));
   const scored: ScoredCandidate[] = [];
+  // R13-1 domain-fit shadow — true only when applyMandalaFilterWithStats ran
+  // (the useYoutubeRankingOnly bypass branch below skips the mandala filter
+  // entirely, so there is no domain-fit-relevant filter output to shadow).
+  let mandalaFilterRanTier2 = false;
 
   if (v3Config.useYoutubeRankingOnly) {
     // CP436 PR-Y0d (Issue #543) — bypass mandala-filter, trust YouTube's
@@ -1260,6 +1282,7 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
         scored.push({ video: enrichedVideo, cellIndex, score: a.score });
       }
     }
+    mandalaFilterRanTier2 = true;
   }
   const tScoringStart = Date.now();
   debug.scoredCandidates = scored.length;
@@ -1269,6 +1292,25 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   const pickedVideoIds = new Set<string>();
   const channelPerCell = new Map<number, Map<string, number>>();
   scored.sort((a, b) => b.score - a.score);
+
+  // R13-1 — domain-fit shadow (Tier 2). Fire-and-forget; enforce-0: reads
+  // `scored` (already sorted, unmodified below) for logging only. The
+  // in-array index IS the candidate's current serve rank for this run.
+  if (mandalaFilterRanTier2) {
+    scheduleDomainFitShadow({
+      stage: 'tier2',
+      centerGoal: input.state.centerGoal,
+      subGoals: input.state.subGoals,
+      candidates: scored.map((sc, rank) => ({
+        videoId: sc.video.videoId,
+        title: sc.video.title,
+        cellIndex: sc.cellIndex,
+        rank,
+        score: sc.score,
+      })),
+    });
+  }
+
   const slots: AssembledSlot[] = [];
   for (const sc of scored) {
     const need = input.deficitCells.find((c) => c.cellIndex === sc.cellIndex)?.need ?? 0;

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -399,6 +399,11 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
       fanoutById,
       metaById,
       language: input.language,
+      // R19 — centerGoal already in scope (used at lines 166/265/266);
+      // forwarded so reusePickedToPool can schedule a domain-fit WRITE-edge
+      // shadow judgment per card (write-shadow.ts). enforce-0: reuse-loop
+      // behavior itself is unchanged by this addition.
+      centerGoal: input.centerGoal,
     }).catch((e) => log.warn(`reuse-loop failed: ${e instanceof Error ? e.message : String(e)}`));
   }
 

--- a/tests/unit/config/domain-fit-shadow-config.test.ts
+++ b/tests/unit/config/domain-fit-shadow-config.test.ts
@@ -17,6 +17,8 @@ describe('loadDomainFitShadowConfig', () => {
     expect(cfg.maxCandidates).toBe(40);
     expect(cfg.scalarEnabled).toBe(false);
     expect(cfg.writeShadowEnabled).toBe(false);
+    expect(cfg.writeEnforceEnabled).toBe(false);
+    expect(cfg.serveShadowEnabled).toBe(false);
   });
 
   it('parses DOMAIN_FIT_SHADOW=true and overrides', () => {
@@ -75,5 +77,31 @@ describe('loadDomainFitShadowConfig', () => {
       DOMAIN_FIT_WRITE_SHADOW: 'false',
     } as NodeJS.ProcessEnv);
     expect(cfg.writeShadowEnabled).toBe(false);
+  });
+
+  it('R23: parses DOMAIN_FIT_WRITE_ENFORCE=true independently of DOMAIN_FIT_WRITE_SHADOW', () => {
+    const cfg = loadDomainFitShadowConfig({
+      DOMAIN_FIT_WRITE_ENFORCE: 'true',
+    } as NodeJS.ProcessEnv);
+    expect(cfg.writeEnforceEnabled).toBe(true);
+    expect(cfg.writeShadowEnabled).toBe(false);
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it('R23: parses DOMAIN_FIT_SERVE_SHADOW=true independently of the master + write flags', () => {
+    const cfg = loadDomainFitShadowConfig({
+      DOMAIN_FIT_SERVE_SHADOW: 'true',
+    } as NodeJS.ProcessEnv);
+    expect(cfg.serveShadowEnabled).toBe(true);
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.writeShadowEnabled).toBe(false);
+    expect(cfg.writeEnforceEnabled).toBe(false);
+  });
+
+  it('R23: DOMAIN_FIT_WRITE_ENFORCE=false explicitly is disabled (not truthy-coerced)', () => {
+    const cfg = loadDomainFitShadowConfig({
+      DOMAIN_FIT_WRITE_ENFORCE: 'false',
+    } as NodeJS.ProcessEnv);
+    expect(cfg.writeEnforceEnabled).toBe(false);
   });
 });

--- a/tests/unit/config/domain-fit-shadow-config.test.ts
+++ b/tests/unit/config/domain-fit-shadow-config.test.ts
@@ -1,0 +1,43 @@
+/**
+ * domain-fit-shadow config — default-off + env-default rule pin.
+ *
+ * CLAUDE.md "신규 env default = 기존 동작" — unset must resolve to enabled:false
+ * and the frozen T3 Ollama endpoint/model, never throwing on a missing env.
+ */
+import { loadDomainFitShadowConfig } from '@/config/domain-fit-shadow';
+
+describe('loadDomainFitShadowConfig', () => {
+  it('defaults to disabled with the frozen T3 Ollama endpoint (unset env)', () => {
+    const cfg = loadDomainFitShadowConfig({});
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.ollamaUrl).toBe('http://100.91.173.17:11434');
+    expect(cfg.model).toBe('mandala-gen:latest');
+    expect(cfg.timeoutMs).toBe(5000);
+    expect(cfg.concurrency).toBe(4);
+    expect(cfg.maxCandidates).toBe(40);
+  });
+
+  it('parses DOMAIN_FIT_SHADOW=true and overrides', () => {
+    const cfg = loadDomainFitShadowConfig({
+      DOMAIN_FIT_SHADOW: 'true',
+      DOMAIN_FIT_SHADOW_MAX_CANDIDATES: '10',
+      DOMAIN_FIT_SHADOW_CONCURRENCY: '2',
+    } as NodeJS.ProcessEnv);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.maxCandidates).toBe(10);
+    expect(cfg.concurrency).toBe(2);
+  });
+
+  it('treats DOMAIN_FIT_SHADOW=false explicitly as disabled (not truthy-coerced)', () => {
+    const cfg = loadDomainFitShadowConfig({ DOMAIN_FIT_SHADOW: 'false' } as NodeJS.ProcessEnv);
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it('falls back to safe defaults on a malformed numeric override', () => {
+    const cfg = loadDomainFitShadowConfig({
+      DOMAIN_FIT_SHADOW_MAX_CANDIDATES: 'not-a-number',
+    } as NodeJS.ProcessEnv);
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.maxCandidates).toBe(40);
+  });
+});

--- a/tests/unit/config/domain-fit-shadow-config.test.ts
+++ b/tests/unit/config/domain-fit-shadow-config.test.ts
@@ -15,6 +15,7 @@ describe('loadDomainFitShadowConfig', () => {
     expect(cfg.timeoutMs).toBe(5000);
     expect(cfg.concurrency).toBe(4);
     expect(cfg.maxCandidates).toBe(40);
+    expect(cfg.scalarEnabled).toBe(false);
   });
 
   it('parses DOMAIN_FIT_SHADOW=true and overrides', () => {
@@ -26,6 +27,19 @@ describe('loadDomainFitShadowConfig', () => {
     expect(cfg.enabled).toBe(true);
     expect(cfg.maxCandidates).toBe(10);
     expect(cfg.concurrency).toBe(2);
+  });
+
+  it('R14-1: parses DOMAIN_FIT_SHADOW_SCALAR=true independently of the master flag', () => {
+    const cfg = loadDomainFitShadowConfig({
+      DOMAIN_FIT_SHADOW: 'true',
+      DOMAIN_FIT_SHADOW_SCALAR: 'true',
+    } as NodeJS.ProcessEnv);
+    expect(cfg.scalarEnabled).toBe(true);
+  });
+
+  it('R14-1: DOMAIN_FIT_SHADOW_SCALAR defaults false even when master flag is on', () => {
+    const cfg = loadDomainFitShadowConfig({ DOMAIN_FIT_SHADOW: 'true' } as NodeJS.ProcessEnv);
+    expect(cfg.scalarEnabled).toBe(false);
   });
 
   it('treats DOMAIN_FIT_SHADOW=false explicitly as disabled (not truthy-coerced)', () => {

--- a/tests/unit/config/domain-fit-shadow-config.test.ts
+++ b/tests/unit/config/domain-fit-shadow-config.test.ts
@@ -16,6 +16,7 @@ describe('loadDomainFitShadowConfig', () => {
     expect(cfg.concurrency).toBe(4);
     expect(cfg.maxCandidates).toBe(40);
     expect(cfg.scalarEnabled).toBe(false);
+    expect(cfg.writeShadowEnabled).toBe(false);
   });
 
   it('parses DOMAIN_FIT_SHADOW=true and overrides', () => {
@@ -53,5 +54,26 @@ describe('loadDomainFitShadowConfig', () => {
     } as NodeJS.ProcessEnv);
     expect(cfg.enabled).toBe(false);
     expect(cfg.maxCandidates).toBe(40);
+  });
+
+  it('R19: parses DOMAIN_FIT_WRITE_SHADOW=true independently of the master flag', () => {
+    const cfg = loadDomainFitShadowConfig({
+      DOMAIN_FIT_WRITE_SHADOW: 'true',
+    } as NodeJS.ProcessEnv);
+    expect(cfg.writeShadowEnabled).toBe(true);
+    expect(cfg.enabled).toBe(false); // master read-path flag untouched
+  });
+
+  it('R19: DOMAIN_FIT_SHADOW=true does not turn on writeShadowEnabled (separate flags)', () => {
+    const cfg = loadDomainFitShadowConfig({ DOMAIN_FIT_SHADOW: 'true' } as NodeJS.ProcessEnv);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.writeShadowEnabled).toBe(false);
+  });
+
+  it('R19: treats DOMAIN_FIT_WRITE_SHADOW=false explicitly as disabled (not truthy-coerced)', () => {
+    const cfg = loadDomainFitShadowConfig({
+      DOMAIN_FIT_WRITE_SHADOW: 'false',
+    } as NodeJS.ProcessEnv);
+    expect(cfg.writeShadowEnabled).toBe(false);
   });
 });

--- a/tests/unit/config/pool-serve-cosine.test.ts
+++ b/tests/unit/config/pool-serve-cosine.test.ts
@@ -20,9 +20,40 @@ describe('loadPoolServeConfig — cosine recruit flags', () => {
   });
 
   it('keeps the keyword-recruit defaults untouched', () => {
-    const cfg = loadPoolServeConfig({ V5_POOL_SERVE_COSINE_RECRUIT: 'true' } as unknown as NodeJS.ProcessEnv);
+    const cfg = loadPoolServeConfig({
+      V5_POOL_SERVE_COSINE_RECRUIT: 'true',
+    } as unknown as NodeJS.ProcessEnv);
     expect(cfg.relevanceMin).toBe(60);
     expect(cfg.minPerCell).toBe(3);
     expect(cfg.candidatesLimit).toBe(12);
+  });
+});
+
+describe('loadPoolServeConfig — R23 POOL_SERVE_SOURCES_EXTRA', () => {
+  it('defaults to an empty array (current behavior: v2_promoted only)', () => {
+    const cfg = loadPoolServeConfig({} as NodeJS.ProcessEnv);
+    expect(cfg.sourcesExtra).toEqual([]);
+  });
+
+  it('parses a single extra source', () => {
+    const cfg = loadPoolServeConfig({
+      POOL_SERVE_SOURCES_EXTRA: 'yt_promoted',
+    } as unknown as NodeJS.ProcessEnv);
+    expect(cfg.sourcesExtra).toEqual(['yt_promoted']);
+  });
+
+  it('parses comma-separated extra sources, trimming whitespace and dropping empties', () => {
+    const cfg = loadPoolServeConfig({
+      POOL_SERVE_SOURCES_EXTRA: ' yt_promoted , , foo_tier ',
+    } as unknown as NodeJS.ProcessEnv);
+    expect(cfg.sourcesExtra).toEqual(['yt_promoted', 'foo_tier']);
+  });
+
+  it('is independent of V5_POOL_SERVE_COSINE_RECRUIT', () => {
+    const cfg = loadPoolServeConfig({
+      V5_POOL_SERVE_COSINE_RECRUIT: 'true',
+    } as unknown as NodeJS.ProcessEnv);
+    expect(cfg.sourcesExtra).toEqual([]);
+    expect(cfg.cosineRecruit).toBe(true);
   });
 });

--- a/tests/unit/modules/domain-fit-lexical-qualifier.test.ts
+++ b/tests/unit/modules/domain-fit-lexical-qualifier.test.ts
@@ -1,0 +1,118 @@
+/**
+ * domain-fit-shadow/lexical-qualifier — non-LLM qualifier-conflict deboost
+ * (R22-1). Pins: conflict detection, absence-is-no-op, category matching
+ * accuracy, multiplier constant.
+ */
+import {
+  extractQualifierValues,
+  detectQualifierConflicts,
+  applyQualifierDeboost,
+  DEFAULT_QUALIFIER_CONFLICT_MULTIPLIER,
+} from '@/modules/domain-fit-shadow/lexical-qualifier';
+
+describe('extractQualifierValues', () => {
+  it('finds a language token in Korean text', () => {
+    expect(extractQualifierValues('100일 영어 회화 완성하기', 'language')).toEqual(new Set(['en']));
+  });
+  it('finds multiple language tokens (comparison title)', () => {
+    expect(extractQualifierValues('일본어 vs 중국어 비교', 'language')).toEqual(
+      new Set(['ja', 'zh'])
+    );
+  });
+  it('returns empty set when no vocab hit', () => {
+    expect(extractQualifierValues('전화 영업 회화 스크립트', 'language').size).toBe(0);
+  });
+  it('is case-insensitive for Latin cloud-vendor tokens', () => {
+    expect(extractQualifierValues('AWS IaC 툴로 컨테이너 개발하기', 'cloud_vendor')).toEqual(
+      new Set(['aws'])
+    );
+    expect(extractQualifierValues('azure 아키텍트 되기', 'cloud_vendor')).toEqual(
+      new Set(['azure'])
+    );
+  });
+  it('normalizes cloud-vendor synonyms to the same canonical id', () => {
+    expect(extractQualifierValues('구글클라우드 강의', 'cloud_vendor')).toEqual(new Set(['gcp']));
+    expect(extractQualifierValues('GCP 자격증', 'cloud_vendor')).toEqual(new Set(['gcp']));
+  });
+  it('finds an instrument token', () => {
+    expect(extractQualifierValues('클래식기타 독학', 'instrument')).toEqual(new Set(['guitar']));
+  });
+});
+
+describe('detectQualifierConflicts — CONFLICT', () => {
+  it('flags a language conflict (영어 goal vs 일본어 title, R20-CONVO-JA-01)', () => {
+    const r = detectQualifierConflicts(
+      '100일 영어 회화 완성하기',
+      '편의점에서 무조건 쓰게되는 쉬운 일본어  -【실전 일본여행회화 3강】'
+    );
+    expect(r.hasConflict).toBe(true);
+    expect(r.multiplier).toBe(DEFAULT_QUALIFIER_CONFLICT_MULTIPLIER);
+    expect(r.conflicts).toEqual([
+      { category: 'language', goalValues: ['en'], titleValues: ['ja'] },
+    ]);
+  });
+
+  it('flags a cloud-vendor conflict (KT goal vs Oracle title, R20-1 R014)', () => {
+    const r = detectQualifierConflicts(
+      'KT 클라우드 강의안 작성',
+      '고객 서비스 클라우드 탄생 배경 [TalkIT, 오라클 클라우드]'
+    );
+    expect(r.hasConflict).toBe(true);
+    expect(r.conflicts[0]?.category).toBe('cloud_vendor');
+    expect(r.conflicts[0]?.goalValues).toEqual(['kt']);
+    expect(r.conflicts[0]?.titleValues).toEqual(['oracle']);
+  });
+
+  it('flags an instrument conflict (piano goal vs guitar title)', () => {
+    const r = detectQualifierConflicts(
+      '성인 피아노 입문하여 1년 내 쇼팽 녹턴 1곡 완성',
+      '클래식기타 - 독학으로 배울 수 있는가?'
+    );
+    expect(r.hasConflict).toBe(true);
+    expect(r.conflicts[0]?.category).toBe('instrument');
+  });
+});
+
+describe('detectQualifierConflicts — ABSENCE never deboosts', () => {
+  it('no-ops when the title has zero vocab hits in a category the goal names (Azure goal, no vendor named in title)', () => {
+    const r = detectQualifierConflicts(
+      '일주일 내 Azure 아키텍트 되기',
+      'IAM Interview Questions - Identity & Access Management Complete Guide for Cybersecurity Jobs'
+    );
+    expect(r.hasConflict).toBe(false);
+    expect(r.multiplier).toBe(1);
+  });
+  it('no-ops when the goal has zero vocab hits (piano goal, no instrument word at all in either text)', () => {
+    const r = detectQualifierConflicts(
+      '독학으로 피아노 중급 달성 후 유튜브 연주 채널 구독자 500명 확보',
+      '클로드 코드 사용법 | 주요 기능 13분만에 마스터하기!'
+    );
+    expect(r.hasConflict).toBe(false);
+  });
+  it('no-ops on a same-value match (both name English) — not a conflict', () => {
+    const r = detectQualifierConflicts('100일 영어 회화 완성하기', '영어 발음 교정 Day1');
+    expect(r.hasConflict).toBe(false);
+    expect(r.multiplier).toBe(1);
+  });
+});
+
+describe('detectQualifierConflicts — legit niche protection (R16 niche_legit sample)', () => {
+  it('does not deboost a legit same-instrument variant title (통기타 vs 클래식기타, both instrument=guitar)', () => {
+    const r = detectQualifierConflicts(
+      'Learn Classical Guitar and Perform 3 Complete Pieces From Memory at a Recital in 18 Months',
+      '누구나 100% 다 할 수 있는 신개념 기타 지판 5분 만에 외우는 법/통기타 강좌 7080'
+    );
+    expect(r.hasConflict).toBe(false);
+  });
+});
+
+describe('applyQualifierDeboost', () => {
+  it('multiplies the score down on conflict', () => {
+    expect(
+      applyQualifierDeboost(1, '100일 영어 회화 완성하기', '실전 일본여행회화 3강 일본어')
+    ).toBeCloseTo(DEFAULT_QUALIFIER_CONFLICT_MULTIPLIER);
+  });
+  it('leaves the score unchanged on absence/no-conflict', () => {
+    expect(applyQualifierDeboost(0.8, '영어 회화', '영어 발음 교정')).toBe(0.8);
+  });
+});

--- a/tests/unit/modules/domain-fit-shadow-client.test.ts
+++ b/tests/unit/modules/domain-fit-shadow-client.test.ts
@@ -6,8 +6,17 @@
  *   - parseFit clean-JSON path + fragile-fallback substring path.
  *   - classifyDomainFit never throws (http error / network throw / timeout
  *     all resolve to { fit: null, ok: false }).
+ *   - R14-1: buildT3ScalarPrompt / parseFitScalar / classifyDomainFitScalar
+ *     (additive scalar-capture variant, frozen "R12 scalar-capture variant").
  */
-import { buildT3Prompt, parseFit, classifyDomainFit } from '@/modules/domain-fit-shadow/client';
+import {
+  buildT3Prompt,
+  buildT3ScalarPrompt,
+  parseFit,
+  parseFitScalar,
+  classifyDomainFit,
+  classifyDomainFitScalar,
+} from '@/modules/domain-fit-shadow/client';
 
 const CFG = {
   ollamaUrl: 'http://100.91.173.17:11434',
@@ -104,5 +113,92 @@ describe('classifyDomainFit — never throws', () => {
       stream: false,
       options: { temperature: 0.1, num_predict: 60 },
     });
+  });
+});
+
+describe('buildT3ScalarPrompt — frozen R12 scalar-capture spec', () => {
+  it('matches the frozen T3_SCALAR template verbatim (docs/qa/domain-fit-probe-T3.md)', () => {
+    const prompt = buildT3ScalarPrompt('영어 프리토킹 달성', '발음 교정 Day1');
+    expect(prompt).toBe(
+      '### Instruction:\n다음 영상 제목과 목표의 주제 적합성을 분류하라 (적합/비적합). 그리고 0.0~1.0 사이의 적합도 confidence 점수도 함께 산정하라 (1.0=완전히 같은 주제, 0.0=전혀 무관). JSON만 출력: {"fit": "적합"|"비적합", "score": 0.0~1.0}\n\n### Input:\n영상 제목: 발음 교정 Day1\n관련 목표: 영어 프리토킹 달성\n\n### Output:\n'
+    );
+  });
+});
+
+describe('parseFitScalar', () => {
+  it('parses clean JSON fit + score', () => {
+    expect(parseFitScalar('{"fit": "적합", "score": 0.85}')).toEqual({
+      parsed: '적합',
+      score: 0.85,
+      ok: true,
+    });
+  });
+  it('parses clean JSON fit with score missing (null)', () => {
+    expect(parseFitScalar('{"fit": "비적합"}')).toEqual({
+      parsed: '비적합',
+      score: null,
+      ok: true,
+    });
+  });
+  it('ignores a non-numeric score field', () => {
+    expect(parseFitScalar('{"fit": "적합", "score": "high"}')).toEqual({
+      parsed: '적합',
+      score: null,
+      ok: true,
+    });
+  });
+  it('falls back to the binary fragile-fallback (score always null) for malformed JSON', () => {
+    expect(parseFitScalar('의 fit 은 비적합 입니다')).toEqual({
+      parsed: '비적합',
+      score: null,
+      ok: false,
+    });
+  });
+});
+
+describe('classifyDomainFitScalar — never throws', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('resolves fit + score on a clean JSON response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: '{"fit": "적합", "score": 0.92}' }),
+    }) as unknown as typeof fetch;
+    const r = await classifyDomainFitScalar('goal', 'title', CFG);
+    expect(r).toMatchObject({ fit: '적합', score: 0.92, ok: true });
+  });
+
+  it('resolves ok:false + score:null on HTTP error (never throws)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'boom',
+    }) as unknown as typeof fetch;
+    const r = await classifyDomainFitScalar('goal', 'title', CFG);
+    expect(r).toMatchObject({ fit: null, score: null, ok: false });
+  });
+
+  it('resolves ok:false + score:null on a network throw (never throws)', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+    const r = await classifyDomainFitScalar('goal', 'title', CFG);
+    expect(r).toMatchObject({ fit: null, score: null, ok: false });
+    expect(r.error).toContain('ECONNREFUSED');
+  });
+
+  it('uses the T3_SCALAR prompt (distinct from the binary T3 call)', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: '{"fit": "적합", "score": 0.5}' }),
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+    await classifyDomainFitScalar('goal', 'title', CFG);
+    const body = JSON.parse((mockFetch.mock.calls[0]?.[1] as { body: string }).body);
+    expect(body.prompt).toContain('confidence 점수도 함께 산정하라');
   });
 });

--- a/tests/unit/modules/domain-fit-shadow-client.test.ts
+++ b/tests/unit/modules/domain-fit-shadow-client.test.ts
@@ -1,0 +1,108 @@
+/**
+ * domain-fit-shadow/client — frozen T3 prompt + parse + Ollama call tests.
+ *
+ * Pins:
+ *   - buildT3Prompt byte-identical to docs/qa/domain-fit-probe-T3.md (frozen).
+ *   - parseFit clean-JSON path + fragile-fallback substring path.
+ *   - classifyDomainFit never throws (http error / network throw / timeout
+ *     all resolve to { fit: null, ok: false }).
+ */
+import { buildT3Prompt, parseFit, classifyDomainFit } from '@/modules/domain-fit-shadow/client';
+
+const CFG = {
+  ollamaUrl: 'http://100.91.173.17:11434',
+  model: 'mandala-gen:latest',
+  timeoutMs: 5000,
+};
+
+describe('buildT3Prompt — frozen spec', () => {
+  it('matches the frozen T3 template verbatim (docs/qa/domain-fit-probe-T3.md)', () => {
+    const prompt = buildT3Prompt('영어 프리토킹 달성', '발음 교정 Day1');
+    expect(prompt).toBe(
+      '### Instruction:\n다음 영상 제목과 목표의 주제 적합성을 분류하라 (적합/비적합). JSON만 출력: {"fit": "적합"|"비적합"}\n\n### Input:\n영상 제목: 발음 교정 Day1\n관련 목표: 영어 프리토킹 달성\n\n### Output:\n'
+    );
+  });
+});
+
+describe('parseFit', () => {
+  it('parses clean JSON fit=적합', () => {
+    expect(parseFit('{"fit": "적합"}')).toEqual({ parsed: '적합', ok: true });
+  });
+  it('parses clean JSON fit=비적합', () => {
+    expect(parseFit('{"fit": "비적합"}')).toEqual({ parsed: '비적합', ok: true });
+  });
+  it('rejects an unrecognized fit value inside otherwise-valid JSON', () => {
+    expect(parseFit('{"fit": "maybe"}')).toEqual({ parsed: null, ok: false });
+  });
+  it('falls back to substring scan for malformed JSON (fragile, ok=false)', () => {
+    expect(parseFit('의 fit 은 비적합 입니다')).toEqual({ parsed: '비적합', ok: false });
+  });
+  it('falls back to substring scan for fit-only text', () => {
+    expect(parseFit('결과: "적합" 맞습니다')).toEqual({ parsed: '적합', ok: false });
+  });
+  it('returns null when neither label appears anywhere', () => {
+    expect(parseFit('모르겠습니다')).toEqual({ parsed: null, ok: false });
+  });
+});
+
+describe('classifyDomainFit — never throws', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('resolves ok:true on a clean JSON response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: '{"fit": "적합"}' }),
+    }) as unknown as typeof fetch;
+    const r = await classifyDomainFit('goal', 'title', CFG);
+    expect(r).toMatchObject({ fit: '적합', ok: true });
+  });
+
+  it('resolves ok:false on HTTP error status (never throws)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'boom',
+    }) as unknown as typeof fetch;
+    const r = await classifyDomainFit('goal', 'title', CFG);
+    expect(r.ok).toBe(false);
+    expect(r.fit).toBeNull();
+    expect(r.error).toContain('500');
+  });
+
+  it('resolves ok:false on a network throw (never throws)', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch;
+    const r = await classifyDomainFit('goal', 'title', CFG);
+    expect(r.ok).toBe(false);
+    expect(r.fit).toBeNull();
+    expect(r.error).toContain('ECONNREFUSED');
+  });
+
+  it('calls the raw /api/generate endpoint with the frozen call shape', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: '{"fit": "적합"}' }),
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+    await classifyDomainFit('goal', 'title', CFG);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${CFG.ollamaUrl}/api/generate`,
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"raw":true'),
+      })
+    );
+    const body = JSON.parse((mockFetch.mock.calls[0]?.[1] as { body: string }).body);
+    expect(body).toMatchObject({
+      model: CFG.model,
+      raw: true,
+      stream: false,
+      options: { temperature: 0.1, num_predict: 60 },
+    });
+  });
+});

--- a/tests/unit/modules/domain-fit-shadow.test.ts
+++ b/tests/unit/modules/domain-fit-shadow.test.ts
@@ -45,6 +45,8 @@ const CFG: DomainFitShadowConfig = {
   maxCandidates: 3,
   scalarEnabled: false,
   writeShadowEnabled: false, // R19 — unrelated to this read-path suite
+  writeEnforceEnabled: false, // R23 — unrelated to this read-path suite
+  serveShadowEnabled: false, // R23 — unrelated to this read-path suite
 };
 
 function baseInput(n: number): ScheduleDomainFitShadowInput {

--- a/tests/unit/modules/domain-fit-shadow.test.ts
+++ b/tests/unit/modules/domain-fit-shadow.test.ts
@@ -1,0 +1,142 @@
+/**
+ * domain-fit-shadow/shadow — R13-1 enforce-0 invariant tests.
+ *
+ * Pins:
+ *   - flag off (enabled:false) → zero classifyDomainFit calls, zero recordTrace
+ *     calls (byte-identical to pre-R13 behavior).
+ *   - empty candidate list → no-op even when enabled.
+ *   - enforce-0: the input candidate array is never mutated or reordered.
+ *   - candidates beyond maxCandidates are not scored (load cap).
+ *   - recordTrace is called with the expected step name + shape (fit/not_fit/
+ *     failed counts + per-candidate rank/cellIndex preserved).
+ *   - runDomainFitShadow never throws even when classifyDomainFit rejects.
+ */
+
+const mockClassify = jest.fn();
+const mockRecordTrace = jest.fn();
+
+jest.mock('@/modules/domain-fit-shadow/client', () => ({
+  classifyDomainFit: (...args: unknown[]) => mockClassify(...args),
+}));
+jest.mock('@/modules/discover-tracing', () => ({
+  recordTrace: (...args: unknown[]) => mockRecordTrace(...args),
+}));
+
+import {
+  scheduleDomainFitShadow,
+  runDomainFitShadow,
+  type ScheduleDomainFitShadowInput,
+} from '@/modules/domain-fit-shadow/shadow';
+import type { DomainFitShadowConfig } from '@/config/domain-fit-shadow';
+
+const CFG: DomainFitShadowConfig = {
+  enabled: true,
+  ollamaUrl: 'http://100.91.173.17:11434',
+  model: 'mandala-gen:latest',
+  timeoutMs: 5000,
+  concurrency: 2,
+  maxCandidates: 3,
+};
+
+function baseInput(n: number): ScheduleDomainFitShadowInput {
+  return {
+    stage: 'tier2',
+    centerGoal: '영어 프리토킹 달성',
+    subGoals: ['발음', '문법', '어휘'],
+    candidates: Array.from({ length: n }, (_, i) => ({
+      videoId: `v${i}`,
+      title: `title ${i}`,
+      cellIndex: i % 3,
+      rank: i,
+      score: 1 - i * 0.01,
+    })),
+  };
+}
+
+beforeEach(() => {
+  mockClassify.mockReset();
+  mockRecordTrace.mockReset();
+  mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+});
+
+describe('scheduleDomainFitShadow — flag gating', () => {
+  it('is a no-op when the flag is off (zero classify calls, zero trace writes)', () => {
+    scheduleDomainFitShadow(baseInput(5), { ...CFG, enabled: false });
+    expect(mockClassify).not.toHaveBeenCalled();
+    expect(mockRecordTrace).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op on an empty candidate list even when enabled', () => {
+    scheduleDomainFitShadow({ ...baseInput(0) }, CFG);
+    expect(mockClassify).not.toHaveBeenCalled();
+    expect(mockRecordTrace).not.toHaveBeenCalled();
+  });
+});
+
+describe('runDomainFitShadow — enforce-0 + logging shape', () => {
+  it('never mutates or reorders the caller candidate array', async () => {
+    const input = baseInput(5);
+    const snapshot = JSON.stringify(input.candidates);
+    await runDomainFitShadow(input, CFG);
+    expect(JSON.stringify(input.candidates)).toBe(snapshot);
+  });
+
+  it('caps scoring at maxCandidates (load guard)', async () => {
+    const input = baseInput(10); // maxCandidates=3 in CFG
+    await runDomainFitShadow(input, CFG);
+    expect(mockClassify).toHaveBeenCalledTimes(3);
+  });
+
+  it('scores every candidate when under the cap', async () => {
+    const input = baseInput(2);
+    await runDomainFitShadow(input, CFG);
+    expect(mockClassify).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves each candidate goal from subGoals[cellIndex]', async () => {
+    const input = baseInput(1);
+    input.candidates[0]!.cellIndex = 1;
+    await runDomainFitShadow(input, CFG);
+    expect(mockClassify).toHaveBeenCalledWith('문법', 'title 0', CFG);
+  });
+
+  it('falls back to centerGoal when cellIndex has no matching subGoal', async () => {
+    const input = baseInput(1);
+    input.candidates[0]!.cellIndex = 99;
+    await runDomainFitShadow(input, CFG);
+    expect(mockClassify).toHaveBeenCalledWith('영어 프리토킹 달성', 'title 0', CFG);
+  });
+
+  it('writes one recordTrace call with step domain_fit_shadow.<stage> and count/candidate shape', async () => {
+    mockClassify
+      .mockResolvedValueOnce({ fit: '적합', ms: 5, ok: true })
+      .mockResolvedValueOnce({ fit: '비적합', ms: 5, ok: true })
+      .mockResolvedValueOnce({ fit: null, ms: 5, ok: false });
+    const input = baseInput(3);
+    await runDomainFitShadow(input, CFG);
+
+    expect(mockRecordTrace).toHaveBeenCalledTimes(1);
+    const call = mockRecordTrace.mock.calls[0]![0];
+    expect(call.step).toBe('domain_fit_shadow.tier2');
+    expect(call.status).toBe('ok');
+    expect(call.response.fit).toBe(1);
+    expect(call.response.not_fit).toBe(1);
+    expect(call.response.failed).toBe(1);
+    expect(call.response.candidates).toHaveLength(3);
+    expect(call.response.candidates[0]).toMatchObject({
+      videoId: 'v0',
+      cellIndex: 0,
+      rank: 0,
+      fit: '적합',
+    });
+  });
+
+  it('never throws even when classifyDomainFit rejects unexpectedly', async () => {
+    mockClassify.mockRejectedValue(new Error('boom'));
+    const input = baseInput(2);
+    await expect(runDomainFitShadow(input, CFG)).resolves.toBeUndefined();
+    // Rejection is swallowed before recordTrace — no observability write on a
+    // hard internal failure (never a crash, but also never a false log).
+    expect(mockRecordTrace).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/modules/domain-fit-shadow.test.ts
+++ b/tests/unit/modules/domain-fit-shadow.test.ts
@@ -1,5 +1,5 @@
 /**
- * domain-fit-shadow/shadow — R13-1 enforce-0 invariant tests.
+ * domain-fit-shadow/shadow — R13-1 enforce-0 invariant tests, R14-1 rescope.
  *
  * Pins:
  *   - flag off (enabled:false) → zero classifyDomainFit calls, zero recordTrace
@@ -10,13 +10,20 @@
  *   - recordTrace is called with the expected step name + shape (fit/not_fit/
  *     failed counts + per-candidate rank/cellIndex preserved).
  *   - runDomainFitShadow never throws even when classifyDomainFit rejects.
+ *   - R14-1: classification is ALWAYS against centerGoal (goal-level), never
+ *     subGoals[cellIndex] — cellIndex is still logged, just not used to pick
+ *     the comparison text.
+ *   - R14-1: scalar capture is additive, off by default, never replaces the
+ *     binary call.
  */
 
 const mockClassify = jest.fn();
+const mockClassifyScalar = jest.fn();
 const mockRecordTrace = jest.fn();
 
 jest.mock('@/modules/domain-fit-shadow/client', () => ({
   classifyDomainFit: (...args: unknown[]) => mockClassify(...args),
+  classifyDomainFitScalar: (...args: unknown[]) => mockClassifyScalar(...args),
 }));
 jest.mock('@/modules/discover-tracing', () => ({
   recordTrace: (...args: unknown[]) => mockRecordTrace(...args),
@@ -36,6 +43,7 @@ const CFG: DomainFitShadowConfig = {
   timeoutMs: 5000,
   concurrency: 2,
   maxCandidates: 3,
+  scalarEnabled: false,
 };
 
 function baseInput(n: number): ScheduleDomainFitShadowInput {
@@ -55,8 +63,10 @@ function baseInput(n: number): ScheduleDomainFitShadowInput {
 
 beforeEach(() => {
   mockClassify.mockReset();
+  mockClassifyScalar.mockReset();
   mockRecordTrace.mockReset();
   mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+  mockClassifyScalar.mockResolvedValue({ fit: '적합', score: 0.9, ms: 5, ok: true });
 });
 
 describe('scheduleDomainFitShadow — flag gating', () => {
@@ -93,18 +103,55 @@ describe('runDomainFitShadow — enforce-0 + logging shape', () => {
     expect(mockClassify).toHaveBeenCalledTimes(2);
   });
 
-  it('resolves each candidate goal from subGoals[cellIndex]', async () => {
+  it('R14-1: always classifies against centerGoal, regardless of cellIndex (goal-level, not per-cell)', async () => {
     const input = baseInput(1);
-    input.candidates[0]!.cellIndex = 1;
+    input.candidates[0]!.cellIndex = 1; // subGoals[1] = '문법' — must NOT be used
     await runDomainFitShadow(input, CFG);
-    expect(mockClassify).toHaveBeenCalledWith('문법', 'title 0', CFG);
+    expect(mockClassify).toHaveBeenCalledWith('영어 프리토킹 달성', 'title 0', CFG);
   });
 
-  it('falls back to centerGoal when cellIndex has no matching subGoal', async () => {
+  it('R14-1: still uses centerGoal even when cellIndex is out of subGoals range', async () => {
     const input = baseInput(1);
     input.candidates[0]!.cellIndex = 99;
     await runDomainFitShadow(input, CFG);
     expect(mockClassify).toHaveBeenCalledWith('영어 프리토킹 달성', 'title 0', CFG);
+  });
+
+  it('R14-1: does not call classifyDomainFitScalar when scalarEnabled is false (default)', async () => {
+    const input = baseInput(2);
+    await runDomainFitShadow(input, CFG);
+    expect(mockClassifyScalar).not.toHaveBeenCalled();
+  });
+
+  it('R14-1: calls classifyDomainFitScalar per candidate when scalarEnabled is true, additive not substitutive', async () => {
+    const input = baseInput(2);
+    await runDomainFitShadow(input, { ...CFG, scalarEnabled: true });
+    expect(mockClassify).toHaveBeenCalledTimes(2);
+    expect(mockClassifyScalar).toHaveBeenCalledTimes(2);
+    expect(mockClassifyScalar).toHaveBeenCalledWith('영어 프리토킹 달성', 'title 0', {
+      ...CFG,
+      scalarEnabled: true,
+    });
+  });
+
+  it('R14-1: logs scalarScore per candidate + scalar_mean in the trace response when scalarEnabled', async () => {
+    mockClassifyScalar
+      .mockResolvedValueOnce({ fit: '적합', score: 0.9, ms: 5, ok: true })
+      .mockResolvedValueOnce({ fit: '적합', score: 0.7, ms: 5, ok: true });
+    const input = baseInput(2);
+    await runDomainFitShadow(input, { ...CFG, scalarEnabled: true });
+    const call = mockRecordTrace.mock.calls[0]![0];
+    expect(call.response.scalar_mean).toBeCloseTo(0.8);
+    expect(call.response.candidates[0].scalarScore).toBe(0.9);
+    expect(call.response.candidates[1].scalarScore).toBe(0.7);
+  });
+
+  it('R14-1: trace request payload marks goal_level:true and scalar_enabled', async () => {
+    const input = baseInput(1);
+    await runDomainFitShadow(input, CFG);
+    const call = mockRecordTrace.mock.calls[0]![0];
+    expect(call.request.goal_level).toBe(true);
+    expect(call.request.scalar_enabled).toBe(false);
   });
 
   it('writes one recordTrace call with step domain_fit_shadow.<stage> and count/candidate shape', async () => {

--- a/tests/unit/modules/domain-fit-shadow.test.ts
+++ b/tests/unit/modules/domain-fit-shadow.test.ts
@@ -44,6 +44,7 @@ const CFG: DomainFitShadowConfig = {
   concurrency: 2,
   maxCandidates: 3,
   scalarEnabled: false,
+  writeShadowEnabled: false, // R19 — unrelated to this read-path suite
 };
 
 function baseInput(n: number): ScheduleDomainFitShadowInput {

--- a/tests/unit/modules/domain-fit-write-gate.test.ts
+++ b/tests/unit/modules/domain-fit-write-gate.test.ts
@@ -1,0 +1,196 @@
+/**
+ * domain-fit-shadow/write-gate — R23 WRITE-edge ENFORCE-capable gate.
+ *
+ * Pins:
+ *   - composite score = (T3 fit ? 1 : 0) * lexical multiplier; threshold 0.5.
+ *   - '적합' + no lexical conflict → passed.
+ *   - '적합' + lexical conflict (R22 pattern) → BLOCKED even though T3 said fit.
+ *   - '비적합' → blocked regardless of lexical signal.
+ *   - classifier failure/timeout (ok:false or fit:null) → FAIL-OPEN (passed:true).
+ *   - runDomainFitWriteEnforce logs exactly one recordTrace call, step
+ *     domain_fit_write_enforce.<stage>, and the returned decision is never
+ *     altered by a trace-logging failure.
+ */
+
+const mockClassify = jest.fn();
+const mockRecordTrace = jest.fn();
+const mockWithTraceContext = jest.fn();
+const mockGetTraceContext = jest.fn();
+
+jest.mock('@/modules/domain-fit-shadow/client', () => {
+  const actual = jest.requireActual('@/modules/domain-fit-shadow/client');
+  return {
+    ...actual,
+    classifyDomainFit: (...args: unknown[]) => mockClassify(...args),
+  };
+});
+jest.mock('@/modules/discover-tracing', () => ({
+  recordTrace: (...args: unknown[]) => mockRecordTrace(...args),
+  getTraceContext: (...args: unknown[]) => mockGetTraceContext(...args),
+  withTraceContext: (ctx: unknown, fn: () => Promise<unknown>) => mockWithTraceContext(ctx, fn),
+}));
+
+import {
+  evaluateDomainFitWriteGate,
+  runDomainFitWriteEnforce,
+  DOMAIN_FIT_WRITE_ENFORCE_THRESHOLD,
+} from '@/modules/domain-fit-shadow/write-gate';
+import type { DomainFitShadowConfig } from '@/config/domain-fit-shadow';
+
+const CFG: DomainFitShadowConfig = {
+  enabled: false,
+  ollamaUrl: 'http://100.91.173.17:11434',
+  model: 'mandala-gen:latest',
+  timeoutMs: 5000,
+  concurrency: 4,
+  maxCandidates: 40,
+  scalarEnabled: false,
+  writeShadowEnabled: false,
+  writeEnforceEnabled: true,
+  serveShadowEnabled: false,
+};
+
+beforeEach(() => {
+  mockClassify.mockReset();
+  mockRecordTrace.mockReset();
+  mockWithTraceContext.mockReset();
+  mockGetTraceContext.mockReset();
+  mockGetTraceContext.mockReturnValue({ mandalaId: 'm1', userId: 'u1', runId: 'r1' });
+  mockWithTraceContext.mockImplementation((_ctx: unknown, fn: () => Promise<unknown>) => fn());
+});
+
+describe('DOMAIN_FIT_WRITE_ENFORCE_THRESHOLD', () => {
+  it('is 0.5 (named constant, no magic number at call sites)', () => {
+    expect(DOMAIN_FIT_WRITE_ENFORCE_THRESHOLD).toBe(0.5);
+  });
+});
+
+describe('evaluateDomainFitWriteGate — composite T3 + lexical decision', () => {
+  it('적합 + no lexical conflict → passed, score 1', async () => {
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    const r = await evaluateDomainFitWriteGate(
+      '100일 영어 회화 완성하기',
+      '영어 발음 교정 Day1',
+      CFG
+    );
+    expect(r.passed).toBe(true);
+    expect(r.fit).toBe('적합');
+    expect(r.score).toBe(1);
+    expect(r.lexicalConflict).toBe(false);
+    expect(r.reason).toBe('fit');
+  });
+
+  it('적합 BUT a lexical qualifier conflict (R22 pattern) → BLOCKED despite T3 fit', async () => {
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    const r = await evaluateDomainFitWriteGate(
+      '100일 영어 회화 완성하기',
+      '실전 일본여행회화 3강 일본어',
+      CFG
+    );
+    expect(r.lexicalConflict).toBe(true);
+    expect(r.score).toBeCloseTo(0.2);
+    expect(r.passed).toBe(false);
+    expect(r.reason).toBe('lexical_conflict');
+  });
+
+  it('비적합 → blocked regardless of lexical signal', async () => {
+    mockClassify.mockResolvedValue({ fit: '비적합', ms: 5, ok: true });
+    const r = await evaluateDomainFitWriteGate('영어 회화', '전혀 무관한 제목', CFG);
+    expect(r.score).toBe(0);
+    expect(r.passed).toBe(false);
+    expect(r.reason).toBe('not_fit');
+  });
+
+  it('classifier failure (ok:false) → FAIL-OPEN (passed:true), never blocks on infra outage', async () => {
+    mockClassify.mockResolvedValue({ fit: null, ms: 5000, ok: false, error: 'timeout' });
+    const r = await evaluateDomainFitWriteGate('영어 회화', '아무 제목', CFG);
+    expect(r.passed).toBe(true);
+    expect(r.classifierOk).toBe(false);
+    expect(r.score).toBeNull();
+    expect(r.reason).toBe('classifier_unavailable_fail_open');
+  });
+
+  it('classifyDomainFit rejecting unexpectedly never throws (classifyDomainFit itself never throws — this is a defensive pin)', async () => {
+    mockClassify.mockResolvedValue({ fit: null, ms: 5, ok: false });
+    await expect(evaluateDomainFitWriteGate('영어 회화', '아무 제목', CFG)).resolves.toMatchObject({
+      passed: true,
+    });
+  });
+});
+
+describe('runDomainFitWriteEnforce — logging shape', () => {
+  it('logs exactly one recordTrace call, step domain_fit_write_enforce.<stage>', async () => {
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    const result = await runDomainFitWriteEnforce(
+      {
+        stage: 'reuse',
+        centerGoal: '영어 회화',
+        videoId: 'vid12345678',
+        title: '영어 발음 교정',
+        source: 'user_live',
+      },
+      CFG
+    );
+    expect(result.passed).toBe(true);
+    expect(mockRecordTrace).toHaveBeenCalledTimes(1);
+    const call = mockRecordTrace.mock.calls[0]![0];
+    expect(call.step).toBe('domain_fit_write_enforce.reuse');
+    expect(call.request.video_id).toBe('vid12345678');
+    expect(call.response.decision).toBe('passed');
+  });
+
+  it('logs decision:blocked on a block verdict', async () => {
+    mockClassify.mockResolvedValue({ fit: '비적합', ms: 5, ok: true });
+    const result = await runDomainFitWriteEnforce(
+      {
+        stage: 'reuse',
+        centerGoal: '영어 회화',
+        videoId: 'vid12345678',
+        title: '전혀 무관',
+        source: 'user_live',
+      },
+      CFG
+    );
+    expect(result.passed).toBe(false);
+    const call = mockRecordTrace.mock.calls[0]![0];
+    expect(call.response.decision).toBe('blocked');
+    expect(call.response.reason).toBe('not_fit');
+  });
+
+  it('creates a scoped trace context when none is bound (mirrors write-shadow.ts)', async () => {
+    mockGetTraceContext.mockReturnValue(null);
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    await runDomainFitWriteEnforce(
+      {
+        stage: 'reuse',
+        centerGoal: '영어 회화',
+        videoId: 'vid12345678',
+        title: '영어 발음 교정',
+        source: 'user_live',
+        mandalaId: 'm-abc',
+        userId: 'u-xyz',
+      },
+      CFG
+    );
+    expect(mockWithTraceContext).toHaveBeenCalledTimes(1);
+    expect(mockWithTraceContext.mock.calls[0]![0]).toEqual({ mandalaId: 'm-abc', userId: 'u-xyz' });
+  });
+
+  it('a trace-logging failure never alters the returned decision', async () => {
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    mockRecordTrace.mockImplementation(() => {
+      throw new Error('trace boom');
+    });
+    const result = await runDomainFitWriteEnforce(
+      {
+        stage: 'reuse',
+        centerGoal: '영어 회화',
+        videoId: 'vid12345678',
+        title: '영어 발음 교정',
+        source: 'user_live',
+      },
+      CFG
+    );
+    expect(result.passed).toBe(true);
+  });
+});

--- a/tests/unit/modules/domain-fit-write-shadow.test.ts
+++ b/tests/unit/modules/domain-fit-write-shadow.test.ts
@@ -47,6 +47,8 @@ const CFG_OFF: DomainFitShadowConfig = {
   maxCandidates: 40,
   scalarEnabled: false,
   writeShadowEnabled: false,
+  writeEnforceEnabled: false,
+  serveShadowEnabled: false,
 };
 const CFG_ON: DomainFitShadowConfig = { ...CFG_OFF, writeShadowEnabled: true };
 

--- a/tests/unit/modules/domain-fit-write-shadow.test.ts
+++ b/tests/unit/modules/domain-fit-write-shadow.test.ts
@@ -1,0 +1,133 @@
+/**
+ * domain-fit-shadow/write-shadow — R19 WRITE-edge shadow enforce-0 invariants.
+ *
+ * Pins:
+ *   - flag off (writeShadowEnabled:false) → zero classifyDomainFit calls,
+ *     zero recordTrace calls (byte-identical to pre-R19 behavior).
+ *   - flag on → exactly one classifyDomainFit call + one recordTrace call,
+ *     step name domain_fit_shadow.write.<stage>.
+ *   - the write decision itself is never touched: scheduleDomainFitWriteShadow
+ *     returns void, no return value a caller could branch a write on.
+ *   - runDomainFitWriteShadow never throws even when classifyDomainFit rejects.
+ *   - when no ambient trace context is bound, a scoped one is created so the
+ *     shadow write is never silently dropped (mirrors reuse-from-v5.ts /
+ *     cards.ts call sites which may run outside `withTraceContext`).
+ *   - when an ambient trace context IS already bound (e.g. add-cards.ts's
+ *     wrap around the v5 executor), the existing context is reused, not
+ *     re-wrapped.
+ */
+
+const mockClassify = jest.fn();
+const mockRecordTrace = jest.fn();
+const mockWithTraceContext = jest.fn();
+const mockGetTraceContext = jest.fn();
+
+jest.mock('@/modules/domain-fit-shadow/client', () => ({
+  classifyDomainFit: (...args: unknown[]) => mockClassify(...args),
+}));
+jest.mock('@/modules/discover-tracing', () => ({
+  recordTrace: (...args: unknown[]) => mockRecordTrace(...args),
+  getTraceContext: (...args: unknown[]) => mockGetTraceContext(...args),
+  withTraceContext: (ctx: unknown, fn: () => Promise<unknown>) => mockWithTraceContext(ctx, fn),
+}));
+
+import {
+  scheduleDomainFitWriteShadow,
+  runDomainFitWriteShadow,
+  type ScheduleDomainFitWriteShadowInput,
+} from '@/modules/domain-fit-shadow/write-shadow';
+import type { DomainFitShadowConfig } from '@/config/domain-fit-shadow';
+
+const CFG_OFF: DomainFitShadowConfig = {
+  enabled: false,
+  ollamaUrl: 'http://100.91.173.17:11434',
+  model: 'mandala-gen:latest',
+  timeoutMs: 5000,
+  concurrency: 4,
+  maxCandidates: 40,
+  scalarEnabled: false,
+  writeShadowEnabled: false,
+};
+const CFG_ON: DomainFitShadowConfig = { ...CFG_OFF, writeShadowEnabled: true };
+
+function baseInput(stage: 'reuse' | 'like' = 'reuse'): ScheduleDomainFitWriteShadowInput {
+  return {
+    stage,
+    centerGoal: '6개월 내 영어 프리토킹 달성',
+    videoId: 'vid12345678',
+    title: '영어 회화 꿀팁 10가지',
+    source: stage === 'reuse' ? 'user_live' : 'user_curated',
+  };
+}
+
+beforeEach(() => {
+  mockClassify.mockReset();
+  mockRecordTrace.mockReset();
+  mockWithTraceContext.mockReset();
+  mockGetTraceContext.mockReset();
+  mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+  mockGetTraceContext.mockReturnValue({ mandalaId: 'm1', userId: 'u1', runId: 'r1' });
+  mockWithTraceContext.mockImplementation((_ctx: unknown, fn: () => Promise<unknown>) => fn());
+});
+
+describe('scheduleDomainFitWriteShadow — flag gating (enforce-0)', () => {
+  it('is a no-op when writeShadowEnabled is off — zero classify calls, zero trace writes', () => {
+    scheduleDomainFitWriteShadow(baseInput(), CFG_OFF);
+    expect(mockClassify).not.toHaveBeenCalled();
+    expect(mockRecordTrace).not.toHaveBeenCalled();
+  });
+
+  it('returns void — no value a caller could branch a write decision on', () => {
+    const ret = scheduleDomainFitWriteShadow(baseInput(), CFG_ON);
+    expect(ret).toBeUndefined();
+  });
+});
+
+describe('runDomainFitWriteShadow — logging shape + async safety', () => {
+  it('writes exactly one recordTrace call with step domain_fit_shadow.write.<stage>', async () => {
+    const input = baseInput('reuse');
+    await runDomainFitWriteShadow(input, CFG_ON);
+    expect(mockClassify).toHaveBeenCalledTimes(1);
+    expect(mockClassify).toHaveBeenCalledWith(input.centerGoal, input.title, CFG_ON);
+    expect(mockRecordTrace).toHaveBeenCalledTimes(1);
+    const call = mockRecordTrace.mock.calls[0]![0];
+    expect(call.step).toBe('domain_fit_shadow.write.reuse');
+    expect(call.status).toBe('ok');
+    expect(call.request.video_id).toBe('vid12345678');
+    expect(call.request.source).toBe('user_live');
+    expect(call.response.fit).toBe('적합');
+    expect(call.response.ok).toBe(true);
+  });
+
+  it('uses the "like" stage step name for the /like call site', async () => {
+    await runDomainFitWriteShadow(baseInput('like'), CFG_ON);
+    const call = mockRecordTrace.mock.calls[0]![0];
+    expect(call.step).toBe('domain_fit_shadow.write.like');
+    expect(call.request.source).toBe('user_curated');
+  });
+
+  it('reuses an existing ambient trace context (does not re-wrap)', async () => {
+    mockGetTraceContext.mockReturnValue({ mandalaId: 'm1', userId: 'u1', runId: 'r1' });
+    await runDomainFitWriteShadow(baseInput(), CFG_ON);
+    expect(mockWithTraceContext).not.toHaveBeenCalled();
+    expect(mockRecordTrace).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a scoped trace context when none is bound (never silently drops the write-log)', async () => {
+    mockGetTraceContext.mockReturnValue(null);
+    const input = { ...baseInput(), mandalaId: 'm-abc', userId: 'u-xyz' };
+    await runDomainFitWriteShadow(input, CFG_ON);
+    expect(mockWithTraceContext).toHaveBeenCalledTimes(1);
+    expect(mockWithTraceContext.mock.calls[0]![0]).toEqual({
+      mandalaId: 'm-abc',
+      userId: 'u-xyz',
+    });
+    expect(mockRecordTrace).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws even when classifyDomainFit rejects unexpectedly', async () => {
+    mockClassify.mockRejectedValue(new Error('boom'));
+    await expect(runDomainFitWriteShadow(baseInput(), CFG_ON)).resolves.toBeUndefined();
+    expect(mockRecordTrace).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/modules/pool-serve-fill.test.ts
+++ b/tests/unit/modules/pool-serve-fill.test.ts
@@ -72,6 +72,16 @@ jest.mock('@/skills/plugins/video-discover/v3/hybrid-rerank', () => ({
   tsvectorKeywordCandidatesPerCell: (...a: unknown[]) => mockPoolCandidates(...a),
 }));
 
+// R23 — SERVE-edge domain-fit shadow call. Fully mocked so the unit suite
+// never makes a real Ollama call; default env (no DOMAIN_FIT_SERVE_SHADOW)
+// means the REAL loadDomainFitShadowConfig() (unmocked below) resolves
+// serveShadowEnabled=false, so scheduleDomainFitShadow's cfgOverride.enabled
+// is false regardless — this mock only lets tests assert the CALL SHAPE.
+const mockScheduleDomainFitShadow = jest.fn();
+jest.mock('@/modules/domain-fit-shadow/shadow', () => ({
+  scheduleDomainFitShadow: (...a: unknown[]) => mockScheduleDomainFitShadow(...a),
+}));
+
 // Partial mock: stub the network fns, keep the REAL title gates so the test
 // exercises the actual hygiene posture (#905 included via the v5 gate below).
 const mockSearchVideos = jest.fn();
@@ -133,6 +143,7 @@ import {
 } from '../../../src/modules/queue/handlers/pool-serve-fill';
 import { JOB_NAMES, type PoolServeFillPayload } from '../../../src/modules/queue/types';
 import { loadPoolServeConfig } from '../../../src/config/pool-serve';
+import { loadDomainFitShadowConfig } from '../../../src/config/domain-fit-shadow';
 
 type Handler = (job: { id: string; data: PoolServeFillPayload }) => Promise<void>;
 
@@ -178,6 +189,8 @@ beforeEach(() => {
   mockYvFindUnique.mockResolvedValue({ id: 'uuid-yv-1' });
   mockUvsCreateMany.mockResolvedValue({ count: 1 });
   delete process.env['RELEVANCE_RUBRIC_ENABLED'];
+  delete process.env['POOL_SERVE_SOURCES_EXTRA'];
+  delete process.env['DOMAIN_FIT_SERVE_SHADOW'];
 });
 
 async function getHandler(): Promise<Handler> {
@@ -405,6 +418,79 @@ describe('CP500+ shorts gate — guard-replication fix', () => {
     await handler({ id: 'js4', data: basePayload });
 
     expect(mockIsShortCached).toHaveBeenCalledWith('liveUnknown', null, expect.anything());
+    expect(mockUvsCreateMany).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── R23 — POOL_SOURCES config-driven extension + SERVE-edge domain-fit shadow ──
+
+describe('R23 — POOL_SERVE_SOURCES_EXTRA (config, not hardcoded)', () => {
+  it('default (unset): recruit sources = base v2_promoted only (byte-identical to pre-R23)', async () => {
+    mockPoolCandidates.mockResolvedValueOnce([]);
+    mockSearchVideos.mockResolvedValueOnce([]);
+    const handler = await getHandler();
+
+    await handler({ id: 'jr1', data: basePayload });
+
+    expect(mockPoolCandidates).toHaveBeenCalledTimes(1);
+    expect(mockPoolCandidates.mock.calls[0][3]).toEqual(['v2_promoted']);
+  });
+
+  it('POOL_SERVE_SOURCES_EXTRA=yt_promoted widens the MAIN keyword recruit call', async () => {
+    process.env['POOL_SERVE_SOURCES_EXTRA'] = 'yt_promoted';
+    mockPoolCandidates.mockResolvedValueOnce([]);
+    mockSearchVideos.mockResolvedValueOnce([]);
+    const handler = await getHandler();
+
+    await handler({ id: 'jr2', data: basePayload });
+
+    expect(mockPoolCandidates.mock.calls[0][3]).toEqual(['v2_promoted', 'yt_promoted']);
+  });
+});
+
+describe('R23 — pool-serve SERVE-edge domain-fit shadow (DOMAIN_FIT_SERVE_SHADOW)', () => {
+  it('config default: serveShadowEnabled is false (unset env, no behavior change)', () => {
+    const cfg = loadDomainFitShadowConfig({} as NodeJS.ProcessEnv);
+    expect(cfg.serveShadowEnabled).toBe(false);
+  });
+
+  it('always schedules the shadow call shape (fire-and-forget) with the FINAL passed set, cfgOverride carrying the flag — never blocks/reorders the insert', async () => {
+    mockPoolCandidates.mockResolvedValueOnce([poolCand('vidA1234567', '쿠버네티스 모니터링 입문')]);
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 82 });
+    const handler = await getHandler();
+
+    await handler({ id: 'jr3', data: basePayload });
+
+    expect(mockScheduleDomainFitShadow).toHaveBeenCalledTimes(1);
+    const [input, cfgOverride] = mockScheduleDomainFitShadow.mock.calls[0];
+    expect(input).toMatchObject({
+      stage: 'pool_serve',
+      centerGoal: basePayload.centerGoal,
+      candidates: [
+        expect.objectContaining({
+          videoId: 'vidA1234567',
+          cellIndex: basePayload.cellIndex,
+          rank: 0,
+        }),
+      ],
+    });
+    // Default env ⇒ serveShadowEnabled false ⇒ cfgOverride.enabled false (no-op
+    // inside the REAL scheduleDomainFitShadow — this mock only pins call shape).
+    expect(cfgOverride.enabled).toBe(false);
+    // The insert still happened — the shadow call never gated it.
+    expect(mockUvsCreateMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('DOMAIN_FIT_SERVE_SHADOW=true flips cfgOverride.enabled to true (still async, still never gates)', async () => {
+    process.env['DOMAIN_FIT_SERVE_SHADOW'] = 'true';
+    mockPoolCandidates.mockResolvedValueOnce([poolCand('vidB1234567', '쿠버네티스 실전')]);
+    mockCompute.mockResolvedValueOnce({ ok: true, relevancePct: 90 });
+    const handler = await getHandler();
+
+    await handler({ id: 'jr4', data: basePayload });
+
+    const [, cfgOverride] = mockScheduleDomainFitShadow.mock.calls[0];
+    expect(cfgOverride.enabled).toBe(true);
     expect(mockUvsCreateMany).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/modules/reuse-from-v5.test.ts
+++ b/tests/unit/modules/reuse-from-v5.test.ts
@@ -2,9 +2,31 @@
  * CP494 ③ reuse loop — prepareReuseRow pure builder.
  * Quality gate, dropped-field re-extraction (description/like_count), source tag,
  * short re-gate revival guard, scrub-restore (title/desc in update), no source overwrite.
+ *
+ * R19 addition — reusePickedToPool's domain-fit WRITE-edge shadow wiring
+ * (enforce-0: the shadow schedule call never gates or alters the upsert).
  */
 
-import { prepareReuseRow, REUSE_SOURCE } from '@/modules/video-pool/reuse-from-v5';
+const mockUpsert = jest.fn().mockResolvedValue({});
+const mockShortGateFields = jest.fn().mockResolvedValue({ is_short: false });
+const mockScheduleWriteShadow = jest.fn();
+
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({ video_pool: { upsert: (...args: unknown[]) => mockUpsert(...args) } }),
+}));
+jest.mock('@/modules/video-pool/is-short', () => ({
+  shortGateFields: (...args: unknown[]) => mockShortGateFields(...args),
+}));
+jest.mock('@/modules/domain-fit-shadow/write-shadow', () => ({
+  scheduleDomainFitWriteShadow: (...args: unknown[]) => mockScheduleWriteShadow(...args),
+}));
+
+import {
+  prepareReuseRow,
+  reusePickedToPool,
+  REUSE_SOURCE,
+  type ReuseInput,
+} from '@/modules/video-pool/reuse-from-v5';
 
 const card = (over = {}) => ({
   videoId: 'vid12345678',
@@ -64,5 +86,72 @@ describe('prepareReuseRow (CP494 reuse loop)', () => {
     const r = prepareReuseRow(card(), new Map(), new Map(), 'ko', { is_short: false });
     expect(r!.create.description).toBeNull();
     expect(r!.create.like_count).toBe(BigInt(0));
+  });
+});
+
+describe('reusePickedToPool — R19 domain-fit WRITE-edge shadow wiring (enforce-0)', () => {
+  beforeEach(() => {
+    mockUpsert.mockClear();
+    mockShortGateFields.mockClear();
+    mockScheduleWriteShadow.mockClear();
+  });
+
+  const baseInput = (over: Partial<ReuseInput> = {}): ReuseInput => ({
+    cards: [card()],
+    fanoutById: fanout(),
+    metaById: meta(),
+    language: 'ko',
+    centerGoal: '도커 입문',
+    ...over,
+  });
+
+  test('schedules the write-shadow call per accepted card, before the upsert (fire-and-forget, never awaited)', async () => {
+    const callOrder: string[] = [];
+    mockScheduleWriteShadow.mockImplementation(() => callOrder.push('shadow'));
+    mockUpsert.mockImplementation(() => {
+      callOrder.push('upsert');
+      return Promise.resolve({});
+    });
+
+    const result = await reusePickedToPool(baseInput());
+
+    expect(result.reused).toBe(1);
+    expect(mockScheduleWriteShadow).toHaveBeenCalledTimes(1);
+    expect(mockScheduleWriteShadow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'reuse',
+        centerGoal: '도커 입문',
+        videoId: 'vid12345678',
+        source: REUSE_SOURCE,
+      })
+    );
+    expect(callOrder).toEqual(['shadow', 'upsert']); // scheduled before, never gates, the upsert
+  });
+
+  test('is a no-op (zero calls) when centerGoal is omitted — enforce-0, upsert unaffected', async () => {
+    const result = await reusePickedToPool(baseInput({ centerGoal: undefined }));
+    expect(mockScheduleWriteShadow).not.toHaveBeenCalled();
+    expect(mockUpsert).toHaveBeenCalledTimes(1); // upsert still happens — write decision untouched
+    expect(result.reused).toBe(1);
+  });
+
+  test('does not schedule the shadow call for a quality-rejected card (never reaches the upsert either)', async () => {
+    const result = await reusePickedToPool(
+      baseInput({ cards: [card({ viewCount: 50 })] }) // below view floor → prepareReuseRow returns null
+    );
+    expect(mockScheduleWriteShadow).not.toHaveBeenCalled();
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+  });
+
+  test('the write-shadow function is called synchronously (schedule, not awaited) — a slow/hanging shadow call cannot delay the upsert', async () => {
+    // Simulate the real scheduleDomainFitWriteShadow contract: it returns
+    // void synchronously and dispatches its own internal work with `void`.
+    // If reusePickedToPool ever accidentally `await`ed a Promise from this
+    // call, this mock returning a never-resolving promise would hang the
+    // test (jest would time out) — asserting the test resolves proves the
+    // call site does not await it.
+    mockScheduleWriteShadow.mockReturnValue(new Promise(() => {}) as unknown as void);
+    await expect(reusePickedToPool(baseInput())).resolves.toEqual({ reused: 1, skipped: 0 });
   });
 });

--- a/tests/unit/modules/reuse-from-v5.test.ts
+++ b/tests/unit/modules/reuse-from-v5.test.ts
@@ -5,11 +5,18 @@
  *
  * R19 addition — reusePickedToPool's domain-fit WRITE-edge shadow wiring
  * (enforce-0: the shadow schedule call never gates or alters the upsert).
+ *
+ * R23 addition — the enforce-capable gate (write-gate.ts), gated by
+ * DOMAIN_FIT_WRITE_ENFORCE (mocked via loadDomainFitShadowConfig below):
+ * off (default) → runDomainFitWriteEnforce is never called, upsert unaffected
+ * (R19-A1 unchanged); on → a block verdict skips the upsert.
  */
 
 const mockUpsert = jest.fn().mockResolvedValue({});
 const mockShortGateFields = jest.fn().mockResolvedValue({ is_short: false });
 const mockScheduleWriteShadow = jest.fn();
+const mockLoadDomainFitShadowConfig = jest.fn();
+const mockRunWriteEnforce = jest.fn();
 
 jest.mock('@/modules/database/client', () => ({
   getPrismaClient: () => ({ video_pool: { upsert: (...args: unknown[]) => mockUpsert(...args) } }),
@@ -19,6 +26,12 @@ jest.mock('@/modules/video-pool/is-short', () => ({
 }));
 jest.mock('@/modules/domain-fit-shadow/write-shadow', () => ({
   scheduleDomainFitWriteShadow: (...args: unknown[]) => mockScheduleWriteShadow(...args),
+}));
+jest.mock('@/config/domain-fit-shadow', () => ({
+  loadDomainFitShadowConfig: (...args: unknown[]) => mockLoadDomainFitShadowConfig(...args),
+}));
+jest.mock('@/modules/domain-fit-shadow/write-gate', () => ({
+  runDomainFitWriteEnforce: (...args: unknown[]) => mockRunWriteEnforce(...args),
 }));
 
 import {
@@ -94,6 +107,10 @@ describe('reusePickedToPool — R19 domain-fit WRITE-edge shadow wiring (enforce
     mockUpsert.mockClear();
     mockShortGateFields.mockClear();
     mockScheduleWriteShadow.mockClear();
+    mockRunWriteEnforce.mockClear();
+    // R23 default: enforce OFF (matches loadDomainFitShadowConfig's real
+    // default), so pre-R23 tests below stay byte-identical without edits.
+    mockLoadDomainFitShadowConfig.mockReturnValue({ writeEnforceEnabled: false });
   });
 
   const baseInput = (over: Partial<ReuseInput> = {}): ReuseInput => ({
@@ -153,5 +170,78 @@ describe('reusePickedToPool — R19 domain-fit WRITE-edge shadow wiring (enforce
     // call site does not await it.
     mockScheduleWriteShadow.mockReturnValue(new Promise(() => {}) as unknown as void);
     await expect(reusePickedToPool(baseInput())).resolves.toEqual({ reused: 1, skipped: 0 });
+  });
+});
+
+describe('reusePickedToPool — R23 domain-fit WRITE-edge ENFORCE gate', () => {
+  beforeEach(() => {
+    mockUpsert.mockClear();
+    mockShortGateFields.mockClear();
+    mockScheduleWriteShadow.mockClear();
+    mockRunWriteEnforce.mockClear();
+  });
+
+  const baseInput = (over: Partial<ReuseInput> = {}): ReuseInput => ({
+    cards: [card()],
+    fanoutById: fanout(),
+    metaById: meta(),
+    language: 'ko',
+    centerGoal: '도커 입문',
+    ...over,
+  });
+
+  test('enforce OFF (default): runDomainFitWriteEnforce is never called, upsert unaffected', async () => {
+    mockLoadDomainFitShadowConfig.mockReturnValue({ writeEnforceEnabled: false });
+    const result = await reusePickedToPool(baseInput());
+    expect(mockRunWriteEnforce).not.toHaveBeenCalled();
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ reused: 1, skipped: 0 });
+  });
+
+  test('enforce ON + PASS verdict → upsert proceeds', async () => {
+    mockLoadDomainFitShadowConfig.mockReturnValue({ writeEnforceEnabled: true });
+    mockRunWriteEnforce.mockResolvedValue({ passed: true, fit: '적합', reason: 'fit' });
+    const result = await reusePickedToPool(baseInput());
+    expect(mockRunWriteEnforce).toHaveBeenCalledTimes(1);
+    expect(mockRunWriteEnforce).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: 'reuse',
+        centerGoal: '도커 입문',
+        videoId: 'vid12345678',
+        source: REUSE_SOURCE,
+      }),
+      expect.objectContaining({ writeEnforceEnabled: true })
+    );
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ reused: 1, skipped: 0 });
+  });
+
+  test('enforce ON + BLOCK verdict → upsert skipped, counted as skipped (not reused)', async () => {
+    mockLoadDomainFitShadowConfig.mockReturnValue({ writeEnforceEnabled: true });
+    mockRunWriteEnforce.mockResolvedValue({ passed: false, fit: '비적합', reason: 'not_fit' });
+    const result = await reusePickedToPool(baseInput());
+    expect(mockRunWriteEnforce).toHaveBeenCalledTimes(1);
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(result).toEqual({ reused: 0, skipped: 1 });
+  });
+
+  test('enforce ON but centerGoal omitted → gate never called (mirrors shadow enforce-0 no-op), upsert proceeds', async () => {
+    mockLoadDomainFitShadowConfig.mockReturnValue({ writeEnforceEnabled: true });
+    const result = await reusePickedToPool(baseInput({ centerGoal: undefined }));
+    expect(mockRunWriteEnforce).not.toHaveBeenCalled();
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ reused: 1, skipped: 0 });
+  });
+
+  test('enforce ON + BLOCK on one card among two → only the blocked card is skipped', async () => {
+    mockLoadDomainFitShadowConfig.mockReturnValue({ writeEnforceEnabled: true });
+    mockRunWriteEnforce
+      .mockResolvedValueOnce({ passed: true, fit: '적합', reason: 'fit' })
+      .mockResolvedValueOnce({ passed: false, fit: '비적합', reason: 'not_fit' });
+    const cardB = card({ videoId: 'vid87654321' });
+    const result = await reusePickedToPool(baseInput({ cards: [card(), cardB] }));
+    expect(mockRunWriteEnforce).toHaveBeenCalledTimes(2);
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ reused: 1, skipped: 1 });
   });
 });


### PR DESCRIPTION
## What
Consolidated CP511 search-redesign durable-fix code (R13→R23). Adds a **domain-fit deboost signal** (LLM classifier + non-LLM lexical qualifier layer) wired at the pool WRITE-edge (enforce-capable) and READ/serve path (shadow), plus a flag to widen pool-serve recruit sources.

**All 4 flags default OFF → deploying this PR is behavior-neutral.** Activation is staged separately via prod compose flags.

## Validated (measurement, real content — see docs/qa/)
- domain-fit classifier (non-circular anchor): over-block 6.1%, drift-catch 93.4%.
- composite (LLM + lexical): 회화 over-pass 40%→13.3%, **legit false-deboost 0/219**, base signal unchanged.
- edge asymmetry: gate the reuse-edge, not /like.

## Flags (default = current behavior)
| Flag | Default | On |
|---|---|---|
| `DOMAIN_FIT_WRITE_ENFORCE` | false | reuse WRITE-edge: block non-fit accumulation (composite gate, local Ollama) |
| `POOL_SERVE_SOURCES_EXTRA` | `''` | append sources (e.g. `yt_promoted`) to pool-serve recruit |
| `DOMAIN_FIT_SERVE_SHADOW` | false | async would-serve logging (no reorder/block) |

## Staged rollout (post-merge, prod compose, each reversible by flipping one flag)
1. Merge (flags off) — zero behavior change.
2. `DOMAIN_FIT_SERVE_SHADOW=true` — pure logging canary.
3. `POOL_SERVE_SOURCES_EXTRA=yt_promoted` — widen recruit.
4. `DOMAIN_FIT_WRITE_ENFORCE=true` (after `V5_REUSE_LOOP` on) — WRITE quality gate.

## Verification
- tsc clean; 96 targeted tests pass; 13 pre-existing failures reproduced on base (0 regressions).
- domain-fit runs on local Ollama (\$0 external); OpenRouter is fallback-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)