### PR TITLE
fix(email): pre-signup beta invite email + note CTA aligned to learning-page source

### DIFF
--- a/frontend/src/__tests__/learning-view-param.test.ts
+++ b/frontend/src/__tests__/learning-view-param.test.ts
@@ -1,0 +1,18 @@
+/**
+ * ?view=note deep-link guard — the note-ready email CTA lands in note mode.
+ * LearningPage flips the store to 'note' when isNoteViewParam matches; this
+ * pins the param contract (exact 'note', nothing else).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isNoteViewParam } from '@/pages/learning/model/useLearningStore';
+
+describe('isNoteViewParam', () => {
+  it('matches only view=note', () => {
+    expect(isNoteViewParam('note')).toBe(true);
+    expect(isNoteViewParam(null)).toBe(false);
+    expect(isNoteViewParam('')).toBe(false);
+    expect(isNoteViewParam('player')).toBe(false);
+    expect(isNoteViewParam('NOTE')).toBe(false);
+  });
+});

--- a/frontend/src/pages/learning/model/useLearningStore.ts
+++ b/frontend/src/pages/learning/model/useLearningStore.ts
@@ -5,6 +5,9 @@ export type CenterTab = 'chapters' | 'summary';
 
 export type CenterViewMode = 'player' | 'note';
 
+/** `?view=note` deep links (note-ready email CTA) land directly in note mode. */
+export const isNoteViewParam = (v: string | null): boolean => v === 'note';
+
 export type ActiveRegion = 'sidebar' | 'player' | 'book-index' | 'notes' | 'chat' | null;
 
 export type PlayerState = 'playing' | 'paused' | 'buffering' | 'ended' | 'unstarted' | 'cued';

--- a/frontend/src/pages/learning/ui/LearningPage.tsx
+++ b/frontend/src/pages/learning/ui/LearningPage.tsx
@@ -3,7 +3,7 @@ import { useRef, useCallback, useState, useLayoutEffect, useEffect } from 'react
 import { useParams, useSearchParams } from 'react-router-dom';
 import { CenterPanel } from './CenterPanel';
 import { RightPanel } from './RightPanel';
-import { useLearningStore } from '@/pages/learning/model/useLearningStore';
+import { useLearningStore, isNoteViewParam } from '@/pages/learning/model/useLearningStore';
 import { useSaveWatchPosition } from '@/pages/learning/model/useSaveWatchPosition';
 import type { YTPlayer } from '@/widgets/video-player/model/youtube-api';
 
@@ -31,6 +31,14 @@ export default function LearningPage() {
   }, [videoId]);
 
   const centerViewMode = useLearningStore((s) => s.centerViewMode);
+  const setCenterViewMode = useLearningStore((s) => s.setCenterViewMode);
+
+  // ?view=note — email deep links promise the note, not the player. Store
+  // default is 'player', so external entries need this to land in note mode.
+  const viewParam = searchParams.get('view');
+  useEffect(() => {
+    if (isNoteViewParam(viewParam)) setCenterViewMode('note');
+  }, [viewParam, setCenterViewMode]);
 
   // CP438+1: ?t=N query param drives in-page seek. When the user clicks
   // an atom timestamp link in the sidebar/panel, the same-video case

