### PR TITLE
feat(mobile): restore YouTube-grammar tap zones across stage — uniform with clips

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -424,8 +424,7 @@
 
   /* ── C1 탭 존 레이어 ── */
   .stagetap{display:none}
-  body.stage .stagetap{display:block; position:absolute; z-index:4; left:0; top:0; bottom:0; width:30px} /* 엣지 스트립 = 레일 */
-  body.stage.railopen .stagetap{width:auto; right:0} /* 미니 무대 탭 = 복귀 */
+  body.stage .stagetap{display:block; position:absolute; inset:0; z-index:4} /* 유튜브 문법 탭 존 [J:07-14] */
 
 
   /* 클립 로딩 베일 — YT 기본 스피너 대체 (재생 시작 시 페이드아웃) */
@@ -1370,25 +1369,42 @@
     if(!playing){ playing=true; setCharging(true); acquireWake(); runBeat(); }
     hudWake();
   }
-  /* 탭 레이어 = 좌측 엣지 스와이프(레일) + 레일 열림 시 복귀 탭 — 컨트롤은 미니 휠 [J:07-14] */
+  /* 탭 존 = 유튜브 문법, 내레이션·클립 동일 [J:07-14 "기존 사용성을 막지 않아야"]
+     중앙 탭=재생/정지 · 좌/우 1/3 더블탭=이전/다음 구간 · 클립 중앙 더블탭=커버.
+     + 좌측 엣지 스와이프=레일, 레일 열림 시 탭=복귀 */
   (function(){
-    var x0=0,t0=0,moved=0,edge=false,onRail=false;
+    var x0=0,y0=0,t0=0,moved=0,edge=false,onRail=false,tapTimer=null,lastT=0,lastZone='';
     stageTapEl.addEventListener('pointerdown',function(e){
-      x0=e.clientX; t0=performance.now(); moved=0;
+      x0=e.clientX; y0=e.clientY; t0=performance.now(); moved=0;
       onRail=document.body.classList.contains('railopen');
-      edge=!onRail;
+      edge=!onRail&&e.clientX<28;
       try{stageTapEl.setPointerCapture(e.pointerId)}catch(err){}
     });
     stageTapEl.addEventListener('pointermove',function(e){
-      moved=Math.max(moved, Math.abs(e.clientX-x0));
+      moved=Math.max(moved, Math.hypot(e.clientX-x0, e.clientY-y0));
       var dx=e.clientX-x0;
       if(edge&&dx>36){ edge=false; openRail(); if(navigator.vibrate) navigator.vibrate(6); }
       if(onRail&&dx<-36){ onRail=false; closeRail(); }
     });
-    stageTapEl.addEventListener('pointerup',function(){
+    stageTapEl.addEventListener('pointerup',function(e){
       if(moved>=12||performance.now()-t0>=450) return;
       if(document.body.classList.contains('railopen')){ closeRail(); return; } // 미니 무대 탭 = 복귀
-      hudWake(); // 엣지 스트립 탭 = HUD만
+      var W=innerWidth, x=e.clientX;
+      var zone=x<W/3?'l':(x>W*2/3?'r':'c');
+      var now=performance.now();
+      if(zone===lastZone&&now-lastT<330){ // 더블탭
+        clearTimeout(tapTimer); lastT=0; lastZone='';
+        if(zone==='c'){ if(document.body.classList.contains('clipmode')) clipbox.classList.toggle('cover'); }
+        else stageJump(zone==='r'?1:-1);
+        if(navigator.vibrate) navigator.vibrate(8);
+        return;
+      }
+      lastZone=zone; lastT=now;
+      clearTimeout(tapTimer);
+      tapTimer=setTimeout(function(){
+        if(zone==='c'){ setPlaying(!playing); }
+        hudWake();
+      },330);
     });
   })();
 


### PR DESCRIPTION
Follow-up to #1207 per James's field guidance: the 8904 confusion was
YouTube's paused chrome (now covered by the pause veil), not the
gestures — so the familiar video grammar returns and applies uniformly
to narration AND clips for a continuous experience:

- center 1/3 single tap = play/pause (+HUD)
- left/right 1/3 double-tap = previous/next beat
- center double-tap on clips = cover/contain toggle (zoom grammar)
- left-edge swipe = rail, rail-open tap = return (unchanged)
- mini wheel coexists (jog, hub position, MENU)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
