### PR TITLE
feat(discover): T5 — long-form harvest ×2 + junk-query skip + MISS first-paint

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -281,6 +281,13 @@ services:
       # 0.49-2.4s, zero hangs vs 3-4/10 at 29.6-30s before) — supervisor
       # staged-flip order FIX-1 -> FIX-3 honored.
       - DISCOVER_NEVER_ZERO_FLOOR=true
+      # T5 (2026-07-12, archetype matrix) — supply x2 + shorts-at-source +
+      # MISS-path first-paint. Measured basis: run 1710a7c8 (James manual):
+      # supply 181, shorts ate 96 (53%), 11 cards; rule queries 0-7 items vs
+      # LLM 50. Rollback = remove these three lines (each independent).
+      - V3_SEARCH_VIDEO_DURATION=medium
+      - DISCOVER_SKIP_RULE_QUERIES=true
+      - DISCOVER_PROGRESSIVE_FILL=true
       # CP416 (2026-04-22) — restore the LoRA action-fill path. Without
       # this, generateMandala() called config.mandalaGen.model=undefined,
       # Ollama /api/generate returned 400, LoRA threw, and the Haiku

--- a/src/config/discover-t5.ts
+++ b/src/config/discover-t5.ts
@@ -1,0 +1,43 @@
+/**
+ * T5 supply/quality knobs (2026-07-12, archetype experiment T5 —
+ * docs/handoffs/version-archetype-matrix-2026-07-12.md).
+ *
+ * Measured basis (run 1710a7c8, James manual, T4/MISS): supply 181 → shorts
+ * ate 96 (53%) → gate-in 30 → 11 cards. Rule (concat) queries returned 0-7
+ * items each (mostly 0) while LLM queries returned 50 each. The 50-70 card
+ * bar is unreachable without ~2-3x effective long-form supply.
+ *
+ * 1. V3_SEARCH_VIDEO_DURATION — search.list `videoDuration` param
+ *    ('medium' = 4-20min). v1 executor always sent medium
+ *    (video-discover/executor.ts:1393); the v2/v3 rewrite dropped it, so
+ *    half the harvest arrives as Shorts and is discarded post-hoc. Setting
+ *    'medium' makes every harvested item long-form (≈2x effective supply
+ *    AND kills the 76-180s Shorts inflow at the source). Unset = legacy
+ *    (no param).
+ *
+ * 2. DISCOVER_SKIP_RULE_QUERIES — skip the rule/concat query round
+ *    ("{centerGoal} {token}" strings that YouTube matches poorly). LLM
+ *    queries + the zero-hit fallback remain. Saves ~10 search.list units
+ *    per run and shortens discover (helping precompute HIT rate). Unset =
+ *    legacy (rule round runs).
+ *
+ * Tuning knobs, not secrets (CP392): code default = legacy, flag alone
+ * rolls back.
+ */
+export type SearchVideoDuration = 'short' | 'medium' | 'long';
+
+export function getSearchVideoDuration(
+  env: NodeJS.ProcessEnv = process.env
+): SearchVideoDuration | null {
+  const v = String(env['V3_SEARCH_VIDEO_DURATION'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'medium' || v === 'long' || v === 'short' ? v : null;
+}
+
+export function isSkipRuleQueriesEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['DISCOVER_SKIP_RULE_QUERIES'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes';
+}

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -54,6 +54,8 @@ import {
   getProgressiveFillConfig,
   planProgressiveChunks,
 } from '@/config/discover-progressive-fill';
+import { getSearchVideoDuration, isSkipRuleQueriesEnabled } from '@/config/discover-t5';
+import { placeAutoAddedCards } from '@/modules/mandala/place-auto-added-cards';
 import { isDiscoverNeverZeroFloorEnabled, getZeroFloorMax } from '@/config/discover-zero-floor';
 import { getCenterGoalEmbedding } from '@/modules/mandala/center-goal-embedding';
 import { withTraceContext, recordTrace } from '@/modules/discover-tracing';
@@ -643,7 +645,44 @@ async function executeImpl(
       // runs and refreshes rec_score (idempotent upsert). Flag default OFF.
       onPartialSlots: isProgressiveFillEnabled()
         ? async (partial) => {
+            // rec_cache first (SSE card_added fires per row)...
             await upsertSlots(ctx.userId, mandalaId, partial, state.subGoals);
+            // ...then straight into user_video_states so the DASHBOARD GRID
+            // (which renders uvs, not rec_cache) paints within seconds on the
+            // precompute-MISS path. Step3 auto-add later delete-and-replaces
+            // the cell from rec_cache — the same videos are in rec_cache by
+            // then, so the final set converges (brief re-insert, no card loss).
+            const byCell = new Map<number, typeof partial>();
+            for (const s of partial) {
+              if (!byCell.has(s.cellIndex)) byCell.set(s.cellIndex, []);
+              byCell.get(s.cellIndex)!.push(s);
+            }
+            for (const [cellIndex, slots] of byCell) {
+              try {
+                await placeAutoAddedCards(
+                  getPrismaClient(),
+                  ctx.userId,
+                  mandalaId,
+                  cellIndex,
+                  slots.map((sl) => ({
+                    videoId: sl.videoId,
+                    title: sl.title,
+                    description: sl.description,
+                    thumbnail: sl.thumbnail,
+                    channelTitle: sl.channelName,
+                    durationSec: sl.durationSec,
+                    viewCount: sl.viewCount,
+                    publishedAt: sl.publishedAt,
+                    recScore: sl.score,
+                  })),
+                  { notify: true }
+                );
+              } catch (err) {
+                log.warn(
+                  `[progressive] partial uvs place failed (non-fatal, cell=${cellIndex}): ${err instanceof Error ? err.message : String(err)}`
+                );
+              }
+            }
           }
         : undefined,
     });
@@ -998,16 +1037,23 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   }
 
   const tKwRuleStart = Date.now();
