### PR TITLE
feat(embedding): active-active hedge — remove Mac Mini embed SPOF (P0 follow-up)

### DIFF
--- a/src/config/embed-active-active.ts
+++ b/src/config/embed-active-active.ts
@@ -1,0 +1,37 @@
+/**
+ * Embedding active-active gate (P0 follow-up 2026-07-10).
+ *
+ * `embedBatch` embeds against a single provider (Mac Mini Ollama by default,
+ * OpenRouter on sequential fallback). The Mac Mini is a home host reached over
+ * Tailscale — a SPOF that took down card serving (0-card incident) when its
+ * GPU could not load the model ("Compute error"). Both providers emit the
+ * SAME 4096-d qwen3-embedding-8b space, so either can serve any request.
+ *
+ * When EMBED_ACTIVE_ACTIVE_ENABLED, embedOneChunk uses a **hedge**: Ollama
+ * primary, and OpenRouter is fired in parallel ONLY when Ollama (a) rejects
+ * fast (e.g. the 500 "Compute error" — immediate) or (b) exceeds
+ * EMBED_HEDGE_MS. A healthy Ollama (measured p50 ~1.9s) never pays the
+ * OpenRouter call, so this removes the SPOF without the always-2× cost of a
+ * blind Promise.any. First success wins; the loser is AbortController-
+ * cancelled. Both dead → throw (downstream lexical path).
+ *
+ * EMBED_HEDGE_MS default 18000 — above the measured p95 (~17.1s, n=32 sparse)
+ * so the hedge fires only on clearly-sick latency, not normal tail. Lower it
+ * via env once the hedge-trigger counter gives denser data (lowering is the
+ * safe direction; starting low risks a silent 2× cost leak).
+ *
+ * Tuning knobs, not secrets (CP392): code default + env override, unset = the
+ * existing sequential-fallback behavior (no-op → flag alone rolls back).
+ */
+export function isEmbedActiveActiveEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['EMBED_ACTIVE_ACTIVE_ENABLED'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes';
+}
+
+/** Hedge delay (ms) before firing the OpenRouter leg on a slow (not rejected) Ollama call. */
+export function getEmbedHedgeMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number(env['EMBED_HEDGE_MS']);
+  return Number.isFinite(raw) && raw > 0 ? raw : 18000;
+}

