### PR TITLE
fix(beta): force-add beta_applications DDL (deploy blocker)

### DIFF
--- a/prisma/migrations/beta/001_beta_applications.sql
+++ b/prisma/migrations/beta/001_beta_applications.sql
@@ -1,0 +1,9 @@
+-- Closed-beta application inbox (2026-07-08). Idempotent.
+CREATE TABLE IF NOT EXISTS public.beta_applications (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email varchar(255) NOT NULL UNIQUE,
+  status varchar(16) NOT NULL DEFAULT 'pending',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  invited_at timestamptz
+);
+CREATE INDEX IF NOT EXISTS idx_beta_applications_status ON public.beta_applications (status);


### PR DESCRIPTION
PR #1115's deploy failed: `Missing SQL file: prisma/migrations/beta/001_beta_applications.sql` — the file is under gitignored `prisma/migrations/*` and was silently dropped by `git add -A`. This force-adds the single idempotent DDL file per the repo's manual-DDL convention. Unblocks /beta on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)