### PR TITLE
feat(admin): raw req/rep popup in Search-Trace + performance parameters doc

### DIFF
--- a/docs/PERFORMANCE_PARAMETERS.md
+++ b/docs/PERFORMANCE_PARAMETERS.md
@@ -1,0 +1,155 @@
+# Insighta 성능 파라미터 종합 (SSOT)
+
+> **목적**: 카드검색·풀·위저드·만다라·임베딩의 모든 성능 파라미터/옵션/룰을 한 곳에.
+> 성능 개선 시 이 표를 보고 무엇을 바꾸면 무엇이 영향받는지 판단하고, 변경 후 테스트 범위를 정한다.
+> **admin 파라미터 관리 기능의 데이터 모델 근거**로 사용.
+>
+> **작성**: 2026-07-09 (CP512). 코드 실측 + prod printenv 기준.
+> **컬럼 의미**: `Default`=코드 기본값 / `Prod`=현재 prod 실제값(다르면 ★) / `범위`=허용 min-max / `영향`=바꾸면 무엇이 달라지나.
+> **갱신 규칙**: 파라미터 추가/변경 PR은 이 표도 같은 PR에서 갱신. prod 값 변경 시 `Prod` 열 갱신.
+
+---
+
+## 0. 한눈에 — Prod가 Default와 다른 것 (★ = 주의)
+
+| 파라미터 | Default | **Prod** | 왜 다른가 |
+|---|---|---|---|
+| V3_CENTER_GATE_MODE | substring | **semantic** ★ | 임베딩 기반 center gate 활성 (관련도↑, 임베딩 의존) |
+| V3_SEMANTIC_MIN_COSINE | 0.35 | **0.5** ★ | 관련도 하한 상향(엄격) |
+| V3_ENABLE_TIER1_CACHE | false | **true** ★ | video_pool 캐시 서빙 ON |
+| V3_TIER1_SOURCES | v2_promoted | **v2_promoted,yt_promoted** ★ | 공급 소스 확대 |
+| V3_RECENCY_WEIGHT | 0.15 | **0.05** ★ | 최신성 가중 완화 |
+| V3_ENABLE_QUALITY_GATE | false | **true** ★ | 품질 게이트 ON |
+| V3_ENABLE_HYBRID_RERANK | (n/a) | **true** ★ | Cohere rerank ON |
+| V5_PICKER_MODE | llm | **cell_binning** ★ | LLM 픽 대신 셀 비닝(비용↓) |
+| V5_QUERY_GEN | rule | **llm** ★ | 쿼리 생성 LLM |
+| V5_SEARCH_MAX_RESULTS | 25 | **40** ★ | search.list 후보/콜 |
+| V5_TARGET_PICKS | 30 | **60** ★ | 셀당 목표 카드 |
+| V5_DEDUP_HARDCAP | 120 | **180** ★ | dedup 상한 |
+| V5_POOL_BACKFILL | false | **<unset>=false** | pool-first OFF (베타 후 검토) |
+| V5_REUSE_LOOP | false | **<unset>=false** | live→pool 축적 OFF (베타 후) |
+| EMBED_ASYNC_SERVE | true | **<unset>=true** | 임베딩 비동기 서빙(CP512) |
+
+---
+
+## 1. 카드 발굴 — YouTube search.list (쿼터 핵심)
+
+| 파라미터 | 위치 | Default | Prod | 범위 | 영향 |
+|---|---|---|---|---|---|
+| **search.list units/콜** | youtube-client.ts:317 | 100 (고정) | 100 | — | YouTube 과금. 1콜=100 units. 일 한도 10,000 = 100콜/일. |
+| **search.list 키** | youtube-client.ts:169 `resolveSearchApiKeys` | 단일키(CP512) | YOUTUBE_API_KEY_SEARCH 1개 | — | ★ToS: 다중키 로테이션 금지(CP512 제거). 쿼터 우회 위반. |
+| V5_SEARCH_MAX_RESULTS | v5/config.ts:25 | 25 | **40** | 10-50 | 콜당 후보 수. ↑=같은 100units에 더 많은 후보(add-cards 재검색 지연). 상한 50(YouTube). |
+| V5_MAX_QUERIES | v5/config.ts:23 | 8 | 8 | 1-20 | 만다라당 search.list 콜 수(셀당 1). ×100 = units/만다라. |
+| V5_SEARCH_TIMEOUT_MS | v5/config.ts:24 | 2000 | 2000 | 500-8000 | fanout 콜 타임아웃. |
+| V3_YOUTUBE_SEARCH_TIMEOUT_MS | v3 env | 3000 | 3000 | — | v3 search.list 타임아웃. |
+| BATCH_COLLECTOR_SEARCH_MAX_RESULTS | batch/manifest.ts:39 | 30 | 30 | — | 트렌드 수집 search.list 후보 수. |
+
+## 2. 풀 우선 조회 (pool-first, quota-free) — **베타 후 검토**
+
+| 파라미터 | 위치 | Default | Prod | 범위 | 영향 |
+|---|---|---|---|---|---|
+| V5_POOL_BACKFILL | v5/config.ts:52 | false | **OFF** | bool | ★풀 우선 게이트. ON=pool 충족 셀 live drop→쿼터 절감. 관련도 미검증 리스크. |
+| V5_POOL_MATCH | v5/config.ts:86 | global | global | global\|per_cell | 셀별 vs 전역 tsvector 매칭. |
+| V5_POOL_MIN_PER_CELL | v5/config.ts:59 | 3 | 3 | 1-20 | 셀 충족 기준(≥N이면 live skip). ↑=더 엄격(live 더 침). |
+| V5_POOL_TIMEOUT_MS | v5/config.ts:62 | 1500 | 1500 | 200-5000 | pool tsvector 타임아웃. 초과→full live fallback(안전). |
+| V5_POOL_SOURCE | v5/config.ts:56 | v2_promoted | v2_promoted | v2_promoted\|all | pool 조회 소스 필터. |
+| V5_POOL_SERVE | v5 env | (n/a) | **true** | bool | pool 서빙 경로 활성. |
+| V5_REUSE_LOOP | v5/config.ts:67 | false | **OFF** | bool | live 픽 결과를 pool 적재(source=user_live). ON=후반 pool 적중↑. |
+| **pool tsvector 관련도 하한** | hybrid-rerank.ts:403-415 | 없음 | 없음 | — | ★어휘 매칭+tier(gold/silver)만. cosine 절대하한 無 = 니치서 트렌드 잔여물 서빙 리스크. |
+
+## 3. 위저드/add-cards 픽 (v5)
+
+| 파라미터 | 위치 | Default | Prod | 범위 | 영향 |
+|---|---|---|---|---|---|
+| V5_PICKER_MODE | v5/config.ts:38 | llm | **cell_binning** | llm\|cell_binning | LLM 픽(비용) vs 셀 비닝(무비용). |
+| V5_QUERY_GEN | v5/config.ts:46 | rule | **llm** | rule\|llm | 쿼리 생성 방식(LLM=Haiku 콜). |
+| V5_TARGET_PICKS | v5/config.ts:26 | 30 | **60** | 10-60 | 만다라당 목표 카드 수. |
+| V5_DEDUP_HARDCAP | v5/config.ts:27 | 120 | **180** | 40-400 | LLM 픽 전 raw 상한. |
+| V5_CELL_SKIP | v5/config.ts:72 | false | **true** | bool | 이미 채운 셀 검색 스킵(쿼터 절감). |
+| V5_CELL_SKIP_THRESHOLD | v5/config.ts:79 | 12 | 12 | 1-60 | 셀 "full" 기준 카드 수. |
+| V5_CHANNEL_HARD_CAP | v5 env | (n/a) | **3** | — | 채널당 최대 카드(다양성). |
+| V5_DIVERSITY_GUARD | v5 env | (n/a) | **true** | bool | 시리즈-에피소드 dedup + 채널 소프트캡. |
+| V5_KO_EN_TITLE_DROP | v5/config.ts:76 | true | **true** | bool | ko 만다라서 영어 우세 제목 드롭. |
+| V5_LIVE_VIEW_FLOOR | v5 env | (n/a) | **0** | — | live 후보 조회수 하한. |
+| V5_SHORT_OVERPICK_FACTOR | v5/config.ts:30 | 1.5 | 1.5 | 1-3 | Shorts 필터 대비 과다픽 배수. |
+| V5_SHORT_PROBE_DEADLINE_MS | v5/config.ts:33 | 8000 | 8000 | 0-15000 | Shorts 판별 타임아웃. |
+
+## 4. v3 서빙 게이트/관련도
+
+| 파라미터 | 위치 | Default | Prod | 범위 | 영향 |
+|---|---|---|---|---|---|
+| VIDEO_DISCOVER_V3 | pipeline-runner.ts:42 | (분기) | **1** | 0\|1 | v3 파이프라인 활성. |
+| V3_CENTER_GATE_MODE | v3/config.ts:69 | substring | **semantic** | substring\|subword\|off\|semantic | center gate 방식. semantic=임베딩 코사인, substring=제목 토큰. ★임베딩 의존. |
+| V3_SEMANTIC_MIN_COSINE | v3/config.ts:260 | 0.35 | **0.5** | 0-1 | semantic center gate 통과 하한. ↑=엄격(카드↓ 관련도↑). |
+| SEMANTIC_MIN_CELL_COSINE | mandala-filter.ts:56 | 0.25 (고정) | 0.25 | — | 셀 배정 코사인 하한. |
+| V3_ENABLE_TIER1_CACHE | v3/config.ts:289 | false | **true** | bool | video_pool 캐시 Tier1 서빙. |
+| V3_TIER1_SOURCES | v3 env | v2_promoted | **v2_promoted,yt_promoted** | — | Tier1 pool 소스. |
+| V3_TIER2_OVERFETCH | v3/config.ts:308 | true | true | bool | Tier2 항상 실행 + 과다fetch. |
+| V3_RECENCY_WEIGHT | mandala-filter.ts:71 | 0.15 | **0.05** | 0-1 | rec_score 최신성 가중. |
+| V3_RECENCY_HALF_LIFE_MONTHS | mandala-filter.ts:74 | 18 | 18 | — | 최신성 반감기(개월). |
+| V3_ENABLE_QUALITY_GATE | v3/config.ts:300 | false | **true** | bool | 품질 게이트. |
+| V3_ENABLE_HYBRID_RERANK | v3 env | (n/a) | **true** | bool | Cohere rerank(cost). |
+| V3_ENABLE_SEMANTIC_RERANK | v3/config.ts:293 | false | false | bool | 시맨틱 rerank. |
+| V3_ENABLE_SIGNAL_EXCLUDE | v3/config.ts:312 | true | true | bool | archive/delete 신호 제외. |
+| V3_ENABLE_ZERO_HIT_RETRY | v3/config.ts:313 | true | true | bool | 0-hit 재시도. |
+| V3_MIN_VIEWS_PER_DAY | v3 env | (n/a) | **33** | — | 조회수/일 하한. |
+| V3_SEMANTIC_MAX_CANDIDATES | v3 env | (n/a) | **100** | — | semantic gate 후보 캡. |
+| V3_EMPTY_TITLE_GATE | v3 env | (n/a) | **on** | — | 빈제목 게이트. |
+| **rec_score 가중** | executor.ts:1543 | iks 0.25 / videoQuality 0.35 / freshness 0.20 / perMandala 0.10 / historical 0.10 | 동일 | — | ★서빙 순위 공식. videoQuality(조회수)=최대 가중. |
+| V3_TARGET_PER_CELL | manifest.ts:33 | 12 (고정) | 12 | — | 셀당 목표 카드. |
+| V3_NUM_CELLS | manifest.ts:34 | 8 (고정) | 8 | — | 만다라 셀 수. |
+
+## 5. 만다라 생성 / 임베딩 (CP512 핵심)
+
+| 파라미터 | 위치 | Default | Prod | 범위 | 영향 |
+|---|---|---|---|---|---|
+| **EMBED_ASYNC_SERVE** | config/index.ts | true | **true** | bool | ★CP512. 임베딩 실패/지연해도 카드 서빙(degraded lexical). false=레거시 하드게이트(임베딩 필수). |
+| EMBEDDING_TIMEOUT_MS (상위) | pipeline-runner.ts:146 | 30_000 (고정) | 30_000 | — | ★임베딩 step 상위 타임아웃. 내부 fallback(20s+retry)보다 짧아 fallback 자름(감독 지적, 베타 후 수정). |
+| EMBED_TIMEOUT_MS (Ollama) | embedding.ts:47 | 20000 (고정) | 20000 | — | Ollama 임베딩 콜 타임아웃. |
+| OPENROUTER_EMBED_MAX_RETRIES | embedding.ts:57 | 2 (고정) | 2 | — | OpenRouter fallback 재시도. |
+| DEFAULT_EMBED_CHUNK_SIZE | embedding.ts:64 | 50 (고정) | 50 | — | 임베딩 배치 chunk 크기. |
+| IKS_EMBED_PROVIDER | config/index.ts:194 | ollama | **openrouter** | ollama\|openrouter | 임베딩 provider. openrouter=fallback 활성. |
+| MANDALA_EMBED_MODEL | config/index.ts:64 | qwen3-embedding:8b | qwen3-embedding:8b | — | 임베딩 모델(4096d). |
+| MANDALA_GEN_TIMEOUT_MS | generator.ts:63 | 600_000 (고정) | 600_000 | — | 만다라 생성 LLM 타임아웃(10분). |
+| MANDALA_GEN_MODEL | config/index.ts:63 | mandala-gen | (Haiku 전환됨) | — | 만다라 구조 생성 모델. |
+| MANDALA_GEN_URL | config/index.ts:62 | localhost:11434 | Mac Mini | — | 임베딩/gen Ollama URL(100.91.173.17). |
+
+## 6. 품질 등급 (batch-collector + pool)
+
+| 파라미터 | 위치 | 값 | 영향 |
+|---|---|---|---|
+| QUALITY_GOLD_VIEW_COUNT | batch/manifest.ts:51 | 100,000 | gold tier 조회수 하한. |
+| QUALITY_SILVER_VIEW_COUNT | batch/manifest.ts:52 | 10,000 | silver tier. |
+| QUALITY_BRONZE_VIEW_COUNT | batch/manifest.ts:53 | 1,000 | bronze tier(pool 서빙 최소). |
+| MIN_DURATION_SEC | batch/manifest.ts:56 | 60 | 최소 길이(Shorts 배제). |
+| MAX_DURATION_SEC | batch/manifest.ts:57 | 3600 | 최대 길이(1시간). |
+| pool 서빙 tier 필터 | hybrid-rerank.ts:409 | gold, silver | pool 후보는 gold/silver만(bronze 제외). |
+
+## 7. 풀 위생 / ToS (CP512)
+
+| 파라미터 | 위치 | Default | Prod | 영향 |
+|---|---|---|---|---|
+| POOL_MAINTENANCE_ENABLED | config/index.ts:232 | true | true | 풀 유지보수 잡(expire+scrub). |
+| POOL_METADATA_REFRESH_ENABLED | config/index.ts:239 | true | true | ★CP512. active 행 videos.list 갱신(ToS 준수). |
+| METADATA_TTL_DAYS | pool-maintenance.ts:38 | 30 (고정) | 30 | YouTube ToS 메타 갱신/삭제 주기. |
+| REFRESH_AFTER_DAYS | refresh-metadata.ts | 20 (고정) | 20 | 30일 전 갱신(10일 마진). |
+| REFRESH_BATCH_LIMIT | refresh-metadata.ts | 500 (고정) | 500 | 갱신 배치/run. |
+| SUPPLY_YT_BRIDGE_ENABLED | config/index.ts | (n/a) | **true** | youtube_videos→video_pool 승격. |
+
+## 8. 변경 시 테스트 범위 매트릭스 (성능 개선 시 참조)
+
+| 바꾸는 것 | 반드시 테스트할 것 |
+|---|---|
+| search.list 관련(units/키/maxResults) | 위저드 카드 수 + 쿼터 소모(Console) + add-cards 반복 |
+| pool-first(POOL_BACKFILL/MIN_PER_CELL) | poolOnlyCells/liveCells 비율 + **pool 카드 품질 육안**(niche 시험대) |
+| center gate/cosine(SEMANTIC_MIN) | 카드 수 vs 관련도 tradeoff + 니치 만다라 |
+| recency weight | 최신 vs 관련 순위 변화 |
+| 임베딩(ASYNC_SERVE/timeout) | ★Ollama 중단 상태 카드 나오나 + 정상 시 결과 불변 |
+| 품질 tier(VIEW_COUNT) | pool 재고 규모 + 서빙 후보 수 |
+| picker(PICKER_MODE/QUERY_GEN) | 픽 품질 + LLM 비용 |
+
+## 9. admin 파라미터 관리 기능 설계 근거
+- 이 표의 각 행 = admin UI의 편집 가능 파라미터 1개.
+- **편집 위험도 3등급**: (a) env flag(재배포 없이 runtime_config로 hot-swap 가능 후보) / (b) 코드 상수(고정, PR 필요) / (c) 서빙 공식(rec_score 가중 — 신중).
+- **Prod≠Default 행(§0)** = 이미 튜닝된 것 = admin 기본 노출 우선순위.
+- 변경 이력 + A/B 근거를 남기도록 = 성능 개선의 감사 추적.

