### PR TITLE
feat(ui): deboost-card fold + indeterminate fill bar

### DIFF
--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -758,7 +758,9 @@
     "statusQueued": "Queued",
     "statusQueuedTooltip": "Pending background analysis",
     "retryEnrichmentTooltip": "Retry caption fetch",
-    "enrichingAria": "Analyzing"
+    "enrichingAria": "Analyzing",
+    "deboostedShow": "Show {{count}} low-relevance cards",
+    "deboostedHide": "Show less"
   },
   "gridView": {
     "badgeNew": "Added"

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -766,7 +766,9 @@
     "statusQueued": "분석 대기",
     "statusQueuedTooltip": "자동 분석 대기 중",
     "retryEnrichmentTooltip": "자막을 다시 가져옵니다",
-    "enrichingAria": "분석 중"
+    "enrichingAria": "분석 중",
+    "deboostedShow": "관련성 낮음 {{count}}장 보기",
+    "deboostedHide": "간략히"
   },
   "gridView": {
     "badgeNew": "추가됨"

--- a/frontend/src/widgets/card-list-view/ui/CardListView.tsx
+++ b/frontend/src/widgets/card-list-view/ui/CardListView.tsx
@@ -11,7 +11,15 @@ import { ListView } from '@/widgets/list-view';
 import { DetailPanel } from '@/widgets/detail-panel';
 import { GraphView } from '@/components/graph/GraphView';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/shared/ui/resizable';
-import { LayoutGrid, Grid3X3, Plus, GripVertical, ArrowDownWideNarrow, Eye } from 'lucide-react';
+import {
+  LayoutGrid,
+  Grid3X3,
+  Plus,
+  GripVertical,
+  ArrowDownWideNarrow,
+  Eye,
+  ChevronDown,
+} from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -25,6 +33,10 @@ import { ContextHeader, SORT_OPTIONS, type SortMode } from './ContextHeader';
 import { LabelFilterPillsV2 } from './LabelFilterPillsV2';
 
 // P3 Stage 1 (CP513) — global (cross-mandala) sort persistence keys.
+
+/** uvs.relevance_pct value the judge writes when it sinks a card (judge-deboost.ts UNFIT_RELEVANCE_PCT). */
+const DEBOOSTED_RELEVANCE_PCT = 2;
+
 const GLOBAL_SORT_KEY = 'insighta:cardSortMode';
 const GLOBAL_SORT_TOAST_KEY = 'insighta:cardSortMode:toastShown';
 
@@ -450,6 +462,21 @@ export function CardListView({
     }
   }, [effectiveCards, sortMode, relevanceRank]);
 
