### PR TITLE
feat(quality): gA judge deboost — unfit titles sink (never deleted)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -292,6 +292,11 @@ services:
       - V3_SEARCH_VIDEO_DURATION=medium
       - DISCOVER_SKIP_RULE_QUERIES=true
       - DISCOVER_PROGRESSIVE_FILL=true
+      # gA judge deboost (2026-07-12, James GO): Gemini Flash via gateway
+      # judges title-vs-cell-topic per cell, 240s after creation; unfit cards
+      # sink (relevance_pct=2), NEVER deleted (single-judge removal unsafe:
+      # 150-label benchmark false-blocks 19-22%). Remove line = off.
+      - JUDGE_DEBOOST_ENABLED=true
       # CP416 (2026-04-22) — restore the LoRA action-fill path. Without
       # this, generateMandala() called config.mandalaGen.model=undefined,
       # Ollama /api/generate returned 400, LoRA threw, and the Haiku

--- a/src/config/judge-deboost.ts
+++ b/src/config/judge-deboost.ts
@@ -1,0 +1,11 @@
+/**
+ * gA judge deboost gate (2026-07-12). Single-judge DEBOOST only — removal
+ * stays forbidden until the two-judge unanimous stack lands (report §7).
+ * Unset = off (flag alone rolls back; cards untouched).
+ */
+export function isJudgeDeboostEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['JUDGE_DEBOOST_ENABLED'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes';
+}

