### PR TITLE
perf(pool-match): two-stage hnsw shortlist — 50,840 brute cosines → 105ms

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -441,6 +441,13 @@ services:
       # instead of orphaning the run at 0 cards. Revert: delete this line
       # (unset => legacy setImmediate). Handler: mandala-pipeline.ts.
       - PIPELINE_DURABLE_ENABLED=true
+      # P2 (2026-07-11) — two-stage pool matching: hnsw shortlist on the MRL
+      # 1024d GENERATED column, exact 4096d re-rank of K x cells pairs.
+      # Replaces the 50,840-op brute-force scan (22.8s cold / 4.9s warm) on
+      # the wizard's synchronous path. Prod recall measured 64/64 at K=32.
+      # DDL pre-applied (prisma/migrations/pool-embeddings-1024/). Revert:
+      # delete this line (unset => brute-force path, no code revert).
+      - V3_POOL_MATCH_TWO_STAGE=true
       # CP493 (2026-06-03) — merged structure+queries generation (canary). ONE
       # Haiku call yields the mandala structure AND a searchable per-cell query
       # in a single continuous context, replacing the two disconnected calls

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2296,6 +2296,13 @@ model video_pool_embeddings {
   id            String                      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   video_id      String                      @db.VarChar(20)
   embedding     Unsupported("vector(4096)")
+  /// P2 (2026-07-11) — MRL truncation of `embedding` (first 1024 dims,
+  /// l2-normalized) as a Postgres GENERATED ALWAYS STORED column + hnsw index
+  /// (4096d exceeds pgvector's 2,000-dim index cap). Writers never touch this
+  /// column — the DB derives it. Raw SQL DDL (incl. the hnsw index + the dead
+  /// 4096d ivfflat drop): prisma/migrations/pool-embeddings-1024/001_*.sql.
+  /// Listed here so `prisma db push` treats it as known and never drops it.
+  embedding_1024 Unsupported("vector(1024)")?
   text_input    String?
   model_version String                      @default("qwen3-embedding-8b") @db.VarChar(50)
   created_at    DateTime                    @default(now()) @db.Timestamptz(6)

--- a/src/modules/search/algorithm-resolver.ts
+++ b/src/modules/search/algorithm-resolver.ts
@@ -140,6 +140,10 @@ function materialize(id: string, parametersJson: unknown): ResolvedAlgorithm {
     V3_ENABLE_USER_CURATED_INGEST: asStr(j['enableUserCuratedIngest']),
     V3_EMPTY_TITLE_GATE_SHADOW: asStr(j['emptyTitleGateShadow']),
     V3_EMPTY_TITLE_GATE: asStr(j['emptyTitleGate']),
+    V3_POOL_MATCH_TWO_STAGE: asStr(j['poolMatchTwoStage']),
+    V3_POOL_MATCH_SHORTLIST_K: asStr(j['poolMatchShortlistK']),
+    V3_POOL_MATCH_OVERFETCH: asStr(j['poolMatchOverfetch']),
+    V3_POOL_MATCH_EF_SEARCH: asStr(j['poolMatchEfSearch']),
   };
 
   const parsed = v3EnvSchema.safeParse(envLike);
@@ -176,6 +180,10 @@ function materialize(id: string, parametersJson: unknown): ResolvedAlgorithm {
     enableUserCuratedIngest: d['V3_ENABLE_USER_CURATED_INGEST'] as boolean,
     emptyTitleGateShadow: d['V3_EMPTY_TITLE_GATE_SHADOW'] as boolean,
     emptyTitleGate: d['V3_EMPTY_TITLE_GATE'] as boolean,
+    poolMatchTwoStage: d['V3_POOL_MATCH_TWO_STAGE'] as boolean,
+    poolMatchShortlistK: d['V3_POOL_MATCH_SHORTLIST_K'] as number,
+    poolMatchOverfetch: d['V3_POOL_MATCH_OVERFETCH'] as number,
+    poolMatchEfSearch: d['V3_POOL_MATCH_EF_SEARCH'] as number,
   };
 
   return { id, parameters: cfg };

--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -45,6 +45,11 @@ describe('loadV3Config', () => {
       enableUserCuratedIngest: true,
       emptyTitleGateShadow: false, // R4 shadow guard default (2026-07-04, BL-17)
       emptyTitleGate: false, // R4 enforce default (2026-07-04, BL-17)
+      // P2 two-stage pool matching (2026-07-11) — default OFF (brute-force path)
+      poolMatchTwoStage: false,
+      poolMatchShortlistK: 32,
+      poolMatchOverfetch: 256,
+      poolMatchEfSearch: 400,
     });
   });
 
