### PR TITLE
feat(beta): real thumbnails + design-mockup background

### DIFF
--- a/frontend/src/pages/beta/ui/BetaApplyPage.tsx
+++ b/frontend/src/pages/beta/ui/BetaApplyPage.tsx
@@ -3,6 +3,17 @@ import { useTranslation } from 'react-i18next';
 import { apiClient } from '@/shared/lib/api-client';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
+// Real YouTube thumbnails (i.ytimg.com — same source the app uses); IDs verified live.
+const yt = (id: string) => `https://i.ytimg.com/vi/${id}/mqdefault.jpg`;
+const CURRICULUM_THUMBS = ['fNk_zzaMoSs', 'kYB8IZa5AuE', 'PFDu9oVAE-g', 'mBcLRGuAFUk'];
+const FEED_THUMBS = [
+  '9bZkp7q19f0',
+  'kJQP7kiw5Fk',
+  'jNQXAC9IVRw',
+  'RgKAFK5djSk',
+  'dQw4w9WgXcQ',
+  'e-ORhEE9VVg',
+];
 const SEATS_LEFT = 40;
 const INVITE_SENT = 160;
 const INVITE_TOTAL = 200;
@@ -29,10 +40,34 @@ function SectionLabel({ no, label }: { no: string; label: string }) {
 function CurriculumMockup() {
   const { t } = useTranslation();
   const rows = [
-    { title: t('beta.mock.v1'), ch: 'Essence of Math', time: '18:24', done: true },
-    { title: t('beta.mock.v2'), ch: 'MIT OpenCourseWare', time: '42:10', done: true },
-    { title: t('beta.mock.v3'), ch: 'StatQuest', time: '27:33', done: false },
-    { title: t('beta.mock.v4'), ch: '3Blue1Brown', time: '21:05', done: false },
+    {
+      title: t('beta.mock.v1'),
+      ch: 'Essence of Math',
+      time: '18:24',
+      done: true,
+      thumb: yt(CURRICULUM_THUMBS[0]),
+    },
+    {
+      title: t('beta.mock.v2'),
+      ch: 'MIT OpenCourseWare',
+      time: '42:10',
+      done: true,
+      thumb: yt(CURRICULUM_THUMBS[1]),
+    },
+    {
+      title: t('beta.mock.v3'),
+      ch: 'StatQuest',
+      time: '27:33',
+      done: false,
+      thumb: yt(CURRICULUM_THUMBS[2]),
+    },
+    {
+      title: t('beta.mock.v4'),
+      ch: '3Blue1Brown',
+      time: '21:05',
+      done: false,
+      thumb: yt(CURRICULUM_THUMBS[3]),
+    },
   ];
   return (
     <div className="w-full max-w-md rounded-2xl border border-white/10 bg-white/[0.04] backdrop-blur px-6 py-5 shadow-[0_24px_80px_rgba(0,0,0,0.45)]">
@@ -103,6 +138,12 @@ function CurriculumMockup() {
               )}
             </span>
             <span className="relative w-14 h-9 rounded-md bg-gradient-to-br from-zinc-700 to-zinc-800 flex-none overflow-hidden">
+              <img
+                src={r.thumb}
+                alt=""
+                loading="lazy"
+                className="absolute inset-0 w-full h-full object-cover"
+              />
               <span className="absolute bottom-0.5 right-1 text-[9px] text-zinc-300 bg-black/60 rounded px-1">
                 {r.time}
               </span>
@@ -151,18 +192,13 @@ function AlgorithmFeedMockup() {
       <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 gap-4">
         {vids.map((v, i) => (
           <div key={v.title}>
-            <div
-              className={`relative aspect-video rounded-lg overflow-hidden bg-gradient-to-br ${
-                [
-                  'from-zinc-600 to-zinc-800',
-                  'from-slate-600 to-zinc-800',
-                  'from-stone-600 to-zinc-800',
-                  'from-zinc-700 to-zinc-900',
-                  'from-slate-700 to-zinc-900',
-                  'from-stone-700 to-zinc-900',
-                ][i]
-              }`}
-            >
+            <div className="relative aspect-video rounded-lg overflow-hidden bg-zinc-800">
+              <img
+                src={yt(FEED_THUMBS[i])}
+                alt=""
+                loading="lazy"
+                className="absolute inset-0 w-full h-full object-cover blur-[2px] brightness-[0.55] saturate-[0.65] scale-105"
+              />
               <span className="absolute bottom-1 right-1.5 text-[10px] text-zinc-200 bg-black/60 rounded px-1">
                 {v.time}
               </span>
@@ -262,329 +298,356 @@ export default function BetaApplyPage() {
   ];
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100 [background-image:radial-gradient(ellipse_60%_40%_at_70%_10%,rgba(108,99,255,0.13),transparent),radial-gradient(ellipse_50%_35%_at_15%_80%,rgba(108,99,255,0.07),transparent)]">
-      {/* header */}
-      <header className="max-w-6xl mx-auto px-6 pt-8 flex items-center justify-between">
-        <div className="flex items-center gap-2.5 font-extrabold text-lg">
-          <span className="w-8 h-8 rounded-lg bg-indigo-500/15 border border-indigo-400/50 flex items-center justify-center">
-            <i className="w-3 h-3 rounded-full border-2 border-indigo-300 inline-block" />
+    <div className="relative min-h-screen bg-[#0b0b14] text-zinc-100 overflow-x-clip">
+      {/* design-mockup background: indigo glows + fine starfield + faint grid */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 [background-image:radial-gradient(ellipse_55%_38%_at_72%_6%,rgba(108,99,255,0.22),transparent_65%),radial-gradient(ellipse_45%_30%_at_12%_38%,rgba(108,99,255,0.10),transparent_60%),radial-gradient(ellipse_50%_32%_at_82%_72%,rgba(108,99,255,0.12),transparent_60%),radial-gradient(ellipse_45%_30%_at_28%_96%,rgba(108,99,255,0.14),transparent_60%)]"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-70 [background-image:radial-gradient(rgba(255,255,255,0.10)_1px,transparent_1.3px),radial-gradient(rgba(255,255,255,0.05)_1px,transparent_1.2px)] [background-size:190px_170px,97px_83px] [background-position:0_0,40px_60px]"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-[0.35] [background-image:linear-gradient(rgba(255,255,255,0.035)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.035)_1px,transparent_1px)] [background-size:88px_88px]"
+      />
+      <div className="relative">
+        {/* header */}
+        <header className="max-w-6xl mx-auto px-6 pt-8 flex items-center justify-between">
+          <div className="flex items-center gap-2.5 font-extrabold text-lg">
+            <span className="w-8 h-8 rounded-lg bg-indigo-500/15 border border-indigo-400/50 flex items-center justify-center">
+              <i className="w-3 h-3 rounded-full border-2 border-indigo-300 inline-block" />
+            </span>
+            Insighta
+          </div>
+          <span className="text-[11px] tracking-[0.25em] text-indigo-300/90 border border-indigo-400/40 bg-indigo-500/10 rounded-full px-4 py-1.5 font-bold">
+            CLOSED BETA
           </span>
-          Insighta
-        </div>
-        <span className="text-[11px] tracking-[0.25em] text-indigo-300/90 border border-indigo-400/40 bg-indigo-500/10 rounded-full px-4 py-1.5 font-bold">
-          CLOSED BETA
-        </span>
-      </header>
+        </header>
 
-      {/* hero */}
-      <section className="max-w-6xl mx-auto px-6 pt-16 pb-24 grid lg:grid-cols-2 gap-14 items-center">
-        <div>
-          <h1 className="text-5xl sm:text-6xl font-extrabold leading-[1.15] tracking-tight">
-            {t('beta.hero.line1')}
-            <br />
-            {t('beta.hero.line2pre')}
-            <span className="text-indigo-300 underline decoration-indigo-400/60 decoration-4 underline-offset-8">
-              {t('beta.hero.line2hl')}
-            </span>
-            {t('beta.hero.line2post')}
-          </h1>
-          <p className="mt-8 text-lg leading-relaxed text-zinc-400 whitespace-pre-line">
-            {t('beta.hero.desc')}
-          </p>
-          <div className="mt-9 flex items-center gap-5">
-            <button
-              type="button"
-              onClick={scrollToApply}
-              className="rounded-xl bg-indigo-500 hover:bg-indigo-400 transition-colors px-7 py-4 text-[15px] font-bold text-white shadow-[0_0_40px_rgba(108,99,255,0.35)]"
-            >
-              {t('beta.hero.cta')} →
-            </button>
-            <span className="text-sm text-zinc-500">{t('beta.hero.ctaNote')}</span>
-          </div>
-        </div>
-        <div className="flex justify-center lg:justify-end">
-          <CurriculumMockup />
-        </div>
-      </section>
-
-      {/* 01 problem */}
-      <section className="max-w-6xl mx-auto px-6 py-24 text-center">
-        <SectionLabel no="01" label={t('beta.s1.label')} />
-        <h2 className="mt-6 text-4xl sm:text-5xl font-extrabold leading-snug whitespace-pre-line">
-          {t('beta.s1.title')}
-        </h2>
-        <p className="mt-6 text-zinc-400 max-w-2xl mx-auto leading-relaxed whitespace-pre-line">
-          {t('beta.s1.desc')}
-        </p>
-        <div className="mt-12 flex justify-center">
-          <AlgorithmFeedMockup />
-        </div>
-        <p className="mt-6 text-sm text-zinc-500">{t('beta.s1.caption')}</p>
-      </section>
-
-      {/* 02 solution */}
-      <section className="max-w-6xl mx-auto px-6 py-24 text-center">
-        <SectionLabel no="02" label={t('beta.s2.label')} />
-        <h2 className="mt-6 text-4xl sm:text-5xl font-extrabold">{t('beta.s2.title')}</h2>
-        <p className="mt-5 text-zinc-400">{t('beta.s2.desc')}</p>
-        <div className="mt-12 grid sm:grid-cols-2 gap-6 max-w-3xl mx-auto">
-          <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-5 text-left">
-            <div className="text-[11px] tracking-widest text-zinc-500 font-bold">
-              BEFORE — {t('beta.s2.before')}
-            </div>
-            <div className="mt-4 relative h-40">
-              {[0, 1, 2, 3].map((i) => (
-                <div
-                  key={i}
-                  className="absolute w-28 h-[4.2rem] rounded-md bg-gradient-to-br from-zinc-600 to-zinc-800 border border-white/10"
-                  style={{
-                    left: `${12 + i * 18}%`,
-                    top: `${8 + (i % 2) * 34}%`,
-                    transform: `rotate(${i * 7 - 10}deg)`,
-                  }}
-                />
-              ))}
-            </div>
-          </div>
-          <div className="rounded-2xl border border-indigo-400/30 bg-indigo-500/[0.06] p-5 text-left">
-            <div className="text-[11px] tracking-widest text-indigo-300 font-bold">
-              AFTER — {t('beta.s2.after')}
-            </div>
-            <ul className="mt-4 space-y-2.5">
-              {[t('beta.mock.v1'), t('beta.mock.v2'), t('beta.mock.v3'), t('beta.mock.v4')].map(
-                (v, i) => (
-                  <li key={v} className="flex items-center gap-2.5">
-                    <span
-                      className={`w-4 h-4 rounded-full border flex-none ${i < 2 ? 'bg-indigo-500 border-indigo-400' : 'border-zinc-600'}`}
-                    />
-                    <span className="w-10 h-6 rounded bg-gradient-to-br from-zinc-700 to-zinc-800 flex-none" />
-                    <span className="text-[12px] text-zinc-300 truncate">{v}</span>
-                  </li>
-                )
-              )}
-            </ul>
-          </div>
-        </div>
-        <div className="mt-8 grid sm:grid-cols-3 gap-5 max-w-4xl mx-auto">
-          {steps.map((s) => (
-            <div
-              key={s.no}
-              className="rounded-2xl border border-white/10 bg-white/[0.03] p-5 text-left"
-            >
-              <div className="text-[11px] tracking-widest text-indigo-300 font-bold">{s.no}</div>
-              <div className="mt-2 font-bold text-zinc-100">{s.title}</div>
-              <p className="mt-2 text-[13px] leading-relaxed text-zinc-500">{s.desc}</p>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      {/* 03 knowledge graph */}
-      <section className="max-w-6xl mx-auto px-6 py-24 text-center">
-        <SectionLabel no="03" label={t('beta.s3.label')} />
-        <h2 className="mt-6 text-4xl sm:text-5xl font-extrabold">{t('beta.s3.title')}</h2>
-        <p className="mt-6 text-zinc-400 max-w-2xl mx-auto leading-relaxed whitespace-pre-line">
-          {t('beta.s3.desc')}
-        </p>
-        <div className="mt-10 max-w-2xl mx-auto">
-          <div className="flex items-center justify-between text-xs text-zinc-500 px-2">
-            <span>{t('beta.s3.graphLabel')}</span>
-            <span className="flex items-center gap-2">
-              {t('beta.s3.accuracy')}
-              <i className="w-10 h-px bg-indigo-400 inline-block" />
-              <b className="text-indigo-300">96%</b>
-            </span>
-          </div>
-          <div className="mt-3 flex justify-center">
-            <KnowledgeGraph />
-          </div>
-          <p className="mt-4 text-sm text-zinc-500">{t('beta.s3.caption')}</p>
-        </div>
-      </section>
-
-      {/* 04 note density */}
-      <section className="max-w-6xl mx-auto px-6 py-24 text-center">
-        <SectionLabel no="04" label={t('beta.s4.label')} />
-        <h2 className="mt-6 text-4xl sm:text-5xl font-extrabold leading-snug whitespace-pre-line">
-          {t('beta.s4.title')}
-        </h2>
-        <div className="mt-12 grid sm:grid-cols-2 gap-6 max-w-3xl mx-auto text-left">
-          <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-6">
-            <div className="flex items-center justify-between">
-              <span className="font-bold">Free</span>
-              <span className="text-[11px] text-zinc-500 border border-white/10 rounded-full px-2.5 py-0.5">
-                {t('beta.s4.freeTag')}
-              </span>
-            </div>
-            <div className="mt-5 space-y-2.5">
-              {[80, 62, 71, 55].map((w, i) => (
-                <div key={i} className="h-2.5 rounded bg-zinc-700/70" style={{ width: `${w}%` }} />
-              ))}
-            </div>
-          </div>
-          <div className="rounded-2xl border border-indigo-400/40 bg-indigo-500/[0.07] p-6">
-            <div className="flex items-center justify-between">
-              <span className="font-bold">Pro</span>
-              <span className="text-[11px] text-indigo-200 bg-indigo-500/30 rounded-full px-2.5 py-0.5">
-                {t('beta.s4.proTag')}
-              </span>
-            </div>
-            <div className="mt-5 space-y-2.5">
-              <div className="h-2.5 rounded bg-indigo-400/80 w-[85%]" />
-              <div className="h-2.5 rounded bg-indigo-400/50 w-[70%]" />
-              <div className="rounded border border-indigo-300/30 bg-black/30 px-3 py-2 text-[12px] font-mono text-indigo-200">
-                A v = λ v
-              </div>
-              <div className="h-2.5 rounded bg-indigo-400/50 w-[64%]" />
-              <div className="h-2.5 rounded bg-indigo-400/30 w-[52%]" />
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* 05 founding member */}
-      <section className="max-w-6xl mx-auto px-6 py-24">
-        <SectionLabel no="05" label={t('beta.s5.label')} />
-        <h2 className="mt-6 text-4xl sm:text-5xl font-extrabold text-center">
-          {t('beta.s5.title')}
-        </h2>
-        <div className="mt-14 grid lg:grid-cols-2 gap-12 items-center max-w-4xl mx-auto">
-          <div className="rounded-2xl border border-indigo-300/25 bg-gradient-to-br from-indigo-500/[0.14] to-white/[0.03] p-7 aspect-[8/5] flex flex-col justify-between shadow-[0_24px_80px_rgba(108,99,255,0.15)]">
-            <div className="flex items-center justify-between text-[11px] tracking-[0.2em] text-zinc-400">
-              <span className="flex items-center gap-2 font-bold text-zinc-200">
-                <i className="w-4 h-4 rounded border border-indigo-300/60 inline-block" /> Insighta
-              </span>
-              <span>FOUNDING MEMBER</span>
-            </div>
-            <div>
-              <div className="text-4xl font-extrabold text-zinc-50">Lifetime</div>
-              <div className="mt-1 text-xs text-zinc-500">{t('beta.s5.cardSub')}</div>
-            </div>
-            <div className="flex items-center justify-between text-[11px] tracking-widest text-zinc-500">
-              <span>No. 0041</span>
-              <span>2026 · VOL.01</span>
-            </div>
-          </div>
+        {/* hero */}
+        <section className="max-w-6xl mx-auto px-6 pt-16 pb-24 grid lg:grid-cols-2 gap-14 items-center">
           <div>
-            <ul className="space-y-6">
-              {perks.map((p) => (
-                <li key={p.title} className="flex gap-4">
-                  <span className="mt-0.5 w-5 h-5 rounded-full bg-indigo-500/20 border border-indigo-400/50 flex items-center justify-center flex-none">
-                    <svg viewBox="0 0 12 12" className="w-2.5 h-2.5">
-                      <path
-                        d="M2.5 6.5l2.2 2.2L9.5 3.6"
-                        fill="none"
-                        stroke="#a5b4fc"
-                        strokeWidth="1.8"
-                        strokeLinecap="round"
+            <h1 className="text-5xl sm:text-6xl font-extrabold leading-[1.15] tracking-tight">
+              {t('beta.hero.line1')}
+              <br />
+              {t('beta.hero.line2pre')}
+              <span className="text-indigo-300 underline decoration-indigo-400/60 decoration-4 underline-offset-8">
+                {t('beta.hero.line2hl')}
+              </span>
+              {t('beta.hero.line2post')}
+            </h1>
+            <p className="mt-8 text-lg leading-relaxed text-zinc-400 whitespace-pre-line">
+              {t('beta.hero.desc')}
+            </p>
+            <div className="mt-9 flex items-center gap-5">
+              <button
+                type="button"
+                onClick={scrollToApply}
+                className="rounded-xl bg-indigo-500 hover:bg-indigo-400 transition-colors px-7 py-4 text-[15px] font-bold text-white shadow-[0_0_40px_rgba(108,99,255,0.35)]"
+              >
+                {t('beta.hero.cta')} →
+              </button>
+              <span className="text-sm text-zinc-500">{t('beta.hero.ctaNote')}</span>
+            </div>
+          </div>
+          <div className="flex justify-center lg:justify-end">
+            <CurriculumMockup />
+          </div>
+        </section>
+
+        {/* 01 problem */}
+        <section className="max-w-6xl mx-auto px-6 py-24 text-center">
+          <SectionLabel no="01" label={t('beta.s1.label')} />
+          <h2 className="mt-6 text-4xl sm:text-5xl font-extrabold leading-snug whitespace-pre-line">
+            {t('beta.s1.title')}
+          </h2>
+          <p className="mt-6 text-zinc-400 max-w-2xl mx-auto leading-relaxed whitespace-pre-line">
+            {t('beta.s1.desc')}
+          </p>
+          <div className="mt-12 flex justify-center">
+            <AlgorithmFeedMockup />
+          </div>
+          <p className="mt-6 text-sm text-zinc-500">{t('beta.s1.caption')}</p>
+        </section>
+
+        {/* 02 solution */}
+        <section className="max-w-6xl mx-auto px-6 py-24 text-center">
+          <SectionLabel no="02" label={t('beta.s2.label')} />
+          <h2 className="mt-6 text-4xl sm:text-5xl font-extrabold">{t('beta.s2.title')}</h2>
+          <p className="mt-5 text-zinc-400">{t('beta.s2.desc')}</p>
+          <div className="mt-12 grid sm:grid-cols-2 gap-6 max-w-3xl mx-auto">
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-5 text-left">
+              <div className="text-[11px] tracking-widest text-zinc-500 font-bold">
+                BEFORE — {t('beta.s2.before')}
+              </div>
+              <div className="mt-4 relative h-40">
+                {[0, 1, 2, 3].map((i) => (
+                  <div
+                    key={i}
+                    className="absolute w-28 h-[4.2rem] rounded-md bg-gradient-to-br from-zinc-600 to-zinc-800 border border-white/10"
+                    style={{
+                      left: `${12 + i * 18}%`,
+                      top: `${8 + (i % 2) * 34}%`,
+                      transform: `rotate(${i * 7 - 10}deg)`,
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+            <div className="rounded-2xl border border-indigo-400/30 bg-indigo-500/[0.06] p-5 text-left">
+              <div className="text-[11px] tracking-widest text-indigo-300 font-bold">
+                AFTER — {t('beta.s2.after')}
+              </div>
+              <ul className="mt-4 space-y-2.5">
+                {[t('beta.mock.v1'), t('beta.mock.v2'), t('beta.mock.v3'), t('beta.mock.v4')].map(
+                  (v, i) => (
+                    <li key={v} className="flex items-center gap-2.5">
+                      <span
+                        className={`w-4 h-4 rounded-full border flex-none ${i < 2 ? 'bg-indigo-500 border-indigo-400' : 'border-zinc-600'}`}
                       />
-                    </svg>
-                  </span>
-                  <span>
-                    <span className="block font-bold text-zinc-100">{p.title}</span>
-                    <span className="block mt-1 text-sm text-zinc-500 leading-relaxed">
-                      {p.desc}
-                    </span>
-                  </span>
-                </li>
-              ))}
-            </ul>
-            <div className="mt-8">
-              <div className="flex items-center justify-between text-xs text-zinc-500">
-                <span>{t('beta.s5.inviteLabel')}</span>
-                <span className="font-bold text-zinc-300">
-                  {INVITE_SENT} / {INVITE_TOTAL}
+                      <span className="relative w-10 h-6 rounded bg-zinc-800 flex-none overflow-hidden">
+                        <img
+                          src={yt(CURRICULUM_THUMBS[i])}
+                          alt=""
+                          loading="lazy"
+                          className="absolute inset-0 w-full h-full object-cover"
+                        />
+                      </span>
+                      <span className="text-[12px] text-zinc-300 truncate">{v}</span>
+                    </li>
+                  )
+                )}
+              </ul>
+            </div>
+          </div>
+          <div className="mt-8 grid sm:grid-cols-3 gap-5 max-w-4xl mx-auto">
+            {steps.map((s) => (
+              <div
+                key={s.no}
+                className="rounded-2xl border border-white/10 bg-white/[0.03] p-5 text-left"
+              >
+                <div className="text-[11px] tracking-widest text-indigo-300 font-bold">{s.no}</div>
+                <div className="mt-2 font-bold text-zinc-100">{s.title}</div>
+                <p className="mt-2 text-[13px] leading-relaxed text-zinc-500">{s.desc}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* 03 knowledge graph */}
+        <section className="max-w-6xl mx-auto px-6 py-24 text-center">
+          <SectionLabel no="03" label={t('beta.s3.label')} />
+          <h2 className="mt-6 text-4xl sm:text-5xl font-extrabold">{t('beta.s3.title')}</h2>
+          <p className="mt-6 text-zinc-400 max-w-2xl mx-auto leading-relaxed whitespace-pre-line">
+            {t('beta.s3.desc')}
+          </p>
+          <div className="mt-10 max-w-2xl mx-auto">
+            <div className="flex items-center justify-between text-xs text-zinc-500 px-2">
+              <span>{t('beta.s3.graphLabel')}</span>
+              <span className="flex items-center gap-2">
+                {t('beta.s3.accuracy')}
+                <i className="w-10 h-px bg-indigo-400 inline-block" />
+                <b className="text-indigo-300">96%</b>
+              </span>
+            </div>
+            <div className="mt-3 flex justify-center">
+              <KnowledgeGraph />
+            </div>
+            <p className="mt-4 text-sm text-zinc-500">{t('beta.s3.caption')}</p>
+          </div>
+        </section>
+
+        {/* 04 note density */}
+        <section className="max-w-6xl mx-auto px-6 py-24 text-center">
+          <SectionLabel no="04" label={t('beta.s4.label')} />
+          <h2 className="mt-6 text-4xl sm:text-5xl font-extrabold leading-snug whitespace-pre-line">
+            {t('beta.s4.title')}
+          </h2>
+          <div className="mt-12 grid sm:grid-cols-2 gap-6 max-w-3xl mx-auto text-left">
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-6">
+              <div className="flex items-center justify-between">
+                <span className="font-bold">Free</span>
+                <span className="text-[11px] text-zinc-500 border border-white/10 rounded-full px-2.5 py-0.5">
+                  {t('beta.s4.freeTag')}
                 </span>
               </div>
-              <div className="mt-2 h-1.5 rounded-full bg-white/10 overflow-hidden">
-                <div
-                  className="h-full rounded-full bg-indigo-400"
-                  style={{ width: `${(INVITE_SENT / INVITE_TOTAL) * 100}%` }}
-                />
+              <div className="mt-5 space-y-2.5">
+                {[80, 62, 71, 55].map((w, i) => (
+                  <div
+                    key={i}
+                    className="h-2.5 rounded bg-zinc-700/70"
+                    style={{ width: `${w}%` }}
+                  />
+                ))}
               </div>
-              <p className="mt-3 text-[13px] text-zinc-500">
-                {t('beta.s5.seatsNote', { seats: SEATS_LEFT })}
-              </p>
+            </div>
+            <div className="rounded-2xl border border-indigo-400/40 bg-indigo-500/[0.07] p-6">
+              <div className="flex items-center justify-between">
+                <span className="font-bold">Pro</span>
+                <span className="text-[11px] text-indigo-200 bg-indigo-500/30 rounded-full px-2.5 py-0.5">
+                  {t('beta.s4.proTag')}
+                </span>
+              </div>
+              <div className="mt-5 space-y-2.5">
+                <div className="h-2.5 rounded bg-indigo-400/80 w-[85%]" />
+                <div className="h-2.5 rounded bg-indigo-400/50 w-[70%]" />
+                <div className="rounded border border-indigo-300/30 bg-black/30 px-3 py-2 text-[12px] font-mono text-indigo-200">
+                  A v = λ v
+                </div>
+                <div className="h-2.5 rounded bg-indigo-400/50 w-[64%]" />
+                <div className="h-2.5 rounded bg-indigo-400/30 w-[52%]" />
+              </div>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* 06 apply */}
-      <section id="apply" className="max-w-6xl mx-auto px-6 py-24 text-center">
-        <SectionLabel no="06" label={t('beta.s6.label')} />
-        <h2 className="mt-6 text-4xl sm:text-5xl font-extrabold leading-snug whitespace-pre-line">
-          {t('beta.s6.title')}
-        </h2>
-        <p className="mt-5 text-zinc-400">{t('beta.s6.desc')}</p>
-
-        {state === 'done' ? (
-          <div
-            role="status"
-            className="mt-12 max-w-xl mx-auto rounded-2xl border border-indigo-400/30 bg-indigo-500/[0.07] px-8 py-10"
-          >
-            <p className="text-xl font-bold">{t('beta.doneTitle')}</p>
-            <p className="mt-3 text-sm text-zinc-400">{t('beta.doneDesc')}</p>
+        {/* 05 founding member */}
+        <section className="max-w-6xl mx-auto px-6 py-24">
+          <SectionLabel no="05" label={t('beta.s5.label')} />
+          <h2 className="mt-6 text-4xl sm:text-5xl font-extrabold text-center">
+            {t('beta.s5.title')}
+          </h2>
+          <div className="mt-14 grid lg:grid-cols-2 gap-12 items-center max-w-4xl mx-auto">
+            <div className="rounded-2xl border border-indigo-300/25 bg-gradient-to-br from-indigo-500/[0.14] to-white/[0.03] p-7 aspect-[8/5] flex flex-col justify-between shadow-[0_24px_80px_rgba(108,99,255,0.15)]">
+              <div className="flex items-center justify-between text-[11px] tracking-[0.2em] text-zinc-400">
+                <span className="flex items-center gap-2 font-bold text-zinc-200">
+                  <i className="w-4 h-4 rounded border border-indigo-300/60 inline-block" />{' '}
+                  Insighta
+                </span>
+                <span>FOUNDING MEMBER</span>
+              </div>
+              <div>
+                <div className="text-4xl font-extrabold text-zinc-50">Lifetime</div>
+                <div className="mt-1 text-xs text-zinc-500">{t('beta.s5.cardSub')}</div>
+              </div>
+              <div className="flex items-center justify-between text-[11px] tracking-widest text-zinc-500">
+                <span>No. 0041</span>
+                <span>2026 · VOL.01</span>
+              </div>
+            </div>
+            <div>
+              <ul className="space-y-6">
+                {perks.map((p) => (
+                  <li key={p.title} className="flex gap-4">
+                    <span className="mt-0.5 w-5 h-5 rounded-full bg-indigo-500/20 border border-indigo-400/50 flex items-center justify-center flex-none">
+                      <svg viewBox="0 0 12 12" className="w-2.5 h-2.5">
+                        <path
+                          d="M2.5 6.5l2.2 2.2L9.5 3.6"
+                          fill="none"
+                          stroke="#a5b4fc"
+                          strokeWidth="1.8"
+                          strokeLinecap="round"
+                        />
+                      </svg>
+                    </span>
+                    <span>
+                      <span className="block font-bold text-zinc-100">{p.title}</span>
+                      <span className="block mt-1 text-sm text-zinc-500 leading-relaxed">
+                        {p.desc}
+                      </span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-8">
+                <div className="flex items-center justify-between text-xs text-zinc-500">
+                  <span>{t('beta.s5.inviteLabel')}</span>
+                  <span className="font-bold text-zinc-300">
+                    {INVITE_SENT} / {INVITE_TOTAL}
+                  </span>
+                </div>
+                <div className="mt-2 h-1.5 rounded-full bg-white/10 overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-indigo-400"
+                    style={{ width: `${(INVITE_SENT / INVITE_TOTAL) * 100}%` }}
+                  />
+                </div>
+                <p className="mt-3 text-[13px] text-zinc-500">
+                  {t('beta.s5.seatsNote', { seats: SEATS_LEFT })}
+                </p>
+              </div>
+            </div>
           </div>
-        ) : (
-          <form onSubmit={submit} className="mt-12 max-w-xl mx-auto text-left">
-            <textarea
-              value={goal}
-              onChange={(e) => setGoal(e.target.value)}
-              rows={3}
-              maxLength={500}
-              placeholder={t('beta.s6.goalPlaceholder')}
-              aria-label={t('beta.s6.goalPlaceholder')}
-              className="w-full rounded-xl border border-white/15 bg-white/[0.04] px-5 py-4 text-sm text-zinc-100 placeholder:text-zinc-600 outline-none focus:border-indigo-400/60 resize-none"
-            />
-            <div className="mt-3 flex flex-col sm:flex-row gap-3">
-              <input
-                type="email"
-                required
-                value={email}
-                onChange={(e) => {
-                  setEmail(e.target.value);
-                  if (state === 'error') setState('idle');
-                }}
-                placeholder={t('beta.emailPlaceholder')}
-                aria-label={t('beta.emailPlaceholder')}
-                className="flex-1 rounded-xl border border-white/15 bg-white/[0.04] px-5 py-4 text-sm text-zinc-100 placeholder:text-zinc-600 outline-none focus:border-indigo-400/60"
+        </section>
+
+        {/* 06 apply */}
+        <section id="apply" className="max-w-6xl mx-auto px-6 py-24 text-center">
+          <SectionLabel no="06" label={t('beta.s6.label')} />
+          <h2 className="mt-6 text-4xl sm:text-5xl font-extrabold leading-snug whitespace-pre-line">
+            {t('beta.s6.title')}
+          </h2>
+          <p className="mt-5 text-zinc-400">{t('beta.s6.desc')}</p>
+
+          {state === 'done' ? (
+            <div
+              role="status"
+              className="mt-12 max-w-xl mx-auto rounded-2xl border border-indigo-400/30 bg-indigo-500/[0.07] px-8 py-10"
+            >
+              <p className="text-xl font-bold">{t('beta.doneTitle')}</p>
+              <p className="mt-3 text-sm text-zinc-400">{t('beta.doneDesc')}</p>
+            </div>
+          ) : (
+            <form onSubmit={submit} className="mt-12 max-w-xl mx-auto text-left">
+              <textarea
+                value={goal}
+                onChange={(e) => setGoal(e.target.value)}
+                rows={3}
+                maxLength={500}
+                placeholder={t('beta.s6.goalPlaceholder')}
+                aria-label={t('beta.s6.goalPlaceholder')}
+                className="w-full rounded-xl border border-white/15 bg-white/[0.04] px-5 py-4 text-sm text-zinc-100 placeholder:text-zinc-600 outline-none focus:border-indigo-400/60 resize-none"
               />
-              <button
-                type="submit"
-                disabled={state === 'submitting'}
-                className="rounded-xl bg-indigo-500 hover:bg-indigo-400 transition-colors px-8 py-4 text-[15px] font-bold text-white disabled:opacity-50"
-              >
-                {state === 'submitting' ? t('beta.submitting') : t('beta.s6.submit')}
-              </button>
-            </div>
-            {state === 'error' && (
-              <p role="alert" className="mt-3 text-sm text-red-400">
-                {t('beta.error')}
-              </p>
-            )}
-            <p className="mt-4 text-center text-xs text-zinc-600">{t('beta.s6.privacy')}</p>
-          </form>
-        )}
-      </section>
+              <div className="mt-3 flex flex-col sm:flex-row gap-3">
+                <input
+                  type="email"
+                  required
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value);
+                    if (state === 'error') setState('idle');
+                  }}
+                  placeholder={t('beta.emailPlaceholder')}
+                  aria-label={t('beta.emailPlaceholder')}
+                  className="flex-1 rounded-xl border border-white/15 bg-white/[0.04] px-5 py-4 text-sm text-zinc-100 placeholder:text-zinc-600 outline-none focus:border-indigo-400/60"
+                />
+                <button
+                  type="submit"
+                  disabled={state === 'submitting'}
+                  className="rounded-xl bg-indigo-500 hover:bg-indigo-400 transition-colors px-8 py-4 text-[15px] font-bold text-white disabled:opacity-50"
+                >
+                  {state === 'submitting' ? t('beta.submitting') : t('beta.s6.submit')}
+                </button>
+              </div>
+              {state === 'error' && (
+                <p role="alert" className="mt-3 text-sm text-red-400">
+                  {t('beta.error')}
+                </p>
+              )}
+              <p className="mt-4 text-center text-xs text-zinc-600">{t('beta.s6.privacy')}</p>
+            </form>
+          )}
+        </section>
 
-      {/* footer */}
-      <footer className="border-t border-white/10">
-        <div className="max-w-6xl mx-auto px-6 py-8 flex flex-col sm:flex-row items-center justify-between gap-3 text-xs text-zinc-600">
-          <span className="flex items-center gap-2 font-bold text-zinc-400">
-            <i className="w-3.5 h-3.5 rounded border border-zinc-500 inline-block" /> Insighta
-          </span>
-          <span className="flex gap-5">
-            <a href="/privacy" className="hover:text-zinc-400">
-              Privacy
-            </a>
-            <a href="/terms" className="hover:text-zinc-400">
-              Terms
-            </a>
-          </span>
-          <span>© 2026 Insighta</span>
-        </div>
-      </footer>
+        {/* footer */}
+        <footer className="border-t border-white/10">
+          <div className="max-w-6xl mx-auto px-6 py-8 flex flex-col sm:flex-row items-center justify-between gap-3 text-xs text-zinc-600">
+            <span className="flex items-center gap-2 font-bold text-zinc-400">
+              <i className="w-3.5 h-3.5 rounded border border-zinc-500 inline-block" /> Insighta
+            </span>
+            <span className="flex gap-5">
+              <a href="/privacy" className="hover:text-zinc-400">
+                Privacy
+              </a>
+              <a href="/terms" className="hover:text-zinc-400">
+                Terms
+              </a>
+            </span>
+            <span>© 2026 Insighta</span>
+          </div>
+        </footer>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
James directives: '카드를 빈 채로 두지 마 — 썸네일 활용' + '배경이 심심하니 목업 보고 적용'.

- **Thumbnails**: curriculum mockup rows + AFTER card get real linear-algebra video thumbnails (i.ytimg.com — the same source the app uses; all IDs curl-verified 200). The 'algorithm feed' junk cards get real thumbnails with blur/dim treatment so the fictional titles still carry the story.
- **Background**: layered indigo radial glows + fine starfield dot texture + faint grid, matching the Claude Design mockup (was flat).

Verified: build pass, browser smoke 14/14 images loaded, full-page visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)