--- a/src/api/routes/admin/beta-applications.ts
+++ b/src/api/routes/admin/beta-applications.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { getPrismaClient } from '../../../modules/database/client';
-import { sendWelcomeEmail } from '../../../modules/email/transactional';
+import { sendBetaInviteEmail } from '../../../modules/email/transactional';
 
 /**
  * Admin — closed-beta application inbox (invitations are sent manually).
@@ -34,8 +34,9 @@ export async function adminBetaApplicationRoutes(fastify: FastifyInstance) {
         where: { id: request.params.id },
         data: { status: 'invited', invited_at: new Date() },
       });
-      // Fire the welcome+onboarding invite email (internally flag-gated + non-fatal).
-      await sendWelcomeEmail(updated.email, { ctaUrl: 'https://insighta.one/login' });
+      // Pre-signup moment: announce the invitation, drive signup with this
+      // email, and carry the onboarding guide (internally flag-gated + non-fatal).
+      await sendBetaInviteEmail(updated.email, { goal: updated.goal });
       return reply.send({ application: updated });
     }
   );

--- a/src/modules/email/note-ready-cta.ts
+++ b/src/modules/email/note-ready-cta.ts
@@ -1,33 +1,20 @@
 /**
- * Note-ready email CTA — pure helpers (config-free, unit-testable).
+ * Note-ready email CTA — pure helper (config-free, unit-testable).
  *
  * The FE learning route is `/learning/:mandalaId/:videoId` (two segments,
- * frontend/src/app/router/index.tsx). A bare `/learning/:mandalaId` matches no
- * route and client-renders the 404 page — the exact bug a sample-email click
- * surfaced on 2026-07-14. Always emit a two-segment URL, or fall back to the
- * mandala dashboard (a real route) when the book has no video to focus.
+ * frontend/src/app/router/index.tsx); `?view=note` lands directly in note mode
+ * (the CTA promises the note, not the player). The focus video MUST come from
+ * the same source the learning page renders (user_local_cards placed cards) —
+ * a book-atom pick can target a mandala whose learning list is empty, which
+ * reads as a broken page (2026-07-14 sample regression). No placed video →
+ * link the mandala dashboard, never a hollow learning deep link.
  */
 
 const SITE_ORIGIN = 'https://insighta.one';
 
-/** Loose book_json walk — DB jsonb, so trust nothing about the shape. */
-export function firstBookVideoId(bookJson: unknown): string | null {
-  const book = bookJson as {
-    chapters?: Array<{ sections?: Array<{ atoms?: Array<{ vid?: unknown }> }> }>;
-  } | null;
-  for (const chapter of book?.chapters ?? []) {
-    for (const section of chapter?.sections ?? []) {
-      for (const atom of section?.atoms ?? []) {
-        if (typeof atom?.vid === 'string' && atom.vid.length > 0) return atom.vid;
-      }
-    }
-  }
-  return null;
-}
-
-/** Two-segment learning deep link when a focus video exists; dashboard otherwise. */
+/** Note-mode learning deep link when a placed video exists; dashboard otherwise. */
 export function noteReadyCtaUrl(mandalaId: string, videoId: string | null): string {
   return videoId
-    ? `${SITE_ORIGIN}/learning/${mandalaId}/${videoId}`
+    ? `${SITE_ORIGIN}/learning/${mandalaId}/${videoId}?view=note`
     : `${SITE_ORIGIN}/mandalas/${mandalaId}`;
 }