--- a/frontend/src/pages/admin/ui/AdminSearchTraceExplorer.tsx
+++ b/frontend/src/pages/admin/ui/AdminSearchTraceExplorer.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { apiClient } from '@/shared/lib/api-client';
 
 interface TraceSummary {
+  id: string;
   trace_id: string;
   mandala_id: string | null;
   user_id: string | null;
@@ -93,6 +94,10 @@ export function AdminSearchTraceExplorer() {
   const [journeyLoading, setJourneyLoading] = useState(false);
   // Raw req/rep popup — full flow start→end (James request).
   const [rawOpen, setRawOpen] = useState(false);
+  // Which list row is selected — the row PK, NOT trace_id (several rows can
+  // share one trace_id, e.g. pool_serve per-cell writes; keying on trace_id
+  // highlighted them all at once).
+  const [selectedRowId, setSelectedRowId] = useState<string | null>(null);
 
   const reloadRecent = useCallback(async () => {
     setLoading(true);
@@ -161,13 +166,14 @@ export function AdminSearchTraceExplorer() {
           {loading && <div className="px-4 py-3 text-sm text-muted-foreground">로딩…</div>}
           {recent.map((t) => (
             <button
-              key={t.trace_id}
+              key={t.id}
               onClick={() => {
+                setSelectedRowId(t.id);
                 setIdInput(t.trace_id);
                 void openJourney(t.trace_id);
               }}
               className={`w-full border-b border-border px-4 py-2 text-left hover:bg-accent ${
-                journey?.trace.trace_id === t.trace_id ? 'bg-accent' : ''
+                selectedRowId === t.id ? 'bg-accent' : ''
               }`}
             >
               <div className="flex items-center justify-between">

--- a/frontend/src/pages/admin/ui/AdminSearchTraceExplorer.tsx
+++ b/frontend/src/pages/admin/ui/AdminSearchTraceExplorer.tsx
@@ -45,12 +45,23 @@ interface Candidate {
   final_cell_index: number | null;
 }
 
+interface RawStep {
+  step: string;
+  status: string;
+  request: unknown;
+  response: unknown;
+  error_message: string | null;
+  latency_ms: number | null;
+  at: string;
+}
+
 interface Journey {
   trace: TraceSummary;
   candidate_count: number;
   funnel: { decision: string; drop_reason: string | null; count: number }[];
   placed_by_cell: { cell: number; cards: Candidate[] }[];
   candidates: Candidate[];
+  raw_steps: RawStep[];
 }
 
 const TRIGGER_TONE: Record<string, string> = {
@@ -61,7 +72,9 @@ const TRIGGER_TONE: Record<string, string> = {
 
 function Pill({ children, tone }: { children: React.ReactNode; tone?: string }) {
   return (
-    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${tone ?? 'bg-muted text-muted-foreground'}`}>
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${tone ?? 'bg-muted text-muted-foreground'}`}
+    >
       {children}
     </span>
   );
@@ -78,6 +91,8 @@ export function AdminSearchTraceExplorer() {
   const [idInput, setIdInput] = useState('');
   const [journey, setJourney] = useState<Journey | null>(null);
   const [journeyLoading, setJourneyLoading] = useState(false);
+  // Raw req/rep popup — full flow start→end (James request).
+  const [rawOpen, setRawOpen] = useState(false);
 
   const reloadRecent = useCallback(async () => {
     setLoading(true);
@@ -158,21 +173,32 @@ export function AdminSearchTraceExplorer() {
               <div className="flex items-center justify-between">
                 <Pill tone={TRIGGER_TONE[t.trigger]}>{t.trigger}</Pill>
                 <span className="text-xs text-muted-foreground">
-                  {(t.outcome?.cards_count as number | undefined) ?? '?'}장 · {t.quota_units ?? '?'}u
+                  {(t.outcome?.cards_count as number | undefined) ?? '?'}장 · {t.quota_units ?? '?'}
+                  u
                 </span>
               </div>
-              <div className="mt-1 truncate text-xs text-muted-foreground">{fmtTime(t.created_at)}</div>
-              <div className="truncate font-mono text-[11px] text-muted-foreground">{t.trace_id}</div>
+              <div className="mt-1 truncate text-xs text-muted-foreground">
+                {fmtTime(t.created_at)}
+              </div>
+              <div className="truncate font-mono text-[11px] text-muted-foreground">
+                {t.trace_id}
+              </div>
             </button>
           ))}
         </aside>
 
         {/* Right — journey */}
         <main className="flex-1 overflow-y-auto p-6">
-          {error && <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-2 text-sm text-destructive">{error}</div>}
+          {error && (
+            <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          )}
           {journeyLoading && <div className="text-sm text-muted-foreground">여정 로딩…</div>}
           {!journey && !journeyLoading && (
-            <div className="text-sm text-muted-foreground">왼쪽에서 요청을 선택하거나 trace_id 를 입력하세요.</div>
+            <div className="text-sm text-muted-foreground">
+              왼쪽에서 요청을 선택하거나 trace_id 를 입력하세요.
+            </div>
           )}
           {journey && (
             <div className="space-y-6">
@@ -180,19 +206,46 @@ export function AdminSearchTraceExplorer() {
               <section className="rounded-lg border border-border bg-card p-4">
                 <div className="flex items-center gap-2">
                   <Pill tone={TRIGGER_TONE[journey.trace.trigger]}>{journey.trace.trigger}</Pill>
-                  <span className="text-sm text-muted-foreground">{fmtTime(journey.trace.started_at)}</span>
-                  {journey.trace.algorithm_version && <Pill>{journey.trace.algorithm_version}</Pill>}
+                  <span className="text-sm text-muted-foreground">
+                    {fmtTime(journey.trace.started_at)}
+                  </span>
+                  {journey.trace.algorithm_version && (
+                    <Pill>{journey.trace.algorithm_version}</Pill>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => setRawOpen(true)}
+                    disabled={!journey.raw_steps?.length}
+                    className="ml-auto rounded-md border border-border px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent disabled:opacity-40"
+                    title="이 flow의 전체 req/rep 원본 (시작→끝)"
+                  >
+                    req/rep 로그 ({journey.raw_steps?.length ?? 0})
+                  </button>
                 </div>
                 <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1 text-sm sm:grid-cols-4">
-                  <div><span className="text-muted-foreground">quota</span> {journey.trace.quota_units ?? '—'}u</div>
-                  <div><span className="text-muted-foreground">쿼리</span> {journey.trace.queries_succeeded ?? '?'}/{journey.trace.queries_attempted ?? '?'} 성공</div>
-                  <div><span className="text-muted-foreground">후보</span> {journey.candidate_count}</div>
-                  <div><span className="text-muted-foreground">카드</span> {(journey.trace.outcome?.cards_count as number | undefined) ?? '?'}</div>
+                  <div>
+                    <span className="text-muted-foreground">quota</span>{' '}
+                    {journey.trace.quota_units ?? '—'}u
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">쿼리</span>{' '}
+                    {journey.trace.queries_succeeded ?? '?'}/
+                    {journey.trace.queries_attempted ?? '?'} 성공
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">후보</span> {journey.candidate_count}
+                  </div>
+                  <div>
+                    <span className="text-muted-foreground">카드</span>{' '}
+                    {(journey.trace.outcome?.cards_count as number | undefined) ?? '?'}
+                  </div>
                 </div>
                 {journey.trace.counts && (
                   <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
                     {Object.entries(journey.trace.counts).map(([k, v]) => (
-                      <span key={k} className="rounded bg-muted px-1.5 py-0.5">{k}: {v}</span>
+                      <span key={k} className="rounded bg-muted px-1.5 py-0.5">
+                        {k}: {v}
+                      </span>
                     ))}
                   </div>
                 )}
@@ -203,12 +256,26 @@ export function AdminSearchTraceExplorer() {
                 <section>
                   <h2 className="mb-2 text-sm font-semibold">생성 쿼리 → raw</h2>
                   <div className="space-y-1">
-                    {(journey.trace.queries_generated as { query: string; source?: string; rawCount?: number; cellIndex?: number }[]).map((q, i) => (
-                      <div key={i} className="flex items-center gap-2 rounded border border-border px-3 py-1.5 text-sm">
-                        <span className="w-8 shrink-0 text-xs text-muted-foreground">c{q.cellIndex ?? '?'}</span>
+                    {(
+                      journey.trace.queries_generated as {
+                        query: string;
+                        source?: string;
+                        rawCount?: number;
+                        cellIndex?: number;
+                      }[]
+                    ).map((q, i) => (
+                      <div
+                        key={i}
+                        className="flex items-center gap-2 rounded border border-border px-3 py-1.5 text-sm"
+                      >
+                        <span className="w-8 shrink-0 text-xs text-muted-foreground">
+                          c{q.cellIndex ?? '?'}
+                        </span>
                         <span className="flex-1 truncate">{q.query}</span>
                         {q.source && <Pill>{q.source}</Pill>}
-                        <span className={`w-14 text-right text-xs ${(q.rawCount ?? 0) < 10 ? 'text-destructive' : 'text-muted-foreground'}`}>
+                        <span
+                          className={`w-14 text-right text-xs ${(q.rawCount ?? 0) < 10 ? 'text-destructive' : 'text-muted-foreground'}`}
+                        >
                           raw {q.rawCount ?? 0}
                         </span>
                       </div>
@@ -225,10 +292,13 @@ export function AdminSearchTraceExplorer() {
                     <span
                       key={`${f.decision}:${f.drop_reason}`}
                       className={`rounded-md px-2 py-1 text-xs ${
-                        f.decision === 'PLACED' ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'
+                        f.decision === 'PLACED'
+                          ? 'bg-primary/15 text-primary'
+                          : 'bg-muted text-muted-foreground'
                       }`}
                     >
-                      {f.decision === 'PLACED' ? 'PLACED' : `drop:${f.drop_reason ?? '?'}`} · {f.count}
+                      {f.decision === 'PLACED' ? 'PLACED' : `drop:${f.drop_reason ?? '?'}`} ·{' '}
+                      {f.count}
                     </span>
                   ))}
                 </div>
@@ -242,15 +312,23 @@ export function AdminSearchTraceExplorer() {
                 )}
                 {journey.placed_by_cell.map(({ cell, cards }) => (
                   <div key={cell} className="mb-3">
-                    <div className="mb-1 text-xs font-medium text-muted-foreground">cell {cell}</div>
+                    <div className="mb-1 text-xs font-medium text-muted-foreground">
+                      cell {cell}
+                    </div>
                     <div className="overflow-hidden rounded-md border border-border">
                       <table className="w-full text-sm">
                         <tbody>
                           {cards.map((c) => (
                             <tr key={c.video_id} className="border-b border-border last:border-0">
-                              <td className="px-3 py-1.5 font-mono text-xs text-muted-foreground">{c.video_id}</td>
-                              <td className="max-w-[220px] truncate px-3 py-1.5">{c.channel_title ?? '—'}</td>
-                              <td className={`px-3 py-1.5 text-right ${(c.view_count ?? 0) < 1000 ? 'text-destructive' : ''}`}>
+                              <td className="px-3 py-1.5 font-mono text-xs text-muted-foreground">
+                                {c.video_id}
+                              </td>
+                              <td className="max-w-[220px] truncate px-3 py-1.5">
+                                {c.channel_title ?? '—'}
+                              </td>
+                              <td
+                                className={`px-3 py-1.5 text-right ${(c.view_count ?? 0) < 1000 ? 'text-destructive' : ''}`}
+                              >
                                 {c.view_count ?? '?'} views
                               </td>
                               <td className="px-3 py-1.5 text-right text-xs text-muted-foreground">
@@ -268,6 +346,90 @@ export function AdminSearchTraceExplorer() {
           )}
         </main>
       </div>
+
+      {/* Raw req/rep popup — the full flow start→end (recordTrace steps). */}
+      {rawOpen && journey && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          onClick={() => setRawOpen(false)}
+        >
+          <div
+            className="flex max-h-[90vh] w-full max-w-4xl flex-col overflow-hidden rounded-lg border border-border bg-card shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between border-b border-border px-4 py-3">
+              <div className="text-sm font-semibold">
+                req/rep 로그 — {journey.trace.trigger} · {journey.raw_steps.length} steps
+                <span className="ml-2 font-mono text-xs text-muted-foreground">
+                  {journey.trace.trace_id}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={() => setRawOpen(false)}
+                className="rounded-md px-2 py-1 text-sm text-muted-foreground hover:bg-accent"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto px-4 py-3">
+              {journey.raw_steps.length === 0 && (
+                <div className="text-sm text-muted-foreground">
+                  이 flow에 기록된 raw step이 없습니다.
+                </div>
+              )}
+              {journey.raw_steps.map((s, i) => (
+                <details
+                  key={`${s.step}-${i}`}
+                  className="mb-2 rounded-md border border-border"
+                  open={s.status !== 'ok'}
+                >
+                  <summary className="flex cursor-pointer items-center gap-2 px-3 py-2 text-sm">
+                    <span className="font-mono text-xs text-muted-foreground">
+                      {String(i + 1).padStart(2, '0')}
+                    </span>
+                    <span className="font-medium">{s.step}</span>
+                    <span
+                      className={`rounded px-1.5 py-0.5 text-xs ${s.status === 'ok' ? 'bg-muted text-muted-foreground' : 'bg-destructive/15 text-destructive'}`}
+                    >
+                      {s.status}
+                    </span>
+                    {s.latency_ms != null && (
+                      <span className="text-xs text-muted-foreground">{s.latency_ms}ms</span>
+                    )}
+                    <span className="ml-auto font-mono text-[10px] text-muted-foreground">
+                      {fmtTime(s.at)}
+                    </span>
+                  </summary>
+                  <div className="space-y-2 border-t border-border px-3 py-2">
+                    {s.error_message && (
+                      <div className="rounded bg-destructive/10 px-2 py-1 text-xs text-destructive">
+                        {s.error_message}
+                      </div>
+                    )}
+                    <div>
+                      <div className="mb-1 text-xs font-semibold text-muted-foreground">
+                        request
+                      </div>
+                      <pre className="max-h-64 overflow-auto rounded bg-muted/50 p-2 text-[11px] leading-relaxed">
+                        {s.request == null ? '—' : JSON.stringify(s.request, null, 2)}
+                      </pre>
+                    </div>
+                    <div>
+                      <div className="mb-1 text-xs font-semibold text-muted-foreground">
+                        response
+                      </div>
+                      <pre className="max-h-80 overflow-auto rounded bg-muted/50 p-2 text-[11px] leading-relaxed">
+                        {s.response == null ? '—' : JSON.stringify(s.response, null, 2)}
+                      </pre>
+                    </div>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -3218,6 +3218,7 @@ class ApiClient {
   }): Promise<{
     count: number;
     traces: Array<{
+      id: string;
       trace_id: string;
       mandala_id: string | null;
       user_id: string | null;

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -3249,6 +3249,16 @@ class ApiClient {
     funnel: Array<{ decision: string; drop_reason: string | null; count: number }>;
     placed_by_cell: Array<{ cell: number; cards: SearchTraceCandidateDTO[] }>;
     candidates: SearchTraceCandidateDTO[];
+    // Raw external-API request/response per step (full flow start→end).
+    raw_steps: Array<{
+      step: string;
+      status: string;
+      request: unknown;
+      response: unknown;
+      error_message: string | null;
+      latency_ms: number | null;
+      at: string;
+    }>;
   }> {
     return this.request(`/admin/search-trace/journey/${encodeURIComponent(traceId)}`);
   }

--- a/src/api/routes/admin/search-trace-explorer.ts
+++ b/src/api/routes/admin/search-trace-explorer.ts
@@ -142,6 +142,25 @@ export const adminSearchTraceExplorerRoutes: FastifyPluginCallback = (fastify, _
         take: CANDIDATE_CAP,
       });
 
+      // Raw request/response timeline for the SAME flow. search_trace.trace_id
+      // === video_discover_traces.run_id (add-cards.ts:574 writeSearchTrace uses
+      // the discover runId as traceId; every recordTrace row shares that runId).
+      // Surfaces the actual external-API req/rep per step so the operator can
+      // read the full flow start→end (James: "실제 내용을 확인해야 개선 가능").
+      const rawSteps = await prisma.video_discover_traces.findMany({
+        where: { run_id: traceId },
+        orderBy: { created_at: 'asc' },
+        select: {
+          step: true,
+          status: true,
+          request: true,
+          response: true,
+          error_message: true,
+          latency_ms: true,
+          created_at: true,
+        },
+      });
+
       // Funnel: decision × drop_reason attrition (drives the §4 funnel chart).
       const funnelMap = new Map<string, number>();
       // Placed cards grouped by cell — the "what the user actually got" view.
@@ -195,6 +214,15 @@ export const adminSearchTraceExplorerRoutes: FastifyPluginCallback = (fastify, _
           .sort((a, b) => a[0] - b[0])
           .map(([cell, cards]) => ({ cell, cards })),
         candidates: cand,
+        raw_steps: rawSteps.map((s) => ({
+          step: s.step,
+          status: s.status,
+          request: s.request,
+          response: s.response,
+          error_message: s.error_message,
+          latency_ms: s.latency_ms,
+          at: s.created_at.toISOString(),
+        })),
       });
     }
   );

--- a/src/api/routes/admin/search-trace-explorer.ts
+++ b/src/api/routes/admin/search-trace-explorer.ts
@@ -25,6 +25,7 @@ function viewToNumber(v: bigint | null): number | null {
 
 /** Summary row shape shared by the list endpoints (no candidates). */
 function toTraceSummary(r: {
+  id: string;
   trace_id: string;
   mandala_id: string | null;
   user_id: string | null;
@@ -42,6 +43,10 @@ function toTraceSummary(r: {
   created_at: Date;
 }) {
   return {
+    // Row PK — unique even when several rows share one trace_id (pool_serve
+    // writes a row per cell/round). The list keys/highlights on this, not
+    // trace_id, so duplicate-trace_id rows don't all select at once.
+    id: r.id,
     trace_id: r.trace_id,
     mandala_id: r.mandala_id,
     user_id: r.user_id,


### PR DESCRIPTION
James: 위저드/add-cards flow의 실제 req/rep(시작→끝)를 admin 페이지에서 팝업으로 봐야 개선 가능.

- **BE** journey에 `raw_steps` 추가: video_discover_traces의 recordTrace 타임라인(run_id === trace_id). step별 raw request/response + status/latency/error, 오래된 순. 관찰 전용, adminAuth.
- **FE** AdminSearchTraceExplorer: request-summary 헤더에 `req/rep 로그 (N)` 버튼 → 전체화면 팝업, step별 collapsible `<details>` + pretty JSON(실패 step 기본 펼침).
- **docs/PERFORMANCE_PARAMETERS.md**: 검색·풀·위저드·만다라·임베딩 전 파라미터 SSOT(file:line·default·PROD 실측·범위·영향) + 변경-테스트 매트릭스 + admin 관리 설계 근거.

BE+FE tsc clean · build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)