### PR TITLE
fix(schema): register t10r_pct2_snapshot — unblock every deploy

### DIFF
--- a/prisma/migrations/t10r_pct2_snapshot/001_create_if_not_exists.sql
+++ b/prisma/migrations/t10r_pct2_snapshot/001_create_if_not_exists.sql
@@ -1,0 +1,11 @@
+-- t10r_pct2_snapshot: T10 judge-round relevance snapshot (CP517, 2026-07-12).
+-- Created ad-hoc on prod; this file keeps environments converged under the
+-- deploy replay. IF NOT EXISTS = no-op on prod (table already there, 276 rows).
+CREATE TABLE IF NOT EXISTS public.t10r_pct2_snapshot (
+  src           text,
+  row_id        text,
+  mandala_id    text,
+  video_ref     text,
+  relevance_pct integer,
+  snapped_at    timestamptz
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2315,6 +2315,23 @@ model video_pool {
 /// re-embedding user mandalas. IVFFlat index is created in raw SQL after
 /// rows accumulate (ivfflat needs training data); until then cosine uses
 /// brute-force `<=>` which is fine for the initial <5k pool size.
+/// T10 judge-round relevance snapshot (CP517 track, 2026-07-12) — created
+/// directly on prod during the T10 measurement; registered here so
+/// `prisma db push` stops proposing to DROP it (blocked every deploy,
+/// 2026-07-13). No PK on the physical table -> @@ignore (schema parity
+/// only; not exposed through the Prisma client).
+model t10r_pct2_snapshot {
+  src           String?
+  row_id        String?
+  mandala_id    String?
+  video_ref     String?
+  relevance_pct Int?
+  snapped_at    DateTime? @db.Timestamptz(6)
+
+  @@ignore
+  @@schema("public")
+}
+
 model video_pool_embeddings {
   id            String                      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   video_id      String                      @db.VarChar(20)


### PR DESCRIPTION
T10 저지 세션이 prod에 직접 만든 스냅샷 테이블(276행)이 schema.prisma 미등재 → 모든 배포의 `prisma db push`가 드롭 제안 → data-loss 가드가 Database Schema Sync를 실패시켜 **전 세션 배포 차단** (run 29235234790부터).

- 모델 등재(@@ignore — PK 없음, 스키마 패리티 전용) + replay-safe DDL(`IF NOT EXISTS`, prod no-op) + 로컬 DB 패리티 적용
- **데이터 무접촉.** T10 트랙이 스냅샷을 정리할 때 테이블+등재를 같은 PR에서 제거 (ivfflat 사고의 교훈 규칙)

🤖 Generated with [Claude Code](https://claude.com/claude-code)