### PR TITLE
fix(mandala): durable video pipeline via pg-boss — no more 0-card on restart (P0)

### DIFF
--- a/src/config/pipeline-durable.ts
+++ b/src/config/pipeline-durable.ts
@@ -1,0 +1,25 @@
+/**
+ * Pipeline durability gate (P0 incident 2026-07-10).
+ *
+ * The mandala post-creation VIDEO pipeline (embeddings → discover → auto-add,
+ * driving recommendation_cache) ran fire-and-forget via `setImmediate` — an
+ * in-process promise that DIES on any container restart (deploy, redeploy,
+ * crash). A restart 12s into a run left the mandala with 0 cards, the run
+ * stuck at status=running, and no retry — the exact durability hole that
+ * `mandala-actions-fill` was migrated to pg-boss to close, but the video
+ * pipeline was left behind.
+ *
+ * PIPELINE_DURABLE_ENABLED=true routes the pipeline through a pg-boss job
+ * (persists across restarts + 2 backoff retries) plus an orphaned-run
+ * watchdog. Unset/false = legacy `setImmediate` path (no-op default → the
+ * flag alone rolls back, no code revert).
+ *
+ * Tuning knob, not a secret (CP392): code default + env override, unset =
+ * existing behavior.
+ */
+export function isPipelineDurableEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['PIPELINE_DURABLE_ENABLED'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes';
+}

--- a/src/modules/mandala/mandala-post-creation.ts
+++ b/src/modules/mandala/mandala-post-creation.ts
@@ -19,6 +19,7 @@
  */
 
 import { logger } from '@/utils/logger';
+import { isPipelineDurableEnabled } from '@/config/pipeline-durable';
 import { createPipelineRun, executePipelineRun } from './pipeline-runner';
 
 const log = logger.child({ module: 'mandala-post-creation' });
