### PR TITLE
fix(video-pool): insertion guard — never promote empty-title rows (P0 recurrence)

### DIFF
--- a/src/modules/video-pool/promote-from-playlists.ts
+++ b/src/modules/video-pool/promote-from-playlists.ts
@@ -182,7 +182,9 @@ export async function promotePlaylistsToVideoPool(
 
   for (const videoId of toImport) {
     const meta = metaByVideoId.get(videoId);
-    if (!meta || !meta.title) {
+    // CP512 — reject blank/whitespace titles too (insertion integrity guard):
+    // an empty-title pool row can't be served and reads as a title-loss defect.
+    if (!meta || !meta.title || !meta.title.trim()) {
       errors.push({ video_id: videoId, error: 'metadata missing or no title' });
       continue;
     }

--- a/src/modules/video-pool/promote-from-v2.ts
+++ b/src/modules/video-pool/promote-from-v2.ts
@@ -212,6 +212,14 @@ export async function promoteV2ToVideoPool(opts: PromoteOptions = {}): Promise<P
       // Cap title/description column lengths to match existing schema use
       // (batch-video-collector slices to 5000).
       const titleSafe = c.yv_title.slice(0, 5000);
+      // CP512 — insertion integrity guard: never promote an empty-title row into
+      // the serving pool (recommender can't display it; it read as a title-loss
+      // defect). The v2_promoted empties recovered in the P0 backfill came from a
+      // time when the joined youtube_videos.title was blank — this stops a recur.
+      if (!titleSafe.trim()) {
+        errors.push({ video_id: c.video_id, error: 'empty title — skipped' });
+        continue;
+      }
       const descSafe = c.yv_description ? c.yv_description.slice(0, 5000) : null;
       const channelSafe = c.yv_channel_title ? c.yv_channel_title.slice(0, 200) : null;
       const langSafe = (c.yv_default_language ?? c.source_language ?? 'ko').slice(0, 5);


### PR DESCRIPTION
CP512 P0 recurrence guard. The 801 empty-title serving rows (video_pool active 746 + rec_cache 55) were backfilled from youtube_videos (100% recoverable, zero cost) — they were historical (promoted when the joined youtube_videos.title was still blank).

This adds the insertion-integrity guard so it can't recur:
- `promote-from-v2.ts`: skip when the joined title is empty/whitespace.
- `promote-from-playlists.ts`: tighten the existing check to also reject whitespace-only titles.

BE tsc clean. (P0 backfill already applied to prod; batch_trend metadata re-fetch is a separate approved track.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)