### PR TITLE
perf(discover): parallel chunks + embed provider preference — 34.7s → ~6-9s target

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -272,6 +272,10 @@ services:
       # DeepInfra recovered (it is one of 3 capacity legs).
       # Full record: docs/qa/wizard-0card-investigation-2026-07-11.md
       - OPENROUTER_EMBED_IGNORE_PROVIDERS=DeepInfra
+      # T5-perf (2026-07-12) — provider PREFERENCE (fallbacks allowed, not a
+      # pin): SiliconFlow measured 0.5-0.9s consistently vs Nebius 0.5-12s
+      # variance (run 8dbb3e67 had a 11.9s embed call). Remove line = router default.
+      - OPENROUTER_EMBED_PROVIDER_ORDER=SiliconFlow
       # P0 2026-07-11 — never-zero floor: when the RANKING gate (center cosine/
       # jaccard) drops every candidate, admit top-N (search-rank, safety gates
       # already applied) into deficit cells instead of "No recommendations" ->

--- a/src/config/embed-provider-prefs.ts
+++ b/src/config/embed-provider-prefs.ts
@@ -20,6 +20,21 @@
  * Tuning knob, not a secret (CP392). Full incident record:
  * docs/qa/wizard-0card-investigation-2026-07-11.md
  */
+/**
+ * Preferred provider ORDER with fallbacks allowed (NOT a pin: allow_fallbacks
+ * stays true, so a down provider falls through — no new SPOF). Measured
+ * 2026-07-12: SiliconFlow 0.5-0.9s consistently vs Nebius 0.5-12s variance.
+ * Unset = no order field (router default).
+ */
+export function getEmbedProviderOrder(env: NodeJS.ProcessEnv = process.env): string[] {
+  const raw = String(env['OPENROUTER_EMBED_PROVIDER_ORDER'] ?? '').trim();
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
 export function getEmbedIgnoreProviders(env: NodeJS.ProcessEnv = process.env): string[] {
   const raw = String(env['OPENROUTER_EMBED_IGNORE_PROVIDERS'] ?? '').trim();
   if (!raw) return [];

--- a/src/skills/plugins/iks-scorer/embedding.ts
+++ b/src/skills/plugins/iks-scorer/embedding.ts
@@ -25,7 +25,7 @@ import { logger } from '@/utils/logger';
 import { getPrismaClient } from '@/modules/database';
 import { Prisma } from '@prisma/client';
 import { config } from '@/config/index';
-import { getEmbedIgnoreProviders } from '@/config/embed-provider-prefs';
+import { getEmbedIgnoreProviders, getEmbedProviderOrder } from '@/config/embed-provider-prefs';
 import { logLLMCall } from '@/modules/llm/call-logger';
 import { recordTrace } from '@/modules/discover-tracing';
 
@@ -448,6 +448,19 @@ async function embedOneChunkViaOpenRouter(
       // probe; ~1/3 of default-routed calls stalled 20-30s -> 40s with retry).
       // Empty list = no provider field, byte-identical legacy request.
       const ignoreProviders = getEmbedIgnoreProviders();
+      const orderProviders = getEmbedProviderOrder();
+      const providerPrefs =
+        ignoreProviders.length > 0 || orderProviders.length > 0
+          ? {
+              provider: {
+                ...(ignoreProviders.length > 0 ? { ignore: ignoreProviders } : {}),
+                // Preference, not a pin: fallbacks stay allowed (no SPOF).
+                ...(orderProviders.length > 0
+                  ? { order: orderProviders, allow_fallbacks: true }
+                  : {}),
+              },
+            }
+          : {};
       res = await fetchFn(`${baseUrl}/embeddings`, {
         method: 'POST',
         headers: {
@@ -457,7 +470,7 @@ async function embedOneChunkViaOpenRouter(
         body: JSON.stringify({
           model,
           input: texts,
-          ...(ignoreProviders.length > 0 ? { provider: { ignore: ignoreProviders } } : {}),
+          ...providerPrefs,
         }),
         signal: controller.signal,
       });

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -1275,85 +1275,92 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
           : ((await embedBatch([input.state.centerGoal], servingEmbedOptions()))[0] ?? null);
         if (centerVec != null) {
           centerEmbedding = centerVec;
-          candidateEmbeddings = new Map<string, number[]>();
+          const embMap = new Map<string, number[]>();
+          candidateEmbeddings = embMap;
           const streamedIds = new Set<string>();
           const chunks = planProgressiveChunks(
             cappedFilterInputs,
             pfCfg,
             (f) => enrichedById.get(f.videoId)?.cellIndexHint ?? null
           );
-          for (const chunk of chunks) {
-            try {
-              const vecs = await embedBatch(
-                chunk.map((f) => f.title),
-                servingEmbedOptions()
-              );
-              for (let i = 0; i < chunk.length; i++) {
-                const vec = vecs[i];
-                const id = chunk[i]?.videoId;
-                if (vec && id) candidateEmbeddings.set(id, vec);
-              }
-              const { byCell: chunkByCell } = applyMandalaFilterWithStats(chunk, {
-                centerGoal: input.state.centerGoal,
-                subGoals: input.state.subGoals,
-                language: input.state.language,
-                focusTags: input.state.focusTags,
-                recencyWeight: v3Config.recencyWeight,
-                recencyHalfLifeMonths: v3Config.recencyHalfLifeMonths,
-                centerGateMode: v3Config.centerGateMode,
-                centerEmbedding,
-                candidateEmbeddings,
-                semanticMinCosine: v3Config.semanticMinCosine,
-                subGoalEmbeddings: input.state.subGoalEmbeddings,
-                emptyTitleGateShadow: v3Config.emptyTitleGateShadow,
-                emptyTitleGate: v3Config.emptyTitleGate,
-              });
-              const partial: AssembledSlot[] = [];
-              const perCell = new Map<number, number>();
-              for (const [cellIndex, list] of chunkByCell) {
-                if (!deficitSet.has(cellIndex)) continue;
-                for (const a of [...list].sort((x, y) => y.score - x.score)) {
-                  if (streamedIds.has(a.candidate.videoId)) continue;
-                  if ((perCell.get(cellIndex) ?? 0) >= pfCfg.perChunkCellCap) break;
-                  const ev = enrichedById.get(a.candidate.videoId);
-                  if (!ev) continue;
-                  partial.push({
-                    videoId: ev.videoId,
-                    title: ev.title,
-                    description: ev.description,
-                    channelName: ev.channelTitle,
-                    channelId: ev.channelId,
-                    thumbnail: ev.thumbnail,
-                    viewCount: ev.viewCount,
-                    likeCount: ev.likeCount,
-                    durationSec: ev.durationSec,
-                    publishedAt: ev.publishedDate,
-                    cellIndex,
-                    score: a.score,
-                    tier: 'realtime',
-                  });
-                  perCell.set(cellIndex, (perCell.get(cellIndex) ?? 0) + 1);
-                  streamedIds.add(a.candidate.videoId);
+          // T5-perf (2026-07-12): chunks run CONCURRENTLY — the sequential
+          // loop serialized embed calls (measured 23.1s gate_embed on run
+          // 8dbb3e67: 5.3+5.8+5.1+1.9+11.9+2.7s). Wall-clock is now
+          // max(chunk) while early chunks still paint the grid first.
+          await Promise.allSettled(
+            chunks.map(async (chunk) => {
+              try {
+                const vecs = await embedBatch(
+                  chunk.map((f) => f.title),
+                  servingEmbedOptions()
+                );
+                for (let i = 0; i < chunk.length; i++) {
+                  const vec = vecs[i];
+                  const id = chunk[i]?.videoId;
+                  if (vec && id) embMap.set(id, vec);
                 }
-              }
-              if (partial.length > 0) {
-                try {
-                  await input.onPartialSlots!(partial);
-                  log.info(
-                    `[progressive] streamed chunk: ${partial.length} slots (chunk size ${chunk.length})`
-                  );
-                } catch (err) {
-                  log.warn(
-                    `[progressive] partial upsert failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
-                  );
+                const { byCell: chunkByCell } = applyMandalaFilterWithStats(chunk, {
+                  centerGoal: input.state.centerGoal,
+                  subGoals: input.state.subGoals,
+                  language: input.state.language,
+                  focusTags: input.state.focusTags,
+                  recencyWeight: v3Config.recencyWeight,
+                  recencyHalfLifeMonths: v3Config.recencyHalfLifeMonths,
+                  centerGateMode: v3Config.centerGateMode,
+                  centerEmbedding: centerVec,
+                  candidateEmbeddings: embMap,
+                  semanticMinCosine: v3Config.semanticMinCosine,
+                  subGoalEmbeddings: input.state.subGoalEmbeddings,
+                  emptyTitleGateShadow: v3Config.emptyTitleGateShadow,
+                  emptyTitleGate: v3Config.emptyTitleGate,
+                });
+                const partial: AssembledSlot[] = [];
+                const perCell = new Map<number, number>();
+                for (const [cellIndex, list] of chunkByCell) {
+                  if (!deficitSet.has(cellIndex)) continue;
+                  for (const a of [...list].sort((x, y) => y.score - x.score)) {
+                    if (streamedIds.has(a.candidate.videoId)) continue;
+                    if ((perCell.get(cellIndex) ?? 0) >= pfCfg.perChunkCellCap) break;
+                    const ev = enrichedById.get(a.candidate.videoId);
+                    if (!ev) continue;
+                    partial.push({
+                      videoId: ev.videoId,
+                      title: ev.title,
+                      description: ev.description,
+                      channelName: ev.channelTitle,
+                      channelId: ev.channelId,
+                      thumbnail: ev.thumbnail,
+                      viewCount: ev.viewCount,
+                      likeCount: ev.likeCount,
+                      durationSec: ev.durationSec,
+                      publishedAt: ev.publishedDate,
+                      cellIndex,
+                      score: a.score,
+                      tier: 'realtime',
+                    });
+                    perCell.set(cellIndex, (perCell.get(cellIndex) ?? 0) + 1);
+                    streamedIds.add(a.candidate.videoId);
+                  }
                 }
+                if (partial.length > 0) {
+                  try {
+                    await input.onPartialSlots!(partial);
+                    log.info(
+                      `[progressive] streamed chunk: ${partial.length} slots (chunk size ${chunk.length})`
+                    );
+                  } catch (err) {
+                    log.warn(
+                      `[progressive] partial upsert failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
+                    );
+                  }
+                }
+              } catch (err) {
+                log.warn(
+                  `[progressive] chunk embed failed — continuing without it: ${err instanceof Error ? err.message : String(err)}`
+                );
               }
-            } catch (err) {
-              log.warn(
-                `[progressive] chunk embed failed — continuing without it: ${err instanceof Error ? err.message : String(err)}`
-              );
-            }
-          }
+            })
+          );
         } else {
           log.warn('[progressive] center embed unavailable — substring fallback');
         }

--- a/tests/unit/modules/embedding-provider-ignore.test.ts
+++ b/tests/unit/modules/embedding-provider-ignore.test.ts
@@ -75,6 +75,23 @@ describe('embedBatch — OpenRouter provider ignore', () => {
     expect(bodies[0]).toMatchObject({ model: 'qwen/qwen3-embedding-8b', input: ['a'] });
   });
 
+  test('provider ORDER preference carries allow_fallbacks:true (not a pin)', async () => {
+    process.env['OPENROUTER_EMBED_PROVIDER_ORDER'] = 'SiliconFlow';
+    const bodies: unknown[] = [];
+    const fetchImpl = jest.fn(async (_url: string, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      return openRouterOk(1);
+    }) as unknown as typeof fetch;
+    try {
+      await embedBatch(['a'], { fetchImpl });
+      expect(bodies[0]).toMatchObject({
+        provider: { order: ['SiliconFlow'], allow_fallbacks: true },
+      });
+    } finally {
+      delete process.env['OPENROUTER_EMBED_PROVIDER_ORDER'];
+    }
+  });
+
   test('multiple ignored providers pass through comma-parsed', async () => {
     process.env[ENV_KEY] = 'DeepInfra, SomeOther';
     const bodies: unknown[] = [];


### PR DESCRIPTION
Run 8dbb3e67: gate_embed 23.1s = my sequential chunk loop × Nebius 0.5–12s swings. (1) chunks now concurrent (wall=max, early paint kept). (2) `OPENROUTER_EMBED_PROVIDER_ORDER=SiliconFlow` — preference with allow_fallbacks:true (no SPOF; measured 0.5–0.9s consistent). Rollback = remove line / flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)