### PR TITLE
fix(book): relink 카드→v2→노트 chain (books=0 since v2 moved to enrich-video path)

### DIFF
--- a/src/modules/ontology/enrichment.ts
+++ b/src/modules/ontology/enrichment.ts
@@ -380,6 +380,8 @@ export async function enrichVideo(
      */
     withRichSummary?: boolean;
     userId?: string;
+    /** Book-chain relink (2026-07-12): enables the post-v2 book/note fill. */
+    mandalaId?: string;
   }
 ): Promise<VideoSummaryResult> {
   const prisma = getPrismaClient();
@@ -527,6 +529,27 @@ export async function enrichVideo(
         transcript,
         segments: richSummarySegments,
       });
+      // Book-chain relink (2026-07-12): v2 now flows through THIS inline path
+      // (wizard trigger -> enrich-video), but the book/note fill was only
+      // enqueued by the standalone enrich-rich-summary job handler — which no
+      // longer runs. Re-fire it here (same 120s-debounced singleton per
+      // mandala) so 카드 -> v2 -> 노트 completes again. Non-fatal.
+      if (options.mandalaId) {
+        const { enqueueMandalaBookFill } =
+          await import('@/modules/queue/handlers/mandala-book-fill');
+        const { bookRefillEnqueueOptions } =
+          await import('@/modules/queue/handlers/book-refill-debounce');
+        await enqueueMandalaBookFill(
+          { userId: options.userId, mandalaId: options.mandalaId, trigger: 'enrich-complete' },
+          bookRefillEnqueueOptions(options.mandalaId)
+        ).catch((err) => {
+          logger.warn('book re-fill enqueue failed (non-fatal)', {
+            videoId,
+            mandalaId: options.mandalaId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
     } catch (err) {
       logger.warn('Rich summary generation failed (non-fatal)', {
         videoId,

--- a/src/modules/queue/handlers/enrich-video.ts
+++ b/src/modules/queue/handlers/enrich-video.ts
@@ -37,7 +37,7 @@ export async function registerEnrichVideoWorker(): Promise<void> {
  * Handle a single enrich-video job.
  */
 async function handleEnrichVideo(job: PgBoss.Job<EnrichVideoPayload>): Promise<void> {
-  const { videoId, title, url, source, withRichSummary, userId } = job.data;
+  const { videoId, title, url, source, withRichSummary, userId, mandalaId } = job.data;
 
   logger.info('enrich-video: processing', {
     jobId: job.id,
@@ -48,7 +48,7 @@ async function handleEnrichVideo(job: PgBoss.Job<EnrichVideoPayload>): Promise<v
   });
 
   try {
-    await enrichVideo(videoId, { title, url, withRichSummary, userId });
+    await enrichVideo(videoId, { title, url, withRichSummary, userId, mandalaId });
 
     logger.info('enrich-video: completed', { jobId: job.id, videoId });
   } catch (err) {

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -117,6 +117,14 @@ export interface EnrichVideoPayload {
    */
   withRichSummary?: boolean;
   userId?: string;
+  /**
+   * Book-chain relink (2026-07-12): the wizard trigger routes v2 through
+   * enrich-video (inline enrichRichSummary), which never carried mandalaId —
+   * so the book/note fill (enqueued on v2 completion) was orphaned once the
+   * standalone enrich-rich-summary job path fell out of use. Threading the
+   * id restores 카드 → v2 → 노트.
+   */
+  mandalaId?: string;
 }
 
 export interface BatchScanPayload {

--- a/src/modules/skills/rich-summary-trigger.ts
+++ b/src/modules/skills/rich-summary-trigger.ts
@@ -96,6 +96,7 @@ export async function enqueueRichSummaryForMandalaCards(params: {
         source: 'user',
         withRichSummary: true,
         userId: params.userId,
+        mandalaId: params.mandalaId,
       });
       enqueued += 1;
     } catch (err) {


### PR DESCRIPTION
Books=0 on all recent mandalas while v2 grew: the inline v2 path (enrich-video) never carried mandalaId nor fired the book fill (only the defunct standalone handler did). Threads mandalaId + fires the existing 120s-debounced singleton fill after inline v2. Transcript probe: Mac Mini 200/450KB (alive), Azure 500 (fallback down, noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)