### PR TITLE
fix(serving): fast-timeout serving embeds — stop 0-card 2min hang (P0 2026-07-10) [C hemostasis]

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -258,10 +258,11 @@ services:
       # hanging the window. Bulk collector/backfill keep the 20s default.
       # 12s is between measured batch p50 (~8.4s, keep) and p90 (~36s, cut).
       # Watch getEmbedServingDowngradeCount after enabling; tune the two
-      # values via env. Unset = existing 20s x 2 behaviour (flag rolls back).
-      # - EMBED_SERVING_FAST_TIMEOUT_ENABLED=true
-      # - EMBED_SERVING_TIMEOUT_MS=12000
-      # - EMBED_SERVING_MAX_RETRIES=0
+      # values via env. Set false / re-comment = existing 20s x 2 rollback.
+      # ENABLED 2026-07-10 (P0 hemostasis, James "배포 진행"):
+      - EMBED_SERVING_FAST_TIMEOUT_ENABLED=true
+      - EMBED_SERVING_TIMEOUT_MS=12000
+      - EMBED_SERVING_MAX_RETRIES=0
       # CP416 (2026-04-22) — restore the LoRA action-fill path. Without
       # this, generateMandala() called config.mandalaGen.model=undefined,
       # Ollama /api/generate returned 400, LoRA threw, and the Haiku

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -249,6 +249,19 @@ services:
       # Revert: delete this line → falls back to ollama-first behaviour.
       # See docs/design/mac-mini-deprecation-2026-05-13.md §4 Phase D1.
       - IKS_EMBED_PROVIDER=openrouter
+      # P0 2026-07-10 — serving-path embed fast-timeout. OpenRouter
+      # qwen3-embedding latency degraded to a 30-42s p90 tail (traces:
+      # embed.batch p50 1.5s->8.4s, p90 2.9s->36s), overrunning the wizard
+      # precompute/post-creation discover window -> 0 cards until manual
+      # refresh (~2min). ON caps the SERVING discover embeds at 12s / 0 retry
+      # so a slow chunk fails fast to lexical (never 0 cards) instead of
+      # hanging the window. Bulk collector/backfill keep the 20s default.
+      # 12s is between measured batch p50 (~8.4s, keep) and p90 (~36s, cut).
+      # Watch getEmbedServingDowngradeCount after enabling; tune the two
+      # values via env. Unset = existing 20s x 2 behaviour (flag rolls back).
+      # - EMBED_SERVING_FAST_TIMEOUT_ENABLED=true
+      # - EMBED_SERVING_TIMEOUT_MS=12000
+      # - EMBED_SERVING_MAX_RETRIES=0
       # CP416 (2026-04-22) — restore the LoRA action-fill path. Without
       # this, generateMandala() called config.mandalaGen.model=undefined,
       # Ollama /api/generate returned 400, LoRA threw, and the Haiku

