### PR TITLE
fix(embed): skip hung OpenRouter provider + serving budget + never-zero floor (P0, beta D-1)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -263,6 +263,22 @@ services:
       - EMBED_SERVING_FAST_TIMEOUT_ENABLED=true
       - EMBED_SERVING_TIMEOUT_MS=12000
       - EMBED_SERVING_MAX_RETRIES=0
+      # P0 2026-07-11 — ROOT CAUSE of the 7/6+ wizard 27-96s serving: OpenRouter
+      # routes qwen3-embedding-8b across Nebius/DeepInfra/SiliconFlow, and
+      # DeepInfra started hanging 25s+ (pinned probe 3/3; ~1/3 of default-routed
+      # calls stalled -> 20s timeout x retries = 40s per call on the wizard
+      # critical path). Skip it at request level. Remove name(s) / unset = no
+      # provider field (exact legacy request). Re-check monthly whether
+      # DeepInfra recovered (it is one of 3 capacity legs).
+      # Full record: docs/qa/wizard-0card-investigation-2026-07-11.md
+      - OPENROUTER_EMBED_IGNORE_PROVIDERS=DeepInfra
+      # P0 2026-07-11 — never-zero floor: when the RANKING gate (center cosine/
+      # jaccard) drops every candidate, admit top-N (search-rank, safety gates
+      # already applied) into deficit cells instead of "No recommendations" ->
+      # 0 cards (kapasi mode: 108 found -> 0 served). "덜 정렬된 카드 > 0장".
+      # Unset/false = legacy fail-closed rollback.
+      # Staged flip (supervisor): verify FIX-1 hang removal first, THEN enable:
+      # - DISCOVER_NEVER_ZERO_FLOOR=true
       # CP416 (2026-04-22) — restore the LoRA action-fill path. Without
       # this, generateMandala() called config.mandalaGen.model=undefined,
       # Ollama /api/generate returned 400, LoRA threw, and the Haiku

--- a/src/config/discover-zero-floor.ts
+++ b/src/config/discover-zero-floor.ts
@@ -1,0 +1,34 @@
+/**
+ * Discover never-zero floor (P0 2026-07-11, kapasi 0-card mode).
+ *
+ * v3 runTier2 is fail-closed: when the mandala-filter gate drops EVERY
+ * candidate, scored=[] -> slots=[] -> executor returns "No recommendations"
+ * -> step3 skipped -> the user sees 0 cards even though search DID find
+ * candidates (kapasi 87960287: 108 found, shorts -59, lang -6, gate input 10,
+ * center-gate -8 -> 0). Design principle (embedding-async-decouple doc,
+ * James): "덜 정렬된 카드 > 카드 0장" — a thin, less-ordered serve beats an
+ * empty mandala.
+ *
+ * DISCOVER_NEVER_ZERO_FLOOR: when on AND the gate output is empty AND
+ * filterable candidates exist, admit the top-N candidates (search-rank order,
+ * shorts/lang/quality gates ALREADY applied upstream — the floor only bypasses
+ * the center/jaccard RANKING gate, never the safety gates). Unset = current
+ * fail-closed behavior (flag alone rolls back).
+ *
+ * DISCOVER_ZERO_FLOOR_MAX: cap on floor-admitted candidates (default 16 =
+ * 2 per cell) — enough to not look broken, small enough that async relevance
+ * backfill re-ranks a mostly-unordered set quickly.
+ */
+const DEFAULT_ZERO_FLOOR_MAX = 16;
+
+export function isDiscoverNeverZeroFloorEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['DISCOVER_NEVER_ZERO_FLOOR'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes';
+}
+
+export function getZeroFloorMax(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number(env['DISCOVER_ZERO_FLOOR_MAX']);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_ZERO_FLOOR_MAX;
+}

