### PR TITLE
feat(beta): mobile gate — app routes redirect to landing on mobile

### DIFF
--- a/frontend/src/__tests__/mobile-gate.test.ts
+++ b/frontend/src/__tests__/mobile-gate.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { isPathAllowedOnMobile } from '@/shared/lib/mobile-gate';
+
+describe('mobile gate allowlist', () => {
+  it.each([
+    '/landing',
+    '/pricing',
+    '/templates',
+    '/templates/study-abroad',
+    '/privacy',
+    '/terms',
+    '/help',
+  ])('allows marketing/legal surface %s on mobile', (path) => {
+    expect(isPathAllowedOnMobile(path)).toBe(true);
+  });
+
+  it.each([
+    '/',
+    '/login',
+    '/mandalas',
+    '/mandalas/new',
+    '/mandalas/abc-123',
+    '/learning/m-1/v-1',
+    '/settings',
+    '/subscription',
+    '/explore',
+    '/admin',
+    '/admin/users',
+  ])('gates app route %s on mobile', (path) => {
+    expect(isPathAllowedOnMobile(path)).toBe(false);
+  });
+
+  it('does not treat prefix-similar paths as allowed', () => {
+    expect(isPathAllowedOnMobile('/helpcenter')).toBe(false);
+    expect(isPathAllowedOnMobile('/pricing2')).toBe(false);
+  });
+});

--- a/frontend/src/app/router/MobileGateNotice.tsx
+++ b/frontend/src/app/router/MobileGateNotice.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { MOBILE_GATE_FLAG_KEY } from '@/shared/lib/mobile-gate';
+
+/**
+ * One-line dismissible notice shown on the landing page right after the
+ * mobile gate redirected an app route. Self-contained so LandingPage stays
+ * untouched.
+ */
+export function MobileGateNotice() {
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(() => {
+    try {
+      return sessionStorage.getItem(MOBILE_GATE_FLAG_KEY) === '1';
+    } catch {
+      return false;
+    }
+  });
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    try {
+      sessionStorage.removeItem(MOBILE_GATE_FLAG_KEY);
+    } catch {
+      /* noop */
+    }
+    setVisible(false);
+  };
+
+  return (
+    <div
+      role="status"
+      className="fixed inset-x-0 bottom-0 z-[400] flex items-center justify-between gap-3 bg-card px-4 py-3 text-sm text-foreground border-t border-border"
+    >
+      <span>{t('mobileGate.notice')}</span>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label={t('mobileGate.dismiss')}
+        className="shrink-0 rounded px-2 py-1 text-muted-foreground hover:text-foreground"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/router/index.tsx
+++ b/frontend/src/app/router/index.tsx
@@ -3,6 +3,12 @@ import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { PageLoader } from '@/shared/ui/PageLoader';
 import { ProtectedRoute } from './ProtectedRoute';
 import { AdminRoute } from './AdminRoute';
+import { MobileGateNotice } from './MobileGateNotice';
+import {
+  isMobileDevice,
+  isPathAllowedOnMobile,
+  MOBILE_GATE_FLAG_KEY,
+} from '@/shared/lib/mobile-gate';
 import { AdminLayout } from '@/pages/admin/ui/AdminLayout';
 import { AdminDashboard } from '@/pages/admin/ui/AdminDashboard';
 import { AdminUsers } from '@/pages/admin/ui/AdminUsers';
@@ -52,9 +58,23 @@ function ScrollToTop() {
 }
 
 export function AppRouter() {
+  const { pathname } = useLocation();
+
+  // Closed-beta mobile gate: app routes are desktop-only until the mobile
+  // redesign — mobile devices land on the marketing pages instead.
+  if (isMobileDevice() && !isPathAllowedOnMobile(pathname)) {
+    try {
+      sessionStorage.setItem(MOBILE_GATE_FLAG_KEY, '1');
+    } catch {
+      /* noop */
+    }
+    return <Navigate to="/landing" replace />;
+  }
+
   return (
     <Suspense fallback={<PageLoader />}>
       <ScrollToTop />
+      <MobileGateNotice />
       <Routes>
         <Route path="/" element={<IndexPage />} />
         <Route path="/login" element={<LoginPage />} />

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -31,6 +31,10 @@
     "comingSoon": "Coming soon",
     "all": "All"
   },
+  "mobileGate": {
+    "notice": "The mobile experience is still in the works. Please use Insighta on desktop.",
+    "dismiss": "Dismiss"
+  },
   "sources": {
     "youtube": {
       "name": "YouTube",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -31,6 +31,10 @@
     "comingSoon": "준비 중입니다",
     "all": "전체"
   },
+  "mobileGate": {
+    "notice": "모바일 화면은 준비 중입니다. 인사이타는 데스크톱에서 이용해 주세요.",
+    "dismiss": "닫기"
+  },
   "sources": {
     "youtube": {
       "name": "YouTube",

--- a/frontend/src/shared/lib/mobile-gate.ts
+++ b/frontend/src/shared/lib/mobile-gate.ts
@@ -1,0 +1,35 @@
+/**
+ * Mobile gate — during closed beta the app is desktop-only; mobile visitors
+ * only see the marketing surfaces until the mobile UX redesign ships.
+ *
+ * Detection combines viewport width AND coarse pointer so narrow desktop
+ * windows (devtools, split screen) are not falsely gated.
+ */
+
+export const MOBILE_GATE_MAX_WIDTH = 767;
+
+/** Marketing/legal surfaces that stay reachable on mobile. */
+const ALLOWED_MOBILE_PATH_PREFIXES = [
+  '/landing',
+  '/pricing',
+  '/templates',
+  '/privacy',
+  '/terms',
+  '/help',
+] as const;
+
+export function isPathAllowedOnMobile(pathname: string): boolean {
+  return ALLOWED_MOBILE_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
+}
+
+export function isMobileDevice(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  const narrow = window.matchMedia(`(max-width: ${MOBILE_GATE_MAX_WIDTH}px)`).matches;
+  const coarse = window.matchMedia('(pointer: coarse)').matches;
+  return narrow && coarse;
+}
+
+/** Session flag so the landing page can explain why the app redirected. */
+export const MOBILE_GATE_FLAG_KEY = 'insighta:mobile-gated';


### PR DESCRIPTION
## What

Closed-beta measure (James directive 2026-07-08): the mobile UX is pending a redesign, so mobile devices now only see the marketing surfaces. App routes redirect to `/landing` with a dismissible one-line notice.

- Gate check: narrow viewport (≤767px) **AND** coarse pointer — desktop narrow windows are not gated
- Mobile allowlist: `/landing`, `/pricing`, `/templates(+slug)`, `/privacy`, `/terms`, `/help`
- Everything else (app, login, admin) redirects to `/landing`; a sessionStorage flag drives the notice banner (LandingPage untouched)
- i18n: `mobileGate.notice/dismiss` (ko/en)

## Why now

The beta intro email goes out next — most email opens happen on mobile, so the CTA landing must be gated **before** the send.

## Verification

- `tsc -p tsconfig.app.json`: 0 new errors (32 pre-existing unchanged)
- vitest: 511/511 (19 new allowlist tests)
- vite build: pass
- Runtime smoke (Playwright, iPhone 13 emulation + desktop 1440px): mobile `/`→`/landing` + notice visible, `/pricing` stays, `/settings`→`/landing`, desktop `/` not gated

## Rollback

Single-commit revert; gate is FE-only, no BE/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)