### PR TITLE
fix(queue): watchdog per-mandala retry cap — kill the re-enqueue chain loop

### DIFF
--- a/src/modules/queue/handlers/mandala-pipeline.ts
+++ b/src/modules/queue/handlers/mandala-pipeline.ts
@@ -125,13 +125,37 @@ export async function handleMandalaPipelineWatchdog(): Promise<void> {
   // terminates pre-flag-on fire-and-forget orphans that never had a pg-boss
   // job (e.g. the run stuck at step1 since before the durable flag was on).
   let reEnqueued = 0;
+  let capped = 0;
   const supersededIds: string[] = [];
   for (const r of stale) {
     try {
+      // Per-mandala retry cap. Supersede (below) bounds each ROW to one retry,
+      // but a re-run that orphans again mints a fresh 'running' row every
+      // cycle — an unbounded chain per mandala. Watchdog re-enqueues always
+      // carry trigger='watchdog' (trigger is log/analytics-only downstream),
+      // so counting them bounds the chain regardless of failure mode.
+      const attempts = await prisma.$queryRawUnsafe<Array<{ n: number }>>(
+        `SELECT count(*)::int AS n
+           FROM mandala_pipeline_runs
+          WHERE mandala_id = $1::uuid
+            AND trigger = 'watchdog'
+            AND created_at > now() - interval '24 hours'`,
+        r.mandala_id
+      );
+      if ((attempts[0]?.n ?? 0) >= QUEUE_CONFIG.MANDALA_PIPELINE_WATCHDOG_MAX_RETRIES) {
+        capped++;
+        supersededIds.push(r.id); // still close the row — a capped mandala must stop matching
+        log.warn('mandala-pipeline-watchdog: retry cap reached — closing without re-enqueue', {
+          mandalaId: r.mandala_id,
+          attempts24h: attempts[0]?.n,
+        });
+        continue;
+      }
+
       const jobId = await enqueueMandalaPipeline({
         mandalaId: r.mandala_id,
         userId: r.user_id,
-        trigger: r.trigger ?? 'watchdog',
+        trigger: 'watchdog',
       });
       if (jobId) {
         reEnqueued++;
@@ -162,6 +186,7 @@ export async function handleMandalaPipelineWatchdog(): Promise<void> {
     stale: stale.length,
     reEnqueued,
     superseded,
+    capped,
   });
 }
 

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -433,6 +433,16 @@ export const QUEUE_CONFIG = {
   MANDALA_PIPELINE_WATCHDOG_CRON: '*/10 * * * *',
   /** A pipeline run stuck at status=running past this age is treated orphaned. */
   MANDALA_PIPELINE_STALE_MINUTES: 10,
+  /**
+   * Watchdog re-enqueue cap per mandala per 24h. #1149's supersede closes the
+   * SAME-row loop, but a re-run that itself orphans (crash/restart mid-run)
+   * creates a fresh 'running' row each cycle — an unbounded per-MANDALA chain
+   * at one re-run per tick (the 7/10 dawn shape: new run every ~10min while
+   * search.list 429'd). Watchdog re-enqueues carry trigger='watchdog'; once
+   * that count reaches this cap in 24h the stale row is still closed out but
+   * no new job is sent.
+   */
+  MANDALA_PIPELINE_WATCHDOG_MAX_RETRIES: 2,
   /** Max concurrent enrichment workers */
   ENRICH_CONCURRENCY: 1,
   /**

--- a/tests/unit/modules/mandala-pipeline.test.ts
+++ b/tests/unit/modules/mandala-pipeline.test.ts
@@ -34,8 +34,12 @@ jest.mock('@/config/pipeline-durable', () => ({
 }));
 
 const mockQueryRaw = jest.fn();
+const mockUpdateMany = jest.fn();
 jest.mock('@/modules/database/client', () => ({
-  getPrismaClient: () => ({ $queryRawUnsafe: (...args: unknown[]) => mockQueryRaw(...args) }),
+  getPrismaClient: () => ({
+    $queryRawUnsafe: (...args: unknown[]) => mockQueryRaw(...args),
+    mandala_pipeline_runs: { updateMany: (...args: unknown[]) => mockUpdateMany(...args) },
+  }),
 }));
 
 jest.mock('@/config/index', () => ({
@@ -61,7 +65,7 @@ import {
   handleMandalaPipelineWatchdog,
   enqueueMandalaPipeline,
 } from '@/modules/queue/handlers/mandala-pipeline';
-import { JOB_NAMES, MANDALA_PIPELINE_OPTIONS } from '@/modules/queue/types';
+import { JOB_NAMES, MANDALA_PIPELINE_OPTIONS, QUEUE_CONFIG } from '@/modules/queue/types';
 import type { MandalaPipelinePayload } from '@/modules/queue/types';
 
 beforeAll(async () => {
@@ -77,6 +81,7 @@ const job = (data: Partial<MandalaPipelinePayload>): PgBoss.Job<MandalaPipelineP
 beforeEach(() => {
   mockCreateRun.mockResolvedValue('run-1');
   mockExecuteRun.mockResolvedValue(undefined);
+  mockUpdateMany.mockResolvedValue({ count: 1 });
 });
 afterEach(() => jest.clearAllMocks());
 
@@ -122,19 +127,52 @@ describe('handleMandalaPipelineWatchdog', () => {
     expect(mockBossInstance.send).not.toHaveBeenCalled();
   });
 
-  it('durable flag ON → re-enqueues each stale running run', async () => {
+  it('durable flag ON → re-enqueues each stale running run + supersedes the rows', async () => {
     mockIsDurable.mockReturnValue(true);
-    mockQueryRaw.mockResolvedValue([
-      { mandala_id: 'm-a', user_id: 'u-a', trigger: 'wizard' },
-      { mandala_id: 'm-b', user_id: 'u-b', trigger: null },
-    ]);
+    // 1st raw call = stale select; subsequent = per-mandala watchdog-attempt counts.
+    mockQueryRaw
+      .mockResolvedValueOnce([
+        { id: 'r-a', mandala_id: 'm-a', user_id: 'u-a', trigger: 'wizard' },
+        { id: 'r-b', mandala_id: 'm-b', user_id: 'u-b', trigger: null },
+      ])
+      .mockResolvedValue([{ n: 0 }]);
     await handleMandalaPipelineWatchdog();
     expect(mockBossInstance.send).toHaveBeenCalledTimes(2);
+    // Re-enqueues are ALWAYS labeled trigger='watchdog' so the retry cap can count them.
     expect(mockBossInstance.send).toHaveBeenCalledWith(
       JOB_NAMES.MANDALA_PIPELINE,
-      { mandalaId: 'm-b', userId: 'u-b', trigger: 'watchdog' },
-      expect.objectContaining({ singletonKey: 'mandala-pipeline-m-b' })
+      { mandalaId: 'm-a', userId: 'u-a', trigger: 'watchdog' },
+      expect.objectContaining({ singletonKey: 'mandala-pipeline-m-a' })
     );
+    // Replaced rows are closed out so the next tick can't re-fire them.
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: { in: ['r-a', 'r-b'] } }),
+        data: expect.objectContaining({ status: 'superseded' }),
+      })
+    );
+  });
+
+  it('retry cap reached → row closed WITHOUT re-enqueue (kills the per-mandala chain loop)', async () => {
+    mockIsDurable.mockReturnValue(true);
+    mockQueryRaw
+      .mockResolvedValueOnce([{ id: 'r-x', mandala_id: 'm-x', user_id: 'u-x', trigger: null }])
+      .mockResolvedValue([{ n: QUEUE_CONFIG.MANDALA_PIPELINE_WATCHDOG_MAX_RETRIES }]);
+    await handleMandalaPipelineWatchdog();
+    expect(mockBossInstance.send).not.toHaveBeenCalled();
+    // Capped row is still superseded — it must stop matching future ticks.
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ id: { in: ['r-x'] } }) })
+    );
+  });
+
+  it('under the cap → re-enqueue proceeds', async () => {
+    mockIsDurable.mockReturnValue(true);
+    mockQueryRaw
+      .mockResolvedValueOnce([{ id: 'r-y', mandala_id: 'm-y', user_id: 'u-y', trigger: null }])
+      .mockResolvedValue([{ n: QUEUE_CONFIG.MANDALA_PIPELINE_WATCHDOG_MAX_RETRIES - 1 }]);
+    await handleMandalaPipelineWatchdog();
+    expect(mockBossInstance.send).toHaveBeenCalledTimes(1);
   });
 
   it('durable flag ON, no stale runs → nothing re-enqueued', async () => {


### PR DESCRIPTION
## Problem
#1149's supersede closes the same-ROW loop, but a watchdog re-run that itself orphans creates a fresh `running` row each cycle — an unbounded **per-mandala** chain (one re-run per 10-min tick). On 2026-07-10 04:00–05:40 UTC this shape burned a full day's Search quota: 22 re-runs × ~16 `search.list` × 100 units, during the #1134 single-key era (`quota_exhausted (single key, no rotation)` × 329 in traces).

## Fix
- Watchdog re-enqueues always carry `trigger='watchdog'` (log/analytics-only downstream) → attempts are countable.
- `MANDALA_PIPELINE_WATCHDOG_MAX_RETRIES=2` per mandala per 24h; at the cap the stale row is still superseded (stops matching future ticks) but no new job is sent.
- Repairs the watchdog unit test broken since #1149 (prisma mock lacked `mandala_pipeline_runs.updateMany`) + adds 3 cap regression tests.

## Verification
- `tsc --noEmit` 0 · target suite 9/9 (was 6/7 with 1 pre-broken).
- Pre-existing failures in `pipeline-runner` / `auto-add-recommendations` / `queue-handlers` suites reproduce identically on clean `origin/main` — out of scope (CI `test` job is non-blocking; follow-up candidate).

## Rollback
Config-level: raise `MANDALA_PIPELINE_WATCHDOG_MAX_RETRIES`; behavior-level: revert this commit (supersede semantics from #1149 unchanged).

Diagnosis SSOT: `memory/project_wizard_17cards_diagnosis_2026-07-11.md` (17-card run + dawn quota massacre full trace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)