### PR TITLE
fix(mobile): /beta hero overflow + Korea→Korean default + banner spacing

### DIFF
--- a/frontend/src/pages/beta/ui/BetaApplyPage.tsx
+++ b/frontend/src/pages/beta/ui/BetaApplyPage.tsx
@@ -409,8 +409,8 @@ export default function BetaApplyPage() {
 
         {/* hero */}
         <section className="max-w-6xl mx-auto px-6 pt-16 pb-24 grid lg:grid-cols-2 gap-14 items-center">
-          <div>
-            <h1 className="text-5xl sm:text-6xl font-extrabold leading-[1.15] tracking-tight">
+          <div className="min-w-0">
+            <h1 className="text-4xl sm:text-6xl font-extrabold leading-[1.15] tracking-tight break-keep">
               {t('beta.hero.line1')}
               <br />
               {t('beta.hero.line2pre')}
@@ -419,14 +419,14 @@ export default function BetaApplyPage() {
               </span>
               {t('beta.hero.line2post')}
             </h1>
-            <p className="mt-8 text-lg leading-relaxed text-zinc-400 whitespace-pre-line">
+            <p className="mt-8 text-base sm:text-lg leading-relaxed text-zinc-400 whitespace-pre-line break-keep">
               {t('beta.hero.desc')}
             </p>
-            <div className="mt-9 flex items-center gap-5">
+            <div className="mt-9 flex flex-col sm:flex-row sm:items-center items-start gap-4 sm:gap-5">
               <button
                 type="button"
                 onClick={scrollToApply}
-                className="rounded-xl bg-indigo-500 hover:bg-indigo-400 transition-colors px-7 py-4 text-[15px] font-bold text-white shadow-[0_0_40px_rgba(108,99,255,0.35)]"
+                className="w-full sm:w-auto rounded-xl bg-indigo-500 hover:bg-indigo-400 transition-colors px-7 py-4 text-[15px] font-bold text-white shadow-[0_0_40px_rgba(108,99,255,0.35)] whitespace-nowrap"
               >
                 {t('beta.hero.cta')} →
               </button>

--- a/frontend/src/pages/landing/ui/components/LTDBanner.tsx
+++ b/frontend/src/pages/landing/ui/components/LTDBanner.tsx
@@ -15,21 +15,21 @@ export function LTDBanner() {
 
   return (
     <div className="relative z-50 bg-foreground text-background">
-      <div className="mx-auto max-w-7xl px-4 py-2.5 flex items-center justify-center gap-3 text-sm">
+      <div className="mx-auto max-w-7xl pl-4 pr-10 py-2.5 flex items-center justify-center gap-2 sm:gap-3 text-sm">
         <Flame className="w-4 h-4 text-primary shrink-0" aria-hidden="true" />
-        <p className="font-medium">
+        <p className="font-medium min-w-0">
           <span className="hidden sm:inline">{t('landing.betaBanner')}</span>
           <span className="sm:hidden">{t('landing.betaBannerShort')}</span>
         </p>
         <Link
           to="/beta"
-          className="inline-flex items-center px-3 py-1 rounded-full bg-primary text-primary-foreground text-xs font-semibold hover:bg-primary/90 transition-colors whitespace-nowrap"
+          className="shrink-0 inline-flex items-center px-3 py-1 rounded-full bg-primary text-primary-foreground text-xs font-semibold hover:bg-primary/90 transition-colors whitespace-nowrap"
         >
           {t('landing.betaBannerCta')}
         </Link>
         <button
           onClick={() => setDismissed(true)}
-          className="absolute right-3 top-1/2 -translate-y-1/2 p-1 rounded-full hover:bg-background/10 transition-colors"
+          className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-full hover:bg-background/10 transition-colors"
           aria-label={t('common.close')}
         >
           <X className="w-3.5 h-3.5" />

--- a/frontend/src/shared/i18n/config.ts
+++ b/frontend/src/shared/i18n/config.ts
@@ -4,8 +4,24 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import ko from './locales/ko.json';
 import en from './locales/en.json';
 
+// Visitors physically in Korea default to Korean even if their device UI
+// language is English — timezone is a reliable proxy for location. A user's
+// explicit choice (localStorage) still wins because it is checked first.
+const languageDetector = new LanguageDetector();
+languageDetector.addDetector({
+  name: 'koreaTimezone',
+  lookup() {
+    try {
+      if (Intl.DateTimeFormat().resolvedOptions().timeZone === 'Asia/Seoul') return 'ko';
+    } catch {
+      /* Intl unavailable — fall through to navigator */
+    }
+    return undefined;
+  },
+});
+
 i18n
-  .use(LanguageDetector)
+  .use(languageDetector)
   .use(initReactI18next)
   .init({
     resources: {
@@ -17,7 +33,7 @@ i18n
       escapeValue: false,
     },
     detection: {
-      order: ['localStorage', 'navigator'],
+      order: ['localStorage', 'koreaTimezone', 'navigator'],
       lookupLocalStorage: 'i18n-language',
       caches: ['localStorage'],
     },


### PR DESCRIPTION
James's iPhone 13 mini (375px) reported clipped text + English UI in Korea.

## Fixes
- **/beta hero clipping**: the page root has `overflow-x-clip`, so overflowing hero text was **cut off** (not scrolled). Root cause = grid/flex child without `min-w-0` + a no-wrap CTA note beside the button. Fixes: `min-w-0` on the text column, `text-4xl` title + `break-keep` on mobile, CTA row `flex-col` with a full-width button so the note wraps below.
- **Korea → Korean default**: added a `koreaTimezone` i18n detector (`Asia/Seoul` → `ko`) before `navigator`, so visitors physically in Korea get Korean even on an English device. Explicit language choice (localStorage) still wins.
- **Landing banner**: reserve right padding for the ✕ + `shrink-0` CTA so the close button stops overlapping the CTA on mobile.

## Verified (375px, Playwright)
- overflow = [] for en / ko / **en-device-in-Korea**
- en device + `Asia/Seoul` timezone → renders Korean
- tsc 0 new · vitest 512 · build pass · visual check (en hero wraps cleanly, was clipping 'lectu'/'tomorro'/'earl')

🤖 Generated with [Claude Code](https://claude.com/claude-code)