### PR TITLE
feat(judge): T11 Stage1 — post-done inflow judge shadow

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -318,6 +318,10 @@ services:
       # T10-R (2026-07-13): judge verdicts unreliable both ways (single=false
       # sinks F16, unanimous=recall 3/10) — OFF until T11 dedicated-column era.
       - JUDGE_DEBOOST_ENABLED=false
+      # T11 Stage1 (2026-07-14, supervisor GO): post-done inflow judge SHADOW —
+      # verdicts+metrics into the dedicated judge_verdicts column only;
+      # placement unchanged. Rollback: delete.
+      - T11_INFLOW_JUDGE_ENABLED=true
       # CP416 (2026-04-22) — restore the LoRA action-fill path. Without
       # this, generateMandala() called config.mandalaGen.model=undefined,
       # Ollama /api/generate returned 400, LoRA threw, and the Haiku

--- a/prisma/migrations/t11-inflow-judge/001_add_judge_verdicts.sql
+++ b/prisma/migrations/t11-inflow-judge/001_add_judge_verdicts.sql
@@ -1,0 +1,4 @@
+-- T11 Stage1 (2026-07-14) — inflow judge verdicts, DEDICATED column.
+-- Data-write rule: judge output never overwrites existing fields.
+ALTER TABLE public.mandala_wizard_precompute
+  ADD COLUMN IF NOT EXISTS judge_verdicts jsonb;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -530,6 +530,10 @@ model mandala_wizard_precompute {
   target_level        String?   @db.VarChar(30)
   /// 'pending' | 'running' | 'done' | 'failed' | 'consumed'
   status              String    @default("pending") @db.VarChar(20)
+  /// T11 Stage1 (2026-07-14) — inflow judge verdicts (post-done race, shadow).
+  /// DEDICATED column per the data-write rule: judge output never touches
+  /// relevance_pct. DDL: prisma/migrations/t11-inflow-judge/001_add_judge_verdicts.sql
+  judge_verdicts      Json?     @db.JsonB
   discover_result     Json?
   error_message       String?
   consumed_mandala_id String?   @db.Uuid

--- a/src/config/t11-inflow-judge.ts
+++ b/src/config/t11-inflow-judge.ts
@@ -1,0 +1,65 @@
+/**
+ * T11 Stage1 — inflow judge shadow (design 2026-07-14, supervisor GO).
+ *
+ * Post-done RACE: the unanimous 2-model judge runs fire-and-forget right
+ * AFTER the precompute row is marked done — the SLA path is untouched by
+ * construction (F12's cause was putting judgment ON the path). Verdicts
+ * land in the DEDICATED judge_verdicts column (data-write rule: judge
+ * output never touches relevance_pct).
+ *
+ * Stage1 = shadow: record + metrics only, placement unchanged.
+ * Stage2 (enforce, separate gate): consume drops unanimous-unfit slots
+ * above the per-cell floor.
+ *
+ * Flag default OFF (unset = no judging at all). Rollback: flag flip.
+ */
+
+export function isT11InflowJudgeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['T11_INFLOW_JUDGE_ENABLED'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes';
+}
+
+export interface CellVerdictInput {
+  videoId: string;
+  cellIndex: number;
+  /** Unanimous verdict: false = both legs said unfit. */
+  fit: boolean;
+}
+
+export interface FloorPlanResult {
+  /** videoIds that WOULD be dropped in Stage2 (unfit above the floor). */
+  wouldDrop: string[];
+  /** unfit videoIds kept to honor the floor (marked kept-despite-unfit). */
+  keptDespiteUnfit: string[];
+}
+
+/**
+ * Cell-floor plan (supervisor ①): keep at least `minPerCell` cards per cell —
+ * "덜 정합한 카드 > 빈 셀" (never-zero-floor principle). Only unfit cards
+ * ABOVE the floor are drop candidates; when dropping would sink the cell
+ * below the floor, the needed count of unfit cards is kept (and marked so
+ * the relevance re-score → tone-down path can demote them visually).
+ * Pure function — unit-tested; Stage1 uses it for the would-drop metric,
+ * Stage2 will use it for the actual drop set.
+ */
+export function planCellFloor(cards: CellVerdictInput[], minPerCell: number): FloorPlanResult {
+  const wouldDrop: string[] = [];
+  const keptDespiteUnfit: string[] = [];
+  const byCell = new Map<number, CellVerdictInput[]>();
+  for (const c of cards) {
+    if (!byCell.has(c.cellIndex)) byCell.set(c.cellIndex, []);
+    byCell.get(c.cellIndex)!.push(c);
+  }
+  for (const cellCards of byCell.values()) {
+    const fitCount = cellCards.filter((c) => c.fit).length;
+    const unfit = cellCards.filter((c) => !c.fit);
+    // How many unfit cards must stay to keep the cell at the floor.
+    const mustKeep = Math.max(0, Math.min(unfit.length, minPerCell - fitCount));
+    // Keep order = input order (caller passes score-descending when it matters).
+    unfit.slice(0, mustKeep).forEach((c) => keptDespiteUnfit.push(c.videoId));
+    unfit.slice(mustKeep).forEach((c) => wouldDrop.push(c.videoId));
+  }
+  return { wouldDrop, keptDespiteUnfit };
+}

--- a/src/modules/judge/card-cell-judge.ts
+++ b/src/modules/judge/card-cell-judge.ts
@@ -149,3 +149,66 @@ export async function judgeCellCards(params: {
     fit: legs.some((leg) => leg[i]?.fit !== false),
   }));
 }
