### PR TITLE
fix(migrations): neutralize legacy 4096d ivfflat files — unblock deploy replay

### DIFF
--- a/prisma/migrations/mandala_embeddings/001_add_ivfflat_index.sql
+++ b/prisma/migrations/mandala_embeddings/001_add_ivfflat_index.sql
@@ -1,11 +1,10 @@
--- IVFFlat cosine index for mandala_embeddings (4096d).
--- Row count 19,369 (2026-05-14, prod) — schema.prisma "after rows accumulate" threshold reached.
--- lists = ceil(N/1000) = 20 per pgvector docs (N < 1M).
--- Used by src/modules/mandala/search.ts:278-305 (Explore template search).
--- CONCURRENTLY to avoid blocking inserts during build (5-10 min @ 19K rows x 4096d).
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mandala_emb_cosine
-  ON public.mandala_embeddings
-  USING ivfflat (embedding vector_cosine_ops)
-  WITH (lists = 20);
-
-ANALYZE public.mandala_embeddings;
+-- NEUTRALIZED 2026-07-11 (was: CREATE ivfflat on the 4096d embedding column).
+--
+-- Same landmine class as video_pool/002_add_ivfflat_index.sql (see the full
+-- writeup there): a 4096d ivfflat predating pgvector's 2,000-dim cap.
+-- Prod evidence 2026-07-11: idx_scan = 0 AND relation size = 0 bytes — the
+-- CONCURRENTLY build had failed, leaving an INVALID zero-byte corpse that
+-- never served src/modules/mandala/search.ts. Dropping it changes no query
+-- plan; keeping the CREATE here would fail every deploy the moment the
+-- index is absent (exactly what video_pool/002 did on 2026-07-11T05:27Z).
+DROP INDEX IF EXISTS public.idx_mandala_emb_cosine;

--- a/prisma/migrations/video_pool/002_add_ivfflat_index.sql
+++ b/prisma/migrations/video_pool/002_add_ivfflat_index.sql
@@ -1,12 +1,18 @@
--- IVFFlat cosine index for video_pool_embeddings (4096d, qwen3-embedding-8b).
--- Row count 11,123 (2026-05-14, prod) — exceeds 5K threshold in 001_create_tables.sql:49.
--- lists = ceil(N/1000) = 12 per pgvector docs (N < 1M).
--- Used by src/skills/plugins/video-discover/v3/cache-matcher.ts matchFromVideoPool +
--- matchFromVideoPoolByCenterGoal (CP457 carryover T1-2).
--- CONCURRENTLY to avoid blocking inserts during build (5-10 min @ 11K rows x 4096d).
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_vpool_emb_cosine
-  ON public.video_pool_embeddings
-  USING ivfflat (embedding vector_cosine_ops)
-  WITH (lists = 12);
-
-ANALYZE public.video_pool_embeddings;
+-- NEUTRALIZED 2026-07-11 (was: CREATE ivfflat on the 4096d embedding column).
+--
+-- The original index (idx_vpool_emb_cosine) was created under an older
+-- pgvector before the 2,000-dim index cap. It physically could not serve
+-- 4096d queries — the planner always avoided it (CP467-family mystery) —
+-- and it hard-failed any table rewrite. It was dropped on prod 2026-07-11
+-- as part of the two-stage pool-matching fix (P2, PR #1156):
+-- prisma/migrations/pool-embeddings-1024/001_add_1024_generated_hnsw.sql
+-- provides the replacement (MRL 1024d GENERATED column + hnsw).
+--
+-- Deploy replay landmine (why this file cannot keep its old content): the
+-- Database Schema Sync step re-applies every migration file. While the dead
+-- index existed, CREATE INDEX IF NOT EXISTS no-op'd; the moment it was
+-- dropped, the replay actually executed and pgvector 0.8 rejected it
+-- ("column cannot have more than 2000 dimensions for ivfflat index"),
+-- failing the whole deploy (run 2026-07-11T05:27Z). This DROP converges all
+-- environments to the dead-index-free state and stays idempotent.
+DROP INDEX IF EXISTS public.idx_vpool_emb_cosine;


### PR DESCRIPTION
## Problem
Deploy run 2026-07-11T05:27Z failed at **Database Schema Sync** (Deploy to EC2 skipped): the migration replay hit `video_pool/002_add_ivfflat_index.sql`, which CREATEs a 4096d ivfflat — impossible under pgvector ≥0.5 (2,000-dim cap). It had been a silent `IF NOT EXISTS` no-op for months only because the dead index still existed; #1156 dropped that corpse (it hard-failed table rewrites), arming the landmine.

## Fix
Replace both legacy 4096d ivfflat migration files with documented, idempotent `DROP INDEX IF EXISTS`:
- `video_pool/002` — index already dropped on prod (planner never used it, CP467-family).
- `mandala_embeddings/001` — same class; prod evidence `idx_scan=0`, **size 0 bytes** (INVALID corpse from a failed CONCURRENTLY build — never served a query). One drop away from the identical deploy failure.

Replacement serving path is already live: `pool-embeddings-1024/001` (MRL 1024d GENERATED + hnsw; prod `idx_scan=48`, 307MB).

## Effect
- Unblocks the deploy pipeline (this merge also finally ships #1156's code + `V3_POOL_MATCH_TWO_STAGE=true`).
- No query-plan change anywhere (both indexes were unusable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)