### PR TITLE
feat(discover): progressive fill — embed/serving decouple, placement-preserving (flag OFF, ready lever)

### DIFF
--- a/src/config/discover-progressive-fill.ts
+++ b/src/config/discover-progressive-fill.ts
@@ -1,0 +1,103 @@
+/**
+ * Progressive fill — embedding/serving decouple, placement-preserving
+ * (2026-07-11, supervisor-approved design; James "분리 진행해").
+ *
+ * The v3 wizard discover embeds ALL capped candidates in one batch before ANY
+ * card is written, so a slow/hung embed provider stalls first-paint (the 7/6+
+ * DeepInfra incident: 27-96s runs). Naive decoupling (serve lexical now,
+ * re-rank later) corrupts CELL PLACEMENT — in semantic mode the sub-goal
+ * argmax IS the embedding, so late re-ranks either shuffle visible cards or
+ * leave them mis-filed (James: "섹터별 카드 배치에 영향 없어?").
+ *
+ * Progressive fill instead keeps the semantic gate but runs it in CHUNKS:
+ * each chunk is embedded + gated + upserted immediately (cardPublisher SSE
+ * fires per row — the original "first card ~1-2s" design), so the grid FILLS
+ * OVER SECONDS and cards never move or vanish. Supervisor conditions:
+ *  1. greedy-loss mitigation — first chunk is small and cell-round-robin
+ *     (grid fills evenly), and each chunk may place at most PER_CHUNK_CELL_CAP
+ *     per cell so later, better candidates keep an open slot;
+ *  2. the never-zero floor must only fire AFTER the final chunk;
+ *  3. SSE lifetime / FE polling fallback is a deploy verification item.
+ *
+ * DEFAULT OFF and NOT enabled in compose — this is a ready lever for the next
+ * embed-provider degradation (flip during beta only if that class recurs);
+ * with embeds healthy (~0.5s) the flip's marginal gain does not justify
+ * changing the serving core on beta D-day (supervisor final call).
+ */
+const DEFAULT_FIRST_CHUNK_SIZE = 12; // cell-coverage first paint (8-16 band)
+const DEFAULT_CHUNK_SIZE = 25;
+const DEFAULT_PER_CHUNK_CELL_CAP = 2;
+
+export function isProgressiveFillEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['DISCOVER_PROGRESSIVE_FILL'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes';
+}
+
+function intEnv(env: NodeJS.ProcessEnv, key: string, fallback: number): number {
+  const raw = Number(env[key]);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : fallback;
+}
+
+export interface ProgressiveFillConfig {
+  firstChunkSize: number;
+  chunkSize: number;
+  perChunkCellCap: number;
+}
+
+export function getProgressiveFillConfig(
+  env: NodeJS.ProcessEnv = process.env
+): ProgressiveFillConfig {
+  return {
+    firstChunkSize: intEnv(env, 'DISCOVER_PF_FIRST_CHUNK', DEFAULT_FIRST_CHUNK_SIZE),
+    chunkSize: intEnv(env, 'DISCOVER_PF_CHUNK', DEFAULT_CHUNK_SIZE),
+    perChunkCellCap: intEnv(env, 'DISCOVER_PF_CELL_CAP', DEFAULT_PER_CHUNK_CELL_CAP),
+  };
+}
+
+/**
+ * Split candidates into embed/gate chunks. The FIRST chunk is built
+ * round-robin across cellIndexHint groups (supervisor cond. 1) so the very
+ * first paint covers cells evenly instead of exhausting one cell; remaining
+ * candidates follow in original (search-rank) order, sliced by chunkSize.
+ * Pure function — unit-tested directly.
+ */
+export function planProgressiveChunks<T>(
+  candidates: T[],
+  cfg: ProgressiveFillConfig,
+  getHint: (c: T) => number | null | undefined = () => null
+): T[][] {
+  if (candidates.length === 0) return [];
+
+  // Round-robin the first chunk across hint groups (nulls form their own lane).
+  const lanes = new Map<number, T[]>();
+  for (const c of candidates) {
+    const lane = getHint(c) ?? -1;
+    if (!lanes.has(lane)) lanes.set(lane, []);
+    lanes.get(lane)!.push(c);
+  }
+  const laneKeys = [...lanes.keys()].sort((a, b) => a - b);
+  const first: T[] = [];
+  const taken = new Set<T>();
+  for (let round = 0; first.length < cfg.firstChunkSize; round++) {
+    let addedThisRound = 0;
+    for (const k of laneKeys) {
+      const lane = lanes.get(k)!;
+      const item = lane[round];
+      if (!item) continue;
+      first.push(item);
+      taken.add(item);
+      addedThisRound++;
+      if (first.length >= cfg.firstChunkSize) break;
+    }
+    if (addedThisRound === 0) break; // all lanes exhausted
+  }
+
+  const rest = candidates.filter((c) => !taken.has(c));
+  const chunks: T[][] = first.length > 0 ? [first] : [];
+  for (let i = 0; i < rest.length; i += cfg.chunkSize) {
+    chunks.push(rest.slice(i, i + cfg.chunkSize));
+  }
+  return chunks;
+}

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -49,6 +49,11 @@ import { filterByQualityGate } from './quality-gate';
 import { applyHybridRerank } from './hybrid-rerank';
 import { embedBatch, cosineToRelevance } from '@/skills/plugins/iks-scorer/embedding';
 import { servingEmbedOptions } from '@/config/embed-serving-timeout';
