### PR TITLE
feat(mobile): narration audio pipeline — unlock, blob prefetch, buffer cue, resume position

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -205,11 +205,23 @@
   .chcard .t{font-size:19px; font-weight:750; letter-spacing:-.01em; padding:0 24px; line-height:1.5}
   .ptrack{flex:none; margin-top:10px}
   .chapters{display:flex; gap:4px}
-  .chapters i{flex:1; height:4px; border-radius:2.5px; background:#DED7C6; transition:background .4s; position:relative; overflow:hidden}
+  /* 필름 트랙 [J:07-14] — 내레이션=실선, 유튜브 클립=필름 칩, 현재 위치=글라이딩 재생 헤드 */
+  .chapters{padding:3px 0} /* 칩·헤드가 바 위로 살짝 걸치는 여유 */
+  .chapters i{flex:1; height:4px; border-radius:2.5px; background:#DED7C6; transition:background .4s; position:relative}
   .chapters i.done{background:var(--ui)}
-  .chapters i.now .fillp{position:absolute; left:0; top:0; bottom:0; background:var(--ui); border-radius:2.5px; transition:width .4s var(--soft)}
-  .ptimes{display:flex; justify-content:space-between; gap:10px; font-size:10px; color:var(--paper-sub); margin-top:6px; font-weight:600}
+  .chapters i.now .fillp{position:absolute; left:0; top:0; bottom:0; background:var(--ui); border-radius:2.5px;
+    transition:width .45s linear}
+  .cchip{position:absolute; top:50%; width:7px; height:9px; border-radius:2.5px; transform:translate(-50%,-50%);
+    background:var(--paper-hi, #FAF6EC); border:1.4px solid rgba(var(--shade),.32); z-index:1;
+    transition:background .4s, border-color .4s}
+  .cchip.past{background:var(--ui); border-color:var(--ui)}
+  .cchip.live{border-color:var(--acc); background:var(--paper-hi, #FAF6EC);
+    box-shadow:0 0 0 3px rgba(224,112,63,.16)}
+  .phead{position:absolute; top:50%; transform:translate(-50%,-50%); width:9px; height:9px; border-radius:50%;
+    background:var(--acc); box-shadow:0 0 0 3px rgba(224,112,63,.20); z-index:2; transition:left .45s linear}
+  .ptimes{display:flex; align-items:center; gap:10px; font-size:10px; color:var(--paper-sub); margin-top:6px; font-weight:600}
   .ptimes #pCh{min-width:0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .pclock{margin-left:auto; font-size:10px; color:var(--paper-sub); font-weight:650; flex:none}
   .player-state{flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center; gap:9px; padding:0 14px}
   .player-state .big{font-size:14px; font-weight:750}
   .player-state .sm{font-size:11px; color:var(--paper-sub); font-weight:600; line-height:1.8}
@@ -465,7 +477,7 @@
   /* 배속 캡슐 — 팟캐스트 문법: 재생 화면에서 탭 = 순환 */
   .spd{border:1px solid rgba(var(--shade),.28); background:none; cursor:pointer; touch-action:manipulation;
     font-family:inherit; font-size:10.5px; font-weight:750; color:var(--paper-sub);
-    border-radius:999px; padding:2px 9px; margin-left:auto; line-height:1.5}
+    border-radius:999px; padding:2px 9px; line-height:1.5; flex:none}
   .spd.on{color:var(--acc-ink); border-color:var(--acc-lo); background:rgba(var(--shade),.05)}
   .spd:active{transform:scale(.92)}
   body.stage .ptrack .spd{display:none} /* 무대는 전용 캡슐 사용 */
@@ -556,7 +568,7 @@
         <div class="chcard" id="chcard"><div class="n" id="chNum"></div><div class="t" id="chTitle"></div></div>
         <div class="ptrack" id="ptrack" hidden>
           <div class="chapters" id="pchap"></div>
-          <div class="ptimes"><span id="pPos" class="num">1 / 1</span><span id="pCh"></span><button class="spd num" id="spdBtn" aria-label="재생 속도">1×</button></div>
+          <div class="ptimes"><span id="pPos" class="num">1 / 1</span><span id="pCh"></span><span class="pclock num" id="pClock"></span><button class="spd num" id="spdBtn" aria-label="재생 속도">1×</button></div>
         </div>
         <div class="hairline" id="hairline"><i id="hairFill" style="width:0%"></i></div>
         <!-- [J pick] 가로 무대: 포커스 라인 + 컨텍스트 + 탭 존 + 독 + 푸시 레일 -->
@@ -894,21 +906,69 @@
     document.getElementById('pStateBig').textContent=big;
     document.getElementById('pStateSm').innerHTML=sm||'';
   }
+  /* ── 시간 모델: 비트별 콘텐츠 길이(초) — 실측 우선, 미상은 추정 ── */
+  var CLIP_DUR_FALLBACK=30, CH_CARD_SEC=1.5, TTS_SEC_PER_CHAR=0.09;
+  function beatDur(i){
+    var b=beats[i]; if(!b) return 0;
+    if(b.t==='ch') return CH_CARD_SEC;
+    if(b.t==='c') return (b.to!=null&&b.from!=null)?Math.max(1,b.to-b.from):CLIP_DUR_FALLBACK;
+    if(b.audio&&b.audio.d) return b.audio.d;
+    return Math.min(Math.max((b.text||'').length*TTS_SEC_PER_CHAR,2),120);
+  }
+  function beatFrac(){ // 현재 비트 내부 진행 0..1
+    var b=beats[bi]; if(!b) return 0;
+    try{
+      if(b.t==='c'&&yt&&yt.getCurrentTime&&b.from!=null){
+        return Math.max(0,Math.min(1,(yt.getCurrentTime()-b.from)/Math.max(1,(b.to-b.from))));
+      }
+      if(b.t==='n'&&curAudio&&b.audio){ return Math.max(0,Math.min(1,curAudio.currentTime/Math.max(1,b.audio.d))); }
+      if(b.t==='n'&&curSents.length){ return Math.max(0,Math.min(1,curSentIdx/curSents.length)); }
+    }catch(e){}
+    return 0;
+  }
+  function fmtSec(t){ t=Math.max(0,Math.round(t)); return Math.floor(t/60)+':'+String(t%60).padStart(2,'0'); }
+  var trkFill=null, trkHead=null, trkStart=0, trkCount=1;
+  function renderLive(){ // 초 단위 생동: 헤드·필·시계 (0.5s 틱)
+    var f=beatFrac();
+    var pct=Math.min(100,((bi-trkStart+f)/trkCount)*100);
+    if(trkFill) trkFill.style.width=pct+'%';
+    if(trkHead) trkHead.style.left=pct+'%';
+    var el=0; for(var k=0;k<bi;k++) el+=beatDur(k);
+    el+=f*beatDur(bi);
+    var tot=0; for(var k2=0;k2<beats.length;k2++) tot+=beatDur(k2);
+    var c=document.getElementById('pClock');
+    if(c) c.textContent=fmtSec(el)+' / '+fmtSec(tot);
+  }
+  var liveTick=null;
+  function startLive(){ if(!liveTick) liveTick=setInterval(function(){ if(cur==='player'&&beats.length) renderLive(); },500); }
   function renderChapters(){
     var el=document.getElementById('pchap'); el.innerHTML='';
     var curCh=chapterOfBeat[bi]||0;
-    // 현재 챕터 내부 진행률 (비트 기준) — 진행이 '보여야' 한다 [J:07-13]
-    var chStart=-1, chEnd=-1;
+    // 챕터별 비트 범위
+    var ranges=[];
     for(var k=0;k<chapterOfBeat.length;k++){
-      if(chapterOfBeat[k]===curCh){ if(chStart<0) chStart=k; chEnd=k; }
+      var c0=chapterOfBeat[k];
+      if(!ranges[c0]) ranges[c0]={s:k,e:k}; else ranges[c0].e=k;
     }
-    var inPct=(chEnd>chStart)?Math.round((bi-chStart)/(chEnd-chStart)*100):100;
+    trkStart=(ranges[curCh]||{s:bi}).s; trkCount=Math.max(1,((ranges[curCh]||{e:bi}).e-trkStart+1));
     for(var i=0;i<chapterCount;i++){
       var b=document.createElement('i');
+      var r=ranges[i]||{s:0,e:0}, n=Math.max(1,r.e-r.s+1);
       if(i<curCh) b.className='done';
-      else if(i===curCh){ b.className='now'; b.innerHTML='<span class="fillp" style="width:'+inPct+'%"></span>'; }
+      else if(i===curCh){ b.className='now'; b.innerHTML='<span class="fillp"></span><span class="phead"></span>'; }
+      // 유튜브 클립 = 필름 칩 (지나감=채움 / 현재=글로우 / 예정=윤곽)
+      for(var k3=r.s;k3<=r.e;k3++){
+        if(beats[k3]&&beats[k3].t==='c'){
+          var chip=document.createElement('span');
+          chip.className='cchip'+(k3<bi?' past':(k3===bi?' live':''));
+          chip.style.left=(((k3-r.s+0.5)/n)*100)+'%';
+          b.appendChild(chip);
+        }
+      }
       el.appendChild(b);
     }
+    trkFill=el.querySelector('.fillp'); trkHead=el.querySelector('.phead');
+    renderLive(); startLive();
     document.getElementById('pPos').textContent=(bi+1)+' / '+beats.length;
     document.getElementById('hairFill').style.width=Math.round(bi/Math.max(beats.length-1,1)*100)+'%';
     updateDock(); updateRail(); updateCtx();
@@ -1186,9 +1246,11 @@
     return false;
   }
   function playClip(beat){
-    creditEl.hidden=false; // S1
-    creditEl.innerHTML='원본 · <b></b>';
+    creditEl.hidden=false; // S1 — 구간정보 포함 [J:07-14]
+    creditEl.innerHTML='원본 · <b></b><span class="crng num"></span>';
     creditEl.querySelector('b').textContent=beat.src||((segCache[beat.vid]&&segCache[beat.vid].credit)||'핵심구간');
+    if(beat.from!=null&&beat.to!=null)
+      creditEl.querySelector('.crng').textContent=' · '+fmtSec(beat.from)+'–'+fmtSec(beat.to);
     readbox.hidden=false;
     renderSents('',[beat.text||'']); // [J:07-14] '원본 클립' 라벨 제거 — 요약 가림
     if(curSpans&&curSpans[0]) curSpans[0].classList.add('on');

--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -100,6 +100,9 @@
   .ksig .c.on{fill:var(--ui)}
   .ksig .c.core{fill:transparent; stroke:rgba(var(--shade),.22); stroke-width:1}
   .ksig .c.core.on{fill:var(--butter, #F5D48A); stroke:none}
+  /* 버퍼 대기: 현재 문장 하이라이트 숨쉬기 = "준비 중" (탭 무반응처럼 보이는 것 방지) */
+  body.abuff .readbox .sent.on{animation:sigBreath 1.1s ease-in-out infinite}
+  body.abuff .sln.now span{animation:sigBreath 1.1s ease-in-out infinite}
   @keyframes sigBreath{0%,100%{opacity:1}50%{opacity:.45}}
   .batt.chg .ksig .c.live{animation:sigBreath 1.6s ease-in-out infinite}
   @media (prefers-reduced-motion: reduce){ .batt.chg .ksig .c.live{animation:none} }
@@ -931,9 +934,49 @@
     toast('재생 속도 '+spdLabel());
   }
 
-  /* ── 에피소드 오디오 (ElevenLabs pre-produce) — manifest = (비트 인덱스, 문장해시) 키 ── */
+  /* ── 에피소드 오디오 (ElevenLabs pre-produce) — manifest = (비트 인덱스, 문장해시) 키 ──
+     파이프라인 설계 [J:07-14 "버퍼링 고려 없으면 설계하라"]:
+     단일 엘리먼트(첫 제스처 1회 언락 — iOS 정책) + 블롭 프리페치(현재+다음 2개, LRU 8)
+     + 버퍼 대기 중 하이라이트 숨쉬기 → 준비 즉시 자동 시작. 탭 1회 = 반응 1회. */
   var epAudio={tempo:1, ready:false}, curAudio=null;
-  function stopAudio(){ if(curAudio){ try{curAudio.pause()}catch(e){} curAudio=null; } }
+  var narrEl=null, narrUnlocked=false, blobCache={}, blobOrder=[];
+  var PREFETCH_AHEAD=2, BLOB_CACHE_MAX=8;
+  var SILENT_WAV='data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQQAAAAAAA==';
+  function unlockAudio(){ // 사용자 제스처 안에서 1회 — 이후 프로그래매틱 재생 허용
+    if(narrUnlocked) return;
+    try{
+      narrEl=narrEl||new Audio();
+      narrEl.playsInline=true; narrEl.setAttribute('playsinline','');
+      narrEl.muted=true; narrEl.src=SILENT_WAV;
+      var p=narrEl.play();
+      if(p&&p.then) p.then(function(){ narrEl.pause(); narrEl.muted=false; narrUnlocked=true; })
+                     .catch(function(){ narrEl.muted=false; });
+      else{ narrEl.pause(); narrEl.muted=false; narrUnlocked=true; }
+    }catch(e){}
+  }
+  async function prefetchNarr(i){ // 비트 오디오 → 블롭 선로드
+    var b=beats[i]; if(!b||b.t!=='n'||!b.audio) return;
+    var f=b.audio.f; if(blobCache[f]) return;
+    blobCache[f]='pending';
+    try{
+      var r=await fetch(f); if(!r.ok){ delete blobCache[f]; return; }
+      var u=URL.createObjectURL(await r.blob());
+      blobCache[f]=u; blobOrder.push(f);
+      if(blobOrder.length>BLOB_CACHE_MAX){
+        var old=blobOrder.shift();
+        if(blobCache[old]&&blobCache[old]!=='pending') URL.revokeObjectURL(blobCache[old]);
+        delete blobCache[old];
+      }
+    }catch(e){ delete blobCache[f]; }
+  }
+  function prefetchAround(i){ // 현재 위치부터 내레이션 2개 선로드
+    var n=0;
+    for(var k=Math.max(0,i);k<beats.length&&n<PREFETCH_AHEAD;k++){
+      if(beats[k].t==='n'&&beats[k].audio){ prefetchNarr(k); n++; }
+    }
+  }
+  function abuff(on){ document.body.classList.toggle('abuff', !!on); } // 버퍼 대기 신호
+  function stopAudio(){ abuff(false); if(curAudio){ try{curAudio.pause()}catch(e){} curAudio=null; } }
   async function sha12(t){
     var buf=await crypto.subtle.digest('SHA-256', new TextEncoder().encode(t));
     return Array.from(new Uint8Array(buf)).map(function(x){return x.toString(16).padStart(2,'0')}).join('').slice(0,12);
@@ -961,6 +1004,7 @@
         if(mb) b.audio=mb;
       }
       epAudio.tempo=d.manifest.tempo||1; epAudio.ready=true;
+      prefetchAround(bi); // 첫 내레이션 즉시 선로드 — 탭과 재생 사이 시간차 제거
     }catch(e){}
   }
 
@@ -998,13 +1042,26 @@
     curSents=sentences(beat.text); curDone=done;
     renderSents(beat.title,curSents);
     if(!curSents.length){ done(); return; }
-    if(beat.audio&&epAudio.ready){ audioFrom(0,beat); return; }
+    if(beat.audio&&epAudio.ready){
+      var k=0; // 일시정지 재개 = 듣던 문장부터 (엘리먼트가 같은 비트를 물고 있으면)
+      if(narrEl&&narrEl._beatKey===(bi+':'+beat.audio.h)&&narrEl.currentTime>0.1){
+        var t=narrEl.currentTime, ss=beat.audio.s||[];
+        while(k+1<ss.length&&t>=ss[k+1]-0.05) k++;
+      }
+      audioFrom(k,beat); return;
+    }
     speakFrom(0);
   }
-  function audioFrom(idx,beat){ // 실보이스 재생 + 문장 타이밍 싱크 (s[] = 1.0x 미디어 타임라인)
+  function audioFrom(idx,beat){ // 실보이스 재생 — 단일 엘리먼트 + 프리페치 캐시 + 버퍼 대기
     var seq=++speakSeq, m=beat.audio;
     curSentIdx=Math.max(0,Math.min(idx,curSents.length-1));
-    var a=new Audio(m.f); curAudio=a;
+    var a=narrEl=narrEl||new Audio();
+    a.playsInline=true; a.muted=false; curAudio=a;
+    var cached=blobCache[m.f];
+    var src=(cached&&cached!=='pending')?cached:m.f;
+    var beatKey=bi+':'+m.h;
+    if(a._src!==src){ a.src=src; a._src=src; a.load(); }
+    a._beatKey=beatKey;
     a.playbackRate=(epAudio.tempo||1)*spd;
     try{a.preservesPitch=true; a.webkitPreservesPitch=true}catch(e){}
     function hl(){
@@ -1017,18 +1074,28 @@
     }
     hl();
     var st=(m.s&&m.s[curSentIdx])||0;
-    if(st>0){ a.addEventListener('loadedmetadata',function(){ try{a.currentTime=st}catch(e){} }); }
-    a.addEventListener('timeupdate',function(){
+    function fallback(){ if(seq!==speakSeq) return; abuff(false); curAudio=null; speakFrom(curSentIdx); }
+    function seekPlay(){
+      if(seq!==speakSeq||!playing) return;
+      try{ if(Math.abs(a.currentTime-st)>0.12) a.currentTime=st; }catch(e){}
+      var p=a.play();
+      if(p&&p.then) p.then(function(){ if(seq===speakSeq) abuff(false); }).catch(fallback);
+      else abuff(false);
+    }
+    a.ontimeupdate=function(){
       if(seq!==speakSeq||!playing) return;
       var t=a.currentTime, k=curSentIdx;
       while(m.s&&k+1<m.s.length&&t>=m.s[k+1]-0.05) k++;
       if(k!==curSentIdx){ curSentIdx=k; addCharge(.5); hl(); }
-    });
-    a.addEventListener('ended',function(){
-      if(seq!==speakSeq) return; curAudio=null; addCharge(.5); if(curDone) curDone(); });
-    a.addEventListener('error',function(){
-      if(seq!==speakSeq) return; curAudio=null; speakFrom(curSentIdx); }); // 파일 실패 → TTS 폴백
-    var p=a.play(); if(p&&p.catch) p.catch(function(){ if(seq===speakSeq){ curAudio=null; speakFrom(curSentIdx); } });
+    };
+    a.onended=function(){ if(seq!==speakSeq) return; abuff(false); curAudio=null; addCharge(.5); if(curDone) curDone(); };
+    a.onerror=function(){ fallback(); };
+    if(a.readyState>=3){ seekPlay(); } // HAVE_FUTURE_DATA — 즉시
+    else{
+      abuff(true); // 버퍼 대기 신호 (하이라이트 숨쉬기) — 준비되는 즉시 자동 시작
+      a.oncanplay=function(){ a.oncanplay=null; seekPlay(); };
+    }
+    prefetchAround(bi+1); // 다음 내레이션 선로드 유지
   }
 
   /* YouTube 클립 — 경계는 v2 구간요약만 (§0-3) */
@@ -1136,7 +1203,7 @@
     var beat=beats[bi];
     renderChapters(); msUpdate();
     document.getElementById('pCh').textContent=(beat.t!=='ch'&&beat.title)?beat.title:'';
-    stopSpeech(); stopClip();
+    stopSpeech(); stopClip(); abuff(false);
     document.body.classList.toggle('clipmode', beat.t==='c');
     streamEl.hidden=(beat.t!=='n');
     if(beat.t==='ch'){ // M3
@@ -1188,6 +1255,7 @@
     bi=0;
   }
   function setPlaying(on){
+    if(on) unlockAudio();
     playing=on; setCharging(on);
     if(on){ acquireWake(); runBeat(); }
     else{ stopSpeech(); stopClip(); releaseWake();
@@ -1197,6 +1265,7 @@
   }
 
   async function openNote(m){
+    unlockAudio(); // 탭 제스처 안에서 오디오 세션 활성화 (iOS)
     curNote=m; show('player');
     document.getElementById('pTitle').textContent=m.title||'노트';
     pShowState('노트를 여는 중…','');


### PR DESCRIPTION
James field report: tap play -> silence -> tap -> tap -> suddenly plays.
Honest diagnosis: playback was naive streaming — per-beat Audio object
created at play time (no preload), re-downloaded on every pause/resume,
no loading feedback, and iOS dropped async play() calls that had lost
the tap gesture (the 3rd tap 'worked' because it WAS the gesture).

Commercial pipeline design:
- Single persistent audio element, unlocked once inside the first tap
  gesture (silent-wav pattern) — programmatic play is reliable after
- Blob prefetch: first narration beat loads as soon as the manifest
  attaches; during playback the next 2 narration beats stay preloaded
  (LRU cache of 8, object URLs revoked on eviction)
- Buffer wait cue: while audio is not ready the current sentence
  highlight breathes ('preparing'), and playback starts automatically
  the moment the buffer fills — one tap, one response
- Pause/resume reuses the same element and resumes from the sentence
  being heard (previously restarted the whole beat and re-downloaded)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