--- a/src/config/embed-serving-timeout.ts
+++ b/src/config/embed-serving-timeout.ts
@@ -1,0 +1,67 @@
+/**
+ * Serving-path embed fast-timeout gate (P0 2026-07-10 incident).
+ *
+ * prod routes card-serving embeds to OpenRouter (IKS_EMBED_PROVIDER=openrouter,
+ * #616 Mac Mini deprecation). OpenRouter's qwen3-embedding-8b latency degraded
+ * to a catastrophic tail: prod video_discover_traces embed.batch p50 1455ms
+ * (07-03) -> 8442ms (07-10), p90 2923ms -> 36073ms (36s), errs ~0 (slow, not
+ * failing). A 30-42s embed on the wizard precompute / post-creation discover
+ * path overruns the serving window, so the mandala shows 0 cards until a manual
+ * refresh (~2 min later) — a precompute HIT -> MISS regression.
+ *
+ * The default embed budget is 20s x 2 retries (EMBED_TIMEOUT_MS /
+ * OPENROUTER_EMBED_MAX_RETRIES) — bulk-safe, no window. This gate lets the
+ * SERVING discover callers pass a tighter budget so a slow chunk fails fast to
+ * the lexical path (per-chunk null -> those candidates drop to lexical ranking,
+ * never 0 cards) instead of hanging the window. Bulk collector / backfill
+ * embeds keep the 20s default: they have no window to protect, and cutting
+ * them would only spike failure rate.
+ *
+ * Timeout default 12000ms is grounded on the measured trace distribution —
+ * ABOVE batch p50 (~8.4s, must NOT cut the median or ~50% of mandalas downgrade
+ * to lexical) and BELOW p90 (~30-42s, the tail we DO cut). 6s would gut the
+ * median. Retries default 0 so a slow/404 chunk is a hard 12s cap, not
+ * 12s x 3. Tune both via env once the downgrade counter
+ * (getEmbedServingDowngradeCount) gives post-deploy data.
+ *
+ * Tuning knobs, not secrets (CP392): code default + env override, unset flag =
+ * the existing 20s x 2 behavior (no-op -> flag alone rolls back).
+ */
+import type { EmbeddingClientOptions } from '@/skills/plugins/iks-scorer/embedding';
+
+const DEFAULT_SERVING_TIMEOUT_MS = 12_000;
+const DEFAULT_SERVING_MAX_RETRIES = 0;
+
+export function isEmbedServingFastTimeoutEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['EMBED_SERVING_FAST_TIMEOUT_ENABLED'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes';
+}
+
+/** Per-call timeout (ms) for serving embeds when the gate is on. Default 12000. */
+export function getEmbedServingTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number(env['EMBED_SERVING_TIMEOUT_MS']);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_SERVING_TIMEOUT_MS;
+}
+
+/** OpenRouter retry budget for serving embeds when the gate is on. Default 0. */
+export function getEmbedServingMaxRetries(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number(env['EMBED_SERVING_MAX_RETRIES']);
+  return Number.isFinite(raw) && raw >= 0 ? Math.floor(raw) : DEFAULT_SERVING_MAX_RETRIES;
+}
+
+/**
+ * EmbeddingClientOptions for a serving/precompute discover embed call.
+ * Returns {} when the gate is off -> embedBatch uses the 20s x 2 default.
+ * When on, the returned opts cap the per-call budget and mark the call
+ * `servingScope` so a downgrade (some inputs null) is counted for alarms.
+ */
+export function servingEmbedOptions(env: NodeJS.ProcessEnv = process.env): EmbeddingClientOptions {
+  if (!isEmbedServingFastTimeoutEnabled(env)) return {};
+  return {
+    timeoutMs: getEmbedServingTimeoutMs(env),
+    maxRetries: getEmbedServingMaxRetries(env),
+    servingScope: true,
+  };
+}

--- a/src/skills/plugins/iks-scorer/embedding.ts
+++ b/src/skills/plugins/iks-scorer/embedding.ts
@@ -90,6 +90,19 @@ export interface EmbeddingClientOptions {
   fetchImpl?: typeof fetch;
   /** Per-call timeout override (ms). Defaults to EMBED_TIMEOUT_MS. */
   timeoutMs?: number;
+  /**
+   * OpenRouter transient-error retry budget override. Defaults to
+   * OPENROUTER_EMBED_MAX_RETRIES (2). The serving/precompute path sets 0 so a
+   * slow / 404 chunk fails fast to lexical instead of multiplying the timeout
+   * (12s x 3). See src/config/embed-serving-timeout.ts.
+   */
+  maxRetries?: number;
+  /**
+   * Marks a serving/precompute discover call. When set, a partial / empty
+   * embed result (some inputs null) increments the lexical-downgrade counter
+   * (getEmbedServingDowngradeCount) so ops can alarm on silent all-lexical.
+   */
+  servingScope?: boolean;
   /** W3 (CP499+) — external abort (e.g. the calling pipeline gave up).
    *  Linked into the per-call controller so an abandoned pipeline doesn't
    *  leave embeds running to completion. */
@@ -118,6 +131,16 @@ export async function isOllamaReachable(opts: EmbeddingClientOptions = {}): Prom
   } catch {
     return false;
   }
