### PR TITLE
feat(grid): P3 Stage 1 — global sort [최신순|조회수] + NEW badge + view_count

### DIFF
--- a/frontend/src/entities/card/model/types.ts
+++ b/frontend/src/entities/card/model/types.ts
@@ -37,6 +37,8 @@ export interface InsightCard {
   updatedAt?: Date;
   /** Source-material publish date (YouTube upload, article date), NOT createdAt. */
   publishedAt?: Date | null;
+  /** P3 Stage 1 (CP513) — YouTube view_count for the 조회수 sort. NULL when absent. */
+  viewCount?: number | null;
   cellIndex: number;
   levelId: string; // Which mandala level this card belongs to
   mandalaId?: string | null; // Which mandala this card belongs to

--- a/frontend/src/features/card-management/lib/youtubeToInsightCard.ts
+++ b/frontend/src/features/card-management/lib/youtubeToInsightCard.ts
@@ -44,6 +44,8 @@ export function convertToInsightCard(data: UserVideoStateWithVideo): InsightCard
     autoAdded: data.auto_added ?? false,
     // CP498 PR3c — user-scoped A-stage relevance score (uvs.relevance_pct).
     relevancePct: data.relevance_pct ?? null,
+    // P3 Stage 1 (CP513) — 조회수 sort key (YouTube view_count).
+    viewCount: video.view_count ?? null,
   };
 }
 

--- a/frontend/src/features/recommendation-feed/lib/recommendationToInsightCard.ts
+++ b/frontend/src/features/recommendation-feed/lib/recommendationToInsightCard.ts
@@ -35,6 +35,14 @@ export function recommendationToInsightCard(
     publishedAt: (rec as Record<string, unknown>).publishedAt
       ? new Date((rec as Record<string, unknown>).publishedAt as string)
       : null,
+    // P3 Stage 1 (CP513) — 조회수 sort key. rec_cache HAS view_count, but the
+    // recommendations API does not yet surface it (BE read-additive pending) —
+    // read either casing when present, else NULL (sorts NULLS LAST).
+    viewCount: ((): number | null => {
+      const r = rec as unknown as Record<string, unknown>;
+      const v = typeof r.viewCount === 'number' ? r.viewCount : r.view_count;
+      return typeof v === 'number' && Number.isFinite(v) ? v : null;
+    })(),
     cellIndex: rec.cellIndex ?? -1,
     levelId: 'root',
     mandalaId,

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -651,6 +651,9 @@
     "retryEnrichmentTooltip": "Retry caption fetch",
     "enrichingAria": "Analyzing"
   },
+  "gridView": {
+    "badgeNew": "NEW"
+  },
   "contextHeader": {
     "home": "Home",
     "mandala": "Mandala",
@@ -661,9 +664,8 @@
     "clearAll": "Clear all",
     "noFilterResults": "No cards match the selected filters",
     "sortLatest": "Latest",
-    "sortOldest": "Oldest",
-    "sortTitleAZ": "Title A-Z",
-    "sortTitleZA": "Title Z-A",
+    "sortViews": "Views",
+    "sortGlobalNotice": "Sort applies to all mandalas",
     "sortRelevance": "By relevance",
     "selectSectorFirst": "Select a sector",
     "selectSectorDesc": "Choose a sector from the pills above to assign cards."

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -659,6 +659,9 @@
     "retryEnrichmentTooltip": "자막을 다시 가져옵니다",
     "enrichingAria": "분석 중"
   },