--- a/src/config/embed-provider-prefs.ts
+++ b/src/config/embed-provider-prefs.ts
@@ -1,0 +1,30 @@
+/**
+ * OpenRouter embed provider routing prefs (P0 2026-07-11, beta D-1).
+ *
+ * OpenRouter routes qwen3-embedding-8b across Nebius / DeepInfra /
+ * SiliconFlow. Pinned-provider probes from the prod container (2026-07-11):
+ *   DeepInfra    25s+ hang 3/3 (100%)   <- the wizard 27-96s serving killer
+ *   SiliconFlow  0.57-0.86s
+ *   Nebius       0.54-6.9s
+ * Default routing hit the hung provider ~1/3 of calls (probe: 3-4 of 10 at
+ * 29.6-30s+), and EMBED_TIMEOUT_MS(20s) x retries turned each hit into a 40s
+ * stall on the wizard critical path. Uptime stats (99.97%+) do NOT show this
+ * — uptime is not latency.
+ *
+ * OPENROUTER_EMBED_IGNORE_PROVIDERS: comma-separated provider names to skip
+ * (request-level `provider: { ignore: [...] }`). Unset/empty = no provider
+ * field at all — exact current behavior (flag alone rolls back). Ignore is
+ * chosen over order-pinning so the remaining healthy providers still load-
+ * balance and a future bad apple can be added without re-ranking the rest.
+ *
+ * Tuning knob, not a secret (CP392). Full incident record:
+ * docs/qa/wizard-0card-investigation-2026-07-11.md
+ */
+export function getEmbedIgnoreProviders(env: NodeJS.ProcessEnv = process.env): string[] {
+  const raw = String(env['OPENROUTER_EMBED_IGNORE_PROVIDERS'] ?? '').trim();
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}

--- a/src/modules/mandala/center-goal-embedding.ts
+++ b/src/modules/mandala/center-goal-embedding.ts
@@ -33,6 +33,7 @@ import {
   vectorToLiteral,
   QWEN3_EMBED_DIMENSION,
 } from '@/skills/plugins/iks-scorer/embedding';
+import { servingEmbedOptions } from '@/config/embed-serving-timeout';
 
 const log = logger.child({ module: 'center-goal-embedding' });
 
@@ -78,7 +79,9 @@ export async function getCenterGoalEmbedding(
   }
 
   // 2. Cache miss → embed via provider chain (Ollama → OpenRouter fallback).
-  const [vec] = await embedBatch([trimmed]);
+  // P0 2026-07-11 — miss path runs inside the wizard discover critical path;
+  // serving budget caps a hung provider (12s/0-retry when flag on).
+  const [vec] = await embedBatch([trimmed], servingEmbedOptions());
   if (!vec || vec.length !== QWEN3_EMBED_DIMENSION) return null;
 
   // 3. Fire-and-forget UPSERT — race-safe via partial unique index.

--- a/src/modules/mandala/ensure-mandala-embeddings.ts
+++ b/src/modules/mandala/ensure-mandala-embeddings.ts
@@ -23,6 +23,7 @@ import { Prisma } from '@prisma/client';
 import { getPrismaClient } from '@/modules/database';
 import { logger } from '@/utils/logger';
 import { embedBatch, vectorToLiteral } from '@/skills/plugins/iks-scorer/embedding';
+import { servingEmbedOptions } from '@/config/embed-serving-timeout';
 
 const log = logger.child({ module: 'ensure-mandala-embeddings' });
 
