### PR TITLE
fix: static-asset URL 404 (SW fallback) + friendly animated 404 page

### DIFF
--- a/frontend/src/pages/not-found/ui/NotFoundPage.tsx
+++ b/frontend/src/pages/not-found/ui/NotFoundPage.tsx
@@ -1,21 +1,87 @@
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Home } from 'lucide-react';
 import { Button } from '@/shared/ui/button';
-import { Header } from '@/widgets/header/ui/Header';
-import { Footer } from '@/widgets/header/ui/Footer';
 
+/**
+ * A cute, brand-consistent 404 mascot — three round characters that gently
+ * float and blink (inline CSS/SVG, no external GIF so there's no PWA/hosting
+ * dependency and it always renders). No emoji, per brand guidelines.
+ */
+function LostMascots() {
+  const chars = [
+    { fill: '#8b83fb', d: 0, look: 'left' },
+    { fill: '#ffb056', d: 0.4, look: 'up' },
+    { fill: '#4fd1a5', d: 0.8, look: 'right' },
+  ];
+  return (
+    <div className="flex items-end justify-center gap-4" aria-hidden="true">
+      <style>{`
+        @keyframes nf-float { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-8px); } }
+        @keyframes nf-blink { 0%,92%,100% { transform: scaleY(1); } 96% { transform: scaleY(0.1); } }
+      `}</style>
+      {chars.map((c, i) => {
+        const ex = c.look === 'left' ? -3 : c.look === 'right' ? 3 : 0;
+        const ey = c.look === 'up' ? -3 : 0;
+        return (
+          <svg
+            key={i}
+            viewBox="0 0 80 80"
+            className="w-16 h-16 sm:w-20 sm:h-20"
+            style={{ animation: `nf-float 2.6s ease-in-out ${c.d}s infinite` }}
+          >
+            <circle cx="40" cy="40" r="34" fill={c.fill} stroke="#1c1c22" strokeWidth="3" />
+            <g
+              style={{
+                animation: `nf-blink 3.4s ease-in-out ${c.d}s infinite`,
+                transformOrigin: '40px 36px',
+              }}
+            >
+              <circle cx={30 + ex} cy={36 + ey} r="4.5" fill="#1c1c22" />
+              <circle cx={50 + ex} cy={36 + ey} r="4.5" fill="#1c1c22" />
+            </g>
+            <path
+              d="M32 52 Q40 46 48 52"
+              fill="none"
+              stroke="#1c1c22"
+              strokeWidth="3"
+              strokeLinecap="round"
+            />
+          </svg>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Public 404 — a clean standalone page (no app header/footer). Shown to any
+ * visitor who hits an unknown URL, including logged-out ones, so it must not
+ * render the logged-in app chrome (the old widgets/header Header/Footer were
+ * the last consumer here and were otherwise unused).
+ */
 export default function NotFoundPage() {
   const navigate = useNavigate();
   const { t } = useTranslation();
 
   return (
     <div className="min-h-screen flex flex-col bg-background">
-      <Header />
+      <header className="px-6 py-5">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 font-bold text-lg hover:opacity-80 transition-opacity"
+        >
+          <span className="w-8 h-8 rounded-lg bg-primary/15 border border-primary/40 flex items-center justify-center">
+            <span className="w-3 h-3 rounded-full border-2 border-primary inline-block" />
+          </span>
+          Insighta
+        </Link>
+      </header>
 
       <main id="main-content" className="flex-1 flex items-center justify-center px-4">
-        <div className="text-center space-y-6">
-          <h1 className="text-7xl font-bold text-primary">404</h1>
+        <div className="text-center space-y-7">
+          <LostMascots />
+          <h1 className="text-6xl font-bold text-primary">404</h1>
           <h2 className="text-2xl font-semibold text-foreground">{t('notFound.title')}</h2>
           <p className="text-muted-foreground max-w-md mx-auto">{t('notFound.description')}</p>
           <Button size="lg" className="gap-2 rounded-xl" onClick={() => navigate('/')}>
@@ -25,7 +91,9 @@ export default function NotFoundPage() {
         </div>
       </main>
 
-      <Footer />
+      <footer className="px-6 py-6 text-center text-xs text-muted-foreground">
+        © 2026 Insighta
+      </footer>
     </div>
   );
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -73,6 +73,13 @@ export default defineConfig(({ mode }) => {
         workbox: {
           maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
           globPatterns: ['**/*.{js,css,html,svg,png,woff2}'],
+          // Static-asset URLs (anything ending in a file extension, e.g.
+          // /beta-notice.gif) must NOT fall back to index.html. Without this,
+          // typing an asset URL in the address bar is treated as a navigation
+          // and the SPA serves its 404 route instead of the real file
+          // (a PWA-registered browser returned 404 for /beta-notice.gif while
+          // the server served the GIF fine). Let these hit the network.
+          navigateFallbackDenylist: [/^\/api\//, /\.[^/]+$/],
           // 2026-04-22 (Phase 2 re-scoped): removed the `/api/*`
           // StaleWhileRevalidate runtime cache. Serving stale API
           // responses is incorrect for mandala-create / wizard-stream


### PR DESCRIPTION
James opening `insighta.one/beta-notice.gif` hit a 404 with an outdated header/footer.

## Fixes
1. **Static assets 404 on direct URL**: the PWA service worker treated `/beta-notice.gif` typed in the address bar as a navigation and served the SPA 404 (index.html), even though the server serves the GIF (curl 200 image/gif). Added `navigateFallbackDenylist: [/^\/api\//, /\.[^/]+$/]` so any URL ending in a file extension bypasses the SPA fallback and hits the network. (Embeds/email already worked — only address-bar navigation was affected.)
2. **404 page old chrome → friendly page**: `NotFoundPage` was the last + only consumer of the deprecated `widgets/header` Header/Footer (logged-in app nav). Replaced with a clean standalone 404: minimal logo header, simple footer, and a **cute animated mascot** — 3 brand-colored round characters that float + blink (inline CSS/SVG, no emoji, no external GIF so no PWA/hosting dependency).

## Verified
tsc 0 new · vitest 512 · build emits sw.js · browser: old app-nav absent, 3 mascots render, clean layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)