### PR TITLE
fix(email): note-ready CTA linked a nonexistent route — emit two-segment learning URL

### DIFF
--- a/src/modules/email/note-ready-cta.ts
+++ b/src/modules/email/note-ready-cta.ts
@@ -1,0 +1,33 @@
+/**
+ * Note-ready email CTA — pure helpers (config-free, unit-testable).
+ *
+ * The FE learning route is `/learning/:mandalaId/:videoId` (two segments,
+ * frontend/src/app/router/index.tsx). A bare `/learning/:mandalaId` matches no
+ * route and client-renders the 404 page — the exact bug a sample-email click
+ * surfaced on 2026-07-14. Always emit a two-segment URL, or fall back to the
+ * mandala dashboard (a real route) when the book has no video to focus.
+ */
+
+const SITE_ORIGIN = 'https://insighta.one';
+
+/** Loose book_json walk — DB jsonb, so trust nothing about the shape. */
+export function firstBookVideoId(bookJson: unknown): string | null {
+  const book = bookJson as {
+    chapters?: Array<{ sections?: Array<{ atoms?: Array<{ vid?: unknown }> }> }>;
+  } | null;
+  for (const chapter of book?.chapters ?? []) {
+    for (const section of chapter?.sections ?? []) {
+      for (const atom of section?.atoms ?? []) {
+        if (typeof atom?.vid === 'string' && atom.vid.length > 0) return atom.vid;
+      }
+    }
+  }
+  return null;
+}
+
+/** Two-segment learning deep link when a focus video exists; dashboard otherwise. */
+export function noteReadyCtaUrl(mandalaId: string, videoId: string | null): string {
+  return videoId
+    ? `${SITE_ORIGIN}/learning/${mandalaId}/${videoId}`
+    : `${SITE_ORIGIN}/mandalas/${mandalaId}`;
+}

--- a/src/modules/queue/handlers/mandala-book-fill.ts
+++ b/src/modules/queue/handlers/mandala-book-fill.ts
@@ -17,6 +17,7 @@ import { getJobQueue } from '../manager';
 import { JOB_NAMES, MANDALA_BOOK_FILL_OPTIONS, type MandalaBookFillPayload } from '../types';
 import { richSummaryWorkOptions } from './rich-summary-work-options';
 import { sendNoteReadyEmail } from '@/modules/email/transactional';
+import { firstBookVideoId, noteReadyCtaUrl } from '@/modules/email/note-ready-cta';
 
 const log = logger.child({ module: 'queue/mandala-book-fill' });
 
@@ -33,9 +34,15 @@ async function notifyNoteReady(userId: string, mandalaId: string): Promise<void>
     });
     const to = mandala?.users?.email ?? '';
     if (!to) return;
+    // The learning route needs a videoId segment — link to the book's first
+    // video, or the mandala dashboard when none is extractable.
+    const book = await getPrismaClient().mandala_books.findUnique({
+      where: { mandala_id: mandalaId },
+      select: { book_json: true },
+    });
     await sendNoteReadyEmail(to, {
       mandalaName: mandala?.title ?? '내 만다라',
-      ctaUrl: `https://insighta.one/learning/${mandalaId}`,
+      ctaUrl: noteReadyCtaUrl(mandalaId, firstBookVideoId(book?.book_json)),
     });
   } catch (err) {
     log.warn('note-ready email skipped (non-fatal)', {

--- a/tests/unit/modules/note-ready-cta.test.ts
+++ b/tests/unit/modules/note-ready-cta.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Note-ready email CTA — route-shape regression guard.
+ *
+ * Bug (2026-07-14, sample-email click): the note-ready CTA linked to
+ * `/learning/:mandalaId` but the FE router only defines
+ * `/learning/:mandalaId/:videoId` — the emailed link client-rendered the 404
+ * page. These tests pin the CTA to real routes: a two-segment learning link
+ * when the book has a video, the mandala dashboard when it does not.
+ */
+
+import { firstBookVideoId, noteReadyCtaUrl } from '../../../src/modules/email/note-ready-cta';
+
+describe('firstBookVideoId', () => {
+  it('returns the first atom vid across chapters/sections', () => {
+    const book = {
+      chapters: [
+        { sections: [{ atoms: [] }, { atoms: [{ vid: 'abc123DEF45' }, { vid: 'zzz' }] }] },
+        { sections: [{ atoms: [{ vid: 'later' }] }] },
+      ],
+    };
+    expect(firstBookVideoId(book)).toBe('abc123DEF45');
+  });
+
+  it('returns null for empty or malformed book_json', () => {
+    expect(firstBookVideoId(null)).toBeNull();
+    expect(firstBookVideoId(undefined)).toBeNull();
+    expect(firstBookVideoId({})).toBeNull();
+    expect(firstBookVideoId({ chapters: [{ sections: [{ atoms: [{ vid: 42 }] }] }] })).toBeNull();
+    expect(firstBookVideoId({ chapters: 'not-an-array' })).toBeNull();
+  });
+});
+
+describe('noteReadyCtaUrl', () => {
+  it('emits the two-segment learning route when a video exists', () => {
+    const url = noteReadyCtaUrl('m-1', 'v-1');
+    expect(url).toBe('https://insighta.one/learning/m-1/v-1');
+    // FE route contract: /learning/:mandalaId/:videoId — exactly two segments.
+    const path = new URL(url).pathname;
+    expect(path.split('/').filter(Boolean)).toHaveLength(3);
+  });
+
+  it('falls back to the mandala dashboard (a real route) without a video', () => {
+    expect(noteReadyCtaUrl('m-1', null)).toBe('https://insighta.one/mandalas/m-1');
+  });
+
+  it('never emits the broken one-segment learning URL', () => {
+    for (const vid of [null, 'v-1']) {
+      const path = new URL(noteReadyCtaUrl('m-1', vid)).pathname;
+      expect(path).not.toMatch(/^\/learning\/[^/]+$/);
+    }
+  });
+});


### PR DESCRIPTION
## Problem
The note-ready email's **노트 읽어보기** CTA linked `/learning/:mandalaId`, but the FE router only defines `/learning/:mandalaId/:videoId` (router/index.tsx:120) — the emailed link client-renders the 404 page. Caught by an owner sample-email click on 2026-07-14.

## Fix
- `note-ready-cta.ts` (pure helpers): `firstBookVideoId()` walks the just-filled `book_json` (chapters → sections → atoms) for the first video; `noteReadyCtaUrl()` emits the two-segment learning deep link, or the mandala dashboard (`/mandalas/:id`, a real route) when no video is extractable.
- `mandala-book-fill.ts` `notifyNoteReady()` reads `mandala_books.book_json` and uses the helpers.

## Verification
- BE tsc 0; 14/14 (5 new route-shape regression tests incl. a "never emit one-segment learning URL" guard + 9 existing gate tests)
- Prod browser check with a real mandala/video pair before the corrected sample is re-sent

Flag-gated as before (`TRANSACTIONAL_EMAIL_ENABLED` off in prod) — no behavior change until flag-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)