### PR TITLE
feat(judge): T11 model panel — 5-leg shadow experiment

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -322,6 +322,9 @@ services:
       # verdicts+metrics into the dedicated judge_verdicts column only;
       # placement unchanged. Rollback: delete.
       - T11_INFLOW_JUDGE_ENABLED=true
+      # T11 model panel (James 2026-07-14): 5-leg shadow experiment — panel
+      # legs recorded, verdict stays the production pair. Rollback: delete.
+      - T11_JUDGE_PANEL_ENABLED=true
       # CP416 (2026-04-22) — restore the LoRA action-fill path. Without
       # this, generateMandala() called config.mandalaGen.model=undefined,
       # Ollama /api/generate returned 400, LoRA threw, and the Haiku

--- a/src/config/t11-inflow-judge.ts
+++ b/src/config/t11-inflow-judge.ts
@@ -14,6 +14,30 @@
  * Flag default OFF (unset = no judging at all). Rollback: flag flip.
  */
 
+/**
+ * T11 model-panel experiment (James-directed, hypothesis-first 2026-07-14).
+ * H1: judge failure axis = Korean-YouTube literacy + instruction adherence,
+ * not model size. H2: legs must come from different vendors. H3: flash tier
+ * suffices. Panel rides the SERVICE shadow path (no offline experiment
+ * scripts — LLM-API hard rule): every organic mandala judges on all panel
+ * models; fixtures (반려견/라떼아트) provide the labeled scorecard.
+ * DeepSeek stays as the control leg for the collapse hypothesis.
+ */
+export const JUDGE_PANEL_MODELS = [
+  'google/gemini-2.5-flash', // 현직 gA — 기준선 (엄격 축)
+  'openai/gpt-4o-mini', // 지시준수 정밀 + 계통 다양성
+  'anthropic/claude-haiku-4.5', // 한국어·지시준수, 서비스 현역
+  'qwen/qwen3-30b-a3b-instruct-2507', // 중국계 대표, v2 현역
+  'deepseek/deepseek-v4-flash', // 현직 gB — 붕괴 가설 대조군
+] as const;
+
+export function isT11JudgePanelEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = String(env['T11_JUDGE_PANEL_ENABLED'] ?? '')
+    .trim()
+    .toLowerCase();
+  return v === 'true' || v === '1' || v === 'yes';
+}
+
 export function isT11InflowJudgeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const v = String(env['T11_INFLOW_JUDGE_ENABLED'] ?? '')
     .trim()