+  "gridView": {
+    "badgeNew": "NEW"
+  },
   "contextHeader": {
     "home": "홈",
     "mandala": "만다라",
@@ -669,9 +672,8 @@
     "clearAll": "모두 해제",
     "noFilterResults": "선택한 필터에 맞는 카드가 없습니다",
     "sortLatest": "최신순",
-    "sortOldest": "오래된순",
-    "sortTitleAZ": "제목 A-Z",
-    "sortTitleZA": "제목 Z-A",
+    "sortViews": "조회수",
+    "sortGlobalNotice": "정렬이 모든 만다라에 적용됩니다",
     "sortRelevance": "관련도순",
     "selectSectorFirst": "섹터를 선택하세요",
     "selectSectorDesc": "카드를 배치할 섹터를 먼저 선택해주세요."

--- a/frontend/src/widgets/card-list-view/ui/CardListView.tsx
+++ b/frontend/src/widgets/card-list-view/ui/CardListView.tsx
@@ -11,16 +11,7 @@ import { ListView } from '@/widgets/list-view';
 import { DetailPanel } from '@/widgets/detail-panel';
 import { GraphView } from '@/components/graph/GraphView';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/shared/ui/resizable';
-import {
-  LayoutGrid,
-  Grid3X3,
-  Plus,
-  GripVertical,
-  ArrowDownWideNarrow,
-  ArrowUpWideNarrow,
-  ArrowDownAZ,
-  ArrowDownZA,
-} from 'lucide-react';
+import { LayoutGrid, Grid3X3, Plus, GripVertical, ArrowDownWideNarrow, Eye } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -29,8 +20,13 @@ import {
   DropdownMenuRadioItem,
 } from '@/shared/ui/dropdown-menu';
 import { Slider } from '@/shared/ui/slider';
+import { toast } from '@/shared/lib/use-toast';
 import { ContextHeader, SORT_OPTIONS, type SortMode } from './ContextHeader';
 import { LabelFilterPillsV2 } from './LabelFilterPillsV2';
+
+// P3 Stage 1 (CP513) — global (cross-mandala) sort persistence keys.
+const GLOBAL_SORT_KEY = 'insighta:cardSortMode';
+const GLOBAL_SORT_TOAST_KEY = 'insighta:cardSortMode:toastShown';
 
 /**
  * CP498 PR3c — A-stage relevance comparator: DESC, NULLS LAST. `?? -1` sinks
@@ -48,11 +44,9 @@ export const compareByRelevanceDesc = (a: InsightCard, b: InsightCard): number =
 
 const SORT_ICON_BY_VALUE: Record<SortMode, typeof ArrowDownWideNarrow> = {
   latest: ArrowDownWideNarrow,
-  oldest: ArrowUpWideNarrow,
-  'title-asc': ArrowDownAZ,
-  'title-desc': ArrowDownZA,
-  // CP498 PR3c — reuse the descending icon; a dedicated relevance glyph /
-  // numeric badge is deferred (visual signal = later per spec).
+  views: Eye,
+  // relevance-desc stays in the type (hidden from SORT_OPTIONS until coverage
+  // ≥60%); reuse the descending icon for when it is re-exposed.
   'relevance-desc': ArrowDownWideNarrow,
 };
 
@@ -228,29 +222,30 @@ export function CardListView({
   // change → re-snapshot with the latest scores on re-pick.
   const [relevanceRank, setRelevanceRank] = useState<Map<string, number> | null>(null);
 
-  // CP499 #1 — persist sort PER-MANDALA (was ephemeral useState → reset to
-  // 'latest' on every refresh). Each mandala keeps its own fit (new w/ scores →
-  // relevance, old → latest).
-  const sortStorageKey = mandalaId ? `insighta:cardSortMode:${mandalaId}` : null;
+  // P3 Stage 1 (CP513, 2026-07-07 supervisor) — sort is now a GLOBAL setting:
+  // one key applies to ALL mandalas (James's original "글로벌 일괄 적용" order).
+  // Supersedes the CP499 per-mandala key. Old `insighta:cardSortMode:<id>` keys
+  // are ignored (no migration — dead-option values are meaningless to carry;
+  // global default resets to 'latest'). First change fires a one-time toast.
   useEffect(() => {
-    if (!sortStorageKey) {
-      setSortMode('latest');
-      setRelevanceRank(null);
-      return;
-    }
-    const saved = localStorage.getItem(sortStorageKey);
+    const saved = localStorage.getItem(GLOBAL_SORT_KEY);
     const valid = SORT_OPTIONS.some((o) => o.value === saved);
     setSortMode(valid ? (saved as SortMode) : 'latest');
     setRelevanceRank(null); // freeze effect re-snapshots below if relevance
-  }, [sortStorageKey]);
+  }, [mandalaId]);
 
   const handleSortChange = useCallback(
     (v: SortMode) => {
       setSortMode(v);
       setRelevanceRank(null); // clear → freeze effect re-snapshots if relevance
-      if (sortStorageKey) localStorage.setItem(sortStorageKey, v);
+      localStorage.setItem(GLOBAL_SORT_KEY, v);
+      // First-ever global sort change → one-time notice that it applies everywhere.
+      if (!localStorage.getItem(GLOBAL_SORT_TOAST_KEY)) {
+        localStorage.setItem(GLOBAL_SORT_TOAST_KEY, '1');
+        toast({ title: t('contextHeader.sortGlobalNotice', '정렬이 모든 만다라에 적용됩니다') });
+      }
     },
-    [sortStorageKey]
+    [t]
   );
 
   const [isExternalDragOver, setIsExternalDragOver] = useState(false);
@@ -403,21 +398,15 @@ export function CardListView({
           if (!aHas && !bHas) return 0;
           return mb - ma;
         });
-      case 'oldest':
+      case 'views':
+        // P3 Stage 1 (CP513) — YouTube view_count DESC, NULLS LAST. Honest
+        // "조회수" (global popularity), NOT "많이 본" (user watch — that axis has
+        // no data yet, behavioural-signal backlog). Stable tiebreak by id.
         return arr.sort((a, b) => {
-          const ma = getPublishedMs(a);
-          const mb = getPublishedMs(b);
-          const aHas = Number.isFinite(ma);
-          const bHas = Number.isFinite(mb);
-          if (aHas && !bHas) return -1;
-          if (!aHas && bHas) return 1;
-          if (!aHas && !bHas) return 0;
-          return ma - mb;
+          const va = a.viewCount ?? -1;
+          const vb = b.viewCount ?? -1;
+          return vb !== va ? vb - va : a.id.localeCompare(b.id);
         });
-      case 'title-asc':
-        return arr.sort((a, b) => (a.title || '').localeCompare(b.title || ''));
-      case 'title-desc':
-        return arr.sort((a, b) => (b.title || '').localeCompare(a.title || ''));
       case 'relevance-desc':
         // CP499 — render in the FROZEN snapshot order (relevanceRank) so the
         // ~17s of background relevance_pct updates don't reorder cards under the

--- a/frontend/src/widgets/card-list-view/ui/ContextHeader.tsx
+++ b/frontend/src/widgets/card-list-view/ui/ContextHeader.tsx
@@ -3,17 +3,17 @@ import { Trash2 } from 'lucide-react';
 import type { ViewMode } from '@/entities/user/model/types';
 import { ViewSwitcher } from '@/features/view-mode';
 
-export type SortMode = 'latest' | 'oldest' | 'title-asc' | 'title-desc' | 'relevance-desc';
+// P3 Stage 1 (CP513, 2026-07-07 supervisor) — visible sort reduced to
+// [latest (default), views (조회수)]. 'oldest' + title sorts removed.
+// 'relevance-desc' stays in the TYPE + comparator (logic preserved) but is NOT
+// exposed here until user-scoped relevance coverage ≥60% (currently 5.7%, so a
+// relevance default would silently degrade to createdAt mislabelled as 관련도).
+// Re-exposing later = one line back into SORT_OPTIONS.
+export type SortMode = 'latest' | 'views' | 'relevance-desc';
 
 export const SORT_OPTIONS: { value: SortMode; labelKey: string }[] = [
   { value: 'latest', labelKey: 'contextHeader.sortLatest' },
-  // CP498 PR3c — A-stage relevance placed 2nd (right after the familiar default
-  // 최신순, above title sorts): "핵심이지만 명시 선택" signal. Default selection
-  // stays 'latest' (CardListView sortMode default) — position only, not default.
-  { value: 'relevance-desc', labelKey: 'contextHeader.sortRelevance' },
-  { value: 'oldest', labelKey: 'contextHeader.sortOldest' },
-  { value: 'title-asc', labelKey: 'contextHeader.sortTitleAZ' },
-  { value: 'title-desc', labelKey: 'contextHeader.sortTitleZA' },
+  { value: 'views', labelKey: 'contextHeader.sortViews' },
 ];
 
 interface ContextHeaderProps {

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -31,6 +31,10 @@ import { ScrollableChipRow } from '@/shared/ui/scrollable-chip-row';
 // never shown to the user, so these are display-only thresholds).
 const RELEVANCE_TIER_CORE = 80; // ≥80 → "핵심"
 const RELEVANCE_TIER_PICK = 70; // 70–79 → "추천" ; <70 → no badge (number never shown)
+
+// P3 Stage 1 (CP513) — "NEW" corner badge shows while a card is younger than this.
+const NEW_BADGE_HOURS = 48;
+const NEW_BADGE_MS = NEW_BADGE_HOURS * 60 * 60 * 1000;
 const RELEVANCE_DIM_MAX = 30; // ≤30 relevance → toned down (unless bookmarked)
 
 // Tier badge styles — complete class strings (RING_STYLES pattern, NO dynamic
@@ -389,9 +393,7 @@ export function InsightCardItemV2({
   // simply stays empty until the next refetch lands the real value.
   // Honest label: a missing publish date must not masquerade as one —
   // the createdAt fallback is rendered as "added N days ago" instead.
-  const relDate = metadataComplete
-    ? formatCardDateLabel(ytMeta.publishedAt, card.createdAt)
-    : null;
+  const relDate = metadataComplete ? formatCardDateLabel(ytMeta.publishedAt, card.createdAt) : null;
   const hasNote = !!card.userNote?.trim();
   // CP475+ blockquote source priority (user-confirmed 2026-05-20):
   // The v2 quick path's `core_argument` is a heavily-simplified Korean
@@ -451,6 +453,10 @@ export function InsightCardItemV2({
   const dimLowRelevance =
     card.relevancePct != null && card.relevancePct <= RELEVANCE_DIM_MAX && !liked;
 
+  // P3 Stage 1 (CP513) — "NEW" badge while the card is < NEW_BADGE_HOURS old.
+  const isNew =
+    card.createdAt != null && Date.now() - new Date(card.createdAt).getTime() < NEW_BADGE_MS;
+
   return (
     <Card
       ref={setNodeRef}
@@ -507,6 +513,21 @@ export function InsightCardItemV2({
             aria-hidden="true"
           />
         </div>
+      )}
+
+      {/* P3 Stage 1 (CP513) — "NEW" corner badge at the card-frame level (not on
+          the thumbnail overlay, so it stays put before the image loads). Reuses
+          the explore card-badge grammar: pill, primary(indigo) bg, no new color. */}
+      {isNew && (
+        <span
+          className={cn(
+            'absolute top-2 right-2 z-10 rounded-[4px] px-2 py-[3px]',
+            'text-[10px] font-semibold leading-none tracking-[0.2px]',
+            'bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))]'
+          )}
+        >
+          {t('gridView.badgeNew', 'NEW')}
+        </span>
       )}
 
       {/* ── Thumbnail ── */}

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -2067,6 +2067,9 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       source: row.weight_version === 0 ? ('manual' as const) : ('auto_recommend' as const),
       recReason: row.rec_reason,
       publishedAt: row.published_at?.toISOString() ?? null,
