### PR TITLE
feat(discover): T9 — domain anchor on deficit-cell subgoal queries

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -124,6 +124,9 @@ services:
       # T7 (matrix §11-b): consume miss → attach to in-flight precompute
       # instead of re-running discover (quota x2, 21-43s). Rollback: delete.
       - PRECOMPUTE_ATTACH_ENABLED=true
+      # T9 (matrix F6): deficit-cell subgoal queries carry a domain anchor
+      # from the center goal ("일본어 JLPT N3" + "청취 회화"). Rollback: delete.
+      - DISCOVER_SUBGOAL_ANCHOR_ENABLED=true
       # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
       # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
       # a cell with ≥3 pool candidates drops its live search.list query → quota

--- a/src/config/subgoal-anchor.ts
+++ b/src/config/subgoal-anchor.ts
@@ -1,0 +1,61 @@
+/**
+ * T9 — domain anchor for deficit-cell subgoal queries (matrix F6).
+ *
+ * The T5 subgoal queries went out as the raw cell topic ("청취 회화",
+ * "모의고사", "시험 전략") with no domain context — on Korean YouTube those
+ * strings are dominated by English-learning / 수능 content, which is how a
+ * JLPT mandala harvested 20 English cards (R-judge-2, all judge-deboosted).
+ *
+ * The anchor is the center goal with its non-domain tokens stripped:
+ * numbers/durations ("6개월", "4시간", "1년") and goal-action words
+ * ("합격", "완주", "마스터", "키우기"). Examples:
+ *   "일본어 JLPT N3 6개월 합격"      → "일본어 JLPT N3"
+ *   "마라톤 풀코스 4시간 완주"        → "마라톤 풀코스"
+ *   "퇴근 후 1시간으로 유튜브 채널 키우기" → "퇴근 후 유튜브 채널"
+ * Query = "<anchor> <subgoal>" — still a natural phrase, unlike the retired
+ * full-centerGoal concat that YouTube matched poorly.
+ *
+ * Default OFF (unset = raw-subgoal legacy). Rollback: flag flip.
+ */
+
+export function isSubgoalAnchorEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['DISCOVER_SUBGOAL_ANCHOR_ENABLED'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes';
+}
+
+/** Numbers with/without Korean duration units, and bare digits: "6개월", "4시간", "1년", "3", "10kg". */
+const NUMERIC_TOKEN_RE =
+  /^\d+(개월|주일?|일|시간|분|년|kg|명|점|회|배|등급?)?(으로|까지|이내|안에|만에)?$/i;
+
+/** Goal-action tokens that carry no searchable domain signal. */
+const ACTION_TOKEN_RE =
+  /^(합격|완주|달성|마스터|완성|입문|독학|시작|도전|성공|만들기|키우기|되기|하기|배우기|끝내기|정복)(하기)?$/;
+
+/** Max anchor tokens — keep "<anchor> <subgoal>" a natural search phrase. */
+const MAX_ANCHOR_TOKENS = 4;
+
+/** Center goal → domain anchor. Empty string when nothing survives stripping. */
+export function extractDomainAnchor(centerGoal: string): string {
+  const tokens = centerGoal
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .filter((t) => !NUMERIC_TOKEN_RE.test(t))
+    .filter((t) => !ACTION_TOKEN_RE.test(t));
+  return tokens.slice(0, MAX_ANCHOR_TOKENS).join(' ');
+}
+
+/** "<anchor> <subgoal>", falling back to the raw subgoal when no anchor survives. */
+export function buildAnchoredSubgoalQuery(centerGoal: string, subGoal: string): string {
+  const anchor = extractDomainAnchor(centerGoal);
+  if (!anchor) return subGoal;
+  // Avoid "마라톤 풀코스 마라톤 페이스" — skip anchor tokens already in the subgoal.
+  const sgLower = subGoal.toLowerCase();
+  const filtered = anchor
+    .split(' ')
+    .filter((t) => !sgLower.includes(t.toLowerCase()))
+    .join(' ');
+  return filtered ? `${filtered} ${subGoal}` : subGoal;
+}

--- a/src/skills/plugins/video-discover/v3/executor.ts
+++ b/src/skills/plugins/video-discover/v3/executor.ts
@@ -55,6 +55,7 @@ import {
   planProgressiveChunks,
 } from '@/config/discover-progressive-fill';
 import { getSearchVideoDuration, isSkipRuleQueriesEnabled } from '@/config/discover-t5';