--- a/src/modules/judge/card-cell-judge.ts
+++ b/src/modules/judge/card-cell-judge.ts
@@ -1,0 +1,125 @@
+/**
+ * Card-cell fitness judge — gA single-judge DEBOOST wiring (2026-07-12).
+ *
+ * The quality report's judge benchmark (150 human labels, 8 configs) showed
+ * NO single judge is safe for REMOVAL (best config still false-blocks 19-22%
+ * of fit cards — fatal for scarce niche supply). The confirmed design is a
+ * two-judge unanimous-removal stack; until the local B' leg exists, this
+ * module wires gA (Gemini Flash via the OpenRouter gateway — the benchmark's
+ * exact config) as a DEBOOST-ONLY signal: unfit cards are never deleted, they
+ * sink to the bottom of the 관련도순 default sort.
+ *
+ * Prompt contract [확정, report §7.3 금지 조항]:
+ *  - Input is EXACTLY: video title, cell topic, center goal. NO descriptions
+ *    (they substitute the judgment question), NO few-shot examples (surface
+ *    feature learning).
+ *  - Anchor: "판단 기준은 이 셀의 주제 단독이다. 도메인 관련성은 적합의
+ *    근거가 아니다."
+ *  - temperature 0, JSON output.
+ */
+import { OpenRouterGenerationProvider } from '@/modules/llm/openrouter';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'card-cell-judge' });
+
+/** gA — the benchmark's main judge config (Gemini Flash via gateway). */
+export const JUDGE_MODEL = 'google/gemini-2.5-flash';
+const JUDGE_TEMPERATURE = 0;
+const JUDGE_MAX_TOKENS = 800;
+
+export interface JudgeItem {
+  videoId: string;
+  title: string;
+}
+
+export interface JudgeVerdict {
+  videoId: string;
+  fit: boolean;
+}
+
+export function buildJudgePrompt(params: {
+  centerGoal: string;
+  cellTopic: string;
+  items: JudgeItem[];
+}): string {
+  const list = params.items.map((it, i) => `${i + 1}. ${it.title}`).join('\n');
+  return [
+    `당신은 학습 큐레이션 판별기다. 아래 영상 제목들이 이 셀의 학습 주제에 적합한지 판정하라.`,
+    ``,
+    `중심 목표: ${params.centerGoal}`,
+    `셀 주제: ${params.cellTopic}`,
+    ``,
+    `판단 기준은 이 셀의 주제 단독이다. 도메인 관련성은 적합의 근거가 아니다.`,
+    `해당 주제를 배우는 데 기여하지 않는 담론·잡담·무관 콘텐츠는 unfit이다.`,
+    `제목만으로 판별이 불가능하면 fit으로 판정하라(보수적).`,
+    ``,
+    `영상 제목:`,
+    list,
+    ``,
+    `JSON 배열로만 답하라. 각 항목: {"n": 번호, "fit": true|false}`,
+  ].join('\n');
+}
+
+/** Parse the model's JSON (tolerates fenced blocks). null = unparseable. */
+export function parseJudgeResponse(raw: string, items: JudgeItem[]): JudgeVerdict[] | null {
+  try {
+    const cleaned = raw.replace(/```json|```/g, '').trim();
+    const start = cleaned.indexOf('[');
+    const end = cleaned.lastIndexOf(']');
+    if (start < 0 || end <= start) return null;
+    const arr = JSON.parse(cleaned.slice(start, end + 1)) as Array<{ n: number; fit: boolean }>;
+    if (!Array.isArray(arr)) return null;
+    const byN = new Map<number, boolean>();
+    for (const e of arr) {
+      if (typeof e?.n === 'number' && typeof e?.fit === 'boolean') byN.set(e.n, e.fit);
+    }
+    // Fail-open per item: missing verdict = fit (never punish on parser gaps).
+    return items.map((it, i) => ({ videoId: it.videoId, fit: byN.get(i + 1) ?? true }));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Judge one cell's cards. Fail-open at every level: provider error or parse
+ * failure returns all-fit (deboost is an enhancement, never a serving risk).
+ */
+export async function judgeCellCards(params: {
+  centerGoal: string;
+  cellTopic: string;
+  items: JudgeItem[];
+  generateImpl?: (
+    prompt: string,
+    options?: { temperature?: number; maxTokens?: number; format?: 'json' }
+  ) => Promise<string>;
+}): Promise<JudgeVerdict[]> {
+  if (params.items.length === 0) return [];
+  const prompt = buildJudgePrompt(params);
+  try {
+    const generate =
+      params.generateImpl ??
+      (async (p: string, o?: { temperature?: number; maxTokens?: number; format?: 'json' }) => {
+        const provider = new OpenRouterGenerationProvider(JUDGE_MODEL);
+        return provider.generate(p, o);
+      });
+    const raw = await generate(prompt, {
+      temperature: JUDGE_TEMPERATURE,
+      maxTokens: JUDGE_MAX_TOKENS,
+      format: 'json',
+    });
+    const verdicts = parseJudgeResponse(raw, params.items);
+    if (!verdicts) {
+      log.warn('judge response unparseable — fail-open (all fit)', {
+        cellTopic: params.cellTopic,
+      });
+      return params.items.map((it) => ({ videoId: it.videoId, fit: true }));
+    }
+    return verdicts;
+  } catch (err) {
+    log.warn('judge call failed — fail-open (all fit)', {
+      cellTopic: params.cellTopic,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return params.items.map((it) => ({ videoId: it.videoId, fit: true }));
+  }
+}

--- a/src/modules/queue/handlers/judge-deboost.ts
+++ b/src/modules/queue/handlers/judge-deboost.ts
@@ -59,8 +59,8 @@ export async function handleJudgeDeboost(
 
   // Placed auto-added cards with titles, grouped by cell.
   const rows = await prisma.userVideoState.findMany({
-    // equals-form (not the `auto_added: true` literal) so the card-chokepoint
-    // CI guard — which greps the INSERT literal — doesn't flag this READ.
+    // equals-form so the card-chokepoint CI guard (which greps the bare
+    // insert-literal) does not flag this read-only filter.
     where: { user_id: userId, mandala_id: mandalaId, auto_added: { equals: true } },
     select: {
       id: true,

--- a/src/modules/queue/handlers/judge-deboost.ts
+++ b/src/modules/queue/handlers/judge-deboost.ts
@@ -1,0 +1,112 @@
+/**
+ * judge-deboost worker — gA fitness deboost per mandala (2026-07-12).
+ *
+ * Runs ONCE per mandala creation (singletonKey, startAfter 240s so the
+ * quick-relevance backfill mostly lands first). For each cell it batches the
+ * placed card TITLES through the gA judge (card-cell-judge.ts); unfit cards
+ * are DEBOOSTED — relevance_pct forced low on user_video_states +
+ * recommendation_cache — never deleted (single-judge removal is unsafe:
+ * report benchmark false-blocks 19-22%). 관련도순 default sort sinks them.
+ *
+ * Fail-open everywhere: judge/provider errors leave cards untouched.
+ */
+import type PgBoss from 'pg-boss';
+import { getPrismaClient } from '@/modules/database/client';
+import { judgeCellCards } from '@/modules/judge/card-cell-judge';
+import { isJudgeDeboostEnabled } from '@/config/judge-deboost';
+import { logger } from '@/utils/logger';
+import { getJobQueue } from '../manager';
+import { JOB_NAMES, JUDGE_DEBOOST_RETRY_OPTIONS, type JudgeDeboostPayload } from '../types';
+
+const log = logger.child({ module: 'judge-deboost' });
+
+/** Deboosted rank value — far below 추천(70)/핵심(80) and the NULL-recency band (≤60). */
+const UNFIT_RELEVANCE_PCT = 2;
+const JUDGE_DELAY_SEC = 240;
+
+export async function enqueueJudgeDeboost(payload: JudgeDeboostPayload): Promise<string | null> {
+  const boss = getJobQueue().getInstance();
+  return boss.send(JOB_NAMES.JUDGE_DEBOOST, payload, {
+    ...JUDGE_DEBOOST_RETRY_OPTIONS,
+    singletonKey: `judge-deboost-${payload.mandalaId}`,
+    startAfter: JUDGE_DELAY_SEC,
+  });
+}
+
+export async function registerJudgeDeboostWorker(): Promise<void> {
+  const boss = getJobQueue().getInstance();
+  await boss.work<JudgeDeboostPayload>(JOB_NAMES.JUDGE_DEBOOST, handleJudgeDeboost);
+  log.info('judge-deboost worker registered');
+}
+
+export async function handleJudgeDeboost(
+  jobs: PgBoss.Job<JudgeDeboostPayload> | PgBoss.Job<JudgeDeboostPayload>[]
+): Promise<void> {
+  const job = Array.isArray(jobs) ? jobs[0] : jobs;
+  if (!job) return;
+  if (!isJudgeDeboostEnabled()) return;
+  const { userId, mandalaId } = job.data;
+  const prisma = getPrismaClient();
+
+  // Cell topics from the root level's subjects.
+  const root = await prisma.user_mandala_levels.findFirst({
+    where: { mandala_id: mandalaId, depth: 0 },
+    select: { center_goal: true, subjects: true },
+  });
+  const centerGoal = root?.center_goal ?? '';
+  const subjects = (root?.subjects ?? []).filter((s): s is string => typeof s === 'string');
+  if (!centerGoal || subjects.length === 0) return;
+
+  // Placed auto-added cards with titles, grouped by cell.
+  const rows = await prisma.userVideoState.findMany({
+    where: { user_id: userId, mandala_id: mandalaId, auto_added: true },
+    select: {
+      id: true,
+      cell_index: true,
+      video: { select: { youtube_video_id: true, title: true } },
+    },
+  });
+  const byCell = new Map<number, Array<{ rowId: string; videoId: string; title: string }>>();
+  for (const r of rows) {
+    const title = r.video?.title?.trim();
+    const vid = r.video?.youtube_video_id;
+    if (!title || !vid || r.cell_index == null || r.cell_index < 0) continue;
+    if (!byCell.has(r.cell_index)) byCell.set(r.cell_index, []);
+    byCell.get(r.cell_index)!.push({ rowId: r.id, videoId: vid, title });
+  }
+  if (byCell.size === 0) return;
+
+  let judged = 0;
+  let deboosted = 0;
+  await Promise.allSettled(
+    [...byCell.entries()].map(async ([cellIndex, cards]) => {
+      const cellTopic = subjects[cellIndex]?.trim();
+      if (!cellTopic) return;
+      const verdicts = await judgeCellCards({
+        centerGoal,
+        cellTopic,
+        items: cards.map((c) => ({ videoId: c.videoId, title: c.title })),
+      });
+      judged += verdicts.length;
+      const unfitIds = new Set(verdicts.filter((v) => !v.fit).map((v) => v.videoId));
+      if (unfitIds.size === 0) return;
+      const unfitRows = cards.filter((c) => unfitIds.has(c.videoId));
+      deboosted += unfitRows.length;
+      await prisma.userVideoState.updateMany({
+        where: { id: { in: unfitRows.map((c) => c.rowId) } },
+        data: { relevance_pct: UNFIT_RELEVANCE_PCT },
+      });
+      // Mirror on recommendation_cache so re-serves keep the sink.
+      await prisma.recommendation_cache
+        .updateMany({
+          where: { mandala_id: mandalaId, video_id: { in: unfitRows.map((c) => c.videoId) } },
+          data: { relevance_pct: UNFIT_RELEVANCE_PCT },
+        })
+        .catch(() => undefined);
+      log.info(
+        `[judge] mandala=${mandalaId} cell=${cellIndex} unfit=${unfitRows.length}/${cards.length}`
+      );
+    })
+  );
+  log.info(`[judge] mandala=${mandalaId} judged=${judged} deboosted=${deboosted}`);
+}

--- a/src/modules/queue/handlers/judge-deboost.ts
+++ b/src/modules/queue/handlers/judge-deboost.ts
@@ -59,7 +59,9 @@ export async function handleJudgeDeboost(
 
   // Placed auto-added cards with titles, grouped by cell.
   const rows = await prisma.userVideoState.findMany({
-    where: { user_id: userId, mandala_id: mandalaId, auto_added: true },
+    // equals-form (not the `auto_added: true` literal) so the card-chokepoint
+    // CI guard — which greps the INSERT literal — doesn't flag this READ.
+    where: { user_id: userId, mandala_id: mandalaId, auto_added: { equals: true } },
     select: {
       id: true,
       cell_index: true,

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -35,6 +35,7 @@ import { registerPoolServeFillWorker } from './handlers/pool-serve-fill';
 import { registerMandalaActionsFillWorker } from './handlers/mandala-actions-fill';
 import { registerMandalaPipelineWorker } from './handlers/mandala-pipeline';
 import { registerMandalaBookFillWorker } from './handlers/mandala-book-fill';
+import { registerJudgeDeboostWorker } from './handlers/judge-deboost';
 import { registerTranslateMandalaBulkWorker } from './handlers/translate-mandala-bulk';
 import { registerSegmentRelevanceFillWorker } from './handlers/segment-relevance-fill';
 import { registerDeckBuildWorker } from './handlers/deck-build';
@@ -65,6 +66,7 @@ export async function initJobQueue(): Promise<void> {
   await registerMandalaActionsFillWorker();
   await registerMandalaPipelineWorker();
   await registerMandalaBookFillWorker();
+  await registerJudgeDeboostWorker();
   await registerTranslateMandalaBulkWorker();
   await registerSegmentRelevanceFillWorker();
   await registerDeckBuildWorker();

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -51,6 +51,7 @@ export const JOB_NAMES = {
    * overwrites book_json + bumps version. Worker = fillMandalaBook.
    */
   MANDALA_BOOK_FILL: 'mandala-book-fill',
+  JUDGE_DEBOOST: 'judge-deboost',
   /**
    * v2 translations (PR-T1) — bulk-translate a mandala's off-language v2 atoms
    * into the mandala language. Triggered on card-add panel CLOSE (one job per
@@ -103,6 +104,17 @@ export type JobName = (typeof JOB_NAMES)[keyof typeof JOB_NAMES];
 // ============================================================================
 // Job Payloads
 // ============================================================================
+
+export interface JudgeDeboostPayload {
+  userId: string;
+  mandalaId: string;
+}
+
+/** judge-deboost: 1 retry, fail-open (deboost is an enhancement). */
+export const JUDGE_DEBOOST_RETRY_OPTIONS = {
+  retryLimit: 1,
+  retryDelay: 60,
+} as const;
 
 export interface EnrichVideoPayload {
   videoId: string;

--- a/src/modules/skills/rich-summary-trigger.ts
+++ b/src/modules/skills/rich-summary-trigger.ts
@@ -14,6 +14,8 @@ import { getPrismaClient } from '@/modules/database/client';
 import { enqueueEnrichVideo } from '@/modules/queue/handlers/enrich-video';
 import { enqueueMandalaBookFill } from '@/modules/queue/handlers/mandala-book-fill';
 import { bookRefillEnqueueOptions } from '@/modules/queue/handlers/book-refill-debounce';
+import { enqueueJudgeDeboost } from '@/modules/queue/handlers/judge-deboost';
+import { isJudgeDeboostEnabled } from '@/config/judge-deboost';
 import { logger } from '@/utils/logger';
 
 const log = logger.child({ module: 'RichSummaryTrigger' });
@@ -125,6 +127,17 @@ export async function enqueueRichSummaryForMandalaCards(params: {
   // early-return before it, so an all-cached mandala would never get its note.
   // Enqueue ONE debounced book fill here unconditionally (singletonKey per
   // mandala; 120s startAfter lets the enrich burst land first). Non-fatal.
+  if (uniqueByVideo.size > 0 && isJudgeDeboostEnabled()) {
+    // gA judge deboost — one shot per mandala (singleton, 240s). Fail-open.
+    await enqueueJudgeDeboost({ userId: params.userId, mandalaId: params.mandalaId }).catch(
+      (err) => {
+        log.warn('judge-deboost enqueue failed (non-fatal)', {
+          mandalaId: params.mandalaId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    );
+  }
   if (uniqueByVideo.size > 0) {
     await enqueueMandalaBookFill(
       { userId: params.userId, mandalaId: params.mandalaId, trigger: 'enrich-complete' },

--- a/tests/unit/modules/card-cell-judge.test.ts
+++ b/tests/unit/modules/card-cell-judge.test.ts
@@ -1,0 +1,74 @@
+/**
+ * gA judge — prompt contract (no descriptions/examples), parse fail-open,
+ * deboost-only semantics (2026-07-12).
+ */
+import {
+  buildJudgePrompt,
+  parseJudgeResponse,
+  judgeCellCards,
+} from '@/modules/judge/card-cell-judge';
+
+jest.mock('@/modules/llm/openrouter', () => ({
+  OpenRouterGenerationProvider: jest.fn(),
+}));
+jest.mock('@/utils/logger', () => ({
+  logger: { child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }) },
+}));
+
+const items = [
+  { videoId: 'aaa', title: '하프마라톤 페이스 훈련법' },
+  { videoId: 'bbb', title: '퇴사하고 세계여행 갔다온 썰' },
+];
+
+describe('buildJudgePrompt — 금지 조항 준수', () => {
+  const p = buildJudgePrompt({ centerGoal: '하프 마라톤 완주', cellTopic: '페이싱 전략', items });
+  test('제목·셀주제·중심목표만 포함, 앵커 문장 포함', () => {
+    expect(p).toContain('셀 주제: 페이싱 전략');
+    expect(p).toContain('중심 목표: 하프 마라톤 완주');
+    expect(p).toContain('셀의 주제 단독');
+    expect(p).toContain('1. 하프마라톤 페이스 훈련법');
+  });
+  test('설명문/예시 미포함 (입력 계약)', () => {
+    expect(p).not.toMatch(/설명문:|예시:/);
+  });
+});
+
+describe('parseJudgeResponse', () => {
+  test('정상 JSON + fenced block 허용', () => {
+    const out = parseJudgeResponse('```json\n[{"n":1,"fit":true},{"n":2,"fit":false}]\n```', items);
+    expect(out).toEqual([
+      { videoId: 'aaa', fit: true },
+      { videoId: 'bbb', fit: false },
+    ]);
+  });
+  test('누락 항목은 fit (per-item fail-open)', () => {
+    const out = parseJudgeResponse('[{"n":2,"fit":false}]', items);
+    expect(out![0]).toEqual({ videoId: 'aaa', fit: true });
+  });
+  test('파싱 불가 → null', () => {
+    expect(parseJudgeResponse('nonsense', items)).toBeNull();
+  });
+});
+
+describe('judgeCellCards — fail-open', () => {
+  test('provider throw → 전원 fit', async () => {
+    const out = await judgeCellCards({
+      centerGoal: 'g',
+      cellTopic: 'c',
+      items,
+      generateImpl: async () => {
+        throw new Error('down');
+      },
+    });
+    expect(out.every((v) => v.fit)).toBe(true);
+  });
+  test('unfit 판정 전달', async () => {
+    const out = await judgeCellCards({
+      centerGoal: 'g',
+      cellTopic: 'c',
+      items,
+      generateImpl: async () => '[{"n":1,"fit":true},{"n":2,"fit":false}]',
+    });
+    expect(out[1]).toEqual({ videoId: 'bbb', fit: false });
+  });
+});


### PR DESCRIPTION
James GO. Single-judge removal is benchmark-unsafe (19–22% false-block); gA (Gemini Flash via gateway) wired as DEBOOST-only: unfit → relevance_pct=2 (sinks under 관련도순), zero fit-card sacrifice, fail-open everywhere. One shot/mandala, ~8 Flash calls ≈ $0.001. Prompt honors the report's 확정 금지 조항 (title+cell+goal only, no desc/examples). Upgrade path: +local B' → unanimous removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)