+      // P3 Stage 1 (CP513) — pure additive field for the FE 조회수 sort. Does NOT
+      // touch ranking/filter/write (rec_score ordering + selection unchanged).
+      viewCount: row.view_count ?? null,
       startSec: anchors.get(row.video_id) ?? null,
       pinnedAt: pinnedAtByVideoId.get(row.video_id)?.toISOString() ?? null,
     }));


### PR DESCRIPTION
## What (P3 Stage 1, CP513 supervisor track)
Grid sort redesign — FE-only + one additive BE field. **Serving pipeline / flags / data untouched.**

- **Global sort scope**: per-mandala key → one global key + one-time toast ("applies to all mandalas").
- **Options** = [Latest (default) | Views]. Removed oldest/title sorts. `relevance-desc` kept in type+comparator but **hidden** until user-relevance coverage ≥60% (currently 5.7% → relevance default would be a silent createdAt fallback).
- **'Views'(조회수)** = YouTube view_count DESC. Honest popularity label, NOT "많이 본"(user watch — no data yet). view_count threaded: InsightCard + 2 converters + **pure additive field** on recommendations API (no ranking/filter/write touch).
- **NEW badge** (createdAt < 48h, NEW_BADGE_HOURS const) on the card frame, primary token reused.
- Dead sort i18n keys removed.

## Diff (9 files, +86/−48, 편승 0)
| file | ± |
|---|---|
| card-list-view/ContextHeader.tsx | +8/−8 |
| card-list-view/CardListView.tsx | +33/−31 |
| card-list/InsightCardItemV2.tsx | +23 |
| entities/card/types.ts | +2 |
| card-management/youtubeToInsightCard.ts | +2 |
| recommendation-feed/recommendationToInsightCard.ts | +8 |
| i18n/ko.json, en.json | +8/−4 each |
| api/routes/mandalas.ts | +3 |

## Verified
FE tsc clean · vitest 5 sort tests pass · **live browser**: dropdown [최신순·조회수] + view_count re-sort (2.7M→1.8M). Supervisor-approved, James prod-gate released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)