+
+export interface JudgeLegDetail {
+  model: string;
+  verdicts: JudgeVerdict[];
+}
+
+export interface JudgeDetailedResult {
+  final: JudgeVerdict[];
+  legs: JudgeLegDetail[];
+}
+
+/**
+ * T11 Stage1 — per-leg detail for the supervisor's shadow metrics (split
+ * rate + directional decomposition gA-only vs gB-only unfit). Same legs and
+ * unanimous rule as judgeCellCards; exposed separately so existing callers
+ * keep the simple contract.
+ */
+export async function judgeCellCardsDetailed(params: {
+  centerGoal: string;
+  cellTopic: string;
+  items: JudgeItem[];
+  generateImpl?: (
+    model: string,
+    prompt: string,
+    options?: { temperature?: number; maxTokens?: number; format?: 'json' }
+  ) => Promise<string>;
+}): Promise<JudgeDetailedResult> {
+  if (params.items.length === 0) return { final: [], legs: [] };
+  const prompt = buildJudgePrompt(params);
+  const generate =
+    params.generateImpl ??
+    (async (
+      model: string,
+      p: string,
+      o?: { temperature?: number; maxTokens?: number; format?: 'json' }
+    ) => {
+      const provider = new OpenRouterGenerationProvider(model);
+      return provider.generate(p, o);
+    });
+  const legs = await Promise.all(
+    JUDGE_MODELS.map(async (model): Promise<JudgeLegDetail> => {
+      try {
+        const raw = await generate(model, prompt, {
+          temperature: JUDGE_TEMPERATURE,
+          maxTokens: JUDGE_MAX_TOKENS,
+          format: 'json',
+        });
+        const verdicts = parseJudgeResponse(raw, params.items);
+        return {
+          model,
+          verdicts: verdicts ?? params.items.map((it) => ({ videoId: it.videoId, fit: true })),
+        };
+      } catch {
+        return { model, verdicts: params.items.map((it) => ({ videoId: it.videoId, fit: true })) };
+      }
+    })
+  );
+  const final = params.items.map((it, i) => ({
+    videoId: it.videoId,
+    fit: legs.some((leg) => leg.verdicts[i]?.fit !== false),
+  }));
+  return { final, legs };
+}

