### PR TITLE
feat(diversity): global channel hard-cap canary — V5_CHANNEL_HARD_CAP=3

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -192,6 +192,14 @@ services:
       # V5_SERIES_DEDUP_SIM (0.8) / V5_CHANNEL_SOFT_CAP (2 = demote from 3rd).
       # Revert: delete this line + redeploy → code default false (기존 동작).
       - V5_DIVERSITY_GUARD=true
+      # 2026-07-06 (James [GO], supervisor canary) — global channel HARD cap.
+      # The per-cell soft cap (2/cell) can't see a channel spread 2 across N cells
+      # (measured: 말트영어 10/49 in a 5-cell 영어 add_cards trace, zero per-cell
+      # violations). This adds a cross-cell hard cap: 4th+ from one channel demoted
+      # (demote-only, count-neutral — measured 10→3 primary, 49→49 total). Fires
+      # only when candidates ≥ V5_CHANNEL_HARD_CAP_MIN_CANDIDATES (30) so thin
+      # cells keep soft-demote. Rollback = set to 0 + redeploy (code default off).
+      - V5_CHANNEL_HARD_CAP=3
       # CP500++ (2026-06-18, James [GO]) — restore the min-view floor on the
       # wizard/auto-add path. #804 (2026-05-30) switched the wizard v3→v5; the v3
       # quality gate (filterByQualityGate, MIN_VIEW 1000) was NOT carried into v5,

--- a/src/config/diversity-guard.ts
+++ b/src/config/diversity-guard.ts
@@ -25,18 +25,50 @@ export const diversityGuardEnvSchema = z.object({
   V5_SERIES_DEDUP_SIM: z.coerce.number().min(0).max(1).default(0.8),
   /** Cards one channel keeps at priority per cell; the (n+1)-th onward is demoted (soft). */
   V5_CHANNEL_SOFT_CAP: z.coerce.number().int().min(1).max(10).default(2),
+  /**
+   * CP511+1 — global (cross-cell) channel cap, closes the gap softChannelCap
+   * cannot (a channel under-cap in every individual cell can still monopolize
+   * the aggregate list). 0 = off (default; unset = 기존 동작). DEMOTE only —
+   * never drops, so the 50~70 card-count floor is never at risk from this
+   * knob alone. Measured rationale: mandala 7d5d759e (영어) add_cards trace
+   * 42da98a6, 2026-07-06 — 말트영어 10/49 PLACED cards (top3 share 34.7%)
+   * with soft-cap=2/cell already active; cap=3 GLOBAL demotes it to 3
+   * primary + 7 tail (top3 share → 22%), count unchanged (49→49).
+   */
+  V5_CHANNEL_HARD_CAP: z.coerce.number().int().min(0).max(20).default(0),
+  /** Hard cap only fires above this pool size (thin-supply skip, same principle as softChannelCap). */
+  V5_CHANNEL_HARD_CAP_MIN_CANDIDATES: z.coerce.number().int().min(1).default(30),
+  /**
+   * CP511+1 — cross-channel (not same-channel-only like dedupeSeries) title
+   * similarity dedup, DEMOTE only. Default off. Measured limitation (same
+   * trace): 3 known near-duplicate "100문장/생활영어" titles from one channel
+   * scored 0.12-0.17 token-Jaccard (stripEpisodeTokens) — well BELOW this
+   * conservative default; SEO-padded titles dilute whole-title token overlap.
+   * Ships as specified but does not (yet) catch that specific spam pattern —
+   * see handoff report.
+   */
+  V5_CROSS_CHANNEL_TITLE_DEDUP: boolFlag.default(false as unknown as string),
+  V5_CROSS_CHANNEL_DEDUP_SIM: z.coerce.number().min(0).max(1).default(0.65),
 });
 
 export interface DiversityGuardConfig {
   enabled: boolean;
   seriesSim: number;
   channelSoftCap: number;
+  channelHardCap: number;
+  channelHardCapMinCandidates: number;
+  crossChannelDedupEnabled: boolean;
+  crossChannelDedupSim: number;
 }
 
 const DEFAULTS: DiversityGuardConfig = {
   enabled: false,
   seriesSim: 0.8,
   channelSoftCap: 2,
+  channelHardCap: 0,
+  channelHardCapMinCandidates: 30,
+  crossChannelDedupEnabled: false,
+  crossChannelDedupSim: 0.65,
 };
 
 export function loadDiversityGuardConfig(
@@ -46,11 +78,19 @@ export function loadDiversityGuardConfig(
     V5_DIVERSITY_GUARD: env['V5_DIVERSITY_GUARD'],
     V5_SERIES_DEDUP_SIM: env['V5_SERIES_DEDUP_SIM'],
     V5_CHANNEL_SOFT_CAP: env['V5_CHANNEL_SOFT_CAP'],
+    V5_CHANNEL_HARD_CAP: env['V5_CHANNEL_HARD_CAP'],
+    V5_CHANNEL_HARD_CAP_MIN_CANDIDATES: env['V5_CHANNEL_HARD_CAP_MIN_CANDIDATES'],
+    V5_CROSS_CHANNEL_TITLE_DEDUP: env['V5_CROSS_CHANNEL_TITLE_DEDUP'],
+    V5_CROSS_CHANNEL_DEDUP_SIM: env['V5_CROSS_CHANNEL_DEDUP_SIM'],
   });
   if (!parsed.success) return DEFAULTS;
   return {
     enabled: parsed.data.V5_DIVERSITY_GUARD,
     seriesSim: parsed.data.V5_SERIES_DEDUP_SIM,
     channelSoftCap: parsed.data.V5_CHANNEL_SOFT_CAP,
+    channelHardCap: parsed.data.V5_CHANNEL_HARD_CAP,
+    channelHardCapMinCandidates: parsed.data.V5_CHANNEL_HARD_CAP_MIN_CANDIDATES,
+    crossChannelDedupEnabled: parsed.data.V5_CROSS_CHANNEL_TITLE_DEDUP,
+    crossChannelDedupSim: parsed.data.V5_CROSS_CHANNEL_DEDUP_SIM,
   };
 }

