### PR TITLE
fix(mandala): guard auto-add + terminate watchdog loop — stop card wipe (CP512 incident)

### DIFF
--- a/src/modules/mandala/auto-add-recommendations.ts
+++ b/src/modules/mandala/auto-add-recommendations.ts
@@ -147,6 +147,15 @@ export async function maybeAutoAddRecommendations(
   let totalInserted = 0;
 
   for (let cellIndex = 0; cellIndex < CELLS_PER_MANDALA; cellIndex++) {
+    // Guard (CP512-regression, 2026-07-10): if discover returned NO recs for
+    // this cell, do NOT touch existing cards. Previously the deleteMany below
+    // ran BEFORE this check, so an empty/failed discover (quota 429 → 0
+    // results, or an orphaned run) deleted the un-touched auto_added rows with
+    // no replacement → card loss. Only delete-and-replace a cell when we
+    // actually have new cards to place there.
+    const allRecsForCell = recsByCell.get(cellIndex) ?? [];
+    if (allRecsForCell.length === 0) continue;
+
     // Selective replace: count user-trace rows in this cell, then delete
     // only the un-touched auto_added rows. ANY trace = preserved forever.
     const preservedCount = await db.userVideoState.count({
@@ -181,9 +190,6 @@ export async function maybeAutoAddRecommendations(
 
     totalPreserved += preservedCount;
     totalDeleted += deleted.count;
-
-    const allRecsForCell = recsByCell.get(cellIndex) ?? [];
-    if (allRecsForCell.length === 0) continue;
 
     const placed = await placeAutoAddedCards(
       db,

--- a/src/modules/queue/handlers/mandala-pipeline.ts
+++ b/src/modules/queue/handlers/mandala-pipeline.ts
@@ -106,9 +106,9 @@ export async function handleMandalaPipelineWatchdog(): Promise<void> {
   }
   const prisma = getPrismaClient();
   const stale = await prisma.$queryRawUnsafe<
-    Array<{ mandala_id: string; user_id: string; trigger: string | null }>
+    Array<{ id: string; mandala_id: string; user_id: string; trigger: string | null }>
   >(
-    `SELECT DISTINCT ON (mandala_id) mandala_id, user_id, trigger
+    `SELECT DISTINCT ON (mandala_id) id, mandala_id, user_id, trigger
        FROM mandala_pipeline_runs
       WHERE status = 'running'
         AND created_at < now() - ($1 || ' minutes')::interval
@@ -118,7 +118,14 @@ export async function handleMandalaPipelineWatchdog(): Promise<void> {
 
   if (stale.length === 0) return;
 
+  // Runs we hand a fresh replacement job. Marking these 'superseded' below is
+  // what closes the CP512-incident loop: a stale run left at status='running'
+  // is re-found by every 10-min tick → re-enqueued forever (12 runs/hr
+  // observed 2026-07-10). This keys purely on status+age, so it also
+  // terminates pre-flag-on fire-and-forget orphans that never had a pg-boss
+  // job (e.g. the run stuck at step1 since before the durable flag was on).
   let reEnqueued = 0;
+  const supersededIds: string[] = [];
   for (const r of stale) {
     try {
       const jobId = await enqueueMandalaPipeline({
@@ -126,7 +133,10 @@ export async function handleMandalaPipelineWatchdog(): Promise<void> {
         userId: r.user_id,
         trigger: r.trigger ?? 'watchdog',
       });
-      if (jobId) reEnqueued++;
+      if (jobId) {
+        reEnqueued++;
+        supersededIds.push(r.id);
+      }
     } catch (err) {
       log.warn('mandala-pipeline-watchdog: re-enqueue failed', {
         mandalaId: r.mandala_id,
@@ -134,9 +144,24 @@ export async function handleMandalaPipelineWatchdog(): Promise<void> {
       });
     }
   }
+
+  // Terminate the stale runs we replaced so the next tick can't re-enqueue
+  // them again. Only runs that actually got a fresh job are superseded; a
+  // freshly-created run (< stale window) is never in this set. Each stuck run
+  // therefore gets exactly one watchdog retry, not an unbounded loop.
+  let superseded = 0;
+  if (supersededIds.length > 0) {
+    const res = await prisma.mandala_pipeline_runs.updateMany({
+      where: { id: { in: supersededIds }, status: 'running' },
+      data: { status: 'superseded', updated_at: new Date() },
+    });
+    superseded = res.count;
+  }
+
   log.info('mandala-pipeline-watchdog: re-enqueued orphaned runs', {
     stale: stale.length,
     reEnqueued,
+    superseded,
   });
 }
 

--- a/tests/unit/modules/mandala/auto-add-empty-recs-guard.test.ts
+++ b/tests/unit/modules/mandala/auto-add-empty-recs-guard.test.ts
@@ -1,0 +1,78 @@
+/**
+ * CP512-incident regression (2026-07-10): auto-add must NOT delete a cell's
+ * existing auto_added cards when discover returned NO new recs for that cell.
+ * The old loop ran deleteMany BEFORE the empty-recs check, so a quota-429 /
+ * empty discover (or an orphaned run) deleted the un-touched cards with no
+ * replacement → card loss (james@insighta.one "수채화" 41 → 2).
+ */
+import { maybeAutoAddRecommendations } from '@/modules/mandala/auto-add-recommendations';
+
+const mockFindMany = jest.fn();
+const mockCount = jest.fn().mockResolvedValue(0);
+const mockDeleteMany = jest.fn().mockResolvedValue({ count: 0 });
+const mockPlace = jest.fn().mockResolvedValue({ inserted: 0 });
+
+jest.mock('@/modules/database', () => ({
+  getPrismaClient: () => ({
+    user_skill_config: {
+      findFirst: jest.fn().mockResolvedValue({ enabled: true, config: { auto_add: true } }),
+    },
+    recommendation_cache: { findMany: (...a: unknown[]) => mockFindMany(...a) },
+    userVideoState: {
+      count: (...a: unknown[]) => mockCount(...a),
+      deleteMany: (...a: unknown[]) => mockDeleteMany(...a),
+    },
+  }),
+}));
+jest.mock('@/modules/mandala/place-auto-added-cards', () => ({
+  placeAutoAddedCards: (...a: unknown[]) => mockPlace(...a),
+}));
+jest.mock('@/config/recommendations', () => ({
+  VIDEO_DISCOVER_SKILL_TYPE: 'video-discover',
+  loadAutoAddGuardConfig: () => ({}),
+}));
+jest.mock('@/modules/discover-tracing', () => ({ recordTrace: jest.fn() }));
+
+const rec = (cell: number) => ({
+  id: `rec-${cell}`,
+  video_id: `vid${cell}`,
+  title: 't',
+  thumbnail: null,
+  channel: null,
+  duration_sec: null,
+  view_count: null,
+  published_at: null,
+  like_ratio: null,
+  rec_score: 1,
+  keyword: null,
+  rec_reason: null,
+  weight_version: 1,
+  cell_index: cell,
+});
+
+describe('maybeAutoAddRecommendations — empty-recs guard (CP512 regression)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('deletes ONLY the cell that has new recs, never the empty cells', async () => {
+    // discover returned recs for cell 3 only; cells 0..2,4..7 are empty.
+    mockFindMany.mockResolvedValue([rec(3)]);
+
+    await maybeAutoAddRecommendations('u-1', 'm-1');
+
+    // pre-fix: 8 deletes (one per cell). post-fix: exactly 1 (cell 3).
+    expect(mockDeleteMany).toHaveBeenCalledTimes(1);
+    expect(mockDeleteMany.mock.calls[0][0].where.cell_index).toBe(3);
+    expect(mockPlace).toHaveBeenCalledTimes(1);
+  });
+
+  test('discover empty for every cell → NO deletes at all (cards preserved)', async () => {
+    // A non-empty rec set that maps to NO valid cells (out-of-range index) —
+    // exercises the per-cell guard rather than the whole-run early return.
+    mockFindMany.mockResolvedValue([{ ...rec(3), cell_index: 99 }]);
+
+    await maybeAutoAddRecommendations('u-1', 'm-1');
+
+    expect(mockDeleteMany).not.toHaveBeenCalled();
+    expect(mockPlace).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/modules/queue/mandala-pipeline-watchdog.test.ts
+++ b/tests/unit/modules/queue/mandala-pipeline-watchdog.test.ts
@@ -1,0 +1,65 @@
+/**
+ * CP512-incident regression (2026-07-10): the orphaned-run watchdog must
+ * TERMINATE the stale runs it re-enqueues. Before this fix it left them at
+ * status='running', so every 10-minute tick re-found and re-enqueued the same
+ * stuck run forever (12 runs/hr observed on prod), each re-run firing the
+ * auto-add delete-then-insert. The stale run that started the incident had NO
+ * pg-boss job (a pre-flag-on fire-and-forget orphan stuck at step1), so the
+ * watchdog must supersede by status+age alone — never by job existence.
+ */
+import { handleMandalaPipelineWatchdog } from '@/modules/queue/handlers/mandala-pipeline';
+
+const mockQueryRaw = jest.fn();
+const mockUpdateMany = jest.fn().mockResolvedValue({ count: 1 });
+const mockSend = jest.fn().mockResolvedValue('job-123');
+
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    $queryRawUnsafe: (...args: unknown[]) => mockQueryRaw(...args),
+    mandala_pipeline_runs: { updateMany: (...args: unknown[]) => mockUpdateMany(...args) },
+  }),
+}));
+jest.mock('@/config/pipeline-durable', () => ({
+  isPipelineDurableEnabled: () => true,
+}));
+jest.mock('@/modules/queue/manager', () => ({
+  getJobQueue: () => ({ getInstance: () => ({ send: (...args: unknown[]) => mockSend(...args) }) }),
+}));
+
+describe('handleMandalaPipelineWatchdog — supersedes re-enqueued stale runs (CP512 loop fix)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('re-enqueues then marks the stale no-job orphan run superseded (breaks the loop)', async () => {
+    // A run stuck at status=running with no pg-boss job — the exact incident case.
+    mockQueryRaw.mockResolvedValue([
+      { id: 'run-1', mandala_id: 'm-1', user_id: 'u-1', trigger: 'wizard' },
+    ]);
+
+    await handleMandalaPipelineWatchdog();
+
+    // fresh replacement job enqueued...
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    // ...and the stale run TERMINATED so the next tick can't re-enqueue it again.
+    expect(mockUpdateMany).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: { in: ['run-1'] }, status: 'running' },
+      data: expect.objectContaining({ status: 'superseded' }),
+    });
+  });
+
+  test('no stale runs → no enqueue, no supersede', async () => {
+    mockQueryRaw.mockResolvedValue([]);
+    await handleMandalaPipelineWatchdog();
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  test('enqueue failure → that run is NOT superseded (retried next tick)', async () => {
+    mockQueryRaw.mockResolvedValue([
+      { id: 'run-2', mandala_id: 'm-2', user_id: 'u-2', trigger: 'watchdog' },
+    ]);
+    mockSend.mockRejectedValueOnce(new Error('queue down'));
+    await handleMandalaPipelineWatchdog();
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Defense-in-depth for the 2026-07-10 card-wipe incident. Root cause (single-key #1134 → Search quota 429 → empty discover) is fixed by #1147; this closes the two mechanisms that turned an empty discover into **data loss**.

## A — auto-add empty-recs guard (`auto-add-recommendations.ts`)
The per-cell loop ran `deleteMany` (un-touched `auto_added` rows) **before** the `if (recs.length === 0) continue` check. So a cell with **no new recs** (empty/failed discover, quota 429, orphaned run) had its existing cards **deleted with no replacement** → card loss (james@insighta.one "수채화" 41 → 2).
**Fix:** moved the empty-recs guard **above** the delete. A cell is only delete-and-replaced when new cards actually exist for it.

## B — watchdog loop terminate (`mandala-pipeline.ts`)
The orphan-run watchdog re-enqueued stale runs but left them at `status='running'`, so **every 10-min tick re-found and re-enqueued the same stuck run forever** (12 runs/hr observed on prod), each re-run firing defect A.
**Fix:** the re-enqueued stale runs are now marked `superseded` (keyed on status+age, so **pre-flag-on fire-and-forget orphans with no pg-boss job are included** — the exact incident run). Each stuck run gets **one** watchdog retry, not an unbounded loop.

## Verification
- `tsc --noEmit` clean.
- **5 new unit tests**: watchdog (no-job orphan → superseded / no-stale no-op / enqueue-fail → not superseded); auto-add (deletes only the cell with recs / empty discover preserves all cells).

## Context
Supervisor-vetted (0709) as **top priority** — the open wipe window. Loop already stopped in prod via a surgical `status='failed'` write on the 2 stuck runs; this makes the fix permanent + regression-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)