### PR TITLE
feat(discover): title_desc gate embed alignment — pool-reuse foundation (iv-A.1)

### DIFF
--- a/src/config/gate-embed-text.ts
+++ b/src/config/gate-embed-text.ts
@@ -1,0 +1,26 @@
+/**
+ * v3 discover semantic-gate embed-text mode (iv-A, 2026-07-10).
+ *
+ * `title` (default) = legacy: the gate embeds candidate TITLES only.
+ * `title_desc` = embed title+desc[:200], byte-identical to how
+ * video_pool_embeddings was built — this reconciles the two representation
+ * rules that had diverged (Tier1 KNN + collector already serve on title+desc
+ * vectors; the title-only gate was the exception) and makes the 39,350-row
+ * pool reusable as a candidate-embed cache (iv-A.2).
+ *
+ * SEPARATE flag from the (B) async-resort gate (supervisor condition 1): one
+ * deploy, but flips independently — never one flip, two variables. Ranking
+ * delta (esp. niche desc-noise) is measured before flip (condition 2).
+ *
+ * Tuning knob, not a secret (CP392). Unset = `title` = current behavior
+ * (no-op → flag alone rolls back).
+ */
+import type { GateEmbedTextMode } from '@/skills/plugins/iks-scorer/embed-text';
+
+export function getGateEmbedTextMode(env: NodeJS.ProcessEnv = process.env): GateEmbedTextMode {
+  return String(env['GATE_EMBED_TEXT'] ?? '')
+    .trim()
+    .toLowerCase() === 'title_desc'
+    ? 'title_desc'
+    : 'title';
+}

--- a/src/skills/plugins/batch-video-collector/executor.ts
+++ b/src/skills/plugins/batch-video-collector/executor.ts
@@ -56,11 +56,11 @@ import {
   QWEN3_EMBED_MODEL,
   vectorToLiteral,
 } from '../iks-scorer/embedding';
+import { buildVideoEmbedText } from '../iks-scorer/embed-text';
 import { shortGateFields } from '@/modules/video-pool/is-short';
 
 const log = logger.child({ module: 'batch-video-collector' });
 
-const DESC_SNIPPET_LEN = 200;
 const DEFAULT_RUN_TYPE = 'daily_trend';
 /** W3 — goal-driven run type: keywords come from user mandala cell sub-goals
  *  (goal-source) instead of trend_signals. Set BATCH_COLLECTOR_RUN_TYPE to this
@@ -381,9 +381,10 @@ function normalizeLimit(raw: unknown): number {
   return Math.min(parsed, 500);
 }
 
+// Delegates to the shared SSOT so the pool this collector writes stays
+// byte-identical to the v3 gate's title_desc embed (iv-A cache co-comparability).
 function buildEmbedText(v: EnrichedVideo): string {
-  const desc = (v.description ?? '').slice(0, DESC_SNIPPET_LEN);
-  return desc ? `${v.title}\n${desc}` : v.title;
+  return buildVideoEmbedText(v.title, v.description);
 }
 
 async function searchAllKeywords(

--- a/src/skills/plugins/iks-scorer/embed-text.ts
+++ b/src/skills/plugins/iks-scorer/embed-text.ts
@@ -1,0 +1,40 @@
+/**
+ * Canonical video embed-text builder (SSOT) — 2026-07-10.
+ *
+ * The embedding of a video's text is a GLOBAL property keyed by video_id, so
+ * every path that embeds a video MUST build byte-identical input:
+ *   - batch-video-collector → populates video_pool_embeddings (39,350 rows),
+ *   - v3 discover semantic gate → (iv-A) reuses those pooled vectors.
+ * If a cache hit (pooled vector) and a live embed for the SAME video used a
+ * different text rule, the two vectors would differ subtly and silently skew
+ * ranking. This is the ONE definition; both callers import it.
+ *
+ * Rule (UNCHANGED — this is exactly what built the pool, so a title_desc gate
+ * embed is byte-identical to the pooled vector): title, newline, description
+ * truncated to EMBED_DESC_SNIPPET_LEN. Title alone when there is no
+ * description. No trim / whitespace-collapse (the pool did not do it either).
+ */
+export const EMBED_DESC_SNIPPET_LEN = 200;
+
+/** `${title}\n${desc[:200]}` (or just title when no desc). Byte-identical to the pool. */
+export function buildVideoEmbedText(title: string, description?: string | null): string {
+  const t = title ?? '';
+  const desc = (description ?? '').slice(0, EMBED_DESC_SNIPPET_LEN);
+  return desc ? `${t}\n${desc}` : t;
+}
+
+export type GateEmbedTextMode = 'title' | 'title_desc';
+
+/**
+ * The text to embed for one discover candidate under the given gate mode.
+ * `title` (default) = legacy title-only gate. `title_desc` = the pool-aligned
+ * text so pooled vectors become reusable (iv-A). Center-goal embeds are NOT
+ * routed through here — only video candidates.
+ */
+export function candidateEmbedText(
+  mode: GateEmbedTextMode,
+  title: string,
+  description?: string | null
+): string {
+  return mode === 'title_desc' ? buildVideoEmbedText(title, description) : (title ?? '');
+}

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -48,7 +48,9 @@ import { resolveAlgorithm } from '@/modules/search/algorithm-resolver';
 import { filterByQualityGate } from './quality-gate';
 import { applyHybridRerank } from './hybrid-rerank';
 import { embedBatch, cosineToRelevance } from '@/skills/plugins/iks-scorer/embedding';