-  const ruleQueries = buildRuleBasedQueriesSync(
-    {
-      centerGoal: input.state.centerGoal,
-      subGoals: deficitSubGoals,
-      focusTags: input.state.focusTags,
-      targetLevel: input.state.targetLevel,
-      language: input.state.language,
-    },
-    v3Config.maxQueries
-  );
+  // T5 — measured: concat rule queries returned 0-7 items each (mostly 0)
+  // while LLM queries returned 50 each (run 1710a7c8). Skipping the rule
+  // round saves ~10 search units and shortens discover (raising precompute
+  // HIT rate); the zero-hit fallback + LLM queries carry cell targeting.
+  const skipRuleQueries = isSkipRuleQueriesEnabled();
+  const ruleQueries = skipRuleQueries
+    ? []
+    : buildRuleBasedQueriesSync(
+        {
+          centerGoal: input.state.centerGoal,
+          subGoals: deficitSubGoals,
+          focusTags: input.state.focusTags,
+          targetLevel: input.state.targetLevel,
+          language: input.state.language,
+        },
+        v3Config.maxQueries
+      );
   debug.timing.keywordRuleMs = Date.now() - tKwRuleStart;
 
   const tKwLlmStart = Date.now();
@@ -1611,6 +1657,10 @@ async function runSearchTraced(
           timeoutMs: v3Config.youtubeSearchTimeoutMs,
           ...(publishedAfter ? { publishedAfter } : {}),
           ...(opts?.videoCategoryId ? { videoCategoryId: opts.videoCategoryId } : {}),
+          // T5 — long-form-only harvest (v1 always sent medium; the v2/v3
+          // rewrite dropped it → 53% of supply arrived as Shorts and was
+          // discarded post-hoc). Unset env = legacy (no param).
+          ...(getSearchVideoDuration() ? { videoDuration: getSearchVideoDuration()! } : {}),
         });
         return { q, items, error: undefined as string | undefined };
       } catch (err) {

--- a/tests/unit/config/discover-t5.test.ts
+++ b/tests/unit/config/discover-t5.test.ts
@@ -1,0 +1,21 @@
+/**
+ * T5 supply/quality knobs (2026-07-12). Unset = legacy (flag alone rolls back).
+ */
+import { getSearchVideoDuration, isSkipRuleQueriesEnabled } from '@/config/discover-t5';
+
+describe('discover-t5 knobs', () => {
+  test('videoDuration: unset/invalid → null (legacy, no param)', () => {
+    expect(getSearchVideoDuration({})).toBeNull();
+    expect(getSearchVideoDuration({ V3_SEARCH_VIDEO_DURATION: 'any' })).toBeNull();
+    expect(getSearchVideoDuration({ V3_SEARCH_VIDEO_DURATION: 'x' })).toBeNull();
+  });
+  test.each(['medium', 'long', 'short', ' MEDIUM '])('videoDuration accepts %s', (v) => {
+    expect(getSearchVideoDuration({ V3_SEARCH_VIDEO_DURATION: v })).toBe(v.trim().toLowerCase());
+  });
+  test('skipRuleQueries: unset → false; true/1/yes → true', () => {
+    expect(isSkipRuleQueriesEnabled({})).toBe(false);
+    expect(isSkipRuleQueriesEnabled({ DISCOVER_SKIP_RULE_QUERIES: 'true' })).toBe(true);
+    expect(isSkipRuleQueriesEnabled({ DISCOVER_SKIP_RULE_QUERIES: '1' })).toBe(true);
+    expect(isSkipRuleQueriesEnabled({ DISCOVER_SKIP_RULE_QUERIES: 'false' })).toBe(false);
+  });
+});


### PR DESCRIPTION
Archetype T5 (pre-registered). Measured basis run 1710a7c8: supply 181, shorts ate 53%, rule queries 0–7 items vs LLM 50, 11 cards. (1) `videoDuration=medium` (v1 had it, v2/v3 rewrite dropped it) → all-long-form harvest ≈2× supply + 76–180s Shorts die at source. (2) skip junk concat round → faster discover, higher precompute HIT. (3) progressive fill now places chunks into uvs via the chokepoint → grid paints in seconds on MISS. Each line independently revertible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)