+}
+
+// Serving-path lexical-downgrade counter (P0 2026-07-10). Incremented when a
+// `servingScope` embedBatch returns fewer vectors than inputs — i.e. a slow /
+// 404 chunk was cut to the lexical path by the tight serving budget. Logged
+// per fire so the daily metrics rollup can alarm if the service is silently
+// running all-lexical (OpenRouter got worse). See config/embed-serving-timeout.
+let embedServingDowngrades = 0;
+export function getEmbedServingDowngradeCount(): number {
+  return embedServingDowngrades;
 }
 
 /**
@@ -164,6 +187,14 @@ export async function embedBatch(
   }
 
   const okCount = out.reduce((n, v) => (v ? n + 1 : n), 0);
+  if (opts.servingScope && okCount < texts.length) {
+    embedServingDowngrades += 1;
+    log.warn(
+      `[embed-serving] lexical downgrade #${embedServingDowngrades}: ${
+        texts.length - okCount
+      }/${texts.length} inputs unembedded (slow/404 cut to lexical) — candidates fall to lexical ranking`
+    );
+  }
   const firstVec = out.find((v): v is number[] => v != null);
   const chunkCount = Math.ceil(texts.length / chunkSize);
   // CP457+ trace — text inputs + vector counts (skip the 4096d vectors
@@ -521,21 +552,24 @@ async function embedOneChunkViaOpenRouterRetrying(
   texts: string[],
   opts: EmbeddingClientOptions
 ): Promise<number[][]> {
+  // Serving/precompute callers pass maxRetries: 0 so a slow / 404 chunk is a
+  // hard timeout cap, not timeout x (retries + 1). Bulk defaults to 2 (CP458).
+  const maxRetries = opts.maxRetries ?? OPENROUTER_EMBED_MAX_RETRIES;
   let lastErr: unknown;
-  for (let attempt = 0; attempt <= OPENROUTER_EMBED_MAX_RETRIES; attempt++) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await embedOneChunkViaOpenRouter(texts, opts);
     } catch (err) {
       lastErr = err;
       // W3 — external abort is terminal: the pipeline gave up, never retry.
       const retryable = err instanceof EmbeddingError && err.retryable && !opts.signal?.aborted;
-      if (!retryable || attempt === OPENROUTER_EMBED_MAX_RETRIES) {
+      if (!retryable || attempt === maxRetries) {
         throw err;
       }
       const backoffMs = OPENROUTER_EMBED_RETRY_BASE_MS * 2 ** attempt;
       log.warn(
         `OpenRouter embed transient error (attempt ${attempt + 1}/${
-          OPENROUTER_EMBED_MAX_RETRIES + 1
+          maxRetries + 1
         }), retrying in ${backoffMs}ms: ${err instanceof Error ? err.message : String(err)}`
       );
       await sleep(backoffMs);

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -48,6 +48,7 @@ import { resolveAlgorithm } from '@/modules/search/algorithm-resolver';
 import { filterByQualityGate } from './quality-gate';
 import { applyHybridRerank } from './hybrid-rerank';
 import { embedBatch, cosineToRelevance } from '@/skills/plugins/iks-scorer/embedding';
+import { servingEmbedOptions } from '@/config/embed-serving-timeout';
 import { getCenterGoalEmbedding } from '@/modules/mandala/center-goal-embedding';
 import { withTraceContext, recordTrace } from '@/modules/discover-tracing';
 import { resolveLanguage } from '@/utils/detect-language';
@@ -475,7 +476,7 @@ async function executeImpl(
         const titles = capped.map((m) => m.title);
         const [centerVec, titleVecs] = await Promise.all([
           getCenterGoalEmbedding(mandalaId, state.centerGoal),
-          embedBatch(titles),
+          embedBatch(titles, servingEmbedOptions()),
         ]);
         const vectorsOk = centerVec != null && titleVecs.length === titles.length;
         if (vectorsOk) {
@@ -1194,10 +1195,10 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
         input.mandalaId
           ? getCenterGoalEmbedding(input.mandalaId, input.state.centerGoal)
           : (async () => {
-              const [v] = await embedBatch([input.state.centerGoal]);
+              const [v] = await embedBatch([input.state.centerGoal], servingEmbedOptions());
               return v ?? null;
             })(),
-        embedBatch(titles),
+        embedBatch(titles, servingEmbedOptions()),
       ]);
       if (centerVec != null && titleVecs.length === titles.length) {
         centerEmbedding = centerVec;
@@ -2001,7 +2002,7 @@ async function runDiscoverEphemeralImpl(
   const existingVideoIds = new Set(redisSlots.map((s) => s.videoId));
   if (v3Config.enableTier1Cache) {
     try {
-      const [centerVec] = await embedBatch([input.centerGoal]);
+      const [centerVec] = await embedBatch([input.centerGoal], servingEmbedOptions());
       if (centerVec && centerVec.length > 0) {
         const tier1Matches = await matchFromVideoPoolByCenterGoal({
           centerEmbedding: centerVec,
@@ -2101,7 +2102,7 @@ async function runDiscoverEphemeralImpl(
       const cappedSlots = allSlots.slice(0, cap);
       const texts = [input.centerGoal, ...cappedSlots.map((s) => s.title)];
       const embedT0 = Date.now();
-      const vectors = await embedBatch(texts);
+      const vectors = await embedBatch(texts, servingEmbedOptions());
       const embedMs = Date.now() - embedT0;
       if (vectors.length === texts.length) {
         const centerEmbedding = vectors[0] ?? undefined;

--- a/tests/unit/config/embed-serving-timeout.test.ts
+++ b/tests/unit/config/embed-serving-timeout.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Serving-path embed fast-timeout gate (P0 2026-07-10). Pure config unit —
+ * unset flag is a no-op ({} opts → embedBatch keeps the 20s x 2 default),
+ * enabled carries the measurement-grounded defaults (12s / 0 retry), and both
+ * are env-tunable. See src/config/embed-serving-timeout.ts.
+ */
+import {
+  isEmbedServingFastTimeoutEnabled,
+  getEmbedServingTimeoutMs,
+  getEmbedServingMaxRetries,
+  servingEmbedOptions,
+} from '@/config/embed-serving-timeout';
+
+describe('embed-serving-timeout gate', () => {
+  test('unset → disabled, servingEmbedOptions is a no-op {} (flag alone rolls back)', () => {
+    expect(isEmbedServingFastTimeoutEnabled({})).toBe(false);
+    expect(servingEmbedOptions({})).toEqual({});
+  });
+
+  test.each(['true', '1', 'yes', 'TRUE', 'Yes'])('enabled by %s', (v) => {
+    expect(isEmbedServingFastTimeoutEnabled({ EMBED_SERVING_FAST_TIMEOUT_ENABLED: v })).toBe(true);
+  });
+
+  test.each(['false', '0', 'no', ''])('stays disabled for %s', (v) => {
+    expect(isEmbedServingFastTimeoutEnabled({ EMBED_SERVING_FAST_TIMEOUT_ENABLED: v })).toBe(false);
+  });
+
+  test('enabled → opts carry the grounded defaults (12000ms, 0 retries, servingScope)', () => {
+    expect(servingEmbedOptions({ EMBED_SERVING_FAST_TIMEOUT_ENABLED: 'true' })).toEqual({
+      timeoutMs: 12_000,
+      maxRetries: 0,
+      servingScope: true,
+    });
+  });
+
+  test('env overrides timeout + retries when enabled', () => {
+    const o = servingEmbedOptions({
+      EMBED_SERVING_FAST_TIMEOUT_ENABLED: '1',
+      EMBED_SERVING_TIMEOUT_MS: '8000',
+      EMBED_SERVING_MAX_RETRIES: '1',
+    });
+    expect(o.timeoutMs).toBe(8000);
+    expect(o.maxRetries).toBe(1);
+    expect(o.servingScope).toBe(true);
+  });
+
+  test('invalid / non-positive env values fall back to defaults', () => {
+    expect(getEmbedServingTimeoutMs({ EMBED_SERVING_TIMEOUT_MS: 'abc' })).toBe(12_000);
+    expect(getEmbedServingTimeoutMs({ EMBED_SERVING_TIMEOUT_MS: '-5' })).toBe(12_000);
+    expect(getEmbedServingTimeoutMs({ EMBED_SERVING_TIMEOUT_MS: '0' })).toBe(12_000);
+    expect(getEmbedServingMaxRetries({ EMBED_SERVING_MAX_RETRIES: 'x' })).toBe(0);
+    expect(getEmbedServingMaxRetries({ EMBED_SERVING_MAX_RETRIES: '-1' })).toBe(0);
+  });
+
+  test('maxRetries override accepts an explicit 0 vs a positive value', () => {
+    expect(getEmbedServingMaxRetries({ EMBED_SERVING_MAX_RETRIES: '0' })).toBe(0);
+    expect(getEmbedServingMaxRetries({ EMBED_SERVING_MAX_RETRIES: '2' })).toBe(2);
+  });
+});