+import { candidateEmbedText } from '@/skills/plugins/iks-scorer/embed-text';
 import { servingEmbedOptions } from '@/config/embed-serving-timeout';
+import { getGateEmbedTextMode } from '@/config/gate-embed-text';
 import { getCenterGoalEmbedding } from '@/modules/mandala/center-goal-embedding';
 import { withTraceContext, recordTrace } from '@/modules/discover-tracing';
 import { resolveLanguage } from '@/utils/detect-language';
@@ -473,7 +475,8 @@ async function executeImpl(
         const capped = fresh.slice(0, cap);
         // CP489 — center_goal embed via cache; candidate title embeddings
         // remain fresh (per-call YouTube candidates change every run).
-        const titles = capped.map((m) => m.title);
+        const gateMode = getGateEmbedTextMode();
+        const titles = capped.map((m) => candidateEmbedText(gateMode, m.title, m.description));
         const [centerVec, titleVecs] = await Promise.all([
           getCenterGoalEmbedding(mandalaId, state.centerGoal),
           embedBatch(titles, servingEmbedOptions()),
@@ -1189,7 +1192,10 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     // CP489 — center_goal via cache when mandalaId known; titles always fresh.
     // Ephemeral path (input.mandalaId undefined) falls back to embedBatch
     // for the center as well via plain embedBatch call.
-    const titles = cappedFilterInputs.map((f) => f.title);
+    const gateMode = getGateEmbedTextMode();
+    const titles = cappedFilterInputs.map((f) =>
+      candidateEmbedText(gateMode, f.title, f.description)
+    );
     try {
       const [centerVec, titleVecs] = await Promise.all([
         input.mandalaId
@@ -2100,7 +2106,11 @@ async function runDiscoverEphemeralImpl(
     try {
       const cap = v3Config.semanticMaxCandidates;
       const cappedSlots = allSlots.slice(0, cap);
-      const texts = [input.centerGoal, ...cappedSlots.map((s) => s.title)];
+      const gateMode = getGateEmbedTextMode();
+      const texts = [
+        input.centerGoal,
+        ...cappedSlots.map((s) => candidateEmbedText(gateMode, s.title, s.description)),
+      ];
       const embedT0 = Date.now();
       const vectors = await embedBatch(texts, servingEmbedOptions());
       const embedMs = Date.now() - embedT0;

--- a/tests/unit/config/gate-embed-text.test.ts
+++ b/tests/unit/config/gate-embed-text.test.ts
@@ -1,0 +1,23 @@
+/**
+ * GATE_EMBED_TEXT mode gate (iv-A). Default `title` = current gate behavior
+ * (no regression). `title_desc` = pool-aligned. Separate flag from the (B)
+ * async-resort gate (supervisor condition 1).
+ */
+import { getGateEmbedTextMode } from '@/config/gate-embed-text';
+
+describe('getGateEmbedTextMode', () => {
+  test('unset → title (no-op, current behavior)', () => {
+    expect(getGateEmbedTextMode({})).toBe('title');
+  });
+
+  test.each(['title_desc', 'TITLE_DESC', ' title_desc '])('%s → title_desc', (v) => {
+    expect(getGateEmbedTextMode({ GATE_EMBED_TEXT: v })).toBe('title_desc');
+  });
+
+  test.each(['title', 'desc', 'both', '1', 'true', ''])(
+    '%s → title (only exact title_desc opts in)',
+    (v) => {
+      expect(getGateEmbedTextMode({ GATE_EMBED_TEXT: v })).toBe('title');
+    }
+  );
+});

--- a/tests/unit/skills/embed-text.test.ts
+++ b/tests/unit/skills/embed-text.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Canonical video embed-text SSOT (iv-A, 2026-07-10).
+ *
+ * Byte-identical guard (supervisor condition 3): the v3 gate's title_desc embed
+ * MUST equal the rule that built video_pool_embeddings, or a pooled-cache hit
+ * and a live embed for the same video would produce different vectors and
+ * silently skew ranking. The pool rule (collector buildEmbedText) is
+ * `${title}\n${desc.slice(0,200)}` — no trim, no whitespace-collapse.
+ */
+import {
+  buildVideoEmbedText,
+  candidateEmbedText,
+  EMBED_DESC_SNIPPET_LEN,
+} from '@/skills/plugins/iks-scorer/embed-text';
+
+describe('buildVideoEmbedText — byte-identical to the pool rule', () => {
+  test('title + desc joined by a single newline (exact pool format)', () => {
+    expect(buildVideoEmbedText('My Title', 'My Description')).toBe('My Title\nMy Description');
+  });
+
+  test('no description → title only (no trailing newline)', () => {
+    expect(buildVideoEmbedText('Only Title', null)).toBe('Only Title');
+    expect(buildVideoEmbedText('Only Title', '')).toBe('Only Title');
+    expect(buildVideoEmbedText('Only Title', undefined)).toBe('Only Title');
+  });
+
+  test('description truncated to EMBED_DESC_SNIPPET_LEN (200), title kept whole', () => {
+    const longDesc = 'x'.repeat(500);
+    const out = buildVideoEmbedText('T', longDesc);
+    expect(out).toBe(`T\n${'x'.repeat(EMBED_DESC_SNIPPET_LEN)}`);
+    expect(out.length).toBe(1 /*T*/ + 1 /*\n*/ + EMBED_DESC_SNIPPET_LEN);
+  });
+
+  test('does NOT trim or collapse whitespace (pool did not either)', () => {
+    // leading/inner spaces preserved verbatim so hit/miss vectors match.
+    expect(buildVideoEmbedText('  spaced  ', '  desc  with   gaps ')).toBe(
+      '  spaced  \n  desc  with   gaps '
+    );
+  });
+
+  test('exact re-implementation of the collector rule for arbitrary inputs', () => {
+    const rule = (title: string, description: string | null) => {
+      const desc = (description ?? '').slice(0, 200);
+      return desc ? `${title}\n${desc}` : title;
+    };
+    const cases: Array<[string, string | null]> = [
+      ['한국어 제목', '설명 텍스트'],
+      ['emoji 🎸 title', null],
+      ['t', 'd'.repeat(201)],
+      ['', 'desc only'],
+    ];
+    for (const [t, d] of cases) {
+      expect(buildVideoEmbedText(t, d)).toBe(rule(t, d));
+    }
+  });
+});
+
+describe('candidateEmbedText — gate mode routing', () => {
+  test('title mode → title only (legacy, no regression)', () => {
+    expect(candidateEmbedText('title', 'A Title', 'ignored desc')).toBe('A Title');
+  });
+
+  test('title_desc mode → pool-aligned title+desc', () => {
+    expect(candidateEmbedText('title_desc', 'A Title', 'A Desc')).toBe('A Title\nA Desc');
+  });
+
+  test('title_desc with null desc → title (still co-comparable with title-only pool rows)', () => {
+    expect(candidateEmbedText('title_desc', 'A Title', null)).toBe('A Title');
+  });
+});


### PR DESCRIPTION
## Step 1 of the converged serving-embed plan (CC + supervisor, 2026-07-10)

Follow-up to #1151 (C hemostasis). The real structural win is **reusing the 39,350 already-computed `video_pool_embeddings` vectors** as a candidate-embed cache so the slow OpenRouter batch shrinks to genuinely-new videos only. But there's a blocker: the v3 gate embeds candidate **titles only**, while the pool was built from **title+desc[:200]** — different text → different vectors → **not co-comparable**. This PR aligns the gate's representation to the pool's so the cache (iv-A.2, next PR) becomes possible.

### Changes
- **`iks-scorer/embed-text.ts` (new, SSOT)** — `buildVideoEmbedText` = `` `${title}\n${desc.slice(0,200)}` `` (no trim — **byte-identical** to the collector rule that built the pool) + `candidateEmbedText(mode, ...)`. **One definition**, imported by both the collector and the gate, so a cache hit and a live embed can never drift (supervisor condition 3).
- **batch-video-collector** — its private `buildEmbedText` now delegates to the SSOT (same bytes; removes the duplicated rule + `DESC_SNIPPET_LEN`).
- **`config/gate-embed-text.ts` (new)** — `GATE_EMBED_TEXT=title|title_desc`, **default `title` = current behavior** (no-op → flag rolls back). SEPARATE flag from the (B) async-resort gate (supervisor condition 1: one flip, one variable).
- **v3/executor.ts** — the 3 candidate-title embed sites route through `candidateEmbedText(mode, title, description)`; center-goal embeds untouched.

### ⚠️ Do NOT flag-on `GATE_EMBED_TEXT=title_desc` yet
Until (a) **iv-A.2 pool cache** lands (else title_desc = longer text + no cache = slower), and (b) the **ranking delta is measured** on anchor (기타/데이터분석) + niche (프랑스 자수) mandalas — desc noise (channel promo/hashtags) must not admit irrelevant videos (supervisor condition 2). **CC + supervisor own that quality call** (flag = safety net), not passed to the user.

### Tests
`tsc --noEmit` clean · **18 new** (byte-identical rule incl. 200-char truncation / no-trim / arbitrary-input re-impl + mode routing). Default `title` path unchanged.

### Rollback
Additive + default `title`. Nothing changes until the flag is flipped; flag alone rolls back.

Design: `docs/design/serving-embed-decouple-converged-2026-07-10.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)