### PR TITLE
feat(landing): top banner → closed-beta entry point

### DIFF
--- a/frontend/src/pages/landing/ui/components/LTDBanner.tsx
+++ b/frontend/src/pages/landing/ui/components/LTDBanner.tsx
@@ -3,6 +3,10 @@ import { X, Flame } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
+/**
+ * Top announcement banner — closed-beta entry point (James 2026-07-08).
+ * Replaced the retired Pioneer LTD promo; links to the /beta landing.
+ */
 export function LTDBanner() {
   const { t } = useTranslation();
   const [dismissed, setDismissed] = useState(false);
@@ -14,14 +18,14 @@ export function LTDBanner() {
       <div className="mx-auto max-w-7xl px-4 py-2.5 flex items-center justify-center gap-3 text-sm">
         <Flame className="w-4 h-4 text-primary shrink-0" aria-hidden="true" />
         <p className="font-medium">
-          <span className="hidden sm:inline">{t('landing.ltdBanner')}</span>
-          <span className="sm:hidden">{t('landing.ltdBannerShort')}</span>
+          <span className="hidden sm:inline">{t('landing.betaBanner')}</span>
+          <span className="sm:hidden">{t('landing.betaBannerShort')}</span>
         </p>
         <Link
-          to="/pricing"
+          to="/beta"
           className="inline-flex items-center px-3 py-1 rounded-full bg-primary text-primary-foreground text-xs font-semibold hover:bg-primary/90 transition-colors whitespace-nowrap"
         >
-          {t('landing.ltdBannerCta')}
+          {t('landing.betaBannerCta')}
         </Link>
         <button
           onClick={() => setDismissed(true)}

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -1338,7 +1338,10 @@
     "ctaUrgency": "This pioneer discount will soon switch to a monthly subscription.",
     "footerDesc": "Capture ideas from any source, structure them with the Mandala framework, and let AI connect the dots.",
     "footerProduct": "Product",
-    "footerLegal": "Legal"
+    "footerLegal": "Legal",
+    "betaBanner": "The Insighta closed beta is open — free Pro during the beta · Lifetime for two outstanding members.",
+    "betaBannerShort": "Closed beta — applications open",
+    "betaBannerCta": "Request invite"
   },
   "pricing": {
     "title": "Pioneer Lifetime Deal",

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -1346,7 +1346,10 @@
     "ctaUrgency": "이번 Pioneer 할인은 곧 월 구독으로 전환됩니다.",
     "footerDesc": "모든 소스에서 아이디어를 캡처하고, 만다라트 프레임워크로 구조화하고, AI가 연결합니다.",
     "footerProduct": "제품",
-    "footerLegal": "법적 고지"
+    "footerLegal": "법적 고지",
+    "betaBanner": "Insighta 클로즈드 베타 사전 신청이 열렸습니다 — 베타 기간 Pro 무료 · 우수 활동 멤버 2명 Lifetime 증정.",
+    "betaBannerShort": "클로즈드 베타 사전 신청 오픈",
+    "betaBannerCta": "베타 신청하기"
   },
   "pricing": {
     "title": "Pioneer 평생 이용권",


### PR DESCRIPTION
Replaces the retired **Pioneer LTD** promo banner on the main landing with the **closed-beta application entry** (James directive — 상단 공지에 베타 진입점):

- Copy (ko/en): closed beta open · free Pro during beta · Lifetime for 2 outstanding members
- CTA `베타 신청하기` → `/beta` (the new beta landing, PR #1117)
- Scope: banner only — hero CTA/pricing surfaces are the follow-up landing-conversion PR

Verified: tsc/vitest 512/build pass; browser smoke — banner renders beta copy, click lands on `/beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)