@@ -125,6 +130,11 @@ describe('loadV3Config', () => {
       enableUserCuratedIngest: true,
       emptyTitleGateShadow: false, // R4 shadow guard default (2026-07-04, BL-17)
       emptyTitleGate: false, // R4 enforce default (2026-07-04, BL-17)
+      // P2 two-stage pool matching (2026-07-11) — default OFF (brute-force path)
+      poolMatchTwoStage: false,
+      poolMatchShortlistK: 32,
+      poolMatchOverfetch: 256,
+      poolMatchEfSearch: 400,
     });
   });
 
@@ -309,5 +319,28 @@ describe('loadV3Config', () => {
       loadV3Config({ V3_EMPTY_TITLE_GATE: 'true', V3_EMPTY_TITLE_GATE_SHADOW: 'false' })
         .emptyTitleGateShadow
     ).toBe(false);
+  });
+});
+
+describe('V3_POOL_MATCH_* (P2 two-stage pool matching, 2026-07-11)', () => {
+  test('defaults: OFF + K=32 / overfetch=256 / ef_search=400', () => {
+    const c = loadV3Config({});
+    expect(c.poolMatchTwoStage).toBe(false);
+    expect(c.poolMatchShortlistK).toBe(32);
+    expect(c.poolMatchOverfetch).toBe(256);
+    expect(c.poolMatchEfSearch).toBe(400);
+  });
+
+  test('env overrides parse', () => {
+    const c = loadV3Config({
+      V3_POOL_MATCH_TWO_STAGE: 'true',
+      V3_POOL_MATCH_SHORTLIST_K: '48',
+      V3_POOL_MATCH_OVERFETCH: '512',
+      V3_POOL_MATCH_EF_SEARCH: '600',
+    });
+    expect(c.poolMatchTwoStage).toBe(true);
+    expect(c.poolMatchShortlistK).toBe(48);
+    expect(c.poolMatchOverfetch).toBe(512);
+    expect(c.poolMatchEfSearch).toBe(600);
   });
 });

--- a/src/skills/plugins/video-discover/v3/cache-matcher.ts
+++ b/src/skills/plugins/video-discover/v3/cache-matcher.ts
@@ -16,6 +16,7 @@ import { getPrismaClient } from '@/modules/database';
 import { Prisma } from '@prisma/client';
 import { logger } from '@/utils/logger';
 import { recordTrace } from '@/modules/discover-tracing';
+import { v3Config } from './config';
 
 const log = logger.child({ module: 'video-discover/v3/cache-matcher' });
 
