### PR TITLE
feat(pool): metadata REFRESH job — keep active rows ToS-compliant AND titled

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -233,6 +233,13 @@ const envSchema = z.object({
     .preprocess((v) => String(v).toLowerCase() !== 'false', z.boolean())
     .default(true),
 
+  // CP512 — metadata REFRESH for active rows (videos.list re-fetch, keeps served
+  // rows ToS-compliant AND titled). Default true; set 'false' to pause refresh
+  // (scrub still only touches inactive rows, so active rows just stop aging-out).
+  POOL_METADATA_REFRESH_ENABLED: z
+    .preprocess((v) => String(v).toLowerCase() !== 'false', z.boolean())
+    .default(true),
+
   // CP494 ② — supply bridge: promote youtube_videos (Mac Mini quota-0 sink)
   // into video_pool (source='yt_promoted'). ONE flag controls the write↔read
   // pair: off = promote endpoint no-ops AND v5 poolSources omits 'yt_promoted'
@@ -423,6 +430,7 @@ export const config = {
   // video_pool ToS hygiene cron (CP494).
   poolMaintenance: {
     enabled: env.POOL_MAINTENANCE_ENABLED,
+    refreshEnabled: env.POOL_METADATA_REFRESH_ENABLED,
   },
 
   // Supply bridge: youtube_videos → video_pool promotion (CP494 ②).

--- a/src/modules/queue/handlers/pool-maintenance.ts
+++ b/src/modules/queue/handlers/pool-maintenance.ts
@@ -29,6 +29,7 @@ import { getPrismaClient } from '@/modules/database/client';
 import { logger } from '@/utils/logger';
 import { getJobQueue } from '../manager';
 import { JOB_NAMES, POOL_MAINTENANCE_RUN_OPTIONS, type PoolMaintenanceRunPayload } from '../types';
+import { runPoolMetadataRefresh } from '@/modules/video-pool/refresh-metadata';
 
 const log = logger.child({ module: 'queue/pool-maintenance' });
 
@@ -118,9 +119,17 @@ async function handlePoolMaintenanceRun(job: PgBoss.Job<PoolMaintenanceRunPayloa
 
   try {
     const result = await runPoolMaintenance(getPrismaClient(), { enabled });
+    // Op3 (CP512) — refresh active rows' metadata before it ages past the TTL,
+    // so served rows stay ToS-compliant AND keep their titles (the correct
+    // "refresh" branch of the 30-day rule, vs the scrub "delete" branch).
+    let refresh = { candidates: 0, refreshed: 0, retired: 0 };
+    if (enabled && config.poolMaintenance.refreshEnabled) {
+      refresh = await runPoolMetadataRefresh();
+    }
     log.info('pool-maintenance: completed', {
       jobId: job.id,
       ...result,
+      refresh,
       durationMs: Date.now() - startedAt,
     });
   } catch (err) {

--- a/src/modules/video-pool/refresh-metadata.ts
+++ b/src/modules/video-pool/refresh-metadata.ts
@@ -1,0 +1,157 @@
+/**
+ * refresh-metadata — keep ACTIVE video_pool rows ToS-compliant AND usable.
+ *
+ * YouTube's 30-day metadata rule is refresh-OR-delete. The old design only did
+ * the "delete" branch (pool-maintenance scrub → title=''), which emptied active
+ * served rows and produced title-less cards (CP512 P0). The correct branch for a
+ * row you keep serving is REFRESH: re-fetch its metadata via videos.list (1 unit
+ * / 50 ids — cheap) and reset refreshed_at. Rows the API no longer returns
+ * (deleted / private / region-blocked) can't be refreshed → retire them
+ * (is_active=false) so the scrub op purges their metadata legitimately.
+ */
+import { getPrismaClient } from '@/modules/database';
+import { logger } from '@/utils/logger';
+import {
+  videosBatchFullMetadata,
+  resolveVideosApiKeys,
+  parseIsoDuration,
+  type YouTubeVideoFullMetadata,
+} from '@/skills/plugins/video-discover/v2/youtube-client';
+
+const log = logger.child({ module: 'video-pool/refresh-metadata' });
+
+/** Refresh this many days before the 30-day ToS TTL so a served row's metadata
+ *  is never older than 30 days (10-day head-room before scrub would apply). */
+export const REFRESH_AFTER_DAYS = 20;
+/** Rows re-fetched per run — bounded so one run stays far under daily quota
+ *  (500 / 50 = 10 videos.list calls = 10 units). */
+export const REFRESH_BATCH_LIMIT = 500;
+
+const TITLE_MAX = 5000;
+
+export interface RefreshResult {
+  candidates: number;
+  refreshed: number;
+  retired: number;
+}
+
+/** Minimal DB surface — satisfied by PrismaClient and by a test mock. */
+export interface RefreshDb {
+  $queryRawUnsafe<T = unknown>(query: string, ...values: unknown[]): Promise<T>;
+  $executeRawUnsafe(query: string, ...values: unknown[]): Promise<number>;
+  video_pool: {
+    update(args: { where: { video_id: string }; data: Record<string, unknown> }): Promise<unknown>;
+  };
+}
+
+export interface RefreshDeps {
+  db: RefreshDb;
+  /** Fetch full metadata for a list of video ids (videos.list, part=snippet…). */
+  fetchMetadata: (videoIds: string[]) => Promise<YouTubeVideoFullMetadata[]>;
+  now: Date;
+  limit: number;
+  afterDays: number;
+}
+
+const toInt = (v?: string): number => {
+  const n = v ? parseInt(v, 10) : 0;
+  return Number.isFinite(n) ? n : 0;
+};
+
+/**
+ * Core logic — pure over injected deps (DB + fetcher + clock) so it is
+ * unit-testable without a real DB or YouTube key.
+ */
+export async function refreshActivePoolMetadataCore(deps: RefreshDeps): Promise<RefreshResult> {
+  const { db, fetchMetadata, now, limit, afterDays } = deps;
+
+  const rows = await db.$queryRawUnsafe<{ video_id: string }[]>(
+    `SELECT video_id FROM public.video_pool
+      WHERE is_active = true
+        AND refreshed_at < now() - interval '${afterDays} days'
+      ORDER BY refreshed_at ASC
+      LIMIT ${limit}`
+  );
+  const videoIds = rows.map((r) => r.video_id);
+  if (videoIds.length === 0) return { candidates: 0, refreshed: 0, retired: 0 };
+
+  let items: YouTubeVideoFullMetadata[];
+  try {
+    items = await fetchMetadata(videoIds);
+  } catch (err) {
+    log.error('refresh: videos.list failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { candidates: videoIds.length, refreshed: 0, retired: 0 };
+  }
+
+  const returned = new Set<string>();
+  let refreshed = 0;
+  for (const item of items) {
+    const id = item.id;
+    if (!id) continue;
+    returned.add(id);
+    const s = item.snippet ?? {};
+    const title = (s.title ?? '').slice(0, TITLE_MAX);
+    // Integrity guard — never write an empty title back onto a row.
+    if (!title.trim()) continue;
+    try {
+      await db.video_pool.update({
+        where: { video_id: id },
+        data: {
+          title,
+          description: s.description ? s.description.slice(0, TITLE_MAX) : null,
+          channel_name: s.channelTitle ? s.channelTitle.slice(0, 200) : null,
+          channel_id: s.channelId ? s.channelId.slice(0, 30) : null,
+          view_count: BigInt(toInt(item.statistics?.viewCount)),
+          like_count: BigInt(toInt(item.statistics?.likeCount)),
+          duration_seconds: parseIsoDuration(item.contentDetails?.duration),
+          published_at: s.publishedAt ? new Date(s.publishedAt) : null,
+          thumbnail_url: s.thumbnails?.high?.url ?? s.thumbnails?.default?.url ?? null,
+          refreshed_at: now,
+        },
+      });
+      refreshed += 1;
+    } catch (err) {
+      log.warn('refresh: update failed', {
+        video_id: id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // Videos the API didn't return = unrefreshable (deleted/private/blocked) →
+  // retire so the scrub op purges their metadata on schedule.
+  const missing = videoIds.filter((id) => !returned.has(id));
+  let retired = 0;
+  if (missing.length > 0) {
+    retired = Number(
+      await db.$executeRawUnsafe(
+        `UPDATE public.video_pool SET is_active = false WHERE video_id = ANY($1::text[])`,
+        missing
+      )
+    );
+  }
+
+  log.info('refresh: done', { candidates: videoIds.length, refreshed, retired });
+  return { candidates: videoIds.length, refreshed, retired };
+}
+
+/** Production entry — wires the real Prisma client + VIDEOS key pool. */
+export async function runPoolMetadataRefresh(opts?: {
+  limit?: number;
+  afterDays?: number;
+}): Promise<RefreshResult> {
+  const apiKeys = resolveVideosApiKeys(process.env);
+  if (apiKeys.length === 0) {
+    log.warn('refresh: no VIDEOS api key — skipping');
+    return { candidates: 0, refreshed: 0, retired: 0 };
+  }
+  return refreshActivePoolMetadataCore({
+    db: getPrismaClient() as unknown as RefreshDb,
+    fetchMetadata: (videoIds) => videosBatchFullMetadata({ videoIds, apiKey: apiKeys }),
+    now: new Date(),
+    limit: opts?.limit ?? REFRESH_BATCH_LIMIT,
+    afterDays: opts?.afterDays ?? REFRESH_AFTER_DAYS,
+  });
+}

--- a/tests/unit/modules/refresh-metadata.test.ts
+++ b/tests/unit/modules/refresh-metadata.test.ts
@@ -1,0 +1,77 @@
+/**
+ * refresh-metadata core logic (CP512) — refresh active pool rows via videos.list,
+ * with an empty-title integrity guard and retire-on-missing. Pure over injected
+ * deps (DB + fetcher + clock), no real DB / YouTube key.
+ */
+import {
+  refreshActivePoolMetadataCore,
+  type RefreshDeps,
+} from '@/modules/video-pool/refresh-metadata';
+import type { YouTubeVideoFullMetadata } from '@/skills/plugins/video-discover/v2/youtube-client';
+
+function makeDeps(
+  candidateIds: string[],
+  items: YouTubeVideoFullMetadata[]
+): { deps: RefreshDeps; updated: Record<string, unknown>[]; retiredIds: string[][] } {
+  const updated: Record<string, unknown>[] = [];
+  const retiredIds: string[][] = [];
+  const deps: RefreshDeps = {
+    db: {
+      $queryRawUnsafe: async () => candidateIds.map((video_id) => ({ video_id })) as never,
+      $executeRawUnsafe: async (_q: string, ids: unknown) => {
+        retiredIds.push(ids as string[]);
+        return (ids as string[]).length;
+      },
+      video_pool: {
+        update: async (args) => {
+          updated.push({ video_id: args.where.video_id, ...args.data });
+          return null;
+        },
+      },
+    },
+    fetchMetadata: async () => items,
+    now: new Date('2026-07-09T00:00:00Z'),
+    limit: 500,
+    afterDays: 20,
+  };
+  return { deps, updated, retiredIds };
+}
+
+const meta = (id: string, title: string | undefined): YouTubeVideoFullMetadata => ({
+  id,
+  snippet: { title, channelTitle: 'ch', publishedAt: '2026-01-01T00:00:00Z' },
+  statistics: { viewCount: '100', likeCount: '5' },
+  contentDetails: { duration: 'PT5M' },
+});
+
+describe('refreshActivePoolMetadataCore', () => {
+  it('refreshes rows with a title and writes refreshed_at', async () => {
+    const { deps, updated } = makeDeps(['a', 'b'], [meta('a', 'Title A'), meta('b', 'Title B')]);
+    const res = await refreshActivePoolMetadataCore(deps);
+    expect(res).toEqual({ candidates: 2, refreshed: 2, retired: 0 });
+    expect(updated.map((u) => u['title'])).toEqual(['Title A', 'Title B']);
+    expect(updated[0]!['refreshed_at']).toBeInstanceOf(Date);
+  });
+
+  it('never writes an empty/whitespace title (integrity guard)', async () => {
+    const { deps, updated } = makeDeps(['a', 'b'], [meta('a', ''), meta('b', '   ')]);
+    const res = await refreshActivePoolMetadataCore(deps);
+    expect(res.refreshed).toBe(0);
+    expect(updated).toHaveLength(0);
+  });
+
+  it('retires candidates the API did not return (deleted/private)', async () => {
+    // Only 'a' comes back; 'b' + 'c' are missing → retired.
+    const { deps, retiredIds } = makeDeps(['a', 'b', 'c'], [meta('a', 'Title A')]);
+    const res = await refreshActivePoolMetadataCore(deps);
+    expect(res.refreshed).toBe(1);
+    expect(res.retired).toBe(2);
+    expect(retiredIds[0]!.sort()).toEqual(['b', 'c']);
+  });
+
+  it('no candidates → no-op', async () => {
+    const { deps } = makeDeps([], []);
+    const res = await refreshActivePoolMetadataCore(deps);
+    expect(res).toEqual({ candidates: 0, refreshed: 0, retired: 0 });
+  });
+});


### PR DESCRIPTION
Completes the CP512 title-loss fix (whole-data-integrity, per James: refresh not scrub).

- The scrub-only design emptied active rows (P0). #1132 stopped scrubbing active rows; this adds the correct **refresh** branch of YouTube's 30-day rule.
- `refresh-metadata.ts`: re-fetch active rows' metadata via videos.list before it ages past the TTL (title/desc/channel/views/duration/thumb + refreshed_at reset). Empty-title integrity guard; retire (is_active=false) videos the API no longer returns.
- pool-maintenance Op3, gated by `POOL_METADATA_REFRESH_ENABLED` (default true, kill-switch).
- **Quota: ~6 units/day** (active pool ~8.3k, each refreshed once per <30-day cycle, 500/run; videos.list = 1 unit/50 vs 10k daily).
- Unit test (DI): refresh / empty-title guard / retire-on-missing / no-op.

BE tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)