### PR TITLE
feat(mobile): real note playback — TTS read-along + YouTube clips + wheel jog

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -4,8 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no">
 <title>Insighta Player</title>
-<meta name="description" content="만다라 하나를, 한 편의 팟캐스트로 듣는다 — Insighta 모바일 플레이어 (콘셉트)">
-<!-- PWA / iOS install -->
+<meta name="description" content="만다라 하나를, 한 편의 팟캐스트로 듣는다 — Insighta 모바일 플레이어">
 <link rel="manifest" href="/mobile/manifest.webmanifest">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">
@@ -15,9 +14,9 @@
 <link rel="apple-touch-icon" href="/mobile/icon-180.png">
 <link rel="icon" type="image/png" sizes="192x192" href="/mobile/icon-192.png">
 <style>
-  /* ============ Insighta Player — 페이퍼 에디션 (콘셉트 앱 v1) ============
-     시안 C v5의 앱 버전. 크림 세라믹 바디 + e-페이퍼 스크린 + 감귤 다이얼.
-     휠 동작: MENU=홈 · 좌우=화면 이동 · 가운데=재생. 컬러웨이 3종 스위처. */
+  /* ============ Insighta Player — Paper Edition v3 (실재생) ============
+     풀-앱 레이아웃(페이지 크롬 제거) · 컬러웨이=MENU · 노트 실재생
+     (내레이션=브라우저 TTS 임시, 클립=YouTube 구간) · 휠 드래그=구간 조그 */
   :root{
     --studio-hi:#F5F2EC; --studio-lo:#E6E1D6; --ink:#2C2925; --ink-2:#837D72; --hair:#DCD6CA;
     --paper:#F6F2E7; --paper-ink:#3B372F; --paper-sub:#8F887A;
@@ -26,16 +25,15 @@
   }
   *{box-sizing:border-box}
   html{-webkit-text-size-adjust:100%}
+  html,body{height:100%}
   body{
     background:radial-gradient(130% 100% at 50% 0%, var(--studio-hi) 0%, var(--studio-lo) 100%);
-    color:var(--ink); margin:0; min-height:100dvh; overflow-x:hidden;
+    color:var(--ink); margin:0; overflow:hidden;
     font-family:"Apple SD Gothic Neo","Pretendard","Noto Sans KR",system-ui,sans-serif; line-height:1.6;
-    display:flex; flex-direction:column; align-items:center;
-    padding:calc(var(--sat) + 14px) 18px calc(var(--sab) + 18px);
+    display:flex; align-items:center; justify-content:center;
+    padding:calc(var(--sat) + 8px) 10px calc(var(--sab) + 8px);
     -webkit-tap-highlight-color:transparent; user-select:none;
   }