--- a/src/skills/plugins/iks-scorer/__tests__/embedding-active-active.test.ts
+++ b/src/skills/plugins/iks-scorer/__tests__/embedding-active-active.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for embedBatch active-active hedge (P0 follow-up 2026-07-10).
+ *
+ * Verifies the hedge in embedOneChunkHedged (flag EMBED_ACTIVE_ACTIVE_ENABLED):
+ *   - healthy Ollama settles first → OpenRouter NEVER called (no 2× cost);
+ *   - Ollama rejects fast → OpenRouter fired immediately → success;
+ *   - Ollama slow (> hedge window) → OpenRouter fired in parallel → wins;
+ *   - both providers dead → null slot, no throw (CP458 per-chunk isolation).
+ *
+ * Why: the Mac Mini Ollama SPOF took card serving to 0 ("Compute error").
+ * The hedge removes the SPOF while a fast, healthy Ollama pays no OpenRouter.
+ */
+
+const FAKE_OLLAMA_VECTOR = new Array(4096).fill(0.1);
+const FAKE_OPENROUTER_VECTOR = new Array(4096).fill(0.2);
+
+const noopFn = jest.fn();
+const noopLogger = {
+  info: noopFn,
+  warn: noopFn,
+  error: noopFn,
+  debug: noopFn,
+  child: () => noopLogger,
+};
+jest.mock('@/utils/logger', () => ({ logger: noopLogger }));
+
+const configMock = {
+  iksEmbed: { provider: 'ollama' as 'ollama' | 'openrouter' },
+  openrouter: { apiKey: 'test-openrouter-key' },
+  mandalaEmbed: {
+    openRouterBaseUrl: 'https://openrouter.ai/api/v1',
+    openRouterModel: 'qwen/qwen3-embedding-8b',
+    openRouterDimension: 4096,
+  },
+};
+jest.mock('@/config/index', () => ({
+  get config() {
+    return configMock;
+  },
+}));
+
+// Active-active ON, tiny hedge window so the "slow" case is fast in tests.
+const aaMock = { enabled: true, hedgeMs: 30 };
+jest.mock('@/config/embed-active-active', () => ({
+  isEmbedActiveActiveEnabled: () => aaMock.enabled,
+  getEmbedHedgeMs: () => aaMock.hedgeMs,
+}));
+
+jest.mock('@/modules/llm/call-logger', () => ({
+  logLLMCall: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/modules/database', () => ({ getPrismaClient: () => ({}) }));
+jest.mock('@/modules/discover-tracing', () => ({ recordTrace: jest.fn() }));
+
+function ollamaOk(count: number): Response {
+  return new Response(
+    JSON.stringify({ embeddings: Array.from({ length: count }, () => FAKE_OLLAMA_VECTOR) }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+}
+function openrouterOk(count: number): Response {
+  return new Response(
+    JSON.stringify({
+      data: Array.from({ length: count }, () => ({ embedding: FAKE_OPENROUTER_VECTOR })),
+      usage: { prompt_tokens: 10 },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+const isOllama = (url: string) => url.includes('/api/embed');
+
+import { embedBatch } from '../embedding';
+
+describe('embedBatch — active-active hedge', () => {
+  beforeEach(() => {
+    configMock.iksEmbed.provider = 'ollama';
+    aaMock.enabled = true;
+    aaMock.hedgeMs = 30;
+  });
+
+  it('healthy Ollama settles first → OpenRouter never called', async () => {
+    const fetchImpl = jest.fn(async (url: RequestInfo | URL) =>
+      isOllama(String(url)) ? ollamaOk(2) : openrouterOk(2)
+    );
+    const out = await embedBatch(['t1', 't2'], { fetchImpl });
+    expect(out[0]).toEqual(FAKE_OLLAMA_VECTOR);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls.every((c) => isOllama(String(c[0])))).toBe(true);
+  });
+
+  it('Ollama rejects fast → OpenRouter fired immediately → success', async () => {
+    const fetchImpl = jest.fn(async (url: RequestInfo | URL) => {
+      if (isOllama(String(url))) throw new TypeError('fetch failed');
+      return openrouterOk(2);
+    });
+    const out = await embedBatch(['t1', 't2'], { fetchImpl });
+    expect(out[0]).toEqual(FAKE_OPENROUTER_VECTOR);
+    expect(fetchImpl.mock.calls.some((c) => !isOllama(String(c[0])))).toBe(true);
+  });
+
+  it('Ollama slow (> hedge window) → OpenRouter wins', async () => {
+    const fetchImpl = jest.fn((url: RequestInfo | URL) => {
+      if (isOllama(String(url)))
+        return new Promise<Response>((r) => setTimeout(() => r(ollamaOk(1)), 300));
+      return Promise.resolve(openrouterOk(1));
+    });
+    const out = await embedBatch(['t1'], { fetchImpl });
+    expect(out[0]).toEqual(FAKE_OPENROUTER_VECTOR);
+    expect(fetchImpl.mock.calls.some((c) => !isOllama(String(c[0])))).toBe(true);
+  });
+
+  it('both providers dead → null slot, no throw (per-chunk isolation)', async () => {
+    const fetchImpl = jest.fn(async (url: RequestInfo | URL) => {
+      if (isOllama(String(url))) throw new TypeError('ollama down');
+      throw new TypeError('openrouter down');
+    });
+    const out = await embedBatch(['t1'], { fetchImpl });
+    expect(out).toEqual([null]);
+  });
+
+  it('flag off → sequential fallback (Ollama success, no OpenRouter)', async () => {
+    aaMock.enabled = false;
+    const fetchImpl = jest.fn(async (url: RequestInfo | URL) =>
+      isOllama(String(url)) ? ollamaOk(1) : openrouterOk(1)
+    );
+    const out = await embedBatch(['t1'], { fetchImpl });
+    expect(out[0]).toEqual(FAKE_OLLAMA_VECTOR);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/skills/plugins/iks-scorer/embedding.ts
+++ b/src/skills/plugins/iks-scorer/embedding.ts
@@ -25,6 +25,7 @@ import { logger } from '@/utils/logger';
 import { getPrismaClient } from '@/modules/database';
 import { Prisma } from '@prisma/client';
 import { config } from '@/config/index';
+import { isEmbedActiveActiveEnabled, getEmbedHedgeMs } from '@/config/embed-active-active';
 import { logLLMCall } from '@/modules/llm/call-logger';
 import { recordTrace } from '@/modules/discover-tracing';
 
@@ -256,10 +257,119 @@ function raceExternalAbort(shared: Promise<number[][]>, signal: AbortSignal): Pr
   });
 }
 
+// Hedge-trigger counter (module-level) — how often the OpenRouter leg was
+// fired because Ollama rejected fast or ran slow. Logged per fire so ops can
+// watch the rate after enabling active-active and tune EMBED_HEDGE_MS down.
+let embedHedgeFires = 0;
+export function getEmbedHedgeFireCount(): number {
+  return embedHedgeFires;
+}
+
+/**
+ * Active-active hedge: Ollama primary; OpenRouter fired in parallel ONLY when
+ * Ollama (a) rejects before the hedge window (fast fail — e.g. 500 "Compute
+ * error", the 0-card incident) or (b) exceeds EMBED_HEDGE_MS (slow). A healthy
+ * Ollama (p50 ~1.9s) settles first and OpenRouter is never called, so this
+ * removes the Mac Mini SPOF without the always-2× cost of a blind race. First
+ * success wins; the loser is AbortController-cancelled (real cancel). Both
+ * dead → throw (downstream lexical path). Both legs emit the same 4096-d space.
+ */
+async function embedOneChunkHedged(
+  texts: string[],
+  opts: EmbeddingClientOptions
+): Promise<number[][]> {
+  const hedgeMs = getEmbedHedgeMs();
+  const ollamaCtrl = new AbortController();
+  const openrouterCtrl = new AbortController();
+  const onExternalAbort = () => {
+    ollamaCtrl.abort();
+    openrouterCtrl.abort();
+  };
+  if (opts.signal?.aborted) onExternalAbort();
+  else opts.signal?.addEventListener('abort', onExternalAbort, { once: true });
+
+  return new Promise<number[][]>((resolve, reject) => {
+    let settled = false;
+    let openrouterStarted = false;
+    let ollamaFailed = false;
+    let openrouterFailed = false;
+    let ollamaErr: unknown;
+    let openrouterErr: unknown;
+    let hedgeTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (hedgeTimer) clearTimeout(hedgeTimer);
+      ollamaCtrl.abort();
+      openrouterCtrl.abort();
+      opts.signal?.removeEventListener('abort', onExternalAbort);
+    };
+    const settleResolve = (v: number[][]) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(v);
+    };
+    const rejectBothDead = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(
+        new EmbeddingError(
+          `active-active embed failed: ollama=${
+            ollamaErr instanceof Error ? ollamaErr.message : String(ollamaErr)
+          } | openrouter=${
+            openrouterErr instanceof Error ? openrouterErr.message : String(openrouterErr)
+          }`
+        )
+      );
+    };
+
+    const startOpenRouter = (reason: string) => {
+      if (openrouterStarted || settled) return;
+      openrouterStarted = true;
+      if (hedgeTimer) {
+        clearTimeout(hedgeTimer);
+        hedgeTimer = undefined;
+      }
+      embedHedgeFires += 1;
+      log.warn(
+        `embed hedge fired (${reason}) — OpenRouter leg starting (chunk=${texts.length}, fires=${embedHedgeFires})`
+      );
+      embedOneChunkViaOpenRouterRetrying(texts, { ...opts, signal: openrouterCtrl.signal }).then(
+        (v) => settleResolve(v),
+        (e) => {
+          openrouterFailed = true;
+          openrouterErr = e;
+          if (ollamaFailed) rejectBothDead();
+        }
+      );
+    };
+
+    // Ollama primary.
+    embedOneChunkViaOllama(texts, { ...opts, signal: ollamaCtrl.signal }).then(
+      (v) => settleResolve(v),
+      (e) => {
+        ollamaFailed = true;
+        ollamaErr = e;
+        if (!openrouterStarted) startOpenRouter('ollama-reject');
+        else if (openrouterFailed) rejectBothDead();
+      }
+    );
+
+    // Slow-path hedge.
+    hedgeTimer = setTimeout(() => startOpenRouter('ollama-slow'), hedgeMs);
+  });
+}
+
 async function embedOneChunkRouted(
   texts: string[],
   opts: EmbeddingClientOptions
 ): Promise<number[][]> {
+  // Active-active hedge (flag-gated) — removes the single-provider SPOF for
+  // ALL embedBatch callers. Unset flag = the sequential-fallback behavior below.
+  if (isEmbedActiveActiveEnabled()) {
+    return embedOneChunkHedged(texts, opts);
+  }
   const provider = config.iksEmbed.provider;
   if (provider === 'openrouter') {
     // OpenRouter primary (retry on transient errors) → Ollama fallback once


### PR DESCRIPTION
## Context (P0 follow-up)
The 0-card incident root cause chain included `embedBatch` depending on a **single provider** — Mac Mini Ollama over Tailscale (OpenRouter only on sequential fallback). When the Mac Mini GPU could not load the model (`{"error":"Compute error."}`), embeddings failed and card serving went to 0. Both providers emit the **same 4096-d qwen3-embedding-8b** space, so either can serve any request.

Supervisor-confirmed order: this ships **after** PR #1144 (pipeline durability) deploys — separate deploy, one variable at a time.

## Change — hedge (not a blind race)
When `EMBED_ACTIVE_ACTIVE_ENABLED`, `embedOneChunk` hedges:
- **Ollama primary.**
- OpenRouter fired in parallel **only** when Ollama (a) **rejects before the hedge window** (fast fail — the 500 `Compute error`, immediate) or (b) **exceeds `EMBED_HEDGE_MS`** (slow).
- **First success wins; loser is AbortController-cancelled** (real cancel, not result-discard — verified the legs honour `opts.signal`).
- Both dead → throw → downstream per-chunk-isolation null → lexical path.
- **Hedge-fire counter logged** per fire for post-deploy rate monitoring.

### Why a hedge, not `Promise.any`
`embedBatch` is shared with **high-volume + bulk** paths (v3 discover semantic gate on every search; batch-video-collector on thousands of videos). A blind `Promise.any` would call OpenRouter on **every** embed → constant 2× cost. The hedge means a **healthy Ollama (measured p50 ~1.9s) never calls OpenRouter**.

### `EMBED_HEDGE_MS` = 18000 (data-derived)
From prod `video_discover_traces` (step=embed.batch, ok, 7d, **n=32 sparse**): p50=1878ms, p90=11244ms, **p95=17128ms**, p99=25524ms. Set **above p95** so the hedge fires only on clearly-sick latency, not the normal tail (a value just below p95 could trigger on sample noise). Lower it via env once the fire-counter gives denser data — lowering is the safe direction.

## Verification
- tsc clean, **5/5** new hedge tests (healthy→no-OpenRouter, fast-reject→immediate, slow→wins, both-dead→null, flag-off→legacy), `embedding-fallback` regression **10/10**.

## Activation
Merge → deploy (flag off = existing sequential fallback, zero change) → `EMBED_ACTIVE_ACTIVE_ENABLED=true` → watch the hedge-fire counter; tune `EMBED_HEDGE_MS` down with real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)