--- a/tests/unit/modules/embedding-serving-timeout.test.ts
+++ b/tests/unit/modules/embedding-serving-timeout.test.ts
@@ -1,0 +1,131 @@
+/**
+ * embedBatch — serving-scope fast budget + lexical-downgrade counter
+ * (P0 2026-07-10 incident).
+ *
+ * The serving/precompute discover path passes maxRetries: 0 so a slow / 404
+ * OpenRouter chunk is a hard timeout cap (not timeout x 3) and fails fast to
+ * lexical. servingScope: true counts each downgrade (some inputs null) so ops
+ * can alarm before the service silently runs all-lexical. These pin:
+ *  - maxRetries: 0 → exactly ONE OpenRouter attempt (default is 3).
+ *  - both providers dead + servingScope → per-chunk null (never throws) AND
+ *    the downgrade counter increments (premise ③: 404→null is handled).
+ *  - no servingScope / full success → counter unchanged.
+ */
+
+const mockConfig = {
+  iksEmbed: { provider: 'openrouter' as 'openrouter' | 'ollama' },
+  openrouter: { apiKey: 'test-key' },
+  mandalaEmbed: {
+    openRouterBaseUrl: 'https://openrouter.test/api/v1',
+    openRouterModel: 'qwen/qwen3-embedding-8b',
+    openRouterDimension: 4096,
+  },
+};
+
+jest.mock('@/config/index', () => ({ config: mockConfig }));
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+  },
+}));
+jest.mock('@/modules/llm/call-logger', () => ({ logLLMCall: jest.fn() }));
+jest.mock('@/modules/discover-tracing', () => ({ recordTrace: jest.fn() }));
+jest.mock('@/modules/database', () => ({ getPrismaClient: jest.fn() }));
+
+import { embedBatch, getEmbedServingDowngradeCount } from '@/skills/plugins/iks-scorer/embedding';
+
+const DIM = 4096;
+const vec = (): number[] => new Array(DIM).fill(0.01);
+
+const openRouterOk = (n: number): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      data: Array.from({ length: n }, () => ({ embedding: vec() })),
+      usage: {},
+    }),
+  }) as unknown as Response;
+
+const ollamaOk = (n: number): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({ embeddings: Array.from({ length: n }, () => vec()) }),
+  }) as unknown as Response;
+
+const httpErr = (status: number): Response =>
+  ({ ok: false, status, text: async () => `${status} error` }) as unknown as Response;
+
+beforeEach(() => {
+  mockConfig.iksEmbed.provider = 'openrouter';
+});
+
+describe('embedBatch — serving-scope fast timeout + downgrade counter', () => {
+  test('maxRetries: 0 → OpenRouter attempted exactly once on a persistent 404 (no retry)', async () => {
+    const orCalls: string[] = [];
+    const ollamaCalls: string[] = [];
+    const fetchImpl = jest.fn(async (url: string) => {
+      if (url.includes('/embeddings')) {
+        orCalls.push(url);
+        return httpErr(404);
+      }
+      ollamaCalls.push(url);
+      return ollamaOk(2);
+    }) as unknown as typeof fetch;
+
+    const out = await embedBatch(['a', 'b'], { fetchImpl, maxRetries: 0 });
+
+    expect(out).toHaveLength(2);
+    expect(orCalls).toHaveLength(1); // default would be 3 (initial + 2 retries)
+    expect(ollamaCalls).toHaveLength(1); // fast fall-through to the fallback leg
+  });
+
+  test('servingScope + both providers fail → per-chunk null (no throw) + downgrade counter increments', async () => {
+    const before = getEmbedServingDowngradeCount();
+    const fetchImpl = jest.fn(async (url: string) =>
+      url.includes('/embeddings') ? httpErr(404) : httpErr(500)
+    ) as unknown as typeof fetch;
+
+    const out = await embedBatch(['a', 'b'], { fetchImpl, maxRetries: 0, servingScope: true });
+
+    expect(out).toEqual([null, null]); // lexical downgrade, NOT a throw / 0 cards upstream
+    expect(getEmbedServingDowngradeCount()).toBe(before + 1);
+  });
+
+  test('no servingScope → counter NOT incremented even when the chunk fails', async () => {
+    const before = getEmbedServingDowngradeCount();
+    const fetchImpl = jest.fn(async (url: string) =>
+      url.includes('/embeddings') ? httpErr(404) : httpErr(500)
+    ) as unknown as typeof fetch;
+
+    await embedBatch(['a', 'b'], { fetchImpl, maxRetries: 0 });
+
+    expect(getEmbedServingDowngradeCount()).toBe(before);
+  });
+
+  test('servingScope + full success → counter unchanged (healthy path pays nothing)', async () => {
+    const before = getEmbedServingDowngradeCount();
+    const fetchImpl = jest.fn(async () => openRouterOk(2)) as unknown as typeof fetch;
+
+    const out = await embedBatch(['a', 'b'], { fetchImpl, servingScope: true });
+
+    expect(out.every((v) => v !== null)).toBe(true);
+    expect(getEmbedServingDowngradeCount()).toBe(before);
+  });
+
+  test('default (no maxRetries) still does the full 3-attempt retry — bulk path unchanged', async () => {
+    const orCalls: string[] = [];
+    const fetchImpl = jest.fn(async (url: string) => {
+      if (url.includes('/embeddings')) {
+        orCalls.push(url);
+        return httpErr(404);
+      }
+      return ollamaOk(2);
+    }) as unknown as typeof fetch;
+
+    await embedBatch(['a', 'b'], { fetchImpl });
+
+    expect(orCalls).toHaveLength(3); // initial + 2 retries (OPENROUTER_EMBED_MAX_RETRIES)
+  });
+});


