### PR TITLE
feat(caption): Azure transcript proxy as primary — fix Mac Mini SPOF

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -270,6 +270,11 @@ jobs:
           # youtube-transcript on EC2 (known to fail) — set both to enable.
           MAC_MINI_TRANSCRIPT_URL: ${{ secrets.MAC_MINI_TRANSCRIPT_URL }}
           MAC_MINI_TRANSCRIPT_TOKEN: ${{ secrets.MAC_MINI_TRANSCRIPT_TOKEN }}
+          # Azure App Service transcript proxy (2026-07-09) — always-on cloud
+          # host running the same Webshare-backed service, off EC2 (ToS). Tried
+          # BEFORE Mac Mini (fixes the Mac Mini SPOF). Non-secret URL = literal
+          # (reuses MAC_MINI_TRANSCRIPT_TOKEN for x-transcript-token auth).
+          AZURE_TRANSCRIPT_URL: https://insighta-transcript-proxy-dqaxe5f7hqgddmdz.eastus2-01.azurewebsites.net
           # ⑤ snapshot get-or-extract — pod slidegen-service. URL = Variable
           # (CP392, not a credential), TOKEN = Secret. Both unset ⇒ extract
           # disabled (numerize-client returns []); serve-from-cache still works.
@@ -281,7 +286,7 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           # CP500++ CONFIG-SSOT — toggle keys removed from this forward list
           # (now compose-SSOT); only secrets + non-conflicting config remain.
-          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,YT_VIDEOS_KEY,YT_VIDEOS_KEY_2,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN,SNAPSHOT_SERVICE_URL,SNAPSHOT_SERVICE_TOKEN
+          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,YT_VIDEOS_KEY,YT_VIDEOS_KEY_2,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN,AZURE_TRANSCRIPT_URL,SNAPSHOT_SERVICE_URL,SNAPSHOT_SERVICE_TOKEN
           script: |
             set -e
             cd /opt/tubearchive
@@ -325,6 +330,9 @@ jobs:
             fi
             if [ -n "${MAC_MINI_TRANSCRIPT_TOKEN}" ]; then
               grep -q '^MAC_MINI_TRANSCRIPT_TOKEN=' .env 2>/dev/null && sed -i "s|^MAC_MINI_TRANSCRIPT_TOKEN=.*|MAC_MINI_TRANSCRIPT_TOKEN=${MAC_MINI_TRANSCRIPT_TOKEN}|" .env || echo "MAC_MINI_TRANSCRIPT_TOKEN=${MAC_MINI_TRANSCRIPT_TOKEN}" >> .env
+            fi
+            if [ -n "${AZURE_TRANSCRIPT_URL}" ]; then
+              grep -q '^AZURE_TRANSCRIPT_URL=' .env 2>/dev/null && sed -i "s|^AZURE_TRANSCRIPT_URL=.*|AZURE_TRANSCRIPT_URL=${AZURE_TRANSCRIPT_URL}|" .env || echo "AZURE_TRANSCRIPT_URL=${AZURE_TRANSCRIPT_URL}" >> .env
             fi
             # ⑤ snapshot get-or-extract — pod slidegen-service URL + token. New
             # keys (not in docker-compose.prod.yml `environment:` literals) so the