@@ -167,7 +168,10 @@ export async function ensureMandalaEmbeddings(mandalaId: string): Promise<Ensure
   const t0 = Date.now();
   let vectors: (number[] | null)[];
   try {
-    vectors = await embedBatch(subjectsToEmbed);
+    // P0 2026-07-11 — step1 sits on the wizard critical path (30s race in
+    // pipeline-runner). Serving budget (12s/0-retry when flag on) keeps a hung
+    // provider from eating the whole race; missing cells backfill next call.
+    vectors = await embedBatch(subjectsToEmbed, servingEmbedOptions());
   } catch (err) {
     return {
       ok: false,

--- a/src/skills/plugins/iks-scorer/embedding.ts
+++ b/src/skills/plugins/iks-scorer/embedding.ts
@@ -25,6 +25,7 @@ import { logger } from '@/utils/logger';
 import { getPrismaClient } from '@/modules/database';
 import { Prisma } from '@prisma/client';
 import { config } from '@/config/index';
+import { getEmbedIgnoreProviders } from '@/config/embed-provider-prefs';
 import { logLLMCall } from '@/modules/llm/call-logger';
 import { recordTrace } from '@/modules/discover-tracing';
 
@@ -443,13 +444,21 @@ async function embedOneChunkViaOpenRouter(
   try {
     let res: Response;
     try {
+      // P0 2026-07-11 — skip hung providers (DeepInfra: 25s+ hang 3/3 pinned
+      // probe; ~1/3 of default-routed calls stalled 20-30s -> 40s with retry).
+      // Empty list = no provider field, byte-identical legacy request.
+      const ignoreProviders = getEmbedIgnoreProviders();
       res = await fetchFn(`${baseUrl}/embeddings`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${apiKey}`,
         },
-        body: JSON.stringify({ model, input: texts }),
+        body: JSON.stringify({
+          model,
+          input: texts,
+          ...(ignoreProviders.length > 0 ? { provider: { ignore: ignoreProviders } } : {}),
+        }),
         signal: controller.signal,
       });
     } catch (err) {

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -49,6 +49,7 @@ import { filterByQualityGate } from './quality-gate';
 import { applyHybridRerank } from './hybrid-rerank';
 import { embedBatch, cosineToRelevance } from '@/skills/plugins/iks-scorer/embedding';
 import { servingEmbedOptions } from '@/config/embed-serving-timeout';
+import { isDiscoverNeverZeroFloorEnabled, getZeroFloorMax } from '@/config/discover-zero-floor';
 import { getCenterGoalEmbedding } from '@/modules/mandala/center-goal-embedding';
 import { withTraceContext, recordTrace } from '@/modules/discover-tracing';
 import { resolveLanguage } from '@/utils/detect-language';
@@ -897,6 +898,8 @@ interface Tier2Debug {
   mandalaFilterSubGoalTokenCounts: number[];
   perCellAssigned: Record<number, number>;
   scoredCandidates: number;
+  /** P0 2026-07-11 — candidates admitted by the never-zero floor (gate emptied). */
+  floorAdmitted: number;
   finalSlots: number;
   centerGoal: string;
   subGoalsSample: string[];
@@ -948,6 +951,7 @@ function makeEmptyDebug(input: Tier2Input): Tier2Debug {
     mandalaFilterSubGoalTokenCounts: [],
     perCellAssigned: {},
     scoredCandidates: 0,
+    floorAdmitted: 0,
     finalSlots: 0,
     centerGoal: input.state.centerGoal,
     subGoalsSample: [...input.state.subGoals],
@@ -1316,6 +1320,37 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     }
     mandalaFilterRanTier2 = true;
   }
+
+  // P0 2026-07-11 — never-zero floor. When the RANKING gate (center cosine /
+  // jaccard) drops every candidate, the run used to return "No recommendations"
+  // → 0 cards, even though search found candidates and the SAFETY gates
+  // (shorts / lang / blocklist / quality) already passed them (kapasi
+  // 87960287: 108 found → gate input 10 → center-gate -8 → 0). Principle:
+  // "덜 정렬된 카드 > 카드 0장" — admit the top-N in search-rank order into
+  // deficit cells; async relevance backfill re-ranks them later. Flag off =
+  // legacy fail-closed. See config/discover-zero-floor.ts.
+  if (scored.length === 0 && filterable.length > 0 && isDiscoverNeverZeroFloorEnabled()) {
+    const deficitCellList = input.deficitCells.map((c) => c.cellIndex);
+    const cap = Math.min(getZeroFloorMax(), filterable.length);
+    let floorScore = 0.05;
+    for (let i = 0; i < cap; i++) {
+      const v = filterable[i]!;
+      const hinted = v.cellIndexHint;
+      const cellIndex =
+        hinted != null && deficitCellSet.has(hinted)
+          ? hinted
+          : deficitCellList[i % deficitCellList.length]!;
+      scored.push({ video: enrichedById.get(v.videoId)!, cellIndex, score: floorScore });
+      floorScore = Math.max(0.01, floorScore - 0.001);
+    }
+    debug.floorAdmitted = scored.length;
+    // Per-fire mandala id (supervisor): floor-served mandalas bypass the
+    // ranking gate — stratified quality checks must identify them.
+    log.warn(
+      `[zero-floor] mandala=${input.mandalaId ?? 'ephemeral'} ranking gate emptied ${filterable.length} candidates — floor-admitted ${scored.length} (cap ${cap})`
+    );
+  }
+
   const tScoringStart = Date.now();
   debug.scoredCandidates = scored.length;
 

--- a/tests/unit/config/discover-zero-floor.test.ts
+++ b/tests/unit/config/discover-zero-floor.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Never-zero floor gate (P0 2026-07-11, kapasi 0-card mode).
+ * Unset = fail-closed legacy (flag alone rolls back).
+ */
+import { isDiscoverNeverZeroFloorEnabled, getZeroFloorMax } from '@/config/discover-zero-floor';
+
+describe('discover-zero-floor config', () => {
+  test('unset → disabled (legacy fail-closed)', () => {
+    expect(isDiscoverNeverZeroFloorEnabled({})).toBe(false);
+  });
+
+  test.each(['true', '1', 'yes', 'TRUE'])('enabled by %s', (v) => {
+    expect(isDiscoverNeverZeroFloorEnabled({ DISCOVER_NEVER_ZERO_FLOOR: v })).toBe(true);
+  });
+
+  test.each(['false', '0', 'no', ''])('disabled for %s', (v) => {
+    expect(isDiscoverNeverZeroFloorEnabled({ DISCOVER_NEVER_ZERO_FLOOR: v })).toBe(false);
+  });
+
+  test('floor max default 16, env override, invalid → default', () => {
+    expect(getZeroFloorMax({})).toBe(16);
+    expect(getZeroFloorMax({ DISCOVER_ZERO_FLOOR_MAX: '8' })).toBe(8);
+    expect(getZeroFloorMax({ DISCOVER_ZERO_FLOOR_MAX: 'abc' })).toBe(16);
+    expect(getZeroFloorMax({ DISCOVER_ZERO_FLOOR_MAX: '0' })).toBe(16);
+    expect(getZeroFloorMax({ DISCOVER_ZERO_FLOOR_MAX: '-3' })).toBe(16);
+  });
+});

--- a/tests/unit/config/embed-provider-prefs.test.ts
+++ b/tests/unit/config/embed-provider-prefs.test.ts
@@ -1,0 +1,28 @@
+/**
+ * OpenRouter embed provider-ignore prefs (P0 2026-07-11 DeepInfra hang).
+ * Unset/empty = [] = no provider field in the request (exact legacy).
+ */
+import { getEmbedIgnoreProviders } from '@/config/embed-provider-prefs';
+
+describe('getEmbedIgnoreProviders', () => {
+  test('unset → [] (no-op)', () => {
+    expect(getEmbedIgnoreProviders({})).toEqual([]);
+  });
+
+  test('empty / whitespace → []', () => {
+    expect(getEmbedIgnoreProviders({ OPENROUTER_EMBED_IGNORE_PROVIDERS: '' })).toEqual([]);
+    expect(getEmbedIgnoreProviders({ OPENROUTER_EMBED_IGNORE_PROVIDERS: '  ' })).toEqual([]);
+  });
+
+  test('single provider', () => {
+    expect(getEmbedIgnoreProviders({ OPENROUTER_EMBED_IGNORE_PROVIDERS: 'DeepInfra' })).toEqual([
+      'DeepInfra',
+    ]);
+  });
+
+  test('comma-separated, trimmed, empty segments dropped', () => {
+    expect(
+      getEmbedIgnoreProviders({ OPENROUTER_EMBED_IGNORE_PROVIDERS: ' DeepInfra , Nebius ,, ' })
+    ).toEqual(['DeepInfra', 'Nebius']);
+  });
+});

--- a/tests/unit/modules/embedding-provider-ignore.test.ts
+++ b/tests/unit/modules/embedding-provider-ignore.test.ts
@@ -1,0 +1,90 @@
+/**
+ * embedBatch — OpenRouter provider-ignore body assembly (P0 2026-07-11).
+ *
+ * DeepInfra (one of 3 providers OpenRouter routes qwen3-embedding-8b to)
+ * started hanging 25s+; OPENROUTER_EMBED_IGNORE_PROVIDERS skips it at the
+ * request level. Pins: env set → body carries provider.ignore; unset → NO
+ * provider field at all (byte-level legacy request shape).
+ */
+
+const mockConfig = {
+  iksEmbed: { provider: 'openrouter' as const },
+  openrouter: { apiKey: 'test-key' },
+  mandalaEmbed: {
+    openRouterBaseUrl: 'https://openrouter.test/api/v1',
+    openRouterModel: 'qwen/qwen3-embedding-8b',
+    openRouterDimension: 4096,
+  },
+};
+
+jest.mock('@/config/index', () => ({ config: mockConfig }));
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+  },
+}));
+jest.mock('@/modules/llm/call-logger', () => ({ logLLMCall: jest.fn() }));
+jest.mock('@/modules/discover-tracing', () => ({ recordTrace: jest.fn() }));
+jest.mock('@/modules/database', () => ({ getPrismaClient: jest.fn() }));
+
+import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
+
+const DIM = 4096;
+const vec = (): number[] => new Array(DIM).fill(0.01);
+const openRouterOk = (n: number): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      data: Array.from({ length: n }, () => ({ embedding: vec() })),
+      usage: {},
+    }),
+  }) as unknown as Response;
+
+const ENV_KEY = 'OPENROUTER_EMBED_IGNORE_PROVIDERS';
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+});
+
+describe('embedBatch — OpenRouter provider ignore', () => {
+  test('env set → request body carries provider.ignore', async () => {
+    process.env[ENV_KEY] = 'DeepInfra';
+    const bodies: unknown[] = [];
+    const fetchImpl = jest.fn(async (_url: string, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      return openRouterOk(2);
+    }) as unknown as typeof fetch;
+
+    const out = await embedBatch(['a', 'b'], { fetchImpl });
+
+    expect(out).toHaveLength(2);
+    expect(bodies[0]).toMatchObject({ provider: { ignore: ['DeepInfra'] } });
+  });
+
+  test('env unset → NO provider field (legacy request shape)', async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    const fetchImpl = jest.fn(async (_url: string, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      return openRouterOk(1);
+    }) as unknown as typeof fetch;
+
+    await embedBatch(['a'], { fetchImpl });
+
+    expect(bodies[0]).not.toHaveProperty('provider');
+    expect(bodies[0]).toMatchObject({ model: 'qwen/qwen3-embedding-8b', input: ['a'] });
+  });
+
+  test('multiple ignored providers pass through comma-parsed', async () => {
+    process.env[ENV_KEY] = 'DeepInfra, SomeOther';
+    const bodies: unknown[] = [];
+    const fetchImpl = jest.fn(async (_url: string, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      return openRouterOk(1);
+    }) as unknown as typeof fetch;
+
+    await embedBatch(['a'], { fetchImpl });
+
+    expect(bodies[0]).toMatchObject({ provider: { ignore: ['DeepInfra', 'SomeOther'] } });
+  });
+});


### PR DESCRIPTION
## Root cause (prod-probed, closes the "worked before 7/6, broke after" boundary)

OpenRouter routes `qwen/qwen3-embedding-8b` across **Nebius / DeepInfra / SiliconFlow**. Pinned-provider probes from the prod container (2026-07-11):

| Provider | probe |
|---|---|
| **DeepInfra** | **25s+ hang 3/3 (100%)** |
| SiliconFlow | 0.57–0.86s |
| Nebius | 0.54–6.9s |

Default routing hit the hung leg ~1/3 of calls (3–4 of 10 probes at 29.6–30s+). `EMBED_TIMEOUT_MS(20s) × retries` turned each hit into a **40s stall**; the wizard discover makes 3–5 embed calls on its critical path → nearly every run ate 1+ hang → **27–96s serving** (embed p90: 2.9s 7/3 → 9.0 7/6 → 19.2 7/7 → 40 7/10). Zero code change at the boundary — an external provider degraded (uptime stats stayed 99.97%+: uptime ≠ latency). `add_cards` stayed fast (3.9s) because its path embeds nothing.

## Fixes (flag-separated, supervisor-reviewed GO)

- **FIX-1 (root)** `OPENROUTER_EMBED_IGNORE_PROVIDERS` → request-level `provider:{ignore:[...]}`. Unset = no provider field (byte-identical legacy). *ignore* over *order-pin*: healthy providers keep load-balancing, no new SPOF. Compose ships `=DeepInfra`. Quarterly probe re-run to refresh the list.
- **FIX-2 (defense)** `servingEmbedOptions()` (12s/0-retry, existing flag) extended to the 2 remaining critical-path embeds: step1 `ensureMandalaEmbeddings` + `getCenterGoalEmbedding` miss.
- **FIX-3 (0-card mode, ships OFF)** `DISCOVER_NEVER_ZERO_FLOOR` — when the RANKING gate empties all candidates (kapasi: 108 found → shorts −59 → gate in 10 → center-gate −8 → "No recommendations" → **0 cards**), floor-admit top-N (16 = 2/cell) in search-rank order into deficit cells. Safety gates already applied upstream; only the ranking gate is bypassed. Per-fire mandala-id log + `floorAdmitted` counter. **Staged flip after FIX-1 verification** (supervisor order FIX-1→2→3).

## Tests
tsc clean · **27/27** (3 new suites + openrouter-retry & serving-timeout regressions).

## Verification after deploy
- [ ] embed.batch p50/p90 back to ~1.5s/3s band (no 40s tails)
- [ ] wizard run s2 back to ~12s band
- [ ] then flip `DISCOVER_NEVER_ZERO_FLOOR=true` (2nd deploy) → confirm 0-slot runs floor-serve

🤖 Generated with [Claude Code](https://claude.com/claude-code)