### PR TITLE
fix(learning): kill chapter-list flicker on book-index navigation

### DIFF
--- a/frontend/src/features/video-side-panel/model/useRichSummary.ts
+++ b/frontend/src/features/video-side-panel/model/useRichSummary.ts
@@ -18,7 +18,7 @@
  * path. This hook is read-only.
  */
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { apiClient, type VideoRichSummaryResponse } from '@/shared/lib/api-client';
 import { queryKeys } from '@/shared/config/query-client';
 
@@ -48,6 +48,11 @@ export function useRichSummary(videoId: string | null | undefined): UseRichSumma
     enabled: Boolean(videoId),
     staleTime: RICH_SUMMARY_STALE_MS,
     refetchOnMount: 'always',
+    // CP512 — keep the previous video's summary visible while the next one
+    // loads on book-index navigation. Without this the chapter list flashed
+    // its empty "not ready" state on every video switch (data → undefined
+    // mid-fetch). Refetch still runs for freshness; the swap is now invisible.
+    placeholderData: keepPreviousData,
     retry: false,
   });
 

--- a/frontend/src/pages/learning/ui/CenterPanel.tsx
+++ b/frontend/src/pages/learning/ui/CenterPanel.tsx
@@ -91,7 +91,7 @@ export function CenterPanel({
 
   // Highlight reel — auto-skip to sections whose relevance_pct >= threshold.
   // Dormant until pre-CP474 rows are backfilled with segments + relevance.
-  const { richSummary: highlightRich } = useRichSummary(videoId);
+  const { richSummary: highlightRich, isLoading: richLoading } = useRichSummary(videoId);
   const highlightSections = highlightRich?.segments?.sections ?? undefined;
   const highlightReel = useHighlightReel({
     sections: highlightSections,
@@ -580,6 +580,7 @@ export function CenterPanel({
             {centerTab === 'chapters' && (
               <ChapterList
                 sections={chapterSections}
+                loading={richLoading}
                 playerRef={playerRef}
                 onUserPlayed={onUserPlayed}
                 onGoSummary={() => setCenterTab('summary')}
@@ -619,11 +620,13 @@ function RelevanceMeter({ level }: { level: RelevanceLevel }) {
  *  Subscribes to player time HERE so the 1s tick re-renders only this list. */
 function ChapterList({
   sections,
+  loading = false,
   playerRef,
   onUserPlayed,
   onGoSummary,
 }: {
   sections: VideoRichSummarySection[];
+  loading?: boolean;
   playerRef: React.MutableRefObject<YTPlayer | null>;
   onUserPlayed?: () => void;
   onGoSummary: () => void;
@@ -631,6 +634,21 @@ function ChapterList({
   const { t } = useTranslation();
   const playerTimeSec = useLearningStore((s) => s.playerTimeSec);
   const playerState = useLearningStore((s) => s.playerState);
+
+  // First load with no data yet — show quiet skeleton rows, NOT the "not
+  // ready" empty state (which used to flash on every navigation, CP512).
+  if (sections.length === 0 && loading) {
+    return (
+      <div className="mt-2 flex flex-col gap-2" aria-hidden>
+        {[0, 1, 2, 3].map((k) => (
+          <div
+            key={k}
+            className="h-[52px] animate-pulse rounded-xl border border-[var(--lp-line-6)] bg-[var(--lp-surface)]"
+          />
+        ))}
+      </div>
+    );
+  }
 
   if (sections.length === 0) {
     return (


### PR DESCRIPTION
James: navigating the book-index flashed the empty '챕터 정보가 아직 준비되지 않았어요' state before chapters appeared — a delay on every switch.

**Root cause:** useRichSummary had `refetchOnMount:'always'` + no keepPreviousData → on videoId change data went undefined mid-fetch → chapterSections=[] → ChapterList empty state → fetch resolved → chapters.

**Fix:**
- useRichSummary: `placeholderData: keepPreviousData` — previous chapters hold during the next load (refetch still runs; swap is invisible).
- ChapterList: gate the empty state on `!loading`; quiet skeleton during a true first load instead of the empty message.

CI tsc clean · build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)