-  .brand{font-size:10px; font-weight:700; letter-spacing:.42em; color:var(--ink-2); margin:6px 0 2px; text-transform:uppercase}
-  .brand i{font-style:normal; color:var(--acc,#E0703F)}
   .num{font-variant-numeric:tabular-nums}
 
   /* ---- 컬러웨이 ---- */
@@ -55,32 +53,25 @@
     --acc:#ECBD6B; --acc-hi:#F5D9A8; --acc-lo:#C8963C; --acc-ink:#6E4E14; --shade:44,60,72;
   }
 
-  /* ---- 디바이스 ---- */
-  .stage3d{perspective:1200px; display:grid; place-items:center; width:100%; flex:1}
+  /* ---- 디바이스: 뷰포트를 채우는 풀-앱 ---- */
   .device{
-    width:min(300px, 88vw); border-radius:42px; padding:18px 17px 22px; position:relative;
+    width:100%; max-width:420px; height:100%; max-height:900px;
+    border-radius:42px; padding:16px 15px 18px; position:relative;
+    display:flex; flex-direction:column;
     background:linear-gradient(160deg,var(--body-hi) 0%,var(--body-mid) 52%,var(--body-lo) 100%);
-    transform-style:preserve-3d; will-change:transform;
-    transition:transform .5s var(--soft), background .6s var(--soft), box-shadow .6s var(--soft);
+    transition:background .6s var(--soft);
     box-shadow:
       inset 0 2.5px 2px rgba(255,255,255,.95),
       inset 0 -5px 10px rgba(var(--shade),.30),
       inset 2.5px 0 5px rgba(255,255,255,.45),
       inset -2.5px 0 6px rgba(var(--shade),.14),
-      0 2px 3px rgba(var(--shade),.10),
-      0 18px 28px -14px rgba(var(--shade),.38),
-      0 46px 80px -30px rgba(var(--shade),.50);
+      0 24px 50px -22px rgba(var(--shade),.5);
   }
   .device::after{content:""; position:absolute; inset:0; border-radius:42px; pointer-events:none;
     box-shadow:inset 0 0 0 1.5px var(--rim), inset 0 0 0 3px rgba(var(--shade),.06)}
-  .device::before{content:""; position:absolute; inset:-2px; border-radius:44px; pointer-events:none; z-index:4;
-    background:linear-gradient(115deg, transparent 30%, rgba(255,255,255,.35) 46%, rgba(255,255,255,.06) 55%, transparent 66%);
-    background-size:280% 100%; background-position:110% 0; opacity:0}
-  .device.sweep::before{animation:sweep 1.4s var(--soft); opacity:1}
-  @keyframes sweep{from{background-position:130% 0}to{background-position:-40% 0}}
 
   .epaper{
-    border-radius:24px; overflow:hidden; position:relative; aspect-ratio:4/4.3;
+    border-radius:24px; overflow:hidden; position:relative; flex:1; min-height:0;
     background:linear-gradient(175deg,#FAF6EC 0%,var(--paper) 60%,#EDE8DA 100%);
     box-shadow:
       inset 0 4px 9px rgba(94,86,72,.30),
@@ -89,23 +80,125 @@
       0 1.5px 0 rgba(255,255,255,.9);
     color:var(--paper-ink);
   }
-  .epaper::after{content:""; position:absolute; inset:0; pointer-events:none; z-index:5;
-    background:linear-gradient(118deg, rgba(255,255,255,.20) 0%, rgba(255,255,255,.04) 16%, transparent 30%)}
   .scr{position:absolute; inset:0; display:flex; flex-direction:column; padding:15px 16px 14px;
-    opacity:0; transform:translateX(14px); transition:opacity .38s var(--soft), transform .38s var(--soft); pointer-events:none}
+    opacity:0; transform:translateX(14px); transition:opacity .32s var(--soft), transform .32s var(--soft); pointer-events:none}
   .scr.active{opacity:1; transform:none; pointer-events:auto}
-  .scr.exit-l{transform:translateX(-14px)}
-  .top{display:flex; justify-content:space-between; align-items:center; font-size:9px; letter-spacing:.16em; color:var(--paper-sub); font-weight:700}
-  .batt{display:inline-flex; align-items:center; gap:2.5px}
+  .top{display:flex; justify-content:space-between; align-items:center; gap:8px;
+    font-size:9.5px; letter-spacing:.14em; color:var(--paper-sub); font-weight:700; flex:none}
+  .top .tt{white-space:nowrap; overflow:hidden; text-overflow:ellipsis; min-width:0}
+  .batt{display:inline-flex; align-items:center; gap:2.5px; flex:none}
   .batt .case{width:20px; height:10px; border-radius:3px; border:1px solid #A99F8C; padding:1.5px}
-  .batt .case i{display:block; height:100%; border-radius:1.5px; background:var(--acc); transition:width .8s var(--soft), background .6s}
+  .batt .case i{display:block; height:100%; border-radius:1.5px; background:var(--acc); transition:width .8s var(--soft), background .6s; width:20%}
   .batt .tip{width:1.8px; height:4px; border-radius:1px; background:#A99F8C}
 
-  .wheelzone{display:grid; place-items:center; padding-top:17px; transform:translateZ(26px)}
+  /* ---- 로그인 ---- */
+  .login-scr{flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center; padding:0 10px}
+  .login-mark{font-size:9px; font-weight:800; letter-spacing:.5em; color:var(--paper-sub)}
+  .login-big{font-size:17px; font-weight:750; line-height:1.5; margin-top:12px}
+  .login-sub{font-size:10px; color:var(--paper-sub); font-weight:600; margin-top:7px}
+  .gbtn{
+    margin-top:18px; display:flex; align-items:center; gap:9px; border:none; cursor:pointer; font-family:inherit;
+    background:#fff; border-radius:99px; padding:12px 19px; font-size:13px; font-weight:750; color:#3B372F;
+    box-shadow:inset 0 0 0 1px rgba(94,86,72,.18), 0 3px 8px -3px rgba(94,86,72,.45);
+    transition:transform .2s var(--spring); touch-action:manipulation;
+  }
+  .gbtn:active{transform:scale(.95)}
+
+  /* ---- 홈 ---- */
+  .goal-pill{
+    margin-top:11px; display:flex; align-items:center; justify-content:center; gap:8px;
+    border:none; cursor:pointer; font-family:inherit; width:100%; flex:none;
+    background:rgba(255,255,255,.6); border-radius:12px; padding:11px; font-size:12px; font-weight:750; color:var(--paper-ink);
+    box-shadow:inset 0 0 0 1.5px var(--acc); transition:transform .2s var(--spring); touch-action:manipulation;
+  }
+  .goal-pill:active{transform:scale(.97)}
+  .gp-plus{width:13px; height:13px; border-radius:50%; background:var(--acc); position:relative; flex:none}
+  .gp-plus::before,.gp-plus::after{content:""; position:absolute; background:#fff; left:50%; top:50%; transform:translate(-50%,-50%)}
+  .gp-plus::before{width:7px; height:1.7px} .gp-plus::after{width:1.7px; height:7px}
+  .rows{margin-top:10px; display:flex; flex-direction:column; gap:8px; overflow-y:auto; flex:1; min-height:0; padding-bottom:4px}
+  .row{display:flex; gap:10px; align-items:center; background:rgba(255,255,255,.55); flex:none;
+    box-shadow:inset 0 0 0 1px rgba(94,86,72,.10), 0 2px 5px -3px rgba(94,86,72,.35); border-radius:12px; padding:9px 10px;
+    transition:transform .2s var(--spring), box-shadow .2s; cursor:pointer; touch-action:manipulation}
+  .row.sel{box-shadow:inset 0 0 0 1.5px var(--acc), 0 3px 8px -3px rgba(94,86,72,.4)}
+  .row:active{transform:scale(.98)}
+  .row .thumb{width:36px; height:36px; border-radius:9px; flex:none; box-shadow:inset 0 0 0 1px rgba(0,0,0,.06), 0 2px 4px -2px rgba(0,0,0,.4)}
+  .row .m{min-width:0; flex:1}
+  .row .a{font-size:11.5px; font-weight:750; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; display:block}
+  .row .b{font-size:8.5px; color:var(--paper-sub); font-weight:600}
+  .row-empty{font-size:10px; color:var(--paper-sub); font-weight:600; text-align:center; padding:22px 0}
+
+  /* ---- MENU 화면 (컬러웨이·공유·설치·로그아웃) ---- */
+  .menu-list{margin-top:12px; display:flex; flex-direction:column; gap:8px}
+  .mrow{display:flex; align-items:center; gap:10px; background:rgba(255,255,255,.55); border:none; width:100%;
+    font-family:inherit; text-align:left; cursor:pointer; color:var(--paper-ink);
+    box-shadow:inset 0 0 0 1px rgba(94,86,72,.10); border-radius:12px; padding:11px 12px; font-size:12px; font-weight:750;
+    transition:transform .2s var(--spring); touch-action:manipulation}
+  .mrow:active{transform:scale(.98)}
+  .mrow .sub{margin-left:auto; font-size:9px; color:var(--paper-sub); font-weight:600}
+  .ways{display:flex; gap:8px; margin-left:auto}
+  .way{width:24px; height:24px; border-radius:50%; border:none; cursor:pointer; padding:0;
+    box-shadow:inset 0 1.5px 2px rgba(255,255,255,.7), inset 0 -2px 4px rgba(0,0,0,.2); touch-action:manipulation}
+  .way.on{outline:2px solid var(--paper-ink); outline-offset:2px}
+  .way-cream{background:radial-gradient(circle at 50% 32%, #FBFAF6 30%, #E2DDD1)}
+  .way-sage{background:radial-gradient(circle at 50% 32%, #D5DECB 30%, #93A788)}
+  .way-mist{background:radial-gradient(circle at 50% 32%, #D7E2EA 30%, #90A7B8)}
+  .menu-note{font-size:9px; color:var(--paper-sub); font-weight:600; text-align:center; margin-top:auto; padding-top:8px}
+
+  /* ---- 플레이어 ---- */
+  .clipbox{border-radius:12px; overflow:hidden; position:relative; aspect-ratio:16/9; flex:none; margin-top:10px;
+    background:linear-gradient(150deg,#8A93C4,#4E5B95 62%,#39406B);
+    box-shadow:0 1px 0 rgba(255,255,255,.7), inset 0 0 0 1px rgba(94,86,72,.12), 0 5px 12px -6px rgba(94,86,72,.45)}
+  .clipbox iframe,.clipbox #yt{position:absolute; inset:0; width:100%; height:100%; border:0}
+  .clipbox .chip{position:absolute; top:8px; left:8px; z-index:2; font-size:7.5px; font-weight:700; letter-spacing:.08em;
+    color:#fff; background:rgba(0,0,0,.35); border-radius:99px; padding:2.5px 8px; pointer-events:none}
+  .clipbox.narr .chip{display:none}
+  .clipbox.narr::after{content:"내레이션"; position:absolute; inset:auto 8px 8px auto; font-size:7.5px; font-weight:700;
+    letter-spacing:.08em; color:#fff; background:rgba(0,0,0,.25); border-radius:99px; padding:2.5px 8px}
+  .readbox{flex:1; min-height:0; overflow-y:auto; margin-top:11px; font-size:12.5px; line-height:1.85; padding-right:2px;
+    -webkit-mask-image:linear-gradient(180deg,transparent 0,#000 12px,#000 calc(100% - 18px),transparent 100%);
+            mask-image:linear-gradient(180deg,transparent 0,#000 12px,#000 calc(100% - 18px),transparent 100%)}
+  .readbox p{margin:0 0 8px}
+  .readbox .sent{border-radius:7px; padding:1px 3px; margin:0 -1px; transition:background .35s var(--soft), color .35s}
+  .readbox .sent.on{background:var(--acc); color:#fff; font-weight:700}
+  .readbox .sec-title{font-size:9.5px; letter-spacing:.12em; font-weight:800; color:var(--paper-sub); margin:2px 0 6px}
+  .ptrack{flex:none; margin-top:10px}
+  .chapters{display:flex; gap:4px}
+  .chapters i{flex:1; height:4px; border-radius:2.5px; background:#DED7C6; transition:background .4s}
+  .chapters i.done{background:var(--acc-lo)}
+  .chapters i.now{background:var(--acc)}
+  .ptimes{display:flex; justify-content:space-between; font-size:8.5px; color:var(--paper-sub); margin-top:6px; font-weight:600}
+  .player-state{flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center; gap:8px}
+  .player-state .big{font-size:13.5px; font-weight:750}
+  .player-state .sm{font-size:9.5px; color:var(--paper-sub); font-weight:600; line-height:1.7}
+  .pulse{width:13px; height:13px; border-radius:50%; background:var(--acc); animation:pu 1.1s var(--soft) infinite}
+  @keyframes pu{0%,100%{transform:scale(.7); opacity:.5}50%{transform:scale(1.15); opacity:1}}
+
+  /* ---- 목표 입력 오버레이 ---- */
+  .goal-ov{position:absolute; inset:0; z-index:6; display:none; flex-direction:column; justify-content:center;
+    background:linear-gradient(175deg,#FAF6ECf2,#F6F2E7f5); padding:20px}
+  .goal-ov.show{display:flex}
+  .go-title{font-size:14px; font-weight:750; text-align:center}
+  .go-body{margin-top:13px}
+  #goalInput{width:100%; border:none; border-radius:13px; padding:13px 14px; font-family:inherit;
+    font-size:16px; font-weight:600; color:var(--paper-ink); background:#fff;
+    box-shadow:inset 0 0 0 1.5px rgba(94,86,72,.22)}
+  #goalInput:focus{outline:none; box-shadow:inset 0 0 0 2px var(--acc)}
+  .go-actions{display:flex; gap:10px; margin-top:12px}
+  .go-cancel,.go-make{flex:1; border:none; cursor:pointer; font-family:inherit; border-radius:12px; padding:12px;
+    font-size:12.5px; font-weight:750; transition:transform .2s var(--spring); touch-action:manipulation}
+  .go-cancel{background:rgba(255,255,255,.7); color:var(--paper-sub); box-shadow:inset 0 0 0 1px rgba(94,86,72,.16)}
+  .go-make{background:var(--acc); color:#fff; box-shadow:0 4px 10px -4px rgba(0,0,0,.35)}
+  .go-cancel:active,.go-make:active{transform:scale(.95)}
+  .go-progress{display:flex; flex-direction:column; align-items:center; gap:11px; margin-top:15px}
+  .go-msg{font-size:11.5px; font-weight:700; text-align:center; line-height:1.7}
+  .go-msg small{display:block; font-size:9px; color:var(--paper-sub); font-weight:600}
+
+  /* ---- 클릭휠 ---- */
+  .wheelzone{display:grid; place-items:center; padding-top:14px; flex:none}
   .wheel{
-    width:66%; aspect-ratio:1; border-radius:50%; position:relative; display:grid; place-items:center;
+    width:min(56vw, 240px); aspect-ratio:1; border-radius:50%; position:relative; display:grid; place-items:center;
     background:radial-gradient(circle at 50% 30%, var(--wheel-hi) 0%, var(--wheel-mid) 46%, var(--wheel-lo) 84%, var(--wheel-mid) 100%);
-    transition:background .6s;
+    transition:background .6s; touch-action:none;
     box-shadow:
       inset 0 3px 3px rgba(255,255,255,.9),
       inset 0 -6px 11px rgba(var(--shade),.36),
@@ -116,15 +209,15 @@
   .wheel::before{content:""; position:absolute; inset:0; border-radius:50%;
     box-shadow:inset 0 0 0 1.5px rgba(255,255,255,.55), inset 0 0 0 3px rgba(var(--shade),.10)}
   .wbtn{position:absolute; border:none; background:none; cursor:pointer; padding:9px 11px; border-radius:12px;
-    font-size:9px; font-weight:700; letter-spacing:.24em; color:#9C9585; font-family:inherit;
-    transition:transform .2s var(--spring), color .2s; touch-action:manipulation}
+    font-size:9.5px; font-weight:700; letter-spacing:.24em; color:#9C9585; font-family:inherit;
+    transition:transform .2s var(--spring), color .2s; touch-action:manipulation; z-index:2}
   .wbtn:active{transform:scale(.86); color:#6E6758}
-  .wbtn.menu{top:6%; left:50%; transform:translateX(-50%)} .wbtn.menu:active{transform:translateX(-50%) scale(.86)}
-  .wbtn.prev{left:5%; top:50%; transform:translateY(-50%)} .wbtn.prev:active{transform:translateY(-50%) scale(.84)}
-  .wbtn.next{right:5%; top:50%; transform:translateY(-50%)} .wbtn.next:active{transform:translateY(-50%) scale(.84)}
-  .wbtn.play{bottom:5%; left:50%; transform:translateX(-50%)} .wbtn.play:active{transform:translateX(-50%) scale(.86)}
+  .wbtn.menu{top:5%; left:50%; transform:translateX(-50%)} .wbtn.menu:active{transform:translateX(-50%) scale(.86)}
+  .wbtn.prev{left:4%; top:50%; transform:translateY(-50%)} .wbtn.prev:active{transform:translateY(-50%) scale(.84)}
+  .wbtn.next{right:4%; top:50%; transform:translateY(-50%)} .wbtn.next:active{transform:translateY(-50%) scale(.84)}
+  .wbtn.play{bottom:4%; left:50%; transform:translateX(-50%)} .wbtn.play:active{transform:translateX(-50%) scale(.86)}
   .core{
-    width:35%; aspect-ratio:1; border-radius:50%; border:none; cursor:pointer; position:relative;
+    width:36%; aspect-ratio:1; border-radius:50%; border:none; cursor:pointer; position:relative; z-index:2;
     background:radial-gradient(circle at 50% 30%, var(--acc-hi) 0%, var(--acc) 52%, var(--acc-lo) 100%);
     transition:transform .25s var(--spring), background .6s, box-shadow .6s; touch-action:manipulation;
     box-shadow:
@@ -136,376 +229,132 @@
   .core::after{content:""; position:absolute; left:26%; top:14%; width:26%; height:17%; border-radius:50%;
     background:radial-gradient(ellipse at center, rgba(255,255,255,.75), transparent 70%)}
   .core:active{transform:scale(.93); box-shadow:inset 0 4px 8px rgba(0,0,0,.32), 0 2px 4px rgba(var(--shade),.2)}
-  .engrave{margin-top:14px; text-align:center; font-size:8px; font-weight:700; letter-spacing:.5em;
+  .engrave{margin-top:11px; text-align:center; font-size:8px; font-weight:700; letter-spacing:.5em; flex:none;
     color:rgba(var(--shade),.34); text-shadow:0 1px 0 rgba(255,255,255,.8)}
-  .ground{width:74%; height:24px; margin:20px auto 0; border-radius:50%;
-    background:radial-gradient(ellipse at center, rgba(var(--shade),.30) 0%, transparent 66%);
-    transition:transform .5s var(--soft)}
 
-  /* ---- 화면 콘텐츠 ---- */
-  .cover{border-radius:11px; aspect-ratio:16/9; position:relative; overflow:hidden; margin-top:11px;
-    box-shadow:0 1px 0 rgba(255,255,255,.7), inset 0 0 0 1px rgba(94,86,72,.12), 0 5px 12px -6px rgba(94,86,72,.45)}
-  .cover .t{position:absolute; left:10px; bottom:8px; right:10px; font-size:8.5px; color:rgba(255,255,255,.9); font-weight:600}
-  .cover .badge{position:absolute; top:8px; left:8px; font-size:7.5px; font-weight:700; letter-spacing:.08em;
-    color:#fff; background:rgba(0,0,0,.25); border-radius:99px; padding:2px 8px}
-  .np-title{font-size:13.5px; font-weight:750; margin-top:12px; letter-spacing:-.01em; transition:opacity .45s}
-  .np-sub{font-size:9px; color:var(--paper-sub); margin-top:2px; font-weight:600}
-  .track{height:3px; border-radius:2px; background:#DED7C6; margin-top:12px; position:relative}
-  .track i{position:absolute; inset:0; width:36%; border-radius:2px; background:var(--acc); transition:width .3s linear, background .6s}
-  .track i::after{content:""; position:absolute; right:-3px; top:50%; width:9px; height:9px; transform:translateY(-50%);
-    border-radius:50%; background:#fff; box-shadow:0 1px 3px rgba(44,41,37,.35), inset 0 0 0 1px rgba(94,86,72,.2)}
-  .times{display:flex; justify-content:space-between; font-size:8.5px; color:var(--paper-sub); margin-top:6px; font-weight:600}
-
-  .rows{margin-top:10px; display:flex; flex-direction:column; gap:7px}
-  .row{display:flex; gap:9px; align-items:center; background:rgba(255,255,255,.55);
-    box-shadow:inset 0 0 0 1px rgba(94,86,72,.10), 0 2px 5px -3px rgba(94,86,72,.35); border-radius:11px; padding:7px 9px;
-    transition:transform .2s var(--spring)}
-  .row.sel{box-shadow:inset 0 0 0 1.5px var(--acc), 0 3px 8px -3px rgba(94,86,72,.4); transform:scale(1.02)}
-  .row .thumb{width:32px; height:32px; border-radius:8px; flex:none; box-shadow:inset 0 0 0 1px rgba(0,0,0,.06), 0 2px 4px -2px rgba(0,0,0,.4)}
-  .row .m{min-width:0}
-  .row .a{font-size:10px; font-weight:750; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; display:block}
-  .row .b{font-size:8px; color:var(--paper-sub); font-weight:600}
-  .row .new{margin-left:auto; font-size:7.5px; font-weight:800; letter-spacing:.1em; color:var(--acc-lo)}
-
-  .fin-scr{display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center; flex:1}
-  .ring{width:68px; height:68px; border-radius:50%; position:relative; display:grid; place-items:center;
-    background:conic-gradient(var(--acc) 360deg, #DED7C6 0); transition:background .6s}
-  .ring::before{content:""; position:absolute; inset:5px; border-radius:50%;
-    background:linear-gradient(175deg,#FAF6EC,var(--paper)); box-shadow:0 1px 3px rgba(94,86,72,.25)}
-  .ring b{position:relative; font-size:9px; letter-spacing:.1em; color:var(--paper-ink); font-weight:800}
-  .fin-big{font-size:13px; font-weight:750; margin-top:12px}
-  .fin-meta{font-size:8.5px; color:var(--paper-sub); margin-top:3px; font-weight:600}
-  .fin-d6{margin-top:10px; font-size:8px; font-weight:800; letter-spacing:.08em; color:var(--acc-ink);
-    box-shadow:inset 0 0 0 1px rgba(94,86,72,.3); border-radius:99px; padding:3px 10px}
-
-  /* ---- 컬러웨이 스위처 ---- */
-  .picker{display:flex; gap:11px; justify-content:center; margin-top:22px; flex-wrap:wrap}
-  .chip{
-    display:flex; align-items:center; gap:8px; border:none; cursor:pointer; font-family:inherit;
-    background:#FFFDF8; border-radius:99px; padding:9px 15px 9px 10px; font-size:12px; font-weight:700; color:var(--ink);
-    box-shadow:inset 0 0 0 1px var(--hair), 0 4px 10px -6px rgba(44,41,37,.3);
-    transition:transform .25s var(--spring), box-shadow .25s; touch-action:manipulation;
-  }
-  .chip:active{transform:scale(.94)}
-  .chip.on{box-shadow:inset 0 0 0 2px var(--ink), 0 6px 14px -6px rgba(44,41,37,.35)}
-  .chip .sw{width:22px; height:22px; border-radius:50%; box-shadow:inset 0 1.5px 2px rgba(255,255,255,.7), inset 0 -2px 4px rgba(0,0,0,.2)}
-  .sw-cream{background:radial-gradient(circle at 50% 32%, #FBFAF6 30%, #E2DDD1)}
-  .sw-sage{background:radial-gradient(circle at 50% 32%, #D5DECB 30%, #93A788)}
-  .sw-mist{background:radial-gradient(circle at 50% 32%, #D7E2EA 30%, #90A7B8)}
-
-  /* ---- 설치 힌트 (브라우저에서만) ---- */
-  .install{
-    display:none; margin-top:18px; max-width:340px; text-align:center;
-    background:#FFFDF8; border-radius:16px; padding:12px 16px; font-size:12px; color:var(--ink-2);
-    box-shadow:inset 0 0 0 1px var(--hair), 0 6px 14px -8px rgba(44,41,37,.3);
-  }
-  .install b{color:var(--ink); font-weight:700}
-  .install.show{display:block}
-  .install button{border:none; background:none; font-family:inherit; font-size:11px; font-weight:700; color:var(--ink-2);
-    margin-top:6px; cursor:pointer; text-decoration:underline; text-underline-offset:2px}
-
-  footer{margin-top:16px; font-size:9.5px; color:var(--ink-2); letter-spacing:.06em; text-align:center}
-  footer button{border:none; background:none; font:inherit; color:var(--ink-2); text-decoration:underline; text-underline-offset:2px; cursor:pointer; padding:2px 4px}
-
-  /* ---- 로그인 화면 ---- */
-  .login-scr{flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center; gap:0; padding:0 10px}
-  .login-mark{font-size:8.5px; font-weight:800; letter-spacing:.5em; color:var(--paper-sub)}
-  .login-big{font-size:15px; font-weight:750; line-height:1.5; margin-top:10px}
-  .login-sub{font-size:9px; color:var(--paper-sub); font-weight:600; margin-top:6px}
-  .gbtn{
-    margin-top:16px; display:flex; align-items:center; gap:8px; border:none; cursor:pointer; font-family:inherit;
-    background:#fff; border-radius:99px; padding:10px 16px; font-size:11.5px; font-weight:750; color:#3B372F;
-    box-shadow:inset 0 0 0 1px rgba(94,86,72,.18), 0 3px 8px -3px rgba(94,86,72,.45);
-    transition:transform .2s var(--spring); touch-action:manipulation;
-  }
-  .gbtn:active{transform:scale(.95)}
-  .login-err{font-size:8.5px; color:#B4472B; font-weight:600; margin-top:9px; min-height:11px}
-
-  /* ---- 목표 입력 ---- */
-  .goal-pill{
-    margin-top:10px; display:flex; align-items:center; justify-content:center; gap:7px;
-    border:none; cursor:pointer; font-family:inherit; width:100%;
-    background:rgba(255,255,255,.6); border-radius:11px; padding:9px; font-size:10.5px; font-weight:750; color:var(--paper-ink);
-    box-shadow:inset 0 0 0 1.5px var(--acc); transition:transform .2s var(--spring); touch-action:manipulation;
-  }
-  .goal-pill:active{transform:scale(.97)}
-  .gp-plus{width:12px; height:12px; border-radius:50%; background:var(--acc); position:relative; flex:none}
-  .gp-plus::before,.gp-plus::after{content:""; position:absolute; background:#fff; left:50%; top:50%; transform:translate(-50%,-50%)}
-  .gp-plus::before{width:6px; height:1.6px} .gp-plus::after{width:1.6px; height:6px}
-
-  .goal-ov{
-    position:absolute; inset:0; z-index:6; display:none; flex-direction:column; justify-content:center;
-    background:linear-gradient(175deg,#FAF6ECf2,#F6F2E7f5); backdrop-filter:blur(2px); padding:18px;
-  }
-  .goal-ov.show{display:flex}
-  .go-title{font-size:13px; font-weight:750; text-align:center; color:var(--paper-ink)}
-  .go-body{margin-top:12px}
-  #goalInput{
-    width:100%; border:none; border-radius:12px; padding:12px 13px; font-family:inherit;
-    font-size:16px; font-weight:600; color:var(--paper-ink); background:#fff;
-    box-shadow:inset 0 0 0 1.5px rgba(94,86,72,.22);
-  }
-  #goalInput:focus{outline:none; box-shadow:inset 0 0 0 2px var(--acc)}
-  .go-actions{display:flex; gap:9px; margin-top:11px}
-  .go-cancel,.go-make{
-    flex:1; border:none; cursor:pointer; font-family:inherit; border-radius:11px; padding:10px;
-    font-size:11.5px; font-weight:750; transition:transform .2s var(--spring); touch-action:manipulation;
-  }
-  .go-cancel{background:rgba(255,255,255,.7); color:var(--paper-sub); box-shadow:inset 0 0 0 1px rgba(94,86,72,.16)}
-  .go-make{background:var(--acc); color:#fff; box-shadow:0 4px 10px -4px rgba(0,0,0,.35)}
-  .go-cancel:active,.go-make:active{transform:scale(.95)}
-  .go-progress{display:flex; flex-direction:column; align-items:center; gap:10px; margin-top:14px}
-  .go-dot{width:12px; height:12px; border-radius:50%; background:var(--acc); animation:godot 1.1s var(--soft) infinite}
-  @keyframes godot{0%,100%{transform:scale(.7); opacity:.5}50%{transform:scale(1.15); opacity:1}}
-  .go-msg{font-size:10.5px; font-weight:700; color:var(--paper-ink); text-align:center; line-height:1.7}
-  .go-msg small{display:block; font-size:8.5px; color:var(--paper-sub); font-weight:600}
-
-  .row-empty{font-size:9.5px; color:var(--paper-sub); font-weight:600; text-align:center; padding:20px 0}
+  .toast{position:fixed; left:50%; bottom:calc(var(--sab) + 26px); transform:translateX(-50%) translateY(20px);
+    background:var(--ink); color:#F5F2EC; font-size:11.5px; font-weight:700; border-radius:99px; padding:9px 16px;
+    opacity:0; transition:opacity .3s, transform .3s var(--spring); pointer-events:none; z-index:9; white-space:nowrap}
+  .toast.show{opacity:1; transform:translateX(-50%) translateY(0)}
 
   @media (prefers-reduced-motion:reduce){
     *,*::before,*::after{animation-duration:.001s !important; transition-duration:.001s !important}
-    .device{transform:none !important}
   }
 </style>
 </head>
 <body>
-  <div class="brand">Insighta <i>·</i> Player</div>
+  <div class="device th-cream" id="dev">
+    <div class="epaper">
 
-  <div class="stage3d" id="stage">
-    <div>
-      <div class="device th-cream" id="dev">
-        <div class="epaper">
-
-          <!-- SCREEN L : 로그인 -->
-          <div class="scr" data-s="login" id="scrLogin">
-            <div class="login-scr">
-              <div class="login-mark">INSIGHTA</div>
-              <div class="login-big">만다라 하나를,<br>한 편의 팟캐스트로.</div>
-              <div class="login-sub">로그인하면 내 만다라가 이 기계에 도착합니다</div>
-              <button class="gbtn" id="bLogin">
-                <svg width="15" height="15" viewBox="0 0 48 48" aria-hidden="true"><path fill="#EA4335" d="M24 9.5c3.5 0 6.6 1.2 9.1 3.6l6.8-6.8C35.8 2.4 30.3 0 24 0 14.6 0 6.5 5.4 2.6 13.2l7.9 6.2C12.4 13.5 17.7 9.5 24 9.5z"/><path fill="#4285F4" d="M46.5 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.7c-.6 3-2.3 5.5-4.8 7.2l7.7 6c4.5-4.2 6.9-10.3 6.9-17.7z"/><path fill="#FBBC05" d="M10.5 28.6a14.5 14.5 0 0 1 0-9.2l-7.9-6.2a24 24 0 0 0 0 21.6l7.9-6.2z"/><path fill="#34A853" d="M24 48c6.3 0 11.6-2.1 15.6-5.8l-7.7-6c-2.1 1.4-4.8 2.3-7.9 2.3-6.3 0-11.6-4-13.5-9.9l-7.9 6.2C6.5 42.6 14.6 48 24 48z"/></svg>
-                Google로 계속하기
-              </button>
-              <div class="login-err" id="loginErr"></div>
-            </div>
-          </div>
-
-          <!-- SCREEN 0 : 홈 (로그인 시 실데이터) -->
-          <div class="scr active" data-s="0">
-            <div class="top"><span>내 만다라</span><span class="batt"><span class="case"><i style="width:38%"></i></span><span class="tip"></span></span></div>
-            <button class="goal-pill" id="bGoal">
-              <span class="gp-plus"></span>원하는 목표 적기
-            </button>
-            <div class="rows" id="rows">
-              <div class="row-empty" id="rowsEmpty">불러오는 중…</div>
-            </div>
-          </div>
-
-          <!-- 목표 입력 오버레이 -->
-          <div class="goal-ov" id="goalOv">
-            <div class="go-title" id="goTitle">무엇을 배우고 싶나요?</div>
-            <div class="go-body" id="goBody">
-              <input id="goalInput" type="text" maxlength="80" placeholder="예: 처음부터 시작하는 수채화" autocomplete="off">
-              <div class="go-actions">
-                <button class="go-cancel" id="goCancel">닫기</button>
-                <button class="go-make" id="goMake">만들기</button>
-              </div>
-            </div>
-            <div class="go-progress" id="goProgress" hidden>
-              <div class="go-dot"></div>
-              <div class="go-msg" id="goMsg">만다라 구조를 그리는 중…</div>
-            </div>
-          </div>
-
-          <!-- SCREEN 1 : 재생 -->
-          <div class="scr" data-s="1">
-            <div class="top"><span>3막 · <span id="pstate">일시정지</span></span><span class="batt"><span class="case"><i id="pbatt" style="width:58%"></i></span><span class="tip"></span></span></div>
-            <div class="cover" style="background:
-              radial-gradient(120% 140% at 20% 15%, #6D7DBE 0%, transparent 55%),
-              linear-gradient(150deg,#8A93C4,#4E5B95 62%,#39406B)">
-              <span class="badge">원본 · 핵심구간</span>
-              <span class="t">컨볼루션 필터가 이미지를 훑는 장면</span>
-            </div>
-            <div class="np-title" id="klyric">"필터 하나는 세로선을 찾습니다"</div>
-            <div class="np-sub">내레이션 · 남 · 요약과 원본은 누르고 돌리기</div>
-            <div class="track"><i id="pfill" style="width:52%"></i></div>
-            <div class="times num"><span id="pt1">52:03</span><span id="pt2">-55:27</span></div>
-          </div>
-
-          <!-- SCREEN 2 : 완결 -->
-          <div class="scr" data-s="2">
-            <div class="top"><span>AI 전문가되기</span><span class="batt"><span class="case"><i style="width:100%"></i></span><span class="tip"></span></span></div>
-            <div class="fin-scr">
-              <div class="ring"><b>8/8</b></div>
-              <div class="fin-big">이번 회차, 다 들었어요</div>
-              <div class="fin-meta num">8막 · 1:47:30 · 배터리 가득</div>
-              <div class="fin-d6 num">다음 회차까지 D-6</div>
-            </div>
-          </div>
-
+      <!-- 로그인 -->
+      <div class="scr" data-s="login" id="scrLogin">
+        <div class="login-scr">
+          <div class="login-mark">INSIGHTA</div>
+          <div class="login-big">만다라 하나를,<br>한 편의 팟캐스트로.</div>
+          <div class="login-sub" id="loginSub">로그인하면 내 만다라가 이 기계에 도착합니다</div>
+          <button class="gbtn" id="bLogin">
+            <svg width="16" height="16" viewBox="0 0 48 48" aria-hidden="true"><path fill="#EA4335" d="M24 9.5c3.5 0 6.6 1.2 9.1 3.6l6.8-6.8C35.8 2.4 30.3 0 24 0 14.6 0 6.5 5.4 2.6 13.2l7.9 6.2C12.4 13.5 17.7 9.5 24 9.5z"/><path fill="#4285F4" d="M46.5 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.7c-.6 3-2.3 5.5-4.8 7.2l7.7 6c4.5-4.2 6.9-10.3 6.9-17.7z"/><path fill="#FBBC05" d="M10.5 28.6a14.5 14.5 0 0 1 0-9.2l-7.9-6.2a24 24 0 0 0 0 21.6l7.9-6.2z"/><path fill="#34A853" d="M24 48c6.3 0 11.6-2.1 15.6-5.8l-7.7-6c-2.1 1.4-4.8 2.3-7.9 2.3-6.3 0-11.6-4-13.5-9.9l-7.9 6.2C6.5 42.6 14.6 48 24 48z"/></svg>
+            Google로 계속하기
+          </button>
         </div>
-
-        <div class="wheelzone">
-          <div class="wheel">
-            <button class="wbtn menu" id="bMenu">MENU</button>
-            <button class="wbtn prev" id="bPrev" aria-label="이전 화면">
-              <svg width="15" height="10" viewBox="0 0 15 10"><path d="M7.5 1 2 5l5.5 4V1Zm5.5 0L7.5 5 13 9V1Z" fill="currentColor"/></svg></button>
-            <button class="wbtn next" id="bNext" aria-label="다음 화면">
-              <svg width="15" height="10" viewBox="0 0 15 10"><path d="M7.5 1 13 5l-5.5 4V1Zm-5.5 0L7.5 5 2 9V1Z" fill="currentColor"/></svg></button>
-            <button class="wbtn play" id="bPlay" aria-label="재생/일시정지">
-              <svg width="16" height="9" viewBox="0 0 16 9"><path d="M1 .8 7 4.5 1 8.2V.8Z" fill="currentColor"/><path d="M10 1h2v7h-2zM14 1h2v7h-2z" fill="currentColor" transform="scale(.9)"/></svg></button>
-            <button class="core" id="bCore" aria-label="선택/재생"></button>
-          </div>
-        </div>
-        <div class="engrave">INSIGHTA</div>
       </div>
-      <div class="ground" id="ground"></div>
+
+      <!-- 홈 -->
+      <div class="scr" data-s="home" id="scrHome">
+        <div class="top"><span class="tt">내 만다라</span><span class="batt"><span class="case"><i id="battHome"></i></span><span class="tip"></span></span></div>
+        <button class="goal-pill" id="bGoal"><span class="gp-plus"></span>원하는 목표 적기</button>
+        <div class="rows" id="rows"><div class="row-empty" id="rowsEmpty">불러오는 중…</div></div>
+      </div>
+
+      <!-- MENU -->
+      <div class="scr" data-s="menu" id="scrMenu">
+        <div class="top"><span class="tt">MENU</span><span class="batt"><span class="case"><i id="battMenu"></i></span><span class="tip"></span></span></div>
+        <div class="menu-list">
+          <div class="mrow" style="cursor:default">
+            컬러웨이
+            <span class="ways">
+              <button class="way way-cream on" data-th="th-cream" aria-label="크림"></button>
+              <button class="way way-sage" data-th="th-sage" aria-label="세이지"></button>
+              <button class="way way-mist" data-th="th-mist" aria-label="안개"></button>
+            </span>
+          </div>
+          <button class="mrow" id="bShare">친구에게 공유<span class="sub">카카오톡 등</span></button>
+          <button class="mrow" id="bInstall">홈 화면에 설치<span class="sub">전체화면 앱</span></button>
+          <button class="mrow" id="bLogout">로그아웃</button>
+        </div>
+        <div class="menu-note">MENU를 다시 누르면 돌아갑니다</div>
+      </div>
+
+      <!-- 플레이어 -->
+      <div class="scr" data-s="player" id="scrPlayer">
+        <div class="top"><span class="tt" id="pTitle">노트</span><span class="batt"><span class="case"><i id="battPlay"></i></span><span class="tip"></span></span></div>
+        <div class="player-state" id="pState">
+          <div class="pulse"></div>
+          <div class="big" id="pStateBig">노트를 여는 중…</div>
+          <div class="sm" id="pStateSm"></div>
+        </div>
+        <div class="clipbox" id="clipbox" hidden>
+          <span class="chip">원본 · 핵심구간</span>
+          <div id="yt"></div>
+        </div>
+        <div class="readbox" id="readbox" hidden></div>
+        <div class="ptrack" id="ptrack" hidden>
+          <div class="chapters" id="pchap"></div>
+          <div class="ptimes"><span id="pPos" class="num">1 / 1</span><span id="pHint">휠을 돌리면 구간 이동</span></div>
+        </div>
+      </div>
+
+      <!-- 목표 입력 -->
+      <div class="goal-ov" id="goalOv">
+        <div class="go-title" id="goTitle">무엇을 배우고 싶나요?</div>
+        <div class="go-body" id="goBody">
+          <input id="goalInput" type="text" maxlength="80" placeholder="예: 처음부터 시작하는 수채화" autocomplete="off">
+          <div class="go-actions">
+            <button class="go-cancel" id="goCancel">닫기</button>
+            <button class="go-make" id="goMake">만들기</button>
+          </div>
+        </div>
+        <div class="go-progress" id="goProgress" hidden>
+          <div class="pulse"></div>
+          <div class="go-msg" id="goMsg">만다라 구조를 그리는 중…</div>
+        </div>
+      </div>
     </div>
+
+    <div class="wheelzone">
+      <div class="wheel" id="wheel">
+        <button class="wbtn menu" id="bMenu">MENU</button>
+        <button class="wbtn prev" id="bPrev" aria-label="이전">
+          <svg width="16" height="11" viewBox="0 0 15 10"><path d="M7.5 1 2 5l5.5 4V1Zm5.5 0L7.5 5 13 9V1Z" fill="currentColor"/></svg></button>
+        <button class="wbtn next" id="bNext" aria-label="다음">
+          <svg width="16" height="11" viewBox="0 0 15 10"><path d="M7.5 1 13 5l-5.5 4V1Zm-5.5 0L7.5 5 2 9V1Z" fill="currentColor"/></svg></button>
+        <button class="wbtn play" id="bPlay" aria-label="재생/일시정지">
+          <svg width="17" height="10" viewBox="0 0 16 9"><path d="M1 .8 7 4.5 1 8.2V.8Z" fill="currentColor"/><path d="M10 1h2v7h-2zM14 1h2v7h-2z" fill="currentColor" transform="scale(.9)"/></svg></button>
+        <button class="core" id="bCore" aria-label="선택/재생"></button>
+      </div>
+    </div>
+    <div class="engrave">INSIGHTA</div>
   </div>
 
-  <div class="picker" role="group" aria-label="컬러웨이 선택">
-    <button class="chip on" data-th="th-cream"><span class="sw sw-cream"></span>크림</button>
-    <button class="chip" data-th="th-sage"><span class="sw sw-sage"></span>세이지</button>
-    <button class="chip" data-th="th-mist"><span class="sw sw-mist"></span>안개</button>
-  </div>
-
-  <div class="install" id="install">
-    앱으로 쓰려면: 사파리 <b>공유 버튼</b> → <b>"홈 화면에 추가"</b>. 아이콘으로 열면 전체화면 앱이 됩니다.
-    <br><button id="installHide">알겠어요, 숨기기</button>
-  </div>
-
-  <footer>INSIGHTA · PLAYER · PAPER EDITION · <button id="bShare">공유</button><span id="footAuth" hidden>· <button id="bLogout">로그아웃</button></span></footer>
+  <div class="toast" id="toast"></div>
 
 <script>
   var reduce=matchMedia('(prefers-reduced-motion: reduce)').matches;
   var dev=document.getElementById('dev');
-  var stage=document.getElementById('stage');
-  var ground=document.getElementById('ground');
-
-  /* 포인터/기울임 3D 틸트 (데스크톱: 포인터, 모바일: 미세 자동 스웨이) */
-  if(!reduce){
-    var raf=null;
-    var fine=matchMedia('(pointer:fine)').matches;
-    if(fine){
-      stage.addEventListener('pointermove',function(e){
-        var r=stage.getBoundingClientRect();
-        var x=(e.clientX-r.left)/r.width-.5, y=(e.clientY-r.top)/r.height-.5;
-        if(raf) return;
-        raf=requestAnimationFrame(function(){
-          dev.style.transform='rotateY('+(x*14)+'deg) rotateX('+(-y*10)+'deg)';
-          ground.style.transform='translateX('+(x*-22)+'px)';
-          raf=null;
-        });
-      });
-      stage.addEventListener('pointerleave',function(){ dev.style.transform=''; ground.style.transform=''; });
-    }else{
-      var t0=0;
-      (function sway(t){
-        if(!t0) t0=t;
-        var s=(t-t0)/1000;
-        dev.style.transform='rotateY('+(Math.sin(s*.5)*3.2)+'deg) rotateX('+(Math.cos(s*.4)*2.2)+'deg)';
-        requestAnimationFrame(sway);
-      })(0);
-    }
+  function toast(msg){
+    var t=document.getElementById('toast'); t.textContent=msg; t.classList.add('show');
+    clearTimeout(t._h); t._h=setTimeout(function(){t.classList.remove('show')},2200);
   }
 
-  /* 컬러웨이 */
-  document.querySelectorAll('.chip').forEach(function(ch){
-    ch.addEventListener('click',function(){
-      document.querySelectorAll('.chip').forEach(function(c){c.classList.remove('on')});
-      ch.classList.add('on');
-      dev.classList.remove('th-cream','th-sage','th-mist');
-      dev.classList.add(ch.dataset.th);
-      dev.classList.remove('sweep'); void dev.offsetWidth; dev.classList.add('sweep');
-      try{localStorage.setItem('insighta-player-th',ch.dataset.th)}catch(e){}
-    });
-  });
-  try{
-    var saved=localStorage.getItem('insighta-player-th');
-    if(saved && /^th-(cream|sage|mist)$/.test(saved)){
-      dev.classList.remove('th-cream'); dev.classList.add(saved);
-      document.querySelectorAll('.chip').forEach(function(c){c.classList.toggle('on',c.dataset.th===saved)});
-    }
-  }catch(e){}
-
-  /* 화면 상태 머신 (숫자 화면만 순환; 로그인 화면은 auth 게이트가 관리) */
-  var scrs=[0,1,2].map(function(i){return document.querySelector('.scr[data-s="'+i+'"]')});
-  var scrLogin=document.getElementById('scrLogin');
-  var cur=0, authed=false;
-  function show(n,dir){
-    if(!authed) return;
-    var nx=((n%3)+3)%3;
-    if(nx===cur) return;
-    scrs[cur].classList.remove('active');
-    scrs[cur].classList.toggle('exit-l',dir>0);
-    cur=nx;
-    scrs[cur].classList.remove('exit-l');
-    scrs[cur].classList.add('active');
-  }
-  document.getElementById('bMenu').onclick=function(){show(0,-1)};
-  document.getElementById('bPrev').onclick=function(){show(cur-1,-1)};
-  document.getElementById('bNext').onclick=function(){show(cur+1,+1)};
-
-  /* 재생 데모 */
-  var playing=false, prog=52*60+3, TOTAL=107*60+30;
-  var fill=document.getElementById('pfill'), batt=document.getElementById('pbatt'),
-      t1=document.getElementById('pt1'), t2=document.getElementById('pt2'),
-      st=document.getElementById('pstate'), ly=document.getElementById('klyric');
-  var lines=['"필터 하나는 세로선을 찾습니다"','"다른 하나는 곡선을 찾습니다"','"실제 모델에선 어떻게 쌓일까요"','"카파시 강의의 한 장면 —"'];
-  var li=0;
-  function fmt(s){var m=Math.floor(s/60),ss=Math.floor(s%60);return m+':'+String(ss).padStart(2,'0')}
-  function togglePlay(){
-    if(cur!==1){show(1,+1)}
-    playing=!playing; st.textContent=playing?'재생 중':'일시정지';
-  }
-  document.getElementById('bPlay').onclick=togglePlay;
-  document.getElementById('bCore').onclick=togglePlay;
-  if(!reduce){
-    setInterval(function(){ if(!playing) return;
-      prog=Math.min(prog+8,TOTAL);
-      var pct=prog/TOTAL*100;
-      fill.style.width=pct+'%';
-      batt.style.width=Math.min(58+(pct-48)*.8,100)+'%';
-      t1.textContent=fmt(prog); t2.textContent='-'+fmt(TOTAL-prog);
-    },1000);
-    setInterval(function(){ if(!playing) return;
-      ly.style.opacity=0;
-      setTimeout(function(){ li=(li+1)%lines.length; ly.textContent=lines[li]; ly.style.opacity=1; },450);
-    },3400);
-  }
-
-  /* 설치 힌트: 브라우저 탭에서만, 설치(standalone) 후엔 숨김 */
-  (function(){
-    var standalone=matchMedia('(display-mode: standalone)').matches || navigator.standalone===true;
-    var hidden=false;
-    try{hidden=localStorage.getItem('insighta-player-install-hide')==='1'}catch(e){}
-    if(!standalone && !hidden){
-      document.getElementById('install').classList.add('show');
-    }
-    document.getElementById('installHide').onclick=function(){
-      document.getElementById('install').classList.remove('show');
-      try{localStorage.setItem('insighta-player-install-hide','1')}catch(e){}
-    };
-  })();
-
-  /* ================= 실계정 연동 =================
-     Supabase Google OAuth(implicit) + 같은 오리진 /api 호출.
-     publishable key는 원래 클라이언트 공개값(메인 SPA 번들과 동일). */
+  /* ================= 인증 (Supabase implicit + 같은 오리진 /api) ================= */
   var SUPA='https://rckkhhjanqgaopynhfgd.supabase.co';
   var SUPA_KEY='sb_publishable_4qmeVEdSP70SEK3Ct_xHdA_Kp9aBfJK';
   var OWN_KEY='insighta-mobile-auth';
   var SPA_KEY='sb-rckkhhjanqgaopynhfgd-auth-token';
-
-  function readJSON(raw){
-    if(!raw) return null;
-    try{
-      if(raw.indexOf('base64-')===0) raw=atob(raw.slice(7));
-      return JSON.parse(raw);
-    }catch(e){ return null }
-  }
+  function readJSON(raw){ if(!raw) return null;
+    try{ if(raw.indexOf('base64-')===0) raw=atob(raw.slice(7)); return JSON.parse(raw); }catch(e){ return null } }
   function saveSession(s){ try{localStorage.setItem(OWN_KEY,JSON.stringify(s))}catch(e){} }
   function loadSession(){
-    // 1) OAuth 콜백 해시 → 2) 자체 저장 → 3) 같은 오리진 SPA 세션 재사용
     if(location.hash.indexOf('access_token=')>=0){
       var p=new URLSearchParams(location.hash.slice(1));
       var s={access_token:p.get('access_token'), refresh_token:p.get('refresh_token'),
@@ -538,55 +387,310 @@
       +encodeURIComponent(location.origin+'/mobile/');
   }
   async function api(path,opts){
-    var tok=await freshToken();
-    if(!tok) throw new Error('unauthenticated');
+    var tok=await freshToken(); if(!tok) throw new Error('unauthenticated');
     opts=opts||{}; opts.headers=Object.assign({Authorization:'Bearer '+tok,'Content-Type':'application/json'},opts.headers||{});
     var r=await fetch('/api/v1'+path,opts);
-    if(!r.ok) throw new Error('HTTP '+r.status);
+    if(!r.ok){ var e=new Error('HTTP '+r.status); e.status=r.status; throw e; }
     return r;
   }
 
-  /* ---- auth 게이트 ---- */
-  function setAuthed(on){
-    authed=on;
-    scrLogin.classList.toggle('active',!on);
-    if(on){ scrs[cur].classList.add('active'); }
-    else { scrs.forEach(function(s){s.classList.remove('active')}); }
-    document.getElementById('footAuth').hidden=!on;
+  /* ================= 화면 상태 머신 ================= */
+  var SCREENS=['login','home','menu','player'];
+  var scr={}; SCREENS.forEach(function(n){scr[n]=document.querySelector('.scr[data-s="'+n+'"]')});
+  var cur='login', lastMain='home';
+  function show(n){
+    if(n===cur) return;
+    scr[cur].classList.remove('active');
+    cur=n; scr[cur].classList.add('active');
+    if(n==='home'||n==='player') lastMain=n;
   }
-  document.getElementById('bLogin').onclick=loginRedirect;
-  document.getElementById('bLogout').onclick=function(){
-    try{localStorage.removeItem(OWN_KEY)}catch(e){}
-    setAuthed(false);
-  };
 
-  /* ---- 홈 리스트 (실데이터) ---- */
+  /* ================= 배터리 = 지식 충전 (실청취만) ================= */
+  var charge=20;
+  function renderBatt(){ ['battHome','battMenu','battPlay'].forEach(function(id){
+    var el=document.getElementById(id); if(el) el.style.width=Math.min(charge,100)+'%'; }); }
+  function addCharge(v){ charge=Math.min(charge+v,100); renderBatt(); }
+  renderBatt();
+
+  /* ================= 컬러웨이 (MENU 내) ================= */
+  document.querySelectorAll('.way').forEach(function(w){
+    w.addEventListener('click',function(){
+      document.querySelectorAll('.way').forEach(function(x){x.classList.remove('on')});
+      w.classList.add('on');
+      dev.classList.remove('th-cream','th-sage','th-mist');
+      dev.classList.add(w.dataset.th);
+      try{localStorage.setItem('insighta-player-th',w.dataset.th)}catch(e){}
+    });
+  });
+  try{
+    var savedTh=localStorage.getItem('insighta-player-th');
+    if(savedTh && /^th-(cream|sage|mist)$/.test(savedTh)){
+      dev.classList.remove('th-cream'); dev.classList.add(savedTh);
+      document.querySelectorAll('.way').forEach(function(w){w.classList.toggle('on',w.dataset.th===savedTh)});
+    }
+  }catch(e){}
+
+  /* ================= 홈: 실데이터 목록 ================= */
   var PALETTE=[['#E8A177','#C1633B'],['#8C9BD1','#4D5C99'],['#8FBBA4','#4A7B60'],['#D9BC7E','#9A7A38'],['#C79BC0','#7C5077'],['#9BBFC7','#4E7A85']];
-  async function loadList(){
+  var mandalas=[], selIdx=0;
+  function renderRows(){
     var rows=document.getElementById('rows');
-    var empty=document.getElementById('rowsEmpty');
+    if(!mandalas.length){ rows.innerHTML='<div class="row-empty">아직 만다라가 없어요 — 첫 목표를 적어보세요</div>'; return; }
+    rows.innerHTML='';
+    mandalas.forEach(function(m,i){
+      var c=PALETTE[i%PALETTE.length];
+      var d=document.createElement('div');
+      d.className='row'+(i===selIdx?' sel':'');
+      d.innerHTML='<span class="thumb" style="background:linear-gradient(150deg,'+c[0]+','+c[1]+')"></span>'
+        +'<span class="m"><span class="a"></span><span class="b">'+(m.cardCount?('카드 '+m.cardCount+'장 · '):'')+'탭해서 듣기</span></span>';
+      d.querySelector('.a').textContent=m.title||'(제목 없음)';
+      d.addEventListener('click',function(){ selIdx=i; renderRows(); openNote(m); });
+      rows.appendChild(d);
+    });
+    var selEl=rows.children[selIdx]; if(selEl&&selEl.scrollIntoView) selEl.scrollIntoView({block:'nearest'});
+  }
+  async function loadList(){
     try{
-      var r=await api('/mandalas/list?limit=6');
+      var r=await api('/mandalas/list?limit=12');
       var j=await r.json();
-      var ms=(j.mandalas||[]);
-      if(!ms.length){ empty.textContent='아직 만다라가 없어요 — 첫 목표를 적어보세요'; return; }
-      rows.innerHTML=ms.slice(0,4).map(function(m,i){
-        var c=PALETTE[i%PALETTE.length];
-        var meta=(m.cardCount!=null?('카드 '+m.cardCount+'장'):'노트 준비 중');
-        return '<div class="row'+(i===0?' sel':'')+'">'
-          +'<span class="thumb" style="background:linear-gradient(150deg,'+c[0]+','+c[1]+')"></span>'
-          +'<span class="m"><span class="a"></span><span class="b">'+meta+'</span></span>'
-          +(i===0?'<span class="new">NEW</span>':'')+'</div>';
-      }).join('');
-      // title은 textContent로 (XSS 방지)
-      var as=rows.querySelectorAll('.a');
-      ms.slice(0,4).forEach(function(m,i){ as[i].textContent=m.title||'(제목 없음)'; });
+      mandalas=j.mandalas||[]; selIdx=0; renderRows();
     }catch(e){
-      empty.textContent='목록을 불러오지 못했어요 — 당겨서 새로고침 대신, 다시 열어주세요';
+      document.getElementById('rows').innerHTML='<div class="row-empty">목록을 불러오지 못했어요</div>';
     }
   }
 
-  /* ---- 목표 입력 → wizard-stream → create-with-data ---- */
+  /* ================= 노트 → 에피소드 (실재생) =================
+     book_json(chapters→sections{narrative,atoms{vid,ts,seg_ref}})을
+     비트 시퀀스로 평탄화: 내레이션 비트(TTS read-along) + 클립 비트(YT 구간). */
+  var beats=[], bi=0, playing=false, curNote=null, chapterOfBeat=[], chapterCount=0;
+  var CLIP_FALLBACK_SEC=22, CLIP_MAX_SEC=45;
+  function stripMd(s){
+    return String(s||'')
+      .replace(/```[\s\S]*?```/g,' ').replace(/\|[^\n]*\|/g,' ')
+      .replace(/[#>*_`~]|\[(.*?)\]\(.*?\)/g,'$1').replace(/\s+/g,' ').trim();
+  }
+  function sentences(s){
+    return stripMd(s).split(/(?<=[.!?다요죠음됨함][\s"')\]]?)\s+/).map(function(x){return x.trim()}).filter(function(x){return x.length>1});
+  }
+  function flatten(book){
+    beats=[]; chapterOfBeat=[];
+    var chs=(book&&book.chapters)||[];
+    chapterCount=chs.length||1;
+    chs.forEach(function(ch,ci){
+      if(ch.intro&&stripMd(ch.intro)) { beats.push({t:'n', title:ch.title, text:ch.intro}); chapterOfBeat.push(ci); }
+      (ch.sections||[]).forEach(function(s){
+        if(s.narrative&&stripMd(s.narrative)){ beats.push({t:'n', title:s.title, text:s.narrative}); chapterOfBeat.push(ci); }
+        (s.atoms||[]).slice(0,2).forEach(function(a){
+          if(!a.vid) return;
+          var from=a.seg_ref?a.seg_ref.from_sec:(a.ts||0);
+          var to=a.seg_ref?Math.min(a.seg_ref.to_sec,from+CLIP_MAX_SEC):(from+CLIP_FALLBACK_SEC);
+          if(to<=from) to=from+CLIP_FALLBACK_SEC;
+          beats.push({t:'c', vid:a.vid, from:from, to:to, text:a.text||''});
+          chapterOfBeat.push(ci);
+        });
+      });
+    });
+  }
+
+  var pState=document.getElementById('pState'), clipbox=document.getElementById('clipbox'),
+      readbox=document.getElementById('readbox'), ptrack=document.getElementById('ptrack');
+  function pShowState(big,sm){
+    pState.style.display='flex'; clipbox.hidden=true; readbox.hidden=true; ptrack.hidden=true;
+    document.getElementById('pStateBig').textContent=big;
+    document.getElementById('pStateSm').innerHTML=sm||'';
+  }
+  function renderChapters(){
+    var el=document.getElementById('pchap'); el.innerHTML='';
+    var curCh=chapterOfBeat[bi]||0;
+    for(var i=0;i<chapterCount;i++){
+      var b=document.createElement('i');
+      if(i<curCh) b.className='done'; else if(i===curCh) b.className='now';
+      el.appendChild(b);
+    }
+    document.getElementById('pPos').textContent=(bi+1)+' / '+beats.length;
+  }
+
+  /* ---- 내레이션 TTS (임시: 브라우저 음성 — 서버 pre-produce 전 단계) ---- */
+  var synth=window.speechSynthesis||null, speakSeq=0;
+  function stopSpeech(){ speakSeq++; if(synth) synth.cancel(); }
+  function speakBeat(beat,done){
+    var sents=sentences(beat.text);
+    readbox.innerHTML='<div class="sec-title">'+(beat.title?String(beat.title).replace(/[<>&]/g,''):'내레이션')+'</div>'
+      +'<p>'+sents.map(function(s,i){return '<span class="sent" data-i="'+i+'"></span>'}).join(' ')+'</p>';
+    var spans=readbox.querySelectorAll('.sent');
+    sents.forEach(function(s,i){spans[i].textContent=s});
+    if(!synth||!sents.length){ // TTS 불가 → 읽기 시간만큼 대기 후 진행
+      var ms=Math.min(Math.max(sents.join(' ').length*90,2500),20000);
+      var seq=++speakSeq; setTimeout(function(){ if(seq===speakSeq&&playing) done(); },ms);
+      return;
+    }
+    var seq=++speakSeq, idx=0;
+    (function next(){
+      if(seq!==speakSeq||!playing) return;
+      if(idx>=sents.length){ done(); return; }
+      spans.forEach(function(sp){sp.classList.remove('on')});
+      var sp=spans[idx]; sp.classList.add('on');
+      if(sp.scrollIntoView) sp.scrollIntoView({block:'center',behavior:reduce?'auto':'smooth'});
+      var u=new SpeechSynthesisUtterance(sents[idx]);
+      u.lang='ko-KR'; u.rate=1.05;
+      u.onend=function(){ idx++; addCharge(.6); next(); };
+      u.onerror=function(){ idx++; next(); };
+      synth.speak(u);
+    })();
+  }
+
+  /* ---- YouTube 클립 (IFrame API, 플레이어 1대 재사용) ---- */
+  var yt=null, ytReady=false, ytPoll=null, ytPending=null;
+  window.onYouTubeIframeAPIReady=function(){
+    yt=new YT.Player('yt',{
+      width:'100%', height:'100%', videoId:'',
+      playerVars:{playsinline:1, rel:0, modestbranding:1, controls:0, disablekb:1},
+      events:{onReady:function(){ ytReady=true; if(ytPending){ playClipNow(ytPending); ytPending=null; } }}
+    });
+  };
+  (function(){ var s=document.createElement('script'); s.src='https://www.youtube.com/iframe_api'; document.head.appendChild(s); })();
+  function stopClip(){ if(ytPoll){clearInterval(ytPoll); ytPoll=null;} try{ if(yt&&yt.pauseVideo) yt.pauseVideo(); }catch(e){} }
+  function playClipNow(beat){
+    try{
+      yt.loadVideoById({videoId:beat.vid, startSeconds:beat.from, endSeconds:beat.to});
+      yt.playVideo();
+      if(ytPoll) clearInterval(ytPoll);
+      ytPoll=setInterval(function(){
+        if(!playing){ return; }
+        try{
+          var st=yt.getPlayerState();
+          var t=yt.getCurrentTime?yt.getCurrentTime():0;
+          if(st===0 || (t&&t>=beat.to-0.4)){ clearInterval(ytPoll); ytPoll=null; addCharge(1.2); nextBeat(1,true); }
+        }catch(e){}
+      },500);
+    }catch(e){ nextBeat(1,true); }
+  }
+  function playClip(beat){
+    readbox.innerHTML='<div class="sec-title">원본 클립</div><p class="sent on" style="display:inline-block">'+String(beat.text||'').replace(/[<>&]/g,'')+'</p>';
+    if(ytReady) playClipNow(beat); else ytPending=beat;
+  }
+
+  /* ---- 비트 실행 ---- */
+  function runBeat(){
+    if(!beats.length){ pShowState('재생할 내용이 없어요',''); return; }
+    bi=Math.max(0,Math.min(bi,beats.length-1));
+    pState.style.display='none'; readbox.hidden=false; ptrack.hidden=false;
+    var beat=beats[bi];
+    renderChapters();
+    stopSpeech(); stopClip();
+    if(beat.t==='c'){ clipbox.hidden=false; clipbox.classList.remove('narr'); playClip(beat); }
+    else{ clipbox.hidden=true; speakBeat(beat,function(){ nextBeat(1,true); }); }
+  }
+  function nextBeat(dir,auto){
+    if(!beats.length) return;
+    var nx=bi+dir;
+    if(nx>=beats.length){ finishNote(); return; }
+    if(nx<0) nx=0;
+    bi=nx;
+    if(playing) runBeat(); else renderChapters();
+  }
+  function finishNote(){
+    playing=false; stopSpeech(); stopClip(); charge=100; renderBatt();
+    pShowState('이번 회차, 다 들었어요','추천도 무한 피드도 없어요 — 오늘은 끝<br>가운데 버튼 = 처음부터 다시');
+    bi=0;
+  }
+  function setPlaying(on){
+    playing=on;
+    if(on) runBeat();
+    else{ stopSpeech(); stopClip(); }
+  }
+
+  async function openNote(m){
+    curNote=m; show('player');
+    document.getElementById('pTitle').textContent=m.title||'노트';
+    pShowState('노트를 여는 중…','');
+    try{
+      var r=await api('/mandalas/'+m.id+'/book');
+      var j=await r.json();
+      flatten(j.data&&j.data.book);
+      if(!beats.length){ pShowState('노트 준비 중','카드가 모이면 에피소드가 생겨요'); return; }
+      bi=0; playing=true; runBeat();
+    }catch(e){
+      if(e.status===404) pShowState('노트 준비 중','아직 이 만다라의 노트가 만들어지지 않았어요<br>카드가 모이면 자동으로 생깁니다');
+      else pShowState('열지 못했어요','네트워크 확인 후 다시 시도해주세요');
+    }
+  }
+
+  /* ================= 휠 배선 ================= */
+  document.getElementById('bMenu').onclick=function(){
+    if(cur!=='login') show(cur==='menu'?lastMain:'menu');
+  };
+  document.getElementById('bPrev').onclick=function(){
+    if(cur==='home'&&mandalas.length){ selIdx=(selIdx-1+mandalas.length)%mandalas.length; renderRows(); }
+    else if(cur==='player'){ nextBeat(-1); if(!playing){playing=true; runBeat();} }
+  };
+  document.getElementById('bNext').onclick=function(){
+    if(cur==='home'&&mandalas.length){ selIdx=(selIdx+1)%mandalas.length; renderRows(); }
+    else if(cur==='player'){ nextBeat(1); if(!playing){playing=true; runBeat();} }
+  };
+  function corePress(){
+    if(cur==='login'){ loginRedirect(); return; }
+    if(cur==='home'){ if(mandalas[selIdx]) openNote(mandalas[selIdx]); return; }
+    if(cur==='player'){ setPlaying(!playing); if(!playing) toast('일시정지'); }
+  }
+  document.getElementById('bCore').onclick=corePress;
+  document.getElementById('bPlay').onclick=function(){
+    if(cur==='player'){ setPlaying(!playing); }
+    else if(cur==='home'&&mandalas[selIdx]) openNote(mandalas[selIdx]);
+  };
+
+  /* ---- 휠 드래그 = 조그 (재생 화면: 구간 이동 / 홈: 목록 이동) ---- */
+  (function(){
+    var wheel=document.getElementById('wheel');
+    var dragging=false, lastAng=0, acc=0, STEP=42; // deg per notch
+    function angOf(e){
+      var r=wheel.getBoundingClientRect();
+      var x=e.clientX-(r.left+r.width/2), y=e.clientY-(r.top+r.height/2);
+      return Math.atan2(y,x)*180/Math.PI;
+    }
+    wheel.addEventListener('pointerdown',function(e){
+      if(e.target.closest('.wbtn')||e.target.closest('.core')) return;
+      dragging=true; lastAng=angOf(e); acc=0;
+      wheel.setPointerCapture(e.pointerId);
+    });
+    wheel.addEventListener('pointermove',function(e){
+      if(!dragging) return;
+      var a=angOf(e), d=a-lastAng;
+      if(d>180) d-=360; if(d<-180) d+=360;
+      lastAng=a; acc+=d;
+      while(acc>=STEP){ acc-=STEP; notch(1); }
+      while(acc<=-STEP){ acc+=STEP; notch(-1); }
+    });
+    ['pointerup','pointercancel'].forEach(function(ev){
+      wheel.addEventListener(ev,function(){ dragging=false; acc=0; });
+    });
+    function notch(dir){
+      if(cur==='player'){ nextBeat(dir); if(!playing){playing=true; runBeat();} }
+      else if(cur==='home'&&mandalas.length){
+        selIdx=(selIdx+dir+mandalas.length)%mandalas.length; renderRows();
+      }
+    }
+  })();
+
+  /* ================= MENU 항목 ================= */
+  document.getElementById('bLogin').onclick=loginRedirect;
+  document.getElementById('bLogout').onclick=function(){
+    try{localStorage.removeItem(OWN_KEY)}catch(e){}
+    setPlaying(false); show('login');
+  };
+  document.getElementById('bShare').onclick=async function(){
+    var url=location.origin+'/mobile/?invite=1';
+    var data={title:'Insighta Player', text:'만다라 하나를, 한 편의 팟캐스트로 — 목표만 적으면 노트가 도착해요', url:url};
+    try{ if(navigator.share){ await navigator.share(data); return; } }catch(e){ if(e&&e.name==='AbortError') return; }
+    try{ await navigator.clipboard.writeText(url); toast('링크가 복사됐어요'); }
+    catch(e){ prompt('이 링크를 복사하세요', url); }
+  };
+  document.getElementById('bInstall').onclick=function(){
+    var standalone=matchMedia('(display-mode: standalone)').matches || navigator.standalone===true;
+    toast(standalone?'이미 앱으로 실행 중':'공유 버튼 → "홈 화면에 추가"');
+  };
+
+  /* ================= 목표 입력 ================= */
   var ov=document.getElementById('goalOv'), goBody=document.getElementById('goBody'),
       goProg=document.getElementById('goProgress'), goMsg=document.getElementById('goMsg'),
       goTitle=document.getElementById('goTitle'), goalInput=document.getElementById('goalInput');
@@ -596,7 +700,6 @@
     setTimeout(function(){goalInput.focus()},60);
   };
   document.getElementById('goCancel').onclick=function(){ ov.classList.remove('show') };
-
   async function wizardStream(goal,sessionId,tok){
     var r=await fetch('/api/v1/mandalas/wizard-stream',{
       method:'POST',
@@ -626,7 +729,6 @@
     }
     return structure;
   }
-
   document.getElementById('goMake').onclick=async function(){
     var goal=(goalInput.value||'').trim();
     if(goal.length<4){ goalInput.focus(); return; }
@@ -654,29 +756,14 @@
     }
   };
 
-  /* ---- 공유 (iOS 공유시트 → 카카오톡 포함) ---- */
-  document.getElementById('bShare').onclick=async function(){
-    var url=location.origin+'/mobile/?invite=1';
-    var data={title:'Insighta Player', text:'만다라 하나를, 한 편의 팟캐스트로 — 목표만 적으면 노트가 도착해요', url:url};
-    try{
-      if(navigator.share){ await navigator.share(data); return; }
-    }catch(e){ if(e && e.name==='AbortError') return; }
-    try{ await navigator.clipboard.writeText(url);
-      this.textContent='링크 복사됨'; var b=this;
-      setTimeout(function(){b.textContent='공유'},1500);
-    }catch(e){ prompt('이 링크를 복사하세요', url); }
-  };
-  /* 초대 링크로 진입 시 로그인 카피 전환 */
+  /* ================= 부팅 ================= */
   if(new URLSearchParams(location.search).get('invite')==='1'){
-    var ls=document.querySelector('.login-sub');
-    if(ls) ls.textContent='친구가 공유한 인사이타 — Google로 3초 만에 시작';
+    document.getElementById('loginSub').textContent='친구가 공유한 인사이타 — Google로 3초 만에 시작';
   }
-
-  /* ---- 부팅: 세션 → 게이트 + 리스트 ---- */
+  scr[cur].classList.add('active');
   (async function boot(){
     var tok=await freshToken();
-    setAuthed(!!tok);
-    if(tok) loadList();
+    if(tok){ show('home'); loadList(); } else { show('login'); }
   })();
 </script>
 </body>


### PR DESCRIPTION
Third increment on `/mobile`. James: "개인계정 내용 로드 + 상하단 제거 + 색상은 메뉴에 + 재생 시 휠 구간이동 — 모두 A안에 구현됐던 사항, 실제 동작하게".

- **Real playback**: `GET /mandalas/:id/book` → book_json → beat sequence (narratives + atom clips). Narration via browser TTS (sentence highlight read-along; interim until server pre-produce), clips via YouTube IFrame API segment seek. 404 → '노트 준비 중'.
- **Wheel jog**: drag-rotate = beat seek in player / list scroll on home (42°/notch), buttons unchanged.
- **Full-app layout**: page chrome gone, device = viewport (safe-area aware).
- **MENU screen**: colorways + share + install hint + logout.
- **Battery**: charges only from real listening; full at completion.

Verified: build + headless render. Static page only, zero SPA changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)