### PR TITLE
feat(search): domain-fit sync-path cache-consume deboost + pool-serve channel hard-cap (flag OFF)

### DIFF
--- a/src/api/routes/add-cards.ts
+++ b/src/api/routes/add-cards.ts
@@ -42,6 +42,9 @@ import { getV5Config } from '@/skills/plugins/video-discover/v5/config';
 import { getFullCellIndices } from '@/modules/mandala/cell-fill';
 import { writeSearchTrace, type DropReason } from '@/modules/search-trace';
 import { randomUUID } from 'node:crypto';
+import { loadDomainFitShadowConfig } from '@/config/domain-fit-shadow';
+import { applyDomainFitSyncConsume } from '@/modules/domain-fit-shadow/sync-consume';
+import { createPrismaDomainFitSyncConsumeCache } from '@/modules/domain-fit-shadow/serve-cache';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const YOUTUBE_VIDEO_ID_RE = /^[A-Za-z0-9_-]{11}$/;
@@ -460,6 +463,30 @@ export const addCardsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
                   `live_gate shadow failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
                 );
               });
+          }
+
+          // R24+1 — sync-path domain-fit cache-consume (supervisor spec):
+          // CACHE-ONLY demote-only reorder, ZERO synchronous Ollama calls
+          // (hot path — a 1-2s classifier round trip per candidate is
+          // forbidden here). Cache misses schedule a fire-and-forget async
+          // classify+persist (never awaited) so the cache warms for the next
+          // request. Flag-gated; default off = zero reads/writes/timing
+          // change at this call site.
+          const domainFitCfg = loadDomainFitShadowConfig(process.env);
+          if (domainFitCfg.syncConsumeEnabled && v5Exposed.length > 0) {
+            const domainFitSyncCache = createPrismaDomainFitSyncConsumeCache(prisma, mandalaId);
+            const wrapped = v5Exposed.map((c) => ({
+              youtubeVideoId: c.videoId,
+              title: c.title,
+              orig: c,
+            }));
+            const syncResult = await applyDomainFitSyncConsume(
+              wrapped,
+              centerGoal,
+              domainFitCfg,
+              domainFitSyncCache
+            );
+            v5Exposed = syncResult.reordered.map((w) => w.orig);
           }
 
           const cards: AddCardCandidate[] = v5Exposed.map((c) => ({

--- a/src/config/domain-fit-shadow.ts
+++ b/src/config/domain-fit-shadow.ts
@@ -113,6 +113,20 @@ export const domainFitShadowEnvSchema = z.object({
    * runs (R23 invariant unchanged, zero extra Ollama calls, zero reorder).
    */
   DOMAIN_FIT_SERVE_ENFORCE: boolFlag.default(false as unknown as string),
+  /**
+   * R24+1 — SYNC-path cache-consume (supervisor spec). SEPARATE from
+   * `DOMAIN_FIT_SERVE_ENFORCE` (which AWAITS a classifier call, safe only
+   * inside the already-async pool-serve-fill job): this flag lets the
+   * synchronous add-cards/v5 HTTP response path
+   * (`src/api/routes/add-cards.ts`) apply a CACHE-ONLY demote-only reorder
+   * (`src/modules/domain-fit-shadow/sync-consume.ts`) — zero synchronous
+   * Ollama calls, ever. Cache misses schedule a fire-and-forget async
+   * classify+persist (`setImmediate`) so the cache warms for the next
+   * request; the current request sees multiplier=1 (untouched) for those.
+   * Default false = zero extra DB reads/writes at this call site, zero
+   * timing change (byte-identical to pre-existing behavior).
+   */
+  DOMAIN_FIT_SYNC_CONSUME: boolFlag.default(false as unknown as string),
 });
 
 export interface DomainFitShadowConfig {
@@ -131,6 +145,8 @@ export interface DomainFitShadowConfig {
   serveShadowEnabled: boolean;
   /** R24 — independent flag: pool-serve SERVE-edge ENFORCE (real reorder). */
   serveEnforceEnabled: boolean;
+  /** R24+1 — independent flag: sync add-cards/v5 path CACHE-ONLY reorder (no sync Ollama call). */
+  syncConsumeEnabled: boolean;
 }
 
 const DEFAULTS: DomainFitShadowConfig = {
@@ -145,6 +161,7 @@ const DEFAULTS: DomainFitShadowConfig = {
   writeEnforceEnabled: false,
   serveShadowEnabled: false,
   serveEnforceEnabled: false,
+  syncConsumeEnabled: false,
 };
 
 export function loadDomainFitShadowConfig(
@@ -162,6 +179,7 @@ export function loadDomainFitShadowConfig(
     DOMAIN_FIT_WRITE_ENFORCE: env['DOMAIN_FIT_WRITE_ENFORCE'],
     DOMAIN_FIT_SERVE_SHADOW: env['DOMAIN_FIT_SERVE_SHADOW'],
     DOMAIN_FIT_SERVE_ENFORCE: env['DOMAIN_FIT_SERVE_ENFORCE'],
+    DOMAIN_FIT_SYNC_CONSUME: env['DOMAIN_FIT_SYNC_CONSUME'],
   });
   if (!parsed.success) return { ...DEFAULTS };
   return {
@@ -176,5 +194,6 @@ export function loadDomainFitShadowConfig(
     writeEnforceEnabled: parsed.data.DOMAIN_FIT_WRITE_ENFORCE,
     serveShadowEnabled: parsed.data.DOMAIN_FIT_SERVE_SHADOW,
     serveEnforceEnabled: parsed.data.DOMAIN_FIT_SERVE_ENFORCE,
+    syncConsumeEnabled: parsed.data.DOMAIN_FIT_SYNC_CONSUME,
   };
 }

--- a/src/modules/domain-fit-shadow/serve-cache.ts
+++ b/src/modules/domain-fit-shadow/serve-cache.ts
@@ -18,6 +18,7 @@
 import type { PrismaClient } from '@prisma/client';
 import type { DomainFitLabel } from './client';
 import type { DomainFitServeCache, DomainFitServeCacheEntry } from './serve-enforce';
+import type { DomainFitSyncConsumeCache } from './sync-consume';
 
 /** Minimal Prisma surface this adapter needs (matches the raw-query style
  *  already used elsewhere in pool-serve-fill.ts for video_mandala_relevance). */
@@ -29,6 +30,10 @@ interface CacheRow {
   multiplier: number;
   model: string;
   scored_at: Date;
+}
+
+interface BatchCacheRow extends CacheRow {
+  video_id: string;
 }
 
 function isFitLabel(v: string | null): v is DomainFitLabel {
@@ -74,6 +79,44 @@ export function createPrismaDomainFitServeCache(
           multiplier = EXCLUDED.multiplier,
           model = EXCLUDED.model,
           scored_at = EXCLUDED.scored_at`;