--- a/src/skills/plugins/video-discover/diversity-guard.ts
+++ b/src/skills/plugins/video-discover/diversity-guard.ts
@@ -288,6 +288,120 @@ export function softChannelCap<T extends DiversityCandidate>(candidates: T[], ca
   return out;
 }
 
+// ── hard channel cap (global, demote-only) ──────────────────────────────────
+
+export interface HardChannelCapResult<T extends DiversityCandidate> {
+  /** Same length as input — DEMOTE only, never drop (card-floor 50~70 불변). */
+  reordered: T[];
+  demoted: number;
+}
+
+/**
+ * Global (cross-cell) channel cap — closes the gap softChannelCap cannot: a
+ * channel under the per-cell cap in EVERY individual cell can still monopolize
+ * the aggregate list (e.g. 2/cell × 5 cells = 10 cards, one channel, zero
+ * per-cell violations). Counted across the WHOLE candidate list regardless of
+ * cellIndex; the cap-th+ occurrence of one channel is DEMOTED to the tail,
+ * preserving relative order — never dropped, so downstream card-count floor
+ * (50~70) is never at risk from this transform alone.
+ *
+ * `minCandidates` gate: below this pool size the cap does not fire at all
+ * (thin-supply protection — same principle as softChannelCap's single-channel
+ * bucket passthrough, applied globally instead of per-cell).
+ */
+export function hardChannelCap<T extends DiversityCandidate>(
+  candidates: T[],
+  cap: number,
+  minCandidates: number
+): HardChannelCapResult<T> {
+  if (cap <= 0 || candidates.length < minCandidates) {
+    return { reordered: candidates, demoted: 0 };
+  }
+  const counts = new Map<string, number>();
+  const primary: T[] = [];
+  const demoted: T[] = [];
+  candidates.forEach((c) => {
+    const ch = channelKey(c);
+    if (!ch) {
+      primary.push(c);
+      return;
+    }
+    const n = (counts.get(ch) ?? 0) + 1;
+    counts.set(ch, n);
+    (n <= cap ? primary : demoted).push(c);
+  });
+  return { reordered: [...primary, ...demoted], demoted: demoted.length };
+}
+
+// ── cross-channel title dedup (demote-only) ─────────────────────────────────
+
+export interface CrossChannelDedupResult<T extends DiversityCandidate> {
+  /** Same length as input — DEMOTE only, never drop. */
+  reordered: T[];
+  demoted: number;
+}
+
+/**
+ * Groups near-identical titles ACROSS channels (unlike dedupeSeries, which is
+ * same-channel-only and requires an episode token) — catches the "동일 문구
+ * 반복 재업로드" pattern (e.g. "왕초보 영어회화 100문장 | 생활영어 …" reposted
+ * with cosmetic wording changes by many small channels). Token-Jaccard over
+ * stripEpisodeTokens output (reused — brackets/lowercase/punctuation strip is
+ * useful here even without an episode marker). Union-find groups transitively
+ * similar titles; representative = first occurrence in input order, the rest
+ * DEMOTED to the tail (never dropped — card-floor invariant).
+ */
+export function crossChannelTitleDedup<T extends DiversityCandidate>(
+  candidates: T[],
+  simThreshold: number
+): CrossChannelDedupResult<T> {
+  const n = candidates.length;
+  const parent = Array.from({ length: n }, (_, i) => i);
+  const find = (x: number): number => {
+    while (parent[x] !== x) {
+      parent[x] = parent[parent[x]!]!;
+      x = parent[x]!;
+    }
+    return x;
+  };
+  const union = (a: number, b: number): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent[Math.max(ra, rb)] = Math.min(ra, rb);
+  };
+
+  const normed = candidates.map((c) => stripEpisodeTokens(c.title || ''));
+  for (let i = 0; i < n; i += 1) {
+    if (!normed[i]) continue; // no title text — never grouped (no fabrication)
+    for (let j = i + 1; j < n; j += 1) {
+      if (!normed[j]) continue;
+      if (strippedTitleSimilarity(candidates[i]!.title, candidates[j]!.title) >= simThreshold) {
+        union(i, j);
+      }
+    }
+  }
+
+  const repOf = new Map<number, number>(); // root → representative (first occurrence)
+  const membersOf = new Map<number, number[]>();
+  for (let i = 0; i < n; i += 1) {
+    const r = find(i);
+    if (!repOf.has(r)) repOf.set(r, i);
+    const arr = membersOf.get(r) ?? [];
+    arr.push(i);
+    membersOf.set(r, arr);
+  }
+  const demotedIdx = new Set<number>();
+  for (const [root, members] of membersOf) {
+    if (members.length <= 1) continue;
+    const rep = repOf.get(root)!;
+    for (const m of members) if (m !== rep) demotedIdx.add(m);
+  }
+  const primary: T[] = [];
+  const demoted: T[] = [];
+  candidates.forEach((c, i) => (demotedIdx.has(i) ? demoted : primary).push(c));
+  return { reordered: [...primary, ...demoted], demoted: demoted.length };
+}
+
 // ── observability (③ raw 모집 채널 분포 1줄) ────────────────────────────────
 
 export interface ChannelDistribution {

--- a/src/skills/plugins/video-discover/v5/executor.ts
+++ b/src/skills/plugins/video-discover/v5/executor.ts
@@ -25,7 +25,12 @@ import {
 } from './youtube-fanout';
 import type { QueryGenMeta } from './llm-query-gen';
 import { getV5Config } from './config';
-import { dedupeSeries, softChannelCap } from '../diversity-guard';
+import {
+  dedupeSeries,
+  softChannelCap,
+  hardChannelCap,
+  crossChannelTitleDedup,
+} from '../diversity-guard';
 import { loadDiversityGuardConfig } from '@/config/diversity-guard';
 import { getVideoPicker } from '@/modules/llm-picker/registry';
 import { getLlmPickerConfig } from '@/config/llm-picker';
@@ -200,6 +205,37 @@ export async function runV5Executor(input: V5ExecuteInput): Promise<V5ExecuteRes
     survivors = softChannelCap(d.kept, diversity.channelSoftCap);
     if (d.dropped > 0) {
       log.info(`v5 diversity guard: series-dedup dropped ${d.dropped}/${afterExcludeFilter}`);
+    }
+
+    // CP511+1 — global channel hard cap + cross-channel title dedup, BOTH
+    // demote-only (never drop — 카드수 50~70 floor 불변). Closes the gap
+    // softChannelCap cannot: a channel under-cap in EVERY individual cell can
+    // still monopolize the aggregate list (measured: mandala 7d5d759e add_cards
+    // trace 42da98a6, 2026-07-06 — 말트영어 10/49 PLACED, soft-cap=2/cell
+    // already active, zero per-cell violations). Flag-gated; unset/0 = 기존
+    // 동작 (byte-identical — hardCap/crossChannelDedup are no-ops when
+    // channelHardCap<=0 / crossChannelDedupEnabled=false).
+    if (diversity.channelHardCap > 0) {
+      const capped = hardChannelCap(
+        survivors,
+        diversity.channelHardCap,
+        diversity.channelHardCapMinCandidates
+      );
+      survivors = capped.reordered;
+      if (capped.demoted > 0) {
+        log.info(
+          `v5 diversity guard: hard channel cap demoted ${capped.demoted}/${survivors.length}`
+        );
+      }
+    }
+    if (diversity.crossChannelDedupEnabled) {
+      const deduped = crossChannelTitleDedup(survivors, diversity.crossChannelDedupSim);
+      survivors = deduped.reordered;
+      if (deduped.demoted > 0) {
+        log.info(
+          `v5 diversity guard: cross-channel title dedup demoted ${deduped.demoted}/${survivors.length}`
+        );
+      }
     }
   }
 

