### PR TITLE
feat(supply): admit yt_promoted into v3 live tier1 sources

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -545,7 +545,12 @@ services:
       # cross-domain noise). Restructured query (eligible CTE first) makes the
       # source filter actually shrink the cosine scan.
       # Rollback: append ,batch_trend — but expect 45-100s Tier 1.
-      - V3_TIER1_SOURCES=v2_promoted
+      # 2026-07-07 (supervisor GO, veto-by-exception) — admit yt_promoted into the
+      # live tier1 path (add-cards/wizard v3) so the Phase 1+2 supply repair
+      # (yt_promoted 84→7,084 active, title-restored) reaches the wizard sync path,
+      # not just pool-serve. Test-condition setup for the 0707 wizard verification.
+      # Rollback: delete yt_promoted → code default ['v2_promoted'] (env one-liner).
+      - V3_TIER1_SOURCES=v2_promoted,yt_promoted
       - V3_SEMANTIC_MIN_COSINE=0.5
       # BL-17 (2026-07-04) — fail-closed empty-title guard. SCRUB (YouTube ToS
       # 30d metadata wipe, is_active-agnostic) + /like zombie upsert leave ~691


### PR DESCRIPTION
## What
Adds `yt_promoted` to `V3_TIER1_SOURCES` (was `v2_promoted` only) so the live add-cards/wizard v3 tier1 path draws from the repaired yt_promoted pool.

## Why
Phase 1+2 supply repair activated yt_promoted 84→7,084 (title-restored via UPDATE-join). That reaches **pool-serve** (via `POOL_SERVE_SOURCES_EXTRA`, #1107) but NOT the **v3 live tier1** path (`matchFromVideoPool`, cache-matcher.ts) which reads `V3_TIER1_SOURCES` separately. This flip closes that gap so the 0707 wizard verification measures the fully-wired state once (saves a re-test quota cycle).

## Risk (honest)
- yt_promoted `quality_tier` was assigned without titles (junk tier, re-scoring pending).
- executor path has no domain-fit enforce → pool-origin noise may surface in cards. That surfacing IS test information (shows the demote-stack is not yet wired).

## Rollback
Delete `yt_promoted` from the env line → code default `['v2_promoted']`. Fully reversible flag.

Supervisor GO (veto-by-exception, 2026-07-07). Test-condition setup, not a standing serving change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)