@@ -71,6 +72,23 @@ interface MatchRow {
 }
 
 /**
+ * Run a two-stage shortlist query with `hnsw.ef_search` pinned for the
+ * transaction. pgvector's default ef_search=40 silently caps an hnsw scan's
+ * result set below our OVERFETCH LIMIT (prod-measured recall collapse
+ * 51/64); SET LOCAL inside the same transaction is the documented way to
+ * raise it per-query without touching the instance default.
+ */
+function runWithEfSearch<T>(
+  db: ReturnType<typeof getPrismaClient>,
+  run: (tx: Prisma.TransactionClient) => Promise<T>
+): Promise<T> {
+  return db.$transaction(async (tx) => {
+    await tx.$executeRawUnsafe(`SET LOCAL hnsw.ef_search = ${v3Config.poolMatchEfSearch}`);
+    return run(tx);
+  });
+}
+
+/**
  * Pull the top `perCell` videos per cell from video_pool whose cosine
  * similarity to the corresponding sub_goal embedding meets `threshold`.
  *
@@ -92,7 +110,67 @@ export async function matchFromVideoPool(opts: MatchFromVideoPoolOpts): Promise<
   // prod: pre-CP458 the planner hash-joined (mandala × Seq Scan ALL 11,123
   // embeddings) → 89k cosine ops → 65-100s. With the eligible CTE first +
   // sources=['v2_promoted'] (1,156 ko rows): ~9k cosine → ~2.9s.
-  const rows = await db.$queryRaw<MatchRow[]>(Prisma.sql`
+  //
+  // P2 (2026-07-11): #1107 admitted yt_promoted (7,083 rows) → eligible ~6.3k
+  // × 8 cells = 50,840 brute-force 4096d cosines → 22.8s cold / 4.9s warm.
+  // V3_POOL_MATCH_TWO_STAGE routes through an hnsw shortlist on the MRL
+  // GENERATED column embedding_1024 (stage 1), then exact 4096d re-rank of
+  // only K×cells pairs (stage 2). Measured recall on prod: true top-8/cell
+  // fully inside the 1024d top-32 shortlist (64/64) — exact at default K=32.
+  const rows = v3Config.poolMatchTwoStage
+    ? await runWithEfSearch(db, (tx) =>
+        tx.$queryRaw<MatchRow[]>(Prisma.sql`
+    WITH mandala_embs AS (
+      SELECT sub_goal_index AS cell_index,
+             embedding,
+             l2_normalize(subvector(embedding, 1, 1024)) AS emb1024
+        FROM public.mandala_embeddings
+       WHERE mandala_id = ${opts.mandalaId}
+         AND level = 1
+         AND embedding IS NOT NULL
+    ),
+    shortlist AS (
+      SELECT me.cell_index, me.embedding AS m_emb, c.video_id, c.emb_full
+      FROM mandala_embs me
+      CROSS JOIN LATERAL (
+        -- pure index top-N first (guaranteed hnsw scan), THEN filter to the
+        -- eligible pool subset and keep K. Overfetch absorbs the ineligible
+        -- fraction; both knobs are env-tunable.
+        SELECT cand.video_id, cand.emb_full
+        FROM (
+          SELECT vpe.video_id, vpe.embedding AS emb_full
+          FROM public.video_pool_embeddings vpe
+          ORDER BY vpe.embedding_1024 <=> me.emb1024
+          LIMIT ${v3Config.poolMatchOverfetch}
+        ) cand
+        JOIN public.video_pool p ON p.video_id = cand.video_id
+        WHERE p.is_active = true
+          AND p.language = ${opts.language}
+          AND p.quality_tier IN ('gold', 'silver')
+          AND p.source = ANY(${sources}::text[])
+        LIMIT ${v3Config.poolMatchShortlistK}
+      ) c
+    ),
+    scored AS (
+      SELECT
+        p.video_id, p.title, p.description, p.channel_name, p.channel_id,
+        p.thumbnail_url, p.view_count, p.like_count, p.duration_seconds, p.published_at,
+        s.cell_index,
+        1 - (s.emb_full <=> s.m_emb) AS score
+      FROM shortlist s
+      JOIN public.video_pool p ON p.video_id = s.video_id
+    ),
+    ranked AS (
+      SELECT s.*,
+        ROW_NUMBER() OVER (PARTITION BY s.cell_index ORDER BY s.score DESC) AS rn
+      FROM scored s
+      WHERE s.score >= ${threshold}
+    )
+    SELECT * FROM ranked WHERE rn <= ${perCell}
+    ORDER BY cell_index ASC, score DESC
+  `)
+      )
+    : await db.$queryRaw<MatchRow[]>(Prisma.sql`
     WITH eligible AS (
       SELECT
         video_id, title, description, channel_name, channel_id,
@@ -157,6 +235,7 @@ export async function matchFromVideoPool(opts: MatchFromVideoPoolOpts): Promise<
       sources,
       threshold,
       perCell,
+      two_stage: v3Config.poolMatchTwoStage,
     },
     response: {
       row_count: rows.length,
@@ -266,7 +345,40 @@ export async function matchFromVideoPoolByCenterGoal(
   // planner choose the embedding index when beneficial. The eligible
   // CTE is still materialised first so only the gold|silver|active
   // subset enters the cosine path.
-  const rows = await db.$queryRaw<CenterMatchRow[]>(Prisma.sql`
+  //
+  // P2 (2026-07-11): flag-gated two-stage variant — hnsw shortlist on the MRL
+  // GENERATED column embedding_1024, exact 4096d re-rank of the shortlist.
+  // Single query vector here, so cost is 1/8th of matchFromVideoPool, but the
+  // same brute-force scan shape — kept consistent per the no-partial-patch rule.
+  const rows = v3Config.poolMatchTwoStage
+    ? await runWithEfSearch(db, (tx) =>
+        tx.$queryRaw<CenterMatchRow[]>(Prisma.sql`
+    WITH shortlist AS (
+      SELECT cand.video_id, cand.emb_full
+      FROM (
+        SELECT vpe.video_id, vpe.embedding AS emb_full
+        FROM public.video_pool_embeddings vpe
+        ORDER BY vpe.embedding_1024 <=> l2_normalize(subvector(${vectorLiteral}::vector, 1, 1024))
+        LIMIT ${v3Config.poolMatchOverfetch}
+      ) cand
+      JOIN public.video_pool p ON p.video_id = cand.video_id
+      WHERE p.is_active = true
+        AND p.language = ${opts.language}
+        AND p.quality_tier IN ('gold', 'silver')
+        AND p.source = ANY(${sources}::text[])
+      LIMIT ${limit}
+    )
+    SELECT
+      p.video_id, p.title, p.description, p.channel_name, p.channel_id,
+      p.thumbnail_url, p.view_count, p.like_count, p.duration_seconds, p.published_at,
+      1 - (s.emb_full <=> ${vectorLiteral}::vector) AS score
+    FROM shortlist s
+    JOIN public.video_pool p ON p.video_id = s.video_id
+    ORDER BY s.emb_full <=> ${vectorLiteral}::vector ASC
+    LIMIT ${limit}
+  `)
+      )
+    : await db.$queryRaw<CenterMatchRow[]>(Prisma.sql`
     WITH eligible AS (
       SELECT
         video_id, title, description, channel_name, channel_id,
@@ -343,6 +455,7 @@ export async function matchFromVideoPoolByCenterGoal(
       limit,
       centerEmbedding_dim: opts.centerEmbedding.length,
       subGoals_count: opts.subGoals.length,
+      two_stage: v3Config.poolMatchTwoStage,
     },
     response: {
       row_count: matches.length,

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -135,6 +135,38 @@ export const DEFAULT_MIN_VIEW_COUNT = 1000;
 export const DEFAULT_MIN_VIEWS_PER_DAY = 10;
 
 /**
+ * Two-stage pool matching (P2 fix, 2026-07-11).
+ *
+ * matchFromVideoPool brute-forces eligible(~6.3k) × 8 cells = 50,840 cosine
+ * ops on vector(4096) per wizard call — EXPLAIN-measured 22.8s cold / 4.9s
+ * warm, sitting on the wizard's synchronous precompute-consume path. pgvector
+ * hnsw/ivfflat cap at 2,000 dims, so the 4096d column cannot be indexed.
+ *
+ * Fix: qwen3-embedding is MRL, so the stored 4096d vectors truncate+renorm to
+ * 1024d without re-embedding (GENERATED column `embedding_1024` + hnsw index,
+ * DDL prisma/migrations/pool-embeddings-1024/). Stage 1 = hnsw shortlist on
+ * 1024d (OVERFETCH raw ordered rows per cell, filtered to eligibility, keep
+ * SHORTLIST_K); stage 2 = exact 4096d re-rank of K×cells pairs.
+ *
+ * Measured on prod (mandala 9c50861b, 2026-07-11): true 4096d top-8/cell is
+ * FULLY contained in the 1024d top-32 shortlist (recall 64/64) — two-stage is
+ * exact at K=32. view_count pre-capping was tested and REJECTED (overlap
+ * 7/64 = 11%; non-semantic pre-filters destroy semantic top-k).
+ *
+ * Default OFF (unset = brute-force path unchanged). Enable via compose
+ * V3_POOL_MATCH_TWO_STAGE=true; rollback = remove the line, no code revert.
+ */
+export const DEFAULT_POOL_MATCH_TWO_STAGE = false;
+export const DEFAULT_POOL_MATCH_SHORTLIST_K = 32;
+export const DEFAULT_POOL_MATCH_OVERFETCH = 256;
+/**
+ * hnsw.ef_search for the shortlist scan. MUST exceed OVERFETCH or the index
+ * silently returns fewer rows than LIMIT asks (pgvector default 40 → measured
+ * recall collapse 51/64). Prod-measured at 400: recall 64/64, warm 105ms.
+ */
+export const DEFAULT_POOL_MATCH_EF_SEARCH = 400;
+
+/**
  * Semantic-mode embedding candidate cap (Issue #543, CP436 PR-Y0b2).
  *
  * When `V3_CENTER_GATE_MODE=semantic`, the executor calls
@@ -285,6 +317,27 @@ const semanticMaxCandidates = z
   )
   .transform((v) => v ?? DEFAULT_SEMANTIC_MAX_CANDIDATES);
 
+const poolMatchShortlistK = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().int().min(8).max(200).optional()
+  )
+  .transform((v) => v ?? DEFAULT_POOL_MATCH_SHORTLIST_K);
+
+const poolMatchOverfetch = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().int().min(32).max(2000).optional()
+  )
+  .transform((v) => v ?? DEFAULT_POOL_MATCH_OVERFETCH);
+
+const poolMatchEfSearch = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().int().min(40).max(1000).optional()
+  )
+  .transform((v) => v ?? DEFAULT_POOL_MATCH_EF_SEARCH);
+
 /**
  * R4 shadow guard kill switch (2026-07-04, BL-17).
  *
@@ -346,6 +399,10 @@ export const v3EnvSchema = z.object({
   V3_ENABLE_USER_CURATED_INGEST: booleanFlag.optional().default(true as unknown as string),
   V3_EMPTY_TITLE_GATE_SHADOW: booleanFlag.optional().default(false as unknown as string),
   V3_EMPTY_TITLE_GATE: booleanFlag.optional().default(false as unknown as string),
+  V3_POOL_MATCH_TWO_STAGE: booleanFlag.optional().default(false as unknown as string),
+  V3_POOL_MATCH_SHORTLIST_K: poolMatchShortlistK,
+  V3_POOL_MATCH_OVERFETCH: poolMatchOverfetch,
+  V3_POOL_MATCH_EF_SEARCH: poolMatchEfSearch,
 });
 
 export interface V3Config {
@@ -408,6 +465,11 @@ export interface V3Config {
    * switch from `emptyTitleGateShadow` above.
    */
   emptyTitleGate: boolean;
