### PR TITLE
feat(narration): ElevenLabs episode pre-produce — lazy render, cache, house hosts (flag-gated)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -216,6 +216,7 @@ jobs:
           OR_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OR_MODEL: ${{ secrets.OPENROUTER_MODEL }}
           COHERE_KEY: ${{ secrets.COHERE_API_KEY }}
+          ELEVEN_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           YT_SEARCH_KEY: ${{ secrets.YOUTUBE_API_KEY_SEARCH }}
           YT_SEARCH_KEY_2: ${{ secrets.YOUTUBE_API_KEY_SEARCH_2 }}
           YT_SEARCH_KEY_3: ${{ secrets.YOUTUBE_API_KEY_SEARCH_3 }}
@@ -295,6 +296,9 @@ jobs:
             # Add OPENROUTER keys if missing, update if present
             grep -q '^OPENROUTER_API_KEY=' .env 2>/dev/null && sed -i "s|^OPENROUTER_API_KEY=.*|OPENROUTER_API_KEY=${OR_KEY}|" .env || echo "OPENROUTER_API_KEY=${OR_KEY}" >> .env
             grep -q '^OPENROUTER_MODEL=' .env 2>/dev/null && sed -i "s|^OPENROUTER_MODEL=.*|OPENROUTER_MODEL=${OR_MODEL}|" .env || echo "OPENROUTER_MODEL=${OR_MODEL}" >> .env
+            # 2026-07-13 — ElevenLabs narration pre-produce key (flag-gated by
+            # NARRATION_PREPRODUCE_ENABLED; see src/modules/narration/). Same pattern.
+            grep -q '^ELEVENLABS_API_KEY=' .env 2>/dev/null && sed -i "s|^ELEVENLABS_API_KEY=.*|ELEVENLABS_API_KEY=${ELEVEN_KEY}|" .env || echo "ELEVENLABS_API_KEY=${ELEVEN_KEY}" >> .env
             # 2026-05-12 — Cohere Rerank API key (hybrid-retrieval spec, Issue #610).
             # Used by src/modules/rerank/cohere-client.ts. Same idempotent pattern.
             # Flag V3_ENABLE_HYBRID_RERANK stays in docker-compose.prod.yml as

