### PR TITLE
feat(beta): config-driven signup gate (no-op by default, fail-open)

### DIFF
--- a/frontend/src/pages/login/ui/LoginPage.tsx
+++ b/frontend/src/pages/login/ui/LoginPage.tsx
@@ -2,23 +2,44 @@ import { useState, useEffect, type FormEvent } from 'react';
 import { useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
-  Loader2, Eye, EyeOff, Mail, CheckCircle2, ChevronLeft,
-  LayoutGrid, Video, Sparkles, Activity,
+  Loader2,
+  Eye,
+  EyeOff,
+  Mail,
+  CheckCircle2,
+  ChevronLeft,
+  LayoutGrid,
+  Video,
+  Sparkles,
+  Activity,
 } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
 import { Label } from '@/shared/ui/label';
 import { useAuth } from '@/features/auth/model/useAuth';
+import { apiClient } from '@/shared/lib/api-client';
 
 // ── SVG Brand Icons ────────────────────────────────────────
 
 function GoogleIcon({ className }: { className?: string }) {
   return (
     <svg viewBox="0 0 24 24" className={className}>
-      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
-      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
-      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
-      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
     </svg>
   );
 }
@@ -80,6 +101,8 @@ export default function LoginPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successState, setSuccessState] = useState<SuccessState>('none');
+  // Closed-beta signup gate (config-driven; defaults to 'open' = no gate).
+  const [signupMode, setSignupMode] = useState<'open' | 'invite_only' | 'closed'>('open');
 
   useEffect(() => {
     if (!isLoading && isLoggedIn) {
@@ -89,6 +112,20 @@ export default function LoginPage() {
       navigate(safeReturnTo, { replace: true });
     }
   }, [isLoggedIn, isLoading, navigate, searchParams]);
+
+  useEffect(() => {
+    apiClient
+      .getBetaConfig()
+      .then((c) => setSignupMode(c.signupMode))
+      .catch(() => setSignupMode('open')); // fail open — never lock out on config error
+  }, []);
+
+  // When signup is fully closed, keep users out of signup mode entirely.
+  useEffect(() => {
+    if (signupMode === 'closed' && mode === 'signup') {
+      navigate('/beta', { replace: true });
+    }
+  }, [signupMode, mode, navigate]);
 
   const storeReturnTo = () => {
     const returnTo = searchParams.get('returnTo');
@@ -117,6 +154,14 @@ export default function LoginPage() {
       if (mode === 'signin') {
         await signInWithEmail(email, password);
       } else {
+        // Closed-beta gate: only invited emails may create an account.
+        if (signupMode !== 'open') {
+          const { allowed } = await apiClient.checkBetaInvite(email);
+          if (!allowed) {
+            navigate('/beta', { replace: true });
+            return;
+          }
+        }
         await signUpWithEmail(email, password, name || undefined);
         setSuccessState('signup');
       }
@@ -185,52 +230,60 @@ export default function LoginPage() {
 
   return (
     <div className="min-h-screen flex bg-background">
-        {/* ═══ LEFT: Brand Panel ═══ */}
-        <div className="hidden lg:flex w-[45%] flex-col items-center justify-center px-12 pb-24 pt-10 relative overflow-hidden border-r border-border/40">
-          {/* Animated gradient background */}
-          <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-purple-500/[0.04]" />
-          <div className="absolute top-[15%] -left-[15%] w-[500px] h-[500px] rounded-full bg-primary/[0.07] blur-[100px] animate-gradient-blob-1 pointer-events-none" />
-          <div className="absolute bottom-[10%] -right-[10%] w-[350px] h-[350px] rounded-full bg-purple-500/[0.05] blur-[80px] animate-gradient-blob-2 pointer-events-none" />
+      {/* ═══ LEFT: Brand Panel ═══ */}
+      <div className="hidden lg:flex w-[45%] flex-col items-center justify-center px-12 pb-24 pt-10 relative overflow-hidden border-r border-border/40">
+        {/* Animated gradient background */}
+        <div className="absolute inset-0 bg-gradient-to-br from-primary/[0.06] via-transparent to-purple-500/[0.04]" />
+        <div className="absolute top-[15%] -left-[15%] w-[500px] h-[500px] rounded-full bg-primary/[0.07] blur-[100px] animate-gradient-blob-1 pointer-events-none" />
+        <div className="absolute bottom-[10%] -right-[10%] w-[350px] h-[350px] rounded-full bg-purple-500/[0.05] blur-[80px] animate-gradient-blob-2 pointer-events-none" />
 
-          <div className="w-full max-w-[480px] relative z-10">
-            {/* Logo */}
-            <div className="flex items-center gap-2.5 mb-12">
-              <img
-                src={logoSrc}
-                alt="Insighta"
-                className="w-9 h-9 rounded-xl dark:invert"
-              />
-              <span className="text-2xl font-bold tracking-tight text-foreground">Insighta</span>
-              <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-md bg-primary/10 text-primary border border-primary/30">
-                {t('common.beta')}
-              </span>
-            </div>
+        <div className="w-full max-w-[480px] relative z-10">
+          {/* Logo */}
+          <div className="flex items-center gap-2.5 mb-12">
+            <img src={logoSrc} alt="Insighta" className="w-9 h-9 rounded-xl dark:invert" />
+            <span className="text-2xl font-bold tracking-tight text-foreground">Insighta</span>
+            <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-md bg-primary/10 text-primary border border-primary/30">
+              {t('common.beta')}
+            </span>
+          </div>
 
-            {/* Headline */}
-            <h1 className="text-[2.5rem] leading-[1.15] font-serif mb-4 text-foreground whitespace-pre-line">
-              {t('login.headline')}
-            </h1>
-            <p className="text-[15px] text-muted-foreground mb-8 leading-relaxed whitespace-pre-line">
-              {t('login.brandSub')}
-            </p>
+          {/* Headline */}
+          <h1 className="text-[2.5rem] leading-[1.15] font-serif mb-4 text-foreground whitespace-pre-line">
+            {t('login.headline')}
+          </h1>
+          <p className="text-[15px] text-muted-foreground mb-8 leading-relaxed whitespace-pre-line">
+            {t('login.brandSub')}
+          </p>
 
-            {/* Features */}
-            <ul className="space-y-4 mb-10">
-              {FEATURES.map((f) => {
-                const Icon = f.icon;
-                return (
-                  <li key={f.key} className="flex items-start gap-3 text-sm text-muted-foreground leading-relaxed">
-                    <div className={`w-7 h-7 rounded-lg flex-shrink-0 flex items-center justify-center mt-0.5 ${f.bgClass}`}>
-                      <Icon className={`w-3.5 h-3.5 ${f.iconClass}`} />
-                    </div>
-                    <span dangerouslySetInnerHTML={{ __html: t(`login.${f.key}`).replace(/^(.+?) — /, '<strong class="text-foreground font-medium">$1</strong> — ') }} />
-                  </li>
-                );
-              })}
-            </ul>
+          {/* Features */}
+          <ul className="space-y-4 mb-10">
+            {FEATURES.map((f) => {
+              const Icon = f.icon;
+              return (
+                <li
+                  key={f.key}
+                  className="flex items-start gap-3 text-sm text-muted-foreground leading-relaxed"
+                >
+                  <div
+                    className={`w-7 h-7 rounded-lg flex-shrink-0 flex items-center justify-center mt-0.5 ${f.bgClass}`}
+                  >
+                    <Icon className={`w-3.5 h-3.5 ${f.iconClass}`} />
+                  </div>
+                  <span
+                    dangerouslySetInnerHTML={{
+                      __html: t(`login.${f.key}`).replace(
+                        /^(.+?) — /,
+                        '<strong class="text-foreground font-medium">$1</strong> — '
+                      ),
+                    }}
+                  />
+                </li>
+              );
+            })}
+          </ul>
 
-            {/* Social proof */}
-            <div className="flex items-center gap-4">
+          {/* Social proof */}
+          <div className="flex items-center gap-4">
             <div className="flex">
               {SOCIAL_PROOF_AVATARS.map((av, i) => (
                 <div
@@ -245,224 +298,230 @@ export default function LoginPage() {
             <span className="text-[13px] text-muted-foreground/70">
               {t('login.socialProof', { cards: SOCIAL_PROOF_CARDS, users: SOCIAL_PROOF_USERS })}
             </span>
-            </div>
-          </div>
-        </div>
-
-        {/* ═══ RIGHT: Auth Panel ═══ */}
-        <div className="flex-1 flex flex-col items-center justify-center p-6 sm:p-10 sm:pt-[12vh] relative">
-          <div className="w-full max-w-[400px]">
-            {successState !== 'none' ? (
-              <SuccessMessage
-                state={successState}
-                email={email}
-                t={t}
-                onBack={backToSignIn}
-              />
-            ) : (
-              <>
-                {/* Mobile logo (hidden on lg+) */}
-                <div className="lg:hidden flex items-center justify-center gap-2.5 mb-8">
-                  <img
-                    src={logoSrc}
-                    alt="Insighta"
-                    className="w-8 h-8 rounded-xl dark:invert"
-                  />
-                  <span className="text-xl font-bold tracking-tight text-foreground">Insighta</span>
-                  <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-md bg-primary/10 text-primary border border-primary/30">
-                    {t('common.beta')}
-                  </span>
-                </div>
-
-                {/* Tabs */}
-                <div className="flex gap-0.5 mb-7 bg-muted rounded-xl p-1">
-                  <button
-                    type="button"
-                    onClick={() => switchMode('signin')}
-                    className={`flex-1 py-2.5 text-center text-[13px] font-semibold rounded-[10px] transition-all ${
-                      mode === 'signin'
-                        ? 'bg-card text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground/70'
-                    }`}
-                  >
-                    {t('login.tabSignIn')}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => switchMode('signup')}
-                    className={`flex-1 py-2.5 text-center text-[13px] font-semibold rounded-[10px] transition-all ${
-                      mode === 'signup'
-                        ? 'bg-card text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground/70'
-                    }`}
-                  >
-                    {t('login.tabCreateAccount')}
-                  </button>
-                </div>
-
-                {/* Social buttons */}
-                <div className="flex flex-col gap-2.5 mb-6">
-                  <button
-                    type="button"
-                    onClick={handleGoogleLogin}
-                    disabled={isSubmitting}
-                    className="w-full h-12 flex items-center justify-center gap-2.5 rounded-xl text-sm font-semibold border border-border bg-card text-foreground hover:bg-accent hover:-translate-y-px hover:shadow-md active:translate-y-0 transition-all disabled:opacity-50"
-                  >
-                    <GoogleIcon className="w-[18px] h-[18px]" />
-                    {t('login.continueWithGoogle')}
-                  </button>
-                  <div className="relative group">
-                    <button
-                      type="button"
-                      disabled
-                      className="w-full h-12 flex items-center justify-center gap-2.5 rounded-xl text-sm font-semibold cursor-not-allowed transition-all border border-[#FEE500]/30 bg-[#FEE500]/20 text-[#FEE500] grayscale-[0.4] opacity-60"
-                    >
-                      <KakaoIcon className="w-[18px] h-[18px]" />
-                      {t('login.continueWithKakao')}
-                    </button>
-                    <span className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs rounded bg-foreground text-background opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none">
-                      {t('login.kakaoComingSoon')}
-                    </span>
-                  </div>
-                </div>
-
-                {/* Divider */}
-                <div className="flex items-center gap-4 mb-6">
-                  <div className="flex-1 h-px bg-border" />
-                  <span className="text-xs text-muted-foreground/60 font-medium whitespace-nowrap">
-                    {t('login.orContinueWithEmail')}
-                  </span>
-                  <div className="flex-1 h-px bg-border" />
-                </div>
-
-                {/* Error */}
-                {error && (
-                  <div className="p-3 rounded-lg bg-destructive/10 border border-destructive/30 text-destructive text-sm mb-4">
-                    {error}
-                  </div>
-                )}
-
-                {/* Email form */}
-                <form onSubmit={handleEmailSubmit} className="space-y-4">
-                  {mode === 'signup' && (
-                    <div className="space-y-1.5">
-                      <Label htmlFor="name" className="text-[13px] font-semibold text-muted-foreground">
-                        {t('login.fullName')}
-                      </Label>
-                      <Input
-                        id="name"
-                        type="text"
-                        placeholder={t('login.fullNamePlaceholder')}
-                        value={name}
-                        onChange={(e) => setName(e.target.value)}
-                        className="h-11"
-                      />
-                    </div>
-                  )}
-
-                  <div className="space-y-1.5">
-                    <Label htmlFor="email" className="text-[13px] font-semibold text-muted-foreground">
-                      {t('login.email')}
-                    </Label>
-                    <Input
-                      id="email"
-                      type="email"
-                      placeholder={t('login.emailPlaceholder')}
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      required
-                      className="h-11"
-                    />
-                  </div>
-
-                  <div className="space-y-1.5">
-                    <Label htmlFor="password" className="text-[13px] font-semibold text-muted-foreground">
-                      {t('login.password')}
-                    </Label>
-                    <div className="relative">
-                      <Input
-                        id="password"
-                        type={showPassword ? 'text' : 'password'}
-                        placeholder={t('login.passwordPlaceholder')}
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        required
-                        className="h-11 pr-10"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => setShowPassword(!showPassword)}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                      </button>
-                    </div>
-                    {mode === 'signin' && (
-                      <button
-                        type="button"
-                        onClick={handleForgotPassword}
-                        className="block text-right w-full text-xs text-primary/80 hover:text-primary hover:underline transition-colors mt-1"
-                      >
-                        {t('login.forgotPassword')}
-                      </button>
-                    )}
-                  </div>
-
-                  <Button
-                    type="submit"
-                    disabled={isSubmitting}
-                    className="w-full h-12 text-sm font-bold rounded-xl mt-2"
-                  >
-                    {isSubmitting ? (
-                      <Loader2 className="w-4 h-4 animate-spin" />
-                    ) : mode === 'signin' ? (
-                      t('login.signIn')
-                    ) : (
-                      t('login.createAccount')
-                    )}
-                  </Button>
-                </form>
-
-                {/* Magic link */}
-                <button
-                  type="button"
-                  onClick={handleMagicLink}
-                  disabled={isSubmitting}
-                  className="w-full mt-3 py-2.5 flex items-center justify-center gap-2 rounded-xl text-[13px] font-semibold text-primary/80 border border-primary/20 hover:bg-primary/[0.06] hover:border-primary/30 transition-all disabled:opacity-50"
-                >
-                  <Mail className="w-4 h-4" />
-                  {t('login.sendMagicLink')}
-                </button>
-
-                {/* Mode switch */}
-                <p className="text-center mt-6 text-[13px] text-muted-foreground">
-                  {mode === 'signin' ? t('login.noAccount') : t('login.hasAccount')}{' '}
-                  <button
-                    type="button"
-                    onClick={() => switchMode(mode === 'signin' ? 'signup' : 'signin')}
-                    className="text-primary/80 font-semibold hover:text-primary hover:underline transition-colors"
-                  >
-                    {mode === 'signin' ? t('login.createOne') : t('login.signInLink')}
-                  </button>
-                </p>
-
-                {/* Terms */}
-                <p className="text-center mt-5 text-[11.5px] text-muted-foreground/60 leading-relaxed">
-                  {t('login.agreeToTerms')}{' '}
-                  <Link to="/terms" className="text-muted-foreground underline underline-offset-2 hover:text-primary transition-colors">
-                    {t('login.termsOfService')}
-                  </Link>{' '}
-                  {t('login.and')}{' '}
-                  <Link to="/privacy" className="text-muted-foreground underline underline-offset-2 hover:text-primary transition-colors">
-                    {t('login.privacyPolicy')}
-                  </Link>
-                  {t('login.agreeSuffix')}
-                </p>
-              </>
-            )}
           </div>
         </div>
       </div>
+
+      {/* ═══ RIGHT: Auth Panel ═══ */}
+      <div className="flex-1 flex flex-col items-center justify-center p-6 sm:p-10 sm:pt-[12vh] relative">
+        <div className="w-full max-w-[400px]">
+          {successState !== 'none' ? (
+            <SuccessMessage state={successState} email={email} t={t} onBack={backToSignIn} />
+          ) : (
+            <>
+              {/* Mobile logo (hidden on lg+) */}
+              <div className="lg:hidden flex items-center justify-center gap-2.5 mb-8">
+                <img src={logoSrc} alt="Insighta" className="w-8 h-8 rounded-xl dark:invert" />
+                <span className="text-xl font-bold tracking-tight text-foreground">Insighta</span>
+                <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-md bg-primary/10 text-primary border border-primary/30">
+                  {t('common.beta')}
+                </span>
+              </div>
+
+              {/* Tabs */}
+              <div className="flex gap-0.5 mb-7 bg-muted rounded-xl p-1">
+                <button
+                  type="button"
+                  onClick={() => switchMode('signin')}
+                  className={`flex-1 py-2.5 text-center text-[13px] font-semibold rounded-[10px] transition-all ${
+                    mode === 'signin'
+                      ? 'bg-card text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground/70'
+                  }`}
+                >
+                  {t('login.tabSignIn')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => switchMode('signup')}
+                  className={`flex-1 py-2.5 text-center text-[13px] font-semibold rounded-[10px] transition-all ${
+                    mode === 'signup'
+                      ? 'bg-card text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground/70'
+                  }`}
+                >
+                  {t('login.tabCreateAccount')}
+                </button>
+              </div>
+
+              {/* Social buttons */}
+              <div className="flex flex-col gap-2.5 mb-6">
+                <button
+                  type="button"
+                  onClick={handleGoogleLogin}
+                  disabled={isSubmitting}
+                  className="w-full h-12 flex items-center justify-center gap-2.5 rounded-xl text-sm font-semibold border border-border bg-card text-foreground hover:bg-accent hover:-translate-y-px hover:shadow-md active:translate-y-0 transition-all disabled:opacity-50"
+                >
+                  <GoogleIcon className="w-[18px] h-[18px]" />
+                  {t('login.continueWithGoogle')}
+                </button>
+                <div className="relative group">
+                  <button
+                    type="button"
+                    disabled
+                    className="w-full h-12 flex items-center justify-center gap-2.5 rounded-xl text-sm font-semibold cursor-not-allowed transition-all border border-[#FEE500]/30 bg-[#FEE500]/20 text-[#FEE500] grayscale-[0.4] opacity-60"
+                  >
+                    <KakaoIcon className="w-[18px] h-[18px]" />
+                    {t('login.continueWithKakao')}
+                  </button>
+                  <span className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 text-xs rounded bg-foreground text-background opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none">
+                    {t('login.kakaoComingSoon')}
+                  </span>
+                </div>
+              </div>
+
+              {/* Divider */}
+              <div className="flex items-center gap-4 mb-6">
+                <div className="flex-1 h-px bg-border" />
+                <span className="text-xs text-muted-foreground/60 font-medium whitespace-nowrap">
+                  {t('login.orContinueWithEmail')}
+                </span>
+                <div className="flex-1 h-px bg-border" />
+              </div>
+
+              {/* Error */}
+              {error && (
+                <div className="p-3 rounded-lg bg-destructive/10 border border-destructive/30 text-destructive text-sm mb-4">
+                  {error}
+                </div>
+              )}
+
+              {/* Email form */}
+              <form onSubmit={handleEmailSubmit} className="space-y-4">
+                {mode === 'signup' && (
+                  <div className="space-y-1.5">
+                    <Label
+                      htmlFor="name"
+                      className="text-[13px] font-semibold text-muted-foreground"
+                    >
+                      {t('login.fullName')}
+                    </Label>
+                    <Input
+                      id="name"
+                      type="text"
+                      placeholder={t('login.fullNamePlaceholder')}
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      className="h-11"
+                    />
+                  </div>
+                )}
+
+                <div className="space-y-1.5">
+                  <Label
+                    htmlFor="email"
+                    className="text-[13px] font-semibold text-muted-foreground"
+                  >
+                    {t('login.email')}
+                  </Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder={t('login.emailPlaceholder')}
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    className="h-11"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label
+                    htmlFor="password"
+                    className="text-[13px] font-semibold text-muted-foreground"
+                  >
+                    {t('login.password')}
+                  </Label>
+                  <div className="relative">
+                    <Input
+                      id="password"
+                      type={showPassword ? 'text' : 'password'}
+                      placeholder={t('login.passwordPlaceholder')}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      required
+                      className="h-11 pr-10"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                    </button>
+                  </div>
+                  {mode === 'signin' && (
+                    <button
+                      type="button"
+                      onClick={handleForgotPassword}
+                      className="block text-right w-full text-xs text-primary/80 hover:text-primary hover:underline transition-colors mt-1"
+                    >
+                      {t('login.forgotPassword')}
+                    </button>
+                  )}
+                </div>
+
+                <Button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="w-full h-12 text-sm font-bold rounded-xl mt-2"
+                >
+                  {isSubmitting ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : mode === 'signin' ? (
+                    t('login.signIn')
+                  ) : (
+                    t('login.createAccount')
+                  )}
+                </Button>
+              </form>
+
+              {/* Magic link */}
+              <button
+                type="button"
+                onClick={handleMagicLink}
+                disabled={isSubmitting}
+                className="w-full mt-3 py-2.5 flex items-center justify-center gap-2 rounded-xl text-[13px] font-semibold text-primary/80 border border-primary/20 hover:bg-primary/[0.06] hover:border-primary/30 transition-all disabled:opacity-50"
+              >
+                <Mail className="w-4 h-4" />
+                {t('login.sendMagicLink')}
+              </button>
+
+              {/* Mode switch */}
+              <p className="text-center mt-6 text-[13px] text-muted-foreground">
+                {mode === 'signin' ? t('login.noAccount') : t('login.hasAccount')}{' '}
+                <button
+                  type="button"
+                  onClick={() => switchMode(mode === 'signin' ? 'signup' : 'signin')}
+                  className="text-primary/80 font-semibold hover:text-primary hover:underline transition-colors"
+                >
+                  {mode === 'signin' ? t('login.createOne') : t('login.signInLink')}
+                </button>
+              </p>
+
+              {/* Terms */}
+              <p className="text-center mt-5 text-[11.5px] text-muted-foreground/60 leading-relaxed">
+                {t('login.agreeToTerms')}{' '}
+                <Link
+                  to="/terms"
+                  className="text-muted-foreground underline underline-offset-2 hover:text-primary transition-colors"
+                >
+                  {t('login.termsOfService')}
+                </Link>{' '}
+                {t('login.and')}{' '}
+                <Link
+                  to="/privacy"
+                  className="text-muted-foreground underline underline-offset-2 hover:text-primary transition-colors"
+                >
+                  {t('login.privacyPolicy')}
+                </Link>
+                {t('login.agreeSuffix')}
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1591,6 +1591,25 @@ class ApiClient {
     });
   }
 
+  /** Public beta config — drives the /beta countdown and the signup gate. */
+  async getBetaConfig(): Promise<{
+    signupMode: 'open' | 'invite_only' | 'closed';
+    phase: 'pre_launch' | 'running' | 'ended';
+    window: { start: string; end: string };
+  }> {
+    return this.request('/beta/config', { method: 'GET' });
+  }
+
+  /** Whether an email may sign up under the current beta signup mode. */
+  async checkBetaInvite(
+    email: string
+  ): Promise<{ allowed: boolean; mode: 'open' | 'invite_only' | 'closed' }> {
+    return this.request('/beta/check-invite', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    });
+  }
+
   // Mandala List & Multi-Mandala CRUD
   // ========================================
 

--- a/src/api/routes/beta.ts
+++ b/src/api/routes/beta.ts
@@ -1,5 +1,13 @@
 import { FastifyPluginCallback } from 'fastify';
 import { getPrismaClient } from '../../modules/database/client';
+import {
+  getSetting,
+  SETTING_KEYS,
+  BETA_DEFAULTS,
+  type BetaSignupMode,
+  type BetaPhase,
+  type BetaWindow,
+} from '../../modules/system-settings';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
 const EMAIL_MAX_LENGTH = 255;
@@ -42,6 +50,50 @@ export const betaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       });
 
       return reply.send({ ok: true });
+    }
+  );
+
+  /**
+   * Public beta config — drives the /beta countdown and the /login signup gate.
+   * Non-sensitive; safe to expose unauthenticated.
+   */
+  fastify.get('/config', async (_request, reply) => {
+    const [signupMode, phase, window] = await Promise.all([
+      getSetting<BetaSignupMode>(SETTING_KEYS.BETA_SIGNUP_MODE, BETA_DEFAULTS.signupMode),
+      getSetting<BetaPhase>(SETTING_KEYS.BETA_PHASE, BETA_DEFAULTS.phase),
+      getSetting<BetaWindow>(SETTING_KEYS.BETA_WINDOW, BETA_DEFAULTS.window),
+    ]);
+    return reply.send({ signupMode, phase, window });
+  });
+
+  /**
+   * Invite check for the signup gate. Returns whether an email may sign up
+   * under the current mode. Never reveals application status beyond the
+   * boolean needed to gate signup.
+   */
+  fastify.post<{ Body: { email?: string } }>(
+    '/check-invite',
+    { config: { rateLimit: { max: 10, timeWindow: '1 minute' } } },
+    async (request, reply) => {
+      const signupMode = await getSetting<BetaSignupMode>(
+        SETTING_KEYS.BETA_SIGNUP_MODE,
+        BETA_DEFAULTS.signupMode
+      );
+      if (signupMode === 'open') {
+        return reply.send({ allowed: true, mode: signupMode });
+      }
+      if (signupMode === 'closed') {
+        return reply.send({ allowed: false, mode: signupMode });
+      }
+      // invite_only — allowed iff the email was invited (or already joined).
+      const email = normalizeBetaEmail(request.body?.email);
+      if (!email) {
+        return reply.send({ allowed: false, mode: signupMode });
+      }
+      const prisma = getPrismaClient();
+      const app = await prisma.beta_applications.findUnique({ where: { email } });
+      const allowed = app?.status === 'invited' || app?.status === 'joined';
+      return reply.send({ allowed, mode: signupMode });
     }
   );
 

--- a/src/modules/system-settings/index.ts
+++ b/src/modules/system-settings/index.ts
@@ -59,4 +59,27 @@ export const SETTING_KEYS = {
    * Admin can override via PUT /api/v1/admin/settings/trend_extract_model.
    */
   TREND_EXTRACT_MODEL: 'trend_extract_model',
+  /**
+   * Closed-beta campaign controls (admin-toggleable, no deploy).
+   * - BETA_SIGNUP_MODE: 'open' | 'invite_only' | 'closed' — default 'open' (= current behavior).
+   * - BETA_PHASE: 'pre_launch' | 'running' | 'ended'.
+   * - BETA_WINDOW: { start: ISO, end: ISO } — drives the /beta countdown.
+   */
+  BETA_SIGNUP_MODE: 'beta_signup_mode',
+  BETA_PHASE: 'beta_phase',
+  BETA_WINDOW: 'beta_window',
 } as const;
+
+export type BetaSignupMode = 'open' | 'invite_only' | 'closed';
+export type BetaPhase = 'pre_launch' | 'running' | 'ended';
+export interface BetaWindow {
+  start: string;
+  end: string;
+}
+
+// Defaults preserve current behavior (open signup) so an unset store is a no-op.
+export const BETA_DEFAULTS = {
+  signupMode: 'open' as BetaSignupMode,
+  phase: 'pre_launch' as BetaPhase,
+  window: { start: '2026-07-13T00:00:00+09:00', end: '2026-08-24T00:00:00+09:00' } as BetaWindow,
+};

--- a/tests/smoke/beta-apply.test.ts
+++ b/tests/smoke/beta-apply.test.ts
@@ -20,3 +20,20 @@ describe('normalizeBetaEmail', () => {
     expect(normalizeBetaEmail(`${'a'.repeat(250)}@example.com`)).toBeNull();
   });
 });