### PR DESCRIPTION
## P0 — new mandala shows 0 cards, ~2min to appear on manual refresh

**Root cause (CC + supervisor, prod-data confirmed).** prod routes card-serving embeds to OpenRouter (`IKS_EMBED_PROVIDER=openrouter`, #616, 2026-05-13). OpenRouter's `qwen3-embedding-8b` latency degraded to a catastrophic tail — `video_discover_traces` `embed.batch`:

| date | batch p50 | batch p90 | item p50 | errs |
|---|---|---|---|---|
| 07-03 | 1455ms | 2923ms | 62ms | 0 |
| 07-10 | **8442ms** | **36073ms** | 339ms | 1 |

A 30–42s embed on the wizard **precompute** / post-creation **discover** path overruns the serving window → precompute **HIT→MISS** → 0 cards until manual refresh (~2min).

**Ruled OUT with data** (not hypotheses): Mac Mini / `-np` (prod doesn't use Mac Mini embeds; Ollama pins embeddings to 1 slot), self-DDoS (isolated ≥ concurrent embed latency — 288–502ms isolated vs 108–339ms concurrent, so our concurrency isn't the cause), #1146 durable pipeline (watchdog loop already terminated by #1149, no `running`/`superseded` runs).

## Fix (C) — fail the slow embed fast to lexical, don't hang the window

`EMBED_SERVING_FAST_TIMEOUT_ENABLED` (**default off**, flag alone rolls back) caps the **v3 serving discover** embeds at **12s / 0 retry**. A slow/404 chunk returns per-chunk `null` → those candidates drop to **lexical** ranking (never 0 cards) instead of hanging. `12s` is grounded between measured batch **p50 ~8.4s (keep the median)** and **p90 ~30–42s (cut the tail)**; 6s would gut the median.

### Supervisor's 3 requirements
1. **Scope-limited** — only the 5 v3 serving `embedBatch` calls pass `servingEmbedOptions()`. **Bulk collector / backfill keep the 20s×2 default** (no window; cutting spikes fail rate). `timeoutMs`/`maxRetries` are per-call opts.
2. **Downgrade counter + alarm** — `getEmbedServingDowngradeCount()` + per-fire `[embed-serving] lexical downgrade #N` log so the daily rollup can alarm before the service silently runs all-lexical.
3. **Premise checks** — 404→`null` is per-chunk-isolated (partial success, never throws → not 0 cards). Deploy-verification below covers the live lexical cell-assignment.

## Scope
- `src/config/embed-serving-timeout.ts` (new) — gate + `servingEmbedOptions()`
- `embedding.ts` — `maxRetries` + `servingScope` opts; `getEmbedServingDowngradeCount()`
- `v3/executor.ts` — 5 serving `embedBatch` calls pass `servingEmbedOptions()`
- `docker-compose.prod.yml` — commented flags (flip on = deploy)

## Tests
`tsc --noEmit` clean · **24/24** — 19 new (config gate + serving-scope / downgrade / no-retry) + OpenRouter-retry regression green.

## Rollback
`EMBED_SERVING_FAST_TIMEOUT_ENABLED` unset = existing 20s×2 behavior. Flag alone rolls back.

## Deploy verification (after flag-on)
- [ ] New mandala serves **5–6s, not 0-card** (precompute HIT restored / fast lexical on tail)
- [ ] `video_discover_traces` `embed.batch` p90 no longer stalls the discover total
- [ ] Degraded (lexical) path **assigns cells and places cards — never 0**
- [ ] `getEmbedServingDowngradeCount()` fire-rate sane (tune `EMBED_SERVING_TIMEOUT_MS` if too high)

## Note
Temporary **hemostasis** with a semantic→lexical quality trade on the tail. **PR-2 (serving/embed decouple — lexical serve now + async semantic backfill/re-sort)** is the structural, quality-lossless fix, **escalated to before-beta** per James.

🤖 Generated with [Claude Code](https://claude.com/claude-code)