### PR TITLE
feat(discover): T8 — long-form v5 harvest + un-cap semantic gate embeds

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -515,7 +515,10 @@ services:
       # exceeded — embedding.ts will chunk into 2-3 batches, adding ~1-2s
       # latency. Acceptable for the candidate-pool expansion gain.
       # Rollback: set back to 30.
-      - V3_SEMANTIC_MAX_CANDIDATES=100
+      # T8b (matrix F5): 100-cap left 95/195 of the marathon harvest with NO
+      # embedding -> auto-dropped by the center gate (silent slaughter). 250
+      # covers the full post-dedup harvest (hardcap 180 + margin).
+      - V3_SEMANTIC_MAX_CANDIDATES=250
       # CP436 PR-Y0d (Issue #543) — bypass mandala-filter and trust YouTube's
       # search.list ranking. User feedback (2026-04-28): the 9-axis filter
       # actively degraded card quality vs the original YouTube-only path
@@ -620,7 +623,10 @@ services:
       # no longer finishes inside wizard review time -> MISS -> blank landing.
       # Re-admit only with an indexed pool-match design (P2 track, post-beta).
       - V3_TIER1_SOURCES=v2_promoted
-      - V3_SEMANTIC_MIN_COSINE=0.5
+      # T8b recall: 0.5 passed only 31/100 embedded on-topic marathon titles.
+      # Precision backstop = judge-deboost (post-placement). Next step 0.42
+      # only with judge deboost-rate evidence.
+      - V3_SEMANTIC_MIN_COSINE=0.45
       # BL-17 (2026-07-04) — fail-closed empty-title guard. SCRUB (YouTube ToS
       # 30d metadata wipe, is_active-agnostic) + /like zombie upsert leave ~691
       # live v2_promoted rows with title=''; their empty-string embedding

--- a/src/skills/plugins/video-discover/v5/youtube-fanout.ts
+++ b/src/skills/plugins/video-discover/v5/youtube-fanout.ts
@@ -27,6 +27,7 @@ import { buildRuleBasedQueriesSync, type SearchQuery } from '../v2/keyword-build
 import { buildLLMQueriesPerCell, type QueryGenMeta } from './llm-query-gen';
 import { translateQueriesToEn } from './en-query-translate';
 import { getV5Config } from './config';
+import { getSearchVideoDuration } from '@/config/discover-t5';
 import { logChannelDistribution } from '../diversity-guard';
 import { detectLanguage } from '@/utils/detect-language';
 import { MERGED_GEN_MODEL } from '@/prompts/mandala-with-queries-generator';
@@ -625,6 +626,11 @@ export async function runYouTubeFanout(input: FanoutInput): Promise<FanoutResult
         regionCode: input.language === 'ko' ? 'KR' : 'US',
         timeoutMs: cfg.searchTimeoutMs,
         publishedAfter: input.publishedAfter,
+        // T8a (matrix §11-b): long-form-only harvest. v3 gained this in T5
+        // (executor runSearchTraced) but the v5 wizard path kept harvesting
+        // shorts and dropping them post-hoc — measured 69/180 (38%) of the
+        // cooking-field harvest wasted (R-T6 round). Same env knob as v3.
+        ...(getSearchVideoDuration() ? { videoDuration: getSearchVideoDuration()! } : {}),
       }).then((items) => ({ items, cellIndex: q.cellIndex ?? null }))
     )
   );

--- a/tests/unit/skills/video-discover/v5-fanout-video-duration.test.ts
+++ b/tests/unit/skills/video-discover/v5-fanout-video-duration.test.ts
@@ -1,0 +1,25 @@
+/**
+ * T8a — v5 fanout must forward V3_SEARCH_VIDEO_DURATION to search.list the
+ * same way the v3 executor does (long-form-only harvest at the source).
+ * We assert on the shared config fn + the option plumbing contract of
+ * searchVideos (videoDuration set only when the env resolves).
+ */
+import { getSearchVideoDuration } from '@/config/discover-t5';
+
+describe('v5 fanout videoDuration plumbing (T8a)', () => {
+  it('env medium resolves for the fanout spread', () => {
+    expect(
+      getSearchVideoDuration({ V3_SEARCH_VIDEO_DURATION: 'medium' } as NodeJS.ProcessEnv)
+    ).toBe('medium');
+  });
+  it('unset env resolves null → fanout omits the param (legacy)', () => {
+    expect(getSearchVideoDuration({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+  it('fanout source spreads videoDuration from the shared config', () => {
+    const fs = require('fs');
+    const path = require.resolve('@/skills/plugins/video-discover/v5/youtube-fanout');
+    const src = fs.readFileSync(path, 'utf8');
+    expect(src).toContain('getSearchVideoDuration');
+    expect(src).toContain('videoDuration');
+  });
+});


### PR DESCRIPTION
## Measured causes (matrix F5 + R-T6)
- **v5 wizard harvest includes shorts** then drops them post-hoc: cooking field lost 69/180 (38%) of raw supply → only 21 slots. v3 got `videoDuration` in T5; v5 never did.
- **V3_SEMANTIC_MAX_CANDIDATES=100** left 95/195 of the marathon harvest with NO embedding — the semantic center gate scores missing vectors 0 and drops them (`droppedByCenterGate: 164`, of which ~95 were never embedded at all).
- Of the 100 embedded, **0.5 cosine passed only 31**.

## Changes
- T8a (code, 3 lines): v5 fanout forwards `V3_SEARCH_VIDEO_DURATION` (same env knob as v3; prod=medium).
- T8b (compose only): `V3_SEMANTIC_MAX_CANDIDATES` 100→250 (embed the whole post-dedup harvest, hardcap 180+margin), `V3_SEMANTIC_MIN_COSINE` 0.5→0.45. Precision backstop = judge-deboost (live, verified 4-field correct). Further 0.42 only with deboost-rate evidence.

## Verification
- tsc 0, tests 9/9 (new plumbing test + existing discover-t5).
- Post-deploy: shorts-heavy field E2E (요리류) — expect shortsDropped≈0, slots 21→50+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)