### PR TITLE
fix(wizard): T6 — inflow-gate off restores done-by-click precompute (+v2 cost gate)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -113,7 +113,14 @@ services:
       # D-04 §4-2 wizard shadow (supervisor-approved after CUT=false zero-
       # impact proof, wizard-precompute.ts:179): judge scores + traces
       # would_cut, slots untouched. CUT stays off until the canary gate.
-      - INFLOW_GATE_ENABLED=true
+      # T6 (2026-07-12, matrix F12): inflow-gate shadow judge added 15-50s to
+      # wizard precompute (v5 discover itself is <1s) — killed done-by-click
+      # since 7/3 (#1085). CUT was never on; judge-deboost (post-placement)
+      # owns precision now. Rollback: flip back to true.
+      - INFLOW_GATE_ENABLED=false
+      # T6 test window cost gate — pause wizard v2 burst + book fill (judge
+      # stays on). REVERT to true (or delete) after the 3-field E2E round.
+      - V2_AUTO_ENRICH_ENABLED=false
       # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
       # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
       # a cell with ≥3 pool candidates drops its live search.list query → quota

--- a/src/config/v2-auto-enrich.ts
+++ b/src/config/v2-auto-enrich.ts
@@ -1,0 +1,13 @@
+/**
+ * V2 auto-enrich gate (T6 round, 2026-07-12). Controls the wizard-creation
+ * bulk v2 chain (enrich-video jobs + trigger-level book fill). Default TRUE —
+ * unset keeps today's behavior; only an explicit false/0/no pauses the chain
+ * (cost-control during E2E test windows, James 2026-07-12). Judge deboost is
+ * NOT gated by this — it stays on its own JUDGE_DEBOOST_ENABLED flag.
+ */
+export function isV2AutoEnrichEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['V2_AUTO_ENRICH_ENABLED'] ?? '')
+    .trim()
+    .toLowerCase();
+  return !(v === 'false' || v === '0' || v === 'no');
+}

--- a/src/modules/skills/rich-summary-trigger.ts
+++ b/src/modules/skills/rich-summary-trigger.ts
@@ -16,6 +16,7 @@ import { enqueueMandalaBookFill } from '@/modules/queue/handlers/mandala-book-fi
 import { bookRefillEnqueueOptions } from '@/modules/queue/handlers/book-refill-debounce';
 import { enqueueJudgeDeboost } from '@/modules/queue/handlers/judge-deboost';
 import { isJudgeDeboostEnabled } from '@/config/judge-deboost';
+import { isV2AutoEnrichEnabled } from '@/config/v2-auto-enrich';
 import { logger } from '@/utils/logger';
 
 const log = logger.child({ module: 'RichSummaryTrigger' });
@@ -91,7 +92,12 @@ export async function enqueueRichSummaryForMandalaCards(params: {
 
   let enqueued = 0;
   let skipped = 0;
-  for (const [videoId, meta] of uniqueByVideo) {
+  // T6 cost gate — enrich burst + trigger book fill pause together; judge
+  // deboost (below) keeps firing so 품질 판정 stays testable while paused.
+  const v2Enabled = isV2AutoEnrichEnabled();
+  for (const [videoId, meta] of v2Enabled
+    ? uniqueByVideo
+    : new Map<string, { title: string | null; url: string }>()) {
     try {
       await enqueueEnrichVideo({
         videoId,
@@ -118,6 +124,7 @@ export async function enqueueRichSummaryForMandalaCards(params: {
     userId: params.userId,
     mandalaId: params.mandalaId,
     uniqueVideos: uniqueByVideo.size,
+    v2Enabled,
     enqueued,
     skipped,
   });
@@ -138,7 +145,7 @@ export async function enqueueRichSummaryForMandalaCards(params: {
       }
     );
   }
-  if (uniqueByVideo.size > 0) {
+  if (uniqueByVideo.size > 0 && v2Enabled) {
     await enqueueMandalaBookFill(
       { userId: params.userId, mandalaId: params.mandalaId, trigger: 'enrich-complete' },
       bookRefillEnqueueOptions(params.mandalaId)

--- a/tests/unit/config/v2-auto-enrich.test.ts
+++ b/tests/unit/config/v2-auto-enrich.test.ts
@@ -1,0 +1,24 @@
+import { isV2AutoEnrichEnabled } from '@/config/v2-auto-enrich';
+
+describe('isV2AutoEnrichEnabled', () => {
+  it('defaults to true when unset (legacy behavior)', () => {
+    expect(isV2AutoEnrichEnabled({} as NodeJS.ProcessEnv)).toBe(true);
+  });
+  it('stays true on arbitrary values', () => {
+    expect(isV2AutoEnrichEnabled({ V2_AUTO_ENRICH_ENABLED: 'yes' } as NodeJS.ProcessEnv)).toBe(
+      true
+    );
+    expect(isV2AutoEnrichEnabled({ V2_AUTO_ENRICH_ENABLED: 'true' } as NodeJS.ProcessEnv)).toBe(
+      true
+    );
+  });
+  it('pauses only on explicit false/0/no', () => {
+    expect(isV2AutoEnrichEnabled({ V2_AUTO_ENRICH_ENABLED: 'false' } as NodeJS.ProcessEnv)).toBe(
+      false
+    );
+    expect(isV2AutoEnrichEnabled({ V2_AUTO_ENRICH_ENABLED: '0' } as NodeJS.ProcessEnv)).toBe(false);
+    expect(isV2AutoEnrichEnabled({ V2_AUTO_ENRICH_ENABLED: 'no' } as NodeJS.ProcessEnv)).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Root cause (matrix F12)
- Wizard precompute (v5 discover) itself runs **<1s** (measured stageMs: fanout 0.4-0.6s + videos 0.2-0.3s).
- The **inflow-gate shadow judge** (armed 7/3 #1085, CUT never enabled = telemetry only) scores all ~60 slots via Haiku **inside startPrecompute**, adding 15-50s (row created->done measured 16-51s, median 24s).
- Result: precompute stopped being done-by-click. consume (6s poll) misses -> full pipeline re-run: 21-43s paint + duplicate YouTube quota. Pre-7/3 first-card offset was **1-4s** (DB), post-7/3 **15-23s** uniform.

## Change
- `INFLOW_GATE_ENABLED=false` (compose). Zero serving effect — cut was never on. Precision judging is owned by post-placement judge-deboost (#1172, live).
- New `V2_AUTO_ENRICH_ENABLED` (default true = legacy). Set false in compose for the E2E test window: pauses wizard v2 burst + trigger-level book fill (cost gate, James directive). Judge deboost stays on. **Revert after the 3-field round.**

## Verification
- tsc 0, new config test 3/3 green.
- Post-deploy: 3-field manual E2E (fast-click) — expect consume HIT + first paint ≈6s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)