--- a/prisma/migrations/episode-narration/001_create_mandala_episode_audio.sql
+++ b/prisma/migrations/episode-narration/001_create_mandala_episode_audio.sql
@@ -1,0 +1,12 @@
+-- Episode narration audio (ElevenLabs pre-produce, 2026-07-13).
+-- Raw DDL alongside schema.prisma per the prisma-db-push silent-fail rule.
+CREATE TABLE IF NOT EXISTS mandala_episode_audio (
+  mandala_id    uuid PRIMARY KEY REFERENCES user_mandalas(id) ON DELETE CASCADE,
+  status        varchar(12) NOT NULL DEFAULT 'pending',
+  host          varchar(8)  NOT NULL DEFAULT 'jun',
+  book_version  integer     NOT NULL DEFAULT 0,
+  manifest_json jsonb,
+  error         text,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -458,6 +458,7 @@ model user_mandalas {
   videoStates      UserVideoState[]
   localCards       user_local_cards[]
   subscriptions    mandala_subscriptions[]
+  episodeAudio     mandala_episode_audio?
   activity_logs    mandala_activity_log[]
   contentEntities  content_entities[]
   sourceMappings   source_mandala_mappings[]
@@ -664,6 +665,26 @@ model mandala_books {
   v2_done       Int           @default(0)
   v2_pending    Int           @default(0)
   generated_at  DateTime      @default(now()) @db.Timestamptz(6)
+  updated_at    DateTime      @default(now()) @updatedAt @db.Timestamptz(6)
+  mandala       user_mandalas @relation(fields: [mandala_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@schema("public")
+}
+
+/// Episode narration audio (ElevenLabs pre-produce, 2026-07-13) — one row per
+/// mandala. manifest_json maps player beat indices (index + text hash) to
+/// cached mp3 URLs + sentence timings. Re-rendered when book version moves;
+/// beat-incremental so retries never double-bill.
+model mandala_episode_audio {
+  mandala_id    String        @id @db.Uuid
+  /// pending | rendering | ready | failed
+  status        String        @default("pending") @db.VarChar(12)
+  /// House host: jun (기술·금융·실무) | seah (인문·언어·습관·라이프)
+  host          String        @default("jun") @db.VarChar(8)
+  book_version  Int           @default(0)
+  manifest_json Json?         @db.JsonB
+  error         String?
+  created_at    DateTime      @default(now()) @db.Timestamptz(6)
   updated_at    DateTime      @default(now()) @updatedAt @db.Timestamptz(6)
   mandala       user_mandalas @relation(fields: [mandala_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 

--- a/src/api/routes/mandala-episode-audio.ts
+++ b/src/api/routes/mandala-episode-audio.ts
@@ -1,0 +1,106 @@
+/**
+ * Episode narration audio — manifest read + lazy render trigger.
+ *
+ * GET /api/v1/mandalas/:id/episode-audio
+ *   Flag off        → 200 { enabled:false }
+ *   No book yet     → 200 { enabled:true, status:'no-book' }
+ *   Ready & fresh   → 200 { enabled:true, status:'ready', manifest }
+ *   Otherwise       → 200 { enabled:true, status:'rendering' } and, for the
+ *                     mandala owner, enqueues a singleton render job (lazy
+ *                     pre-produce — first open pays the render, replays are
+ *                     cached; stale book version re-renders changed beats only).
+ *
+ * Registered under the /mandalas prefix. Lives in its own file to avoid
+ * conflicts with in-flight mandalas.ts work from other sessions.
+ */
+
+import { FastifyInstance } from 'fastify';
+import { getPrismaClient } from '@/modules/database/client';
+import { config } from '@/config/index';
+import { logger } from '@/utils/logger';
+import { enqueueEpisodeNarrationRender } from '@/modules/queue/handlers/episode-narration-render';
+import type { EpisodeManifest } from '@/modules/narration/render-episode';
+
+const log = logger.child({ module: 'routes/mandala-episode-audio' });
+
+interface EpisodeAudioRow {
+  status: string;
+  host: string;
+  book_version: number;
+  manifest_json: EpisodeManifest | null;
+  error: string | null;
+}
+
+export async function mandalaEpisodeAudioRoutes(fastify: FastifyInstance): Promise<void> {
+  fastify.get<{ Params: { id: string } }>(
+    '/:id/episode-audio',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const userId = (request.user as { userId?: string } | undefined)?.userId;
+      if (!userId) {
+        return reply.code(401).send({ status: 'error', error: 'Unauthorized' });
+      }
+      const { id: mandalaId } = request.params;
+
+      if (!config.narration.enabled) {
+        return reply.code(200).send({ status: 'ok', data: { enabled: false } });
+      }
+
+      const prisma = getPrismaClient();
+      const mandala = await prisma.user_mandalas.findFirst({
+        where: { id: mandalaId, OR: [{ user_id: userId }, { is_public: true }] },
+        select: { id: true, user_id: true },
+      });
+      if (!mandala) {
+        return reply.code(404).send({ status: 'error', error: 'Mandala not found' });
+      }
+
+      const books = await prisma.$queryRawUnsafe<Array<{ version: number }>>(
+        `SELECT version FROM mandala_books WHERE mandala_id = $1::uuid LIMIT 1`,
+        mandalaId
+      );
+      if (!books[0]) {
+        return reply.code(200).send({ status: 'ok', data: { enabled: true, status: 'no-book' } });
+      }
+      const bookVersion = books[0].version;
+
+      const rows = await prisma.$queryRawUnsafe<EpisodeAudioRow[]>(
+        `SELECT status, host, book_version, manifest_json, error
+         FROM mandala_episode_audio WHERE mandala_id = $1::uuid LIMIT 1`,
+        mandalaId
+      );
+      const row = rows[0];
+
+      if (row?.status === 'ready' && row.book_version === bookVersion) {
+        return reply.code(200).send({
+          status: 'ok',
+          data: { enabled: true, status: 'ready', manifest: row.manifest_json },
+        });
+      }
+
+      // Terminal failure for the current book version — surface without
+      // re-enqueueing (over-budget etc. would fail identically again).
+      if (row?.status === 'failed' && row.book_version === bookVersion) {
+        return reply.code(200).send({
+          status: 'ok',
+          data: { enabled: true, status: 'failed' },
+        });
+      }
+
+      // Lazy trigger — owner only, and only when not already in flight.
+      // singletonKey on the job dedupes racing requests.
+      if (mandala.user_id === userId && row?.status !== 'rendering') {
+        try {
+          await enqueueEpisodeNarrationRender({ mandalaId });
+        } catch (err) {
+          log.error('failed to enqueue narration render', {
+            mandalaId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      return reply.code(200).send({ status: 'ok', data: { enabled: true, status: 'rendering' } });
+    }
+  );
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -16,6 +16,7 @@ import { analyticsRoutes } from './routes/analytics';
 import { syncRoutes } from './routes/sync';
 import { quotaRoutes } from './routes/quota';
 import { mandalaRoutes } from './routes/mandalas';
+import { mandalaEpisodeAudioRoutes } from './routes/mandala-episode-audio';
 import { imageRoutes } from './routes/images';
 import { ontologyRoutes } from './routes/ontology';
 import { searchRoutes } from './routes/search';
@@ -302,6 +303,10 @@ export async function buildServer() {
 
       // Register mandala routes
       await instance.register(mandalaRoutes, { prefix: '/mandalas' });
+
+      // Episode narration audio (ElevenLabs pre-produce) — separate plugin to
+      // avoid conflicts with in-flight mandalas.ts work; same /mandalas prefix.
+      await instance.register(mandalaEpisodeAudioRoutes, { prefix: '/mandalas' });
 
       // Register image proxy routes
       await instance.register(imageRoutes, { prefix: '/images' });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -25,6 +25,17 @@ const envSchema = z.object({
   SUPABASE_URL: z.string().optional(),
   SUPABASE_ANON_KEY: z.string().optional(),
   SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
+
+  // ── Narration pre-produce (ElevenLabs, 2026-07-13) ─────────────────────
+  // Default off = current behaviour exactly (browser TTS on /mobile).
+  // Rollback = flag off, no code revert. Key: see credentials.md ElevenLabs.
+  NARRATION_PREPRODUCE_ENABLED: z
+    .string()
+    .default('false')
+    .transform((v) => v === 'true' || v === '1'),
+  ELEVENLABS_API_KEY: z.string().optional(),
+  // Per-episode character ceiling — cost guard against runaway books.
+  NARRATION_MAX_CHARS_PER_EPISODE: z.coerce.number().int().positive().default(60000),
   SUPABASE_JWT_SECRET: z.string().optional(),
 
   // YouTube API
@@ -306,6 +317,11 @@ export const config = {
   },
 
   // Supabase
+  narration: {
+    enabled: env.NARRATION_PREPRODUCE_ENABLED,
+    elevenLabsApiKey: env.ELEVENLABS_API_KEY,
+    maxCharsPerEpisode: env.NARRATION_MAX_CHARS_PER_EPISODE,
+  },
   supabase: {
     url: env.SUPABASE_URL,
     anonKey: env.SUPABASE_ANON_KEY,

--- a/src/modules/narration/audio-storage.ts
+++ b/src/modules/narration/audio-storage.ts
@@ -1,0 +1,63 @@
+/**
+ * Supabase Storage helper for episode narration audio.
+ *
+ * Self-contained on purpose: the general storage wrapper
+ * (src/modules/storage/supabase-storage.ts) ships in the unmerged
+ * sales-resources branch — consolidate onto it once that lands.
+ * Uploads are upsert (re-render replaces stale beats idempotently).
+ */
+
+import { config } from '@/config/index';
+
+export const EPISODE_AUDIO_BUCKET = 'episode-audio';
+
+function requireStorage(): { url: string; key: string } {
+  const url = config.supabase.url;
+  const key = config.supabase.serviceRoleKey;
+  if (!url || !key) {
+    throw new Error(
+      'Supabase storage not configured: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing'
+    );
+  }
+  return { url, key };
+}
+
+/** Create the public bucket if it does not exist (idempotent). */
+export async function ensureEpisodeAudioBucket(): Promise<void> {
+  const { url, key } = requireStorage();
+  const res = await fetch(`${url}/storage/v1/bucket`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ id: EPISODE_AUDIO_BUCKET, name: EPISODE_AUDIO_BUCKET, public: true }),
+  });
+  // 409 = already exists — fine. Anything else non-2xx is a real failure.
+  if (!res.ok && res.status !== 409) {
+    const detail = (await res.text()).slice(0, 200);
+    if (!/already exists/i.test(detail)) {
+      throw new Error(`ensureEpisodeAudioBucket HTTP ${res.status}: ${detail}`);
+    }
+  }
+}
+
+export async function uploadEpisodeAudio(path: string, body: Buffer): Promise<void> {
+  const { url, key } = requireStorage();
+  const res = await fetch(`${url}/storage/v1/object/${EPISODE_AUDIO_BUCKET}/${path}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${key}`,
+      'content-type': 'audio/mpeg',
+      'x-upsert': 'true',
+    },
+    body: new Uint8Array(body),
+  });
+  if (!res.ok) {
+    const detail = (await res.text()).slice(0, 200);
+    throw new Error(`uploadEpisodeAudio ${path} HTTP ${res.status}: ${detail}`);
+  }
+}
+
+/** Public URL for a stored object (bucket is public). */
+export function episodeAudioPublicUrl(path: string): string {
+  const { url } = requireStorage();
+  return `${url}/storage/v1/object/public/${EPISODE_AUDIO_BUCKET}/${path}`;
+}

--- a/src/modules/narration/elevenlabs.ts
+++ b/src/modules/narration/elevenlabs.ts
@@ -1,0 +1,65 @@
+/**
+ * ElevenLabs TTS client (fetch-based, no extra deps).
+ *
+ * Uses the with-timestamps endpoint so the player can advance the focus-line
+ * highlight per sentence against audio.currentTime (media timeline; unchanged
+ * by client playbackRate).
+ */
+
+import { config } from '@/config/index';
+import type { HostPreset } from './preset';
+
+const API_BASE = 'https://api.elevenlabs.io/v1';
+const OUTPUT_FORMAT = 'mp3_44100_128';
+
+interface AlignmentPayload {
+  characters: string[];
+  character_start_times_seconds: number[];
+  character_end_times_seconds: number[];
+}
+
+export interface TtsResult {
+  audio: Buffer;
+  /** Start time (s) of each requested char offset, media timeline at 1.0x. */
+  charStartTimes: (offset: number) => number;
+  durationSec: number;
+}
+
+function requireKey(): string {
+  const key = config.narration.elevenLabsApiKey;
+  if (!key) throw new Error('ELEVENLABS_API_KEY is not configured');
+  return key;
+}
+
+export async function ttsWithTimestamps(preset: HostPreset, text: string): Promise<TtsResult> {
+  const res = await fetch(
+    `${API_BASE}/text-to-speech/${preset.voiceId}/with-timestamps?output_format=${OUTPUT_FORMAT}`,
+    {
+      method: 'POST',
+      headers: { 'xi-api-key': requireKey(), 'content-type': 'application/json' },
+      body: JSON.stringify({
+        text,
+        model_id: preset.modelId,
+        voice_settings: preset.voiceSettings,
+      }),
+    }
+  );
+  if (!res.ok) {
+    const detail = (await res.text()).slice(0, 300);
+    throw new Error(`ElevenLabs TTS HTTP ${res.status}: ${detail}`);
+  }
+  const json = (await res.json()) as { audio_base64: string; alignment: AlignmentPayload | null };
+  const audio = Buffer.from(json.audio_base64, 'base64');
+  const starts = json.alignment?.character_start_times_seconds ?? [];
+  const ends = json.alignment?.character_end_times_seconds ?? [];
+  const durationSec = ends.length ? (ends[ends.length - 1] ?? 0) : 0;
+  return {
+    audio,
+    charStartTimes: (offset: number) => {
+      if (!starts.length) return 0;
+      const i = Math.max(0, Math.min(offset, starts.length - 1));
+      return starts[i] ?? 0;
+    },
+    durationSec,
+  };
+}

--- a/src/modules/narration/flatten-book.ts
+++ b/src/modules/narration/flatten-book.ts
@@ -1,0 +1,56 @@
+/**
+ * Book → beat sequence, mirroring the /mobile player's flatten() exactly
+ * (frontend/public/mobile/index.html). Beat INDICES must match the player's,
+ * because the audio manifest is keyed by (index, text-hash). Only narration
+ * ('n') beats get TTS; chapter cards and clips are silent on the server side.
+ * Change here ⇒ change the player flatten() + parity fixtures in the same PR.
+ */
+
+import { stripMd } from './sentences';
+
+export interface BookAtom {
+  vid?: string;
+  ts?: number;
+  text?: string;
+  src?: string | null;
+  seg_ref?: { from_sec: number; to_sec: number };
+}
+
+export interface BookSection {
+  title?: string;
+  narrative?: string;
+  atoms?: BookAtom[];
+}
+
+export interface BookChapter {
+  title?: string;
+  intro?: string;
+  sections?: BookSection[];
+}
+
+export interface BookJson {
+  chapters?: BookChapter[];
+}
+
+export type Beat =
+  | { t: 'ch'; num: number; title: string }
+  | { t: 'n'; title?: string; text: string }
+  | { t: 'c'; vid: string };
+
+export function flattenBook(book: BookJson): Beat[] {
+  const beats: Beat[] = [];
+  const chs = book?.chapters ?? [];
+  chs.forEach((ch, ci) => {
+    beats.push({ t: 'ch', num: ci + 1, title: ch.title || `챕터 ${ci + 1}` });
+    if (ch.intro && stripMd(ch.intro)) beats.push({ t: 'n', title: ch.title, text: ch.intro });
+    (ch.sections ?? []).forEach((s) => {
+      if (s.narrative && stripMd(s.narrative))
+        beats.push({ t: 'n', title: s.title, text: s.narrative });
+      (s.atoms ?? []).slice(0, 2).forEach((a) => {
+        if (!a.vid) return;
+        beats.push({ t: 'c', vid: a.vid });
+      });
+    });
+  });
+  return beats;
+}

--- a/src/modules/narration/preset.ts
+++ b/src/modules/narration/preset.ts
@@ -1,0 +1,115 @@
+/**
+ * Narration presets — James-approved recipe + house hosts.
+ *
+ * Recipe SSOT: ~/Documents/insighta-manual-assets-20260703/narration-preset.json
+ * (confirmed 2026-07-06, "nat-v3b-fast"). Do not change voice_settings without
+ * a new James confirmation.
+ *
+ * House hosts (2026-07-10 decision): domain tone → default host, series keeps
+ * its host. 준(male) = clear/plain explainer for tech·finance·practical.
+ * 세아(female) = calm/warm guide for humanities·language·habit·life.
+ *
+ * Tempo: the approved recipe post-processes with ffmpeg atempo=1.06. The
+ * service render keeps audio at 1.0x and ships `tempo` in the manifest —
+ * the player applies playbackRate=1.06 with preservesPitch, which keeps
+ * ElevenLabs character-alignment timestamps valid (media timeline unscaled).
+ */
+
+export type NarrationHost = 'jun' | 'seah';
+
+export interface HostPreset {
+  host: NarrationHost;
+  /** ElevenLabs voice id (account voice; see credentials.md ElevenLabs section). */
+  voiceId: string;
+  voiceName: string;
+  modelId: string;
+  voiceSettings: {
+    stability: number;
+    similarity_boost: number;
+    style: number;
+    use_speaker_boost: boolean;
+  };
+}
+
+/** Playback tempo the player applies (recipe: atempo=1.06, pitch kept). */
+export const NARRATION_TEMPO = 1.06;
+
+export const HOSTS: Record<NarrationHost, HostPreset> = {
+  jun: {
+    host: 'jun',
+    voiceId: 'i4rvH83fgM9aBqIBZ5zH',
+    voiceName: 'Jihu - Calm Korean Narrator (seoul male)',
+    modelId: 'eleven_v3',
+    voiceSettings: {
+      stability: 0.42,
+      similarity_boost: 0.82,
+      style: 0.55,
+      use_speaker_boost: true,
+    },
+  },
+  seah: {
+    host: 'seah',
+    // Anna Kim - Tender, Calm and Clear (ko female) — matches the 세아 character
+    // spec ("차분하고 따뜻한 안내자"). 15s candidate samples in ~/Downloads
+    // (2026-07-13); swap here if James picks Yu Haon (B8rl62CpT9zOQ7RC3Mdl).
+    voiceId: 'uyVNoMrnUku1dZyVEXwD',
+    voiceName: 'Anna Kim - Tender, Calm and Clear (ko female)',
+    modelId: 'eleven_v3',
+    voiceSettings: {
+      stability: 0.42,
+      similarity_boost: 0.82,
+      style: 0.55,
+      use_speaker_boost: true,
+    },
+  },
+};
+
+/**
+ * Domain keywords → 세아 (인문·언어·습관·라이프). Everything else defaults to
+ * 준 (기술·금융·실무) per the 2026-07-10 assignment table. Checked against
+ * the mandala title + domain column, lowercase substring match. v1 heuristic —
+ * the upgrade path is a proper topic classifier, not more keywords.
+ */
+const SEAH_DOMAIN_KEYWORDS = [
+  // 언어
+  '영어',
+  '언어',
+  '회화',
+  '스페인어',
+  '일본어',
+  '중국어',
+  'hsk',
+  '토익',
+  '단어',
+  // 인문
+  '역사',
+  '철학',
+  '심리',
+  '문학',
+  '글쓰기',
+  '독서',
+  '인문',
+  '예술',
+  '미술',
+  '음악',
+  // 습관·라이프
+  '습관',
+  '루틴',
+  '명상',
+  '마음',
+  '수면',
+  '요리',
+  '살림',
+  '정리',
+  '육아',
+  '건강',
+  '수채화',
+  '그림',
+  '여행',
+  '행복',
+];
+
+export function classifyHost(title: string, domain?: string | null): NarrationHost {
+  const hay = `${title} ${domain ?? ''}`.toLowerCase();
+  return SEAH_DOMAIN_KEYWORDS.some((k) => hay.includes(k)) ? 'seah' : 'jun';
+}

--- a/src/modules/narration/render-episode.ts
+++ b/src/modules/narration/render-episode.ts
@@ -1,0 +1,211 @@
+/**
+ * Episode narration renderer — book_json → per-beat ElevenLabs mp3 + manifest.
+ *
+ * Lazy pre-produce: rendered once per (mandala, book version, host) and cached
+ * in Supabase Storage; playback never bills. Beat-incremental: the manifest is
+ * persisted after every beat, so a retried job re-renders only missing beats
+ * (no double billing). Voice/recipe: src/modules/narration/preset.ts.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { logger } from '@/utils/logger';
+import { config } from '@/config/index';
+import { HOSTS, NARRATION_TEMPO, classifyHost, type NarrationHost } from './preset';
+import { flattenBook, type BookJson } from './flatten-book';
+import { sentences, beatTextHash } from './sentences';
+import { ttsWithTimestamps } from './elevenlabs';
+import {
+  ensureEpisodeAudioBucket,
+  uploadEpisodeAudio,
+  episodeAudioPublicUrl,
+} from './audio-storage';
+
+const log = logger.child({ module: 'narration/render-episode' });
+
+export interface ManifestBeat {
+  /** Beat index in the player's flatten() order. */
+  i: number;
+  /** sha256(joined sentences) first 12 hex — player-side lookup key. */
+  h: string;
+  /** Public mp3 URL. */
+  f: string;
+  /** Duration in seconds (media timeline, 1.0x). */
+  d: number;
+  /** Sentence start times in seconds (media timeline, 1.0x). */
+  s: number[];
+}
+
+export interface EpisodeManifest {
+  v: 1;
+  host: NarrationHost;
+  voiceId: string;
+  tempo: number;
+  bookVersion: number;
+  beats: ManifestBeat[];
+}
+
+interface EpisodeRow {
+  mandala_id: string;
+  status: string;
+  host: string;
+  book_version: number;
+  manifest_json: EpisodeManifest | null;
+}
+
+async function readRow(mandalaId: string): Promise<EpisodeRow | null> {
+  // Raw SQL — same regen-lag-proof stance as the /book route.
+  const rows = await getPrismaClient().$queryRawUnsafe<EpisodeRow[]>(
+    `SELECT mandala_id, status, host, book_version, manifest_json
+     FROM mandala_episode_audio WHERE mandala_id = $1::uuid LIMIT 1`,
+    mandalaId
+  );
+  return rows[0] ?? null;
+}
+
+async function upsertRow(
+  mandalaId: string,
+  fields: {
+    status: string;
+    host: string;
+    bookVersion: number;
+    manifest: EpisodeManifest | null;
+    error?: string | null;
+  }
+): Promise<void> {
+  await getPrismaClient().$executeRawUnsafe(
+    `INSERT INTO mandala_episode_audio (mandala_id, status, host, book_version, manifest_json, error, updated_at)
+     VALUES ($1::uuid, $2, $3, $4, $5::jsonb, $6, now())
+     ON CONFLICT (mandala_id) DO UPDATE SET
+       status = EXCLUDED.status, host = EXCLUDED.host, book_version = EXCLUDED.book_version,
+       manifest_json = EXCLUDED.manifest_json, error = EXCLUDED.error, updated_at = now()`,
+    mandalaId,
+    fields.status,
+    fields.host,
+    fields.bookVersion,
+    JSON.stringify(fields.manifest),
+    fields.error ?? null
+  );
+}
+
+export interface RenderResult {
+  ok: boolean;
+  action: 'rendered' | 'fresh' | 'skipped-no-book' | 'skipped-over-budget' | 'failed';
+  renderedBeats?: number;
+}
+
+export async function renderEpisodeNarration(mandalaId: string): Promise<RenderResult> {
+  const prisma = getPrismaClient();
+
+  const mandala = await prisma.user_mandalas.findFirst({
+    where: { id: mandalaId },
+    select: { id: true, title: true, domain: true },
+  });
+  if (!mandala) return { ok: false, action: 'skipped-no-book' };
+
+  const books = await prisma.$queryRawUnsafe<Array<{ book_json: BookJson; version: number }>>(
+    `SELECT book_json, version FROM mandala_books WHERE mandala_id = $1::uuid LIMIT 1`,
+    mandalaId
+  );
+  if (!books[0]) return { ok: false, action: 'skipped-no-book' };
+  const { book_json: book, version: bookVersion } = books[0];
+
+  const existing = await readRow(mandalaId);
+  // Series keeps its host across episodes/versions; classify only once.
+  const host: NarrationHost =
+    existing && (existing.host === 'jun' || existing.host === 'seah')
+      ? existing.host
+      : classifyHost(mandala.title ?? '', mandala.domain);
+  const preset = HOSTS[host];
+
+  if (existing?.status === 'ready' && existing.book_version === bookVersion) {
+    return { ok: true, action: 'fresh' };
+  }
+
+  const beats = flattenBook(book);
+  const narrBeats = beats
+    .map((b, i) => ({ b, i }))
+    .filter((x): x is { b: { t: 'n'; title?: string; text: string }; i: number } => x.b.t === 'n');
+
+  const totalChars = narrBeats.reduce((n, x) => n + x.b.text.length, 0);
+  if (totalChars > config.narration.maxCharsPerEpisode) {
+    log.warn('episode over char budget — skipping render', { mandalaId, totalChars });
+    await upsertRow(mandalaId, {
+      status: 'failed',
+      host,
+      bookVersion,
+      manifest: null,
+      error: `over char budget: ${totalChars} > ${config.narration.maxCharsPerEpisode}`,
+    });
+    return { ok: false, action: 'skipped-over-budget' };
+  }
+
+  await ensureEpisodeAudioBucket();
+
+  // Resume: keep beats whose (index, hash) already match — no double billing.
+  const prior = new Map<string, ManifestBeat>(
+    (existing?.manifest_json?.beats ?? []).map((m) => [`${m.i}:${m.h}`, m])
+  );
+  const manifest: EpisodeManifest = {
+    v: 1,
+    host,
+    voiceId: preset.voiceId,
+    tempo: NARRATION_TEMPO,
+    bookVersion,
+    beats: [],
+  };
+  await upsertRow(mandalaId, { status: 'rendering', host, bookVersion, manifest });
+
+  let rendered = 0;
+  try {
+    for (const { b, i } of narrBeats) {
+      const sents = sentences(b.text);
+      if (!sents.length) continue;
+      const hash = beatTextHash(sents);
+      const kept = prior.get(`${i}:${hash}`);
+      if (kept) {
+        manifest.beats.push(kept);
+        continue;
+      }
+
+      const joined = sents.join(' ');
+      const tts = await ttsWithTimestamps(preset, joined);
+
+      // Sentence start offsets in the joined text → start times.
+      const starts: number[] = [];
+      let offset = 0;
+      for (const sent of sents) {
+        starts.push(tts.charStartTimes(offset));
+        offset += sent.length + 1; // + joining space
+      }
+
+      const path = `mandala/${mandalaId}/v${bookVersion}/${host}/narr-${i}.mp3`;
+      await uploadEpisodeAudio(path, tts.audio);
+      manifest.beats.push({
+        i,
+        h: hash,
+        f: episodeAudioPublicUrl(path),
+        d: tts.durationSec,
+        s: starts,
+      });
+      rendered++;
+
+      // Persist incrementally so a crash/retry resumes instead of re-billing.
+      await upsertRow(mandalaId, { status: 'rendering', host, bookVersion, manifest });
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error('episode render failed mid-way', { mandalaId, rendered, error: message });
+    await upsertRow(mandalaId, { status: 'failed', host, bookVersion, manifest, error: message });
+    return { ok: false, action: 'failed', renderedBeats: rendered };
+  }
+
+  await upsertRow(mandalaId, { status: 'ready', host, bookVersion, manifest });
+  log.info('episode narration ready', {
+    mandalaId,
+    host,
+    bookVersion,
+    beats: manifest.beats.length,
+    rendered,
+  });
+  return { ok: true, action: 'rendered', renderedBeats: rendered };
+}

--- a/src/modules/narration/sentences.ts
+++ b/src/modules/narration/sentences.ts
@@ -1,0 +1,30 @@
+/**
+ * Sentence splitting — byte-for-byte port of the /mobile player's stripMd() +
+ * sentences() (frontend/public/mobile/index.html). The player looks up
+ * pre-rendered audio by sha256(joined sentences), so BOTH sides must split
+ * identically; tests/smoke/narration.test.ts pins the parity fixtures.
+ * Change here ⇒ change the player + fixtures in the same PR.
+ */
+
+import { createHash } from 'node:crypto';
+
+export function stripMd(s: unknown): string {
+  return String(s ?? '')
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/\|[^\n]*\|/g, ' ')
+    .replace(/[#>*_`~]|\[(.*?)\]\(.*?\)/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function sentences(s: unknown): string[] {
+  return stripMd(s)
+    .split(/(?<=[.!?다요죠음됨함][\s"')\]]?)\s+/)
+    .map((x) => x.trim())
+    .filter((x) => x.length > 1);
+}
+
+/** Beat text key: sha256 hex of the sentence-joined text, first 12 chars. */
+export function beatTextHash(sents: string[]): string {
+  return createHash('sha256').update(sents.join(' ')).digest('hex').slice(0, 12);
+}

--- a/src/modules/queue/handlers/episode-narration-render.ts
+++ b/src/modules/queue/handlers/episode-narration-render.ts
@@ -1,0 +1,66 @@
+/**
+ * Episode narration render worker — durable lane for ElevenLabs pre-produce.
+ *
+ * One job per mandala (singletonKey = mandalaId) so concurrent /episode-audio
+ * requests cannot double-render (= double-bill). The renderer itself is
+ * beat-incremental, so pg-boss retries resume instead of re-billing.
+ */
+
+import PgBoss from 'pg-boss';
+import { logger } from '@/utils/logger';
+import { getJobQueue } from '../manager';
+import {
+  JOB_NAMES,
+  EPISODE_NARRATION_RENDER_OPTIONS,
+  type EpisodeNarrationRenderPayload,
+} from '../types';
+import { richSummaryWorkOptions } from './rich-summary-work-options';
+
+const log = logger.child({ module: 'queue/episode-narration-render' });
+
+// External TTS API lane — keep it serial-ish; an episode is many sequential
+// HTTP calls already and ElevenLabs rate-limits per account.
+const NARRATION_RENDER_CONCURRENCY = 1;
+
+export async function registerEpisodeNarrationRenderWorker(): Promise<void> {
+  const boss = getJobQueue().getInstance();
+  await boss.work<EpisodeNarrationRenderPayload>(
+    JOB_NAMES.EPISODE_NARRATION_RENDER,
+    richSummaryWorkOptions(NARRATION_RENDER_CONCURRENCY),
+    handleEpisodeNarrationRender
+  );
+  log.info('episode-narration-render worker registered', {
+    concurrency: NARRATION_RENDER_CONCURRENCY,
+  });
+}
+
+export async function handleEpisodeNarrationRender(
+  job: PgBoss.Job<EpisodeNarrationRenderPayload>
+): Promise<void> {
+  const { mandalaId } = job.data ?? ({} as EpisodeNarrationRenderPayload);
+  if (!mandalaId) {
+    log.warn('episode-narration-render: missing mandalaId, dropping', { jobId: job.id });
+    return;
+  }
+
+  // Lazy import keeps the queue boot path free of the narration import chain.
+  const { renderEpisodeNarration } = await import('@/modules/narration/render-episode');
+  const result = await renderEpisodeNarration(mandalaId);
+
+  if (!result.ok && result.action === 'failed') {
+    // Throw → pg-boss retry with backoff; renderer resumes from the manifest.
+    throw new Error(`episode narration render failed for ${mandalaId}`);
+  }
+}
+
+export async function enqueueEpisodeNarrationRender(
+  payload: EpisodeNarrationRenderPayload,
+  options?: PgBoss.SendOptions
+): Promise<string | null> {
+  const boss = getJobQueue().getInstance();
+  return boss.send(JOB_NAMES.EPISODE_NARRATION_RENDER, payload, {
+    ...EPISODE_NARRATION_RENDER_OPTIONS,
+    singletonKey: payload.mandalaId,
+    ...options,
+  });
+}

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -23,6 +23,7 @@ export { enqueueBatchVideoCollectorRun } from './handlers/batch-video-collector'
 export { enqueuePoolMaintenanceRun } from './handlers/pool-maintenance';
 export { enqueueRelevanceQuick } from './handlers/enrich-relevance-quick';
 export { enqueueNoteCvEnrich } from './handlers/note-cv-enrich';
+export { enqueueEpisodeNarrationRender } from './handlers/episode-narration-render';
 
 import { getJobQueue } from './manager';
 import { registerEnrichVideoWorker } from './handlers/enrich-video';
@@ -35,6 +36,7 @@ import { registerPoolServeFillWorker } from './handlers/pool-serve-fill';
 import { registerMandalaActionsFillWorker } from './handlers/mandala-actions-fill';
 import { registerMandalaPipelineWorker } from './handlers/mandala-pipeline';
 import { registerMandalaBookFillWorker } from './handlers/mandala-book-fill';
+import { registerEpisodeNarrationRenderWorker } from './handlers/episode-narration-render';
 import { registerJudgeDeboostWorker } from './handlers/judge-deboost';
 import { registerTranslateMandalaBulkWorker } from './handlers/translate-mandala-bulk';
 import { registerSegmentRelevanceFillWorker } from './handlers/segment-relevance-fill';
@@ -67,6 +69,7 @@ export async function initJobQueue(): Promise<void> {
   await registerMandalaActionsFillWorker();
   await registerMandalaPipelineWorker();
   await registerMandalaBookFillWorker();
+  await registerEpisodeNarrationRenderWorker();
   await registerJudgeDeboostWorker();
   await registerTranslateMandalaBulkWorker();
   await registerSegmentRelevanceFillWorker();

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -51,6 +51,12 @@ export const JOB_NAMES = {
    * overwrites book_json + bumps version. Worker = fillMandalaBook.
    */
   MANDALA_BOOK_FILL: 'mandala-book-fill',
+  /**
+   * ElevenLabs episode narration pre-produce (2026-07-13) — lazy render of a
+   * mandala book into per-beat narration mp3s + manifest. Flag-gated
+   * (NARRATION_PREPRODUCE_ENABLED); singleton per mandala.
+   */
+  EPISODE_NARRATION_RENDER: 'episode-narration-render',
   JUDGE_DEBOOST: 'judge-deboost',
   /**
    * v2 translations (PR-T1) — bulk-translate a mandala's off-language v2 atoms
@@ -386,6 +392,21 @@ export const MANDALA_BOOK_FILL_OPTIONS = {
   retryBackoff: true,
   expireInMinutes: 10,
 } as const;
+
+/**
+ * Episode narration render (narration pre-produce) — retries resume from the
+ * persisted manifest, so a generous retry budget cannot double-bill.
+ */
+export const EPISODE_NARRATION_RENDER_OPTIONS = {
+  retryLimit: 3,
+  retryDelay: 60,
+  retryBackoff: true,
+  expireInMinutes: 30,
+} as const;
+
+export interface EpisodeNarrationRenderPayload {
+  mandalaId: string;
+}
 
 export interface MandalaBookFillPayload {
   userId: string;

--- a/tests/smoke/narration.test.ts
+++ b/tests/smoke/narration.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Narration pre-produce unit tests (2026-07-13).
+ *
+ * The critical contract is FE↔BE parity: the /mobile player looks up
+ * pre-rendered audio by (beat index, sha256(joined sentences)), so
+ * sentences()/flattenBook() here must behave exactly like the player's
+ * copies in frontend/public/mobile/index.html. These fixtures pin that.
+ */
+
+import { sentences, stripMd, beatTextHash } from '@/modules/narration/sentences';
+import { flattenBook } from '@/modules/narration/flatten-book';
+import { classifyHost, HOSTS, NARRATION_TEMPO } from '@/modules/narration/preset';
+
+describe('narration sentences (player parity)', () => {
+  it('splits Korean sentence enders like the player', () => {
+    expect(sentences('물의 양이 투명도를 결정합니다. 마르기 전에 칠하면 번지고요. 끝.')).toEqual([
+      '물의 양이 투명도를 결정합니다.',
+      '마르기 전에 칠하면 번지고요.',
+      // '끝.' is a single-char sentence body; length filter keeps it (2 chars incl. dot)
+      '끝.',
+    ]);
+  });
+
+  it('strips markdown the way the player does', () => {
+    expect(stripMd('## 제목\n**굵게** [링크](http://x)와 `코드`')).toBe('제목 굵게 링크와 코드');
+  });
+
+  it('filters fragments of length <= 1', () => {
+    expect(sentences('가. 나머지는 유지됩니다.')).toEqual(['가.', '나머지는 유지됩니다.']);
+    expect(sentences('.')).toEqual([]);
+  });
+
+  it('hashes are stable and 12 hex chars', () => {
+    const h = beatTextHash(['한 문장.', '두 문장.']);
+    expect(h).toMatch(/^[0-9a-f]{12}$/);
+    expect(beatTextHash(['한 문장.', '두 문장.'])).toBe(h);
+  });
+});
+
+describe('narration flattenBook (player parity)', () => {
+  const book = {
+    chapters: [
+      {
+        title: '1부',
+        intro: '인트로 문장입니다.',
+        sections: [
+          {
+            title: '섹션A',
+            narrative: '섹션 내레이션입니다.',
+            atoms: [
+              { vid: 'v1', ts: 10 },
+              { vid: 'v2', ts: 20 },
+              { vid: 'v3', ts: 30 },
+            ],
+          },
+          { title: '섹션B', narrative: '', atoms: [{ ts: 5 }] },
+        ],
+      },
+      { title: '2부', intro: '', sections: [{ title: '섹션C', narrative: '마지막 내레이션.' }] },
+    ],
+  };
+
+  it('produces the exact player beat order and indices', () => {
+    const beats = flattenBook(book);
+    expect(beats.map((b) => b.t)).toEqual([
+      'ch', // 0: 1부
+      'n', // 1: intro
+      'n', // 2: 섹션A narrative
+      'c', // 3: v1
+      'c', // 4: v2  (atoms sliced to 2 — v3 dropped)
+      'ch', // 5: 2부 (섹션B: empty narrative skipped, atom without vid skipped)
+      'n', // 6: 섹션C narrative
+    ]);
+  });
+});
+
+describe('narration host assignment (2026-07-10 table)', () => {
+  it('routes 기술/금융 to 준 by default', () => {
+    expect(classifyHost('MCP 기반 AI 에이전트 개발')).toBe('jun');
+    expect(classifyHost('ETF 투자 첫걸음')).toBe('jun');
+  });
+
+  it('routes 인문·언어·습관·라이프 to 세아', () => {
+    expect(classifyHost('처음부터 시작하는 수채화')).toBe('seah');
+    expect(classifyHost('영어 회화 100일')).toBe('seah');
+    expect(classifyHost('아침 루틴 만들기')).toBe('seah');
+  });
+
+  it('presets carry the James-approved recipe', () => {
+    for (const host of ['jun', 'seah'] as const) {
+      expect(HOSTS[host].modelId).toBe('eleven_v3');
+      expect(HOSTS[host].voiceSettings).toEqual({
+        stability: 0.42,
+        similarity_boost: 0.82,
+        style: 0.55,
+        use_speaker_boost: true,
+      });
+    }
+    expect(NARRATION_TEMPO).toBe(1.06);
+  });
+});


### PR DESCRIPTION
## What

Service wiring for the ElevenLabs voice decision: newly (and previously) created mandala notes get real narrated audio, rendered lazily once per episode and cached — playback never bills.

- **Recipe**: James-approved narration-preset.json verbatim (eleven_v3, stability .42 / similarity .82 / style .55, speaker boost, tempo 1.06). Tempo is applied at playback (playbackRate + preservesPitch) so ElevenLabs character-alignment timestamps stay valid — perceptually identical to the recipe's ffmpeg atempo, without an ffmpeg image dependency.
- **House hosts** (2026-07-10 assignment table): **준** = Jihu → tech/finance/practical, **세아** = Anna Kim → humanities/language/habit/life. Keyword classifier on title+domain; a mandala keeps its host once assigned (series = same host). Seah candidate samples (Anna Kim vs Yu Haon, same recipe) are in ~/Downloads for a listen — swapping is one voiceId in preset.ts.
- **Renderer**: book_json → player-parity flatten → per-beat TTS (with-timestamps) → Supabase Storage (public `episode-audio` bucket) → manifest keyed by (beat index, sha256 of joined sentences) with per-sentence start times for the focus-line sync. Beat-incremental persistence — pg-boss retries resume, never double-bill.
- **API**: `GET /api/v1/mandalas/:id/episode-audio` (own route file — avoids conflicts with in-flight mandalas.ts work). Owner request lazily enqueues a singleton render job; non-owners of public mandalas read the cache only.
- **Safety**: `NARRATION_PREPRODUCE_ENABLED` default off = zero behavior change (rollback = flag off). `NARRATION_MAX_CHARS_PER_EPISODE` (60k) cost ceiling. ElevenLabs key: GH secret set + deploy.yml sync (idempotent pattern).
- **DB**: `mandala_episode_audio` — schema.prisma + raw DDL per the silent-fail rule; applied to local dev DB and verified (8 columns). Write path is the renderer upsert only.
- **Tests**: FE-parity fixtures for sentences()/flatten() (the audio lookup contract), host classifier, recipe pin — 8/8 green. `tsc --noEmit` clean.

## Next PR

/mobile player consumes the manifest (per-beat audio + sentence-timed focus line, browser-TTS fallback when disabled/rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)