+    },
+  };
+}
+
+/**
+ * Sync-consume variant — ONE batched `= ANY(...)` read for the whole
+ * candidate set (hot-path latency budget, see `./sync-consume.ts`) instead of
+ * N sequential single-video reads. `set` is the SAME write path as
+ * `createPrismaDomainFitServeCache` (composed, not duplicated).
+ */
+export function createPrismaDomainFitSyncConsumeCache(
+  prisma: DomainFitServeCachePrisma,
+  mandalaId: string
+): DomainFitSyncConsumeCache {
+  const base = createPrismaDomainFitServeCache(prisma, mandalaId);
+  return {
+    // Arrow-wrapped (not `base.set` directly) — avoids the unbound-method
+    // lint rule while still delegating to the same write path.
+    set: (youtubeVideoId, entry) => base.set(youtubeVideoId, entry),
+    async getMany(youtubeVideoIds: string[]): Promise<Map<string, DomainFitServeCacheEntry>> {
+      const map = new Map<string, DomainFitServeCacheEntry>();
+      if (youtubeVideoIds.length === 0) return map;
+      const rows = await prisma.$queryRaw<BatchCacheRow[]>`
+        SELECT video_id, fit, lexical_conflict, multiplier, model, scored_at
+        FROM video_domain_fit_cache
+        WHERE mandala_id = ${mandalaId}::uuid
+          AND video_id = ANY(${youtubeVideoIds}::text[])`;
+      for (const row of rows) {
+        if (!isFitLabel(row.fit)) continue;
+        map.set(row.video_id, {
+          fit: row.fit,
+          lexicalConflict: row.lexical_conflict,
+          multiplier: row.multiplier,
+          model: row.model,
+          scoredAt: row.scored_at.toISOString(),
+        });
+      }
+      return map;
     },
   };
 }

