### PR TITLE
feat(mobile): stage final — focus-line stream, push rail, tap zones, dock

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -347,8 +347,8 @@
 
   /* ── [J pick] 포커스 라인 스트림 (가로 내레이션) ── */
   .s-ctx{display:none}
-  body.stage .s-ctx{display:block; position:absolute; z-index:5; left:10%; right:10%; top:calc(var(--sat) + 12px);
-    text-align:center; font-size:11px; letter-spacing:.28em; color:#8F877A; font-weight:700;
+  body.stage .s-ctx{display:block; position:absolute; z-index:5; left:25%; right:25%; top:calc(var(--sat) + 12px);
+    text-align:center; font-size:11px; letter-spacing:.3em; color:#8F877A; font-weight:700;
     white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
   body.stage .s-ctx b{color:var(--acc); font-weight:800}
   .stream{display:none}
@@ -357,16 +357,15 @@
   .stream .ln{max-width:72vw; line-height:1.6; transition:opacity .35s var(--soft)}
   .stream .prv,.stream .nxt{font-size:19px; color:rgba(237,231,220,.28); font-weight:600}
   .stream .now{font-size:30px; line-height:1.65; color:#EDE7DC; font-weight:750}
-  .stream .now .sent-hl{background:var(--butter); color:#3B372F; border-radius:9px; padding:1px 8px;
+  .stream .now .sent-hl{background:var(--butter); color:#3B372F; border-radius:6px; padding:1px 5px;
     box-decoration-break:clone; -webkit-box-decoration-break:clone}
-  body.stage #scrPlayer .top .tt{visibility:hidden} /* 제목은 s-ctx로 — 배터리는 유지 */
   body.stage.clipmode .s-ctx{opacity:0; transition:opacity .3s}
   body.stage.clipmode.hud .s-ctx{opacity:1}
   body.stage .readbox{display:none !important} /* 가로 내레이션 = 스트림 전용 */
 
   /* ── 엣지 그립 + 푸시 레일 ── */
   .grip{display:none}
-  body.stage .grip{display:block; position:absolute; z-index:6; left:0; top:38%; bottom:38%; width:3px;
+  body.stage .grip{display:block; position:absolute; z-index:6; left:0; top:38%; bottom:38%; width:2px;
     border-radius:0 2px 2px 0; background:rgba(255,255,255,.22)}
   .rail{display:none}
   body.stage .rail{display:flex; position:absolute; z-index:1; left:0; top:0; bottom:0; width:31%;
@@ -839,7 +838,7 @@
     }
     document.getElementById('pPos').textContent=(bi+1)+' / '+beats.length;
     document.getElementById('hairFill').style.width=Math.round(bi/Math.max(beats.length-1,1)*100)+'%';
-    updateDock(); updateRail();
+    updateDock(); updateRail(); updateCtx();
     if(curNote&&!curNote.sample) saveResume(curNote.id,bi,beats.length,false);
   }
 
@@ -974,7 +973,7 @@
     document.getElementById('pCh').textContent=(beat.t!=='ch'&&beat.title)?beat.title:'';
     stopSpeech(); stopClip();
     document.body.classList.toggle('clipmode', beat.t==='c');
-    streamEl.hidden=(beat.t!=='n'); updateCtx(beat);
+    streamEl.hidden=(beat.t!=='n');
     if(beat.t==='ch'){ // M3
       clipbox.hidden=true; readbox.hidden=true; creditEl.hidden=true;
       document.getElementById('chNum').textContent=beat.num+'부';
@@ -1198,10 +1197,12 @@
     dkPos.textContent=(bi+1)+' / '+beats.length;
     dkPlay.innerHTML=playing?SVG_PAUSE:SVG_PLAY;
   }
-  function updateCtx(beat){
-    sCtx.innerHTML='<b></b><span></span>';
-    sCtx.querySelector('b').textContent=(curNote&&curNote.title)||'노트';
-    sCtx.querySelector('span').textContent=(beat&&beat.t!=='ch'&&beat.title)?(' · '+beat.title):'';
+  function updateCtx(){ // 목업 ①: "N부 · 섹션 · n/총"
+    var beat=beats[bi]; if(!beat){ sCtx.textContent=''; return; }
+    sCtx.innerHTML='<b></b><span></span><span class="num"></span>';
+    sCtx.querySelector('b').textContent=((chapterOfBeat[bi]||0)+1)+'부';
+    sCtx.querySelector('span').textContent=(beat.t!=='ch'&&beat.title)?(' · '+beat.title):'';
+    sCtx.querySelector('.num').textContent=' · '+(bi+1)+' / '+beats.length;
   }
   function buildRail(){ // 섹션 목록 = 구간 점프
     rlList.innerHTML='';

--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -343,21 +343,79 @@
   body.stage.clipmode .hairline{opacity:0; transition:opacity .3s}
   body.stage.clipmode.hud .hairline{opacity:1}
   body.stage .ptrack{display:none}
-  body.stage .player-state{position:absolute; inset:0}
+  body.stage .player-state{position:absolute; inset:0; z-index:6} /* 완료 화면 버튼 = 탭레이어 위 */
 
-  /* ---- 게임핸들 — §2.4 A 기록 원형 ---- */
-  #stick{display:none; position:fixed; right:12vw; bottom:22px; width:84px; height:84px; border-radius:50%;
-    background:radial-gradient(circle, rgba(255,255,255,.16) 55%, rgba(255,255,255,.04) 78%, transparent 100%);
-    -webkit-backdrop-filter:blur(6px); backdrop-filter:blur(6px);
-    z-index:40; touch-action:none; user-select:none; -webkit-user-select:none;
-    opacity:0; transition:opacity .3s var(--soft)} /* 라벨·외곽선 없음 */
-  body.stage #stick{display:block}
-  #stick.on,#stick.hint{opacity:1}
-  #stick .knob{position:absolute; left:50%; top:50%; width:44px; height:44px; border-radius:50%;
-    transform:translate(-50%,-50%); background:rgba(255,255,255,.55);
-    box-shadow:inset 0 1px 2px rgba(255,255,255,.8), 0 2px 6px rgba(0,0,0,.3);
-    transition:transform .18s var(--soft)}
-  #stick.rot{box-shadow:0 0 18px rgba(90,140,255,.5)} /* A 원문값 */ /* 회전모드 = 소프트 글로우 */
+  /* ── [J pick] 포커스 라인 스트림 (가로 내레이션) ── */
+  .s-ctx{display:none}
+  body.stage .s-ctx{display:block; position:absolute; z-index:5; left:10%; right:10%; top:calc(var(--sat) + 12px);
+    text-align:center; font-size:11px; letter-spacing:.28em; color:#8F877A; font-weight:700;
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  body.stage .s-ctx b{color:var(--acc); font-weight:800}
+  .stream{display:none}
+  body.stage .stream:not([hidden]){display:flex; position:absolute; inset:0; z-index:2;
+    flex-direction:column; justify-content:center; align-items:center; padding:0 10%; gap:18px; text-align:center}
+  .stream .ln{max-width:72vw; line-height:1.6; transition:opacity .35s var(--soft)}
+  .stream .prv,.stream .nxt{font-size:19px; color:rgba(237,231,220,.28); font-weight:600}
+  .stream .now{font-size:30px; line-height:1.65; color:#EDE7DC; font-weight:750}
+  .stream .now .sent-hl{background:var(--butter); color:#3B372F; border-radius:9px; padding:1px 8px;
+    box-decoration-break:clone; -webkit-box-decoration-break:clone}
+  body.stage #scrPlayer .top .tt{visibility:hidden} /* 제목은 s-ctx로 — 배터리는 유지 */
+  body.stage.clipmode .s-ctx{opacity:0; transition:opacity .3s}
+  body.stage.clipmode.hud .s-ctx{opacity:1}
+  body.stage .readbox{display:none !important} /* 가로 내레이션 = 스트림 전용 */
+
+  /* ── 엣지 그립 + 푸시 레일 ── */
+  .grip{display:none}
+  body.stage .grip{display:block; position:absolute; z-index:6; left:0; top:38%; bottom:38%; width:3px;
+    border-radius:0 2px 2px 0; background:rgba(255,255,255,.22)}
+  .rail{display:none}
+  body.stage .rail{display:flex; position:absolute; z-index:1; left:0; top:0; bottom:0; width:31%;
+    flex-direction:column; gap:8px; padding:calc(var(--sat) + 16px) 2.6% 16px;
+    visibility:hidden; opacity:0; transition:opacity .3s var(--soft), visibility 0s .3s}
+  body.stage.railopen .rail{visibility:visible; opacity:1; transition:opacity .3s var(--soft)}
+  .rl-it.hd{font-size:11px; letter-spacing:.18em; color:var(--acc); margin-top:6px}
+  .rl-ch{font-size:11px; letter-spacing:.3em; color:var(--acc); font-weight:800}
+  .rl-list{flex:1; min-height:0; overflow-y:auto; display:flex; flex-direction:column; gap:6px}
+  .rl-it{border:none; background:none; font-family:inherit; text-align:left; cursor:pointer; touch-action:manipulation;
+    font-size:13px; font-weight:700; color:rgba(237,231,220,.45); padding:7px 10px; border-radius:8px; line-height:1.5}
+  .rl-it.done{color:rgba(237,231,220,.45)}
+  .rl-it.done::after{content:" ✓"; color:rgba(237,231,220,.35)}
+  .rl-it.now{color:#EDE7DC; font-weight:750; background:rgba(224,112,63,.16); border-left:3px solid var(--acc)}
+  .rl-foot{font-size:10px; color:#8F877A; font-weight:600}
+  /* 푸시: 무대가 우측 69% 박스로 동형 축소 (목업 기하 — 오버레이/블러 없음) */
+  body.stage #scrPlayer{transition:left .35s var(--soft), transform .35s var(--soft), border-radius .35s, box-shadow .35s}
+  body.stage.railopen #scrPlayer{left:31%; transform:scale(.94); transform-origin:right center;
+    border-radius:14px; overflow:hidden; background:#131317;
+    box-shadow:0 0 0 1px rgba(255,255,255,.07), -14px 0 34px rgba(0,0,0,.5)}
+  body.stage.railopen .stream{padding:0 7%}
+  body.stage.railopen .stream .prv,body.stage.railopen .stream .nxt{font-size:16px}
+  body.stage.railopen .stream .now{font-size:25px}
+  body.stage.railopen .grip{display:none}
+
+  /* ── C1 탭 존 레이어 ── */
+  .stagetap{display:none}
+  body.stage .stagetap{display:block; position:absolute; inset:0; z-index:4}
+  body.stage.clipmode .stagetap{z-index:4} /* 클립 가드 위 */
+
+  /* ── C2 독 ── */
+  .dock{display:none}
+  body.stage .dock{display:flex; position:absolute; z-index:8; left:6%; right:6%; bottom:calc(var(--sab) + 12px);
+    height:44px; border-radius:14px; align-items:center; gap:12px; padding:0 14px;
+    background:rgba(20,20,24,.78); -webkit-backdrop-filter:blur(8px); backdrop-filter:blur(8px);
+    opacity:0; pointer-events:none; transform:translateY(8px);
+    transition:opacity .25s var(--soft), transform .25s var(--soft)}
+  body.stage.hud .dock{opacity:1; pointer-events:auto; transform:none}
+  .dk{border:none; background:none; cursor:pointer; color:#EDE7DC; padding:8px; touch-action:manipulation;
+    transition:transform var(--snap) var(--spring)}
+  .dk:active{transform:scale(.86)}
+  .dk svg{display:block; fill:currentColor}
+  .dk.core{width:32px; height:32px; border-radius:50%; padding:0; display:grid; place-items:center;
+    background:linear-gradient(178deg, var(--acc-lo), var(--acc) 55%, var(--acc-hi))}
+  .dkbar{flex:1; height:4px; border-radius:3px; background:rgba(255,255,255,.18); position:relative; cursor:pointer;
+    touch-action:manipulation}
+  .dkbar::before{content:""; position:absolute; inset:-14px 0} /* 터치 타깃 확장 */
+  .dkbar i{position:absolute; left:0; top:0; bottom:0; width:0%; border-radius:3px; background:var(--acc)}
+  .dkpos{font-size:11px; color:#8F877A; font-weight:600}
 
   .toast{position:fixed; left:50%; bottom:calc(var(--sab) + 26px); transform:translateX(-50%) translateY(20px);
     background:var(--ink); color:#F5F2EC; font-size:11.5px; font-weight:700; border-radius:99px; padding:9px 16px;
@@ -440,7 +498,27 @@
           <div class="ptimes"><span id="pPos" class="num">1 / 1</span><span id="pCh"></span></div>
         </div>
         <div class="hairline" id="hairline"><i id="hairFill" style="width:0%"></i></div>
+        <!-- [J pick] 가로 무대: 포커스 라인 + 컨텍스트 + 탭 존 + 독 + 푸시 레일 -->
+        <div class="s-ctx" id="sCtx"></div>
+        <div class="stream" id="stream" hidden>
+          <div class="ln prv" id="lnPrev"></div>
+          <div class="ln now" id="lnNow"></div>
+          <div class="ln nxt" id="lnNext"></div>
+        </div>
+        <div class="grip" id="grip" aria-hidden="true"></div>
+        <div class="stagetap" id="stageTap" aria-hidden="true"></div>
+        <div class="dock" id="dock">
+          <button class="dk" id="dkPrev" aria-label="이전 구간"><svg width="16" height="11" viewBox="0 0 15 10"><path d="M7.5 1 2 5l5.5 4V1Zm5.5 0L7.5 5 13 9V1Z" fill="currentColor"/></svg></button>
+          <button class="dk core" id="dkPlay" aria-label="재생/정지"><svg width="14" height="14" viewBox="0 0 16 16"><path d="M4 2.5v11l9.5-5.5Z" fill="#fff"/></svg></button>
+          <button class="dk" id="dkNext" aria-label="다음 구간"><svg width="16" height="11" viewBox="0 0 15 10"><path d="M7.5 1 13 5l-5.5 4V1Zm-5.5 0L7.5 5 2 9V1Z" fill="currentColor"/></svg></button>
+          <div class="dkbar" id="dkBar"><i id="dkFill"></i></div>
+          <span class="dkpos num" id="dkPos">1 / 1</span>
+        </div>
       </div>
+
+      <!-- 푸시 레일 — epaper 직속 (무대 transform 비종속) -->
+      <div class="rail" id="rail"><div class="rl-ch" id="rlCh"></div><div class="rl-list" id="rlList"></div>
+        <div class="rl-foot num" id="rlFoot"></div></div>
 
       <!-- 목표 입력 -->
       <div class="goal-ov" id="goalOv">
@@ -476,8 +554,6 @@
     <div class="engrave">INSIGHTA</div>
   </div>
 
-  <!-- 게임핸들 (가로 무대) — A 기록: 무표시 글래스 + 물리 노브 -->
-  <div id="stick"><div class="knob"></div></div>
 
   <div class="toast" id="toast"></div>
 
@@ -553,7 +629,8 @@
     var on=land && cur==='player';
     var was=document.body.classList.contains('stage');
     document.body.classList.toggle('stage', on);
-    if(on&&!was){ stickHint(); }
+    if(on&&!was){ hudWake(); updateStream(); updateDock(); }
+    if(!on&&was){ document.body.classList.remove('railopen'); }
   }
   addEventListener('resize', syncStage);
   addEventListener('orientationchange', syncStage);
@@ -741,6 +818,7 @@
     pState.innerHTML='<div class="pulse"></div><div class="big" id="pStateBig"></div><div class="sm" id="pStateSm"></div>';
     clipbox.hidden=true; readbox.hidden=true; ptrack.hidden=true;
     creditEl.hidden=true; chcard.classList.remove('show');
+    streamEl.hidden=true; sCtx.textContent='';
     document.getElementById('pStateBig').textContent=big;
     document.getElementById('pStateSm').innerHTML=sm||'';
   }
@@ -761,6 +839,7 @@
     }
     document.getElementById('pPos').textContent=(bi+1)+' / '+beats.length;
     document.getElementById('hairFill').style.width=Math.round(bi/Math.max(beats.length-1,1)*100)+'%';
+    updateDock(); updateRail();
     if(curNote&&!curNote.sample) saveResume(curNote.id,bi,beats.length,false);
   }
 
@@ -781,6 +860,7 @@
       if(curSentIdx>=curSents.length){ if(curDone) curDone(); return; }
       curSpans.forEach(function(sp){sp.classList.remove('on')});
       var sp=curSpans[curSentIdx]; sp.classList.add('on');
+      updateStream();
       if(sp.scrollIntoView) sp.scrollIntoView({block:'center',behavior:reduce?'auto':'smooth'});
       if(!synth){ var ms=Math.min(Math.max(curSents[curSentIdx].length*90,1600),12000);
         setTimeout(function(){ if(seq===speakSeq&&playing){ curSentIdx++; addCharge(.5); next(); } },ms); return; }
@@ -796,12 +876,6 @@
     renderSents(beat.title,curSents);
     if(!curSents.length){ done(); return; }
     speakFrom(0);
-  }
-  function jogSentence(dir){ // 핸들 조그: 내레이션 = 문장 단위 (§4 명시 차이)
-    if(!curSents.length){ nextBeat(dir); return; }
-    var nx=curSentIdx+dir;
-    if(nx<0||nx>=curSents.length){ nextBeat(dir); return; }
-    stopSpeech(); speakFrom(nx);
   }
 
   /* YouTube 클립 — 경계는 v2 구간요약만 (§0-3) */
@@ -900,6 +974,7 @@
     document.getElementById('pCh').textContent=(beat.t!=='ch'&&beat.title)?beat.title:'';
     stopSpeech(); stopClip();
     document.body.classList.toggle('clipmode', beat.t==='c');
+    streamEl.hidden=(beat.t!=='n'); updateCtx(beat);
     if(beat.t==='ch'){ // M3
       clipbox.hidden=true; readbox.hidden=true; creditEl.hidden=true;
       document.getElementById('chNum').textContent=beat.num+'부';
@@ -952,6 +1027,7 @@
     playing=on; setCharging(on);
     if(on){ acquireWake(); runBeat(); }
     else{ stopSpeech(); stopClip(); releaseWake(); }
+    updateDock();
   }
 
   async function openNote(m){
@@ -978,6 +1054,7 @@
     }
     flatten(book);
     if(!beats.length){ pShowState('노트 준비 중','카드가 모이면 에피소드가 자동으로 생겨요'); return; }
+    buildRail();
     if(!m.sample) prefetchBounds();
     var res=m.sample?null:loadResume(m.id);
     bi=(res&&!res.done&&res.bi>0&&res.bi<beats.length)?res.bi:0;
@@ -1097,75 +1174,120 @@
     };
   })());
 
