### PR TITLE
chore(serving): flip DISCOVER_PROGRESSIVE_FILL=true (James GO)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -281,6 +281,10 @@ services:
       # 0.49-2.4s, zero hangs vs 3-4/10 at 29.6-30s before) — supervisor
       # staged-flip order FIX-1 -> FIX-3 honored.
       - DISCOVER_NEVER_ZERO_FLOOR=true
+      # FLIPPED 2026-07-11 (James "해바"): progressive fill — first cards 3-5s,
+      # rest stream via SSE; embed calls (Nebius 4-14s) off the first-paint
+      # path, cell placement preserved. Rollback = remove this line.
+      - DISCOVER_PROGRESSIVE_FILL=true
       # CP416 (2026-04-22) — restore the LoRA action-fill path. Without
       # this, generateMandala() called config.mandalaGen.model=undefined,
       # Ollama /api/generate returned 400, LoRA threw, and the Haiku


### PR DESCRIPTION
Run cccc7b2f: 44 cards but 27s, 14.5s embed dominant. Flip the ready lever (#1160): first cards 3–5s, rest SSE-stream, placement preserved. Rollback = remove line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)