+  // Deboost fold (James-approved 2026-07-13, YouTube-fold as reference only):
+  // judge-sunk cards (relevancePct === DEBOOSTED_RELEVANCE_PCT) leave the main
+  // grid and collapse behind a centered pill — inflow stays visible on demand,
+  // felt garbage goes to zero. Grid mode only (list modes already sink them
+  // via the relevance sort).
+  const [showDeboosted, setShowDeboosted] = useState(false);
+  const mainCards = useMemo(
+    () => sortedCards.filter((c) => c.relevancePct !== DEBOOSTED_RELEVANCE_PCT),
+    [sortedCards]
+  );
+  const deboostedCards = useMemo(
+    () => sortedCards.filter((c) => c.relevancePct === DEBOOSTED_RELEVANCE_PCT),
+    [sortedCards]
+  );
+
   // Sector card counts (0-7)
   const sectorCounts = useMemo(() => {
     if (!sectorSubjects || !cardsByCell) return [];
@@ -708,7 +735,7 @@ export function CardListView({
             {sectorPillsElement}
           </div>
           <CardList
-            cards={sortedCards}
+            cards={mainCards}
             isLoading={isLoading}
             title={title}
             gridColumns={gridColumns}
@@ -726,6 +753,50 @@ export function CardListView({
             failedEnrichCardIds={failedEnrichCardIds}
             onRetryEnrich={onRetryEnrich}
           />
+          {deboostedCards.length > 0 && (
+            <div className="pb-6">
+              <div className="flex justify-center py-3">
+                <button
+                  onClick={() => setShowDeboosted((v) => !v)}
+                  className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full border border-border bg-card text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                >
+                  {showDeboosted
+                    ? t('cards.deboostedHide', '간략히')
+                    : t('cards.deboostedShow', '관련성 낮음 {{count}}장 보기', {
+                        count: deboostedCards.length,
+                      })}
+                  <ChevronDown
+                    className={cn(
+                      'h-3.5 w-3.5 transition-transform',
+                      showDeboosted && 'rotate-180'
+                    )}
+                  />
+                </button>
+              </div>
+              {showDeboosted && (
+                <div className="opacity-60 animate-fade-in">
+                  <CardList
+                    cards={deboostedCards}
+                    isLoading={false}
+                    title={title}
+                    gridColumns={gridColumns}
+                    compact={gridColumns >= COMPACT_THRESHOLD}
+                    sectorSubjects={sectorSubjects}
+                    showChannel={selectedCellIndex != null && selectedCellIndex >= 0}
+                    onCardClick={onCardClick ? (card) => onCardClick(card, sortedCards) : undefined}
+                    onCardDragStart={onCardDragStart}
+                    onMultiCardDragStart={onMultiCardDragStart}
+                    onSaveNote={onSaveNote}
+                    onDeleteCards={onDeleteCards}
+                    onSelectionChange={handleSelectionChange}
+                    enrichingCardIds={enrichingCardIds}
+                    failedEnrichCardIds={failedEnrichCardIds}
+                    onRetryEnrich={onRetryEnrich}
+                  />
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
     );

--- a/frontend/src/widgets/card-list-view/ui/ContextHeader.tsx
+++ b/frontend/src/widgets/card-list-view/ui/ContextHeader.tsx
@@ -48,69 +48,71 @@ export function ContextHeader({
   const titleInitial = title.charAt(0).toUpperCase();
 
   return (
-    <div data-card-chrome className="flex items-center justify-between mb-1 pr-2">
-      {/* Left: sector badge + title + count + selection */}
-      <div className="flex items-center gap-2 min-w-0">
-        {titleLoading ? (
-          <div
-            className="w-6 h-6 rounded bg-foreground/[0.06] animate-pulse shrink-0"
+    <div data-card-chrome className="mb-1">
+      {/* Fill indicator (James 2026-07-13): thin indeterminate bar under the
+          title row — replaces the arc spinner ("아마추어" feedback). Sits in
+          normal flow so nothing overlaps; collapses when idle. */}
+      {isFilling && (
+        <div
+          className="relative h-[2px] w-full overflow-hidden rounded-full bg-primary/10 mb-1 animate-fade-in"
+          role="progressbar"
+          aria-label={t('contextHeader.filling', '채우는 중')}
+        >
+          <span
+            className="absolute inset-y-0 left-0 w-1/4 rounded-full bg-primary/70 animate-progress-slide motion-reduce:animate-pulse motion-reduce:w-full"
             aria-hidden="true"
           />
-        ) : (
-          <div className="flex items-center justify-center w-6 h-6 rounded bg-primary/10 text-primary text-[11px] font-semibold shrink-0">
-            {titleInitial}
-          </div>
-        )}
-
-        {titleLoading ? (
-          <div className="h-5 w-32 rounded bg-foreground/[0.06] animate-pulse" aria-hidden="true" />
-        ) : (
-          <h3 className="text-lg font-semibold leading-tight truncate">{title}</h3>
-        )}
-
-        <span className="text-[11px] text-muted-foreground tabular-nums shrink-0 flex items-center gap-1">
-          {t('contextHeader.cardCount', '{{count}} cards', { count: totalCardCount })}
-          {isFilling && (
-            <span
-              className="relative inline-block h-3.5 w-3.5 animate-fade-in"
-              role="status"
-              aria-label={t('contextHeader.filling', '채우는 중')}
-            >
-              {/* Dimensional spinner (James 2026-07-12): two counter-rotating
-                  arcs at different depths — subtle 3D feel, no text. */}
-              <span
-                className="absolute inset-0 rounded-full border-[1.5px] border-primary/70 border-t-transparent border-l-transparent animate-spin [animation-duration:0.9s]"
-                aria-hidden="true"
-              />
-              <span
-                className="absolute inset-[3px] rounded-full border-[1.5px] border-primary/30 border-b-transparent border-r-transparent animate-spin [animation-direction:reverse] [animation-duration:1.5s]"
-                aria-hidden="true"
-              />
-            </span>
+        </div>
+      )}
+      <div className="flex items-center justify-between pr-2">
+        {/* Left: sector badge + title + count + selection */}
+        <div className="flex items-center gap-2 min-w-0">
+          {titleLoading ? (
+            <div
+              className="w-6 h-6 rounded bg-foreground/[0.06] animate-pulse shrink-0"
+              aria-hidden="true"
+            />
+          ) : (
+            <div className="flex items-center justify-center w-6 h-6 rounded bg-primary/10 text-primary text-[11px] font-semibold shrink-0">
+              {titleInitial}
+            </div>
           )}
-        </span>
 
-        {selectedCardIds.length > 0 && (
-          <div className="flex items-center gap-1 animate-fade-in shrink-0">
-            <span className="text-[10px] bg-primary text-primary-foreground px-1.5 py-0.5 rounded-full">
-              {t('cards.selected', { count: selectedCardIds.length })}
-            </span>
-            <button
-              onClick={onDeleteSelected}
-              className="p-0.5 rounded text-destructive hover:bg-destructive/10 transition-colors"
-              title={t('cards.deleteSelected')}
-            >
-              <Trash2 className="w-3 h-3" />
-            </button>
-          </div>
-        )}
-      </div>
+          {titleLoading ? (
+            <div
+              className="h-5 w-32 rounded bg-foreground/[0.06] animate-pulse"
+              aria-hidden="true"
+            />
+          ) : (
+            <h3 className="text-lg font-semibold leading-tight truncate">{title}</h3>
+          )}
 
-      {/* Right: slider + drag hint + sort + view */}
-      <div className="flex items-center gap-1.5 shrink-0">
-        {sliderElement}
-        {trailingAction}
-        <ViewSwitcher value={viewMode} onChange={onViewModeChange} />
+          <span className="text-[11px] text-muted-foreground tabular-nums shrink-0">
+            {t('contextHeader.cardCount', '{{count}} cards', { count: totalCardCount })}
+          </span>
+
+          {selectedCardIds.length > 0 && (
+            <div className="flex items-center gap-1 animate-fade-in shrink-0">
+              <span className="text-[10px] bg-primary text-primary-foreground px-1.5 py-0.5 rounded-full">
+                {t('cards.selected', { count: selectedCardIds.length })}
+              </span>
+              <button
+                onClick={onDeleteSelected}
+                className="p-0.5 rounded text-destructive hover:bg-destructive/10 transition-colors"
+                title={t('cards.deleteSelected')}
+              >
+                <Trash2 className="w-3 h-3" />
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Right: slider + drag hint + sort + view */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          {sliderElement}
+          {trailingAction}
+          <ViewSwitcher value={viewMode} onChange={onViewModeChange} />
+        </div>
       </div>
     </div>
   );

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -102,6 +102,14 @@ export default {
   					height: '0'
   				}
   			},
+  			'progress-slide': {
+  				from: {
+  					transform: 'translateX(-100%)'
+  				},
+  				to: {
+  					transform: 'translateX(350%)'
+  				}
+  			},
   			'fade-in': {
   				from: {
   					opacity: '0',
@@ -299,6 +307,7 @@ export default {
 			'accordion-down': 'accordion-down 0.2s ease-out',
 			'accordion-up': 'accordion-up 0.2s ease-out',
 			'fade-in': 'fade-in 0.3s ease-out',
+			'progress-slide': 'progress-slide 1.4s cubic-bezier(0.4, 0, 0.2, 1) infinite',
 			'scale-in': 'scale-in 0.2s ease-out',
 			'slide-up': 'slide-up 0.4s ease-out',
 			'ripple-expand': 'ripple-expand 700ms ease-out forwards',


### PR DESCRIPTION
## What (both James-approved 2026-07-13)
1. **Deboost fold (grid)**: judge-sunk cards (`relevance_pct=2`) leave the main grid; a centered Insighta-styled pill '관련성 낮음 N장 보기 ⌄' expands a dimmed section ('간략히 ⌃' folds back). YouTube's fold pattern as interaction reference only — styled with our tokens. Reorder disabled inside the fold; list/list-detail modes unchanged (relevance sort already sinks them). Kills the felt-garbage problem from the 반려견 report while keeping inflow inspectable.
2. **Fill indicator**: ContextHeader dual-arc spinner ('아마추어' feedback) → 2px indeterminate progress bar under the title row (Linear/GitHub style). Normal flow (no overlap), `motion-reduce` fallback, `role=progressbar`.

## Verification (/verify)
FE tsc 0 · vitest 512/512 · build pass · dev-server 5199 module 200, 0 errors. D&D untouched (fold section omits reorder handler only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)