### PR TITLE
chore(deploy): flag-on PIPELINE_DURABLE_ENABLED (durable pipeline #1144)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -403,6 +403,12 @@ services:
       # Table: mandala_wizard_precompute (10min TTL, pg_cron sweep */5 min).
       # Revert: delete this line → feature no-ops.
       - WIZARD_PRECOMPUTE_ENABLED=true
+      # P0 (2026-07-10) — durable video pipeline via pg-boss. Routes the
+      # post-creation pipeline (embeddings->discover->auto-add) through a
+      # pg-boss job so a container restart mid-run redelivers+retries
+      # instead of orphaning the run at 0 cards. Revert: delete this line
+      # (unset => legacy setImmediate). Handler: mandala-pipeline.ts.
+      - PIPELINE_DURABLE_ENABLED=true
       # CP493 (2026-06-03) — merged structure+queries generation (canary). ONE
       # Haiku call yields the mandala structure AND a searchable per-cell query
       # in a single continuous context, replacing the two disconnected calls


### PR DESCRIPTION
Activates the durable pg-boss video pipeline from #1144 via the docker-compose.prod.yml `environment:` toggle (SSOT per CP500++). **Merging = flag-on on next deploy.**

## Do NOT merge until the restart test is staffed
Supervisor requires a real end-to-end verification (job-flow alone is insufficient — it doesn't reproduce the incident's mid-run-restart orphan). After this deploys:
1. Create a mandala; confirm step1 (embedding) is running.
2. At that moment, deliberately restart the api container (low-traffic).
3. Verify the run does NOT stay orphaned — the pg-boss job is redelivered, the pipeline resumes to completion, and cards actually serve (James observes on prod).
4. Pass → keep. Fail → revert (delete the line + redeploy).

config-ssot guard passes (toggle only in compose, not .env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)