--- a/src/modules/judge/card-cell-judge.ts
+++ b/src/modules/judge/card-cell-judge.ts
@@ -170,6 +170,8 @@ export async function judgeCellCardsDetailed(params: {
   centerGoal: string;
   cellTopic: string;
   items: JudgeItem[];
+  /** Leg models (default: production JUDGE_MODELS). Panel runs pass more. */
+  models?: readonly string[];
   generateImpl?: (
     model: string,
     prompt: string,
@@ -177,6 +179,7 @@ export async function judgeCellCardsDetailed(params: {
   ) => Promise<string>;
 }): Promise<JudgeDetailedResult> {
   if (params.items.length === 0) return { final: [], legs: [] };
+  const models = params.models ?? JUDGE_MODELS;
   const prompt = buildJudgePrompt(params);
   const generate =
     params.generateImpl ??
@@ -189,7 +192,7 @@ export async function judgeCellCardsDetailed(params: {
       return provider.generate(p, o);
     });
   const legs = await Promise.all(
-    JUDGE_MODELS.map(async (model): Promise<JudgeLegDetail> => {
+    models.map(async (model): Promise<JudgeLegDetail> => {
       try {
         const raw = await generate(model, prompt, {
           temperature: JUDGE_TEMPERATURE,
@@ -206,9 +209,13 @@ export async function judgeCellCardsDetailed(params: {
       }
     })
   );
+  // Continuity: `final` stays the PRODUCTION unanimous pair even when a
+  // wider panel runs — panel legs are experiment data, not the verdict.
+  const prodLegs = legs.filter((l) => (JUDGE_MODELS as readonly string[]).includes(l.model));
+  const verdictLegs = prodLegs.length > 0 ? prodLegs : legs;
   const final = params.items.map((it, i) => ({
     videoId: it.videoId,
-    fit: legs.some((leg) => leg.verdicts[i]?.fit !== false),
+    fit: verdictLegs.some((leg) => leg.verdicts[i]?.fit !== false),
   }));
   return { final, legs };
 }

--- a/src/modules/mandala/inflow-judge-shadow.ts
+++ b/src/modules/mandala/inflow-judge-shadow.ts
@@ -17,7 +17,12 @@
 import { Prisma } from '@prisma/client';
 import { getPrismaClient } from '@/modules/database/client';
 import { judgeCellCardsDetailed } from '@/modules/judge/card-cell-judge';
-import { planCellFloor, type CellVerdictInput } from '@/config/t11-inflow-judge';
+import {
+  planCellFloor,
+  isT11JudgePanelEnabled,
+  JUDGE_PANEL_MODELS,
+  type CellVerdictInput,
+} from '@/config/t11-inflow-judge';
 import { loadPoolServeConfig } from '@/config/pool-serve';
 import { logger } from '@/utils/logger';
 
@@ -47,6 +52,8 @@ export async function runInflowJudgeShadow(input: {
 
     let judged = 0;
     let split = 0;
+    const modelUnfit: Record<string, number> = {};
+    const modelJudged: Record<string, number> = {};
     let gaOnlyUnfit = 0;
     let gbOnlyUnfit = 0;
     const verdictInputs: CellVerdictInput[] = [];
@@ -60,11 +67,19 @@ export async function runInflowJudgeShadow(input: {
           centerGoal: input.centerGoal,
           cellTopic,
           items: slots.map((s) => ({ videoId: s.videoId, title: s.title })),
+          // Panel experiment (James 2026-07-14): wider legs ride the same
+          // service call; `final` stays the production pair.
+          ...(isT11JudgePanelEnabled() ? { models: JUDGE_PANEL_MODELS } : {}),
         });
         const cellOut: { videoId: string; fit: boolean; legs: boolean[] }[] = [];
         detailed.final.forEach((v, i) => {
           judged += 1;
           const legFits = detailed.legs.map((leg) => leg.verdicts[i]?.fit !== false);
+          for (let li = 0; li < detailed.legs.length; li++) {
+            const model = detailed.legs[li]!.model;
+            if (!legFits[li]) modelUnfit[model] = (modelUnfit[model] ?? 0) + 1;
+            modelJudged[model] = (modelJudged[model] ?? 0) + 1;
+          }
           const [ga, gb] = [legFits[0] !== false, legFits[1] !== false];
           if (ga !== gb) {
             split += 1;
@@ -85,6 +100,9 @@ export async function runInflowJudgeShadow(input: {
       schema: 1,
       computed_at: new Date().toISOString(),
       duration_ms: Date.now() - t0,
+      panel: isT11JudgePanelEnabled()
+        ? { models: [...JUDGE_PANEL_MODELS], model_judged: modelJudged, model_unfit: modelUnfit }
+        : undefined,
       metrics: {
         judged,
         unanimous_unfit: verdictInputs.filter((v) => !v.fit).length,


### PR DESCRIPTION
## Hypotheses (James-directed, 가설→선정→테스트)
- **H1**: judge failure axis = Korean-YouTube title literacy + instruction adherence (not model size). Evidence: DeepSeek unfit **0/60** on the first organic run — all 20 splits gA-only = judgment collapse suspicion.
- **H2**: unanimous legs need **vendor diversity** (same-vendor pairs share bias).
- **H3**: flash tier suffices (1-line binary verdicts).

## Panel (selection rationale in commit)
Gemini 2.5 Flash (baseline) · GPT-4o-mini · Claude Haiku 4.5 · Qwen3-30b-a3b-instruct · DeepSeek V4 Flash (control). Grok → round 2 wildcard; GLM excluded (H1 predicts control-identical failure).

## Mechanics (LLM-API hard-rule compliant)
Panel rides the **service shadow path** — no offline experiment scripts. Per-model judged/unfit counts → `judge_verdicts.panel`. **Production verdict unchanged** (JUDGE_MODELS pair); panel legs are experiment data only. `T11_JUDGE_PANEL_ENABLED` (default off), compose on. ~10¢/mandala.

## Next (after deploy)
Fixture scorecard (반려견 fit/unfit 라벨 + 라떼아트 garbage 6) via container service-module run → per-model garbage-recall / fit-protection / bias table → supervisor review → 조합 확정 보고.

T11 / Data-Write: none-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)