### PR TITLE
chore(search): flip DOMAIN_FIT_SERVE_ENFORCE=true (serve-edge deboost live)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -175,6 +175,11 @@ services:
       # line → code default false (DOMAIN_FIT_SERVE_SHADOW off).
       # NOTE: this config's boolFlag accepts only true/1/yes (NOT "on") — use =true.
       - DOMAIN_FIT_SERVE_SHADOW=true
+      # R24 SERVE-edge enforce flip (supervisor [GO] 2026-07-06, PR #1104 code).
+      # Demote-only composite deboost on pool-serve-fill pool + live-fallback
+      # branches; card count preserved; classifier-unavailable = fail-open
+      # (multiplier 1, not cached). Rollback = delete line → code default false.
+      - DOMAIN_FIT_SERVE_ENFORCE=true
       # G3 W1③ supply bridge — serve the backfilled yt_promoted rows.
       # W1① backfill embedded 7,015 yt_promoted (gold/silver, classifyQuality —
       # same gate as v2_promoted, NOT batch_trend). Measured: cohort cos>=0.5


### PR DESCRIPTION
## What

One-line compose env flip activating the R24 serve-edge domain-fit enforce shipped flag-off in #1104.

## Preconditions verified (prod, post-#1104 deploy)

- `video_domain_fit_cache` live: 7 columns + PK + mandala index (information_schema probe via insighta-api container).
- `/health` 200 after deploy 28769654235.
- Current env: `DOMAIN_FIT_SERVE_SHADOW=true` only — enforce absent (code default false).

## Behavior

Demote-only composite deboost (×0.25 on not-fit verdict) at pool-serve-fill pool + live-fallback branches. Card count preserved. Classifier-unavailable ⇒ fail-open (multiplier 1, not cached).

## Post-flip verification plan

Firing trace ≥1 (enforce log line on next pool-serve dispatch) + fail-open occurrence-rate logging check. Done gate = James add-cards 화면 실측 (per supervisor verdict — enforce does not cover the synchronous add-cards path until the follow-up sync-consume PR).

## Rollback

Delete the compose line → redeploy (code default false). Config-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)