### PR TITLE
fix(judge): T10 — unanimous 2-judge + self-healing restore + rejudge + fold scroll fix

### DIFF
--- a/frontend/src/widgets/card-list-view/ui/CardListView.tsx
+++ b/frontend/src/widgets/card-list-view/ui/CardListView.tsx
@@ -776,6 +776,7 @@ export function CardListView({
               {showDeboosted && (
                 <div className="opacity-60 animate-fade-in">
                   <CardList
+                    suppressSetScrollReset
                     cards={deboostedCards}
                     isLoading={false}
                     title={title}

--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -56,6 +56,13 @@ function safeVideoId(videoUrl: string): string | null {
 }
 
 interface CardListProps {
+  /**
+   * T10 (2026-07-13) — secondary embedded instances (deboost fold) must NOT
+   * reset the shared [data-scroll-container] on mount/set-change: the fold
+   * toggle jumped the grid to the top because this instance's set-change
+   * effect fired scrollCardSetContainerToTop.
+   */
+  suppressSetScrollReset?: boolean;
   cards: InsightCard[];
   isLoading?: boolean;
   title: string;
@@ -125,6 +132,7 @@ function cardGridStyle(gridColumns: number): CSSProperties {
 }
 
 export function CardList({
+  suppressSetScrollReset,
   cards,
   isLoading,
   onCardClick,
@@ -294,8 +302,10 @@ export function CardList({
     // the observer). A new card set starts at the top — which also guarantees
     // the sentinel begins below the viewport, so the observer's first real
     // trigger is a clean user-scroll intersection change.
-    scrollCardSetContainerToTop(gridRef.current);
-  }, [cardListKey, resetVisibleCount]);
+    // T10: embedded fold instances skip the reset (their mount is not a
+    // card-set navigation — resetting jumped the grid to the top).
+    if (!suppressSetScrollReset) scrollCardSetContainerToTop(gridRef.current);
+  }, [cardListKey, resetVisibleCount, suppressSetScrollReset]);
 
   const visibleCards = useMemo(
     () => sortedCards.slice(0, visibleCount),

--- a/src/api/routes/admin/performance.ts
+++ b/src/api/routes/admin/performance.ts
@@ -238,6 +238,25 @@ export async function adminPerformanceRoutes(fastify: FastifyInstance) {
     );
   });
 
+  // Re-judge a mandala with the CURRENT judge stack (unanimous 2-model) —
+  // re-appliable after prompt/stack changes; sinks unfit, restores fit-but-sunk.
+  fastify.post('/rejudge', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
+    const { mandalaId } = z.object({ mandalaId: z.string().uuid() }).parse(request.body ?? {});
+    const mandala = await db.user_mandalas.findUnique({
+      where: { id: mandalaId },
+      select: { id: true, user_id: true },
+    });
+    if (!mandala) return reply.code(404).send({ error: { message: 'mandala not found' } });
+    const { judgeMandala } = await import('@/modules/queue/handlers/judge-deboost');
+    setImmediate(() => {
+      void judgeMandala(mandala.user_id, mandalaId).catch((err) =>
+        log.warn(`admin rejudge failed: ${err instanceof Error ? err.message : String(err)}`)
+      );
+    });
+    log.info(`admin rejudge dispatched: mandala=${mandalaId}`);
+    return reply.send(createSuccessResponse({ dispatched: true, mandalaId }));
+  });
+
   fastify.post('/events', adminAuth, async (request: FastifyRequest, reply: FastifyReply) => {
     const body = ManualEventSchema.parse(request.body ?? {});
     const row = await db.config_change_events.create({

--- a/src/modules/judge/card-cell-judge.ts
+++ b/src/modules/judge/card-cell-judge.ts
@@ -22,8 +22,16 @@ import { logger } from '@/utils/logger';
 
 const log = logger.child({ module: 'card-cell-judge' });
 
-/** gA — the benchmark's main judge config (Gemini Flash via gateway). */
-export const JUDGE_MODEL = 'google/gemini-2.5-flash';
+/**
+ * Unanimous 2-judge stack (2026-07-13 — 반려견 false-sink incident: single gA
+ * sank 5 clearly-relevant dog-training cards). The quality report's confirmed
+ * design: NO single judge is safe; sinking requires UNANIMOUS unfit across
+ * different model families. A failed/unparseable leg votes fit (fail-open =
+ * blocks sinking, never causes it).
+ */
+export const JUDGE_MODELS = ['google/gemini-2.5-flash', 'deepseek/deepseek-v4-flash'] as const;
+/** @deprecated single-judge era; kept for log compat. */
+export const JUDGE_MODEL = JUDGE_MODELS[0];
 const JUDGE_TEMPERATURE = 0;
 const JUDGE_MAX_TOKENS = 800;
 
@@ -90,37 +98,54 @@ export async function judgeCellCards(params: {
   cellTopic: string;
   items: JudgeItem[];
   generateImpl?: (
+    model: string,
     prompt: string,
     options?: { temperature?: number; maxTokens?: number; format?: 'json' }
   ) => Promise<string>;
 }): Promise<JudgeVerdict[]> {
   if (params.items.length === 0) return [];
   const prompt = buildJudgePrompt(params);
-  try {
-    const generate =
-      params.generateImpl ??
-      (async (p: string, o?: { temperature?: number; maxTokens?: number; format?: 'json' }) => {
-        const provider = new OpenRouterGenerationProvider(JUDGE_MODEL);
-        return provider.generate(p, o);
-      });
-    const raw = await generate(prompt, {
-      temperature: JUDGE_TEMPERATURE,
-      maxTokens: JUDGE_MAX_TOKENS,
-      format: 'json',
+  const generate =
+    params.generateImpl ??
+    (async (
+      model: string,
+      p: string,
+      o?: { temperature?: number; maxTokens?: number; format?: 'json' }
+    ) => {
+      const provider = new OpenRouterGenerationProvider(model);
+      return provider.generate(p, o);
     });
-    const verdicts = parseJudgeResponse(raw, params.items);
-    if (!verdicts) {
-      log.warn('judge response unparseable — fail-open (all fit)', {
-        cellTopic: params.cellTopic,
-      });
-      return params.items.map((it) => ({ videoId: it.videoId, fit: true }));
-    }
-    return verdicts;
-  } catch (err) {
-    log.warn('judge call failed — fail-open (all fit)', {
-      cellTopic: params.cellTopic,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return params.items.map((it) => ({ videoId: it.videoId, fit: true }));
-  }
+
+  // One vote per model; any leg failure = that leg votes all-fit.
+  const legs = await Promise.all(
+    JUDGE_MODELS.map(async (model): Promise<JudgeVerdict[]> => {
+      try {
+        const raw = await generate(model, prompt, {
+          temperature: JUDGE_TEMPERATURE,
+          maxTokens: JUDGE_MAX_TOKENS,
+          format: 'json',
+        });
+        const verdicts = parseJudgeResponse(raw, params.items);
+        if (!verdicts) {
+          log.warn(`judge leg unparseable — leg votes fit (model=${model})`, {
+            cellTopic: params.cellTopic,
+          });
+          return params.items.map((it) => ({ videoId: it.videoId, fit: true }));
+        }
+        return verdicts;
+      } catch (err) {
+        log.warn(`judge leg failed — leg votes fit (model=${model})`, {
+          cellTopic: params.cellTopic,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return params.items.map((it) => ({ videoId: it.videoId, fit: true }));
+      }
+    })
+  );
+
+  // Unanimous rule: unfit ONLY when every leg says unfit.
+  return params.items.map((it, i) => ({
+    videoId: it.videoId,
+    fit: legs.some((leg) => leg[i]?.fit !== false),
+  }));
 }

--- a/src/modules/queue/handlers/judge-deboost.ts
+++ b/src/modules/queue/handlers/judge-deboost.ts
@@ -45,7 +45,17 @@ export async function handleJudgeDeboost(
   const job = Array.isArray(jobs) ? jobs[0] : jobs;
   if (!job) return;
   if (!isJudgeDeboostEnabled()) return;
-  const { userId, mandalaId } = job.data;
+  await judgeMandala(job.data.userId, job.data.mandalaId);
+}
+
+/**
+ * Judge core — reusable by the queue worker AND the admin re-judge endpoint
+ * (2026-07-13 반려견 inversion: verdicts must be re-appliable after prompt/
+ * stack changes). Idempotent both ways: unfit sinks to UNFIT_RELEVANCE_PCT;
+ * a card judged FIT that is currently sunk RESTORES to NULL and the quick
+ * relevance backfill re-scores it (its IS NULL filter makes this safe).
+ */
+export async function judgeMandala(userId: string, mandalaId: string): Promise<void> {
   const prisma = getPrismaClient();
 
   // Cell topics from the root level's subjects.
@@ -65,21 +75,28 @@ export async function handleJudgeDeboost(
     select: {
       id: true,
       cell_index: true,
+      relevance_pct: true,
       video: { select: { youtube_video_id: true, title: true } },
     },
   });
-  const byCell = new Map<number, Array<{ rowId: string; videoId: string; title: string }>>();
+  const byCell = new Map<
+    number,
+    Array<{ rowId: string; videoId: string; title: string; relevancePct: number | null }>
+  >();
   for (const r of rows) {
     const title = r.video?.title?.trim();
     const vid = r.video?.youtube_video_id;
     if (!title || !vid || r.cell_index == null || r.cell_index < 0) continue;
     if (!byCell.has(r.cell_index)) byCell.set(r.cell_index, []);
-    byCell.get(r.cell_index)!.push({ rowId: r.id, videoId: vid, title });
+    byCell
+      .get(r.cell_index)!
+      .push({ rowId: r.id, videoId: vid, title, relevancePct: r.relevance_pct ?? null });
   }
   if (byCell.size === 0) return;
 
   let judged = 0;
   let deboosted = 0;
+  let restored = 0;
   await Promise.allSettled(
     [...byCell.entries()].map(async ([cellIndex, cards]) => {
       const cellTopic = subjects[cellIndex]?.trim();
@@ -91,24 +108,55 @@ export async function handleJudgeDeboost(
       });
       judged += verdicts.length;
       const unfitIds = new Set(verdicts.filter((v) => !v.fit).map((v) => v.videoId));
-      if (unfitIds.size === 0) return;
       const unfitRows = cards.filter((c) => unfitIds.has(c.videoId));
-      deboosted += unfitRows.length;
-      await prisma.userVideoState.updateMany({
-        where: { id: { in: unfitRows.map((c) => c.rowId) } },
-        data: { relevance_pct: UNFIT_RELEVANCE_PCT },
-      });
-      // Mirror on recommendation_cache so re-serves keep the sink.
-      await prisma.recommendation_cache
-        .updateMany({
-          where: { mandala_id: mandalaId, video_id: { in: unfitRows.map((c) => c.videoId) } },
+      // Restore: judged FIT but currently sunk (earlier verdict) → NULL, so
+      // the quick relevance backfill (IS NULL filter) re-scores it.
+      const restoreRows = cards.filter(
+        (c) => !unfitIds.has(c.videoId) && c.relevancePct === UNFIT_RELEVANCE_PCT
+      );
+      if (unfitRows.length > 0) {
+        deboosted += unfitRows.length;
+        await prisma.userVideoState.updateMany({
+          where: { id: { in: unfitRows.map((c) => c.rowId) } },
           data: { relevance_pct: UNFIT_RELEVANCE_PCT },
-        })
-        .catch(() => undefined);
+        });
+        // Mirror on recommendation_cache so re-serves keep the sink.
+        await prisma.recommendation_cache
+          .updateMany({
+            where: { mandala_id: mandalaId, video_id: { in: unfitRows.map((c) => c.videoId) } },
+            data: { relevance_pct: UNFIT_RELEVANCE_PCT },
+          })
+          .catch(() => undefined);
+      }
+      if (restoreRows.length > 0) {
+        restored += restoreRows.length;
+        await prisma.userVideoState.updateMany({
+          where: { id: { in: restoreRows.map((c) => c.rowId) } },
+          data: { relevance_pct: null },
+        });
+        await prisma.recommendation_cache
+          .updateMany({
+            where: { mandala_id: mandalaId, video_id: { in: restoreRows.map((c) => c.videoId) } },
+            data: { relevance_pct: null },
+          })
+          .catch(() => undefined);
+      }
       log.info(
-        `[judge] mandala=${mandalaId} cell=${cellIndex} unfit=${unfitRows.length}/${cards.length}`
+        `[judge] mandala=${mandalaId} cell=${cellIndex} unfit=${unfitRows.length} restored=${restoreRows.length} of=${cards.length}`
       );
     })
   );
-  log.info(`[judge] mandala=${mandalaId} judged=${judged} deboosted=${deboosted}`);
+  if (restored > 0) {
+    // Re-score restored cards (fire-and-forget; IS NULL filter = idempotent).
+    setImmediate(() => {
+      void import('@/modules/relevance/relevance-backfill-trigger')
+        .then(({ enqueueRelevanceBackfillForMandala }) =>
+          enqueueRelevanceBackfillForMandala({ userId, mandalaId, applyCutoff: false })
+        )
+        .catch(() => undefined);
+    });
+  }
+  log.info(
+    `[judge] mandala=${mandalaId} judged=${judged} deboosted=${deboosted} restored=${restored}`
+  );
 }

--- a/tests/unit/modules/card-cell-judge.test.ts
+++ b/tests/unit/modules/card-cell-judge.test.ts
@@ -60,8 +60,8 @@ describe('parseJudgeResponse', () => {
   });
 });
 
-describe('judgeCellCards — fail-open', () => {
-  test('provider throw → 전원 fit', async () => {
+describe('judgeCellCards — unanimous 2-judge + fail-open', () => {
+  test('provider throw (both legs) → 전원 fit', async () => {
     const out = await judgeCellCards({
       centerGoal: 'g',
       cellTopic: 'c',
@@ -72,7 +72,7 @@ describe('judgeCellCards — fail-open', () => {
     });
     expect(out.every((v) => v.fit)).toBe(true);
   });
-  test('unfit 판정 전달', async () => {
+  test('만장일치 unfit → sink', async () => {
     const out = await judgeCellCards({
       centerGoal: 'g',
       cellTopic: 'c',
@@ -80,5 +80,30 @@ describe('judgeCellCards — fail-open', () => {
       generateImpl: async () => '[{"n":1,"fit":true},{"n":2,"fit":false}]',
     });
     expect(out[1]).toEqual({ videoId: 'bbb', fit: false });
+    expect(out[0]).toEqual({ videoId: 'aaa', fit: true });
+  });
+  test('의견 분열 (한 leg만 unfit) → fit 유지 (오침전 방지, 2026-07-13 반려견)', async () => {
+    const out = await judgeCellCards({
+      centerGoal: 'g',
+      cellTopic: 'c',
+      items,
+      generateImpl: async (model: string) =>
+        model.includes('gemini')
+          ? '[{"n":1,"fit":true},{"n":2,"fit":false}]'
+          : '[{"n":1,"fit":true},{"n":2,"fit":true}]',
+    });
+    expect(out[1]).toEqual({ videoId: 'bbb', fit: true });
+  });
+  test('한 leg 실패 + 다른 leg unfit → fit 유지 (실패 leg는 침전 차단)', async () => {
+    const out = await judgeCellCards({
+      centerGoal: 'g',
+      cellTopic: 'c',
+      items,
+      generateImpl: async (model: string) => {
+        if (model.includes('gemini')) throw new Error('down');
+        return '[{"n":1,"fit":false},{"n":2,"fit":false}]';
+      },
+    });
+    expect(out.every((v) => v.fit)).toBe(true);
   });
 });


### PR DESCRIPTION
## Incident (F16 — James report)
반려견 mandala: 10 sunk cards included **5 clearly-relevant dog-training cards** (기다려 훈련, 배변훈련, 보호자 리더십…) while 5 human-psych cards stayed in the main grid. Single-judge false-block (benchmark warned 19-22%) materialized. Fold toggle also jumped the grid to top.

## Fixes (all global — no per-mandala data patches)
1. **Unanimous 2-judge**: Gemini Flash + DeepSeek V4 Flash; sink ONLY on unanimous unfit. Failed/unparseable leg votes fit (fail-open blocks sinking). Tests: unanimous / split-vote / leg-failure semantics.
2. **Self-healing restore**: judged-FIT-but-currently-sunk → relevance_pct NULL + quick relevance backfill re-scores (IS NULL filter = idempotent). Every future judge run retroactively heals wrong verdicts.
3. **Admin rejudge** `POST /admin/performance/rejudge` (adminAuth): re-apply current stack to an existing mandala.
4. **FE fold scroll jump**: embedded fold CardList's set-change effect fired `scrollCardSetContainerToTop` on mount → new `suppressSetScrollReset` prop (main-grid navigation reset behavior unchanged).

## Verification plan (post-deploy, per James 내용확인/조치/테스트/점검)
Rejudge 반려견 → DB two-way content check (sunk = human-psych only / restored dog cards re-scored) → browser: fold contents + main grid + toggle scroll stability.

BE tsc 0 · judge tests 10/10 · FE tsc 0 · vitest 512/512 · build pass · /verify PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)