### PR TITLE
feat(search): domain-fit SERVE-edge enforce — deboost re-rank + video_domain_fit_cache (flag OFF)

### DIFF
--- a/prisma/migrations/domain-fit-serve-cache/001_create_video_domain_fit_cache.sql
+++ b/prisma/migrations/domain-fit-serve-cache/001_create_video_domain_fit_cache.sql
@@ -1,0 +1,39 @@
+-- video_domain_fit_cache — R24 SERVE-edge domain-fit ENFORCE cache
+-- (search redesign, blast-0). video-intrinsic per-mandala cache, same PK
+-- shape as video_mandala_relevance but a DELIBERATELY SEPARATE table — the
+-- ENFORCE addition never shares a write path with the existing relevance
+-- cache, so it carries zero risk to that table's read/write semantics.
+--
+-- Avoids a repeat Ollama T3 classification call for the same
+-- (video_id, mandala_id) pair across pool-serve-fill's pool + live stages
+-- and across separate fill dispatches for the same mandala — domain-fit
+-- classification is goal-level (R14-1), i.e. mandala-wide, not per-cell, so
+-- one score serves every cell of the mandala.
+--
+-- Flag-gated by DOMAIN_FIT_SERVE_ENFORCE (default false) — this table stays
+-- completely inert (never read or written) until the flag is flipped on. See
+-- src/modules/domain-fit-shadow/serve-enforce.ts + serve-cache.ts.
+--
+-- Per CLAUDE.md "prisma db push Silent Fail 대응": this raw DDL ships
+-- alongside the Prisma schema model so the table exists even if
+-- `prisma db push` silently no-ops against the Supabase-managed schema.
+
+CREATE TABLE IF NOT EXISTS public.video_domain_fit_cache (
+  video_id         varchar(11) NOT NULL,
+  mandala_id       uuid NOT NULL REFERENCES public.user_mandalas(id) ON DELETE CASCADE,
+  -- '적합' | '비적합'. NULL is never persisted (classifier-unavailable
+  -- results fail-open with multiplier=1 and are NOT cached — see
+  -- serve-enforce.ts — so a transient Mac Mini outage self-heals on the
+  -- next call instead of being pinned as a cached failure).
+  fit              varchar(10),
+  lexical_conflict boolean NOT NULL DEFAULT false,
+  -- Composite deboost multiplier applied at serve time (1.0 = no-op,
+  -- DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER on a 비적합 verdict).
+  multiplier       double precision NOT NULL,
+  model            varchar(64) NOT NULL,
+  scored_at        timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (video_id, mandala_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_video_domain_fit_cache_mandala
+  ON public.video_domain_fit_cache (mandala_id);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -454,6 +454,7 @@ model user_mandalas {
   levels           user_mandala_levels[]
   videoRelevance   video_mandala_relevance[]
   segmentRelevance video_mandala_segment_relevance[]
+  domainFitCache   video_domain_fit_cache[]
   videoStates      UserVideoState[]
   localCards       user_local_cards[]
   subscriptions    mandala_subscriptions[]
@@ -2434,6 +2435,38 @@ model video_mandala_relevance {
 
   @@id([video_id, mandala_id])
   @@index([mandala_id], map: "idx_vmr_mandala")
+  @@schema("public")
+}
+
+/// R24 — SERVE-edge domain-fit ENFORCE cache (search redesign, blast-0).
+/// video-intrinsic per-mandala cache, SAME PK shape as video_mandala_relevance
+/// (deliberately a SEPARATE table — never shares a write path with the
+/// relevance cache above, so this ENFORCE addition carries zero risk to the
+/// existing relevance-gate cache read/write semantics). Avoids a repeat
+/// Ollama T3 classification call for the same (video, mandala) pair across
+/// pool-serve-fill's pool + live stages and across separate fill dispatches
+/// for the same mandala — domain-fit classification is goal-level (R14-1),
+/// i.e. mandala-wide, not per-cell, so one score serves every cell.
+/// Flag-gated by DOMAIN_FIT_SERVE_ENFORCE (default false) — this table is
+/// inert (never read or written) until the flag is on. See
+/// src/modules/domain-fit-shadow/serve-enforce.ts + serve-cache.ts.
+model video_domain_fit_cache {
+  video_id         String        @db.VarChar(11)
+  mandala_id       String        @db.Uuid
+  /// '적합' | '비적합' — NULL is never persisted (classifier-unavailable
+  /// results fail-open with multiplier=1 and are NOT cached, so a transient
+  /// Mac Mini outage self-heals on the next call instead of being pinned).
+  fit              String?       @db.VarChar(10)
+  lexical_conflict Boolean       @default(false)
+  /// Composite deboost multiplier applied at serve time (1.0 = no-op,
+  /// DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER on a 비적합 verdict).
+  multiplier       Float
+  model            String        @db.VarChar(64)
+  scored_at        DateTime      @default(now()) @db.Timestamptz(6)
+  mandala          user_mandalas @relation(fields: [mandala_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@id([video_id, mandala_id])
+  @@index([mandala_id], map: "idx_video_domain_fit_cache_mandala")
   @@schema("public")
 }
 

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -170,6 +170,11 @@ APPLY_FILES=(
   # change); inert until /api/v1/search is called.
   "prisma/migrations/global-search/001_pg_trgm_indexes.sql"
   "prisma/migrations/channel-blocklist/001_create_channel_blocklist.sql"
+  # Search redesign R24 — video_domain_fit_cache (per-mandala domain-fit
+  # verdict cache for SERVE-edge enforce). CREATE TABLE/INDEX IF NOT EXISTS —
+  # fully idempotent. Inert (never read or written) until
+  # DOMAIN_FIT_SERVE_ENFORCE flips on.
+  "prisma/migrations/domain-fit-serve-cache/001_create_video_domain_fit_cache.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "

--- a/src/config/domain-fit-shadow.ts
+++ b/src/config/domain-fit-shadow.ts
@@ -100,6 +100,19 @@ export const domainFitShadowEnvSchema = z.object({
    * Default false = zero extra Ollama calls at this call site.
    */
   DOMAIN_FIT_SERVE_SHADOW: boolFlag.default(false as unknown as string),
+  /**
+   * R24 — pool-serve SERVE-edge ENFORCE (search redesign, blast-0; deploy /
+   * flag-flip is James-gated, NOT part of this module's scope). SEPARATE
+   * from `DOMAIN_FIT_SERVE_SHADOW` (would-serve LOGGING only, never
+   * reorders): this flag lets `src/modules/queue/handlers/pool-serve-fill.ts`
+   * AWAIT the composite T3+lexical DEBOOST score
+   * (`src/modules/domain-fit-shadow/serve-enforce.ts`) and REORDER (never
+   * drop) the pre-gate candidate list so low domain-fit candidates are
+   * demoted to the tail before the relevance gate's per-cell budget cutoff.
+   * Default false = the existing serve-shadow call is the only thing that
+   * runs (R23 invariant unchanged, zero extra Ollama calls, zero reorder).
+   */
+  DOMAIN_FIT_SERVE_ENFORCE: boolFlag.default(false as unknown as string),
 });
 
 export interface DomainFitShadowConfig {
@@ -116,6 +129,8 @@ export interface DomainFitShadowConfig {
   writeEnforceEnabled: boolean;
   /** R23 — independent flag: pool-serve SERVE-edge would-serve shadow log. */
   serveShadowEnabled: boolean;
+  /** R24 — independent flag: pool-serve SERVE-edge ENFORCE (real reorder). */
+  serveEnforceEnabled: boolean;
 }
 
 const DEFAULTS: DomainFitShadowConfig = {
@@ -129,6 +144,7 @@ const DEFAULTS: DomainFitShadowConfig = {
   writeShadowEnabled: false,
   writeEnforceEnabled: false,
   serveShadowEnabled: false,
+  serveEnforceEnabled: false,
 };
 
 export function loadDomainFitShadowConfig(
@@ -145,6 +161,7 @@ export function loadDomainFitShadowConfig(
     DOMAIN_FIT_WRITE_SHADOW: env['DOMAIN_FIT_WRITE_SHADOW'],
     DOMAIN_FIT_WRITE_ENFORCE: env['DOMAIN_FIT_WRITE_ENFORCE'],
     DOMAIN_FIT_SERVE_SHADOW: env['DOMAIN_FIT_SERVE_SHADOW'],
+    DOMAIN_FIT_SERVE_ENFORCE: env['DOMAIN_FIT_SERVE_ENFORCE'],
   });
   if (!parsed.success) return { ...DEFAULTS };
   return {
@@ -158,5 +175,6 @@ export function loadDomainFitShadowConfig(
     writeShadowEnabled: parsed.data.DOMAIN_FIT_WRITE_SHADOW,
     writeEnforceEnabled: parsed.data.DOMAIN_FIT_WRITE_ENFORCE,
     serveShadowEnabled: parsed.data.DOMAIN_FIT_SERVE_SHADOW,
+    serveEnforceEnabled: parsed.data.DOMAIN_FIT_SERVE_ENFORCE,
   };
 }

--- a/src/modules/domain-fit-shadow/serve-cache.ts
+++ b/src/modules/domain-fit-shadow/serve-cache.ts
@@ -1,0 +1,79 @@
+/**
+ * Prisma-backed adapter for `DomainFitServeCache` (see `./serve-enforce.ts`).
+ *
+ * Table `video_domain_fit_cache` — video-intrinsic per-mandala cache, a
+ * DELIBERATELY SEPARATE table from `video_mandala_relevance` (never shares a
+ * write path with the existing relevance-gate cache, so this addition
+ * carries zero risk to that table's read/write semantics — see the schema
+ * comment in prisma/schema.prisma and the migration SQL under
+ * prisma/migrations/domain-fit-serve-cache/).
+ *
+ * Thin I/O layer only — no business logic here (that lives in
+ * `serve-enforce.ts`'s pure `applyDomainFitServeEnforce`), kept separate so
+ * the reorder logic is unit-testable with a simple in-memory fake cache
+ * (`createNoopDomainFitServeCache` / a Map-based test double) without a real
+ * Prisma client.
+ */
+
+import type { PrismaClient } from '@prisma/client';
+import type { DomainFitLabel } from './client';
+import type { DomainFitServeCache, DomainFitServeCacheEntry } from './serve-enforce';
+
+/** Minimal Prisma surface this adapter needs (matches the raw-query style
+ *  already used elsewhere in pool-serve-fill.ts for video_mandala_relevance). */
+export type DomainFitServeCachePrisma = Pick<PrismaClient, '$queryRaw' | '$executeRaw'>;
+
+interface CacheRow {
+  fit: string | null;
+  lexical_conflict: boolean;
+  multiplier: number;
+  model: string;
+  scored_at: Date;
+}
+
+function isFitLabel(v: string | null): v is DomainFitLabel {
+  return v === '적합' || v === '비적합';
+}
+
+/**
+ * `video_domain_fit_cache`-backed cache, scoped to one mandala for the
+ * lifetime of a single pool-serve-fill job (mandalaId is fixed per job —
+ * see `handlePoolServeFill`'s `p.mandalaId`).
+ */
+export function createPrismaDomainFitServeCache(
+  prisma: DomainFitServeCachePrisma,
+  mandalaId: string
+): DomainFitServeCache {
+  return {
+    async get(youtubeVideoId: string): Promise<DomainFitServeCacheEntry | null> {
+      const rows = await prisma.$queryRaw<CacheRow[]>`
+        SELECT fit, lexical_conflict, multiplier, model, scored_at
+        FROM video_domain_fit_cache
+        WHERE video_id = ${youtubeVideoId} AND mandala_id = ${mandalaId}::uuid`;
+      const row = rows[0];
+      if (!row || !isFitLabel(row.fit)) return null;
+      return {
+        fit: row.fit,
+        lexicalConflict: row.lexical_conflict,
+        multiplier: row.multiplier,
+        model: row.model,
+        scoredAt: row.scored_at.toISOString(),
+      };
+    },
+    async set(youtubeVideoId: string, entry: DomainFitServeCacheEntry): Promise<void> {
+      await prisma.$executeRaw`
+        INSERT INTO video_domain_fit_cache
+          (video_id, mandala_id, fit, lexical_conflict, multiplier, model, scored_at)
+        VALUES (
+          ${youtubeVideoId}, ${mandalaId}::uuid, ${entry.fit}, ${entry.lexicalConflict},
+          ${entry.multiplier}, ${entry.model}, ${entry.scoredAt}::timestamptz
+        )
+        ON CONFLICT (video_id, mandala_id) DO UPDATE SET
+          fit = EXCLUDED.fit,
+          lexical_conflict = EXCLUDED.lexical_conflict,
+          multiplier = EXCLUDED.multiplier,
+          model = EXCLUDED.model,
+          scored_at = EXCLUDED.scored_at`;
+    },
+  };
+}

--- a/src/modules/domain-fit-shadow/serve-enforce.ts
+++ b/src/modules/domain-fit-shadow/serve-enforce.ts
@@ -1,0 +1,284 @@
+/**
+ * Domain-fit SERVE-edge ENFORCE (R24 — search redesign, blast-0 code-only;
+ * deploy/flag-flip is James-gated, NOT part of this module's scope).
+ *
+ * The enforce counterpart of `shadow.ts`'s R23 pool-serve SERVE-edge shadow
+ * (`stage: 'pool_serve'`, would-serve LOGGING only). This module actually
+ * REORDERS the pre-gate candidate list: the frozen T3 binary classifier
+ * (`./client.ts`) combined with the R22 lexical qualifier-conflict signal
+ * (`./lexical-qualifier.ts`) into one composite DEBOOST multiplier, applied
+ * as a stable demote-only sort — same "reorder, never drop" contract as the
+ * diversity-guard transforms (`src/skills/plugins/video-discover/diversity-guard.ts`
+ * hardChannelCap / softChannelCap / crossChannelTitleDedup): domain-fit is
+ * simply another reorder layer at the SAME pipeline position (after
+ * hygiene/diversity/shorts-drop, BEFORE the relevance gate decides the
+ * per-cell budget), never a hard cut — the 50~70 card-count floor can never
+ * be put at risk by this transform alone (output length === input length,
+ * always, regardless of flag state or classifier outcome).
+ *
+ * Placement in the pipeline matters: reordering BEFORE the relevance gate
+ * (`gate()` in pool-serve-fill.ts) means a demoted, low domain-fit candidate
+ * can lose a limited per-cell budget SLOT to a higher domain-fit candidate
+ * further down the recruit-rank order — a real reorder-driven outcome
+ * change, not just cosmetic in-cell display order (contrast: reordering
+ * AFTER the gate's budget cutoff has already run could only reorder display
+ * position among an already-fixed selected set).
+ *
+ * Latency posture (see module docstring in pool-serve-fill.ts — this ALWAYS
+ * runs inside the already-ASYNC pg-boss job, never the synchronous
+ * wizard/add-cards HTTP read path):
+ *   1. video-intrinsic CACHE (`./serve-cache.ts`, table `video_domain_fit_cache`,
+ *      keyed by (youtube_video_id, mandala_id) — same PK shape as the
+ *      existing `video_mandala_relevance` cache) avoids a repeat Ollama call
+ *      for the same video within one mandala (R14-1: goal-level scoring is
+ *      mandala-wide, so one score serves every cell + every re-dispatch).
+ *   2. bounded to `cfg.maxCandidates` (shared cap with the shadow sibling,
+ *      default 40) — realistic per-cell recruit sets (~12-22, see
+ *      pool-serve config V5_POOL_SERVE_CANDIDATES_LIMIT/LIVE_FALLBACK_MAX_RESULTS)
+ *      stay well under this; anything beyond the cap is appended UNSCORED at
+ *      the tail (never dropped).
+ *   3. bounded concurrency burst (`cfg.concurrency`, default 4) — same
+ *      burst-width discipline as the shadow/write-gate siblings, avoids
+ *      hammering the single Mac Mini Ollama instance
+ *      (feedback_no_repeated_hammering.md).
+ *   4. per-call timeout (`cfg.timeoutMs`, default 5000ms, AbortController —
+ *      see client.ts) + FAIL-OPEN: a classifier timeout/HTTP-error/unparsable
+ *      response never demotes (multiplier=1, i.e. no reorder for that
+ *      candidate) and is NEVER cached (a transient Mac Mini outage
+ *      self-heals on the next call instead of pinning a false failure).
+ *   Honest worst-case wall time (all calls miss cache AND time out):
+ *   ceil(maxCandidates / concurrency) * timeoutMs = ceil(40/4)*5000ms = 50s;
+ *   at realistic recruit-set sizes ceil(22/4)*5000ms ≈ 30s. This runs inside
+ *   the fire-and-forget pool-serve-fill job (user sees the W1b "filling"
+ *   state meanwhile) — same property the R23 shadow sibling already has,
+ *   not a NEW risk introduced by ENFORCE specifically.
+ *
+ * Compliance: inference is local-only (Mac Mini via Tailscale). No Anthropic /
+ * OpenRouter / YouTube API calls are made by this module.
+ */
+
+import { logger } from '@/utils/logger';
+import { recordTrace, withTraceContext, getTraceContext } from '@/modules/discover-tracing';
+import type { DomainFitShadowConfig } from '@/config/domain-fit-shadow';
+import { classifyDomainFit, type DomainFitLabel } from './client';
+import { detectQualifierConflicts } from './lexical-qualifier';
+
+const log = logger.child({ module: 'domain-fit-shadow/serve-enforce' });
+
+/**
+ * Deboost multiplier applied on a 비적합 (not-fit) verdict — NOT a hard cut
+ * (demote-only, never 0/drop). Named constant (no magic number at call
+ * sites), same spirit as `DEFAULT_QUALIFIER_CONFLICT_MULTIPLIER` in
+ * lexical-qualifier.ts and `DOMAIN_FIT_WRITE_ENFORCE_THRESHOLD` in
+ * write-gate.ts. Range per the supervisor spec: 0.2-0.3; 0.25 chosen as the
+ * midpoint — a candidate stays serveable (never zeroed) but sinks below any
+ * '적합' peer regardless of recruit rank.
+ */
+export const DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER = 0.25;
+
+/** Minimal candidate shape this module needs — matches pool-serve-fill's
+ *  `GateCandidate` (youtubeVideoId/title) so no field-mapping step is needed
+ *  at the call site. */
+export interface DomainFitServeCandidate {
+  youtubeVideoId: string;
+  title: string;
+}
+
+export interface DomainFitServeCacheEntry {
+  fit: DomainFitLabel;
+  lexicalConflict: boolean;
+  multiplier: number;
+  model: string;
+  scoredAt: string;
+}
+
+/** Injectable cache — decouples the pure reorder logic below from any DB
+ *  specifics (see `./serve-cache.ts` for the real `video_domain_fit_cache`
+ *  backed implementation; tests use a simple in-memory fake). */
+export interface DomainFitServeCache {
+  get(youtubeVideoId: string): Promise<DomainFitServeCacheEntry | null>;
+  set(youtubeVideoId: string, entry: DomainFitServeCacheEntry): Promise<void>;
+}
+
+/** Every call is a miss; `set` is a no-op — used when no persistent cache is
+ *  wired (e.g. a caller that only wants the reorder, not the DB round-trip). */
+export function createNoopDomainFitServeCache(): DomainFitServeCache {
+  return {
+    get: async () => null,
+    set: async () => {},
+  };
+}
+
+export interface ApplyDomainFitServeEnforceResult<T> {
+  /** Same length as input, ALWAYS — DEMOTE only, never drop (card-floor invariant). */
+  reordered: T[];
+  /** Count of candidates whose multiplier < 1 (i.e. actually demoted). */
+  demoted: number;
+  /** Count of fresh (non-cached) classifier calls made. */
+  scored: number;
+  cacheHits: number;
+  /** Classifier timeout/error/unparsable — fail-open, never demoted, never cached. */
+  classifierFailed: number;
+}
+
+/**
+ * Pure reorder — classify + lexical-deboost combined into one composite
+ * multiplier per candidate (cache-first), then a STABLE demote-only sort
+ * (multiplier descending; ties preserve original recruit-rank order —
+ * `Array.prototype.sort` is stable since ES2019 / all supported Node
+ * runtimes). No trace/logging side effect; see `runDomainFitServeEnforce`
+ * for the logged wrapper used at the actual call site.
+ *
+ * `cfg.serveEnforceEnabled` gates everything: off (default) is a synchronous
+ * zero-cost no-op — same array reference returned, zero cache/classifier
+ * calls — so every existing pool-serve-fill call site is byte-identical when
+ * the flag is unset.
+ */
+export async function applyDomainFitServeEnforce<T extends DomainFitServeCandidate>(
+  candidates: T[],
+  centerGoal: string,
+  cfg: DomainFitShadowConfig,
+  cache: DomainFitServeCache
+): Promise<ApplyDomainFitServeEnforceResult<T>> {
+  if (!cfg.serveEnforceEnabled || candidates.length === 0) {
+    return { reordered: candidates, demoted: 0, scored: 0, cacheHits: 0, classifierFailed: 0 };
+  }
+
+  // Bounded cap — anything beyond stays unscored, appended untouched at the
+  // tail (never dropped; just not reordered).
+  const capped = candidates.slice(0, cfg.maxCandidates);
+  const overflow = candidates.slice(cfg.maxCandidates);
+
+  let scored = 0;
+  let cacheHits = 0;
+  let classifierFailed = 0;
+  const withMultiplier: { c: T; multiplier: number }[] = [];
+
+  for (let i = 0; i < capped.length; i += cfg.concurrency) {
+    const burst = capped.slice(i, i + cfg.concurrency);
+    const results = await Promise.all(
+      burst.map(async (c): Promise<{ c: T; multiplier: number }> => {
+        const cached = await cache.get(c.youtubeVideoId).catch((err: unknown) => {
+          log.debug(
+            `domain-fit serve-enforce cache read failed (treated as miss): ${err instanceof Error ? err.message : String(err)}`
+          );
+          return null;
+        });
+        if (cached) {
+          cacheHits += 1;
+          return { c, multiplier: cached.multiplier };
+        }
+
+        const r = await classifyDomainFit(centerGoal, c.title, cfg);
+        if (!r.ok || r.fit === null) {
+          // Fail-open — a classifier outage must never demote a candidate,
+          // and is deliberately NOT cached (self-heals on the next call).
+          classifierFailed += 1;
+          return { c, multiplier: 1 };
+        }
+        scored += 1;
+
+        const { hasConflict, multiplier: lexicalMultiplier } = detectQualifierConflicts(
+          centerGoal,
+          c.title
+        );
+        const multiplier =
+          r.fit === '비적합'
+            ? DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER * (hasConflict ? lexicalMultiplier : 1)
+            : hasConflict
+              ? lexicalMultiplier
+              : 1;
+
+        await cache
+          .set(c.youtubeVideoId, {
+            fit: r.fit,
+            lexicalConflict: hasConflict,
+            multiplier,
+            model: cfg.model,
+            scoredAt: new Date().toISOString(),
+          })
+          .catch((err: unknown) => {
+            // Cache-write failure never blocks the reorder this request is doing.
+            log.debug(
+              `domain-fit serve-enforce cache write failed (swallowed): ${err instanceof Error ? err.message : String(err)}`
+            );
+          });
+        return { c, multiplier };
+      })
+    );
+    withMultiplier.push(...results);
+  }
+
+  const indexed = withMultiplier.map((r, idx) => ({ ...r, idx }));
+  indexed.sort((a, b) => b.multiplier - a.multiplier || a.idx - b.idx);
+  const demoted = indexed.filter((r) => r.multiplier < 1).length;
+  const reordered: T[] = [...indexed.map((r) => r.c), ...overflow];
+
+  return { reordered, demoted, scored, cacheHits, classifierFailed };
+}
+
+export interface DomainFitServeEnforceInput<T extends DomainFitServeCandidate> {
+  /** 'pool' | 'live' — the two pool-serve-fill call sites (both use the same
+   *  `gate()` budget-cutoff downstream). */
+  stage: 'pool' | 'live';
+  centerGoal: string;
+  cellIndex: number;
+  mandalaId?: string | null;
+  userId?: string | null;
+  candidates: T[];
+}
+
+/**
+ * Evaluate + log (recordTrace) the ENFORCE reorder — step
+ * `domain_fit_serve_enforce.<stage>`, for supervisor L2 sampling. Callers
+ * MUST await this (unlike shadow.ts's fire-and-forget `scheduleDomainFitShadow`):
+ * the reordered list feeds directly into the relevance gate's budget
+ * decision. A trace-logging failure is swallowed — it can never block or
+ * alter the returned (possibly reordered) candidate list.
+ */
+export async function runDomainFitServeEnforce<T extends DomainFitServeCandidate>(
+  input: DomainFitServeEnforceInput<T>,
+  cfg: DomainFitShadowConfig,
+  cache: DomainFitServeCache
+): Promise<T[]> {
+  if (!cfg.serveEnforceEnabled || input.candidates.length === 0) return input.candidates;
+
+  const t0 = Date.now();
+  const result = await applyDomainFitServeEnforce(input.candidates, input.centerGoal, cfg, cache);
+  try {
+    const writeTrace = () =>
+      recordTrace({
+        step: `domain_fit_serve_enforce.${input.stage}`,
+        status: 'ok',
+        request: {
+          model: cfg.model,
+          cell_index: input.cellIndex,
+          candidates_total: input.candidates.length,
+          max_candidates: cfg.maxCandidates,
+        },
+        response: {
+          demoted: result.demoted,
+          scored: result.scored,
+          cache_hits: result.cacheHits,
+          classifier_failed: result.classifierFailed,
+        },
+        latencyMs: Date.now() - t0,
+      });
+
+    if (getTraceContext()) {
+      writeTrace();
+    } else {
+      await withTraceContext(
+        { mandalaId: input.mandalaId ?? null, userId: input.userId ?? null },
+        async () => writeTrace()
+      );
+    }
+  } catch (err) {
+    // Never let a trace-logging failure surface anywhere near the reordered
+    // list this is observing.
+    log.debug(
+      `domain-fit serve-enforce trace failed (swallowed): ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  return result.reordered;
+}

--- a/src/modules/queue/handlers/pool-serve-fill.ts
+++ b/src/modules/queue/handlers/pool-serve-fill.ts
@@ -56,6 +56,8 @@ import { config } from '@/config/index';
 import { writeSearchTrace, type SearchTraceCandidateInput } from '@/modules/search-trace';
 import { loadDomainFitShadowConfig } from '@/config/domain-fit-shadow';
 import { scheduleDomainFitShadow } from '@/modules/domain-fit-shadow/shadow';
+import { runDomainFitServeEnforce } from '@/modules/domain-fit-shadow/serve-enforce';
+import { createPrismaDomainFitServeCache } from '@/modules/domain-fit-shadow/serve-cache';
 import { getJobQueue } from '../manager';
 import { JOB_NAMES, POOL_SERVE_FILL_RETRY_OPTIONS, type PoolServeFillPayload } from '../types';
 import { richSummaryWorkOptions } from './rich-summary-work-options';
@@ -140,6 +142,11 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
   const poolSourceTier: string | null = poolSources.length === 1 ? (poolSources[0] ?? null) : null;
   const domainFitCfg = loadDomainFitShadowConfig();
   const prisma = getPrismaClient();
+  // R24 — ENFORCE cache scoped to this mandala (video-intrinsic per-mandala,
+  // table video_domain_fit_cache). Construction itself is zero-I/O; get/set
+  // only fire when DOMAIN_FIT_SERVE_ENFORCE is actually on (see
+  // runDomainFitServeEnforce's flag-gated short-circuit).
+  const domainFitServeCache = createPrismaDomainFitServeCache(prisma, p.mandalaId);
   const result: PoolServeCellResult = {
     recruited: 0,
     scored: 0,
@@ -349,25 +356,43 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
     }
     result.recruited = recruits.length;
     const passed: PassedCandidate[] = [];
+    const poolPreGate = await dropShorts(
+      applyDiversity(
+        hygienic(
+          recruits.map((c) => ({
+            youtubeVideoId: c.videoId,
+            title: c.title,
+            description: c.description,
+            channelTitle: c.channelName,
+            thumbnail: c.thumbnail,
+            publishedAt: c.publishedAt,
+            durationSec: c.durationSec,
+            tsRank: c.rec_score,
+            sourceKind: 'pool' as const,
+            sourceTier: poolSourceTier,
+          }))
+        ),
+        []
+      )
+    );
+    // R24 — SERVE-edge domain-fit ENFORCE (real reorder, demote-only, never
+    // drop — see serve-enforce.ts). Runs BEFORE the relevance gate's per-cell
+    // budget cutoff so a low domain-fit candidate can genuinely lose a
+    // limited slot to a better-fit candidate further down the recruit-rank
+    // order. Gated by `DOMAIN_FIT_SERVE_ENFORCE` (default false ⇒ zero-cost
+    // no-op, same array reference returned — byte-identical to pre-R24).
     await gate(
-      await dropShorts(
-        applyDiversity(
-          hygienic(
-            recruits.map((c) => ({
-              youtubeVideoId: c.videoId,
-              title: c.title,
-              description: c.description,
-              channelTitle: c.channelName,
-              thumbnail: c.thumbnail,
-              publishedAt: c.publishedAt,
-              durationSec: c.durationSec,
-              tsRank: c.rec_score,
-              sourceKind: 'pool' as const,
-              sourceTier: poolSourceTier,
-            }))
-          ),
-          []
-        )
+      await runDomainFitServeEnforce(
+        {
+          stage: 'pool',
+          centerGoal: p.centerGoal,
+          cellIndex: p.cellIndex,
+          mandalaId: p.mandalaId,
+          userId: p.userId,
+          candidates: poolPreGate,
+        },
+        domainFitCfg,
+        domainFitServeCache
       ),
       passed
     );
@@ -422,7 +447,24 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
           }
         }
         const before = passed.length;
-        await gate(await dropShorts(applyDiversity(liveCands, passed)), passed);
+        const livePreGate = await dropShorts(applyDiversity(liveCands, passed));
+        // R24 — same ENFORCE reorder as the pool stage above (demote-only,
+        // flag-gated no-op by default).
+        await gate(
+          await runDomainFitServeEnforce(
+            {
+              stage: 'live',
+              centerGoal: p.centerGoal,
+              cellIndex: p.cellIndex,
+              mandalaId: p.mandalaId,
+              userId: p.userId,
+              candidates: livePreGate,
+            },
+            domainFitCfg,
+            domainFitServeCache
+          ),
+          passed
+        );
         result.livePassed = passed.length - before;
       } catch (err) {
         // Live failure never fails the job — pool passes still insert.

--- a/tests/unit/modules/domain-fit-serve-cache.test.ts
+++ b/tests/unit/modules/domain-fit-serve-cache.test.ts
@@ -1,0 +1,86 @@
+/**
+ * domain-fit-shadow/serve-cache — thin Prisma adapter for DomainFitServeCache.
+ *
+ * Pins:
+ *   - get(): row present + a valid fit label → mapped entry; NO row, or a
+ *     row whose fit column isn't a valid label (defensive — should never
+ *     happen since set() only ever writes '적합'/'비적합') → null (miss).
+ *   - set(): issues an upsert (INSERT ... ON CONFLICT DO UPDATE) scoped to
+ *     the (video_id, mandala_id) the cache was constructed with.
+ */
+
+import { createPrismaDomainFitServeCache } from '@/modules/domain-fit-shadow/serve-cache';
+
+function makePrismaMock() {
+  const queryRaw = jest.fn();
+  const executeRaw = jest.fn().mockResolvedValue(1);
+  return {
+    prisma: { $queryRaw: queryRaw, $executeRaw: executeRaw } as unknown as Parameters<
+      typeof createPrismaDomainFitServeCache
+    >[0],
+    queryRaw,
+    executeRaw,
+  };
+}
+
+describe('createPrismaDomainFitServeCache — get()', () => {
+  it('maps a cached row to a DomainFitServeCacheEntry', async () => {
+    const { prisma, queryRaw } = makePrismaMock();
+    const scoredAt = new Date('2026-07-01T00:00:00Z');
+    queryRaw.mockResolvedValueOnce([
+      {
+        fit: '비적합',
+        lexical_conflict: true,
+        multiplier: 0.2,
+        model: 'mandala-gen:latest',
+        scored_at: scoredAt,
+      },
+    ]);
+    const cache = createPrismaDomainFitServeCache(prisma, 'mandala-1');
+    const entry = await cache.get('vid12345678');
+    expect(entry).toEqual({
+      fit: '비적합',
+      lexicalConflict: true,
+      multiplier: 0.2,
+      model: 'mandala-gen:latest',
+      scoredAt: scoredAt.toISOString(),
+    });
+  });
+
+  it('returns null on an empty result (cache miss)', async () => {
+    const { prisma, queryRaw } = makePrismaMock();
+    queryRaw.mockResolvedValueOnce([]);
+    const cache = createPrismaDomainFitServeCache(prisma, 'mandala-1');
+    await expect(cache.get('vid12345678')).resolves.toBeNull();
+  });
+
+  it('defensively treats a row with a non-fit-label fit column as a miss', async () => {
+    const { prisma, queryRaw } = makePrismaMock();
+    queryRaw.mockResolvedValueOnce([
+      {
+        fit: null,
+        lexical_conflict: false,
+        multiplier: 1,
+        model: 'mandala-gen:latest',
+        scored_at: new Date(),
+      },
+    ]);
+    const cache = createPrismaDomainFitServeCache(prisma, 'mandala-1');
+    await expect(cache.get('vid12345678')).resolves.toBeNull();
+  });
+});
+
+describe('createPrismaDomainFitServeCache — set()', () => {
+  it('issues exactly one $executeRaw upsert call', async () => {
+    const { prisma, executeRaw } = makePrismaMock();
+    const cache = createPrismaDomainFitServeCache(prisma, 'mandala-1');
+    await cache.set('vid12345678', {
+      fit: '적합',
+      lexicalConflict: false,
+      multiplier: 1,
+      model: 'mandala-gen:latest',
+      scoredAt: new Date('2026-07-01T00:00:00Z').toISOString(),
+    });
+    expect(executeRaw).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/modules/domain-fit-serve-enforce.test.ts
+++ b/tests/unit/modules/domain-fit-serve-enforce.test.ts
@@ -1,0 +1,331 @@
+/**
+ * domain-fit-shadow/serve-enforce — R24 SERVE-edge ENFORCE (real reorder).
+ *
+ * Pins:
+ *   - flag OFF (serveEnforceEnabled:false) → zero classify calls, zero cache
+ *     calls, same array REFERENCE returned (byte-identical no-op).
+ *   - empty candidate list → no-op even when enabled.
+ *   - deboost multiplier: 적합 (no lexical conflict) → 1.0; 비적합 →
+ *     DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER (0.25); 적합 + lexical
+ *     conflict → the lexical multiplier alone (0.2).
+ *   - DROP invariant: output length === input length, ALWAYS (flag on/off,
+ *     any mix of fit/not-fit/classifier-failure) — demote-only, never drop.
+ *   - reorder: 비적합 candidates sink to the tail; ties preserve original
+ *     recruit-rank order (stable sort).
+ *   - cache HIT avoids a classifyDomainFit call entirely; a cache MISS calls
+ *     the classifier once and writes the result back.
+ *   - classifier failure (ok:false / fit:null) → fail-open (multiplier 1,
+ *     never demoted) AND never cached.
+ *   - candidates beyond maxCandidates are appended unscored at the tail
+ *     (load cap, never dropped).
+ *   - runDomainFitServeEnforce logs exactly one recordTrace call, step
+ *     domain_fit_serve_enforce.<stage>, and the returned (reordered) list is
+ *     never altered by a trace-logging failure.
+ */
+
+const mockClassify = jest.fn();
+const mockRecordTrace = jest.fn();
+const mockWithTraceContext = jest.fn();
+const mockGetTraceContext = jest.fn();
+
+jest.mock('@/modules/domain-fit-shadow/client', () => {
+  const actual = jest.requireActual('@/modules/domain-fit-shadow/client');
+  return {
+    ...actual,
+    classifyDomainFit: (...args: unknown[]) => mockClassify(...args),
+  };
+});
+jest.mock('@/modules/discover-tracing', () => ({
+  recordTrace: (...args: unknown[]) => mockRecordTrace(...args),
+  getTraceContext: (...args: unknown[]) => mockGetTraceContext(...args),
+  withTraceContext: (ctx: unknown, fn: () => Promise<unknown>) => mockWithTraceContext(ctx, fn),
+}));
+
+import {
+  applyDomainFitServeEnforce,
+  runDomainFitServeEnforce,
+  createNoopDomainFitServeCache,
+  DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER,
+  type DomainFitServeCache,
+  type DomainFitServeCacheEntry,
+} from '@/modules/domain-fit-shadow/serve-enforce';
+import type { DomainFitShadowConfig } from '@/config/domain-fit-shadow';
+
+const CFG_OFF: DomainFitShadowConfig = {
+  enabled: false,
+  ollamaUrl: 'http://100.91.173.17:11434',
+  model: 'mandala-gen:latest',
+  timeoutMs: 5000,
+  concurrency: 4,
+  maxCandidates: 40,
+  scalarEnabled: false,
+  writeShadowEnabled: false,
+  writeEnforceEnabled: false,
+  serveShadowEnabled: false,
+  serveEnforceEnabled: false,
+};
+const CFG_ON: DomainFitShadowConfig = { ...CFG_OFF, serveEnforceEnabled: true };
+
+/** Simple Map-based fake — same contract as the prisma-backed adapter without any DB. */
+function makeFakeCache(): DomainFitServeCache & { store: Map<string, DomainFitServeCacheEntry> } {
+  const store = new Map<string, DomainFitServeCacheEntry>();
+  return {
+    store,
+    get: async (id) => store.get(id) ?? null,
+    set: async (id, entry) => {
+      store.set(id, entry);
+    },
+  };
+}
+
+const cand = (id: string, title: string) => ({ youtubeVideoId: id, title });
+
+beforeEach(() => {
+  mockClassify.mockReset();
+  mockRecordTrace.mockReset();
+  mockWithTraceContext.mockReset();
+  mockGetTraceContext.mockReset();
+  mockGetTraceContext.mockReturnValue({ mandalaId: 'm1', userId: 'u1', runId: 'r1' });
+  mockWithTraceContext.mockImplementation((_ctx: unknown, fn: () => Promise<unknown>) => fn());
+});
+
+describe('DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER', () => {
+  it('is 0.25 (named constant, within the 0.2-0.3 spec range)', () => {
+    expect(DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER).toBe(0.25);
+  });
+});
+
+describe('applyDomainFitServeEnforce — flag gating', () => {
+  it('flag OFF: zero classify/cache calls, SAME array reference returned (byte-identical no-op)', async () => {
+    const cache = makeFakeCache();
+    const input = [cand('v1', 'title a'), cand('v2', 'title b')];
+    const result = await applyDomainFitServeEnforce(input, 'goal', CFG_OFF, cache);
+    expect(result.reordered).toBe(input); // same reference, not just equal
+    expect(mockClassify).not.toHaveBeenCalled();
+    expect(result.scored).toBe(0);
+    expect(result.cacheHits).toBe(0);
+    expect(cache.store.size).toBe(0);
+  });
+
+  it('empty candidate list is a no-op even when enabled', async () => {
+    const cache = makeFakeCache();
+    const result = await applyDomainFitServeEnforce([], 'goal', CFG_ON, cache);
+    expect(result.reordered).toEqual([]);
+    expect(mockClassify).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyDomainFitServeEnforce — composite deboost multiplier', () => {
+  it('적합 + no lexical conflict → multiplier 1.0 (no demotion)', async () => {
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    const cache = makeFakeCache();
+    const result = await applyDomainFitServeEnforce(
+      [cand('v1', '영어 발음 교정 Day1')],
+      '100일 영어 회화 완성하기',
+      CFG_ON,
+      cache
+    );
+    expect(result.demoted).toBe(0);
+    expect(cache.store.get('v1')?.multiplier).toBe(1);
+  });
+
+  it('비적합 → multiplier DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER (demoted)', async () => {
+    mockClassify.mockResolvedValue({ fit: '비적합', ms: 5, ok: true });
+    const cache = makeFakeCache();
+    const result = await applyDomainFitServeEnforce(
+      [cand('v1', '전혀 무관한 제목')],
+      '영어 회화',
+      CFG_ON,
+      cache
+    );
+    expect(result.demoted).toBe(1);
+    expect(cache.store.get('v1')?.multiplier).toBeCloseTo(
+      DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER
+    );
+  });
+
+  it('적합 BUT a lexical qualifier conflict (R22 pattern) → multiplier = lexical multiplier alone (0.2)', async () => {
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    const cache = makeFakeCache();
+    const result = await applyDomainFitServeEnforce(
+      [cand('v1', '실전 일본여행회화 3강 일본어')],
+      '100일 영어 회화 완성하기',
+      CFG_ON,
+      cache
+    );
+    expect(result.demoted).toBe(1);
+    expect(cache.store.get('v1')?.multiplier).toBeCloseTo(0.2);
+    expect(cache.store.get('v1')?.lexicalConflict).toBe(true);
+  });
+
+  it('classifier failure (ok:false) → FAIL-OPEN multiplier 1, never cached', async () => {
+    mockClassify.mockResolvedValue({ fit: null, ms: 5000, ok: false, error: 'timeout' });
+    const cache = makeFakeCache();
+    const result = await applyDomainFitServeEnforce(
+      [cand('v1', '아무 제목')],
+      '영어 회화',
+      CFG_ON,
+      cache
+    );
+    expect(result.classifierFailed).toBe(1);
+    expect(result.demoted).toBe(0);
+    expect(cache.store.has('v1')).toBe(false); // never cached — self-heals next call
+  });
+});
+
+describe('applyDomainFitServeEnforce — DROP invariant (demote-only, never drop)', () => {
+  it('output length === input length regardless of fit outcome', async () => {
+    mockClassify
+      .mockResolvedValueOnce({ fit: '적합', ms: 5, ok: true })
+      .mockResolvedValueOnce({ fit: '비적합', ms: 5, ok: true })
+      .mockResolvedValueOnce({ fit: null, ms: 5, ok: false });
+    const cache = makeFakeCache();
+    const input = [cand('v1', 'a'), cand('v2', 'b'), cand('v3', 'c')];
+    const result = await applyDomainFitServeEnforce(input, 'goal', CFG_ON, cache);
+    expect(result.reordered).toHaveLength(3);
+    expect(result.reordered.map((c) => c.youtubeVideoId).sort()).toEqual(['v1', 'v2', 'v3']);
+  });
+
+  it('candidates beyond maxCandidates are appended UNSCORED at the tail (load cap, never dropped)', async () => {
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    const cache = makeFakeCache();
+    const cfg = { ...CFG_ON, maxCandidates: 2 };
+    const input = [cand('v1', 'a'), cand('v2', 'b'), cand('v3', 'c'), cand('v4', 'd')];
+    const result = await applyDomainFitServeEnforce(input, 'goal', cfg, cache);
+    expect(result.reordered).toHaveLength(4); // never dropped
+    expect(mockClassify).toHaveBeenCalledTimes(2); // only the capped head is scored
+    // Overflow (v3, v4) preserved untouched at the tail, in original order.
+    expect(result.reordered.slice(2).map((c) => c.youtubeVideoId)).toEqual(['v3', 'v4']);
+  });
+});
+
+describe('applyDomainFitServeEnforce — reorder (demote to tail, stable)', () => {
+  it('비적합 candidates sink below 적합 peers regardless of original recruit-rank order', async () => {
+    mockClassify
+      .mockResolvedValueOnce({ fit: '비적합', ms: 5, ok: true }) // v1 — recruited FIRST but not-fit
+      .mockResolvedValueOnce({ fit: '적합', ms: 5, ok: true }); // v2 — recruited SECOND, fit
+    const cache = makeFakeCache();
+    const input = [cand('v1', '무관 제목'), cand('v2', '영어 회화 제목')];
+    const result = await applyDomainFitServeEnforce(input, '영어 회화', CFG_ON, cache);
+    expect(result.reordered.map((c) => c.youtubeVideoId)).toEqual(['v2', 'v1']);
+  });
+
+  it('ties (same multiplier) preserve original recruit-rank order (stable sort)', async () => {
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    const cache = makeFakeCache();
+    const input = [cand('v1', 'a'), cand('v2', 'b'), cand('v3', 'c')];
+    const result = await applyDomainFitServeEnforce(input, 'goal', CFG_ON, cache);
+    expect(result.reordered.map((c) => c.youtubeVideoId)).toEqual(['v1', 'v2', 'v3']);
+  });
+});
+
+describe('applyDomainFitServeEnforce — cache hit avoids a repeat classifier call', () => {
+  it('a cache HIT skips classifyDomainFit entirely and reuses the cached multiplier', async () => {
+    const cache = makeFakeCache();
+    await cache.set('v1', {
+      fit: '비적합',
+      lexicalConflict: false,
+      multiplier: DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER,
+      model: 'mandala-gen:latest',
+      scoredAt: new Date().toISOString(),
+    });
+    const result = await applyDomainFitServeEnforce([cand('v1', 'x')], 'goal', CFG_ON, cache);
+    expect(mockClassify).not.toHaveBeenCalled();
+    expect(result.cacheHits).toBe(1);
+    expect(result.scored).toBe(0);
+    expect(result.demoted).toBe(1);
+  });
+
+  it('a cache MISS calls the classifier once and writes the result back for next time', async () => {
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    const cache = makeFakeCache();
+    const result = await applyDomainFitServeEnforce([cand('v1', 'x')], 'goal', CFG_ON, cache);
+    expect(mockClassify).toHaveBeenCalledTimes(1);
+    expect(result.scored).toBe(1);
+    expect(cache.store.has('v1')).toBe(true);
+  });
+});
+
+describe('createNoopDomainFitServeCache', () => {
+  it('every get() is a miss; set() is a no-op (safe default for callers without a persistent cache)', async () => {
+    const cache = createNoopDomainFitServeCache();
+    await expect(cache.get('v1')).resolves.toBeNull();
+    await expect(cache.set('v1', {} as DomainFitServeCacheEntry)).resolves.toBeUndefined();
+    await expect(cache.get('v1')).resolves.toBeNull(); // set() truly no-ops
+  });
+});
+
+describe('runDomainFitServeEnforce — logging shape', () => {
+  it('logs exactly one recordTrace call, step domain_fit_serve_enforce.<stage>', async () => {
+    mockClassify.mockResolvedValue({ fit: '비적합', ms: 5, ok: true });
+    const cache = makeFakeCache();
+    const reordered = await runDomainFitServeEnforce(
+      {
+        stage: 'pool',
+        centerGoal: '영어 회화',
+        cellIndex: 2,
+        candidates: [cand('v1', '무관')],
+      },
+      CFG_ON,
+      cache
+    );
+    expect(reordered).toHaveLength(1);
+    expect(mockRecordTrace).toHaveBeenCalledTimes(1);
+    const call = mockRecordTrace.mock.calls[0]![0];
+    expect(call.step).toBe('domain_fit_serve_enforce.pool');
+    expect(call.request.cell_index).toBe(2);
+    expect(call.response.demoted).toBe(1);
+  });
+
+  it('flag OFF: zero recordTrace calls (short-circuits before scoring)', async () => {
+    const cache = makeFakeCache();
+    const input = [cand('v1', 'a')];
+    const reordered = await runDomainFitServeEnforce(
+      { stage: 'live', centerGoal: 'goal', cellIndex: 0, candidates: input },
+      CFG_OFF,
+      cache
+    );
+    expect(reordered).toBe(input);
+    expect(mockRecordTrace).not.toHaveBeenCalled();
+    expect(mockClassify).not.toHaveBeenCalled();
+  });
+
+  it('creates a scoped trace context when none is bound (mirrors write-gate.ts)', async () => {
+    mockGetTraceContext.mockReturnValue(null);
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    const cache = makeFakeCache();
+    await runDomainFitServeEnforce(
+      {
+        stage: 'pool',
+        centerGoal: '영어 회화',
+        cellIndex: 0,
+        mandalaId: 'm-abc',
+        userId: 'u-xyz',
+        candidates: [cand('v1', '영어 발음')],
+      },
+      CFG_ON,
+      cache
+    );
+    expect(mockWithTraceContext).toHaveBeenCalledTimes(1);
+    expect(mockWithTraceContext.mock.calls[0]![0]).toEqual({ mandalaId: 'm-abc', userId: 'u-xyz' });
+  });
+
+  it('a trace-logging failure never alters the returned (reordered) list', async () => {
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    mockRecordTrace.mockImplementation(() => {
+      throw new Error('trace boom');
+    });
+    const cache = makeFakeCache();
+    const reordered = await runDomainFitServeEnforce(
+      {
+        stage: 'pool',
+        centerGoal: '영어 회화',
+        cellIndex: 0,
+        candidates: [cand('v1', '영어 발음')],
+      },
+      CFG_ON,
+      cache
+    );
+    expect(reordered).toHaveLength(1);
+  });
+});

--- a/tests/unit/modules/domain-fit-shadow.test.ts
+++ b/tests/unit/modules/domain-fit-shadow.test.ts
@@ -47,6 +47,7 @@ const CFG: DomainFitShadowConfig = {
   writeShadowEnabled: false, // R19 — unrelated to this read-path suite
   writeEnforceEnabled: false, // R23 — unrelated to this read-path suite
   serveShadowEnabled: false, // R23 — unrelated to this read-path suite
+  serveEnforceEnabled: false, // R24 — unrelated to this read-path suite
 };
 
 function baseInput(n: number): ScheduleDomainFitShadowInput {

--- a/tests/unit/modules/domain-fit-write-gate.test.ts
+++ b/tests/unit/modules/domain-fit-write-gate.test.ts
@@ -48,6 +48,7 @@ const CFG: DomainFitShadowConfig = {
   writeShadowEnabled: false,
   writeEnforceEnabled: true,
   serveShadowEnabled: false,
+  serveEnforceEnabled: false,
 };
 
 beforeEach(() => {

--- a/tests/unit/modules/domain-fit-write-shadow.test.ts
+++ b/tests/unit/modules/domain-fit-write-shadow.test.ts
@@ -49,6 +49,7 @@ const CFG_OFF: DomainFitShadowConfig = {
   writeShadowEnabled: false,
   writeEnforceEnabled: false,
   serveShadowEnabled: false,
+  serveEnforceEnabled: false,
 };
 const CFG_ON: DomainFitShadowConfig = { ...CFG_OFF, writeShadowEnabled: true };
 


### PR DESCRIPTION
## What

R24 serve-edge enforce for the search redesign track (blast-0, behavior-neutral):

- `runDomainFitServeEnforce()` — PRE-gate, demote-only re-rank (deboost multiplier 0.25) applied inside `pool-serve-fill` at both the pool recruit branch and the live-fallback branch. Card count preserved (demote-only, no drops).
- New table `video_domain_fit_cache` (PK video_id+mandala_id) — caches the per-mandala domain-fit verdict so the Ollama T3 classification is never repeated for the same pair. Raw idempotent DDL at `prisma/migrations/domain-fit-serve-cache/001_create_video_domain_fit_cache.sql` + registered in `apply-custom-sql.sh` allowlist (prisma-db-push silent-fail hard rule).
- Flag `DOMAIN_FIT_SERVE_ENFORCE` default **false** — table and code path fully inert until flipped. Classifier-unavailable results fail-open (multiplier 1, not cached).

## Coverage (measured, file:line)

Enforce hook call sites are `pool-serve-fill.ts:385` (pool) and `:454` (live-fallback) only. Surfaces covered: pool-serve fill + wizard async pool refill. **Not covered**: add-cards / v5 wizard synchronous serving (no enforce hook on that path) — follow-up PR wires a cache-consume hook there (supervisor verdict (b)).

## Write paths

New table written only by `serve-cache.ts` (flag-gated). No existing table's write path touched.

## Verification

- 25 unit tests (serve-enforce 331 lines + serve-cache 86 lines of tests), tsc clean (verified at build time, CP511-cont session).
- Allowlist commit: `bash -n` pass; DDL is CREATE TABLE/INDEX IF NOT EXISTS (idempotent).

## Deploy order & rollback

1. Merge (flag off — zero behavior change; DDL applied by deploy pipeline via allowlist).
2. Flip `DOMAIN_FIT_SERVE_ENFORCE` = James gate (separate decision; firing trace + fail-open logging to be confirmed on flip).
Rollback: flag off (config-only, no code revert needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)