### PR TITLE
fix(pool-match): tx timeout knob + brute-force fallback — kill the 0-card failure mode

### DIFF
--- a/src/modules/search/algorithm-resolver.ts
+++ b/src/modules/search/algorithm-resolver.ts
@@ -144,6 +144,7 @@ function materialize(id: string, parametersJson: unknown): ResolvedAlgorithm {
     V3_POOL_MATCH_SHORTLIST_K: asStr(j['poolMatchShortlistK']),
     V3_POOL_MATCH_OVERFETCH: asStr(j['poolMatchOverfetch']),
     V3_POOL_MATCH_EF_SEARCH: asStr(j['poolMatchEfSearch']),
+    V3_POOL_MATCH_TX_TIMEOUT_MS: asStr(j['poolMatchTxTimeoutMs']),
   };
 
   const parsed = v3EnvSchema.safeParse(envLike);
@@ -184,6 +185,7 @@ function materialize(id: string, parametersJson: unknown): ResolvedAlgorithm {
     poolMatchShortlistK: d['V3_POOL_MATCH_SHORTLIST_K'] as number,
     poolMatchOverfetch: d['V3_POOL_MATCH_OVERFETCH'] as number,
     poolMatchEfSearch: d['V3_POOL_MATCH_EF_SEARCH'] as number,
+    poolMatchTxTimeoutMs: d['V3_POOL_MATCH_TX_TIMEOUT_MS'] as number,
   };
 
   return { id, parameters: cfg };

--- a/src/skills/plugins/video-discover/v3/__tests__/cache-matcher-fallback.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/cache-matcher-fallback.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression: two-stage pool matching must degrade to the brute-force path
+ * instead of throwing — a cold-cache run blew Prisma's 5s default transaction
+ * timeout and zeroed out step2 (0-card mandala, 2026-07-11 08:08Z).
+ */
+
+jest.mock('@/modules/database', () => ({ getPrismaClient: jest.fn() }));
+jest.mock('@/modules/discover-tracing', () => ({ recordTrace: jest.fn() }));
+jest.mock('../config', () => ({
+  v3Config: {
+    poolMatchTwoStage: true,
+    poolMatchShortlistK: 32,
+    poolMatchOverfetch: 256,
+    poolMatchEfSearch: 400,
+    poolMatchTxTimeoutMs: 30000,
+  },
+}));
+
+import { getPrismaClient } from '@/modules/database';
+import { recordTrace } from '@/modules/discover-tracing';
+import { matchFromVideoPool, matchFromVideoPoolByCenterGoal } from '../cache-matcher';
+
+const mockGetPrismaClient = getPrismaClient as jest.Mock;
+const mockRecordTrace = recordTrace as jest.Mock;
+
+function poolRow(overrides: Record<string, unknown> = {}) {
+  return {
+    video_id: 'vid-1',
+    title: 'brute row',
+    description: null,
+    channel_name: null,
+    channel_id: null,
+    thumbnail_url: null,
+    view_count: null,
+    like_count: null,
+    duration_seconds: null,
+    published_at: null,
+    cell_index: 0,
+    score: 0.9,
+    rn: 1n,
+    ...overrides,
+  };
+}
+
+describe('two-stage pool match fallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('matchFromVideoPool: tx failure falls back to brute query instead of throwing', async () => {
+    const db = {
+      $transaction: jest
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            'Transaction already closed: A query cannot be executed on an expired transaction.'
+          )
+        ),
+      $queryRaw: jest.fn().mockResolvedValue([poolRow()]),
+    };
+    mockGetPrismaClient.mockReturnValue(db);
+
+    const out = await matchFromVideoPool({ mandalaId: 'm-1', language: 'ko' });
+
+    expect(out).toHaveLength(1);
+    expect(out[0]!.videoId).toBe('vid-1');
+    expect(db.$queryRaw).toHaveBeenCalledTimes(1); // brute path ran
+    const trace = mockRecordTrace.mock.calls[0]![0];
+    expect(trace.request.two_stage_fallback).toBe(true);
+  });
+
+  test('matchFromVideoPool: two-stage success does not touch the brute query', async () => {
+    const db = {
+      $transaction: jest.fn().mockResolvedValue([poolRow({ title: 'two-stage row' })]),
+      $queryRaw: jest.fn(),
+    };
+    mockGetPrismaClient.mockReturnValue(db);
+
+    const out = await matchFromVideoPool({ mandalaId: 'm-1', language: 'ko' });
+
+    expect(out[0]!.title).toBe('two-stage row');
+    expect(db.$queryRaw).not.toHaveBeenCalled();
+    // the tx timeout knob must reach Prisma — default 5s is what broke prod
+    expect(db.$transaction).toHaveBeenCalledWith(expect.any(Function), { timeout: 30000 });
+    const trace = mockRecordTrace.mock.calls[0]![0];
+    expect(trace.request.two_stage_fallback).toBe(false);
+  });
+
+  test('matchFromVideoPoolByCenterGoal: tx failure falls back to brute query', async () => {
+    const db = {
+      $transaction: jest.fn().mockRejectedValue(new Error('boom')),
+      $queryRaw: jest.fn().mockResolvedValue([poolRow({ cell_index: undefined, rn: undefined })]),
+    };
+    mockGetPrismaClient.mockReturnValue(db);
+
+    const out = await matchFromVideoPoolByCenterGoal({
+      centerEmbedding: [0.1, 0.2],
+      language: 'ko',
+      subGoals: ['a', 'b'],
+    });
+
+    expect(out).toHaveLength(1);
+    expect(db.$queryRaw).toHaveBeenCalledTimes(1);
+    const trace = mockRecordTrace.mock.calls[0]![0];
+    expect(trace.request.two_stage_fallback).toBe(true);
+  });
+});

