### PR TITLE
feat(supply): P3 flip — admit yt_promoted into pool-serve sources

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -197,6 +197,12 @@ services:
       # V5_SERIES_DEDUP_SIM (0.8) / V5_CHANNEL_SOFT_CAP (2 = demote from 3rd).
       # Revert: delete this line + redeploy → code default false (기존 동작).
       - V5_DIVERSITY_GUARD=true
+      # P3 supply flip (2026-07-06, supervisor green-light + James durable delegation).
+      # Admit yt_promoted (7,064 direct-collected, currently unused) into pool-serve
+      # sources alongside v2_promoted (1,365 active). Probe pattern — measure niche
+      # (기타/DA) re-serve poolPassed/livePassed then decide retain vs revert.
+      # Revert: delete this line + redeploy → code default POOL_SOURCES_BASE=['v2_promoted'].
+      - POOL_SERVE_SOURCES_EXTRA=yt_promoted
       # 2026-07-06 (James [GO], supervisor canary) — global channel HARD cap.
       # The per-cell soft cap (2/cell) can't see a channel spread 2 across N cells
       # (measured: 말트영어 10/49 in a 5-cell 영어 add_cards trace, zero per-cell


### PR DESCRIPTION
## What
Adds `POOL_SERVE_SOURCES_EXTRA=yt_promoted` to the prod api service env, so pool-serve draws from the **7,064 direct-collected yt_promoted rows** alongside `v2_promoted` (1,365 active).

## Why
Supply starvation was measured as a root cause of the search-quality collapse: pool had a single active source (`v2_promoted` 1,365) while 7,064 yt_promoted rows sat unused. This flip is the **P3 supply lever** from the search-redesign track.

## How it works
`pool-serve-fill.ts:169` — `sourcesExtra.length > 0 ? [...POOL_SOURCES_BASE, ...cfg.sourcesExtra] : POOL_SOURCES_BASE`. Setting the env expands the source set; the sync/consume path (`:366-377`) already merges `yt_promoted` keyword-first.

## Scope
- Affects **pool-serve only** (not the v3 live tier1 path, which reads `V3_TIER1_SOURCES=v2_promoted` separately — a second flip if live coverage is wanted later).
- `channelKey` falls back to `channel_name` (6,987/7,064 populated) so the channel cap holds despite NULL channel_id.

## Probe pattern
Measure niche (기타/DA) re-serve `poolPassed`/`livePassed`/total-served after deploy, then decide retain vs revert.

## Rollback
Delete the env line + redeploy → code default `POOL_SOURCES_BASE=['v2_promoted']` (no-op). Fully reversible flag.

Supervisor green-light + James durable delegation (2026-07-06).

🤖 Generated with [Claude Code](https://claude.com/claude-code)