### PR TITLE
fix(mobile): stage narration column — restore A-record symmetric 9vw

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -327,7 +327,8 @@
   body.stage .credit b{color:#fff}
   @keyframes metaAway{0%,70%{opacity:1}100%{opacity:0}}
   /* 내레이션: 와이드 에디토리얼 — 21px/1.8 max 32em */
-  body.stage .readbox{position:absolute; left:max(16%, 150px); right:8%; top:16%; bottom:calc(var(--sab) + 40px); margin:0;
+  /* [A 원문] #s-narr{padding:20px 9vw} — 좌우 대칭, 32em 컬럼 중앙 */
+  body.stage .readbox{position:absolute; left:9vw; right:9vw; top:14%; bottom:calc(var(--sab) + 40px); margin:0;
     font-size:21px; line-height:1.8}
   body.stage .readbox p{max-width:32em; margin:0 auto 12px}
   body.stage .readbox .sec-title{color:#8F877A; max-width:32em; margin:2px auto 10px}


### PR DESCRIPTION
가로 내레이션 컬럼의 좌측 데드 거터(좌핸들 시절 잔재 `left:max(16%,150px)`) 제거 — A 원문 `padding:20px 9vw` 대칭 + 32em 중앙 복원. 명세 §2.2와 구현의 드리프트 교정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)