+import {
+  isProgressiveFillEnabled,
+  getProgressiveFillConfig,
+  planProgressiveChunks,
+} from '@/config/discover-progressive-fill';
 import { isDiscoverNeverZeroFloorEnabled, getZeroFloorMax } from '@/config/discover-zero-floor';
 import { getCenterGoalEmbedding } from '@/modules/mandala/center-goal-embedding';
 import { withTraceContext, recordTrace } from '@/modules/discover-tracing';
@@ -633,6 +638,14 @@ async function executeImpl(
       existingVideoIds,
       // CP489 — enable center_goal cache for mandala-bound runs.
       mandalaId,
+      // Progressive fill: each gated chunk upserts immediately (SSE fires per
+      // row) so the grid fills over seconds. Final full-set upsert below still
+      // runs and refreshes rec_score (idempotent upsert). Flag default OFF.
+      onPartialSlots: isProgressiveFillEnabled()
+        ? async (partial) => {
+            await upsertSlots(ctx.userId, mandalaId, partial, state.subGoals);
+          }
+        : undefined,
     });
     slots.push(...tier2Fill.slots);
     tier2Count = tier2Fill.slots.length;
@@ -864,6 +877,14 @@ interface Tier2Input {
    * to fresh embed.
    */
   mandalaId?: string;
+  /**
+   * Progressive fill (2026-07-11) — when set AND DISCOVER_PROGRESSIVE_FILL is
+   * on, each embedded+gated candidate CHUNK is handed out immediately so the
+   * caller can upsert it (cardPublisher SSE fires per row → grid fills over
+   * seconds). Cards never move or vanish: the final full-set gate pass still
+   * runs and converges to the same placement (deterministic argmax).
+   */
+  onPartialSlots?: (slots: AssembledSlot[]) => Promise<void>;
 }
 
 interface Tier2Debug {
@@ -1194,39 +1215,146 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
     // Ephemeral path (input.mandalaId undefined) falls back to embedBatch
     // for the center as well via plain embedBatch call.
     const titles = cappedFilterInputs.map((f) => f.title);
-    try {
-      const [centerVec, titleVecs] = await Promise.all([
-        input.mandalaId
-          ? getCenterGoalEmbedding(input.mandalaId, input.state.centerGoal)
-          : (async () => {
-              const [v] = await embedBatch([input.state.centerGoal], servingEmbedOptions());
-              return v ?? null;
-            })(),
-        embedBatch(titles, servingEmbedOptions()),
-      ]);
-      if (centerVec != null && titleVecs.length === titles.length) {
-        centerEmbedding = centerVec;
-        candidateEmbeddings = new Map<string, number[]>();
-        for (let i = 0; i < cappedFilterInputs.length; i++) {
-          const vec = titleVecs[i];
-          const id = cappedFilterInputs[i]?.videoId;
-          if (vec && id) candidateEmbeddings.set(id, vec);
+    const progressive = isProgressiveFillEnabled() && input.onPartialSlots != null;
+    if (progressive) {
+      // Progressive fill (supervisor-approved 2026-07-11): embed+gate per
+      // CHUNK and hand each gated chunk out for immediate upsert (early
+      // visibility only). The full-set gate below still runs over the
+      // accumulated embeddings and remains the authoritative placement.
+      const pfCfg = getProgressiveFillConfig();
+      const deficitSet = new Set(input.deficitCells.map((c) => c.cellIndex));
+      try {
+        const centerVec = input.mandalaId
+          ? await getCenterGoalEmbedding(input.mandalaId, input.state.centerGoal)
+          : ((await embedBatch([input.state.centerGoal], servingEmbedOptions()))[0] ?? null);
+        if (centerVec != null) {
+          centerEmbedding = centerVec;
+          candidateEmbeddings = new Map<string, number[]>();
+          const streamedIds = new Set<string>();
+          const chunks = planProgressiveChunks(
+            cappedFilterInputs,
+            pfCfg,
+            (f) => enrichedById.get(f.videoId)?.cellIndexHint ?? null
+          );
+          for (const chunk of chunks) {
+            try {
+              const vecs = await embedBatch(
+                chunk.map((f) => f.title),
+                servingEmbedOptions()
+              );
+              for (let i = 0; i < chunk.length; i++) {
+                const vec = vecs[i];
+                const id = chunk[i]?.videoId;
+                if (vec && id) candidateEmbeddings.set(id, vec);
+              }
+              const { byCell: chunkByCell } = applyMandalaFilterWithStats(chunk, {
+                centerGoal: input.state.centerGoal,
+                subGoals: input.state.subGoals,
+                language: input.state.language,
+                focusTags: input.state.focusTags,
+                recencyWeight: v3Config.recencyWeight,
+                recencyHalfLifeMonths: v3Config.recencyHalfLifeMonths,
+                centerGateMode: v3Config.centerGateMode,
+                centerEmbedding,
+                candidateEmbeddings,
+                semanticMinCosine: v3Config.semanticMinCosine,
+                subGoalEmbeddings: input.state.subGoalEmbeddings,
+                emptyTitleGateShadow: v3Config.emptyTitleGateShadow,
+                emptyTitleGate: v3Config.emptyTitleGate,
+              });
+              const partial: AssembledSlot[] = [];
+              const perCell = new Map<number, number>();
+              for (const [cellIndex, list] of chunkByCell) {
+                if (!deficitSet.has(cellIndex)) continue;
+                for (const a of [...list].sort((x, y) => y.score - x.score)) {
+                  if (streamedIds.has(a.candidate.videoId)) continue;
+                  if ((perCell.get(cellIndex) ?? 0) >= pfCfg.perChunkCellCap) break;
+                  const ev = enrichedById.get(a.candidate.videoId);
+                  if (!ev) continue;
+                  partial.push({
+                    videoId: ev.videoId,
+                    title: ev.title,
+                    description: ev.description,
+                    channelName: ev.channelTitle,
+                    channelId: ev.channelId,
+                    thumbnail: ev.thumbnail,
+                    viewCount: ev.viewCount,
+                    likeCount: ev.likeCount,
+                    durationSec: ev.durationSec,
+                    publishedAt: ev.publishedDate,
+                    cellIndex,
+                    score: a.score,
+                    tier: 'realtime',
+                  });
+                  perCell.set(cellIndex, (perCell.get(cellIndex) ?? 0) + 1);
+                  streamedIds.add(a.candidate.videoId);
+                }
+              }
+              if (partial.length > 0) {
+                try {
+                  await input.onPartialSlots!(partial);
+                  log.info(
+                    `[progressive] streamed chunk: ${partial.length} slots (chunk size ${chunk.length})`
+                  );
+                } catch (err) {
+                  log.warn(
+                    `[progressive] partial upsert failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+                  );
+                }
+              }
+            } catch (err) {
+              log.warn(
+                `[progressive] chunk embed failed — continuing without it: ${err instanceof Error ? err.message : String(err)}`
+              );
+            }
+          }
+        } else {
+          log.warn('[progressive] center embed unavailable — substring fallback');
         }
-      } else {
+      } catch (err) {
         log.warn(
-          `semantic gate embed vector mismatch: center=${centerVec != null} titles=${titleVecs.length}/${titles.length} — falling back to substring`
+          `[progressive] setup failed — substring fallback: ${err instanceof Error ? err.message : String(err)}`
         );
       }
-    } catch (err) {
-      log.warn(
-        `semantic gate embed failed: ${err instanceof Error ? err.message : String(err)} — falling back to substring`
+      debug.timing.semanticGateEmbedMs = Date.now() - tSemEmbedStart;
+      log.info(
+        `semantic gate (progressive): candidates=${filterInputs.length} capped=${cappedFilterInputs.length} embedMs=${debug.timing.semanticGateEmbedMs}`
+      );
+    } else {
+      try {
+        const [centerVec, titleVecs] = await Promise.all([
+          input.mandalaId
+            ? getCenterGoalEmbedding(input.mandalaId, input.state.centerGoal)
+            : (async () => {
+                const [v] = await embedBatch([input.state.centerGoal], servingEmbedOptions());
+                return v ?? null;
+              })(),
+          embedBatch(titles, servingEmbedOptions()),
+        ]);
+        if (centerVec != null && titleVecs.length === titles.length) {
+          centerEmbedding = centerVec;
+          candidateEmbeddings = new Map<string, number[]>();
+          for (let i = 0; i < cappedFilterInputs.length; i++) {
+            const vec = titleVecs[i];
+            const id = cappedFilterInputs[i]?.videoId;
+            if (vec && id) candidateEmbeddings.set(id, vec);
+          }
+        } else {
+          log.warn(
+            `semantic gate embed vector mismatch: center=${centerVec != null} titles=${titleVecs.length}/${titles.length} — falling back to substring`
+          );
+        }
+      } catch (err) {
+        log.warn(
+          `semantic gate embed failed: ${err instanceof Error ? err.message : String(err)} — falling back to substring`
+        );
+      }
+      debug.timing.semanticGateEmbedMs = Date.now() - tSemEmbedStart;
+      log.info(
+        `semantic gate: candidates=${filterInputs.length} capped=${cappedFilterInputs.length} ` +
+          `overflow=${overflow} cap=${cap} embedMs=${debug.timing.semanticGateEmbedMs}`
       );
     }
-    debug.timing.semanticGateEmbedMs = Date.now() - tSemEmbedStart;
-    log.info(
-      `semantic gate: candidates=${filterInputs.length} capped=${cappedFilterInputs.length} ` +
-        `overflow=${overflow} cap=${cap} embedMs=${debug.timing.semanticGateEmbedMs}`
-    );
   }
 
   const tMandalaFilterStart = Date.now();

--- a/tests/unit/config/discover-progressive-fill.test.ts
+++ b/tests/unit/config/discover-progressive-fill.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Progressive fill config + chunk planner (2026-07-11, supervisor conditions).
+ */
+import {
+  isProgressiveFillEnabled,
+  getProgressiveFillConfig,
+  planProgressiveChunks,
+} from '@/config/discover-progressive-fill';
+
+describe('progressive fill config', () => {
+  test('unset → disabled (flag alone rolls back)', () => {
+    expect(isProgressiveFillEnabled({})).toBe(false);
+  });
+  test.each(['true', '1', 'yes'])('enabled by %s', (v) => {
+    expect(isProgressiveFillEnabled({ DISCOVER_PROGRESSIVE_FILL: v })).toBe(true);
+  });
+  test('defaults 12/25/2, env override, invalid → default', () => {
+    expect(getProgressiveFillConfig({})).toEqual({
+      firstChunkSize: 12,
+      chunkSize: 25,
+      perChunkCellCap: 2,
+    });
+    expect(
+      getProgressiveFillConfig({ DISCOVER_PF_FIRST_CHUNK: '8', DISCOVER_PF_CHUNK: 'x' })
+    ).toEqual({ firstChunkSize: 8, chunkSize: 25, perChunkCellCap: 2 });
+  });
+});
+
+describe('planProgressiveChunks — first chunk round-robin (supervisor cond. 1)', () => {
+  const cfg = { firstChunkSize: 4, chunkSize: 3, perChunkCellCap: 2 };
+  const c = (id: string, hint: number | null) => ({ id, hint });
+
+  test('first chunk covers cells evenly, not one lane', () => {
+    const cands = [c('a0', 0), c('a1', 0), c('a2', 0), c('b0', 1), c('b1', 1), c('c0', 2)];
+    const chunks = planProgressiveChunks(cands, cfg, (x) => x.hint);
+    // round 1 picks one per lane (0,1,2) then round 2 starts lane 0 → a0,b0,c0,a1
+    expect(chunks[0]!.map((x) => x.id)).toEqual(['a0', 'b0', 'c0', 'a1']);
+  });
+
+  test('rest is sliced by chunkSize in original order; no candidate lost or duplicated', () => {
+    const cands = Array.from({ length: 11 }, (_, i) => c(`v${i}`, i % 3));
+    const chunks = planProgressiveChunks(cands, cfg, (x) => x.hint);
+    const flat = chunks.flat().map((x) => x.id);
+    expect(flat.sort()).toEqual(cands.map((x) => x.id).sort());
+    expect(new Set(flat).size).toBe(11);
+    expect(chunks[0]!.length).toBe(4);
+    for (const ch of chunks.slice(1)) expect(ch.length).toBeLessThanOrEqual(3);
+  });
+
+  test('null hints form their own lane; empty input → no chunks', () => {
+    expect(planProgressiveChunks([], cfg, () => null)).toEqual([]);
+    const chunks = planProgressiveChunks([c('x', null), c('y', 2)], cfg, (v) => v.hint);
+    expect(chunks[0]!.length).toBe(2);
+  });
+
+  test('fewer candidates than firstChunkSize → single chunk, loop terminates', () => {
+    const chunks = planProgressiveChunks([c('a', 0), c('b', 1)], cfg, (x) => x.hint);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]!.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Why
Wizard discover embeds ALL candidates in one batch before ANY card is written → a hung embed provider stalls first-paint (7/6+ DeepInfra: 27–96s runs). Naive decouple (serve lexical, re-rank later) corrupts **cell placement** — in semantic mode the sub-goal argmax IS the embedding (James: "섹터별 카드 배치에 영향 없어?").

## What
**Progressive fill**: keep the semantic gate, run it in **chunks** — each chunk embed→gate→upsert immediately (existing `cardPublisher` SSE fires per row), grid fills over seconds, **cards never move or vanish**. Full-set gate still runs after as the authoritative pass (deterministic argmax → same placement; idempotent upsert refreshes scores).

Supervisor conditions implemented: ① first chunk 12 + cell round-robin + per-chunk cell cap 2 (greedy-loss mitigation) ② floor fires only after the full pass ③ SSE lifetime/폴링 폴백 = flip-time verification item.

## Ships OFF (supervisor final call)
`DISCOVER_PROGRESSIVE_FILL` default off, **not** in compose. With embeds healthy (0.5s) + 12s cap + floor, this is a **ready lever** for the next provider degradation — not a beta D-day serving-core flip. Flag-off path byte-identical.

## Tests
tsc clean · 9 new (flag/knobs, round-robin coverage, no-loss/no-dup, termination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)