--- a/src/modules/email/templates.ts
+++ b/src/modules/email/templates.ts
@@ -102,11 +102,78 @@ export function buildWelcomeEmail(params: WelcomeEmailParams): { subject: string
       <div style="text-align:center;font-size:12px;color:${MUTED};margin-top:16px">3분이면 충분해요 · 언제든 이어서 할 수 있어요</div>
     </td></tr>`;
   return {
-    subject: 'Insighta 클로즈드 베타에 초대합니다 — 3분이면 첫 만다라',
+    // Post-signup welcome tone — the pre-signup moment is buildBetaInviteEmail.
+    subject: '환영해요 — 3분이면 첫 만다라',
     html: shell(
       { label: 'WELCOME', color: GOLD },
       inner,
       '목표만 정하세요, 영상은 저희가 채울게요.'
+    ),
+  };
+}
+
+export interface BetaInviteEmailParams {
+  /** Learning-goal sentence from the beta application form (optional). */
+  goal?: string | null;
+  ctaUrl?: string;
+}
+
+/**
+ * Beta invite — sent when admin marks an application invited. The recipient is
+ * NOT a member yet: the email must announce the invitation, drive signup with
+ * the applied email (the invite gate matches on it), and carry the onboarding
+ * guide in one message.
+ */
+export function buildBetaInviteEmail(params: BetaInviteEmailParams): {
+  subject: string;
+  html: string;
+} {
+  const url = params.ctaUrl ?? `${SITE_ORIGIN}/login`;
+  const goal = params.goal?.trim() ? esc(params.goal.trim()) : '';
+  const goalCard = goal
+    ? `<table role="presentation" width="100%" style="border:2px solid ${INK};border-radius:14px;background:#fff;margin-top:16px"><tr>
+        <td style="padding:13px 16px">
+          <div style="font-size:11px;font-weight:800;letter-spacing:.08em;color:${MUTED}">남겨주신 학습 목표</div>
+          <div style="font-size:14px;font-weight:800;color:${INK};margin-top:4px">“${goal}”</div>
+        </td>
+      </tr></table>`
+    : '';
+  const rows = [
+    ['신청하신 이메일로 로그인', '이 이메일의 구글 계정으로 로그인하면 초대가 바로 적용돼요.'],
+    ['목표 하나를 정하기', '남겨주신 목표를 만다라로 펼쳐, 딱 맞는 영상을 채워 드려요.'],
+    ['노트가 저절로', '담은 영상의 핵심을 엮어 ‘10분만에 보는 책’ 노트를 만들어 드려요.'],
+  ]
+    .map(
+      ([t, d], i) =>
+        `<tr><td style="padding:13px 2px;border-top:1px dashed #d7d3c6">
+          <table role="presentation"><tr>
+            <td style="width:28px;height:28px;border:2px solid ${INK};border-radius:9px;color:${INDIGO};font-weight:800;font-size:13px;text-align:center;background:#fff">${i + 1}</td>
+            <td style="padding-left:14px">
+              <div style="font-size:14.5px;font-weight:800;color:${INK}">${t}</div>
+              <div style="font-size:12.5px;color:${MUTED};margin-top:2px">${d}</div>
+            </td>
+          </tr></table>
+        </td></tr>`
+    )
+    .join('');
+  const inner = `
+    <tr><td style="padding:14px 26px 2px;text-align:center">${mascot('mascot-welcome.gif')}</td></tr>
+    <tr><td style="padding:8px 30px 2px;text-align:center">
+      ${heading('베타테스트에', '초대합니다')}
+      <div style="font-size:14px;color:${MUTED};margin:10px auto 0;max-width:330px;line-height:1.5">신청해 주셔서 감사해요. 자리가 준비됐어요 — 이 이메일로 로그인하면 바로 시작돼요.</div>
+    </td></tr>
+    <tr><td style="padding:4px 30px 30px">
+      ${goalCard}
+      <table role="presentation" width="100%" style="margin-top:14px">${rows}</table>
+      <div style="text-align:center;margin-top:24px">${cta('베타 참여 시작하기', url, INDIGO)}</div>
+      <div style="text-align:center;font-size:12px;color:${MUTED};margin-top:16px">베타 기간 2026. 7. 13 – 8. 24 · 베타 기간에는 모든 기능이 무료예요</div>
+    </td></tr>`;
+  return {
+    subject: 'Insighta 클로즈드 베타에 초대합니다 — 자리가 준비됐어요',
+    html: shell(
+      { label: 'INVITED', color: INDIGO },
+      inner,
+      '클로즈드 베타 자리가 준비됐어요 — 이 이메일로 로그인하면 시작돼요.'
     ),
   };
 }

--- a/src/modules/email/transactional.ts
+++ b/src/modules/email/transactional.ts
@@ -11,8 +11,10 @@ import { logger } from '@/utils/logger';
 import {
   buildWelcomeEmail,
   buildNoteReadyEmail,
+  buildBetaInviteEmail,
   type WelcomeEmailParams,
   type NoteReadyEmailParams,
+  type BetaInviteEmailParams,
 } from './templates';
 
 const log = logger.child({ module: 'email/transactional' });
@@ -48,6 +50,14 @@ async function send(to: string, subject: string, html: string, tag: string): Pro
 export async function sendWelcomeEmail(to: string, params: WelcomeEmailParams): Promise<void> {
   const { subject, html } = buildWelcomeEmail(params);
   await send(to, subject, html, 'welcome-email');
+}
+
+export async function sendBetaInviteEmail(
+  to: string,
+  params: BetaInviteEmailParams
+): Promise<void> {
+  const { subject, html } = buildBetaInviteEmail(params);
+  await send(to, subject, html, 'beta-invite-email');
 }
 
 export async function sendNoteReadyEmail(to: string, params: NoteReadyEmailParams): Promise<void> {

--- a/src/modules/queue/handlers/mandala-book-fill.ts
+++ b/src/modules/queue/handlers/mandala-book-fill.ts
@@ -17,7 +17,7 @@ import { getJobQueue } from '../manager';
 import { JOB_NAMES, MANDALA_BOOK_FILL_OPTIONS, type MandalaBookFillPayload } from '../types';
 import { richSummaryWorkOptions } from './rich-summary-work-options';
 import { sendNoteReadyEmail } from '@/modules/email/transactional';
-import { firstBookVideoId, noteReadyCtaUrl } from '@/modules/email/note-ready-cta';
+import { noteReadyCtaUrl } from '@/modules/email/note-ready-cta';
 
 const log = logger.child({ module: 'queue/mandala-book-fill' });
 
@@ -34,15 +34,21 @@ async function notifyNoteReady(userId: string, mandalaId: string): Promise<void>
     });
     const to = mandala?.users?.email ?? '';
     if (!to) return;
-    // The learning route needs a videoId segment — link to the book's first
-    // video, or the mandala dashboard when none is extractable.
-    const book = await getPrismaClient().mandala_books.findUnique({
-      where: { mandala_id: mandalaId },
-      select: { book_json: true },
+    // Focus video from the SAME source the learning page renders (placed
+    // cards) — a book-atom pick can land on an empty learning list.
+    const firstCard = await getPrismaClient().user_local_cards.findFirst({
+      where: {
+        user_id: userId,
+        mandala_id: mandalaId,
+        cell_index: { gte: 0 },
+        video_id: { not: null },
+      },
+      orderBy: [{ cell_index: 'asc' }, { sort_order: 'asc' }],
+      select: { video_id: true },
     });
     await sendNoteReadyEmail(to, {
       mandalaName: mandala?.title ?? '내 만다라',
-      ctaUrl: noteReadyCtaUrl(mandalaId, firstBookVideoId(book?.book_json)),
+      ctaUrl: noteReadyCtaUrl(mandalaId, firstCard?.video_id ?? null),
     });
   } catch (err) {
     log.warn('note-ready email skipped (non-fatal)', {

--- a/tests/unit/modules/beta-invite-email.test.ts
+++ b/tests/unit/modules/beta-invite-email.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Beta invite email — content contract.
+ *
+ * Service-planning correction (2026-07-14): the mark-invited moment is
+ * PRE-signup. The email must announce the invitation, drive signup with the
+ * applied email, and carry the onboarding guide — the post-signup welcome
+ * template was the wrong tone for this moment.
+ */
+
+import { buildBetaInviteEmail, buildWelcomeEmail } from '../../../src/modules/email/templates';
+
+describe('buildBetaInviteEmail', () => {
+  it('announces the invite, drives signup, and carries onboarding', () => {
+    const { subject, html } = buildBetaInviteEmail({ goal: '토플 성적 100점 달성' });
+    expect(subject).toContain('초대');
+    // Signup CTA — invite gate matches on the applied email at /login.
+    expect(html).toContain('https://insighta.one/login');
+    expect(html).toContain('신청하신 이메일로 로그인');
+    // Onboarding guide travels in the same email.
+    expect(html).toContain('목표 하나를 정하기');
+    expect(html).toContain('노트가 저절로');
+    // Applicant's goal is echoed back.
+    expect(html).toContain('토플 성적 100점 달성');
+    expect(html).toContain('INVITED');
+  });
+
+  it('escapes the applicant goal and tolerates a missing one', () => {
+    const withXss = buildBetaInviteEmail({ goal: '<script>x</script>' });
+    expect(withXss.html).not.toContain('<script>');
+    expect(withXss.html).toContain('&lt;script&gt;');
+    const without = buildBetaInviteEmail({});
+    expect(without.html).toContain('https://insighta.one/login');
+    expect(without.html).not.toContain('남겨주신 학습 목표');
+  });
+
+  it('welcome template keeps the post-signup tone (no invite subject)', () => {
+    expect(buildWelcomeEmail({}).subject).not.toContain('초대');
+  });
+});

--- a/tests/unit/modules/note-ready-cta.test.ts
+++ b/tests/unit/modules/note-ready-cta.test.ts
@@ -1,42 +1,26 @@
 /**
  * Note-ready email CTA — route-shape regression guard.
  *
- * Bug (2026-07-14, sample-email click): the note-ready CTA linked to
- * `/learning/:mandalaId` but the FE router only defines
- * `/learning/:mandalaId/:videoId` — the emailed link client-rendered the 404
- * page. These tests pin the CTA to real routes: a two-segment learning link
- * when the book has a video, the mandala dashboard when it does not.
+ * Bug lineage (2026-07-14): ① CTA linked `/learning/:mandalaId` but the FE
+ * router only defines `/learning/:mandalaId/:videoId` → emailed link 404s.
+ * ② A book-atom video pick landed on a mandala whose learning list (placed
+ * cards) was empty → hollow page. The CTA now uses the page's own source and
+ * opens note mode directly (`?view=note`); with no placed video it links the
+ * dashboard instead.
  */
 
-import { firstBookVideoId, noteReadyCtaUrl } from '../../../src/modules/email/note-ready-cta';
-
-describe('firstBookVideoId', () => {
-  it('returns the first atom vid across chapters/sections', () => {
-    const book = {
-      chapters: [
-        { sections: [{ atoms: [] }, { atoms: [{ vid: 'abc123DEF45' }, { vid: 'zzz' }] }] },
-        { sections: [{ atoms: [{ vid: 'later' }] }] },
-      ],
-    };
-    expect(firstBookVideoId(book)).toBe('abc123DEF45');
-  });
-
-  it('returns null for empty or malformed book_json', () => {
-    expect(firstBookVideoId(null)).toBeNull();
-    expect(firstBookVideoId(undefined)).toBeNull();
-    expect(firstBookVideoId({})).toBeNull();
-    expect(firstBookVideoId({ chapters: [{ sections: [{ atoms: [{ vid: 42 }] }] }] })).toBeNull();
-    expect(firstBookVideoId({ chapters: 'not-an-array' })).toBeNull();
-  });
-});
+import { noteReadyCtaUrl } from '../../../src/modules/email/note-ready-cta';
 
 describe('noteReadyCtaUrl', () => {
-  it('emits the two-segment learning route when a video exists', () => {
+  it('emits the two-segment learning route in note mode when a video exists', () => {
     const url = noteReadyCtaUrl('m-1', 'v-1');
-    expect(url).toBe('https://insighta.one/learning/m-1/v-1');
+    const parsed = new URL(url);
+    expect(parsed.origin).toBe('https://insighta.one');
     // FE route contract: /learning/:mandalaId/:videoId — exactly two segments.
-    const path = new URL(url).pathname;
-    expect(path.split('/').filter(Boolean)).toHaveLength(3);
+    expect(parsed.pathname).toBe('/learning/m-1/v-1');
+    expect(parsed.pathname.split('/').filter(Boolean)).toHaveLength(3);
+    // The CTA promises the note — must land in note mode.
+    expect(parsed.searchParams.get('view')).toBe('note');
   });
 
   it('falls back to the mandala dashboard (a real route) without a video', () => {


### PR DESCRIPTION
## What

**1. Beta invite email (service-planning correction)**
Mark-invited is a PRE-signup moment — the applicant is not a member yet. New `buildBetaInviteEmail` announces the invitation, drives signup with the applied email (the invite gate matches on it at /login), echoes the applicant's learning goal, and carries the 3-step onboarding guide — one email, same approved design language (cream card, INVITED pill, GIF mascot). `mark-invited` now sends this instead of the post-signup welcome template (which stays for a future signup hook, subject re-toned).

**2. Note-ready CTA follow-through (widens #1212)**
An owner click showed the emailed link landing on a learning page with an empty list (0 videos): the focus video was picked from `book_json` atoms while the page renders `user_local_cards` placed cards — different sources. The CTA now:
- picks the first **placed card** (`cell_index >= 0`, `video_id` present) — the page's own source
- opens **note mode directly** via new `?view=note` deep-link param on LearningPage (the CTA promises the note, not the player)
- falls back to the mandala dashboard when no placed video exists (never a hollow learning page)

## Verification
- BE tsc 0; 30/30 (invite content contract incl. XSS-escape + CTA route-shape guards + gate/beta smoke)
- FE tsc 0; vitest 514/514; build + dev smoke 200
- Invite sample rendered from this branch and sent to the owner inbox for visual sign-off

Still fully flag-gated (`TRANSACTIONAL_EMAIL_ENABLED` off in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)