--- a/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
+++ b/src/skills/plugins/video-discover/v3/__tests__/config.test.ts
@@ -50,6 +50,7 @@ describe('loadV3Config', () => {
       poolMatchShortlistK: 32,
       poolMatchOverfetch: 256,
       poolMatchEfSearch: 400,
+      poolMatchTxTimeoutMs: 30000,
     });
   });
 
@@ -135,6 +136,7 @@ describe('loadV3Config', () => {
       poolMatchShortlistK: 32,
       poolMatchOverfetch: 256,
       poolMatchEfSearch: 400,
+      poolMatchTxTimeoutMs: 30000,
     });
   });
 
@@ -323,12 +325,13 @@ describe('loadV3Config', () => {
 });
 
 describe('V3_POOL_MATCH_* (P2 two-stage pool matching, 2026-07-11)', () => {
-  test('defaults: OFF + K=32 / overfetch=256 / ef_search=400', () => {
+  test('defaults: OFF + K=32 / overfetch=256 / ef_search=400 / txTimeout=30000', () => {
     const c = loadV3Config({});
     expect(c.poolMatchTwoStage).toBe(false);
     expect(c.poolMatchShortlistK).toBe(32);
     expect(c.poolMatchOverfetch).toBe(256);
     expect(c.poolMatchEfSearch).toBe(400);
+    expect(c.poolMatchTxTimeoutMs).toBe(30000);
   });
 
   test('env overrides parse', () => {
@@ -337,10 +340,12 @@ describe('V3_POOL_MATCH_* (P2 two-stage pool matching, 2026-07-11)', () => {
       V3_POOL_MATCH_SHORTLIST_K: '48',
       V3_POOL_MATCH_OVERFETCH: '512',
       V3_POOL_MATCH_EF_SEARCH: '600',
+      V3_POOL_MATCH_TX_TIMEOUT_MS: '60000',
     });
     expect(c.poolMatchTwoStage).toBe(true);
     expect(c.poolMatchShortlistK).toBe(48);
     expect(c.poolMatchOverfetch).toBe(512);
     expect(c.poolMatchEfSearch).toBe(600);
+    expect(c.poolMatchTxTimeoutMs).toBe(60000);
   });
 });

--- a/src/skills/plugins/video-discover/v3/cache-matcher.ts
+++ b/src/skills/plugins/video-discover/v3/cache-matcher.ts
@@ -82,10 +82,35 @@ function runWithEfSearch<T>(
   db: ReturnType<typeof getPrismaClient>,
   run: (tx: Prisma.TransactionClient) => Promise<T>
 ): Promise<T> {
-  return db.$transaction(async (tx) => {
-    await tx.$executeRawUnsafe(`SET LOCAL hnsw.ef_search = ${v3Config.poolMatchEfSearch}`);
-    return run(tx);
-  });
+  return db.$transaction(
+    async (tx) => {
+      await tx.$executeRawUnsafe(`SET LOCAL hnsw.ef_search = ${v3Config.poolMatchEfSearch}`);
+      return run(tx);
+    },
+    // Prisma's 5s default expired on cold-cache runs (15.6s measured,
+    // 2026-07-11) and zeroed out step2 — see DEFAULT_POOL_MATCH_TX_TIMEOUT_MS.
+    { timeout: v3Config.poolMatchTxTimeoutMs }
+  );
+}
+
+/**
+ * Two-stage must never be able to fail a discover step the brute path would
+ * have survived (0-card incident 2026-07-11): any two-stage error logs and
+ * degrades to the pre-two-stage brute query.
+ */
+async function twoStageWithFallback<T>(
+  label: string,
+  twoStage: () => Promise<T>,
+  brute: () => Promise<T>
+): Promise<{ rows: T; fellBack: boolean }> {
+  try {
+    return { rows: await twoStage(), fellBack: false };
+  } catch (err) {
+    log.warn(
+      `two-stage ${label} failed — falling back to brute-force: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return { rows: await brute(), fellBack: true };
+  }
 }
 
 /**
@@ -117,60 +142,8 @@ export async function matchFromVideoPool(opts: MatchFromVideoPoolOpts): Promise<
   // GENERATED column embedding_1024 (stage 1), then exact 4096d re-rank of
   // only K×cells pairs (stage 2). Measured recall on prod: true top-8/cell
   // fully inside the 1024d top-32 shortlist (64/64) — exact at default K=32.
-  const rows = v3Config.poolMatchTwoStage
-    ? await runWithEfSearch(db, (tx) =>
-        tx.$queryRaw<MatchRow[]>(Prisma.sql`
-    WITH mandala_embs AS (
-      SELECT sub_goal_index AS cell_index,
-             embedding,
-             l2_normalize(subvector(embedding, 1, 1024)) AS emb1024
-        FROM public.mandala_embeddings
-       WHERE mandala_id = ${opts.mandalaId}
-         AND level = 1
-         AND embedding IS NOT NULL
-    ),
-    shortlist AS (
-      SELECT me.cell_index, me.embedding AS m_emb, c.video_id, c.emb_full
-      FROM mandala_embs me
-      CROSS JOIN LATERAL (
-        -- pure index top-N first (guaranteed hnsw scan), THEN filter to the
-        -- eligible pool subset and keep K. Overfetch absorbs the ineligible
-        -- fraction; both knobs are env-tunable.
-        SELECT cand.video_id, cand.emb_full
-        FROM (
-          SELECT vpe.video_id, vpe.embedding AS emb_full
-          FROM public.video_pool_embeddings vpe
-          ORDER BY vpe.embedding_1024 <=> me.emb1024
-          LIMIT ${v3Config.poolMatchOverfetch}
-        ) cand
-        JOIN public.video_pool p ON p.video_id = cand.video_id
-        WHERE p.is_active = true
-          AND p.language = ${opts.language}
-          AND p.quality_tier IN ('gold', 'silver')
-          AND p.source = ANY(${sources}::text[])
-        LIMIT ${v3Config.poolMatchShortlistK}
-      ) c
-    ),
-    scored AS (
-      SELECT
-        p.video_id, p.title, p.description, p.channel_name, p.channel_id,
-        p.thumbnail_url, p.view_count, p.like_count, p.duration_seconds, p.published_at,
-        s.cell_index,
-        1 - (s.emb_full <=> s.m_emb) AS score
-      FROM shortlist s
-      JOIN public.video_pool p ON p.video_id = s.video_id
-    ),
-    ranked AS (
-      SELECT s.*,
-        ROW_NUMBER() OVER (PARTITION BY s.cell_index ORDER BY s.score DESC) AS rn
-      FROM scored s
-      WHERE s.score >= ${threshold}
-    )
-    SELECT * FROM ranked WHERE rn <= ${perCell}
-    ORDER BY cell_index ASC, score DESC
-  `)
-      )
-    : await db.$queryRaw<MatchRow[]>(Prisma.sql`
+  const bruteQuery = () =>
+    db.$queryRaw<MatchRow[]>(Prisma.sql`
     WITH eligible AS (
       SELECT
         video_id, title, description, channel_name, channel_id,
@@ -221,6 +194,64 @@ export async function matchFromVideoPool(opts: MatchFromVideoPoolOpts): Promise<
     ORDER BY cell_index ASC, score DESC
   `);
 
+  const twoStageQuery = () =>
+    runWithEfSearch(db, (tx) =>
+      tx.$queryRaw<MatchRow[]>(Prisma.sql`
+    WITH mandala_embs AS (
+      SELECT sub_goal_index AS cell_index,
+             embedding,
+             l2_normalize(subvector(embedding, 1, 1024)) AS emb1024
+        FROM public.mandala_embeddings
+       WHERE mandala_id = ${opts.mandalaId}
+         AND level = 1
+         AND embedding IS NOT NULL
+    ),
+    shortlist AS (
+      SELECT me.cell_index, me.embedding AS m_emb, c.video_id, c.emb_full
+      FROM mandala_embs me
+      CROSS JOIN LATERAL (
+        -- pure index top-N first (guaranteed hnsw scan), THEN filter to the
+        -- eligible pool subset and keep K. Overfetch absorbs the ineligible
+        -- fraction; both knobs are env-tunable.
+        SELECT cand.video_id, cand.emb_full
+        FROM (
+          SELECT vpe.video_id, vpe.embedding AS emb_full
+          FROM public.video_pool_embeddings vpe
+          ORDER BY vpe.embedding_1024 <=> me.emb1024
+          LIMIT ${v3Config.poolMatchOverfetch}
+        ) cand
+        JOIN public.video_pool p ON p.video_id = cand.video_id
+        WHERE p.is_active = true
+          AND p.language = ${opts.language}
+          AND p.quality_tier IN ('gold', 'silver')
+          AND p.source = ANY(${sources}::text[])
+        LIMIT ${v3Config.poolMatchShortlistK}
+      ) c
+    ),
+    scored AS (
+      SELECT
+        p.video_id, p.title, p.description, p.channel_name, p.channel_id,
+        p.thumbnail_url, p.view_count, p.like_count, p.duration_seconds, p.published_at,
+        s.cell_index,
+        1 - (s.emb_full <=> s.m_emb) AS score
+      FROM shortlist s
+      JOIN public.video_pool p ON p.video_id = s.video_id
+    ),
+    ranked AS (
+      SELECT s.*,
+        ROW_NUMBER() OVER (PARTITION BY s.cell_index ORDER BY s.score DESC) AS rn
+      FROM scored s
+      WHERE s.score >= ${threshold}
+    )
+    SELECT * FROM ranked WHERE rn <= ${perCell}
+    ORDER BY cell_index ASC, score DESC
+  `)
+    );
+
+  const { rows, fellBack: twoStageFellBack } = v3Config.poolMatchTwoStage
+    ? await twoStageWithFallback('match_from_video_pool', twoStageQuery, bruteQuery)
+    : { rows: await bruteQuery(), fellBack: false };
+
   log.info(
     `cache match: mandala=${opts.mandalaId} lang=${opts.language} matches=${rows.length} threshold=${threshold}`
   );
@@ -236,6 +267,7 @@ export async function matchFromVideoPool(opts: MatchFromVideoPoolOpts): Promise<
       threshold,
       perCell,
       two_stage: v3Config.poolMatchTwoStage,
+      two_stage_fallback: twoStageFellBack,
     },
     response: {
       row_count: rows.length,
@@ -350,35 +382,8 @@ export async function matchFromVideoPoolByCenterGoal(
   // GENERATED column embedding_1024, exact 4096d re-rank of the shortlist.
   // Single query vector here, so cost is 1/8th of matchFromVideoPool, but the
   // same brute-force scan shape — kept consistent per the no-partial-patch rule.
-  const rows = v3Config.poolMatchTwoStage
-    ? await runWithEfSearch(db, (tx) =>
-        tx.$queryRaw<CenterMatchRow[]>(Prisma.sql`
-    WITH shortlist AS (
-      SELECT cand.video_id, cand.emb_full
-      FROM (
-        SELECT vpe.video_id, vpe.embedding AS emb_full
-        FROM public.video_pool_embeddings vpe
-        ORDER BY vpe.embedding_1024 <=> l2_normalize(subvector(${vectorLiteral}::vector, 1, 1024))
-        LIMIT ${v3Config.poolMatchOverfetch}
-      ) cand
-      JOIN public.video_pool p ON p.video_id = cand.video_id
-      WHERE p.is_active = true
-        AND p.language = ${opts.language}
-        AND p.quality_tier IN ('gold', 'silver')
-        AND p.source = ANY(${sources}::text[])
-      LIMIT ${limit}
-    )
-    SELECT
-      p.video_id, p.title, p.description, p.channel_name, p.channel_id,
-      p.thumbnail_url, p.view_count, p.like_count, p.duration_seconds, p.published_at,
-      1 - (s.emb_full <=> ${vectorLiteral}::vector) AS score
-    FROM shortlist s
-    JOIN public.video_pool p ON p.video_id = s.video_id
-    ORDER BY s.emb_full <=> ${vectorLiteral}::vector ASC
-    LIMIT ${limit}
-  `)
-      )
-    : await db.$queryRaw<CenterMatchRow[]>(Prisma.sql`
+  const bruteQuery = () =>
+    db.$queryRaw<CenterMatchRow[]>(Prisma.sql`
     WITH eligible AS (
       SELECT
         video_id, title, description, channel_name, channel_id,
@@ -407,6 +412,39 @@ export async function matchFromVideoPoolByCenterGoal(
     ORDER BY vpe.embedding <=> ${vectorLiteral}::vector ASC
     LIMIT ${limit}
   `);
+
+  const twoStageQuery = () =>
+    runWithEfSearch(db, (tx) =>
+      tx.$queryRaw<CenterMatchRow[]>(Prisma.sql`
+    WITH shortlist AS (
+      SELECT cand.video_id, cand.emb_full
+      FROM (
+        SELECT vpe.video_id, vpe.embedding AS emb_full
+        FROM public.video_pool_embeddings vpe
+        ORDER BY vpe.embedding_1024 <=> l2_normalize(subvector(${vectorLiteral}::vector, 1, 1024))
+        LIMIT ${v3Config.poolMatchOverfetch}
+      ) cand
+      JOIN public.video_pool p ON p.video_id = cand.video_id
+      WHERE p.is_active = true
+        AND p.language = ${opts.language}
+        AND p.quality_tier IN ('gold', 'silver')
+        AND p.source = ANY(${sources}::text[])
+      LIMIT ${limit}
+    )
+    SELECT
+      p.video_id, p.title, p.description, p.channel_name, p.channel_id,
+      p.thumbnail_url, p.view_count, p.like_count, p.duration_seconds, p.published_at,
+      1 - (s.emb_full <=> ${vectorLiteral}::vector) AS score
+    FROM shortlist s
+    JOIN public.video_pool p ON p.video_id = s.video_id
+    ORDER BY s.emb_full <=> ${vectorLiteral}::vector ASC
+    LIMIT ${limit}
+  `)
+    );
+
+  const { rows, fellBack: twoStageFellBack } = v3Config.poolMatchTwoStage
+    ? await twoStageWithFallback('match_by_center_goal', twoStageQuery, bruteQuery)
+    : { rows: await bruteQuery(), fellBack: false };
 
   // Post-fetch threshold gate — preserves semantic floor without
   // poisoning the SQL planner.
@@ -456,6 +494,7 @@ export async function matchFromVideoPoolByCenterGoal(
       centerEmbedding_dim: opts.centerEmbedding.length,
       subGoals_count: opts.subGoals.length,
       two_stage: v3Config.poolMatchTwoStage,
+      two_stage_fallback: twoStageFellBack,
     },
     response: {
       row_count: matches.length,

--- a/src/skills/plugins/video-discover/v3/config.ts
+++ b/src/skills/plugins/video-discover/v3/config.ts
@@ -165,6 +165,13 @@ export const DEFAULT_POOL_MATCH_OVERFETCH = 256;
  * recall collapse 51/64). Prod-measured at 400: recall 64/64, warm 105ms.
  */
 export const DEFAULT_POOL_MATCH_EF_SEARCH = 400;
+/**
+ * Interactive-transaction timeout for the SET LOCAL + shortlist query.
+ * Prisma's default 5s expired on a cold-cache run (15.6s measured,
+ * 2026-07-11 08:08Z) and killed step2 entirely → 0-card mandala. 30s covers
+ * the measured cold worst case ×2; failures past it fall back to brute-force.
+ */
+export const DEFAULT_POOL_MATCH_TX_TIMEOUT_MS = 30_000;
 
 /**
  * Semantic-mode embedding candidate cap (Issue #543, CP436 PR-Y0b2).
@@ -338,6 +345,13 @@ const poolMatchEfSearch = z
   )
   .transform((v) => v ?? DEFAULT_POOL_MATCH_EF_SEARCH);
 
+const poolMatchTxTimeoutMs = z
+  .preprocess(
+    (v) => (v == null || v === '' ? undefined : Number(v)),
+    z.number().finite().int().min(5_000).max(120_000).optional()
+  )
+  .transform((v) => v ?? DEFAULT_POOL_MATCH_TX_TIMEOUT_MS);
+
 /**
  * R4 shadow guard kill switch (2026-07-04, BL-17).
  *
@@ -403,6 +417,7 @@ export const v3EnvSchema = z.object({
   V3_POOL_MATCH_SHORTLIST_K: poolMatchShortlistK,
   V3_POOL_MATCH_OVERFETCH: poolMatchOverfetch,
   V3_POOL_MATCH_EF_SEARCH: poolMatchEfSearch,
+  V3_POOL_MATCH_TX_TIMEOUT_MS: poolMatchTxTimeoutMs,
 });
 
 export interface V3Config {
@@ -470,6 +485,7 @@ export interface V3Config {
   poolMatchShortlistK: number;
   poolMatchOverfetch: number;
   poolMatchEfSearch: number;
+  poolMatchTxTimeoutMs: number;
 }
 
 export function loadV3Config(env: V3EnvInput = process.env): V3Config {
@@ -503,6 +519,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     V3_POOL_MATCH_SHORTLIST_K: env['V3_POOL_MATCH_SHORTLIST_K'],
     V3_POOL_MATCH_OVERFETCH: env['V3_POOL_MATCH_OVERFETCH'],
     V3_POOL_MATCH_EF_SEARCH: env['V3_POOL_MATCH_EF_SEARCH'],
+    V3_POOL_MATCH_TX_TIMEOUT_MS: env['V3_POOL_MATCH_TX_TIMEOUT_MS'],
   });
   if (!parsed.success) {
     return {
@@ -535,6 +552,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
       poolMatchShortlistK: DEFAULT_POOL_MATCH_SHORTLIST_K,
       poolMatchOverfetch: DEFAULT_POOL_MATCH_OVERFETCH,
       poolMatchEfSearch: DEFAULT_POOL_MATCH_EF_SEARCH,
+      poolMatchTxTimeoutMs: DEFAULT_POOL_MATCH_TX_TIMEOUT_MS,
     };
   }
   return {
@@ -567,6 +585,7 @@ export function loadV3Config(env: V3EnvInput = process.env): V3Config {
     poolMatchShortlistK: parsed.data.V3_POOL_MATCH_SHORTLIST_K,
     poolMatchOverfetch: parsed.data.V3_POOL_MATCH_OVERFETCH,
     poolMatchEfSearch: parsed.data.V3_POOL_MATCH_EF_SEARCH,
+    poolMatchTxTimeoutMs: parsed.data.V3_POOL_MATCH_TX_TIMEOUT_MS,
   };
 }
 


### PR DESCRIPTION
## Incident
Two-stage pool matching (#1156) wrapped its shortlist query in a Prisma interactive transaction with the **default 5s timeout**. A cold-cache run took **15.6s** (prod-measured, 2026-07-11 08:08Z, mandala 4ec20e1e), the transaction expired, step2 failed outright, step3 skipped → **0-card mandala** — worse than the brute path it replaced, which had no transaction wrapper and survived slow-but-alive (17-card floor).

Cold/warm re-measurement on prod right after the incident: cold 4.0s / warm 34ms — cold variance is real and unbounded by page-cache state on the Free-tier instance.

## Fix
1. **`V3_POOL_MATCH_TX_TIMEOUT_MS`** knob (default 30s = measured cold worst ×2), wired through config zod schema + algorithm-resolver, passed to `$transaction`.
2. **Structural guarantee**: any two-stage failure logs a warning and **falls back to the pre-two-stage brute query** in both `matchFromVideoPool` and `matchFromVideoPoolByCenterGoal` — two-stage can never fail a discover step the brute path would survive.
3. Trace field `two_stage_fallback` for observability (video_discover_traces.request).

## Tests
- `cache-matcher-fallback.test.ts` (new): tx failure → brute rows returned + trace flags fallback; success path passes `{timeout: 30000}` to Prisma and never touches brute.
- `config.test.ts`: default + env-override coverage for the new knob.
- tsc 0 errors, v3+search suites 126/126.

## Rollback
Flag-level: remove `V3_POOL_MATCH_TWO_STAGE=true` from compose (brute path, no transaction). Code-level: revert this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)