### PR TITLE
feat(wizard): T7 — attach to in-flight precompute on consume miss

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -121,6 +121,9 @@ services:
       # T6 test window cost gate — pause wizard v2 burst + book fill (judge
       # stays on). REVERT to true (or delete) after the 3-field E2E round.
       - V2_AUTO_ENRICH_ENABLED=false
+      # T7 (matrix §11-b): consume miss → attach to in-flight precompute
+      # instead of re-running discover (quota x2, 21-43s). Rollback: delete.
+      - PRECOMPUTE_ATTACH_ENABLED=true
       # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
       # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
       # a cell with ≥3 pool candidates drops its live search.list query → quota

--- a/src/config/precompute-attach.ts
+++ b/src/config/precompute-attach.ts
@@ -1,0 +1,32 @@
+/**
+ * T7 — precompute attach (matrix 2026-07-12 §11-b).
+ *
+ * When the wizard consume poll (6s) expires while the precompute is still
+ * running, legacy behavior re-runs the FULL discover pipeline: 21-43s to
+ * first card + a duplicate YouTube quota spend for work the precompute
+ * finishes seconds later anyway (measured: marathon missed done by ~6s,
+ * JLPT by ~12s). Attach instead: a detached watcher waits for the row to
+ * turn done and re-consumes it; pipeline step2 skips while a YOUNG
+ * precompute is in flight so the quota is spent once.
+ *
+ * Default OFF (unset = legacy re-run). Rollback: flag flip, no code revert.
+ */
+export function isPrecomputeAttachEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['PRECOMPUTE_ATTACH_ENABLED'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes';
+}
+
+/** Watcher gives the precompute this long past consume-miss before falling back. */
+export const ATTACH_BUDGET_MS = 30_000;
+export const ATTACH_POLL_INTERVAL_MS = 500;
+
+/**
+ * Discover step2 skips only while the in-flight precompute row is younger
+ * than this — old enough rows mean the precompute is anomalous (post-T6 p95
+ * is ~9s) and the pipeline must own placement again. Keep this well below
+ * ATTACH_BUDGET_MS so the watcher's fallback re-trigger never dead-ends on
+ * its own skip condition.
+ */
+export const ATTACH_INFLIGHT_MAX_AGE_MS = 20_000;

--- a/src/modules/mandala/pipeline-runner.ts
+++ b/src/modules/mandala/pipeline-runner.ts
@@ -22,6 +22,7 @@ import { logger } from '@/utils/logger';
 import { ensureMandalaEmbeddings } from './ensure-mandala-embeddings';
 import { maybeAutoAddRecommendations } from './auto-add-recommendations';
 import { withTraceContext } from '@/modules/discover-tracing';
+import { isPrecomputeAttachEnabled, ATTACH_INFLIGHT_MAX_AGE_MS } from '@/config/precompute-attach';
 
 const log = logger.child({ module: 'pipeline-runner' });
 
@@ -334,6 +335,24 @@ async function checkDiscoverPreconditions(
     select: { id: true },
   });
   if (recent) return 'recent discover within 5min window';
