### PR TITLE
fix(mandala-book): stop LLM retries on JSON parse failure + per-stage cost tags

### DIFF
--- a/src/modules/llm/openrouter.ts
+++ b/src/modules/llm/openrouter.ts
@@ -137,7 +137,7 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
             logLLMCall({
               videoId: options?.videoId,
               userId: options?.userId,
-              module: 'openrouter',
+              module: options?.purpose ?? 'openrouter',
               model: this.model,
               latencyMs,
               status: 'error',
@@ -148,7 +148,7 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
           logLLMCall({
             videoId: options?.videoId,
             userId: options?.userId,
-            module: 'openrouter',
+            module: options?.purpose ?? 'openrouter',
             model: this.model,
             latencyMs,
             status: 'error',
@@ -159,7 +159,7 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
         logLLMCall({
           videoId: options?.videoId,
           userId: options?.userId,
-          module: 'openrouter',
+          module: options?.purpose ?? 'openrouter',
           model: this.model,
           latencyMs,
           status: 'error',
@@ -179,7 +179,7 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
         logLLMCall({
           videoId: options?.videoId,
           userId: options?.userId,
-          module: 'openrouter',
+          module: options?.purpose ?? 'openrouter',
           model: this.model,
           latencyMs: Date.now() - startTime,
           status: 'error',
@@ -196,7 +196,7 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
       logLLMCall({
         videoId: options?.videoId,
         userId: options?.userId,
-        module: 'openrouter',
+        module: options?.purpose ?? 'openrouter',
         model: this.model,
         latencyMs: Date.now() - startTime,
         status: 'error',
@@ -224,7 +224,7 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
       logLLMCall({
         videoId: options?.videoId,
         userId: options?.userId,
-        module: 'openrouter',
+        module: options?.purpose ?? 'openrouter',
         model: this.model,
         inputTokens: data.usage?.prompt_tokens,
         outputTokens: data.usage?.completion_tokens,
@@ -243,7 +243,7 @@ export class OpenRouterGenerationProvider implements GenerationProvider {
     logLLMCall({
       videoId: options?.videoId,
       userId: options?.userId,
-      module: 'openrouter',
+      module: options?.purpose ?? 'openrouter',
       model: this.model,
       inputTokens: data.usage?.prompt_tokens,
       outputTokens: data.usage?.completion_tokens,

--- a/src/modules/llm/provider.ts
+++ b/src/modules/llm/provider.ts
@@ -28,6 +28,15 @@ export interface GenerateOptions {
    */
   videoId?: string;
   userId?: string;
+  /**
+   * Cost-attribution STAGE tag (CP504 §3) — the logical caller/purpose of this
+   * generation (e.g. 'cell_synthesis', 'book_skeleton', 'chapter_weave',
+   * 'book_research', 'book_factcheck', 'mandala_gen'). Written to the existing
+   * llm_call_logs.module column so per-stage cost is a plain GROUP BY module —
+   * no schema change. Absent = 'openrouter' (prior behavior; audit revealed
+   * every call collapsed to that single label, hiding which stage spends).
+   */
+  purpose?: string;
 }
 
 export interface GenerationProvider {

--- a/src/modules/mandala-book/book-body.ts
+++ b/src/modules/mandala-book/book-body.ts
@@ -149,6 +149,7 @@ async function attemptBody(
       format: 'json',
       temperature: TEMPERATURE,
       maxTokens: MAX_TOKENS,
+      purpose: 'chapter_weave', // CP504 §3 per-stage cost attribution
     });
   } catch (err) {
     return {

--- a/src/modules/mandala-book/book-factcheck.ts
+++ b/src/modules/mandala-book/book-factcheck.ts
@@ -220,6 +220,7 @@ async function verifyClaims(claims: FactSentence[], cseClient: CseClient): Promi
         format: 'json',
         temperature: TEMPERATURE,
         maxTokens: MAX_TOKENS,
+        purpose: 'book_factcheck', // CP504 §3 per-stage cost attribution
       });
     } catch (err) {
       lastReason = `provider_error: ${err instanceof Error ? err.message : String(err)}`;

--- a/src/modules/mandala-book/book-research.ts
+++ b/src/modules/mandala-book/book-research.ts
@@ -238,6 +238,7 @@ async function attemptPerspective(
       format: 'json',
       temperature: TEMPERATURE,
       maxTokens: MAX_TOKENS,
+      purpose: 'book_research', // CP504 §3 per-stage cost attribution
     });
   } catch (err) {
     return {

--- a/src/modules/mandala-book/book-skeleton.ts
+++ b/src/modules/mandala-book/book-skeleton.ts
@@ -22,6 +22,7 @@
 
 import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
 import { logger } from '@/utils/logger';
+import { parseJsonLenient } from '@/utils/lenient-json';
 
 const log = logger.child({ module: 'mandala-book/book-skeleton' });
 
@@ -129,9 +130,15 @@ export async function synthesizeBookSkeleton(
       return r;
     }
     lastReason = r.reason;
-    if (attempt < SKELETON_ATTEMPTS) {
-      log.warn('book-skeleton attempt failed — retrying', { attempt, reason: r.reason });
+    // CP504 §11 — retry PROVIDER faults only. Parse failures are salvaged
+    // in-attempt (parseSkeletonResponse → parseJsonLenient), so re-calling Sonnet
+    // for a parse error just burns cost.
+    const retryable = r.reason.startsWith('provider_error');
+    if (retryable && attempt < SKELETON_ATTEMPTS) {
+      log.warn('book-skeleton provider error — retrying', { attempt, reason: r.reason });
+      continue;
     }
+    break; // non-retryable (parse/structural) → stop; do not waste an LLM call
   }
   log.error('book-skeleton HARD FAIL after retries (NOT a silent legacy revert)', {
     topics: topics.length,
@@ -153,6 +160,7 @@ async function attemptSkeleton(
       format: 'json',
       temperature: TEMPERATURE,
       maxTokens: MAX_TOKENS,
+      purpose: 'book_skeleton', // CP504 §3 per-stage cost attribution
     });
   } catch (err) {
     return {
@@ -194,11 +202,13 @@ export function parseSkeletonResponse(
     .replace(/\n?\s*```\s*$/i, '')
     .trim();
 
-  let json: { chapters?: unknown };
-  try {
-    json = JSON.parse(stripped) as { chapters?: unknown };
-  } catch (err) {
-    return { ok: false, reason: `json_parse: ${err instanceof Error ? err.message : String(err)}` };
+  // CP504 §11 — lenient parse: salvage unescaped-newline / truncation in-place
+  // (no LLM retry). `via` is the parse-recovery counter (logged for verification).
+  const json = parseJsonLenient<{ chapters?: unknown }>(stripped, (via) => {
+    log.info('book-skeleton json salvaged in-attempt (no LLM retry)', { via });
+  });
+  if (json === null) {
+    return { ok: false, reason: 'json_parse: unparseable after lenient salvage' };
   }
   if (!Array.isArray(json.chapters)) return { ok: false, reason: 'no_chapters_array' };
 

--- a/src/modules/mandala-book/topic-synthesis.ts
+++ b/src/modules/mandala-book/topic-synthesis.ts
@@ -10,11 +10,13 @@
 // Deliberately ISOLATED from build-book (which stays a PURE function). This is
 // the ONLY non-deterministic step; build-book consumes its output.
 //
-// Service module — OpenRouter Haiku is a production LLM call (the deployed
+// Service module — OpenRouter Sonnet is a production LLM call (the deployed
 // pipeline / a James-run prototype invokes it; CC must not call it for tests).
+// (Header said "Haiku" pre-CP504; the model is Sonnet — see the §1⑤ note below.)
 
 import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
 import { logger } from '@/utils/logger';
+import { parseJsonLenient } from '@/utils/lenient-json';
 
 const log = logger.child({ module: 'mandala-book/topic-synthesis' });
 
@@ -140,13 +142,20 @@ export async function synthesizeCellTopics(
       return r;
     }
     lastReason = r.reason;
-    if (attempt < SYNTHESIS_ATTEMPTS) {
-      log.warn('topic-synthesis attempt failed — retrying', {
+    // CP504 §11 — SYNTHESIS_ATTEMPTS is now for PROVIDER faults only. Parse
+    // failures are salvaged in-attempt (parseJsonLenient: unescaped-newline +
+    // truncation), so a re-call to Sonnet no longer buys anything and just burns
+    // cost — measured 4 of 13 calls per book were these parse retries.
+    const retryable = r.reason.startsWith('provider_error');
+    if (retryable && attempt < SYNTHESIS_ATTEMPTS) {
+      log.warn('topic-synthesis provider error — retrying', {
         cellTitle,
         attempt,
         reason: r.reason,
       });
+      continue;
     }
+    break; // non-retryable (parse/structural) → stop; do not waste an LLM call
   }
   log.error('topic-synthesis HARD FAIL after retries (NOT a silent legacy revert)', {
     cellTitle,
@@ -180,6 +189,7 @@ async function attemptSynthesis(
       format: 'json',
       temperature: TEMPERATURE,
       maxTokens: MAX_TOKENS,
+      purpose: 'cell_synthesis', // CP504 §3 per-stage cost attribution
     });
   } catch (err) {
     return {
@@ -194,11 +204,15 @@ async function attemptSynthesis(
     .replace(/\n?\s*```\s*$/i, '')
     .trim();
 
-  let json: { sections?: unknown };
-  try {
-    json = JSON.parse(stripped) as { sections?: unknown };
-  } catch (err) {
-    return { ok: false, reason: `json_parse: ${err instanceof Error ? err.message : String(err)}` };
+  // CP504 §11 — lenient parse: salvage the unescaped-newline / truncation cases
+  // in-attempt (no LLM retry). `via` is the parse-recovery counter — logged so we
+  // can confirm retries dropped to 0 while salvages absorb the model's stray
+  // newlines (the prompt-side "개행 금지" defense is not reliably obeyed).
+  const json = parseJsonLenient<{ sections?: unknown }>(stripped, (via) => {
+    log.info('topic-synthesis json salvaged in-attempt (no LLM retry)', { cellTitle, via });
+  });
+  if (json === null) {
+    return { ok: false, reason: 'json_parse: unparseable after lenient salvage' };
   }
   if (!Array.isArray(json.sections)) return { ok: false, reason: 'no_sections_array' };
 

--- a/src/modules/mandala/generator.ts
+++ b/src/modules/mandala/generator.ts
@@ -11,6 +11,7 @@ import type { Prisma } from '@prisma/client';
 import { config } from '../../config';
 import { logger } from '../../utils/logger';
 import { MemoryCache } from '../../utils/memory-cache';
+import { escapeUnescapedJsonNewlines, closeUnclosedJsonBrackets } from '../../utils/lenient-json';
 import { getPrismaClient } from '../database/client';
 import { searchMandalasByGoal, formatMandalasForFewShot, type MandalaSearchResult } from './search';
 import { loadWizardMergedGenConfig } from '@/config/wizard-merged-gen';
@@ -186,36 +187,6 @@ function removeOutputField(text: string): string {
   return text;
 }
 
-/** Escape unescaped newlines inside JSON string values (tracks string context) */
-function escapeInnerNewlines(text: string): string {
-  let result = '';
-  let inStr = false;
-  let esc = false;
-  for (const ch of text) {
-    if (esc) {
-      result += ch;
-      esc = false;
-      continue;
-    }
-    if (ch === '\\' && inStr) {
-      result += ch;
-      esc = true;
-      continue;
-    }
-    if (ch === '"') {
-      inStr = !inStr;
-      result += ch;
-      continue;
-    }
-    if (inStr && (ch === '\n' || ch === '\r')) {
-      result += ch === '\n' ? '\\n' : '\\r';
-      continue;
-    }
-    result += ch;
-  }
-  return result;
-}
-
 /** Remove bare trailing arrays (e.g., `] ["label1", ...]` without key) — string-aware */
 function removeBareTrailingArrays(text: string): string {
   // Find the last top-level `}` and truncate anything after it if it starts with `[`
@@ -255,36 +226,6 @@ function removeBareTrailingArrays(text: string): string {
   return text;
 }
 
-/** Count unclosed brackets in a prefix (string-aware) */
-function closeBrackets(truncated: string): string {
-  const stack: string[] = [];
-  let inStr = false;
-  let esc = false;
-  for (const ch of truncated) {
-    if (esc) {
-      esc = false;
-      continue;
-    }
-    if (ch === '\\' && inStr) {
-      esc = true;
-      continue;
-    }
-    if (ch === '"') {
-      inStr = !inStr;
-      continue;
-    }
-    if (inStr) continue;
-    if (ch === '{') stack.push('}');
-    else if (ch === '[') stack.push(']');
-    else if ((ch === '}' || ch === ']') && stack.length > 0 && stack[stack.length - 1] === ch) {
-      stack.pop();
-    }
-  }
-  let result = truncated;
-  while (stack.length > 0) result += stack.pop();
-  return result;
-}
-
 function extractJsonRobust(text: string): GeneratedMandala | null {
   const start = text.indexOf('{');
   if (start === -1) return null;
@@ -303,7 +244,7 @@ function extractJsonRobust(text: string): GeneratedMandala | null {
   // v4.1 preprocessing pipeline
   fragment = fixBracketTypos(fragment);
   fragment = removeOutputField(fragment);
-  fragment = escapeInnerNewlines(fragment);
+  fragment = escapeUnescapedJsonNewlines(fragment);
   fragment = removeBareTrailingArrays(fragment);
 
   // Method 1: Direct parse
@@ -335,7 +276,7 @@ function extractJsonRobust(text: string): GeneratedMandala | null {
   if (bestCut > 0) {
     let truncated = fragment.slice(0, bestCut).trimEnd();
     if (truncated.endsWith(',')) truncated = truncated.slice(0, -1);
-    truncated = closeBrackets(truncated);
+    truncated = closeUnclosedJsonBrackets(truncated);
 
     try {
       return JSON.parse(truncated) as GeneratedMandala;

--- a/src/utils/lenient-json.ts
+++ b/src/utils/lenient-json.ts
@@ -1,0 +1,124 @@
+// Lenient JSON salvage for LLM output (CP504 §11).
+//
+// LLMs (Sonnet/Haiku) intermittently corrupt otherwise-valid JSON in two ways:
+//   1. a raw newline INSIDE a string value (JSON forbids it → JSON.parse trips)
+//   2. a maxTokens truncation that cuts the object mid-way (unclosed brackets)
+//
+// Both were previously "handled" by burning an LLM RETRY (topic-synthesis /
+// book-skeleton re-called Sonnet on a parse failure) — cost hiding a bug. These
+// helpers salvage the SAME response in-process (no new LLM call), so a parse
+// failure stops being a retry reason. Extracted from mandala/generator.ts, whose
+// robust-extract pipeline proved the string-context-aware algorithms; both
+// modules now share one copy.
+
+/**
+ * Escape unescaped newline / carriage-return chars that appear INSIDE a JSON
+ * string literal, so JSON.parse survives an LLM that emitted a literal newline
+ * in a string value. String-context aware: only touches chars inside a "..."
+ * literal, never structural whitespace. Content is preserved (the newline is
+ * restored on parse as a real \n — no text is lost).
+ */
+export function escapeUnescapedJsonNewlines(text: string): string {
+  let result = '';
+  let inStr = false;
+  let esc = false;
+  for (const ch of text) {
+    if (esc) {
+      result += ch;
+      esc = false;
+      continue;
+    }
+    if (ch === '\\' && inStr) {
+      result += ch;
+      esc = true;
+      continue;
+    }
+    if (ch === '"') {
+      inStr = !inStr;
+      result += ch;
+      continue;
+    }
+    if (inStr && (ch === '\n' || ch === '\r')) {
+      result += ch === '\n' ? '\\n' : '\\r';
+      continue;
+    }
+    result += ch;
+  }
+  return result;
+}
+
+/**
+ * Append the closing brackets/braces a truncated JSON prefix is missing
+ * (string-context aware), salvaging a maxTokens-truncated response into a
+ * parseable — if partial — object. Never removes content; only closes.
+ */
+export function closeUnclosedJsonBrackets(text: string): string {
+  const stack: string[] = [];
+  let inStr = false;
+  let esc = false;
+  for (const ch of text) {
+    if (esc) {
+      esc = false;
+      continue;
+    }
+    if (ch === '\\' && inStr) {
+      esc = true;
+      continue;
+    }
+    if (ch === '"') {
+      inStr = !inStr;
+      continue;
+    }
+    if (inStr) continue;
+    if (ch === '{') stack.push('}');
+    else if (ch === '[') stack.push(']');
+    else if ((ch === '}' || ch === ']') && stack.length > 0 && stack[stack.length - 1] === ch) {
+      stack.pop();
+    }
+  }
+  let result = text;
+  while (stack.length > 0) result += stack.pop();
+  return result;
+}
+
+/** How a lenient parse was recovered (for the parse-recovery counter). */
+export type JsonSalvageVia = 'newline' | 'truncation';
+
+/**
+ * Parse JSON an LLM may have corrupted with unescaped newlines or a maxTokens
+ * truncation. Order: direct → newline-escaped → newline-escaped + bracket-closed.
+ * Returns the parsed value, or null (caller decides the honest fail). `onSalvage`
+ * fires with the technique that worked — this is the parse-recovery signal that
+ * replaces the old LLM retry (verify it stays low/zero after the §11 fix).
+ */
+export function parseJsonLenient<T>(
+  stripped: string,
+  onSalvage?: (via: JsonSalvageVia) => void
+): T | null {
+  try {
+    return JSON.parse(stripped) as T;
+  } catch {
+    /* corrupted — try salvage below */
+  }
+  const escaped = escapeUnescapedJsonNewlines(stripped);
+  if (escaped !== stripped) {
+    try {
+      const v = JSON.parse(escaped) as T;
+      onSalvage?.('newline');
+      return v;
+    } catch {
+      /* newline alone did not fix it — try truncation-close too */
+    }
+  }
+  const closed = closeUnclosedJsonBrackets(escaped);
+  if (closed !== escaped) {
+    try {
+      const v = JSON.parse(closed) as T;
+      onSalvage?.('truncation');
+      return v;
+    } catch {
+      /* give up — genuinely malformed */
+    }
+  }
+  return null;
+}

--- a/tests/unit/modules/book-skeleton.test.ts
+++ b/tests/unit/modules/book-skeleton.test.ts
@@ -69,6 +69,27 @@ describe('parseSkeletonResponse (pure — no LLM)', () => {
     }
   });
 
+  // CP504 §11 — a RAW (unescaped) newline inside intro/title is what actually
+  // trips JSON.parse in prod. parseJsonLenient escapes it in-place, so the parse
+  // succeeds WITHOUT the caller paying an LLM retry.
+  it('salvages a RAW unescaped newline inside a string value (lenient parse)', () => {
+    const raw = '{"chapters":[{"title":"도입","intro":"첫 줄\n둘째 줄","topic_idx":[0]}]}';
+    const r = parseSkeletonResponse(raw, 1, 12);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.skeleton.chapters).toHaveLength(1);
+      expect(r.skeleton.chapters[0]!.intro).toBe('첫 줄 둘째 줄'); // restored then collapsed (no loss)
+    }
+  });
+
+  // A maxTokens truncation is salvaged too (close the open brackets) — no retry.
+  it('salvages a truncated skeleton response (bracket-close)', () => {
+    const raw = '{"chapters":[{"title":"도입","intro":"i","topic_idx":[0';
+    const r = parseSkeletonResponse(raw, 2, 12);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.skeleton.chapters[0]!.topic_refs).toEqual([0]);
+  });
+
   it('fails on non-array / invalid JSON / no-valid-refs', () => {
     expect(parseSkeletonResponse('{"chapters":"x"}', 1, 12).ok).toBe(false);
     expect(parseSkeletonResponse('not json', 1, 12).ok).toBe(false);
@@ -86,7 +107,9 @@ describe('synthesizeBookSkeleton (OpenRouter mocked)', () => {
   ];
 
   it('returns skeleton + computes unplaced topics (transparency)', async () => {
-    mockGenerate.mockResolvedValueOnce('{"chapters":[{"title":"도입","intro":"i","topic_idx":[0,2]}]}');
+    mockGenerate.mockResolvedValueOnce(
+      '{"chapters":[{"title":"도입","intro":"i","topic_idx":[0,2]}]}'
+    );
     const r = await synthesizeBookSkeleton(topics, 'goal');
     expect(r.ok).toBe(true);
     if (r.ok) {
@@ -113,7 +136,12 @@ describe('buildBookJson skeleton mode (gate[2]: cross-cell, ch sequential, intro
   const seg = (atoms: Array<{ text: string; timestamp_sec: number }>): RichSummarySegments =>
     ({
       sections: [],
-      atoms: atoms.map((a, i) => ({ idx: i, type: 'fact', text: a.text, timestamp_sec: a.timestamp_sec })),
+      atoms: atoms.map((a, i) => ({
+        idx: i,
+        type: 'fact',
+        text: a.text,
+        timestamp_sec: a.timestamp_sec,
+      })),
     }) as unknown as RichSummarySegments;
 
   // Two cells, one topic each; the skeleton MERGES both into a single chapter.
@@ -125,14 +153,34 @@ describe('buildBookJson skeleton mode (gate[2]: cross-cell, ch sequential, intro
       {
         cellIndex: 0,
         title: '기초',
-        videos: [{ videoId: 'vidA', title: 'A', analysis: null, segments: seg([{ text: '인사 표현', timestamp_sec: 10 }]), lora: null }],
-        topics: [{ topic_title: '인사', summary: '인사 표현', atom_refs: [{ vid: 'vidA', ts: 10 }] }],
+        videos: [
+          {
+            videoId: 'vidA',
+            title: 'A',
+            analysis: null,
+            segments: seg([{ text: '인사 표현', timestamp_sec: 10 }]),
+            lora: null,
+          },
+        ],
+        topics: [
+          { topic_title: '인사', summary: '인사 표현', atom_refs: [{ vid: 'vidA', ts: 10 }] },
+        ],
       },
       {
         cellIndex: 1,
         title: '실전',
-        videos: [{ videoId: 'vidB', title: 'B', analysis: null, segments: seg([{ text: '주문 표현', timestamp_sec: 20 }]), lora: null }],
-        topics: [{ topic_title: '주문', summary: '주문 표현', atom_refs: [{ vid: 'vidB', ts: 20 }] }],
+        videos: [
+          {
+            videoId: 'vidB',
+            title: 'B',
+            analysis: null,
+            segments: seg([{ text: '주문 표현', timestamp_sec: 20 }]),
+            lora: null,
+          },
+        ],
+        topics: [
+          { topic_title: '주문', summary: '주문 표현', atom_refs: [{ vid: 'vidB', ts: 20 }] },
+        ],
       },
     ],
     skeleton,
@@ -141,7 +189,11 @@ describe('buildBookJson skeleton mode (gate[2]: cross-cell, ch sequential, intro
   it('builds chapters FROM the skeleton — cross-cell merge, ch sequential, intro populated', () => {
     // flat topics: [0]=인사(cell0), [1]=주문(cell1). One chapter merges both.
     const { book } = buildBookJson(
-      input({ chapters: [{ title: '한 권의 책: 기초→실전', intro: '기초를 다지고 실전으로', topic_refs: [0, 1] }] })
+      input({
+        chapters: [
+          { title: '한 권의 책: 기초→실전', intro: '기초를 다지고 실전으로', topic_refs: [0, 1] },
+        ],
+      })
     );
     expect(book.chapters).toHaveLength(1); // NOT 2 cells → reconstruction (gate 2a)
     const ch = book.chapters[0]!;

--- a/tests/unit/modules/lenient-json.test.ts
+++ b/tests/unit/modules/lenient-json.test.ts
@@ -1,0 +1,78 @@
+/**
+ * lenient-json (CP504 §11) — salvage LLM-corrupted JSON WITHOUT an LLM retry.
+ * Pure string util (no env / no LLM). Locks: unescaped-newline escape, truncation
+ * bracket-close, string-context awareness (never touches structural whitespace),
+ * salvage-signal callback, and honest null on genuinely-malformed input.
+ */
+
+import {
+  escapeUnescapedJsonNewlines,
+  closeUnclosedJsonBrackets,
+  parseJsonLenient,
+} from '../../../src/utils/lenient-json';
+
+describe('escapeUnescapedJsonNewlines', () => {
+  it('escapes a raw newline INSIDE a string value so JSON.parse survives', () => {
+    const bad = '{"a":"line1\nline2"}';
+    expect(() => JSON.parse(bad)).toThrow(); // raw newline is invalid JSON
+    const fixed = escapeUnescapedJsonNewlines(bad);
+    expect(JSON.parse(fixed)).toEqual({ a: 'line1\nline2' }); // newline preserved (no loss)
+  });
+
+  it('handles \\r and leaves structural whitespace (outside strings) untouched', () => {
+    const bad = '{\n  "a":"x\ry"\n}';
+    const fixed = escapeUnescapedJsonNewlines(bad);
+    expect(JSON.parse(fixed)).toEqual({ a: 'x\ry' });
+  });
+
+  it('does not double-escape an already-escaped newline', () => {
+    const good = '{"a":"line1\\nline2"}'; // already-valid \n escape
+    expect(escapeUnescapedJsonNewlines(good)).toBe(good);
+    expect(JSON.parse(escapeUnescapedJsonNewlines(good))).toEqual({ a: 'line1\nline2' });
+  });
+});
+
+describe('closeUnclosedJsonBrackets', () => {
+  it('closes a truncated object/array prefix into a parseable value', () => {
+    const truncated = '{"sections":[{"title":"T","atom_idx":[0,1';
+    const closed = closeUnclosedJsonBrackets(truncated);
+    expect(JSON.parse(closed)).toEqual({ sections: [{ title: 'T', atom_idx: [0, 1] }] });
+  });
+
+  it('leaves already-balanced JSON unchanged', () => {
+    const ok = '{"a":[1,2]}';
+    expect(closeUnclosedJsonBrackets(ok)).toBe(ok);
+  });
+
+  it('does not count brackets that appear inside string values', () => {
+    const s = '{"a":"has ] and } inside"';
+    expect(JSON.parse(closeUnclosedJsonBrackets(s))).toEqual({ a: 'has ] and } inside' });
+  });
+});
+
+describe('parseJsonLenient', () => {
+  it('returns the value on clean JSON without invoking salvage', () => {
+    const onSalvage = jest.fn();
+    expect(parseJsonLenient('{"x":1}', onSalvage)).toEqual({ x: 1 });
+    expect(onSalvage).not.toHaveBeenCalled();
+  });
+
+  it('salvages an unescaped newline and reports via="newline"', () => {
+    const onSalvage = jest.fn();
+    const v = parseJsonLenient<{ a: string }>('{"a":"l1\nl2"}', onSalvage);
+    expect(v).toEqual({ a: 'l1\nl2' });
+    expect(onSalvage).toHaveBeenCalledWith('newline');
+  });
+
+  it('salvages a truncation and reports via="truncation"', () => {
+    const onSalvage = jest.fn();
+    const v = parseJsonLenient<{ a: number[] }>('{"a":[1,2', onSalvage);
+    expect(v).toEqual({ a: [1, 2] });
+    expect(onSalvage).toHaveBeenCalledWith('truncation');
+  });
+
+  it('returns null (honest fail) on genuinely malformed input', () => {
+    const onSalvage = jest.fn();
+    expect(parseJsonLenient('not json at all }{', onSalvage)).toBeNull();
+  });
+});

--- a/tests/unit/modules/topic-synthesis.test.ts
+++ b/tests/unit/modules/topic-synthesis.test.ts
@@ -118,29 +118,75 @@ describe('synthesizeCellTopics (compression)', () => {
     expect(r.reason).toContain('json_parse');
   });
 
+  // CP504 §11 — the actual observed failure: the model emits a RAW newline inside
+  // a string value, which JSON.parse rejects. This is now salvaged in-attempt
+  // (escape-in-string) with NO second LLM call (was: burned a retry).
+  it('salvages an unescaped newline in content IN-ATTEMPT (no LLM retry)', async () => {
+    // Raw newline inside "content" — invalid JSON as-is (mirrors real Sonnet output).
+    mockGenerate.mockResolvedValue(
+      '{"sections":[{"title":"API","content":"line1\nline2","atom_idx":[0,1]}]}'
+    );
+    const r = await synthesizeCellTopics('c', atoms, GOAL);
+    expect(mockGenerate).toHaveBeenCalledTimes(1); // salvaged, NOT retried
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.topics[0]!.topic_title).toBe('API');
+    expect(r.topics[0]!.summary).toBe('line1 line2'); // newline restored then collapsed (no loss)
+    expect(r.topics[0]!.atom_refs).toEqual([
+      { vid: 'vidA', ts: 10 },
+      { vid: 'vidA', ts: 50 },
+    ]);
+  });
+
+  // A parse failure is NO LONGER a retry reason (CP504 §11) — it either salvages
+  // in-attempt or hard-fails on the first attempt without a wasted second call.
+  it('does NOT retry on an unsalvageable parse failure (one call, honest fail)', async () => {
+    mockGenerate.mockResolvedValue('not json at all {{{');
+    const r = await synthesizeCellTopics('c', atoms, GOAL);
+    expect(mockGenerate).toHaveBeenCalledTimes(1); // parse failure ⇒ no retry
+    expect(r.ok).toBe(false);
+  });
+
   it('honest fail when atoms empty (no LLM call)', async () => {
     const r = await synthesizeCellTopics('c', [], GOAL);
     expect(r.ok).toBe(false);
     expect(mockGenerate).not.toHaveBeenCalled();
   });
 
-  it('retries once on a truncated/parse failure, then succeeds (no silent revert)', async () => {
+  // CP504 §11 — a maxTokens truncation is salvaged in-attempt (close the open
+  // brackets) rather than paying a fresh Sonnet call. One call, partial-but-valid.
+  it('salvages a truncated response IN-ATTEMPT (no LLM retry)', async () => {
+    mockGenerate.mockResolvedValue('{"sections":[{"title":"T","content":"x","atom_idx":[0,1'); // truncated
+    const r = await synthesizeCellTopics('c', atoms, GOAL);
+    expect(mockGenerate).toHaveBeenCalledTimes(1); // salvaged, NOT retried
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.topics[0]!.topic_title).toBe('T');
+    expect(r.topics[0]!.atom_refs).toEqual([
+      { vid: 'vidA', ts: 10 },
+      { vid: 'vidA', ts: 50 },
+    ]);
+  });
+
+  // Retries are reserved for PROVIDER faults (network/API), which a fresh
+  // generation can actually fix — SYNTHESIS_ATTEMPTS covers only these now.
+  it('retries a provider error, then succeeds (no silent revert)', async () => {
     mockGenerate
-      .mockResolvedValueOnce('{"sections":[{"title":"T","atom_idx":[0,1') // truncated
+      .mockRejectedValueOnce(new Error('ECONNRESET')) // transient provider fault
       .mockResolvedValueOnce(
         JSON.stringify({ sections: [{ title: 'API', content: '', atom_idx: [0, 1, 2] }] })
       );
     const r = await synthesizeCellTopics('c', atoms, GOAL);
-    expect(mockGenerate).toHaveBeenCalledTimes(2); // retried
+    expect(mockGenerate).toHaveBeenCalledTimes(2); // retried the provider error
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.topics[0]!.topic_title).toBe('API');
   });
 
-  it('hard-fails (loud) after all retries exhausted', async () => {
-    mockGenerate.mockResolvedValue('not json'); // both attempts fail
+  it('hard-fails (loud) after provider retries exhausted', async () => {
+    mockGenerate.mockRejectedValue(new Error('provider down')); // both attempts fault
     const r = await synthesizeCellTopics('c', atoms, GOAL);
-    expect(mockGenerate).toHaveBeenCalledTimes(2);
+    expect(mockGenerate).toHaveBeenCalledTimes(2); // SYNTHESIS_ATTEMPTS (provider only)
     expect(r.ok).toBe(false);
     if (r.ok) return;
     expect(r.reason).toContain('hard_fail'); // surfaced as hard fail, not silent


### PR DESCRIPTION
## Problem (measured)
Book-fill makes **9–17 Sonnet calls/book** vs the §7.5 "book당 1콜" cost model. One driver confirmed in code + OpenRouter CSV: the model emits a **raw newline** (or a maxTokens truncation) inside a JSON string → `JSON.parse` trips → `SYNTHESIS_ATTEMPTS`/`SKELETON_ATTEMPTS` **re-called Sonnet** to dodge it. **4 of a measured 13 calls/book were these parse retries.** The prompt-side "개행 금지" defense (`topic-synthesis.ts:111`) is not reliably obeyed — the fix belongs in the parser, not the prompt.

## Fix (CP504 §11) — salvage in-attempt, no new LLM call
- **`src/utils/lenient-json.ts`** (new): `escapeUnescapedJsonNewlines` + `closeUnclosedJsonBrackets` + `parseJsonLenient` (direct → newline-escape → bracket-close). Extracted from `mandala/generator.ts`'s proven robust-extract helpers → three parsers now share **one** copy (generator imports them; −65 lines of dup).
- **topic-synthesis / book-skeleton**: parse via `parseJsonLenient`; `*_ATTEMPTS` now retry **PROVIDER faults only** (parse failure is no longer a retry reason). A `via` counter is logged so we can verify retries → 0 post-fix. Content preserved (newline restored on parse, collapsed to space as before — no word loss).

## Per-stage cost instrumentation (CP504 §3)
`cost_usd` is already priced (`llm-pricing.ts`), but every call logged `module='openrouter'`, hiding which stage spends. Add `GenerateOptions.purpose` → written to the **existing** `llm_call_logs.module` column (no schema change). Book stages now tag `cell_synthesis` / `book_skeleton` / `chapter_weave` / `book_research` / `book_factcheck` → per-stage cost = `GROUP BY module`. Absent = `'openrouter'` (additive no-op).

## Verification
- `tsc --noEmit`: clean
- New/updated tests: lenient-json (10), topic-synthesis salvage + no-retry-on-parse (26 total), book-skeleton raw-newline/truncation salvage, generator DRY regression (19). All pass.
- `hardcode-audit`: unchanged (33 baseline)
- Backend-only; **no serving-path change**. The 3 unit suites that fail locally (pipeline-runner / key-alarm / auto-add-recommendations) fail **identically on origin/main** — pre-existing env-dependent, unrelated to this diff.

## Out of scope (measurement-gated)
`cell→book 1-call` consolidation (§2-2) and `skeleton` model downgrade (§2-3): the design doc defers these to **"측정 후 확정"**, and they need a prod A/B the LLM-ban blocks CC from running. Analysis found **2-2 is call-count 8× but not cost 8× (output tokens ≈ constant)** — it is primarily a *quality* fix (cross-cell narrative + chapter intro). The purpose tags here land the measurement basis so 2-2/2-3 can be decided on real per-stage numbers under James's quality gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)