### PR TITLE
revert(t10): remove deboost fold UI + judge relevance_pct writes (T10-R)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -315,7 +315,9 @@ services:
       # judges title-vs-cell-topic per cell, 240s after creation; unfit cards
       # sink (relevance_pct=2), NEVER deleted (single-judge removal unsafe:
       # 150-label benchmark false-blocks 19-22%). Remove line = off.
-      - JUDGE_DEBOOST_ENABLED=true
+      # T10-R (2026-07-13): judge verdicts unreliable both ways (single=false
+      # sinks F16, unanimous=recall 3/10) — OFF until T11 dedicated-column era.
+      - JUDGE_DEBOOST_ENABLED=false
       # CP416 (2026-04-22) — restore the LoRA action-fill path. Without
       # this, generateMandala() called config.mandalaGen.model=undefined,
       # Ollama /api/generate returned 400, LoRA threw, and the Haiku

--- a/frontend/src/shared/i18n/locales/en.json
+++ b/frontend/src/shared/i18n/locales/en.json
@@ -758,9 +758,7 @@
     "statusQueued": "Queued",
     "statusQueuedTooltip": "Pending background analysis",
     "retryEnrichmentTooltip": "Retry caption fetch",
-    "enrichingAria": "Analyzing",
-    "deboostedShow": "Show {{count}} low-relevance cards",
-    "deboostedHide": "Show less"
+    "enrichingAria": "Analyzing"
   },
   "gridView": {
     "badgeNew": "Added"

--- a/frontend/src/shared/i18n/locales/ko.json
+++ b/frontend/src/shared/i18n/locales/ko.json
@@ -766,9 +766,7 @@
     "statusQueued": "분석 대기",
     "statusQueuedTooltip": "자동 분석 대기 중",
     "retryEnrichmentTooltip": "자막을 다시 가져옵니다",
-    "enrichingAria": "분석 중",
-    "deboostedShow": "관련성 낮음 {{count}}장 보기",
-    "deboostedHide": "간략히"
+    "enrichingAria": "분석 중"
   },
   "gridView": {
     "badgeNew": "추가됨"

--- a/frontend/src/widgets/card-list-view/ui/CardListView.tsx
+++ b/frontend/src/widgets/card-list-view/ui/CardListView.tsx
@@ -34,9 +34,6 @@ import { LabelFilterPillsV2 } from './LabelFilterPillsV2';
 
 // P3 Stage 1 (CP513) — global (cross-mandala) sort persistence keys.
 
-/** uvs.relevance_pct value the judge writes when it sinks a card (judge-deboost.ts UNFIT_RELEVANCE_PCT). */
-const DEBOOSTED_RELEVANCE_PCT = 2;
-
 const GLOBAL_SORT_KEY = 'insighta:cardSortMode';
 const GLOBAL_SORT_TOAST_KEY = 'insighta:cardSortMode:toastShown';
 
@@ -462,21 +459,6 @@ export function CardListView({
     }
   }, [effectiveCards, sortMode, relevanceRank]);
 