--- a/tests/unit/skills/video-discover/diversity-guard.test.ts
+++ b/tests/unit/skills/video-discover/diversity-guard.test.ts
@@ -14,6 +14,8 @@ import {
   hasEpisodeToken,
   seriesMarker,
   softChannelCap,
+  hardChannelCap,
+  crossChannelTitleDedup,
   strippedTitleSimilarity,
   type DiversityCandidate,
 } from '@/skills/plugins/video-discover/diversity-guard';
@@ -166,12 +168,113 @@ describe('softChannelCap', () => {
   });
 });
 
+describe('hardChannelCap (CP511+1 — global, demote-only)', () => {
+  const mk = (ch: string, n: number, cell: number | null = null): DiversityCandidate[] =>
+    Array.from({ length: n }, (_, i) => ({
+      title: `${ch} video ${i + 1}`,
+      channelId: ch,
+      channelTitle: ch,
+      cellIndex: cell,
+    }));
+
+  it('REGRESSION-MEASURED — one channel at soft-cap=2/cell across 5 cells (10 total, 0 per-cell violations) still gets globally capped', () => {
+    // Mirrors the measured prod pattern (mandala 7d5d759e add_cards, 2026-07-06):
+    // softChannelCap alone never fires here (exactly 2/cell everywhere).
+    const oneChannelAcross5Cells = [0, 1, 2, 3, 4].flatMap((cell) => mk('MALT', 2, cell));
+    const other = Array.from({ length: 39 }, (_, i) => mk(`OTHER-${i}`, 1)[0]!); // 39 distinct single-appearance channels
+    const list = [...oneChannelAcross5Cells, ...other];
+    expect(list).toHaveLength(49);
+
+    const afterSoft = softChannelCap(list, 2);
+    // soft cap never demotes anything — every cell bucket already at exactly 2.
+    expect(afterSoft).toEqual(list);
+
+    const { reordered, demoted } = hardChannelCap(afterSoft, 3, 30);
+    expect(reordered).toHaveLength(49); // count preserved — demote only
+    expect(demoted).toBe(7); // MALT: 10 total, cap=3 → 7 demoted
+    const primary = reordered.slice(0, reordered.length - demoted);
+    expect(primary.filter((c) => c.channelId === 'MALT')).toHaveLength(3);
+  });
+
+  it('below minCandidates — skip entirely (thin-supply protection)', () => {
+    const list = mk('A', 10); // one channel, 10 cards, cap would fire without the gate
+    const { reordered, demoted } = hardChannelCap(list, 3, 30); // 10 < 30 → no-op
+    expect(reordered).toEqual(list);
+    expect(demoted).toBe(0);
+  });
+
+  it('cap<=0 — no-op (flag-off byte-identical)', () => {
+    const list = mk('A', 40);
+    const { reordered, demoted } = hardChannelCap(list, 0, 30);
+    expect(reordered).toEqual(list);
+    expect(demoted).toBe(0);
+  });
+
+  it('preserves relative order within primary + within demoted tail', () => {
+    const list = mk('A', 5);
+    const { reordered, demoted } = hardChannelCap(list, 2, 3);
+    expect(reordered.map((c) => c.title)).toEqual([
+      'A video 1',
+      'A video 2',
+      'A video 3',
+      'A video 4',
+      'A video 5',
+    ]);
+    expect(demoted).toBe(3);
+  });
+});
+
+describe('crossChannelTitleDedup (CP511+1 — cross-channel, demote-only)', () => {
+  const cand = (title: string, channelId: string): DiversityCandidate => ({
+    title,
+    channelId,
+    channelTitle: channelId,
+  });
+
+  it('groups near-identical titles ACROSS different channels (no episode token needed)', () => {
+    const a = cand('도커 완전 정복 강의 — 초보자를 위한 컨테이너 입문', 'UC-1');
+    const b = cand('도커 완전 정복 강의 초보자를 위한 컨테이너 입문 총정리', 'UC-2');
+    const c = cand('전혀 다른 주제의 파이썬 데이터분석 강의', 'UC-3');
+    const { reordered, demoted } = crossChannelTitleDedup([a, b, c], 0.6);
+    expect(reordered).toHaveLength(3); // count preserved — demote only
+    expect(demoted).toBe(1);
+    expect(reordered[0]).toBe(a); // representative = first occurrence
+    expect(reordered[reordered.length - 1]).toBe(b); // duplicate demoted to tail
+  });
+
+  it('MEASURED LIMITATION (real prod titles, 2026-07-06) — SEO-padded 100문장 titles score far below the 0.6-0.7 conservative range', () => {
+    // 3 known near-duplicate titles from one prod channel (mandala 7d5d759e,
+    // trace 42da98a6) — measured token-Jaccard 0.12-0.17, i.e. this transform
+    // as specified does NOT catch this specific spam pattern on real data.
+    const titles = [
+      '기초영어 100문장｜왕초보도 말문 트이는 생활영어 회화 매일 듣기 반복학습',
+      '왕초보 영어회화 100문장 듣기 루틴｜매일 1시간만 틀어두면 자동으로 익혀집니다 (한글발음 포함)',
+      '왕초보 기초 영어회화 100문장 | 생활영어 첫걸음 이것부터 외우세요(흘려듣기)',
+    ].map((t, i) => cand(t, `UC-malt-${i}`));
+    const { reordered, demoted } = crossChannelTitleDedup(titles, 0.65);
+    expect(reordered).toHaveLength(3);
+    expect(demoted).toBe(0); // documents the measured gap — not a false claim of success
+  });
+
+  it('missing title text never groups (no fabrication) — count preserved', () => {
+    const a: DiversityCandidate = { title: '', channelId: 'UC-1' };
+    const b: DiversityCandidate = { title: '', channelId: 'UC-2' };
+    const { reordered, demoted } = crossChannelTitleDedup([a, b], 0.1);
+    expect(reordered).toHaveLength(2);
+    expect(demoted).toBe(0);
+  });
+});
+
 describe('config + observability', () => {
   it('flag default OFF (unset = 기존 동작, hard rule) + provisional knobs', () => {
     const cfg = loadDiversityGuardConfig({} as NodeJS.ProcessEnv);
     expect(cfg.enabled).toBe(false);
     expect(cfg.seriesSim).toBe(0.8);
     expect(cfg.channelSoftCap).toBe(2);
+    expect(cfg.channelHardCap).toBe(0);
+    expect(cfg.channelHardCapMinCandidates).toBe(30);
+    expect(cfg.crossChannelDedupEnabled).toBe(false);
+    expect(cfg.crossChannelDedupSim).toBe(0.65);
   });
 
   it('env overrides parse', () => {
@@ -179,8 +282,20 @@ describe('config + observability', () => {
       V5_DIVERSITY_GUARD: 'true',
       V5_SERIES_DEDUP_SIM: '0.7',
       V5_CHANNEL_SOFT_CAP: '3',
+      V5_CHANNEL_HARD_CAP: '3',
+      V5_CHANNEL_HARD_CAP_MIN_CANDIDATES: '25',
+      V5_CROSS_CHANNEL_TITLE_DEDUP: 'true',
+      V5_CROSS_CHANNEL_DEDUP_SIM: '0.6',
     } as unknown as NodeJS.ProcessEnv);
-    expect(cfg).toEqual({ enabled: true, seriesSim: 0.7, channelSoftCap: 3 });
+    expect(cfg).toEqual({
+      enabled: true,
+      seriesSim: 0.7,
+      channelSoftCap: 3,
+      channelHardCap: 3,
+      channelHardCapMinCandidates: 25,
+      crossChannelDedupEnabled: true,
+      crossChannelDedupSim: 0.6,
+    });
   });
 
   it('channelDistribution computes total/distinct/top3 share', () => {


### PR DESCRIPTION
## Root cause
Per-cell soft-cap (2/cell) can't see a channel spread 2 across N cells. Real 영어 add_cards trace (49 cards): 말트영어 = **10/49**, exactly 2/cell across 5 cells → zero per-cell violations, guard never fires.

## Fix (demote-only, count-neutral)
- `hardChannelCap(3)` global cross-cell; 4th+ from one channel demoted (not dropped). Fires only when candidates ≥ 30 (thin cells keep soft-demote → protects 50-70 floor).
- `crossChannelTitleDedup` built but **flag OFF** (whole-title Jaccard 0.12-0.17 on SEO "100문장" titles; coverage 8/49 — needs n-gram/embedding, follow-up).

## Measured (real 49-set, offline): 말트영어 10→3 primary +7 demoted; top3 34.7%→22%; **49→49** (nothing dropped). 49<50 floor = pre-existing supply gap (separate track).

## Flags: `V5_CHANNEL_HARD_CAP=3` (canary) · `_MIN_CANDIDATES=30` · title-dedup OFF. Rollback = cap→0.
Verify: tsc clean; diversity-guard 25/25, v5-executor 10/10, suite 116/116. Done = James re-runs 영어 add-cards → 말트영어 top ≤3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)