--- a/src/modules/domain-fit-shadow/serve-enforce.ts
+++ b/src/modules/domain-fit-shadow/serve-enforce.ts
@@ -122,12 +122,78 @@ export interface ApplyDomainFitServeEnforceResult<T> {
 }
 
 /**
+ * STABLE demote-only sort by multiplier (descending; ties preserve original
+ * order — `Array.prototype.sort` is stable since ES2019 / all supported Node
+ * runtimes). Shared by `applyDomainFitServeEnforce` (async serve-enforce
+ * reorder) and the sync-consume cache-only reorder (`./sync-consume.ts`) so
+ * the reorder semantics never drift between the two call sites.
+ */
+export function reorderByMultiplier<T>(items: { c: T; multiplier: number }[]): T[] {
+  const indexed = items.map((r, idx) => ({ ...r, idx }));
+  indexed.sort((a, b) => b.multiplier - a.multiplier || a.idx - b.idx);
+  return indexed.map((r) => r.c);
+}
+
+export interface ScoreAndCacheDomainFitResult {
+  /** false = classifier timeout/error/unparsable (fail-open, never cached). */
+  ok: boolean;
+  /** 1 when !ok (fail-open contract — never demotes on classifier failure). */
+  multiplier: number;
+}
+
+/**
+ * Shared classify + lexical-deboost + cache-write core — the ONE place a
+ * candidate is actually scored against Ollama. Used both by the AWAITED
+ * serve-enforce miss-branch below and by the sync-consume fire-and-forget
+ * cache-warm path (`./sync-consume.ts`), so the composite scoring logic
+ * never duplicates between the two call sites. Fail-open: a classifier
+ * failure never demotes and is deliberately NOT cached (self-heals on the
+ * next call instead of pinning a false failure).
+ */
+export async function scoreAndCacheDomainFit<T extends DomainFitServeCandidate>(
+  c: T,
+  centerGoal: string,
+  cfg: DomainFitShadowConfig,
+  cache: Pick<DomainFitServeCache, 'set'>
+): Promise<ScoreAndCacheDomainFitResult> {
+  const r = await classifyDomainFit(centerGoal, c.title, cfg);
+  if (!r.ok || r.fit === null) {
+    return { ok: false, multiplier: 1 };
+  }
+  const { hasConflict, multiplier: lexicalMultiplier } = detectQualifierConflicts(
+    centerGoal,
+    c.title
+  );
+  const multiplier =
+    r.fit === '비적합'
+      ? DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER * (hasConflict ? lexicalMultiplier : 1)
+      : hasConflict
+        ? lexicalMultiplier
+        : 1;
+
+  await cache
+    .set(c.youtubeVideoId, {
+      fit: r.fit,
+      lexicalConflict: hasConflict,
+      multiplier,
+      model: cfg.model,
+      scoredAt: new Date().toISOString(),
+    })
+    .catch((err: unknown) => {
+      // Cache-write failure never blocks the reorder/warm this call is doing.
+      log.debug(
+        `domain-fit score-and-cache write failed (swallowed): ${err instanceof Error ? err.message : String(err)}`
+      );
+    });
+  return { ok: true, multiplier };
+}
+
+/**
  * Pure reorder — classify + lexical-deboost combined into one composite
  * multiplier per candidate (cache-first), then a STABLE demote-only sort
- * (multiplier descending; ties preserve original recruit-rank order —
- * `Array.prototype.sort` is stable since ES2019 / all supported Node
- * runtimes). No trace/logging side effect; see `runDomainFitServeEnforce`
- * for the logged wrapper used at the actual call site.
+ * (see `reorderByMultiplier`). No trace/logging side effect; see
+ * `runDomainFitServeEnforce` for the logged wrapper used at the actual call
+ * site.
  *
  * `cfg.serveEnforceEnabled` gates everything: off (default) is a synchronous
  * zero-cost no-op — same array reference returned, zero cache/classifier
@@ -169,50 +235,20 @@ export async function applyDomainFitServeEnforce<T extends DomainFitServeCandida
           return { c, multiplier: cached.multiplier };
         }
 
-        const r = await classifyDomainFit(centerGoal, c.title, cfg);
-        if (!r.ok || r.fit === null) {
-          // Fail-open — a classifier outage must never demote a candidate,
-          // and is deliberately NOT cached (self-heals on the next call).
+        const res = await scoreAndCacheDomainFit(c, centerGoal, cfg, cache);
+        if (!res.ok) {
           classifierFailed += 1;
           return { c, multiplier: 1 };
         }
         scored += 1;
-
-        const { hasConflict, multiplier: lexicalMultiplier } = detectQualifierConflicts(
-          centerGoal,
-          c.title
-        );
-        const multiplier =
-          r.fit === '비적합'
-            ? DOMAIN_FIT_SERVE_ENFORCE_DEBOOST_MULTIPLIER * (hasConflict ? lexicalMultiplier : 1)
-            : hasConflict
-              ? lexicalMultiplier
-              : 1;
-
-        await cache
-          .set(c.youtubeVideoId, {
-            fit: r.fit,
-            lexicalConflict: hasConflict,
-            multiplier,
-            model: cfg.model,
-            scoredAt: new Date().toISOString(),
-          })
-          .catch((err: unknown) => {
-            // Cache-write failure never blocks the reorder this request is doing.
-            log.debug(
-              `domain-fit serve-enforce cache write failed (swallowed): ${err instanceof Error ? err.message : String(err)}`
-            );
-          });
-        return { c, multiplier };
+        return { c, multiplier: res.multiplier };
       })
     );
     withMultiplier.push(...results);
   }
 
-  const indexed = withMultiplier.map((r, idx) => ({ ...r, idx }));
-  indexed.sort((a, b) => b.multiplier - a.multiplier || a.idx - b.idx);
-  const demoted = indexed.filter((r) => r.multiplier < 1).length;
-  const reordered: T[] = [...indexed.map((r) => r.c), ...overflow];
+  const demoted = withMultiplier.filter((r) => r.multiplier < 1).length;
+  const reordered: T[] = [...reorderByMultiplier(withMultiplier), ...overflow];
 
   return { reordered, demoted, scored, cacheHits, classifierFailed };
 }

--- a/src/modules/domain-fit-shadow/sync-consume.ts
+++ b/src/modules/domain-fit-shadow/sync-consume.ts
@@ -1,0 +1,151 @@
+/**
+ * Domain-fit SYNC-path cache-consume (supervisor spec — sync add-cards/v5
+ * serving path deboost WITHOUT any synchronous Ollama call).
+ *
+ * Unlike `./serve-enforce.ts` (AWAITS a classifier call on cache miss, safe
+ * only inside the already-async pg-boss pool-serve-fill job), this module
+ * runs in the synchronous HTTP request path (`src/api/routes/add-cards.ts`)
+ * where a 1-2s-per-candidate Ollama round trip is forbidden (hot path,
+ * p95<200ms budget). Contract:
+ *   - cache HIT → apply the cached multiplier (same demote-only stable sort
+ *     as serve-enforce, via the shared `reorderByMultiplier` helper).
+ *   - cache MISS → multiplier 1 (untouched, no reorder effect) AND a
+ *     fire-and-forget cache-warm classify+persist is scheduled
+ *     (`setImmediate`, never awaited by the request) so the NEXT request for
+ *     the same (video, mandala) pair is a cache hit. Errors are swallowed +
+ *     logged; a classifier failure is never cached (same fail-open contract
+ *     as `scoreAndCacheDomainFit`).
+ *
+ * `cfg.syncConsumeEnabled` gates everything: off (default) is a synchronous
+ * zero-cost no-op — same array reference returned, zero cache reads, zero
+ * warm scheduling.
+ */
+
+import { logger } from '@/utils/logger';
+import type { DomainFitShadowConfig } from '@/config/domain-fit-shadow';
+import {
+  reorderByMultiplier,
+  scoreAndCacheDomainFit,
+  type DomainFitServeCandidate,
+  type DomainFitServeCacheEntry,
+} from './serve-enforce';
+
+const log = logger.child({ module: 'domain-fit-shadow/sync-consume' });
+
+/** Batch-read + single-write cache surface for the sync-consume path — a
+ *  SEPARATE shape from `DomainFitServeCache` (get is single-video) because
+ *  the sync path needs exactly ONE SQL round trip for the whole candidate
+ *  set (hot-path latency budget), not N sequential single-video reads. */
+export interface DomainFitSyncConsumeCache {
+  getMany(youtubeVideoIds: string[]): Promise<Map<string, DomainFitServeCacheEntry>>;
+  set(youtubeVideoId: string, entry: DomainFitServeCacheEntry): Promise<void>;
+}
+
+/** Every call is a miss; `set` is a no-op — mirrors `createNoopDomainFitServeCache`. */
+export function createNoopDomainFitSyncConsumeCache(): DomainFitSyncConsumeCache {
+  return {
+    getMany: async () => new Map(),
+    set: async () => {},
+  };
+}
+
+export interface DomainFitSyncConsumeResult<T> {
+  /** Same length as input, ALWAYS — DEMOTE only, never drop (card-floor invariant). */
+  reordered: T[];
+  /** Count of candidates whose multiplier < 1 (i.e. actually demoted). */
+  demoted: number;
+  cacheHits: number;
+  /** Uncached candidates enqueued for async cache-warm classification (NOT scored synchronously). */
+  enqueued: number;
+}
+
+/**
+ * Bursted (bounded by `cfg.concurrency`) fire-and-forget cache warm — awaits
+ * internally so Ollama is never hammered with an unbounded fan-out, but the
+ * CALLER never awaits this function itself (see `applyDomainFitSyncConsume`'s
+ * `setImmediate` scheduling). Every candidate error is swallowed + logged;
+ * a classifier failure is never cached (fail-open, self-heals next request).
+ */
+async function warmDomainFitSyncCache<T extends DomainFitServeCandidate>(
+  candidates: T[],
+  centerGoal: string,
+  cfg: DomainFitShadowConfig,
+  cache: Pick<DomainFitSyncConsumeCache, 'set'>
+): Promise<void> {
+  for (let i = 0; i < candidates.length; i += cfg.concurrency) {
+    const burst = candidates.slice(i, i + cfg.concurrency);
+    await Promise.all(
+      burst.map((c) =>
+        scoreAndCacheDomainFit(c, centerGoal, cfg, cache).catch((err: unknown) => {
+          log.debug(
+            `domain-fit sync-consume warm candidate failed (swallowed): ${err instanceof Error ? err.message : String(err)}`
+          );
+        })
+      )
+    );
+  }
+}
+
+/**
+ * Schedules the cache warm OFF the request's synchronous path via
+ * `setImmediate` — the request returns before this even starts running.
+ * Exported separately so tests can assert it was invoked without needing a
+ * real event-loop tick.
+ */
+export function scheduleDomainFitSyncWarm<T extends DomainFitServeCandidate>(
+  uncached: T[],
+  centerGoal: string,
+  cfg: DomainFitShadowConfig,
+  cache: Pick<DomainFitSyncConsumeCache, 'set'>
+): void {
+  if (uncached.length === 0) return;
+  setImmediate(() => {
+    void warmDomainFitSyncCache(uncached, centerGoal, cfg, cache).catch((err: unknown) => {
+      log.warn(
+        `domain-fit sync-consume warm batch failed (swallowed): ${err instanceof Error ? err.message : String(err)}`
+      );
+    });
+  });
+}
+
+/**
+ * Sync-path pure reorder — CACHE READ ONLY, zero synchronous classifier
+ * calls. See module docstring for the full contract.
+ */
+export async function applyDomainFitSyncConsume<T extends DomainFitServeCandidate>(
+  candidates: T[],
+  centerGoal: string,
+  cfg: DomainFitShadowConfig,
+  cache: DomainFitSyncConsumeCache
+): Promise<DomainFitSyncConsumeResult<T>> {
+  if (!cfg.syncConsumeEnabled || candidates.length === 0) {
+    return { reordered: candidates, demoted: 0, cacheHits: 0, enqueued: 0 };
+  }
+
+  // Bounded cap — anything beyond stays untouched, appended at the tail
+  // (never dropped; just not reordered) — same posture as serve-enforce.
+  const capped = candidates.slice(0, cfg.maxCandidates);
+  const overflow = candidates.slice(cfg.maxCandidates);
+
+  const cached = await cache.getMany(capped.map((c) => c.youtubeVideoId)).catch((err: unknown) => {
+    log.debug(
+      `domain-fit sync-consume cache read failed (treated as all-miss): ${err instanceof Error ? err.message : String(err)}`
+    );
+    return new Map<string, DomainFitServeCacheEntry>();
+  });
+
+  const uncached: T[] = [];
+  const withMultiplier = capped.map((c) => {
+    const entry = cached.get(c.youtubeVideoId);
+    if (entry) return { c, multiplier: entry.multiplier };
+    uncached.push(c);
+    return { c, multiplier: 1 };
+  });
+
+  scheduleDomainFitSyncWarm(uncached, centerGoal, cfg, cache);
+
+  const demoted = withMultiplier.filter((r) => r.multiplier < 1).length;
+  const reordered: T[] = [...reorderByMultiplier(withMultiplier), ...overflow];
+
+  return { reordered, demoted, cacheHits: cached.size, enqueued: uncached.length };
+}

