### PR TITLE
fix(mobile): installed-app geometry + concave hub + handle sensitivity overhaul

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -243,10 +243,10 @@
   .go-msg small{display:block; font-size:9px; color:var(--paper-sub); font-weight:600}
 
   /* ================= 클릭휠 — §1.1 + §1.1a ================= */
-  /* [클래식 §1.0] 하단 필드 = 폭과 같은 정사각, 휠 정중앙 → 4방 여백 균등 */
-  .wheelzone{display:grid; place-items:center; flex:none; aspect-ratio:1; width:100%}
+  /* [J:07-13 설치앱 판정] 휠 = 하단 고정 — 화면 공간 최우선 (정사각 필드 폐기) */
+  .wheelzone{display:grid; place-items:center; flex:none; width:100%; padding-top:12px}
   .wheel{
-    width:62%; aspect-ratio:1; border-radius:50%; position:relative; display:grid; place-items:center; /* [클래식] 38.5/61.8 */
+    width:74%; aspect-ratio:1; border-radius:50%; position:relative; display:grid; place-items:center; /* [J:07-13] 클래식 62% 대비 +20% — 설치앱 하단 낭비 교정 */
     /* 평평한 매트 도넛 — 명암 ±4%, 돔 금지 */
     background:radial-gradient(circle at 50% 38%, var(--wheel-a) 0%, var(--wheel-b) 60%, var(--wheel-c) 100%);
     transition:background .6s; touch-action:none;
@@ -273,9 +273,10 @@
     box-shadow:inset 0 2px 4px rgba(var(--shade),.22), inset 0 -1px 1.5px rgba(255,255,255,.7)}
   .core{
     width:39%; aspect-ratio:1; border-radius:50%; border:none; cursor:pointer; position:relative; z-index:2;
-    background:linear-gradient(178deg, var(--acc-hi) 0%, var(--acc) 42%, var(--acc-lo) 100%);
+    /* [클래식] 오목 접시(dish): 위 그늘·아래 빛받음 — 볼록 금지 (§1.1) */
+    background:linear-gradient(178deg, var(--acc-lo) 0%, var(--acc) 55%, var(--acc-hi) 100%);
     transition:transform var(--snap) var(--spring), background .6s, filter var(--snap); touch-action:manipulation;
-    box-shadow:inset 0 1px 1.5px rgba(255,255,255,.28), inset 0 -1.5px 3px rgba(0,0,0,.16);
+    box-shadow:inset 0 2.5px 4px rgba(0,0,0,.20), inset 0 -1px 1.5px rgba(255,255,255,.35);
   }
   .core:active{transform:scale(.965); filter:brightness(.96)}
   .wbtn{position:absolute; border:none; background:none; cursor:pointer; padding:9px 11px; border-radius:12px;
@@ -287,7 +288,7 @@
   .wbtn.prev{left:14px; top:50%; transform:translateY(-50%)} .wbtn.prev:active{transform:translateY(-50%) scale(.84)}
   .wbtn.next{right:14px; top:50%; transform:translateY(-50%)} .wbtn.next:active{transform:translateY(-50%) scale(.84)}
   .wbtn.play{bottom:14px; left:50%; transform:translateX(-50%)} .wbtn.play:active{transform:translateX(-50%) scale(.86)}
-  .engrave{margin-top:0; text-align:center; font-size:8px; font-weight:700; letter-spacing:.5em; flex:none;
+  .engrave{margin-top:7px; text-align:center; font-size:8px; font-weight:700; letter-spacing:.5em; flex:none;
     color:rgba(var(--shade),.28); text-shadow:0 1px 0 rgba(255,255,255,.8)}
 
   /* ================= 가로 ================= */
@@ -295,7 +296,7 @@
     body{padding:calc(var(--sat) + 6px) 10px calc(var(--sab) + 6px)}
     .device{max-width:none; max-height:none; flex-direction:row; align-items:stretch; gap:14px; padding:14px 16px}
     .epaper{flex:1}
-    .wheelzone{width:34%; aspect-ratio:auto; align-self:center}
+    .wheelzone{width:34%; padding:0; align-self:center}
     .wheel{width:min(88%, 36vh)}
     .engrave{display:none}
   }
@@ -367,7 +368,6 @@
   @media (max-height: 820px) and (orientation: portrait){
     body{padding-bottom:calc(var(--sab) + 4px)}
     .device{padding-bottom:8px}
-    .engrave{display:none}
   }
 
   @media (prefers-reduced-motion:reduce){
@@ -1125,21 +1125,30 @@
     if(!stRot){
       if(r>22){
         if(stLastAng!==null){ var d=ang-stLastAng; if(d>180)d-=360; if(d<-180)d+=360; stAcc+=d;
-          if(Math.abs(stAcc)>46){ stRot=true; stick.classList.add('rot'); stArmed=false; } }
+          if(Math.abs(stAcc)>70){ stRot=true; stick.classList.add('rot'); stArmed=false; } } // [J] 회전 진입 완화 46→70
         stLastAng=ang;
       } else stLastAng=null;
-      if(!stRot && stArmed && r>34){
-        if(Math.abs(dx)>Math.abs(dy)){ if(!playing){playing=true;setCharging(true);acquireWake();} nextBeat(dx>0?1:-1); runBeat(); }
-        else if(dy>0){ setPlaying(!playing); }
-        else { setPlaying(false); document.body.classList.remove('clipmode'); show('home'); renderRows(); }
-        stArmed=false; hudWake();
-        if(navigator.vibrate) navigator.vibrate(10);
+      if(!stRot && stArmed && r>40){
+        // [J:07-13] 웨지 판정: 축 기준 ±30° 안에서만 발동 — 대각선 = 무동작 (오발 차단)
+        var deg=Math.atan2(dy,dx)*180/Math.PI; // 0=우, 90=하, ±180=좌, -90=상
+        var act=null;
+        if(deg>-30&&deg<30) act='next';
+        else if(deg>150||deg<-150) act='prev';
+        else if(deg>60&&deg<120) act='toggle';
+        else if(deg<-60&&deg>-120) act='menu';
+        if(act){
+          if(act==='next'||act==='prev'){ if(!playing){playing=true;setCharging(true);acquireWake();} nextBeat(act==='next'?1:-1); runBeat(); }
+          else if(act==='toggle'){ setPlaying(!playing); }
+          else { setPlaying(false); document.body.classList.remove('clipmode'); show('home'); renderRows(); }
+          stArmed=false; hudWake();
+          if(navigator.vibrate) navigator.vibrate(10);
+        }
       }
-      if(r<12) stArmed=true;
+      if(r<14) stArmed=true;
     } else {
       var d2=ang-stLastAng; if(d2>180)d2-=360; if(d2<-180)d2+=360; stLastAng=ang; stDetent+=d2;
-      while(stDetent>=26){ stDetent-=26; stickJog(1); if(navigator.vibrate) navigator.vibrate(4); }
-      while(stDetent<=-26){ stDetent+=26; stickJog(-1); if(navigator.vibrate) navigator.vibrate(4); }
+      while(stDetent>=32){ stDetent-=32; stickJog(1); if(navigator.vibrate) navigator.vibrate(4); } // [J] 디텐트 26→32
+      while(stDetent<=-32){ stDetent+=32; stickJog(-1); if(navigator.vibrate) navigator.vibrate(4); }
     }
   },{passive:false});
   function stickJog(dir){


### PR DESCRIPTION
설치 앱 실기기 판정 3건 (명세 supersede 태깅 완료):

1. **화면 최대화**: 정사각 휠 필드가 설치앱(브라우저 크롬 없는 긴 뷰포트)에서 하단 낭비 → **휠 +20%(74%) · 하단 고정 · 로고 복원** — 잉여 세로 전부 화면으로.
2. **오목 허브**: 클래식 접시형(위 그늘/아래 빛) — 명세 §1.1은 오목이었는데 볼록으로 출고됐던 것 교정.
3. **가로 핸들 감도**: D-pad **축 ±30° 웨지에서만 발동(대각선 무동작)** · 반경 34→40 · 회전 진입 46→70° · 디텐트 26→32°.

검증: standalone 375pt 렌더 (화면 ~62% 확보).

🤖 Generated with [Claude Code](https://claude.com/claude-code)