--- a/src/modules/mandala/inflow-judge-shadow.ts
+++ b/src/modules/mandala/inflow-judge-shadow.ts
@@ -1,0 +1,119 @@
+/**
+ * T11 Stage1 — inflow judge shadow runner (design 2026-07-14, supervisor GO).
+ *
+ * Called fire-and-forget AFTER the precompute row is marked done (post-done
+ * race — the SLA path never waits on this). Runs the unanimous 2-model judge
+ * per cell over the precomputed slots and stores verdicts + the supervisor's
+ * four shadow metrics in the DEDICATED judge_verdicts column:
+ *
+ *   split rate            — legs disagree / judged (3-model 재론 트리거 데이터)
+ *   directional split     — gA-only unfit vs gB-only unfit (계통 편향 검출)
+ *   would-drop (floored)  — unfit above the per-cell floor (Stage2 preview)
+ *   verdict arrival race  — consume compares consumed_at vs computed_at
+ *
+ * Shadow contract: NO effect on placement; NO writes outside judge_verdicts.
+ */
+
+import { Prisma } from '@prisma/client';
+import { getPrismaClient } from '@/modules/database/client';
+import { judgeCellCardsDetailed } from '@/modules/judge/card-cell-judge';
+import { planCellFloor, type CellVerdictInput } from '@/config/t11-inflow-judge';
+import { loadPoolServeConfig } from '@/config/pool-serve';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'inflow-judge-shadow' });
+
+export interface InflowSlot {
+  videoId: string;
+  title: string;
+  cellIndex: number;
+}
+
+export async function runInflowJudgeShadow(input: {
+  sessionId: string;
+  centerGoal: string;
+  subGoals: string[];
+  slots: InflowSlot[];
+}): Promise<void> {
+  const t0 = Date.now();
+  try {
+    const byCell = new Map<number, InflowSlot[]>();
+    for (const s of input.slots) {
+      if (s.cellIndex == null || s.cellIndex < 0 || !s.title) continue;
+      if (!byCell.has(s.cellIndex)) byCell.set(s.cellIndex, []);
+      byCell.get(s.cellIndex)!.push(s);
+    }
+    if (byCell.size === 0) return;
+
+    let judged = 0;
+    let split = 0;
+    let gaOnlyUnfit = 0;
+    let gbOnlyUnfit = 0;
+    const verdictInputs: CellVerdictInput[] = [];
+    const cells: Record<string, { videoId: string; fit: boolean; legs: boolean[] }[]> = {};
+
+    await Promise.all(
+      [...byCell.entries()].map(async ([cellIndex, slots]) => {
+        const cellTopic = input.subGoals[cellIndex]?.trim();
+        if (!cellTopic) return;
+        const detailed = await judgeCellCardsDetailed({
+          centerGoal: input.centerGoal,
+          cellTopic,
+          items: slots.map((s) => ({ videoId: s.videoId, title: s.title })),
+        });
+        const cellOut: { videoId: string; fit: boolean; legs: boolean[] }[] = [];
+        detailed.final.forEach((v, i) => {
+          judged += 1;
+          const legFits = detailed.legs.map((leg) => leg.verdicts[i]?.fit !== false);
+          const [ga, gb] = [legFits[0] !== false, legFits[1] !== false];
+          if (ga !== gb) {
+            split += 1;
+            if (!ga && gb) gaOnlyUnfit += 1;
+            if (ga && !gb) gbOnlyUnfit += 1;
+          }
+          verdictInputs.push({ videoId: v.videoId, cellIndex, fit: v.fit });
+          cellOut.push({ videoId: v.videoId, fit: v.fit, legs: legFits });
+        });
+        cells[String(cellIndex)] = cellOut;
+      })
+    );
+
+    const minPerCell = loadPoolServeConfig().minPerCell;
+    const floor = planCellFloor(verdictInputs, minPerCell);
+
+    const payload = {
+      schema: 1,
+      computed_at: new Date().toISOString(),
+      duration_ms: Date.now() - t0,
+      metrics: {
+        judged,
+        unanimous_unfit: verdictInputs.filter((v) => !v.fit).length,
+        split,
+        ga_only_unfit: gaOnlyUnfit,
+        gb_only_unfit: gbOnlyUnfit,
+        would_drop_after_floor: floor.wouldDrop.length,
+        kept_despite_unfit: floor.keptDespiteUnfit.length,
+        min_per_cell: minPerCell,
+      },
+      would_drop: floor.wouldDrop,
+      kept_despite_unfit: floor.keptDespiteUnfit,
+      cells,
+    };
+
+    const db = getPrismaClient();
+    await db.mandala_wizard_precompute.update({
+      where: { session_id: input.sessionId },
+      data: { judge_verdicts: payload as unknown as Prisma.InputJsonValue },
+    });
+    log.info(
+      `[t11-shadow] session=${input.sessionId} judged=${judged} unfit=${payload.metrics.unanimous_unfit} ` +
+        `split=${split} (gaOnly=${gaOnlyUnfit} gbOnly=${gbOnlyUnfit}) wouldDrop=${floor.wouldDrop.length} ` +
+        `keptDespiteUnfit=${floor.keptDespiteUnfit.length} duration_ms=${payload.duration_ms}`
+    );
+  } catch (err) {
+    // Shadow must never disturb anything — swallow (row may be TTL-swept).
+    log.warn(
+      `[t11-shadow] failed (non-fatal): session=${input.sessionId} ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}

--- a/src/modules/mandala/wizard-precompute.ts
+++ b/src/modules/mandala/wizard-precompute.ts
@@ -39,6 +39,7 @@ import {
   ATTACH_BUDGET_MS,
   ATTACH_POLL_INTERVAL_MS,
 } from '@/config/precompute-attach';
+import { isT11InflowJudgeEnabled } from '@/config/t11-inflow-judge';
 import { randomUUID } from 'crypto';
 
 const log = logger.child({ module: 'wizard-precompute' });
@@ -261,6 +262,29 @@ export async function startPrecompute(input: StartPrecomputeInput): Promise<void
         discover_result: result as unknown as Prisma.InputJsonValue,
       },
     });
+
+    // T11 Stage1 (post-done race, supervisor GO 2026-07-14): the unanimous
+    // judge runs AFTER done is marked — the consume SLA path never waits on
+    // it (F12's cause was judging ON the path). Shadow: verdicts + metrics
+    // land in the dedicated judge_verdicts column only; placement unchanged.
+    if (isT11InflowJudgeEnabled() && result.slots.length > 0) {
+      setImmediate(() => {
+        void import('./inflow-judge-shadow')
+          .then(({ runInflowJudgeShadow }) =>
+            runInflowJudgeShadow({
+              sessionId: input.sessionId,
+              centerGoal: input.goal,
+              subGoals: input.subGoals,
+              slots: result.slots.map((sl) => ({
+                videoId: sl.videoId,
+                title: sl.title,
+                cellIndex: sl.cellIndex,
+              })),
+            })
+          )
+          .catch(() => undefined);
+      });
+    }
 
     log.info(
       `precompute done: session=${input.sessionId} slots=${result.slots.length} ` +

--- a/tests/unit/config/t11-inflow-judge.test.ts
+++ b/tests/unit/config/t11-inflow-judge.test.ts
@@ -1,0 +1,62 @@
+/**
+ * T11 Stage1 — flag gate + cell-floor plan semantics (supervisor ①:
+ * keep ≥ minPerCell per cell, drop only the excess unfit; kept-despite-unfit
+ * marked for the tone-down path).
+ */
+import {
+  isT11InflowJudgeEnabled,
+  planCellFloor,
+  type CellVerdictInput,
+} from '@/config/t11-inflow-judge';
+
+const card = (videoId: string, cellIndex: number, fit: boolean): CellVerdictInput => ({
+  videoId,
+  cellIndex,
+  fit,
+});
+
+describe('T11 inflow judge', () => {
+  it('flag defaults off', () => {
+    expect(isT11InflowJudgeEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+    expect(isT11InflowJudgeEnabled({ T11_INFLOW_JUDGE_ENABLED: 'true' } as NodeJS.ProcessEnv)).toBe(
+      true
+    );
+  });
+
+  it('drops unfit only above the floor (개의 심리 case: 10 cards, 7 unfit, floor 3)', () => {
+    const cards = [
+      ...[1, 2, 3].map((i) => card(`fit${i}`, 1, true)),
+      ...[1, 2, 3, 4, 5, 6, 7].map((i) => card(`bad${i}`, 1, false)),
+    ];
+    const plan = planCellFloor(cards, 3);
+    // 3 fit already meet the floor → all 7 unfit droppable.
+    expect(plan.wouldDrop).toHaveLength(7);
+    expect(plan.keptDespiteUnfit).toHaveLength(0);
+  });
+
+  it('keeps unfit to honor the floor when fit cards are scarce (1 fit, 4 unfit, floor 3)', () => {
+    const cards = [card('fit1', 2, true), ...[1, 2, 3, 4].map((i) => card(`bad${i}`, 2, false))];
+    const plan = planCellFloor(cards, 3);
+    expect(plan.keptDespiteUnfit).toHaveLength(2); // 1 fit + 2 kept = floor 3
+    expect(plan.wouldDrop).toHaveLength(2);
+  });
+
+  it('all-unfit thin cell keeps everything up to the floor (2 unfit, floor 3 → drop 0)', () => {
+    const cards = [card('bad1', 3, false), card('bad2', 3, false)];
+    const plan = planCellFloor(cards, 3);
+    expect(plan.wouldDrop).toHaveLength(0);
+    expect(plan.keptDespiteUnfit).toHaveLength(2);
+  });
+
+  it('cells are independent', () => {
+    const cards = [
+      card('a1', 0, false),
+      card('a2', 0, true),
+      ...[1, 2, 3, 4].map((i) => card(`b${i}`, 1, true)),
+      card('b5', 1, false),
+    ];
+    const plan = planCellFloor(cards, 1);
+    expect(plan.wouldDrop.sort()).toEqual(['a1', 'b5']);
+    expect(plan.keptDespiteUnfit).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Design (T11, supervisor Stage1 GO 2026-07-14)
**Post-done race, not capped-pre-done**: the unanimous 2-model judge fires AFTER `status='done'` — the consume SLA path never waits on it (F12/#1085's failure mode was judging ON the path). Verdicts race the user's click (measured window: create→consume p50 18s, discover 5-11s). Stage2 (separate gate, after shadow data) will let consume drop unanimous-unfit slots **above the per-cell floor**.

## Stage1 = shadow only
- Verdicts + supervisor's 4 metrics → **new dedicated `judge_verdicts` JSONB** on `mandala_wizard_precompute` (raw DDL companion): split rate · gA-only vs gB-only unfit (계통 편향) · would-drop after floor (tail distribution) · computed_at for arrival-race measurement.
- **Placement unchanged, no UI change, `relevance_pct` untouched** (T10 data-write rule).
- `planCellFloor`: ≥ `V5_POOL_SERVE_MIN_PER_CELL`(3) per cell — '덜 정합한 카드 > 빈 셀' (supervisor ①); kept-despite-unfit marked for the canonical tone-down path. Pure fn, 5 tests incl. the 개의심리 7/10-unfit case.
- Flag `T11_INFLOW_JUDGE_ENABLED` (default off), compose on.

## Verification
tsc 0 · tests 15/15 (floor semantics + judge suite) · hardcode-audit baseline. Local dev DB lacks the parent table (pre-existing drift) — DDL via CI push + manual psql fallback if silent-fail. Post-deploy: E2E wizard run → `judge_verdicts` populated + `[t11-shadow]` metrics log + precompute p95/HIT unchanged.

Data-Write: none-existing (new dedicated column only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)