@@ -44,6 +45,26 @@ export function triggerMandalaPostCreationAsync(
     // priority puts the pipeline on the faster path (cards) while actions
     // fill in progressively for the edit view.
     (async () => {
+      // P0 (2026-07-10) — durable path: when PIPELINE_DURABLE_ENABLED, route
+      // the video pipeline through pg-boss (persists across restarts + 2
+      // retries + orphan watchdog) instead of this in-process promise that
+      // died on any container restart → 0-card orphan runs. Enqueue only; the
+      // worker calls createPipelineRun + executePipelineRun. If the queue is
+      // down, fall through to the legacy inline run so cards still have SOME
+      // execution path right now.
+      if (isPipelineDurableEnabled()) {
+        try {
+          const { enqueueMandalaPipeline } =
+            await import('@/modules/queue/handlers/mandala-pipeline');
+          const jobId = await enqueueMandalaPipeline({ mandalaId, userId, trigger });
+          log.info(`pipeline enqueued (durable): job=${jobId} mandala=${mandalaId}`);
+          return;
+        } catch (enqueueErr) {
+          log.warn(
+            `pipeline enqueue failed (${enqueueErr instanceof Error ? enqueueErr.message : String(enqueueErr)}) — falling back to inline run for mandala=${mandalaId}`
+          );
+        }
+      }
       const runId = await createPipelineRun(mandalaId, userId, trigger);
       log.info(`Pipeline run created: ${runId} mandala=${mandalaId} trigger=${trigger}`);
       await executePipelineRun(runId);

--- a/src/modules/queue/handlers/mandala-pipeline.ts
+++ b/src/modules/queue/handlers/mandala-pipeline.ts
@@ -1,0 +1,156 @@
+/**
+ * Mandala post-creation VIDEO pipeline — durable worker (P0, 2026-07-10).
+ *
+ * Replaces the fire-and-forget `setImmediate` pipeline in
+ * mandala-post-creation: that in-process promise died with the process on any
+ * container restart (deploy/redeploy/crash). A restart mid-run left the
+ * mandala at 0 cards, the run stuck at status=running, with no retry — the
+ * same failure class `mandala-actions-fill` was moved to pg-boss to close, but
+ * the video pipeline was left behind (P0 incident: restart 12s into a run →
+ * orphaned run → 0 cards).
+ *
+ * pg-boss gives: persistence across restarts (redelivery) + 2 backoff retries
+ * (MANDALA_PIPELINE_OPTIONS). A `singletonKey` per mandala dedups concurrent
+ * enqueues (create + watchdog). The watchdog re-enqueues runs orphaned by a
+ * restart that happened between job pickup and completion.
+ *
+ * Gated by PIPELINE_DURABLE_ENABLED — the enqueue site (mandala-post-creation)
+ * only routes here when the flag is on; the worker + watchdog are always
+ * registered but the watchdog no-ops when the flag is off (legacy behavior).
+ */
+
+import PgBoss from 'pg-boss';
+import { logger } from '@/utils/logger';
+import { getPrismaClient } from '@/modules/database/client';
+import { isPipelineDurableEnabled } from '@/config/pipeline-durable';
+import { getJobQueue } from '../manager';
+import {
+  JOB_NAMES,
+  QUEUE_CONFIG,
+  MANDALA_PIPELINE_OPTIONS,
+  type MandalaPipelinePayload,
+} from '../types';
+
+const log = logger.child({ module: 'queue/mandala-pipeline' });
+
+// The pipeline is heavy (embeddings on Mac Mini + discover + Haiku, ~55s).
+// Keep concurrency low so a burst of mandala creates cannot overload the
+// single embedding host. Explicit teamSize per the pg-boss trap (CP498).
+const WORKER_TEAM = { teamConcurrency: 2, teamSize: 2 } as const;
+
+/** pg-boss job id or null; singletonKey dedups per mandala. */
+export async function enqueueMandalaPipeline(
+  payload: MandalaPipelinePayload,
+  options?: PgBoss.SendOptions
+): Promise<string | null> {
+  const boss = getJobQueue().getInstance();
+  return boss.send(JOB_NAMES.MANDALA_PIPELINE, payload, {
+    ...MANDALA_PIPELINE_OPTIONS,
+    singletonKey: `mandala-pipeline-${payload.mandalaId}`,
+    ...options,
+  });
+}
+
+export async function handleMandalaPipeline(
+  job: PgBoss.Job<MandalaPipelinePayload>
+): Promise<void> {
+  const startedAt = Date.now();
+  const { mandalaId, userId, trigger } = job.data ?? {};
+  if (!mandalaId || !userId) {
+    // Malformed payload — retrying cannot fix it; complete without throwing.
+    log.warn('mandala-pipeline: missing mandalaId/userId, dropping', { jobId: job.id });
+    return;
+  }
+
+  // Lazy import keeps the queue boot path free of the discover/OpenRouter
+  // import graph — same convention as the old inline call site.
+  const { createPipelineRun, executePipelineRun } =
+    await import('@/modules/mandala/pipeline-runner');
+
+  const runId = await createPipelineRun(mandalaId, userId, trigger ?? 'wizard');
+  log.info('mandala-pipeline: run created', { jobId: job.id, runId, mandalaId, trigger });
+
+  try {
+    await executePipelineRun(runId);
+  } catch (err) {
+    // Throw → pg-boss retry (2× backoff). This is the guarantee the old
+    // fire-and-forget lacked.
+    log.warn('mandala-pipeline: run failed, will retry', {
+      jobId: job.id,
+      runId,
+      mandalaId,
+      error: err instanceof Error ? err.message : String(err),
+      durationMs: Date.now() - startedAt,
+    });
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+
+  log.info('mandala-pipeline: completed', {
+    jobId: job.id,
+    runId,
+    mandalaId,
+    durationMs: Date.now() - startedAt,
+  });
+}
+
+/**
+ * Watchdog — re-enqueue pipeline runs stuck at status=running past the stale
+ * window (orphaned by a restart between pickup and completion, or legacy
+ * setImmediate runs from before the flag was on). No-op when the durable flag
+ * is off so flag-off === exact legacy behavior.
+ */
+export async function handleMandalaPipelineWatchdog(): Promise<void> {
+  if (!isPipelineDurableEnabled()) {
+    log.info('mandala-pipeline-watchdog: durable mode off — skipping');
+    return;
+  }
+  const prisma = getPrismaClient();
+  const stale = await prisma.$queryRawUnsafe<
+    Array<{ mandala_id: string; user_id: string; trigger: string | null }>
+  >(
+    `SELECT DISTINCT ON (mandala_id) mandala_id, user_id, trigger
+       FROM mandala_pipeline_runs
+      WHERE status = 'running'
+        AND created_at < now() - ($1 || ' minutes')::interval
+      ORDER BY mandala_id, created_at DESC`,
+    String(QUEUE_CONFIG.MANDALA_PIPELINE_STALE_MINUTES)
+  );
+
+  if (stale.length === 0) return;
+
+  let reEnqueued = 0;
+  for (const r of stale) {
+    try {
+      const jobId = await enqueueMandalaPipeline({
+        mandalaId: r.mandala_id,
+        userId: r.user_id,
+        trigger: r.trigger ?? 'watchdog',
+      });
+      if (jobId) reEnqueued++;
+    } catch (err) {
+      log.warn('mandala-pipeline-watchdog: re-enqueue failed', {
+        mandalaId: r.mandala_id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  log.info('mandala-pipeline-watchdog: re-enqueued orphaned runs', {
+    stale: stale.length,
+    reEnqueued,
+  });
+}
+
+export async function registerMandalaPipelineWorker(): Promise<void> {
+  const boss = getJobQueue().getInstance();
+  await boss.work<MandalaPipelinePayload>(
+    JOB_NAMES.MANDALA_PIPELINE,
+    WORKER_TEAM,
+    handleMandalaPipeline
+  );
+  await boss.work(JOB_NAMES.MANDALA_PIPELINE_WATCHDOG, handleMandalaPipelineWatchdog);
+  await boss.schedule(
+    JOB_NAMES.MANDALA_PIPELINE_WATCHDOG,
+    QUEUE_CONFIG.MANDALA_PIPELINE_WATCHDOG_CRON
+  );
+  log.info('mandala-pipeline worker + watchdog registered');
+}

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -33,6 +33,7 @@ import { registerPoolMaintenanceWorker } from './handlers/pool-maintenance';
 import { registerEnrichRelevanceQuickWorker } from './handlers/enrich-relevance-quick';
 import { registerPoolServeFillWorker } from './handlers/pool-serve-fill';
 import { registerMandalaActionsFillWorker } from './handlers/mandala-actions-fill';
+import { registerMandalaPipelineWorker } from './handlers/mandala-pipeline';
 import { registerMandalaBookFillWorker } from './handlers/mandala-book-fill';
 import { registerTranslateMandalaBulkWorker } from './handlers/translate-mandala-bulk';
 import { registerSegmentRelevanceFillWorker } from './handlers/segment-relevance-fill';
@@ -62,6 +63,7 @@ export async function initJobQueue(): Promise<void> {
   await registerEnrichRelevanceQuickWorker();
   await registerPoolServeFillWorker();
   await registerMandalaActionsFillWorker();
+  await registerMandalaPipelineWorker();
   await registerMandalaBookFillWorker();
   await registerTranslateMandalaBulkWorker();
   await registerSegmentRelevanceFillWorker();
@@ -70,5 +72,5 @@ export async function initJobQueue(): Promise<void> {
   await registerKeyAlarmWorker();
   await registerSearchMetricsRollupWorker();
 
-  logger.info('Job queue fully initialized (pg-boss + 15 workers)');
+  logger.info('Job queue fully initialized (pg-boss + 16 workers)');
 }

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -88,6 +88,14 @@ export const JOB_NAMES = {
    * + funnel from the Phase 1 trail log into search_metrics_daily (one row/day).
    */
   SEARCH_METRICS_ROLLUP: 'search-metrics-rollup',
+  /**
+   * P0 (2026-07-10) — durable mandala post-creation VIDEO pipeline (embeddings
+   * → discover → auto-add). Replaces the fire-and-forget setImmediate path that
+   * died on container restart (deploy/redeploy/crash) → 0-card orphan runs.
+   */
+  MANDALA_PIPELINE: 'mandala-pipeline',
+  /** Re-enqueues pipeline runs stuck at status=running (orphaned by restart). */
+  MANDALA_PIPELINE_WATCHDOG: 'mandala-pipeline-watchdog',
 } as const;
 
 export type JobName = (typeof JOB_NAMES)[keyof typeof JOB_NAMES];
@@ -324,6 +332,28 @@ export interface MandalaActionsFillPayload {
 }
 
 /**
+ * Mandala post-creation VIDEO pipeline — embeddings → discover → auto-add
+ * (drives recommendation_cache). ~55s observed worst case (embeddings on Mac
+ * Mini + discover + Haiku keyword gen). 2 retries with backoff so a transient
+ * embedding/discover failure OR a container restart mid-run does not leave the
+ * mandala at 0 cards — the exact durability guarantee the fire-and-forget
+ * setImmediate path lacked (P0 incident 2026-07-10: restart 12s into a run →
+ * orphaned status=running, no retry, 0 cards).
+ */
+export const MANDALA_PIPELINE_OPTIONS = {
+  retryLimit: 2,
+  retryDelay: 60,
+  retryBackoff: true,
+  expireInMinutes: 10,
+} as const;
+
+export interface MandalaPipelinePayload {
+  mandalaId: string;
+  userId: string;
+  trigger?: string;
+}
+
+/**
  * Book-index fill — pure DB+assembly, no LLM. Retry on transient DB errors so a
  * triggered fill is not lost; the work is idempotent (version bump + overwrite).
  */
@@ -399,6 +429,10 @@ export const QUEUE_CONFIG = {
   KEY_ALARM_CRON: '7 8 * * *',
   /** Observability Phase 2-B daily metrics rollup: daily at 08:13 (off-hour). */
   SEARCH_METRICS_ROLLUP_CRON: '13 8 * * *',
+  /** Orphaned-pipeline-run watchdog: every 10 minutes. */
+  MANDALA_PIPELINE_WATCHDOG_CRON: '*/10 * * * *',
+  /** A pipeline run stuck at status=running past this age is treated orphaned. */
+  MANDALA_PIPELINE_STALE_MINUTES: 10,
   /** Max concurrent enrichment workers */
   ENRICH_CONCURRENCY: 1,
   /**

--- a/tests/unit/modules/mandala-pipeline.test.ts
+++ b/tests/unit/modules/mandala-pipeline.test.ts
@@ -1,0 +1,146 @@
+/**
+ * mandala-pipeline worker + watchdog tests — P0 durability (2026-07-10).
+ *
+ * Locks the guarantee the fire-and-forget setImmediate pipeline lacked:
+ *   - executePipelineRun throws ⇒ THROW (pg-boss retry engages);
+ *   - success ⇒ createPipelineRun + executePipelineRun both run, no throw;
+ *   - malformed payload (no mandalaId/userId) ⇒ drop without throw or run;
+ *   - enqueue carries MANDALA_PIPELINE_OPTIONS + per-mandala singletonKey;
+ *   - watchdog no-ops when the durable flag is off (legacy behavior);
+ *   - watchdog re-enqueues each stale status=running run when the flag is on.
+ */
+
+const mockBossInstance = {
+  start: jest.fn().mockResolvedValue(undefined),
+  stop: jest.fn().mockResolvedValue(undefined),
+  on: jest.fn(),
+  work: jest.fn().mockResolvedValue('worker-id'),
+  send: jest.fn().mockResolvedValue('job-123'),
+  schedule: jest.fn().mockResolvedValue(undefined),
+  getQueueSize: jest.fn().mockResolvedValue(0),
+};
+jest.mock('pg-boss', () => jest.fn().mockImplementation(() => mockBossInstance));
+
+const mockCreateRun = jest.fn();
+const mockExecuteRun = jest.fn();
+jest.mock('@/modules/mandala/pipeline-runner', () => ({
+  createPipelineRun: (...args: unknown[]) => mockCreateRun(...args),
+  executePipelineRun: (...args: unknown[]) => mockExecuteRun(...args),
+}));
+
+const mockIsDurable = jest.fn();
+jest.mock('@/config/pipeline-durable', () => ({
+  isPipelineDurableEnabled: () => mockIsDurable(),
+}));
+
+const mockQueryRaw = jest.fn();
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({ $queryRawUnsafe: (...args: unknown[]) => mockQueryRaw(...args) }),
+}));
+
+jest.mock('@/config/index', () => ({
+  config: {
+    database: { url: 'postgresql://postgres:pass@127.0.0.1:5432/postgres', directUrl: undefined },
+    app: { isDevelopment: true, isProduction: false, isTest: true },
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import type PgBoss from 'pg-boss';
+import { getJobQueue } from '@/modules/queue/manager';
+import {
+  handleMandalaPipeline,
+  handleMandalaPipelineWatchdog,
+  enqueueMandalaPipeline,
+} from '@/modules/queue/handlers/mandala-pipeline';
+import { JOB_NAMES, MANDALA_PIPELINE_OPTIONS } from '@/modules/queue/types';
+import type { MandalaPipelinePayload } from '@/modules/queue/types';
+
+beforeAll(async () => {
+  await getJobQueue().start();
+});
+afterAll(async () => {
+  await getJobQueue().stop();
+});
+
+const job = (data: Partial<MandalaPipelinePayload>): PgBoss.Job<MandalaPipelinePayload> =>
+  ({ id: 'job-1', data }) as PgBoss.Job<MandalaPipelinePayload>;
+
+beforeEach(() => {
+  mockCreateRun.mockResolvedValue('run-1');
+  mockExecuteRun.mockResolvedValue(undefined);
+});
+afterEach(() => jest.clearAllMocks());
+
+describe('handleMandalaPipeline (durability guarantee)', () => {
+  it('success → creates run then executes, no throw', async () => {
+    await expect(
+      handleMandalaPipeline(job({ mandalaId: 'm-1', userId: 'u-1', trigger: 'wizard' }))
+    ).resolves.toBeUndefined();
+    expect(mockCreateRun).toHaveBeenCalledWith('m-1', 'u-1', 'wizard');
+    expect(mockExecuteRun).toHaveBeenCalledWith('run-1');
+  });
+
+  it('executePipelineRun throws → rethrows so pg-boss retries', async () => {
+    mockExecuteRun.mockRejectedValue(new Error('embedding timeout'));
+    await expect(handleMandalaPipeline(job({ mandalaId: 'm-2', userId: 'u-2' }))).rejects.toThrow(
+      /embedding timeout/
+    );
+  });
+
+  it('malformed payload (no userId) is dropped without throw or run', async () => {
+    await expect(handleMandalaPipeline(job({ mandalaId: 'm-3' }))).resolves.toBeUndefined();
+    expect(mockCreateRun).not.toHaveBeenCalled();
+  });
+});
+
+describe('enqueueMandalaPipeline', () => {
+  it('sends with retry options + per-mandala singletonKey', async () => {
+    const id = await enqueueMandalaPipeline({ mandalaId: 'm-4', userId: 'u-4', trigger: 'wizard' });
+    expect(id).toBe('job-123');
+    expect(mockBossInstance.send).toHaveBeenCalledWith(
+      JOB_NAMES.MANDALA_PIPELINE,
+      { mandalaId: 'm-4', userId: 'u-4', trigger: 'wizard' },
+      expect.objectContaining({ ...MANDALA_PIPELINE_OPTIONS, singletonKey: 'mandala-pipeline-m-4' })
+    );
+  });
+});
+
+describe('handleMandalaPipelineWatchdog', () => {
+  it('durable flag OFF → no query, no re-enqueue (legacy behavior)', async () => {
+    mockIsDurable.mockReturnValue(false);
+    await handleMandalaPipelineWatchdog();
+    expect(mockQueryRaw).not.toHaveBeenCalled();
+    expect(mockBossInstance.send).not.toHaveBeenCalled();
+  });
+
+  it('durable flag ON → re-enqueues each stale running run', async () => {
+    mockIsDurable.mockReturnValue(true);
+    mockQueryRaw.mockResolvedValue([
+      { mandala_id: 'm-a', user_id: 'u-a', trigger: 'wizard' },
+      { mandala_id: 'm-b', user_id: 'u-b', trigger: null },
+    ]);
+    await handleMandalaPipelineWatchdog();
+    expect(mockBossInstance.send).toHaveBeenCalledTimes(2);
+    expect(mockBossInstance.send).toHaveBeenCalledWith(
+      JOB_NAMES.MANDALA_PIPELINE,
+      { mandalaId: 'm-b', userId: 'u-b', trigger: 'watchdog' },
+      expect.objectContaining({ singletonKey: 'mandala-pipeline-m-b' })
+    );
+  });
+
+  it('durable flag ON, no stale runs → nothing re-enqueued', async () => {
+    mockIsDurable.mockReturnValue(true);
+    mockQueryRaw.mockResolvedValue([]);
+    await handleMandalaPipelineWatchdog();
+    expect(mockBossInstance.send).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## P0 incident (2026-07-10)

A new mandala served **0 cards**. Root cause (evidence): the post-creation VIDEO pipeline (embeddings → discover → auto-add, driving `recommendation_cache`) ran **fire-and-forget via `setImmediate`** — an in-process promise that dies on any container restart. A restart **12s into a run** (another session's `docker compose up`; RestartCount=0, clean recreate) left the run stuck at `status=running`, no retry, 0 cards.

This is the **same durability hole** `mandala-actions-fill` was migrated to pg-boss to close (code comment: *"died with the process (deploy restarts!)"*) — the video pipeline was left behind. Embedding health was **not** the cause here (a separate Mac Mini SPOF, already recovered); this fires even with perfectly healthy embeddings whenever a deploy/restart overlaps a run.

## Change
- New pg-boss job **`mandala-pipeline`** = `createPipelineRun` + `executePipelineRun`, **2 backoff retries**, per-mandala `singletonKey` → survives restarts (redelivery) + retries.
- **Orphan watchdog** (`mandala-pipeline-watchdog`, every 10m): re-enqueues runs stuck at `status=running` past the stale window; no-op when the flag is off.
- Gated by **`PIPELINE_DURABLE_ENABLED`** — unset/false = legacy `setImmediate` (the flag alone rolls back, no code revert). Enqueue falls back to the inline run if the queue is down.

## Verification
- tsc clean (changed files), **7/7** new unit tests, `mandala-actions-fill` regression **5/5**.

## Activation (staged, safe)
1. Merge → CI deploy: worker + watchdog registered, **flag off = zero behavior change**.
2. `PIPELINE_DURABLE_ENABLED=true` → durable path on.
3. Verify: create a mandala during a redeploy → cards survive.

## Not in this PR (follow-up, per supervisor order)
Embedding A-A (OpenRouter 2nd leg) as a **separate deploy** after this ships; then lexical decouple (0-card guard) + 0-card-on-create alarm + Mac Mini dual-Ollama hardening + external health cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)