+  /** Two-stage pool matching — see DEFAULT_POOL_MATCH_TWO_STAGE writeup. */
+  poolMatchTwoStage: boolean;
+  poolMatchShortlistK: number;
+  poolMatchOverfetch: number;
+  poolMatchEfSearch: number;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -437,6 +499,10 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_ENABLE_USER_CURATED_INGEST: env['V3_ENABLE_USER_CURATED_INGEST'],
     V3_EMPTY_TITLE_GATE_SHADOW: env['V3_EMPTY_TITLE_GATE_SHADOW'],
     V3_EMPTY_TITLE_GATE: env['V3_EMPTY_TITLE_GATE'],
+    V3_POOL_MATCH_TWO_STAGE: env['V3_POOL_MATCH_TWO_STAGE'],
+    V3_POOL_MATCH_SHORTLIST_K: env['V3_POOL_MATCH_SHORTLIST_K'],
+    V3_POOL_MATCH_OVERFETCH: env['V3_POOL_MATCH_OVERFETCH'],
+    V3_POOL_MATCH_EF_SEARCH: env['V3_POOL_MATCH_EF_SEARCH'],
   });
   if (!parsed.success) {
     return {
@@ -465,6 +531,10 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       enableUserCuratedIngest: true,
       emptyTitleGateShadow: DEFAULT_EMPTY_TITLE_GATE_SHADOW,
       emptyTitleGate: DEFAULT_EMPTY_TITLE_GATE,
+      poolMatchTwoStage: DEFAULT_POOL_MATCH_TWO_STAGE,
+      poolMatchShortlistK: DEFAULT_POOL_MATCH_SHORTLIST_K,
+      poolMatchOverfetch: DEFAULT_POOL_MATCH_OVERFETCH,
+      poolMatchEfSearch: DEFAULT_POOL_MATCH_EF_SEARCH,
     };
   }
   return {
@@ -493,6 +563,10 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     enableUserCuratedIngest: parsed.data.V3_ENABLE_USER_CURATED_INGEST,
     emptyTitleGateShadow: parsed.data.V3_EMPTY_TITLE_GATE_SHADOW,
     emptyTitleGate: parsed.data.V3_EMPTY_TITLE_GATE,
+    poolMatchTwoStage: parsed.data.V3_POOL_MATCH_TWO_STAGE,
+    poolMatchShortlistK: parsed.data.V3_POOL_MATCH_SHORTLIST_K,
+    poolMatchOverfetch: parsed.data.V3_POOL_MATCH_OVERFETCH,
+    poolMatchEfSearch: parsed.data.V3_POOL_MATCH_EF_SEARCH,
   };
 }
 