-  /* ================= 게임핸들 — §2.4 A 기록 이식 ================= */
-  var stick=document.getElementById('stick'), knob=stick.querySelector('.knob');
-  var stAct=false, stArmed=true, stRot=false, stLastAng=null, stAcc=0, stDetent=0;
-  var stX0=0, stY0=0, stMoved=0, stT0=0, stWasOn=false, stHide=null;
-  function stickCenter(){ var r=stick.getBoundingClientRect(); return [r.left+r.width/2, r.top+r.height/2]; }
-  function hudWake(){ // G2: 핸들 활성 동안 HUD(헤어라인·상단) 동반 표시
+  /* ================= 무대 컨트롤러 — §2.2 [J pick] 포커스 라인 + 푸시 레일 + C1/C2 ================= */
+  function hudWake(){ // HUD(헤어라인·상단·독) 표시 후 자동 숨김
     document.body.classList.add('hud');
     clearTimeout(hudWake._t); hudWake._t=setTimeout(function(){document.body.classList.remove('hud')},2600);
   }
-  function stickHint(){ stick.classList.add('hint'); setTimeout(function(){stick.classList.remove('hint')},1600); }
-  stick.addEventListener('pointerdown',function(e){
-    stAct=true; stArmed=true; stRot=false; stLastAng=null; stAcc=0; stDetent=0;
-    stWasOn=stick.classList.contains('on'); clearTimeout(stHide);
-    stX0=e.clientX; stY0=e.clientY; stMoved=0; stT0=performance.now();
-    stick.classList.add('on'); hudWake();
-    stick.setPointerCapture(e.pointerId); e.preventDefault();
-  });
-  stick.addEventListener('pointermove',function(e){
-    if(!stAct) return; e.preventDefault();
-    stMoved=Math.max(stMoved, Math.hypot(e.clientX-stX0, e.clientY-stY0));
-    var c=stickCenter();
-    var dx=e.clientX-c[0], dy=e.clientY-c[1], r=Math.hypot(dx,dy);
-    var kx=Math.max(-26,Math.min(26,dx)), ky=Math.max(-26,Math.min(26,dy));
-    knob.style.transition='none';
-    knob.style.transform='translate(calc(-50% + '+kx+'px), calc(-50% + '+ky+'px))';
-    var ang=Math.atan2(dy,dx)*180/Math.PI;
-    if(!stRot){
-      if(r>22){
-        if(stLastAng!==null){ var d=ang-stLastAng; if(d>180)d-=360; if(d<-180)d+=360; stAcc+=d;
-          if(Math.abs(stAcc)>70){ stRot=true; stick.classList.add('rot'); stArmed=false; } } // [J] 회전 진입 완화 46→70
-        stLastAng=ang;
-      } else stLastAng=null;
-      if(!stRot && stArmed && r>40){
-        // [J:07-13] 웨지 판정: 축 기준 ±30° 안에서만 발동 — 대각선 = 무동작 (오발 차단)
-        var deg=Math.atan2(dy,dx)*180/Math.PI; // 0=우, 90=하, ±180=좌, -90=상
-        var act=null;
-        if(deg>-30&&deg<30) act='next';
-        else if(deg>150||deg<-150) act='prev';
-        else if(deg>60&&deg<120) act='toggle';
-        else if(deg<-60&&deg>-120) act='menu';
-        if(act){
-          if(act==='next'||act==='prev'){ if(!playing){playing=true;setCharging(true);acquireWake();} nextBeat(act==='next'?1:-1); runBeat(); }
-          else if(act==='toggle'){ setPlaying(!playing); }
-          else { setPlaying(false); document.body.classList.remove('clipmode'); show('home'); renderRows(); }
-          stArmed=false; hudWake();
-          if(navigator.vibrate) navigator.vibrate(10);
-        }
-      }
-      if(r<14) stArmed=true;
-    } else {
-      var d2=ang-stLastAng; if(d2>180)d2-=360; if(d2<-180)d2+=360; stLastAng=ang; stDetent+=d2;
-      while(stDetent>=32){ stDetent-=32; stickJog(1); if(navigator.vibrate) navigator.vibrate(4); } // [J] 디텐트 26→32
-      while(stDetent<=-32){ stDetent+=32; stickJog(-1); if(navigator.vibrate) navigator.vibrate(4); }
-    }
-  },{passive:false});
-  function stickJog(dir){
-    hudWake();
-    var beat=beats[bi];
-    if(beat&&beat.t==='n'){ jogSentence(dir); }
-    else { if(!playing){playing=true;setCharging(true);acquireWake();} nextBeat(dir); runBeat(); }
+  var streamEl=document.getElementById('stream'), sCtx=document.getElementById('sCtx'),
+      lnPrev=document.getElementById('lnPrev'), lnNow=document.getElementById('lnNow'), lnNext=document.getElementById('lnNext'),
+      rlList=document.getElementById('rlList'), rlCh=document.getElementById('rlCh'), rlFoot=document.getElementById('rlFoot'),
+      stageTapEl=document.getElementById('stageTap'),
+      dkPlay=document.getElementById('dkPlay'), dkFill=document.getElementById('dkFill'),
+      dkPos=document.getElementById('dkPos'), dkBar=document.getElementById('dkBar');
+  var SVG_PLAY='<svg width="14" height="14" viewBox="0 0 16 16"><path d="M4 2.5v11l9.5-5.5Z" fill="#fff"/></svg>',
+      SVG_PAUSE='<svg width="14" height="14" viewBox="0 0 16 16"><path d="M4 2.5h3v11H4Zm5 0h3v11H9Z" fill="#fff"/></svg>';
+  function updateStream(){ // 포커스 라인: 현재 문장 크게 중앙, 전/후 흐릿
+    lnPrev.textContent=curSentIdx>0?curSents[curSentIdx-1]:'';
+    lnNext.textContent=curSentIdx<curSents.length-1?curSents[curSentIdx+1]:'';
+    lnNow.innerHTML='<span class="sent-hl"></span>';
+    lnNow.querySelector('.sent-hl').textContent=curSents[curSentIdx]||'';
   }
-  ['pointerup','pointercancel'].forEach(function(ev){
-    stick.addEventListener(ev,function(){
-      var isTap=(ev==='pointerup')&&!stRot&&stMoved<10&&(performance.now()-stT0)<450;
-      if(isTap&&stWasOn){ setPlaying(!playing); if(navigator.vibrate) navigator.vibrate(10); }
-      stAct=false; stRot=false; stick.classList.remove('rot');
-      clearTimeout(stHide); stHide=setTimeout(function(){ if(!stAct) stick.classList.remove('on'); },2200);
-      knob.style.transition='transform .18s cubic-bezier(.22,.9,.3,1)'; knob.style.transform='translate(-50%,-50%)';
+  function updateDock(){
+    dkFill.style.width=Math.round(bi/Math.max(beats.length-1,1)*100)+'%';
+    dkPos.textContent=(bi+1)+' / '+beats.length;
+    dkPlay.innerHTML=playing?SVG_PAUSE:SVG_PLAY;
+  }
+  function updateCtx(beat){
+    sCtx.innerHTML='<b></b><span></span>';
+    sCtx.querySelector('b').textContent=(curNote&&curNote.title)||'노트';
+    sCtx.querySelector('span').textContent=(beat&&beat.t!=='ch'&&beat.title)?(' · '+beat.title):'';
+  }
+  function buildRail(){ // 섹션 목록 = 구간 점프
+    rlList.innerHTML='';
+    rlCh.textContent=(curNote&&curNote.title)||'노트';
+    var last='';
+    beats.forEach(function(b,i){
+      var label=null, head=false;
+      if(b.t==='ch'){ label=b.num+'부 · '+b.title; head=true; last=b.title; } // 인트로(동명) 중복 방지
+      else if(b.t==='n'&&b.title&&b.title!==last){ label=b.title; last=b.title; }
+      if(label==null) return;
+      var btn=document.createElement('button');
+      btn.className='rl-it'+(head?' hd':''); btn.textContent=label; btn.dataset.bi=i;
+      btn.addEventListener('click',function(){ bi=i; closeRail(); stageResume(); });
+      rlList.appendChild(btn);
     });
+    rlFoot.textContent=chapterCount+'부 · '+beats.length+'구간';
+  }
+  function updateRail(){
+    var its=rlList.children;
+    for(var j=0;j<its.length;j++){
+      var s=+its[j].dataset.bi, e=beats.length, k;
+      if(its[j].classList.contains('hd')){ // 부(헤더) 범위 = 다음 부까지
+        for(k=j+1;k<its.length;k++){ if(its[k].classList.contains('hd')){ e=+its[k].dataset.bi; break; } }
+      } else if(j+1<its.length){ e=+its[j+1].dataset.bi; }
+      its[j].classList.toggle('now', bi>=s&&bi<e&&!its[j].classList.contains('hd'));
+      its[j].classList.toggle('done', bi>=e);
+    }
+  }
+  function openRail(){
+    document.body.classList.add('railopen'); updateRail();
+    var nw=rlList.querySelector('.now'); if(nw&&nw.scrollIntoView) nw.scrollIntoView({block:'center'});
+  }
+  function closeRail(){ document.body.classList.remove('railopen'); }
+  function stageResume(){ if(!playing){ playing=true; setCharging(true); acquireWake(); } runBeat(); }
+  function stageJump(dir){ // dispatchNotch와 동일 계약
+    if(bi+dir>=beats.length){ finishNote(); return; }
+    nextBeat(dir);
+    if(!playing){ playing=true; setCharging(true); acquireWake(); runBeat(); }
+    hudWake();
+  }
+  /* C1 탭 존: 중앙 탭=재생/HUD · 좌우 1/3 더블탭=구간 · 클립 중앙 더블탭=커버 */
+  (function(){
+    var x0=0,y0=0,t0=0,moved=0,edge=false,onRail=false,tapTimer=null,lastT=0,lastZone='';
+    stageTapEl.addEventListener('pointerdown',function(e){
+      x0=e.clientX; y0=e.clientY; t0=performance.now(); moved=0;
+      onRail=document.body.classList.contains('railopen');
+      edge=!onRail&&e.clientX<28; // 좌측 엣지 스와이프 = 레일
+      try{stageTapEl.setPointerCapture(e.pointerId)}catch(err){}
+    });
+    stageTapEl.addEventListener('pointermove',function(e){
+      moved=Math.max(moved, Math.hypot(e.clientX-x0, e.clientY-y0));
+      var dx=e.clientX-x0;
+      if(edge&&dx>36){ edge=false; openRail(); if(navigator.vibrate) navigator.vibrate(6); }
+      if(onRail&&dx<-36){ onRail=false; closeRail(); }
+    });
+    stageTapEl.addEventListener('pointerup',function(e){
+      if(moved>=12||performance.now()-t0>=450) return;
+      if(document.body.classList.contains('railopen')){ closeRail(); return; } // 미니 무대 탭 = 복귀
+      var W=innerWidth, x=e.clientX;
+      var zone=x<W/3?'l':(x>W*2/3?'r':'c');
+      var now=performance.now();
+      if(zone===lastZone&&now-lastT<330){ // 더블탭
+        clearTimeout(tapTimer); lastT=0; lastZone='';
+        if(zone==='c'){ if(document.body.classList.contains('clipmode')) clipbox.classList.toggle('cover'); }
+        else stageJump(zone==='r'?1:-1);
+        if(navigator.vibrate) navigator.vibrate(8);
+        return;
+      }
+      lastZone=zone; lastT=now;
+      clearTimeout(tapTimer);
+      tapTimer=setTimeout(function(){
+        if(zone==='c'){ setPlaying(!playing); }
+        hudWake();
+      },330);
+    });
+  })();
+  /* C2 독 */
+  document.getElementById('dkPrev').addEventListener('click',function(){ stageJump(-1) });
+  document.getElementById('dkNext').addEventListener('click',function(){ stageJump(1) });
+  dkPlay.addEventListener('click',function(){ setPlaying(!playing); hudWake(); });
+  dkBar.addEventListener('click',function(e){
+    if(!beats.length) return;
+    var r=dkBar.getBoundingClientRect();
+    var ratio=Math.max(0,Math.min(1,(e.clientX-r.left)/r.width));
+    bi=Math.round(ratio*(beats.length-1));
+    stageResume(); hudWake();
   });
 
   /* ================= Wake Lock (C2) + 인터럽트 (C6) ================= */


### PR DESCRIPTION
## What

Final approved stage design for /mobile landscape player (spec §2.2 [J pick]): concept 3 (focus line) + push rail + C1 tap zones + C2 dock. Game handle removed entirely (discarded — unusable verdict; §2.3 forbids reintroduction).

## Changes

- **Focus-line stream**: current sentence large and centered with butter highlight, previous/next sentences dimmed above/below (Apple Music lyrics grammar). Landscape narration is stream-only; portrait readbox untouched.
- **Context line**: single top line (note title · section) replaces the title row in stage; battery indicator kept top-right.
- **Push rail**: left-edge swipe (>36px from x<28) opens a 31% section list; the stage shrinks to a same-shape rounded box anchored in the right 69% at scale(.94) — no overlay, no blur (approved mockup geometry). Tap a section = jump to that beat. Part headers with done/now states; tap mini stage or swipe left = close.
- **C1 tap zones**: center tap = play/pause + HUD; left/right third double-tap = previous/next beat; center double-tap in clip = cover toggle (kept).
- **C2 dock**: prev/play/next + tappable seek bar + position counter, bottom capsule, auto-hides with HUD (2.6s).
- **Handle removal**: all #stick HTML/CSS/JS deleted, sentence-jog helper removed (unreferenced).

## Verification (spec §7b gate)

- Forced-state render matrix at 812×375 (headless, top-left crop): stage default / rail open / dock (HUD) / clipmode — all match the approved mockup geometry; portrait 375×812 sanity shows zero regression (readbox, wheel, progress intact).
- `node --check` on extracted inline script: pass.
- Rail dedupe (chapter intro vs header) and header done-range verified by re-render.

Real-device checklist ships in the session report (landscape gestures need touch hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)