+
+  // T7 attach — a YOUNG in-flight wizard precompute owns placement: its
+  // watcher re-consumes on done (or re-triggers this pipeline on failure/
+  // timeout), so running discover here would double the YouTube quota for
+  // the same goal. Age-capped so an anomalous hung precompute can never
+  // starve discover: past ATTACH_INFLIGHT_MAX_AGE_MS this gate opens again.
+  if (isPrecomputeAttachEnabled()) {
+    const inflightCutoff = new Date(Date.now() - ATTACH_INFLIGHT_MAX_AGE_MS);
+    const inflight = await db.mandala_wizard_precompute.findFirst({
+      where: {
+        user_id: userId,
+        status: { in: ['pending', 'running'] },
+        created_at: { gt: inflightCutoff },
+      },
+      select: { session_id: true },
+    });
+    if (inflight) return 'wizard precompute in flight (attach owns placement)';
+  }
 
   // Opt-in gate
   const config = await db.user_skill_config.findFirst({

--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -34,6 +34,11 @@ import { writeSearchTrace, type SearchTraceCandidateInput } from '@/modules/sear
 import { loadInflowGateConfig } from '@/config/inflow-gate';
 import { notifyCardAdded, type CardPayload } from '@/modules/recommendations/publisher';
 import { MS_PER_DAY } from '@/utils/time-constants';
+import {
+  isPrecomputeAttachEnabled,
+  ATTACH_BUDGET_MS,
+  ATTACH_POLL_INTERVAL_MS,
+} from '@/config/precompute-attach';
 import { randomUUID } from 'crypto';
 
 const log = logger.child({ module: 'wizard-precompute' });
@@ -396,7 +401,10 @@ export async function consumePrecompute(
     );
   }
 
-  if (row.status !== 'done') return { consumed: false, reason: 'not-done' };
+  if (row.status !== 'done') {
+    scheduleAttachWatcher(input, row.status);
+    return { consumed: false, reason: 'not-done' };
+  }
   if (row.expires_at.getTime() < Date.now()) return { consumed: false, reason: 'expired' };
 
   // Goal match: allow minor whitespace / case variance but reject substantive
@@ -639,6 +647,69 @@ export async function consumePrecompute(
   }
 
   return { consumed: true, cardsInserted: inserted, slotsCount: slots.length };
+}
+
+// ---------------------------------------------------------------------------
+// T7 — attach watcher (matrix §11-b): consume missed while the precompute was
+// still running. Instead of letting the full pipeline re-run discover, wait
+// for the row to turn done (≤ATTACH_BUDGET_MS) and re-consume it. On failure
+// or timeout, re-trigger the pipeline; checkDiscoverPreconditions only skips
+// for YOUNG in-flight rows, so this fallback cannot dead-end on its own skip.
+// ---------------------------------------------------------------------------
+
+const activeAttachSessions = new Set<string>();
+
+function scheduleAttachWatcher(input: ConsumePrecomputeInput, statusAtMiss: string): void {
+  if (!isPrecomputeAttachEnabled()) return;
+  if (statusAtMiss !== 'pending' && statusAtMiss !== 'running') return; // failed/consumed: nothing to wait for
+  if (activeAttachSessions.has(input.sessionId)) return;
+  activeAttachSessions.add(input.sessionId);
+
+  setImmediate(() => {
+    void (async () => {
+      const db = getPrismaClient();
+      const t0 = Date.now();
+      try {
+        while (Date.now() - t0 < ATTACH_BUDGET_MS) {
+          await new Promise<void>((resolve) => setTimeout(resolve, ATTACH_POLL_INTERVAL_MS));
+          const row = await db.mandala_wizard_precompute.findUnique({
+            where: { session_id: input.sessionId },
+            select: { status: true },
+          });
+          if (!row || row.status === 'failed' || row.status === 'consumed') break;
+          if (row.status === 'done') {
+            // Re-enter consume: status=done skips the poll, inserts slots and
+            // runs the same inline auto-add path as a first-try hit.
+            const outcome = await consumePrecompute(input);
+            log.info(
+              `attach consumed after miss: session=${input.sessionId} waited_ms=${Date.now() - t0} ` +
+                `consumed=${outcome.consumed} inserted=${outcome.cardsInserted ?? 0}`
+            );
+            if (outcome.consumed) return;
+            break; // consume miss on a done row (expired/goal-mismatch) → fallback
+          }
+        }
+        // Failed, vanished, timed out, or post-done consume miss → pipeline owns it.
+        log.info(
+          `attach fallback → pipeline re-trigger: session=${input.sessionId} waited_ms=${Date.now() - t0}`
+        );
+        const { triggerMandalaPostCreationAsync } = await import('./mandala-post-creation');
+        triggerMandalaPostCreationAsync(
+          input.userId,
+          input.mandalaId,
+          'precompute-attach-fallback'
+        );
+      } catch (err) {
+        log.warn(
+          `attach watcher threw (non-fatal): session=${input.sessionId} error=${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      } finally {
+        activeAttachSessions.delete(input.sessionId);
+      }
+    })();
+  });
 }
 
 /**

--- a/tests/unit/config/precompute-attach.test.ts
+++ b/tests/unit/config/precompute-attach.test.ts
@@ -1,0 +1,30 @@
+import {
+  isPrecomputeAttachEnabled,
+  ATTACH_BUDGET_MS,
+  ATTACH_INFLIGHT_MAX_AGE_MS,
+} from '@/config/precompute-attach';
+
+describe('isPrecomputeAttachEnabled', () => {
+  it('defaults to false when unset (legacy re-run behavior)', () => {
+    expect(isPrecomputeAttachEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+  it('enables on true/1/yes', () => {
+    expect(
+      isPrecomputeAttachEnabled({ PRECOMPUTE_ATTACH_ENABLED: 'true' } as NodeJS.ProcessEnv)
+    ).toBe(true);
+    expect(isPrecomputeAttachEnabled({ PRECOMPUTE_ATTACH_ENABLED: '1' } as NodeJS.ProcessEnv)).toBe(
+      true
+    );
+    expect(
+      isPrecomputeAttachEnabled({ PRECOMPUTE_ATTACH_ENABLED: 'yes' } as NodeJS.ProcessEnv)
+    ).toBe(true);
+  });
+  it('stays off on other values', () => {
+    expect(
+      isPrecomputeAttachEnabled({ PRECOMPUTE_ATTACH_ENABLED: 'false' } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+  it('keeps the inflight skip window well below the watcher budget (no dead-end)', () => {
+    expect(ATTACH_INFLIGHT_MAX_AGE_MS).toBeLessThan(ATTACH_BUDGET_MS);
+  });
+});


### PR DESCRIPTION
## Problem (matrix F3/F4)
consume polls 6s → not-done → full pipeline re-run: 21-43s first card + duplicate YouTube quota. Measured misses were near-misses: marathon's precompute finished ~6s after the poll gave up, JLPT ~12s after.

## Change (flag: `PRECOMPUTE_ATTACH_ENABLED`, default off)
- On not-done, a detached watcher waits ≤30s for the precompute row to turn `done`, then re-enters `consumePrecompute` — same slot insert + inline auto-add as a first-try HIT. On failure/timeout → `triggerMandalaPostCreationAsync` fallback.
- `checkDiscoverPreconditions` skips step2 while a YOUNG (<20s) precompute is in flight (quota spent once). Age cap < watcher budget ⇒ the fallback re-trigger cannot dead-end on its own skip condition.
- Compose: flag on.

## Verification
- tsc 0, config tests 4/4 green. Unrelated local zod-env failures reproduce on clean main (CI green there).
- Post-deploy E2E: fast-click wizard in a slow-supply field; expect either HIT or attach-consume ≤~15s, and step2 'precompute in flight' skip in pipeline logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)