### PR DESCRIPTION
## Problem
`matchFromVideoPool` brute-forces eligible(~6.3k) × 8 cells = **50,840 cosine ops on vector(4096)** per wizard call — EXPLAIN-measured **22.8s cold / 4.9s warm**, on the wizard's synchronous path (the "느려졌어" of the 2026-07-11 diagnosis). #1107 grew the candidate set 8×. pgvector caps hnsw/ivfflat at 2,000 dims → the 4096d column can't be indexed.

## Fix (flag-gated, default OFF = brute path byte-identical)
1. **MRL 1024d GENERATED column + hnsw** — qwen3-embedding is Matryoshka: existing 4096d vectors truncate+renormalize in-DB, zero re-embedding, all 4 writer paths untouched. DDL **pre-applied to local + prod** (`prisma/migrations/pool-embeddings-1024/`), incl. dropping a legacy 4096d ivfflat that physically could never serve queries (and hard-failed table rewrites).
2. **Stage 1**: hnsw shortlist (overfetch 256 → filter to eligible → K=32/cell) with `SET LOCAL hnsw.ef_search=400` — the default 40 silently caps the scan (measured recall collapse 51/64).
3. **Stage 2**: exact 4096d re-rank of K×cells pairs only (256 vs 50,840).

## Measurements (prod, mandala 9c50861b)
| variant | warm | recall vs brute top-8/cell |
|---|---|---|
| brute force (current) | 1,428ms (4.9s logged, 22.8s cold) | — |
| view_count pre-cap 2k | 431ms | **7/64 — REJECTED** |
| two-stage, ef_search 40 (default) | 33ms | 51/64 — insufficient |
| **two-stage, ef_search 400 (shipped)** | **105ms** | **64/64 — exact** |

## Verification
- `tsc --noEmit` 0 · v3 config suite 26/26 (incl. 2 new knob tests)
- `prisma db push` diff vs local: new column untouched (no drift/drop; schema lists it as `Unsupported("vector(1024)")?`)
- Pre-existing failures (`trace-candidates`, `pipeline-runner`, `auto-add-recommendations`, `queue-handlers`) reproduce identically on clean main — out of scope.

## Rollback
Delete `V3_POOL_MATCH_TWO_STAGE=true` from compose → brute-force path, no code revert. Knobs: `V3_POOL_MATCH_SHORTLIST_K/OVERFETCH/EF_SEARCH`.

Diagnosis SSOT: `memory/project_wizard_17cards_diagnosis_2026-07-11.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)