-  // Deboost fold (James-approved 2026-07-13, YouTube-fold as reference only):
-  // judge-sunk cards (relevancePct === DEBOOSTED_RELEVANCE_PCT) leave the main
-  // grid and collapse behind a centered pill — inflow stays visible on demand,
-  // felt garbage goes to zero. Grid mode only (list modes already sink them
-  // via the relevance sort).
-  const [showDeboosted, setShowDeboosted] = useState(false);
-  const mainCards = useMemo(
-    () => sortedCards.filter((c) => c.relevancePct !== DEBOOSTED_RELEVANCE_PCT),
-    [sortedCards]
-  );
-  const deboostedCards = useMemo(
-    () => sortedCards.filter((c) => c.relevancePct === DEBOOSTED_RELEVANCE_PCT),
-    [sortedCards]
-  );
-
   // Sector card counts (0-7)
   const sectorCounts = useMemo(() => {
     if (!sectorSubjects || !cardsByCell) return [];
@@ -735,7 +717,7 @@ export function CardListView({
             {sectorPillsElement}
           </div>
           <CardList
-            cards={mainCards}
+            cards={sortedCards}
             isLoading={isLoading}
             title={title}
             gridColumns={gridColumns}
@@ -753,51 +735,6 @@ export function CardListView({
             failedEnrichCardIds={failedEnrichCardIds}
             onRetryEnrich={onRetryEnrich}
           />
-          {deboostedCards.length > 0 && (
-            <div className="pb-6">
-              <div className="flex justify-center py-3">
-                <button
-                  onClick={() => setShowDeboosted((v) => !v)}
-                  className="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full border border-border bg-card text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-                >
-                  {showDeboosted
-                    ? t('cards.deboostedHide', '간략히')
-                    : t('cards.deboostedShow', '관련성 낮음 {{count}}장 보기', {
-                        count: deboostedCards.length,
-                      })}
-                  <ChevronDown
-                    className={cn(
-                      'h-3.5 w-3.5 transition-transform',
-                      showDeboosted && 'rotate-180'
-                    )}
-                  />
-                </button>
-              </div>
-              {showDeboosted && (
-                <div className="opacity-60 animate-fade-in">
-                  <CardList
-                    suppressSetScrollReset
-                    cards={deboostedCards}
-                    isLoading={false}
-                    title={title}
-                    gridColumns={gridColumns}
-                    compact={gridColumns >= COMPACT_THRESHOLD}
-                    sectorSubjects={sectorSubjects}
-                    showChannel={selectedCellIndex != null && selectedCellIndex >= 0}
-                    onCardClick={onCardClick ? (card) => onCardClick(card, sortedCards) : undefined}
-                    onCardDragStart={onCardDragStart}
-                    onMultiCardDragStart={onMultiCardDragStart}
-                    onSaveNote={onSaveNote}
-                    onDeleteCards={onDeleteCards}
-                    onSelectionChange={handleSelectionChange}
-                    enrichingCardIds={enrichingCardIds}
-                    failedEnrichCardIds={failedEnrichCardIds}
-                    onRetryEnrich={onRetryEnrich}
-                  />
-                </div>
-              )}
-            </div>
-          )}
         </div>
       </div>
     );

--- a/frontend/src/widgets/card-list/ui/CardList.tsx
+++ b/frontend/src/widgets/card-list/ui/CardList.tsx
@@ -56,13 +56,6 @@ function safeVideoId(videoUrl: string): string | null {
 }
 
 interface CardListProps {
-  /**
-   * T10 (2026-07-13) — secondary embedded instances (deboost fold) must NOT
-   * reset the shared [data-scroll-container] on mount/set-change: the fold
-   * toggle jumped the grid to the top because this instance's set-change
-   * effect fired scrollCardSetContainerToTop.
-   */
-  suppressSetScrollReset?: boolean;
   cards: InsightCard[];
   isLoading?: boolean;
   title: string;
@@ -132,7 +125,6 @@ function cardGridStyle(gridColumns: number): CSSProperties {
 }
 
 export function CardList({
-  suppressSetScrollReset,
   cards,
   isLoading,
   onCardClick,
@@ -302,10 +294,8 @@ export function CardList({
     // the observer). A new card set starts at the top — which also guarantees
     // the sentinel begins below the viewport, so the observer's first real
     // trigger is a clean user-scroll intersection change.
-    // T10: embedded fold instances skip the reset (their mount is not a
-    // card-set navigation — resetting jumped the grid to the top).
-    if (!suppressSetScrollReset) scrollCardSetContainerToTop(gridRef.current);
-  }, [cardListKey, resetVisibleCount, suppressSetScrollReset]);
+    scrollCardSetContainerToTop(gridRef.current);
+  }, [cardListKey, resetVisibleCount]);
 
   const visibleCards = useMemo(
     () => sortedCards.slice(0, visibleCount),

--- a/src/modules/queue/handlers/judge-deboost.ts
+++ b/src/modules/queue/handlers/judge-deboost.ts
@@ -1,12 +1,13 @@
 /**
- * judge-deboost worker — gA fitness deboost per mandala (2026-07-12).
+ * judge worker — unanimous 2-model card-fitness verdicts, LOG-ONLY (T10-R).
  *
- * Runs ONCE per mandala creation (singletonKey, startAfter 240s so the
- * quick-relevance backfill mostly lands first). For each cell it batches the
- * placed card TITLES through the gA judge (card-cell-judge.ts); unfit cards
- * are DEBOOSTED — relevance_pct forced low on user_video_states +
- * recommendation_cache — never deleted (single-judge removal is unsafe:
- * report benchmark false-blocks 19-22%). 관련도순 default sort sinks them.
+ * History: T10 wrote verdicts into relevance_pct (sentinel 2) — that field is
+ * the INPUT of tone-down/sorting/serving, so the write destroyed original
+ * scores with no history (13 mandalas / 141 rows, 2026-07-13 incident;
+ * restored via snapshot + re-score). Supervisor-mandated contract since:
+ * this worker performs NO WRITES. Verdicts are logged for calibration only.
+ * T11 re-use: judge output goes to a DEDICATED column (e.g. uvs.judge_unfit
+ * boolean) — never relevance_pct.
  *
  * Fail-open everywhere: judge/provider errors leave cards untouched.
  */
@@ -20,8 +21,6 @@ import { JOB_NAMES, JUDGE_DEBOOST_RETRY_OPTIONS, type JudgeDeboostPayload } from
 
 const log = logger.child({ module: 'judge-deboost' });
 
-/** Deboosted rank value — far below 추천(70)/핵심(80) and the NULL-recency band (≤60). */
-const UNFIT_RELEVANCE_PCT = 2;
 const JUDGE_DELAY_SEC = 240;
 
 export async function enqueueJudgeDeboost(payload: JudgeDeboostPayload): Promise<string | null> {
@@ -49,11 +48,9 @@ export async function handleJudgeDeboost(
 }
 
 /**
- * Judge core — reusable by the queue worker AND the admin re-judge endpoint
- * (2026-07-13 반려견 inversion: verdicts must be re-appliable after prompt/
- * stack changes). Idempotent both ways: unfit sinks to UNFIT_RELEVANCE_PCT;
- * a card judged FIT that is currently sunk RESTORES to NULL and the quick
- * relevance backfill re-scores it (its IS NULL filter makes this safe).
+ * Judge core — reusable by the queue worker AND the admin re-judge endpoint.
+ * LOG-ONLY (see module header): computes unanimous verdicts per cell and logs
+ * them; no persistence until the T11 dedicated-column design.
  */
 export async function judgeMandala(userId: string, mandalaId: string): Promise<void> {
   const prisma = getPrismaClient();
@@ -96,7 +93,6 @@ export async function judgeMandala(userId: string, mandalaId: string): Promise<v
 
   let judged = 0;
   let deboosted = 0;
-  let restored = 0;
   await Promise.allSettled(
     [...byCell.entries()].map(async ([cellIndex, cards]) => {
       const cellTopic = subjects[cellIndex]?.trim();
@@ -109,54 +105,18 @@ export async function judgeMandala(userId: string, mandalaId: string): Promise<v
       judged += verdicts.length;
       const unfitIds = new Set(verdicts.filter((v) => !v.fit).map((v) => v.videoId));
       const unfitRows = cards.filter((c) => unfitIds.has(c.videoId));
-      // Restore: judged FIT but currently sunk (earlier verdict) → NULL, so
-      // the quick relevance backfill (IS NULL filter) re-scores it.
-      const restoreRows = cards.filter(
-        (c) => !unfitIds.has(c.videoId) && c.relevancePct === UNFIT_RELEVANCE_PCT
-      );
-      if (unfitRows.length > 0) {
-        deboosted += unfitRows.length;
-        await prisma.userVideoState.updateMany({
-          where: { id: { in: unfitRows.map((c) => c.rowId) } },
-          data: { relevance_pct: UNFIT_RELEVANCE_PCT },
-        });
-        // Mirror on recommendation_cache so re-serves keep the sink.
-        await prisma.recommendation_cache
-          .updateMany({
-            where: { mandala_id: mandalaId, video_id: { in: unfitRows.map((c) => c.videoId) } },
-            data: { relevance_pct: UNFIT_RELEVANCE_PCT },
-          })
-          .catch(() => undefined);
-      }
-      if (restoreRows.length > 0) {
-        restored += restoreRows.length;
-        await prisma.userVideoState.updateMany({
-          where: { id: { in: restoreRows.map((c) => c.rowId) } },
-          data: { relevance_pct: null },
-        });
-        await prisma.recommendation_cache
-          .updateMany({
-            where: { mandala_id: mandalaId, video_id: { in: restoreRows.map((c) => c.videoId) } },
-            data: { relevance_pct: null },
-          })
-          .catch(() => undefined);
-      }
+      deboosted += unfitRows.length;
+      // T10-R (2026-07-13, supervisor-mandated landmine removal): NO WRITES.
+      // The T10 incident root: this handler OVERWROTE relevance_pct — a field
+      // that is the INPUT of tone-down, sorting and serving — destroying the
+      // original scores with no history (13 mandalas, 141 rows). Verdicts are
+      // now log-only. T11 re-use contract: judge output goes to a DEDICATED
+      // column (e.g. uvs.judge_unfit boolean); it must never write
+      // relevance_pct again.
       log.info(
-        `[judge] mandala=${mandalaId} cell=${cellIndex} unfit=${unfitRows.length} restored=${restoreRows.length} of=${cards.length}`
+        `[judge] mandala=${mandalaId} cell=${cellIndex} unfit=${unfitRows.length} of=${cards.length}`
       );
     })
   );
-  if (restored > 0) {
-    // Re-score restored cards (fire-and-forget; IS NULL filter = idempotent).
-    setImmediate(() => {
-      void import('@/modules/relevance/relevance-backfill-trigger')
-        .then(({ enqueueRelevanceBackfillForMandala }) =>
-          enqueueRelevanceBackfillForMandala({ userId, mandalaId, applyCutoff: false })
-        )
-        .catch(() => undefined);
-    });
-  }
-  log.info(
-    `[judge] mandala=${mandalaId} judged=${judged} deboosted=${deboosted} restored=${restored}`
-  );
+  log.info(`[judge] mandala=${mandalaId} judged=${judged} deboosted=${deboosted}`);
 }


### PR DESCRIPTION
## Why (supervisor-reviewed revert plan; James-approved)
T10 failed in both directions and violated the data time-machine principle:
- Fold membership = stale single-judge verdicts across **13 mandalas** (only the incident mandala was ever re-judged); unanimous stack recall too low to justify the surface (3/10).
- The product already has a canonical low-relevance signal: **≤30 tone-down + tier badge** (in-place demotion — consistent with the no-move invariant). The fold moved/hid cards → the fleet-wide exposure James found.
- Judge wrote its verdict INTO `relevance_pct` — the input of tone-down/sorting/serving — destroying original scores with no history.

## Changes
- FE: fold UI fully removed (progress bar kept — separately approved). `suppressSetScrollReset` reverted.
- BE: judge worker **LOG-ONLY** — `relevance_pct` writes physically removed so a future flag-flip cannot repeat the damage. Unanimous stack + rejudge endpoint preserved as T11 parts (contract: dedicated `judge_unfit` column only).
- `JUDGE_DEBOOST_ENABLED=false`.

## Not in this PR
Data restore (141 uvs + 135 rec_cache rows, 13 mandalas): snapshot (DB table + file) → `2→NULL` → re-score backfill — ships on explicit GO. Done = James visually checks 2-3 mandalas (not job completion).

## Verification
BE tsc 0 · judge tests 10/10 · FE tsc 0 · vitest 512/512 · build pass · dev smoke 200 · /verify PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)