--- a/src/config/transcript.ts
+++ b/src/config/transcript.ts
@@ -28,14 +28,32 @@ const optionalStr = z.preprocess((v) => {
 export const transcriptEnvSchema = z.object({
   MAC_MINI_TRANSCRIPT_URL: optionalStr.default(''),
   MAC_MINI_TRANSCRIPT_TOKEN: optionalStr.default(''),
+  // Azure App Service transcript proxy (2026-07-09) — an always-on cloud host
+  // running the SAME Webshare-backed service, off EC2 (ToS: scraping must not
+  // run on EC2). Fixes the Mac Mini SPOF (home machine + Tailscale cold-path).
+  // Reuses MAC_MINI_TRANSCRIPT_TOKEN (the Azure service validates the same token).
+  AZURE_TRANSCRIPT_URL: optionalStr.default(''),
 });
 
+/** One transcript proxy the extractor can forward a caption fetch to. */
+export interface TranscriptProxy {
+  name: string;
+  url: string;
+  token: string;
+}
+
 export interface TranscriptConfig {
-  /** Mac Mini proxy base URL. Empty string ⇒ proxy disabled. */
+  /**
+   * Ordered proxy list — the extractor tries each in sequence and uses the
+   * first that REACHES YouTube (segments or an authoritative "no captions").
+   * Azure first (reliable always-on cloud), Mac Mini second (KR-IP fallback).
+   */
+  proxies: TranscriptProxy[];
+  /** Mac Mini proxy base URL. Empty string ⇒ proxy disabled. (back-compat) */
   macMiniUrl: string;
   /** Bearer token (`x-transcript-token` header) for the Mac Mini proxy. */
   macMiniToken: string;
-  /** True iff both URL and token are non-empty. */
+  /** True iff at least one proxy (Azure or Mac Mini) is configured. */
   macMiniEnabled: boolean;
 }
 
@@ -43,14 +61,28 @@ export function loadTranscriptConfig(env: NodeJS.ProcessEnv = process.env): Tran
   const parsed = transcriptEnvSchema.safeParse({
     MAC_MINI_TRANSCRIPT_URL: env['MAC_MINI_TRANSCRIPT_URL'],
     MAC_MINI_TRANSCRIPT_TOKEN: env['MAC_MINI_TRANSCRIPT_TOKEN'],
+    AZURE_TRANSCRIPT_URL: env['AZURE_TRANSCRIPT_URL'],
   });
   if (!parsed.success) {
-    return { macMiniUrl: '', macMiniToken: '', macMiniEnabled: false };
+    return { proxies: [], macMiniUrl: '', macMiniToken: '', macMiniEnabled: false };
   }
-  const { MAC_MINI_TRANSCRIPT_URL: url, MAC_MINI_TRANSCRIPT_TOKEN: token } = parsed.data;
+  const {
+    MAC_MINI_TRANSCRIPT_URL: macUrl,
+    MAC_MINI_TRANSCRIPT_TOKEN: token,
+    AZURE_TRANSCRIPT_URL: azureUrl,
+  } = parsed.data;
+
+  // The shared token gates both proxies. Azure first, then Mac Mini.
+  const proxies: TranscriptProxy[] = [];
+  if (token.length > 0) {
+    if (azureUrl.length > 0) proxies.push({ name: 'azure', url: azureUrl, token });
+    if (macUrl.length > 0) proxies.push({ name: 'mac-mini', url: macUrl, token });
+  }
+
   return {
-    macMiniUrl: url,
+    proxies,
+    macMiniUrl: macUrl,
     macMiniToken: token,
-    macMiniEnabled: url.length > 0 && token.length > 0,
+    macMiniEnabled: proxies.length > 0,
   };
 }

--- a/src/modules/caption/extractor.ts
+++ b/src/modules/caption/extractor.ts
@@ -29,9 +29,7 @@ import { loadTranscriptConfig } from '@/config/transcript';
 // Tailscale; the EC2 caption-extractor falls back to direct youtube-
 // transcript only if the proxy is unreachable (defence in depth).
 const TRANSCRIPT_CONFIG = loadTranscriptConfig();
-const MAC_MINI_URL = TRANSCRIPT_CONFIG.macMiniUrl;
-const MAC_MINI_TOKEN = TRANSCRIPT_CONFIG.macMiniToken;
-const MAC_MINI_TIMEOUT_MS = 30_000;
+const PROXY_TIMEOUT_MS = 30_000;
 
 interface MacMiniSegment {
   text: string;
@@ -46,26 +44,36 @@ interface MacMiniResponse {
   error?: string;
 }
 
-async function fetchViaMacMini(youtubeId: string, lang: string): Promise<MacMiniSegment[] | null> {
-  if (!MAC_MINI_URL || !MAC_MINI_TOKEN) return null;
+/**
+ * Fetch a transcript through ONE proxy host (Azure App Service or Mac Mini —
+ * same Webshare-backed service, same token). Returns segments on success, `[]`
+ * when the proxy REACHED YouTube but there are no captions in this language,
+ * and `null` when the proxy is unreachable (so the caller tries the next proxy).
+ */
+async function fetchViaProxy(
+  proxy: { name: string; url: string; token: string },
+  youtubeId: string,
+  lang: string
+): Promise<MacMiniSegment[] | null> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), MAC_MINI_TIMEOUT_MS);
+  const timer = setTimeout(() => controller.abort(), PROXY_TIMEOUT_MS);
   try {
     const resp = await fetch(
-      `${MAC_MINI_URL.replace(/\/$/, '')}/transcript/${encodeURIComponent(youtubeId)}?lang=${encodeURIComponent(lang)}`,
+      `${proxy.url.replace(/\/$/, '')}/transcript/${encodeURIComponent(youtubeId)}?lang=${encodeURIComponent(lang)}`,
       {
         method: 'GET',
-        headers: { 'x-transcript-token': MAC_MINI_TOKEN },
+        headers: { 'x-transcript-token': proxy.token },
         signal: controller.signal,
       }
     );
     if (resp.status === 404) {
-      // service reachable, captions absent in this language — bubble up
-      // as "no captions" so the outer loop can try the next language
+      // service reachable, captions absent in this language — bubble up as
+      // "no captions" so the outer loop can try the next language.
       return [];
     }
     if (!resp.ok) {
-      logger.warn('Mac Mini transcript proxy non-200', {
+      logger.warn('transcript proxy non-200', {
+        proxy: proxy.name,
         youtubeId,
         lang,
         status: resp.status,
@@ -74,7 +82,8 @@ async function fetchViaMacMini(youtubeId: string, lang: string): Promise<MacMini
     }
     const data = (await resp.json()) as MacMiniResponse;
     if (!data.success || !Array.isArray(data.segments)) {
-      logger.warn('Mac Mini transcript proxy returned no segments', {
+      logger.warn('transcript proxy returned no segments', {
+        proxy: proxy.name,
         youtubeId,
         lang,
         error: data.error,
@@ -83,7 +92,8 @@ async function fetchViaMacMini(youtubeId: string, lang: string): Promise<MacMini
     }
     return data.segments;
   } catch (err) {
-    logger.warn('Mac Mini transcript proxy fetch failed (falling back)', {
+    logger.warn('transcript proxy fetch failed (falling back)', {
+      proxy: proxy.name,
       youtubeId,
       lang,
       error: err instanceof Error ? err.message : String(err),
@@ -92,6 +102,20 @@ async function fetchViaMacMini(youtubeId: string, lang: string): Promise<MacMini
   } finally {
     clearTimeout(timer);
   }
+}
+
+/**
+ * Try each configured proxy in order (Azure → Mac Mini). Returns the result of
+ * the FIRST proxy that reaches YouTube (segments or `[]` = no captions); returns
+ * `null` only when every proxy is unreachable (caller then tries direct).
+ */
+async function fetchViaProxies(youtubeId: string, lang: string): Promise<MacMiniSegment[] | null> {
+  for (const proxy of TRANSCRIPT_CONFIG.proxies) {
+    const r = await fetchViaProxy(proxy, youtubeId, lang);
+    if (r !== null) return r; // reached (segments or 404 no-captions) — stop
+    // r === null → this proxy is unreachable; try the next one.
+  }
+  return null; // all proxies unreachable
 }
 import type {
   CaptionSegment,
@@ -128,11 +152,12 @@ export class CaptionExtractor {
       for (const lang of LANG_PRIORITY) {
         logger.info('Extracting captions', { videoId: youtubeId, language: lang });
 
-        // Path 1 — Mac Mini Tailscale proxy (preferred). EC2 outbound IP
-        // is blocked by YouTube for caption fetch; Mac Mini uses a KR ISP
-        // residential IP that successfully fetches. When the env vars are
-        // configured and the proxy returns a usable result, skip path 2.
-        const macMini = await fetchViaMacMini(youtubeId, lang);
+        // Path 1 — Webshare-backed proxies (Azure primary → Mac Mini fallback).
+        // EC2 outbound IP is blocked by YouTube AND scraping must not run on EC2
+        // (ToS); the proxies fetch through a Webshare residential IP off-EC2.
+        // Azure is an always-on cloud host (fixes the Mac Mini SPOF). When a
+        // proxy returns a usable result, skip path 2.
+        const macMini = await fetchViaProxies(youtubeId, lang);
         if (macMini && macMini.length > 0) {
           segments = macMini.map((item) => ({
             text: item.text,

--- a/tests/unit/modules/transcript-config.test.ts
+++ b/tests/unit/modules/transcript-config.test.ts
@@ -1,0 +1,60 @@
+/**
+ * loadTranscriptConfig — proxy ordering + back-compat (2026-07-09 Azure fallback).
+ * The extractor tries proxies in order: Azure (always-on cloud) BEFORE Mac Mini
+ * (KR-IP fallback). The shared token gates both. Pure function over an injected
+ * env — no config/index / no DB.
+ */
+
+import { loadTranscriptConfig } from '../../../src/config/transcript';
+
+const TOKEN = 'shared-secret';
+const AZURE = 'https://insighta-transcript-proxy-x.eastus2-01.azurewebsites.net';
+const MAC = 'http://100.91.173.17:4242';
+
+describe('loadTranscriptConfig', () => {
+  it('orders Azure before Mac Mini when both are set', () => {
+    const c = loadTranscriptConfig({
+      MAC_MINI_TRANSCRIPT_URL: MAC,
+      MAC_MINI_TRANSCRIPT_TOKEN: TOKEN,
+      AZURE_TRANSCRIPT_URL: AZURE,
+    } as NodeJS.ProcessEnv);
+    expect(c.proxies.map((p) => p.name)).toEqual(['azure', 'mac-mini']);
+    expect(c.proxies[0]).toEqual({ name: 'azure', url: AZURE, token: TOKEN });
+    expect(c.proxies[1]).toEqual({ name: 'mac-mini', url: MAC, token: TOKEN });
+    expect(c.macMiniEnabled).toBe(true);
+  });
+
+  it('uses only Azure when Mac Mini URL is unset (reuses the shared token)', () => {
+    const c = loadTranscriptConfig({
+      MAC_MINI_TRANSCRIPT_TOKEN: TOKEN,
+      AZURE_TRANSCRIPT_URL: AZURE,
+    } as NodeJS.ProcessEnv);
+    expect(c.proxies.map((p) => p.name)).toEqual(['azure']);
+    expect(c.macMiniEnabled).toBe(true);
+  });
+
+  it('uses only Mac Mini when Azure URL is unset (back-compat)', () => {
+    const c = loadTranscriptConfig({
+      MAC_MINI_TRANSCRIPT_URL: MAC,
+      MAC_MINI_TRANSCRIPT_TOKEN: TOKEN,
+    } as NodeJS.ProcessEnv);
+    expect(c.proxies.map((p) => p.name)).toEqual(['mac-mini']);
+    expect(c.macMiniUrl).toBe(MAC);
+    expect(c.macMiniToken).toBe(TOKEN);
+  });
+
+  it('has no proxies when the shared token is unset (token gates both)', () => {
+    const c = loadTranscriptConfig({
+      MAC_MINI_TRANSCRIPT_URL: MAC,
+      AZURE_TRANSCRIPT_URL: AZURE,
+    } as NodeJS.ProcessEnv);
+    expect(c.proxies).toEqual([]);
+    expect(c.macMiniEnabled).toBe(false);
+  });
+
+  it('has no proxies when nothing is configured', () => {
+    const c = loadTranscriptConfig({} as NodeJS.ProcessEnv);
+    expect(c.proxies).toEqual([]);
+    expect(c.macMiniEnabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why
Caption fetch had ONE working prod path: the Mac Mini Tailscale proxy (KR-IP, Webshare-backed). That's a **SPOF** — a home machine + a Tailscale link that goes cold (EC2→Mac Mini = HTTP 000/12s timeout → the v2=0 incident 2026-07-09). And **scraping must NOT run on EC2 (ToS)**, so EC2-direct is out.

This adds an **always-on cloud host (Azure App Service, off EC2)** running the SAME Webshare-backed service, tried **first**.

## Changes
- **`config/transcript.ts`**: `AZURE_TRANSCRIPT_URL` + an ordered `proxies` list (`azure` → `mac-mini`). Both gated by the shared `MAC_MINI_TRANSCRIPT_TOKEN` (the Azure service validates the same token). Back-compat `macMini*` fields kept.
- **`caption/extractor.ts`**: generalize `fetchViaMacMini` → `fetchViaProxy(proxy,…)` + `fetchViaProxies()` — returns the first proxy to **reach** YouTube (segments or an authoritative 404 no-captions), and `null` only when **all** proxies are unreachable (then the direct fallback runs, exactly as before). Single-proxy behavior unchanged.
- **`deploy.yml`**: wire `AZURE_TRANSCRIPT_URL` (non-secret literal, reuses the token secret) into the container `.env` — same mechanism as `MAC_MINI_TRANSCRIPT_URL`.

Result: Azure (reliable always-on cloud) is primary → no more cold-Tailscale caption failures; Mac Mini stays as the KR-IP fallback; direct `youtube-transcript` remains last resort.

## Verification
- **End-to-end**: EC2 → Azure → Webshare → YouTube returned real caption segments (`{"success":true,…,"segments":[…]}`).
- `tsc --noEmit`: clean · `transcript-config` (5) + `caption-extractor` (2) pass · `hardcode-audit` unchanged (33) · backend + CI-config only (no frontend).

## ⚠️ Ops note
The Webshare **Rotating Residential plan is currently CANCELLED** (in its grace period). **Reactivate before it lapses** — otherwise BOTH proxies lose their residential egress and all caption fetch dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)