+
+// Gate config defaults must preserve current behavior (open signup = no-op).
+import { BETA_DEFAULTS } from '../../src/modules/system-settings';
+
+describe('beta gate defaults (regression: unset store = open, no-op)', () => {
+  it('defaults signup to open so an unconfigured store never blocks signup', () => {
+    expect(BETA_DEFAULTS.signupMode).toBe('open');
+  });
+  it('defaults phase to pre_launch', () => {
+    expect(BETA_DEFAULTS.phase).toBe('pre_launch');
+  });
+  it('has a valid 6-week window (start Mon 2026-07-13, end 2026-08-24)', () => {
+    const start = Date.parse(BETA_DEFAULTS.window.start);
+    const end = Date.parse(BETA_DEFAULTS.window.end);
+    expect(end - start).toBe(42 * 24 * 60 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
**PR-A of the beta campaign console** (design: `docs/design/beta-campaign-admin-console-2026-07-08.md`). Regression-critical (touches /login right before beta) — designed as a **no-op by default**.

## What
- `system_settings` keys: `beta_signup_mode` (`open`|`invite_only`|`closed`), `beta_phase`, `beta_window` — admin-toggleable, **no deploy** (existing getSetting/setSetting + cache invalidation).
- Public `GET /api/v1/beta/config` (countdown + gate) and `POST /api/v1/beta/check-invite`.
- `/login`: `open` = unchanged; `invite_only` = email must be in `beta_applications(invited/joined)` else redirect `/beta`; `closed` = signup hidden + redirect.

## Regression safety (James: '베타 직전 심각할 수 있음')
- **Default = `open` = current behavior** (unset store → no gate). Admin must explicitly flip it.
- **Fail-open**: config fetch error → `open` (never locks users out).
- **signin never gated** — existing users always log in.
- Signup runs client-side (`supabase.auth.signUp`), so this is the FE soft-gate (design §4 계층 1); a Supabase `enable_signup=false` hard-lock is an optional operator step.

## Verification
BE tsc + jest 15 (incl. default-open regression tests) · FE tsc + vitest 512 + build · **e2e**: open → all allowed; invite_only → invited allowed, pending/unknown blocked (API) + **browser: non-invited signup redirects to /beta, signin form unchanged**. Local DB reset after test.

## Follow-ups (design PR-B..E)
Admin console (inbox + toggles), evaluation engine + dashboard, transparency view, winner→Lifetime — timed to beta progression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)