### PR TITLE
feat(grid): P3 Stage 2 — 3-filter sort [관련도순 default|최신순|조회수] + relevance backfill

### DIFF
--- a/frontend/src/features/recommendation-feed/lib/recommendationToInsightCard.ts
+++ b/frontend/src/features/recommendation-feed/lib/recommendationToInsightCard.ts
@@ -43,6 +43,13 @@ export function recommendationToInsightCard(
       const v = typeof r.viewCount === 'number' ? r.viewCount : r.view_count;
       return typeof v === 'number' && Number.isFinite(v) ? v : null;
     })(),
+    // P3 Stage 2 (CP513) — 관련도순 sort key. rec_cache.relevance_pct surfaced via
+    // the recommendations API (relevancePct). NULL until the pgvector backfill runs.
+    relevancePct: ((): number | null => {
+      const r = rec as unknown as Record<string, unknown>;
+      const v = typeof r.relevancePct === 'number' ? r.relevancePct : r.relevance_pct;
+      return typeof v === 'number' && Number.isFinite(v) ? v : null;
+    })(),
     cellIndex: rec.cellIndex ?? -1,
     levelId: 'root',
     mandalaId,

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -652,7 +652,7 @@
     "enrichingAria": "Analyzing"
   },
   "gridView": {
-    "badgeNew": "NEW"
+    "badgeNew": "Added"
   },
   "contextHeader": {
     "home": "Home",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -660,7 +660,7 @@
     "enrichingAria": "분석 중"
   },
   "gridView": {
-    "badgeNew": "NEW"
+    "badgeNew": "추가됨"
   },
   "contextHeader": {
     "home": "홈",

--- a/frontend/src/widgets/card-list-view/ui/CardListView.tsx
+++ b/frontend/src/widgets/card-list-view/ui/CardListView.tsx
@@ -28,19 +28,39 @@ import { LabelFilterPillsV2 } from './LabelFilterPillsV2';
 const GLOBAL_SORT_KEY = 'insighta:cardSortMode';
 const GLOBAL_SORT_TOAST_KEY = 'insighta:cardSortMode:toastShown';
 
-/**
- * CP498 PR3c — A-stage relevance comparator: DESC, NULLS LAST. `?? -1` sinks
- * null/undefined relevancePct below any real 0-100 score. Pure + exported so
- * the ordering contract (highest-first, unscored-last) is unit-tested against a
- * sign-flip regression. NEVER reads the video-keyed v2MandalaRelevancePct.
- */
-export const compareByRelevanceDesc = (a: InsightCard, b: InsightCard): number => {
-  // DESC by relevancePct (NULLS LAST via ?? -1) + stable tiebreak by id so the
-  // large equal-score band (title-only "70s cluster") does NOT reshuffle on
-  // refetch — e.g. after a Heart/like invalidates the cards query. CP498 PR3c.
-  const d = (b.relevancePct ?? -1) - (a.relevancePct ?? -1);
-  return d !== 0 ? d : a.id.localeCompare(b.id);
+// P3 Stage 2 (CP513, James finalize) — NULL-relevance cards must NOT be dumped
+// to the bottom ("createdAt 혼합 폴백, 최하단 강등 금지"). An unscored card falls
+// back to a recency proxy: createdAt mapped onto a [0, NULL_RECENCY_CAP] band so
+// a brand-new card interleaves near the mid tier instead of sinking below every
+// scored card. Capped below the 추천(70)/핵심(80) tiers so a real high-relevance
+// hit still outranks a fresh unscored card. Post-backfill NULLs are rare.
+const NULL_RECENCY_CAP = 60;
+const NULL_RECENCY_WINDOW_MS = 90 * 24 * 60 * 60 * 1000; // 90d linear fade to 0
+
+/** Relevance sort value: real 0-100 score, or a recency proxy when unscored. */
+export const relevanceSortValue = (c: InsightCard, nowMs: number): number => {
+  if (c.relevancePct != null) return c.relevancePct;
+  const created = c.createdAt ? new Date(c.createdAt).getTime() : 0;
+  const frac = Math.max(0, 1 - (nowMs - created) / NULL_RECENCY_WINDOW_MS);
+  return frac * NULL_RECENCY_CAP;
 };
+
+/**
+ * A-stage relevance comparator: DESC by relevance, NULL cards interleaved by
+ * recency (see relevanceSortValue). `nowMs` is threaded so the comparator stays
+ * pure/testable. Stable id tiebreak keeps the equal-score band from reshuffling
+ * on refetch. NEVER reads the video-keyed v2MandalaRelevancePct.
+ */
+export const makeRelevanceComparator =
+  (nowMs: number) =>
+  (a: InsightCard, b: InsightCard): number => {
+    const d = relevanceSortValue(b, nowMs) - relevanceSortValue(a, nowMs);
+    return d !== 0 ? d : a.id.localeCompare(b.id);
+  };
+
+/** Back-compat default comparator (uses current time). */
+export const compareByRelevanceDesc = (a: InsightCard, b: InsightCard): number =>
+  makeRelevanceComparator(Date.now())(a, b);
 
 const SORT_ICON_BY_VALUE: Record<SortMode, typeof ArrowDownWideNarrow> = {
   latest: ArrowDownWideNarrow,
@@ -215,7 +235,7 @@ export function CardListView({
   const [activeCard, setActiveCard] = useState<InsightCard | null>(null);
   const [isMobile, setIsMobile] = useState(false);
   const [selectedCardIds, setSelectedCardIds] = useState<string[]>([]);
-  const [sortMode, setSortMode] = useState<SortMode>('latest');
+  const [sortMode, setSortMode] = useState<SortMode>('relevance-desc');
   // CP499 freeze — snapshot of the relevance order (id→rank), captured when
   // relevance-sort is (re)selected, so background scoring (~17s of relevance_pct
   // updates) does NOT live-reorder cards under the user. Cleared on sort/mandala
@@ -226,11 +246,13 @@ export function CardListView({
   // one key applies to ALL mandalas (James's original "글로벌 일괄 적용" order).
   // Supersedes the CP499 per-mandala key. Old `insighta:cardSortMode:<id>` keys
   // are ignored (no migration — dead-option values are meaningless to carry;
-  // global default resets to 'latest'). First change fires a one-time toast.
+  // global default is now 'relevance-desc' — P3 Stage 2 (James finalize) makes
+  // relevance the default once the pgvector backfill populates coverage). First
+  // change fires a one-time toast.
   useEffect(() => {
     const saved = localStorage.getItem(GLOBAL_SORT_KEY);
     const valid = SORT_OPTIONS.some((o) => o.value === saved);
-    setSortMode(valid ? (saved as SortMode) : 'latest');
+    setSortMode(valid ? (saved as SortMode) : 'relevance-desc');
     setRelevanceRank(null); // freeze effect re-snapshots below if relevance
   }, [mandalaId]);
 

--- a/frontend/src/widgets/card-list-view/ui/ContextHeader.tsx
+++ b/frontend/src/widgets/card-list-view/ui/ContextHeader.tsx
@@ -3,15 +3,15 @@ import { Trash2 } from 'lucide-react';
 import type { ViewMode } from '@/entities/user/model/types';
 import { ViewSwitcher } from '@/features/view-mode';
 
-// P3 Stage 1 (CP513, 2026-07-07 supervisor) — visible sort reduced to
-// [latest (default), views (조회수)]. 'oldest' + title sorts removed.
-// 'relevance-desc' stays in the TYPE + comparator (logic preserved) but is NOT
-// exposed here until user-scoped relevance coverage ≥60% (currently 5.7%, so a
-// relevance default would silently degrade to createdAt mislabelled as 관련도).
-// Re-exposing later = one line back into SORT_OPTIONS.
+// P3 Stage 2 (CP513, 2026-07-07 James finalize) — restored to the approved
+// 3-filter design: [relevance (default) | latest | most-viewed]. relevance is
+// re-exposed AND made the default now that the pgvector relevance backfill
+// populates coverage (P3 Stage 1 hid it at 5.7% to avoid a NULL-default fraud).
+// 'views' keeps its view_count DESC backing and the honest "조회수" label.
 export type SortMode = 'latest' | 'views' | 'relevance-desc';
 
 export const SORT_OPTIONS: { value: SortMode; labelKey: string }[] = [
+  { value: 'relevance-desc', labelKey: 'contextHeader.sortRelevance' },
   { value: 'latest', labelKey: 'contextHeader.sortLatest' },
   { value: 'views', labelKey: 'contextHeader.sortViews' },
 ];

--- a/frontend/src/widgets/card-list-view/ui/cardSort.relevance.test.ts
+++ b/frontend/src/widgets/card-list-view/ui/cardSort.relevance.test.ts
@@ -1,73 +1,72 @@
 /**
- * CP498 PR3c — "관련도순" comparator: DESC, NULLS LAST.
+ * "관련도순" comparator contract (P3 Stage 2, CP513 James finalize).
  *
- * Locks the ordering contract against a sign-flip / null-handling regression:
  *   - higher relevancePct ranks first;
- *   - cards with null/undefined relevancePct sink to the bottom (never removed).
+ *   - a real 0 is a score (ranks above any lower/proxied value);
+ *   - NULL-relevance cards are NOT dumped to the bottom — they fall back to a
+ *     recency proxy (createdAt) so a fresh unscored card interleaves near the
+ *     mid tier (cap 60, below 추천 70 / 핵심 80), and an old unscored card fades
+ *     toward 0. `makeRelevanceComparator(nowMs)` is pure (now is threaded).
+ *   - ties break by id ascending — stable across refetch.
  */
 import { describe, it, expect } from 'vitest';
-import { compareByRelevanceDesc } from './CardListView';
+import { makeRelevanceComparator, relevanceSortValue } from './CardListView';
 import type { InsightCard } from '@/entities/card/model/types';
 
-function card(id: string, relevancePct: number | null | undefined): InsightCard {
+const NOW = new Date('2026-07-08T00:00:00Z').getTime();
+const cmp = makeRelevanceComparator(NOW);
+const daysAgo = (d: number) => new Date(NOW - d * 24 * 60 * 60 * 1000);
+
+function card(
+  id: string,
+  relevancePct: number | null | undefined,
+  createdAt = daysAgo(200)
+): InsightCard {
   return {
     id,
     videoUrl: `https://x/${id}`,
     title: id,
     thumbnail: '',
     userNote: '',
-    createdAt: new Date('2026-01-01'),
+    createdAt,
     cellIndex: 0,
     levelId: 'root',
     relevancePct,
   } as InsightCard;
 }
 
-describe('compareByRelevanceDesc — DESC NULLS LAST', () => {
-  it('orders by relevancePct descending, unscored last', () => {
+describe('relevance comparator — DESC, NULL interleaved by recency', () => {
+  it('orders scored cards by relevancePct descending', () => {
+    const arr = [card('off-low', 5), card('rel-high', 82), card('mid', 62)];
+    expect([...arr].sort(cmp).map((c) => c.id)).toEqual(['rel-high', 'mid', 'off-low']);
+  });
+
+  it('an OLD unscored card sinks toward the bottom (proxy → 0), below scored cards', () => {
+    const arr = [card('null-old', null, daysAgo(200)), card('off-low', 5), card('mid', 62)];
+    // null-old proxy ≈ 0 (>90d) → below 5 and 62.
+    expect([...arr].sort(cmp).map((c) => c.id)).toEqual(['mid', 'off-low', 'null-old']);
+  });
+
+  it('a FRESH unscored card interleaves (NOT bottom) — above low scores, below high', () => {
     const arr = [
-      card('off-low', 5),
-      card('null-a', null),
       card('rel-high', 82),
-      card('undef', undefined),
-      card('mid', 62),
+      card('null-fresh', null, daysAgo(0)), // proxy = 60
+      card('off-low', 5),
     ];
-    const sorted = [...arr].sort(compareByRelevanceDesc).map((c) => c.id);
-    // 82 > 62 > 5 > (null/undefined at the bottom, in any order among themselves)
-    expect(sorted.slice(0, 3)).toEqual(['rel-high', 'mid', 'off-low']);
-    expect(sorted.slice(3).sort()).toEqual(['null-a', 'undef']);
+    // 82 > 60(fresh null) > 5 → fresh null must sit in the MIDDLE, not last.
+    expect([...arr].sort(cmp).map((c) => c.id)).toEqual(['rel-high', 'null-fresh', 'off-low']);
   });
 
-  it('a real 0 still ranks above null (0 is a score, null is "unscored")', () => {
-    const sorted = [card('null', null), card('zero', 0)]
-      .sort(compareByRelevanceDesc)
-      .map((c) => c.id);
-    expect(sorted).toEqual(['zero', 'null']);
+  it('recency proxy is capped below the 추천/핵심 tiers', () => {
+    // A fresh null (60) never outranks a real 70+ score.
+    expect(relevanceSortValue(card('n', null, daysAgo(0)), NOW)).toBeLessThan(70);
+    expect(relevanceSortValue(card('n', null, daysAgo(0)), NOW)).toBeGreaterThan(0);
   });
 
-  it('mirrors the measured fixed-sample ordering (relevant cluster above off-target)', () => {
-    // From the 1-mandala gate: relevant 72-82 must all rank above off-target 5-62.
-    const arr = [
-      card('off-젠레스', 5),
-      card('rel-8가지', 82),
-      card('off-수능체대', 62),
-      card('rel-결심', 72),
-      card('off-미식', 15),
-      card('rel-성공이유', 72),
-    ];
-    const sorted = [...arr].sort(compareByRelevanceDesc).map((c) => c.id);
-    const firstThree = new Set(sorted.slice(0, 3));
-    expect(firstThree).toEqual(new Set(['rel-8가지', 'rel-결심', 'rel-성공이유']));
-  });
-
-  it('ties (equal relevancePct) break by id ascending — stable, no reshuffle on refetch', () => {
-    // The title-only "70s cluster" produces many equal scores; without a
-    // tiebreak they reshuffled when a Heart/like invalidated + refetched the
-    // cards query (input order changed → tie order changed). id-asc pins it.
+  it('ties (equal relevancePct) break by id ascending — stable across refetch', () => {
     const a = [card('z-id', 72), card('a-id', 72), card('m-id', 72)];
-    const b = [card('m-id', 72), card('z-id', 72), card('a-id', 72)]; // different input order
-    expect([...a].sort(compareByRelevanceDesc).map((c) => c.id)).toEqual(['a-id', 'm-id', 'z-id']);
-    // same output regardless of input order = stable across refetch
-    expect([...b].sort(compareByRelevanceDesc).map((c) => c.id)).toEqual(['a-id', 'm-id', 'z-id']);
+    const b = [card('m-id', 72), card('z-id', 72), card('a-id', 72)];
+    expect([...a].sort(cmp).map((c) => c.id)).toEqual(['a-id', 'm-id', 'z-id']);
+    expect([...b].sort(cmp).map((c) => c.id)).toEqual(['a-id', 'm-id', 'z-id']);
   });
 });

--- a/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
+++ b/frontend/src/widgets/card-list/ui/InsightCardItemV2.tsx
@@ -515,21 +515,6 @@ export function InsightCardItemV2({
         </div>
       )}
 
-      {/* P3 Stage 1 (CP513) — "NEW" corner badge at the card-frame level (not on
-          the thumbnail overlay, so it stays put before the image loads). Reuses
-          the explore card-badge grammar: pill, primary(indigo) bg, no new color. */}
-      {isNew && (
-        <span
-          className={cn(
-            'absolute top-2 right-2 z-10 rounded-[4px] px-2 py-[3px]',
-            'text-[10px] font-semibold leading-none tracking-[0.2px]',
-            'bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))]'
-          )}
-        >
-          {t('gridView.badgeNew', 'NEW')}
-        </span>
-      )}
-
       {/* ── Thumbnail ── */}
       <div className="relative aspect-video overflow-hidden bg-gradient-to-br from-[#1a1c28] to-[#13141c] transition-[filter] duration-300 group-hover:brightness-[0.96] group-hover:contrast-[1.04]">
         <img
@@ -559,11 +544,24 @@ export function InsightCardItemV2({
         {/* CP463 — TL relevance badge moved to the new footer row
             (sector ◀ ▶ relevance %). The thumbnail TL slot is now free. */}
 
-        {/* Top-right: Duration (moved from BR — Pin slot retired) */}
-        {duration && (
-          <span className="absolute top-1.5 right-1.5 text-[10px] font-mono font-medium px-[5px] py-[2px] rounded bg-black/75 text-white/85">
-            {duration}
-          </span>
+        {/* Top-right chip stack (P3 Stage 2, CP513 James finalize): a horizontal
+            flex row [추가됨 badge][duration]. Duration keeps the rightmost corner;
+            the "추가됨" badge sits inline to its left, sized to match the duration
+            chip (same height/radius). With no duration the badge auto-takes the
+            corner — no separate branch (flex). */}
+        {(isNew || duration) && (
+          <div className="absolute top-1.5 right-1.5 z-10 flex flex-row items-center justify-end gap-1">
+            {isNew && (
+              <span className="text-[10px] font-medium leading-none tracking-[0.2px] px-[5px] py-[2px] rounded bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))]">
+                {t('gridView.badgeNew', '추가됨')}
+              </span>
+            )}
+            {duration && (
+              <span className="text-[10px] font-mono font-medium leading-none px-[5px] py-[2px] rounded bg-black/75 text-white/85">
+                {duration}
+              </span>
+            )}
+          </div>
         )}
 
         {/* CP463 — top-center 3-phase chip removed per user directive

--- a/prisma/migrations/rec-cache-relevance/001_add_columns.sql
+++ b/prisma/migrations/rec-cache-relevance/001_add_columns.sql
@@ -1,0 +1,13 @@
+-- P3 Stage 2 (CP513, James finalize) — display-only relevance_pct on
+-- recommendation_cache for the "관련도순" grid sort.
+--
+-- Additive nullable Int (0-100 A-stage relevance), computed by the pgvector
+-- backfill using the mandala-filter formula (0.5·centerCos + 0.5·bestCellCos
+-- → cosineToRelevance). NEVER summed into rec_score — serving ranking / gates
+-- are untouched; this is a display/sort field only.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS. Must be in apply-custom-sql.sh allowlist
+-- so the deploy applies it BEFORE the new Prisma client (which selects the
+-- column on every recommendation_cache findMany) goes live — CP499+ LEVEL-3.
+ALTER TABLE public.recommendation_cache
+  ADD COLUMN IF NOT EXISTS relevance_pct integer;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2109,6 +2109,12 @@ model recommendation_cache {
   duration_sec   Int?
   rec_score      Float
   iks_score      Float?
+  /// P3 Stage 2 (CP513, James finalize) — DISPLAY-ONLY A-stage relevance (0-100)
+  /// for the "관련도순" grid sort. Computed by the pgvector backfill using the
+  /// mandala-filter formula (0.5·centerCos + 0.5·bestCellCos → cosineToRelevance).
+  /// Additive + nullable — NEVER summed into rec_score (serving ranking untouched).
+  /// Raw SQL DDL: prisma/migrations/rec-cache-relevance/001_add_columns.sql
+  relevance_pct  Int?
   trend_keywords Json      @default("[]")
   rec_reason     String?
   status         String    @default("pending") @db.VarChar(20)

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -95,6 +95,10 @@ APPLY_FILES=(
   # (PK video_id+mandala_id+segment_idx). CREATE TABLE IF NOT EXISTS + CHECK
   # constraints — idempotent. Inert until the slidegen gate / fill job consume it.
   "prisma/migrations/bookindex/001_video_mandala_segment_relevance.sql"
+  # P3 Stage 2 (CP513) — display-only relevance_pct on recommendation_cache for
+  # the "관련도순" grid sort. ADD COLUMN IF NOT EXISTS — idempotent. Must apply
+  # before the new Prisma client selects the column (CP499+ LEVEL-3).
+  "prisma/migrations/rec-cache-relevance/001_add_columns.sql"
   # CP466 — Add Cards Phase 1 (surfacing). `surfaced_at` column + partial
   # index on user_video_states for Layer 1 Coverage dedup. ADD COLUMN IF
   # NOT EXISTS / CREATE INDEX IF NOT EXISTS — idempotent.

--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -2070,6 +2070,9 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       // P3 Stage 1 (CP513) — pure additive field for the FE 조회수 sort. Does NOT
       // touch ranking/filter/write (rec_score ordering + selection unchanged).
       viewCount: row.view_count ?? null,
+      // P3 Stage 2 (CP513) — display-only A-stage relevance (0-100) for the
+      // 관련도순 sort. Additive; NEVER summed into rec_score.
+      relevancePct: row.relevance_pct ?? null,
       startSec: anchors.get(row.video_id) ?? null,
       pinnedAt: pinnedAtByVideoId.get(row.video_id)?.toISOString() ?? null,
     }));
@@ -2872,6 +2875,8 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           source: row.weight_version === 0 ? 'manual' : 'auto_recommend',
           recReason: row.rec_reason,
           publishedAt: row.published_at?.toISOString() ?? null,
+          // P3 Stage 2 (CP513) — display-only relevance for 관련도순 (additive).
+          relevancePct: row.relevance_pct ?? null,
           startSec: backlogAnchors.get(row.video_id) ?? null,
           pinnedAt: backlogPinnedAtByVideoId.get(row.video_id)?.toISOString() ?? null,
         };

--- a/src/modules/recommendations/publisher.ts
+++ b/src/modules/recommendations/publisher.ts
@@ -46,6 +46,8 @@ export interface CardPayload {
   source: 'auto_recommend' | 'manual';
   recReason: string | null;
   publishedAt: string | null;
+  /** P3 Stage 2 (CP513) — display-only A-stage relevance (0-100) for 관련도순. */
+  relevancePct?: number | null;
   /**
    * Best-matching transcript chunk start time, in seconds.
    * When non-null, the FE may build a YouTube URL like

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -47,7 +47,7 @@ import { v3Config, type V3Config } from './config';
 import { resolveAlgorithm } from '@/modules/search/algorithm-resolver';
 import { filterByQualityGate } from './quality-gate';
 import { applyHybridRerank } from './hybrid-rerank';
-import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
+import { embedBatch, cosineToRelevance } from '@/skills/plugins/iks-scorer/embedding';
 import { getCenterGoalEmbedding } from '@/modules/mandala/center-goal-embedding';
 import { withTraceContext, recordTrace } from '@/modules/discover-tracing';
 import { resolveLanguage } from '@/utils/detect-language';
@@ -122,6 +122,12 @@ export interface AssembledSlot {
   publishedAt: Date | null;
   cellIndex: number;
   score: number;
+  /**
+   * P3 Stage 2 (CP513) — display-only A-stage relevance (0-100) for the 관련도순
+   * sort. Set on the Tier-1 semantic path from the mandala-filter score; null on
+   * paths that don't compute it (backfill covers those). NEVER feeds rec_score.
+   */
+  relevancePct?: number | null;
   /** 'cache' = Tier 1 (video_pool), 'realtime' = Tier 2 (YouTube fresh). */
   tier: 'cache' | 'realtime';
 }
@@ -441,6 +447,10 @@ async function executeImpl(
     // Without this, cross-domain noise (e.g. cell 6 "모의고사" sub_goal
     // matching 28 토익스피킹 videos at cosine 0.55+) surfaces unfiltered.
     let filteredTier1: typeof fresh = fresh;
+    // P3 Stage 2 (CP513) — capture the mandala-filter per-candidate relevance
+    // (0.5·center + 0.5·bestCell) so the placement write can persist relevance_pct.
+    // Display-only; does NOT affect the gate or rec_score. Empty on unfiltered paths.
+    const relevanceByVideoId = new Map<string, number>();
     if (fresh.length > 0 && v3Config.centerGateMode === 'semantic') {
       try {
         const cap = v3Config.semanticMaxCandidates;
@@ -485,7 +495,10 @@ async function executeImpl(
           });
           const keptIds = new Set<string>();
           for (const assignments of byCell.values()) {
-            for (const a of assignments) keptIds.add(a.candidate.videoId);
+            for (const a of assignments) {
+              keptIds.add(a.candidate.videoId);
+              relevanceByVideoId.set(a.candidate.videoId, a.score);
+            }
           }
           filteredTier1 = capped.filter((m) => keptIds.has(m.videoId));
           log.info(
@@ -555,6 +568,9 @@ async function executeImpl(
         publishedAt: m.publishedAt,
         cellIndex: m.cellIndex,
         score: m.score,
+        relevancePct: relevanceByVideoId.has(m.videoId)
+          ? Math.round(cosineToRelevance(relevanceByVideoId.get(m.videoId)!) * 100)
+          : null,
         tier: 'cache',
       });
       existingVideoIds.add(m.videoId);
@@ -1584,6 +1600,9 @@ async function upsertSlots(
         ? Math.min(slot.likeCount / slot.viewCount, 1)
         : null,
     recScore: Math.max(0, Math.min(1, slot.score)),
+    // P3 Stage 2 (CP513) — display-only relevance_pct write. null → COALESCE keeps
+    // any backfilled value on re-serve. Never part of rec_score.
+    relevancePct: slot.relevancePct ?? null,
   }));
 
   // ------------------------------------------------------------------
@@ -1593,7 +1612,7 @@ async function upsertSlots(
   try {
     // Build a VALUES list: one Prisma.sql fragment per row, then join.
     const valueFragments = prepared.map(
-      ({ slot, keyword, likeRatio, recScore }) =>
+      ({ slot, keyword, likeRatio, recScore, relevancePct }) =>
         Prisma.sql`(
         ${userId}::uuid,
         ${mandalaId}::uuid,
@@ -1607,6 +1626,7 @@ async function upsertSlots(
         ${likeRatio}::float8,
         ${slot.durationSec}::int,
         ${recScore}::float8,
+        ${relevancePct}::int,
         ${slot.tier},
         ${RECOMMENDATION_STATUS_PENDING}::varchar(20),
         ${WEIGHT_VERSION}::int,
@@ -1619,11 +1639,12 @@ async function upsertSlots(
       INSERT INTO recommendation_cache (
         user_id, mandala_id, cell_index, keyword, video_id,
         title, thumbnail, channel, view_count, like_ratio,
-        duration_sec, rec_score, rec_reason, status, weight_version,
+        duration_sec, rec_score, relevance_pct, rec_reason, status, weight_version,
         expires_at, published_at
       )
       VALUES ${Prisma.join(valueFragments)}
       ON CONFLICT (user_id, mandala_id, video_id) DO UPDATE SET
+        relevance_pct  = COALESCE(EXCLUDED.relevance_pct, recommendation_cache.relevance_pct),
         cell_index     = EXCLUDED.cell_index,
         keyword        = EXCLUDED.keyword,
         title          = EXCLUDED.title,
@@ -1655,7 +1676,7 @@ async function upsertSlots(
   // ------------------------------------------------------------------
   if (upsertedRows === null) {
     let count = 0;
-    for (const { slot, keyword, likeRatio, recScore } of prepared) {
+    for (const { slot, keyword, likeRatio, recScore, relevancePct } of prepared) {
       try {
         const row = await db.recommendation_cache.upsert({
           where: {
@@ -1678,6 +1699,8 @@ async function upsertSlots(
             like_ratio: likeRatio,
             duration_sec: slot.durationSec,
             rec_score: recScore,
+            // P3 Stage 2 (CP513) — display-only relevance_pct (null if uncomputed).
+            relevance_pct: relevancePct,
             rec_reason: slot.tier,
             status: RECOMMENDATION_STATUS_PENDING,
             weight_version: WEIGHT_VERSION,
@@ -1694,6 +1717,8 @@ async function upsertSlots(
             like_ratio: likeRatio,
             duration_sec: slot.durationSec,
             rec_score: recScore,
+            // Only overwrite when computed — preserves any backfilled value (COALESCE parity).
+            ...(relevancePct != null ? { relevance_pct: relevancePct } : {}),
             rec_reason: slot.tier,
             weight_version: WEIGHT_VERSION,
             expires_at: expiresAt,


### PR DESCRIPTION
## What
Restores the approved 3-filter grid sort over P3 Stage 1's [최신순|조회수], with the relevance backfill that makes 관련도순 the default meaningful.

### FE
- **ContextHeader**: `SORT_OPTIONS = [관련도순(default) | 최신순 | 조회수]`. 조회수 label kept (James: many-viewed→조회수 reverted).
- **CardListView**: default `relevance-desc`; NULL-relevance cards interleave by a **recency proxy** (`makeRelevanceComparator`, cap 60 < 추천 70) instead of sinking to the bottom. Comparator kept pure/testable (nowMs threaded); test rewritten for the new contract.
- **InsightCardItemV2**: badge renamed NEW→**"추가됨"**, moved into a top-right **flex stack `[추가됨][duration]`** sized to the duration chip; duration keeps the corner, badge inline-left (no-duration → badge auto-corners).

### BE (all additive — serving ranking / gates / flags untouched)
- `recommendation_cache.relevance_pct` (nullable Int) — schema + raw SQL DDL + `apply-custom-sql.sh` allowlist (CP499+ safe: DDL applies before the new Prisma client selects it).
- API mappings (feed + backlog) + FE converter + `CardPayload`.
- **Placement write**: v3 executor persists `relevance_pct` from the mandala-filter per-candidate score (`cosineToRelevance × 100`), COALESCE-preserving backfilled values. **NEVER summed into rec_score.**

## Backfill (separate prod run, already executed)
- Formula: `round(cosineToRelevance(0.5·centerScore + 0.5·bestCellScore) × 100)` — center-gate preserved (avg-then-map).
- Coverage **5.7% → 57.6%** (rec_cache 4515/4515 scorable; ulc 21 NULL→scored, existing non-NULL untouched). 42% unembedded → recency fallback.

## Verify
BE+FE tsc clean · vitest 6 pass (new NULL-interleave contract) · FE build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)