### PR TITLE
feat(ci): T-ledger completeness + data-write reversibility guards (T10-R follow-up)

### DIFF
--- a/scripts/ci/check-t-ledger.sh
+++ b/scripts/ci/check-t-ledger.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# T-ledger guard (2026-07-14, supervisor-approved) — INV-T-LEDGER-COMPLETE
+#
+# The T-ledger (docs/handoffs/version-archetype-matrix-2026-07-12.md) is the
+# time-machine index for ALL search-performance changes. One unnumbered change
+# breaks its completeness guarantee — which happened on 2026-07-13 (the judge
+# track ran through 2 PRs with no T number until James asked). Memory-only
+# discipline has a documented 0% hold rate in this repo (Rule H/J/A.2);
+# guards hold. So: a PR that touches search-performance paths MUST carry a
+# T number ("T10", "T11", "T10-R"...) in its title or body.
+#
+# Scope is deliberately NARROW (supervisor: never block unrelated PRs).
+# Env: PR_TITLE / PR_BODY (from the workflow), BASE_REF (default origin/main).
+
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+PR_TEXT="${PR_TITLE:-} ${PR_BODY:-}"
+
+# Search-performance code paths (keep in sync with the T-ledger §11 scope).
+PERF_PATHS_RE='^src/(skills/plugins/(video-discover|iks-scorer)/|modules/(judge|relevance)/|modules/mandala/(wizard-precompute|pipeline-runner|place-auto-added-cards|auto-add-recommendations)\.ts|config/(discover-|judge-|wizard-|precompute-|pool-serve|subgoal-anchor|inflow-gate|embed-))'
+# Perf flags inside compose (the file itself hosts many unrelated envs).
+PERF_FLAG_RE='(V3_|V5_|DISCOVER_|JUDGE_|WIZARD_|PRECOMPUTE_|INFLOW_GATE|EMBED_SERVING_|OPENROUTER_EMBED_|POOL_SERVE|AUTO_ADD_)'
+
+CHANGED=$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || true)
+
+touched_perf=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  if echo "$f" | grep -qE "$PERF_PATHS_RE"; then
+    touched_perf="${touched_perf}${f}\n"
+  fi
+done <<< "$CHANGED"
+
+# compose: only when the DIFF HUNKS touch perf flags, not any compose edit.
+if echo "$CHANGED" | grep -q '^docker-compose.prod.yml$'; then
+  if git diff "${BASE_REF}...HEAD" -- docker-compose.prod.yml | grep -E '^[+-]' | grep -qE "$PERF_FLAG_RE"; then
+    touched_perf="${touched_perf}docker-compose.prod.yml (perf flag)\n"
+  fi
+fi
+
+if [ -z "$touched_perf" ]; then
+  echo "t-ledger: OK — no search-performance paths touched"
+  exit 0
+fi
+
+if echo "$PR_TEXT" | grep -qE '\bT[0-9]+(-[A-Z]+)?\b'; then
+  echo "t-ledger: OK — T number present for perf change"
+  exit 0
+fi
+
+echo "t-ledger: FAIL — search-performance paths changed without a T number."
+echo "Touched:"
+printf "%b" "$touched_perf" | sed 's/^/  - /'
+echo ""
+echo "Fix: register the change in docs/handoffs/version-archetype-matrix-2026-07-12.md"
+echo "and put its T number (e.g. 'T11') in the PR title or body."
+exit 1

--- a/scripts/ci/check-write-guard.sh
+++ b/scripts/ci/check-write-guard.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Data-write reversibility guard (2026-07-14) — INV-DATA-TIMEMACHINE
+#
+# T10 incident (2026-07-13): a worker OVERWROTE relevance_pct — a field that
+# is the INPUT of tone-down/sorting/serving — destroying 141 original values
+# with no history. A feature flag only stops FUTURE writes; it cannot undo
+# data. Hard rule (memory + supervisor-confirmed): a change that writes to
+# EXISTING columns ships only with (a) original-field-immutable design
+# (derived/dedicated column), or (b) a snapshot + rollback plan, and (c) a
+# statement of whether the target field is another system's input.
+#
+# CI cannot verify semantics — this is a chokepoint-style declaration check
+# (supervisor: PR-template self-report alone is too weak; grep-enforce it):
+# when the diff ADDS bulk-write patterns in src/**, the PR body must carry a
+# "Data-Write:" declaration block. "Data-Write: none-existing" declares the
+# writes target NEW/dedicated columns only (case a).
+#
+# Env: PR_BODY, BASE_REF (default origin/main).
+
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+BODY="${PR_BODY:-}"
+
+# Added lines introducing bulk/raw writes (tests excluded).
+ADDED_WRITES=$(git diff "${BASE_REF}...HEAD" -- 'src/**/*.ts' ':!src/**/__tests__/**' \
+  | grep -E '^\+' \
+  | grep -E '\.updateMany\(|\$executeRaw|UPDATE [a-z_]+ SET' || true)
+
+if [ -z "$ADDED_WRITES" ]; then
+  echo "write-guard: OK — no new bulk-write patterns"
+  exit 0
+fi
+
+if echo "$BODY" | grep -qiE 'Data-Write:'; then
+  echo "write-guard: OK — Data-Write declaration present"
+  exit 0
+fi
+
+echo "write-guard: FAIL — new bulk-write pattern(s) without a Data-Write declaration."
+echo "New write lines:"
+echo "$ADDED_WRITES" | head -10 | sed 's/^/  /'
+echo ""
+echo "Add a 'Data-Write:' block to the PR body declaring:"
+echo "  1) target table.column(s)"
+echo "  2) is the field another system's INPUT? (tone-down/sort/serving 등)"
+echo "  3) reversibility: dedicated/new column (원본 불변) OR snapshot+rollback plan"
+echo "  (writes to new/dedicated columns only → 'Data-Write: none-existing')"
+exit 1


### PR DESCRIPTION
## What (both supervisor-approved; James GO 2026-07-14)
Two chokepoint-style guards in a new `T-Ledger & Write Guard` CI job (PR-only):

**1. T-ledger guard** — PRs touching search-performance paths must carry a `T##` in title/body:
- Paths: `video-discover/` · `iks-scorer/` · `modules/judge/` · `modules/relevance/` · wizard-precompute/pipeline-runner/place-auto-added-cards/auto-add-recommendations · perf config modules · **compose only when the diff hunks touch perf flags** (V3_/V5_/DISCOVER_/JUDGE_/… — an unrelated compose edit passes).
- Why: one unnumbered change breaks the ledger's time-machine completeness (2026-07-13 incident — judge track ran 2 PRs unnumbered).

**2. Data-write guard** — diffs **adding** `updateMany`/`$executeRaw`/raw-UPDATE patterns in `src/**` require a `Data-Write:` declaration in the PR body (target columns / input-field statement / reversibility plan).
- Why: T10 root cause — judge overwrote `relevance_pct` (input of tone-down/sort/serving), destroying 141 originals; a flag cannot undo data.

## Verification (committed-bait test, 4/4)
no-T → **FAIL** · no-declaration → **FAIL** · T present → OK · declaration present → OK. Clean branch → both OK (no false positives on this PR itself... which contains no perf paths).

Data-Write: none (CI scripts only, no runtime code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)