### PR TITLE
feat(learning): gold watched-progress line on the /learning player

### DIFF
--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -26,6 +26,7 @@ import { useMandalaCards } from '../model/useMandalaCards';
 import { useMandalaQuery } from '@/features/mandala';
 import { FloatingVideoNavigator } from './FloatingVideoNavigator';
 import { PlayerChrome } from './PlayerChrome';
+import { PlayerWatchedBar } from './PlayerWatchedBar';
 import {
   relevanceLevel,
   relevanceCssVar,
@@ -460,6 +461,8 @@ export function CenterPanel({
           playerRef={playerRef}
           onUserPlayed={onUserPlayed}
         />
+        {/* "내가 본 구간" — gold watched-progress line (CP512, James). */}
+        <PlayerWatchedBar />
       </div>
 
       {centerViewMode === 'player' && (

--- a/frontend/src/pages/learning/ui/PlayerChrome.tsx
+++ b/frontend/src/pages/learning/ui/PlayerChrome.tsx
@@ -51,8 +51,8 @@ const GAP = 4;
 /** Measured 2026 embed UI: bar top ≈74px above bottom, ≈28px side insets.
  *  +8px breathing room — flush placement made the pointer-accepting strip
  *  swallow clicks aimed at the native bar (James, 2026-07-03). */
-const STRIP_BOTTOM_PX = 82;
-const STRIP_INSET_PX = 28;
+export const STRIP_BOTTOM_PX = 82;
+export const STRIP_INSET_PX = 28;
 /** Scrim above the strip so tier colors read over bright footage (mockup
  *  .shade). Stops AT the strip base — never dims the native controls. */
 const SCRIM_EXTRA_PX = 82;

--- a/frontend/src/pages/learning/ui/PlayerWatchedBar.tsx
+++ b/frontend/src/pages/learning/ui/PlayerWatchedBar.tsx
@@ -1,0 +1,34 @@
+import { useLearningStore } from '../model/useLearningStore';
+import { STRIP_BOTTOM_PX, STRIP_INSET_PX } from './PlayerChrome';
+
+/**
+ * Watched-progress line on the /learning native player — the "내가 본 구간"
+ * indicator, in the chapter GOLD (James, CP512). Sibling of PlayerChrome so it
+ * is independent of the relevance-heatmap gate (renders even when a video has no
+ * relevance segments). Always visible (not hover-only) so progress is readable
+ * at a glance. Reads the live player position the player already streams into the
+ * store via onTimeUpdate — no extra wiring. pointer-events-none (never steals a
+ * click from the native bar / the heatmap strip).
+ */
+export function PlayerWatchedBar() {
+  const playerTimeSec = useLearningStore((s) => s.playerTimeSec);
+  const playerDurationSec = useLearningStore((s) => s.playerDurationSec);
+  const playerState = useLearningStore((s) => s.playerState);
+
+  const started = playerState === 'playing' || playerTimeSec > 0;
+  if (!started || playerDurationSec <= 0) return null;
+  const pct = Math.min(100, Math.max(0, (playerTimeSec / playerDurationSec) * 100));
+
+  return (
+    <div
+      className="pointer-events-none absolute z-30"
+      aria-hidden
+      style={{ bottom: STRIP_BOTTOM_PX, left: STRIP_INSET_PX, right: STRIP_INSET_PX, height: 3 }}
+    >
+      <div className="h-full w-full rounded-full bg-black/30">
+        {/* Gold = the learning chapter accent (--nm-accent #c2a878). */}
+        <div className="h-full rounded-full bg-[var(--nm-accent)]" style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
James (CP512): show "내가 본 구간" on the learning-page video player too, in the chapter **GOLD** (not the dashboard red).

## What
- New `PlayerWatchedBar`: a thin gold (`--nm-accent` #c2a878) line at the relevance-strip baseline, width = `playerTimeSec/playerDurationSec` (the live position the player already streams to the store via `onTimeUpdate`). Always visible for at-a-glance progress.
- Sibling of `PlayerChrome` — **independent of the relevance-heatmap gate** (shows even when a video has no relevance segments), `pointer-events-none` (never steals a click from the native bar / heatmap strip).
- Reuses `PlayerChrome`'s calibrated `STRIP_BOTTOM_PX`/`STRIP_INSET_PX` (now exported) so geometry is single-sourced. **PlayerChrome logic untouched.**

## Verify
CI tsc (`tsc --noEmit`) clean · FE build ✅. Additive component; no other file's behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)