--- a/src/modules/queue/handlers/pool-serve-fill.ts
+++ b/src/modules/queue/handlers/pool-serve-fill.ts
@@ -49,8 +49,12 @@ import { isShortCached, SHORT_MAX_DURATION_SEC } from '@/modules/video-pool/is-s
 import { getV5Config } from '@/skills/plugins/video-discover/v5/config';
 import { parseIsoDurationSeconds } from '@/skills/plugins/video-discover/v5/executor';
 import { isOffLanguageTitleToggled } from '@/skills/plugins/video-discover/v5/youtube-fanout';
-import { dedupeSeries, softChannelCap } from '@/skills/plugins/video-discover/diversity-guard';
-import { loadDiversityGuardConfig } from '@/config/diversity-guard';
+import {
+  dedupeSeries,
+  softChannelCap,
+  hardChannelCap,
+} from '@/skills/plugins/video-discover/diversity-guard';
+import { loadDiversityGuardConfig, type DiversityGuardConfig } from '@/config/diversity-guard';
 import { logger } from '@/utils/logger';
 import { config } from '@/config/index';
 import { writeSearchTrace, type SearchTraceCandidateInput } from '@/modules/search-trace';
@@ -115,6 +119,30 @@ interface PassedCandidate extends GateCandidate {
   relevancePct: number;
   /** Observability — the gate axis value (gc / goalContribution or composite). */
   gatePct: number;
+}
+
+/**
+ * Pool-serve diversity transform — series-dedup + soft channel cap (existing
+ * behavior) PLUS the global channel hard cap (measured gap — hardChannelCap
+ * was wired only in v5/executor.ts, never here; see diversity-guard.ts's
+ * V5_CHANNEL_HARD_CAP doc comment for the rationale/measurement). Same
+ * demote-only semantics as the v5 executor usage: cap<=0 is a no-op
+ * (byte-identical to pre-existing behavior). Exported as a pure function so
+ * the wiring is directly unit-testable without spinning the full pg-boss job
+ * handler.
+ */
+export function applyPoolServeDiversity<T extends GateCandidate>(
+  cands: T[],
+  against: T[],
+  cfg: DiversityGuardConfig
+): T[] {
+  if (!cfg.enabled) return cands;
+  const d = dedupeSeries(cands, { simThreshold: cfg.seriesSim, against });
+  let out = softChannelCap(d.kept, cfg.channelSoftCap);
+  if (cfg.channelHardCap > 0) {
+    out = hardChannelCap(out, cfg.channelHardCap, cfg.channelHardCapMinCandidates).reordered;
+  }
+  return out;
 }
 
 export interface PoolServeCellResult {
@@ -198,11 +226,8 @@ async function handlePoolServeFill(job: PgBoss.Job<PoolServeFillPayload>): Promi
     // limit: already-OWNED cards' titles are not loaded (id-only exclude), so
     // cross-run series dups are out of scope here (backlog).
     const diversity = loadDiversityGuardConfig();
-    const applyDiversity = (cands: GateCandidate[], against: GateCandidate[]): GateCandidate[] => {
-      if (!diversity.enabled) return cands;
-      const d = dedupeSeries(cands, { simThreshold: diversity.seriesSim, against });
-      return softChannelCap(d.kept, diversity.channelSoftCap);
-    };
+    const applyDiversity = (cands: GateCandidate[], against: GateCandidate[]): GateCandidate[] =>
+      applyPoolServeDiversity(cands, against, diversity);
 
     // CP500+ shorts gate — EXACT replica of the v5 placement gate
     // (v5/executor.ts step 6): duration>=180 short-circuits with no HTTP;

--- a/tests/unit/modules/domain-fit-serve-enforce.test.ts
+++ b/tests/unit/modules/domain-fit-serve-enforce.test.ts
@@ -63,6 +63,7 @@ const CFG_OFF: DomainFitShadowConfig = {
   writeEnforceEnabled: false,
   serveShadowEnabled: false,
   serveEnforceEnabled: false,
+  syncConsumeEnabled: false,
 };
 const CFG_ON: DomainFitShadowConfig = { ...CFG_OFF, serveEnforceEnabled: true };
 

--- a/tests/unit/modules/domain-fit-shadow.test.ts
+++ b/tests/unit/modules/domain-fit-shadow.test.ts
@@ -48,6 +48,7 @@ const CFG: DomainFitShadowConfig = {
   writeEnforceEnabled: false, // R23 — unrelated to this read-path suite
   serveShadowEnabled: false, // R23 — unrelated to this read-path suite
   serveEnforceEnabled: false, // R24 — unrelated to this read-path suite
+  syncConsumeEnabled: false, // R24+1 — unrelated to this read-path suite
 };
 
 function baseInput(n: number): ScheduleDomainFitShadowInput {

--- a/tests/unit/modules/domain-fit-sync-consume.test.ts
+++ b/tests/unit/modules/domain-fit-sync-consume.test.ts
@@ -1,0 +1,198 @@
+/**
+ * domain-fit-shadow/sync-consume — R24+1 SYNC-path cache-consume.
+ *
+ * Pins:
+ *   - flag OFF (syncConsumeEnabled:false) → zero cache calls, same array
+ *     REFERENCE returned (byte-identical no-op).
+ *   - flag ON + cache HIT with a 비적합 verdict → the cached candidate is
+ *     DEMOTED (stable reorder), count preserved, ZERO classifyDomainFit calls
+ *     (the sync path never scores synchronously).
+ *   - flag ON + cache MISS → candidate untouched (multiplier 1, no reorder
+ *     effect) AND the cache-warm scheduler is invoked with exactly the
+ *     uncached candidates (never awaited by the caller).
+ *   - DROP invariant: output length === input length always.
+ */
+
+const mockClassify = jest.fn();
+jest.mock('@/modules/domain-fit-shadow/client', () => {
+  const actual = jest.requireActual('@/modules/domain-fit-shadow/client');
+  return {
+    ...actual,
+    classifyDomainFit: (...args: unknown[]) => mockClassify(...args),
+  };
+});
+
+import {
+  applyDomainFitSyncConsume,
+  scheduleDomainFitSyncWarm,
+  createNoopDomainFitSyncConsumeCache,
+  type DomainFitSyncConsumeCache,
+} from '@/modules/domain-fit-shadow/sync-consume';
+import type { DomainFitServeCacheEntry } from '@/modules/domain-fit-shadow/serve-enforce';
+import type { DomainFitShadowConfig } from '@/config/domain-fit-shadow';
+
+const CFG_OFF: DomainFitShadowConfig = {
+  enabled: false,
+  ollamaUrl: 'http://100.91.173.17:11434',
+  model: 'mandala-gen:latest',
+  timeoutMs: 5000,
+  concurrency: 4,
+  maxCandidates: 40,
+  scalarEnabled: false,
+  writeShadowEnabled: false,
+  writeEnforceEnabled: false,
+  serveShadowEnabled: false,
+  serveEnforceEnabled: false,
+  syncConsumeEnabled: false,
+};
+const CFG_ON: DomainFitShadowConfig = { ...CFG_OFF, syncConsumeEnabled: true };
+
+function makeFakeCache(): DomainFitSyncConsumeCache & {
+  store: Map<string, DomainFitServeCacheEntry>;
+  getManyMock: jest.Mock;
+  setMock: jest.Mock;
+} {
+  const store = new Map<string, DomainFitServeCacheEntry>();
+  const getManyMock = jest.fn(async (ids: string[]) => {
+    const out = new Map<string, DomainFitServeCacheEntry>();
+    for (const id of ids) {
+      const entry = store.get(id);
+      if (entry) out.set(id, entry);
+    }
+    return out;
+  });
+  const setMock = jest.fn(async (id: string, entry: DomainFitServeCacheEntry) => {
+    store.set(id, entry);
+  });
+  return { store, getManyMock, setMock, getMany: getManyMock, set: setMock };
+}
+
+const cand = (id: string, title: string) => ({ youtubeVideoId: id, title });
+
+beforeEach(() => {
+  mockClassify.mockReset();
+});
+
+/** Drain any real setImmediate scheduled by the test that just ran (the
+ *  cache-warm path is deliberately fire-and-forget) — without this, a
+ *  pending warm classify call can fire during the NEXT test and pollute its
+ *  mockClassify call-count assertions. */
+afterEach(async () => {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+});
+
+describe('applyDomainFitSyncConsume — flag gating', () => {
+  it('flag OFF: zero cache calls, SAME array reference returned (byte-identical no-op)', async () => {
+    const cache = makeFakeCache();
+    const input = [cand('v1', 'a'), cand('v2', 'b')];
+    const result = await applyDomainFitSyncConsume(input, 'goal', CFG_OFF, cache);
+    expect(result.reordered).toBe(input);
+    expect(cache.getManyMock).not.toHaveBeenCalled();
+    expect(cache.setMock).not.toHaveBeenCalled();
+    expect(mockClassify).not.toHaveBeenCalled();
+  });
+
+  it('empty candidate list is a no-op even when enabled', async () => {
+    const cache = makeFakeCache();
+    const result = await applyDomainFitSyncConsume([], 'goal', CFG_ON, cache);
+    expect(result.reordered).toEqual([]);
+    expect(cache.getManyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyDomainFitSyncConsume — cache HIT (no synchronous classify call)', () => {
+  it('a cached 비적합 verdict demotes the candidate, count preserved, zero classify calls', async () => {
+    const cache = makeFakeCache();
+    await cache.set('v1', {
+      fit: '비적합',
+      lexicalConflict: false,
+      multiplier: 0.25,
+      model: 'mandala-gen:latest',
+      scoredAt: new Date().toISOString(),
+    });
+    const input = [cand('v1', '무관 제목'), cand('v2', '영어 회화 제목')];
+    const result = await applyDomainFitSyncConsume(input, '영어 회화', CFG_ON, cache);
+
+    expect(result.reordered).toHaveLength(2); // count preserved
+    expect(result.reordered.map((c) => c.youtubeVideoId)).toEqual(['v2', 'v1']); // demoted to tail
+    expect(result.demoted).toBe(1);
+    expect(result.cacheHits).toBe(1);
+    expect(mockClassify).not.toHaveBeenCalled(); // sync path NEVER classifies inline
+    expect(cache.getManyMock).toHaveBeenCalledTimes(1); // single batched read
+    expect(cache.getManyMock).toHaveBeenCalledWith(['v1', 'v2']);
+  });
+
+  it('cache-only reorder does not schedule a warm for already-cached candidates', () => {
+    // scheduleDomainFitSyncWarm is a no-op given an empty uncached list.
+    const cache = makeFakeCache();
+    scheduleDomainFitSyncWarm([], 'goal', CFG_ON, cache);
+    expect(cache.setMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyDomainFitSyncConsume — cache MISS (untouched + async warm enqueued)', () => {
+  it('uncached candidates keep multiplier 1 (untouched order) and are reported as enqueued', async () => {
+    const cache = makeFakeCache(); // empty store — every id misses
+    const input = [cand('v1', 'a'), cand('v2', 'b')];
+    const result = await applyDomainFitSyncConsume(input, 'goal', CFG_ON, cache);
+
+    expect(result.reordered).toHaveLength(2);
+    expect(result.reordered.map((c) => c.youtubeVideoId)).toEqual(['v1', 'v2']); // untouched order
+    expect(result.demoted).toBe(0);
+    expect(result.enqueued).toBe(2);
+    expect(mockClassify).not.toHaveBeenCalled(); // NOT scored synchronously
+  });
+
+  it('scheduleDomainFitSyncWarm is invoked with exactly the uncached candidates, never awaited by the caller', async () => {
+    mockClassify.mockResolvedValue({ fit: '적합', ms: 5, ok: true });
+    const cache = makeFakeCache();
+    const input = [cand('v1', 'a')];
+    const result = await applyDomainFitSyncConsume(input, 'goal', CFG_ON, cache);
+
+    // The request-path promise resolves BEFORE the warm classify runs —
+    // the real setImmediate has not fired yet, so cache.set has not been called.
+    expect(result.enqueued).toBe(1);
+    expect(cache.setMock).not.toHaveBeenCalled();
+    expect(mockClassify).not.toHaveBeenCalled();
+
+    // Let the scheduled real setImmediate + its internal await flush.
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockClassify).toHaveBeenCalledTimes(1);
+    expect(cache.setMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a classifier failure during warm is swallowed and never cached (fail-open)', async () => {
+    mockClassify.mockResolvedValue({ fit: null, ms: 5000, ok: false, error: 'timeout' });
+    const cache = makeFakeCache();
+    await applyDomainFitSyncConsume([cand('v1', 'a')], 'goal', CFG_ON, cache);
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockClassify).toHaveBeenCalledTimes(1);
+    expect(cache.setMock).not.toHaveBeenCalled(); // fail-open — never cached
+  });
+});
+
+describe('applyDomainFitSyncConsume — DROP invariant + overflow cap', () => {
+  it('candidates beyond maxCandidates are appended UNTOUCHED at the tail (never dropped)', async () => {
+    const cache = makeFakeCache();
+    const cfg = { ...CFG_ON, maxCandidates: 2 };
+    const input = [cand('v1', 'a'), cand('v2', 'b'), cand('v3', 'c'), cand('v4', 'd')];
+    const result = await applyDomainFitSyncConsume(input, 'goal', cfg, cache);
+    expect(result.reordered).toHaveLength(4);
+    expect(result.reordered.slice(2).map((c) => c.youtubeVideoId)).toEqual(['v3', 'v4']);
+    expect(cache.getManyMock).toHaveBeenCalledWith(['v1', 'v2']); // overflow never queried
+  });
+});
+
+describe('createNoopDomainFitSyncConsumeCache', () => {
+  it('getMany always returns an empty map; set() is a no-op', async () => {
+    const cache = createNoopDomainFitSyncConsumeCache();
+    await expect(cache.getMany(['v1'])).resolves.toEqual(new Map());
+    await expect(cache.set('v1', {} as DomainFitServeCacheEntry)).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/modules/domain-fit-write-gate.test.ts
+++ b/tests/unit/modules/domain-fit-write-gate.test.ts
@@ -49,6 +49,7 @@ const CFG: DomainFitShadowConfig = {
   writeEnforceEnabled: true,
   serveShadowEnabled: false,
   serveEnforceEnabled: false,
+  syncConsumeEnabled: false,
 };
 
 beforeEach(() => {

--- a/tests/unit/modules/domain-fit-write-shadow.test.ts
+++ b/tests/unit/modules/domain-fit-write-shadow.test.ts
@@ -50,6 +50,7 @@ const CFG_OFF: DomainFitShadowConfig = {
   writeEnforceEnabled: false,
   serveShadowEnabled: false,
   serveEnforceEnabled: false,
+  syncConsumeEnabled: false,
 };
 const CFG_ON: DomainFitShadowConfig = { ...CFG_OFF, writeShadowEnabled: true };
 

--- a/tests/unit/modules/pool-serve-diversity.test.ts
+++ b/tests/unit/modules/pool-serve-diversity.test.ts
@@ -1,0 +1,81 @@
+/**
+ * pool-serve-fill.ts — applyPoolServeDiversity (global channel hardCap wiring).
+ *
+ * Measured gap: hardChannelCap (diversity-guard.ts:312, V5_CHANNEL_HARD_CAP)
+ * was wired only into v5/executor.ts:219 — pool-serve-fill.ts's applyDiversity
+ * only ran dedupeSeries + softChannelCap. This pins the pool-serve wiring at
+ * the equivalent position (after softChannelCap), same demote-only semantics
+ * as the v5 executor call site.
+ */
+
+import {
+  applyPoolServeDiversity,
+  type GateCandidate,
+} from '@/modules/queue/handlers/pool-serve-fill';
+import type { DiversityGuardConfig } from '@/config/diversity-guard';
+
+const BASE_CFG: DiversityGuardConfig = {
+  enabled: true,
+  seriesSim: 0.8,
+  channelSoftCap: 2,
+  channelHardCap: 0,
+  channelHardCapMinCandidates: 3,
+  crossChannelDedupEnabled: false,
+  crossChannelDedupSim: 0.65,
+};
+
+function cand(id: string, channelTitle: string): GateCandidate {
+  return {
+    youtubeVideoId: id,
+    title: `title ${id}`,
+    description: null,
+    channelTitle,
+    thumbnail: null,
+    publishedAt: null,
+  };
+}
+
+describe('applyPoolServeDiversity — diversity.enabled gate', () => {
+  it('disabled: same array reference returned (byte-identical no-op)', () => {
+    const cfg: DiversityGuardConfig = { ...BASE_CFG, enabled: false, channelHardCap: 5 };
+    const input = [cand('v1', 'A')];
+    expect(applyPoolServeDiversity(input, [], cfg)).toBe(input);
+  });
+});
+
+describe('applyPoolServeDiversity — V5_CHANNEL_HARD_CAP=0 (default) is a no-op', () => {
+  it('channelHardCap=0: only dedupeSeries + softChannelCap run (existing behavior unchanged)', () => {
+    const cfg: DiversityGuardConfig = { ...BASE_CFG, channelHardCap: 0 };
+    // 4 distinct-channel candidates — softChannelCap(2) never fires (1 each).
+    const input = [cand('v1', 'A'), cand('v2', 'B'), cand('v3', 'C'), cand('v4', 'D')];
+    const out = applyPoolServeDiversity(input, [], cfg);
+    expect(out.map((c) => c.youtubeVideoId)).toEqual(['v1', 'v2', 'v3', 'v4']); // untouched order
+  });
+});
+
+describe('applyPoolServeDiversity — hardChannelCap honored (demote-only, count preserved)', () => {
+  it('cap=1: the 2nd+ card from one channel is demoted to the tail, never dropped', () => {
+    const cfg: DiversityGuardConfig = {
+      ...BASE_CFG,
+      channelSoftCap: 10, // soft cap high enough it never fires alone
+      channelHardCap: 1,
+      channelHardCapMinCandidates: 3,
+    };
+    const input = [cand('v1', 'A'), cand('v2', 'A'), cand('v3', 'B')];
+    const out = applyPoolServeDiversity(input, [], cfg);
+    expect(out).toHaveLength(3); // never dropped
+    expect(out.map((c) => c.youtubeVideoId)).toEqual(['v1', 'v3', 'v2']); // v2 demoted
+  });
+
+  it('below channelHardCapMinCandidates: hard cap does not fire (thin-supply protection)', () => {
+    const cfg: DiversityGuardConfig = {
+      ...BASE_CFG,
+      channelSoftCap: 10,
+      channelHardCap: 1,
+      channelHardCapMinCandidates: 10, // pool below this size
+    };
+    const input = [cand('v1', 'A'), cand('v2', 'A')];
+    const out = applyPoolServeDiversity(input, [], cfg);
+    expect(out.map((c) => c.youtubeVideoId)).toEqual(['v1', 'v2']); // untouched
+  });
+});


### PR DESCRIPTION
## What (supervisor-approved structure, R24+1)

1. **Sync-path cache-consume deboost** — flag `DOMAIN_FIT_SYNC_CONSUME` (default **false** = zero behavior/timing change). When ON, the add-cards v5 response path (add-cards.ts:465-486, post-executor gate band) does a single batched `video_id = ANY($1)` read of `video_domain_fit_cache` and applies the same demote-only multiplier reorder as serve-enforce — **zero synchronous Ollama calls**. Cache misses are untouched (multiplier 1) and enqueue a fire-and-forget async classify+persist (never awaited; classifier-unavailable results are NOT cached — same fail-open contract).
2. **Shared pure helpers** — `reorderByMultiplier` + `scoreAndCacheDomainFit` extracted from serve-enforce; enforce and sync-consume share one implementation (no logic fork).
3. **Global channel hard-cap wired into pool-serve** — measured gap: `hardChannelCap` (V5_CHANNEL_HARD_CAP, #1103) was wired only in the v5 executor; pool-serve applied only softChannelCap. New pure `applyPoolServeDiversity` (dedupeSeries → softChannelCap → hardChannelCap) used by pool-serve-fill. `V5_CHANNEL_HARD_CAP=0` (default) stays a no-op.

## Wizard synchronous-serving coverage — answer: (ii) separate follow-up

Measured basis (origin/main):
- Wizard card **selection is finalized at precompute time inside the v5 executor** (final slice). `consumePrecompute` promotes ALL precomputed rows (wizard-precompute.ts:495-575, all-rows auto-add) — a consume-time reorder would not change placement.
- At precompute time **the mandala does not exist yet** (wizard-precompute.ts comment "mandala did not exist at precompute time") — `video_domain_fit_cache` PK is (video_id, mandala_id), so the cache cannot be queried on that path as-is.
- Fixing this needs a goal-keyed cache (or the redesign's unified gate=pool-load chokepoint) — redesign-gate scope, not this bundle.
- **Stated limitation**: until then, wizard initial placement gets no domain-fit treatment; only the async pool-refill top-up (enforce, #1104/#1105) is covered. James wizard 실측 must be read with that scope.

## Verification

- 35 tests green (14 new: sync-consume 9 + pool-serve diversity 5), wider domain-fit suite 154 green, `tsc --noEmit` 0 errors — re-verified after cherry-pick rebase onto origin/main (post-#1104 squash).
- Not yet verified (honest gap): live-DB round trip of the batched cache read (unit tests mock `$queryRaw`) — to be exercised on dev before the flag flips.

## Rollback

Both features flag-gated / env-gated; rollback = flag off (config-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)