### PR TITLE
fix(security): admin beta-applications require auth (PII leak)

### DIFF
--- a/src/api/routes/admin/beta-applications.ts
+++ b/src/api/routes/admin/beta-applications.ts
@@ -1,11 +1,18 @@
-import { FastifyPluginCallback } from 'fastify';
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { getPrismaClient } from '../../../modules/database/client';
 
-/** Admin — closed-beta application inbox (invitations are sent manually). */
-export const adminBetaApplicationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+/**
+ * Admin — closed-beta application inbox (invitations are sent manually).
+ * Every route is admin-gated: applicant emails + goals are PII and must never
+ * be served without authentication.
+ */
+export async function adminBetaApplicationRoutes(fastify: FastifyInstance) {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
   fastify.get<{ Querystring: { status?: string } }>(
     '/beta-applications',
-    async (request, reply) => {
+    adminAuth,
+    async (request: FastifyRequest<{ Querystring: { status?: string } }>, reply: FastifyReply) => {
       const prisma = getPrismaClient();
       const status = request.query.status;
       const applications = await prisma.beta_applications.findMany({
@@ -19,7 +26,8 @@ export const adminBetaApplicationRoutes: FastifyPluginCallback = (fastify, _opts
 
   fastify.post<{ Params: { id: string } }>(
     '/beta-applications/:id/mark-invited',
-    async (request, reply) => {
+    adminAuth,
+    async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
       const prisma = getPrismaClient();
       const updated = await prisma.beta_applications.update({
         where: { id: request.params.id },
@@ -28,6 +36,4 @@ export const adminBetaApplicationRoutes: FastifyPluginCallback = (fastify, _opts
       return reply.send({ application: updated });
     }
   );
-
-  done();
-};
+}


### PR DESCRIPTION
**Security hotfix.** `GET /api/v1/admin/beta-applications` was serving applicant **emails + learning goals without authentication** — the route was registered without the admin-auth `onRequest` guard that every other admin route uses.

Prod repro (before): `curl https://insighta.one/api/v1/admin/beta-applications` → 200 with PII. After: 401.

Fix: add `{ onRequest: [fastify.authenticate, fastify.authenticateAdmin] }` to both routes (list + mark-invited).

Verified locally: unauthenticated → 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)