### PR TITLE
fix(email): note CTA focus video from uvs∪ulc + pin supabase CLI (EF deploy rate-limit)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,9 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # Pinned: 'latest' resolves via unauthenticated GitHub API and rate-limits
+          # on shared runners (2 consecutive EF-deploy failures, 2026-07-14).
+          version: 2.109.1
 
       - name: Deploy Edge Functions
         env:

--- a/src/modules/queue/handlers/mandala-book-fill.ts
+++ b/src/modules/queue/handlers/mandala-book-fill.ts
@@ -34,21 +34,37 @@ async function notifyNoteReady(userId: string, mandalaId: string): Promise<void>
     });
     const to = mandala?.users?.email ?? '';
     if (!to) return;
-    // Focus video from the SAME source the learning page renders (placed
-    // cards) — a book-atom pick can land on an empty learning list.
-    const firstCard = await getPrismaClient().user_local_cards.findFirst({
+    // Focus video from the SAME sources the learning page renders
+    // (useMandalaCards = user_video_states ∪ user_local_cards, placed only).
+    // uvs is the dominant table (auto-add/wizard cards) and is video-UUID
+    // keyed — join youtube_videos for the 11-char id the /learning route uses.
+    const synced = await getPrismaClient().userVideoState.findFirst({
       where: {
         user_id: userId,
         mandala_id: mandalaId,
         cell_index: { gte: 0 },
-        video_id: { not: null },
+        is_in_ideation: false,
       },
       orderBy: [{ cell_index: 'asc' }, { sort_order: 'asc' }],
-      select: { video_id: true },
+      select: { video: { select: { youtube_video_id: true } } },
     });
+    let focusVideoId = synced?.video?.youtube_video_id ?? null;
+    if (!focusVideoId) {
+      const local = await getPrismaClient().user_local_cards.findFirst({
+        where: {
+          user_id: userId,
+          mandala_id: mandalaId,
+          cell_index: { gte: 0 },
+          video_id: { not: null },
+        },
+        orderBy: [{ cell_index: 'asc' }, { sort_order: 'asc' }],
+        select: { video_id: true },
+      });
+      focusVideoId = local?.video_id ?? null;
+    }
     await sendNoteReadyEmail(to, {
       mandalaName: mandala?.title ?? '내 만다라',
-      ctaUrl: noteReadyCtaUrl(mandalaId, firstCard?.video_id ?? null),
+      ctaUrl: noteReadyCtaUrl(mandalaId, focusVideoId),
     });
   } catch (err) {
     log.warn('note-ready email skipped (non-fatal)', {


### PR DESCRIPTION
## What

**1. Note CTA picks from the learning page's REAL sources**
`useMandalaCards` renders `user_video_states ∪ user_local_cards` (placed, out-of-ideation). The #1214 picker queried ulc only — uvs is the dominant table (auto-add/wizard cards; a real owner account had ZERO placed ulc rows), so real emails would all have fallen back to the dashboard. Now: uvs first (joined to `youtube_videos.youtube_video_id` — uvs is video-UUID keyed, the /learning route wants the 11-char id) → ulc → dashboard.

**2. EF deploy rate-limit root fix**
`supabase/setup-cli` with `version: latest` resolves via the unauthenticated GitHub API and rate-limited two consecutive EF deploys today. Pinned to 2.109.1 (what latest resolves to, measured).

## Verification
- BE tsc 0; 12/12 (CTA route-shape + gate/refill smoke)
- Prod read-only queries verified the source split (ulc placed = 0 for the owner across all mandalas; uvs is where placed cards live)

Flag-gated as before — no email goes out until `TRANSACTIONAL_EMAIL_ENABLED` is flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)