+import { isSubgoalAnchorEnabled, buildAnchoredSubgoalQuery } from '@/config/subgoal-anchor';
 import { placeAutoAddedCards } from '@/modules/mandala/place-auto-added-cards';
 import { isDiscoverNeverZeroFloorEnabled, getZeroFloorMax } from '@/config/discover-zero-floor';
 import { getCenterGoalEmbedding } from '@/modules/mandala/center-goal-embedding';
@@ -1104,7 +1105,13 @@ async function runTier2(input: Tier2Input): Promise<Tier2Output> {
   if (isSkipRuleQueriesEnabled()) {
     for (const { cellIndex } of input.deficitCells) {
       const sg = (input.state.subGoals[cellIndex] ?? '').trim();
-      if (sg) subGoalQueries.push({ query: sg, source: 'subgoal', cellIndex });
+      if (!sg) continue;
+      // T9 (matrix F6): raw subgoals like "청취 회화" harvest English-learning
+      // junk on Korean YouTube. Prefix a domain anchor from the center goal.
+      const q = isSubgoalAnchorEnabled()
+        ? buildAnchoredSubgoalQuery(input.state.centerGoal, sg)
+        : sg;
+      subGoalQueries.push({ query: q, source: 'subgoal', cellIndex });
     }
   }
   const usedQueryTexts = new Set(ruleQueries.map((q) => q.query.toLowerCase()));

--- a/tests/unit/config/subgoal-anchor.test.ts
+++ b/tests/unit/config/subgoal-anchor.test.ts
@@ -1,0 +1,40 @@
+import {
+  isSubgoalAnchorEnabled,
+  extractDomainAnchor,
+  buildAnchoredSubgoalQuery,
+} from '@/config/subgoal-anchor';
+
+describe('subgoal-anchor (T9)', () => {
+  it('flag defaults off (legacy raw subgoal)', () => {
+    expect(isSubgoalAnchorEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+    expect(
+      isSubgoalAnchorEnabled({ DISCOVER_SUBGOAL_ANCHOR_ENABLED: 'true' } as NodeJS.ProcessEnv)
+    ).toBe(true);
+  });
+
+  it('strips durations and goal-action words', () => {
+    expect(extractDomainAnchor('일본어 JLPT N3 6개월 합격')).toBe('일본어 JLPT N3');
+    expect(extractDomainAnchor('마라톤 풀코스 4시간 완주')).toBe('마라톤 풀코스');
+    expect(extractDomainAnchor('퇴근 후 1시간으로 유튜브 채널 키우기')).toBe('퇴근 후 유튜브 채널');
+    expect(extractDomainAnchor('자취생 기본 요리 마스터')).toBe('자취생 기본 요리');
+  });
+
+  it('caps anchor length at 4 tokens', () => {
+    expect(
+      extractDomainAnchor('아주 매우 정말 몹시 대단히 긴 목표').split(' ').length
+    ).toBeLessThanOrEqual(4);
+  });
+
+  it('builds "<anchor> <subgoal>" and falls back to raw subgoal', () => {
+    expect(buildAnchoredSubgoalQuery('일본어 JLPT N3 6개월 합격', '청취 회화')).toBe(
+      '일본어 JLPT N3 청취 회화'
+    );
+    expect(buildAnchoredSubgoalQuery('4시간 완주', '레이스 준비')).toBe('레이스 준비');
+  });
+
+  it('drops anchor tokens already present in the subgoal (no stutter)', () => {
+    expect(buildAnchoredSubgoalQuery('마라톤 풀코스 4시간 완주', '마라톤 페이스 훈련')).toBe(
+      '풀코스 마라톤 페이스 훈련'
+    );
+  });
+});


### PR DESCRIPTION
## Problem (matrix F6)
T5's deficit-cell subgoal queries go out as the raw cell topic. On Korean YouTube, '청취 회화'/'모의고사'/'시험 전략' are dominated by English-learning and 수능 content — the JLPT mandala harvested 20 English cards this way (R-judge-2; judge sank them all, but they waste harvest slots and pollute thin cells).

## Change (flag: `DISCOVER_SUBGOAL_ANCHOR_ENABLED`, default off)
- `extractDomainAnchor(centerGoal)`: strip duration/number tokens (6개월, 4시간, 1년) + goal-action words (합격, 완주, 마스터, 키우기), cap 4 tokens.
- Query = `<anchor> <subgoal>` with stutter-dedup ('일본어 JLPT N3 청취 회화'). No anchor survives → raw subgoal fallback.
- Compose: flag on.

## Verification
- tsc 0; 5/5 unit tests incl. the four real goals from today's rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)