### PR TITLE
fix(pwa): /learning deep links bypass SW app-shell fallback (stale-bundle note CTA)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -81,7 +81,13 @@ export default defineConfig(({ mode }) => {
           // the server served the GIF fine). Let these hit the network.
           // /mobile is a standalone static page (its own PWA manifest/scope),
           // not an SPA route — the app-shell fallback must not swallow it.
-          navigateFallbackDenylist: [/^\/api\//, /^\/mobile(\/|$)/, /\.[^/]+$/],
+          // /learning deep links (note-ready email CTA) must always run the
+          // CURRENT bundle: a stale SW serving the precached index.html ran
+          // pre-?view=note code and opened the player instead of the note
+          // (owner-reported, 2026-07-14). Hard navigations to /learning hit
+          // the network for fresh index.html; in-app moves are client-side
+          // routing and never reach the SW navigation route.
+          navigateFallbackDenylist: [/^\/api\//, /^\/mobile(\/|$)/, /^\/learning\//, /\.[^/]+$/],
           // 2026-04-22 (Phase 2 re-scoped): removed the `/api/*`
           // StaleWhileRevalidate runtime cache. Serving stale API
           // responses is incorrect for mandala-create / wizard-stream


### PR DESCRIPTION
## Problem
Email note-CTA deep links (`/learning/:m/:v?view=note`) ran the STALE precached bundle for any user whose PWA service worker predated the deploy — pre-`?view=note` code opened the player instead of the note (owner-reported with screenshot; the same link rendered note mode on a hard-reloaded tab). autoUpdate installs the new SW in the background, but the CURRENT navigation is already served from the old precache — every FE deploy re-opens this window (#952).

## Fix
Add `/^\/learning\//` to `navigateFallbackDenylist` (same mechanism as #1141's asset-URL entry): hard navigations to /learning fetch fresh `index.html` from the network → always the current bundle → `?view=note` honored regardless of SW staleness. In-app navigation is client-side routing and never reaches the SW navigation route; offline-PWA loses nothing (the learning page needs the network anyway).

## Verification
- FE tsc 0 / vitest 514 / build — `dist/sw.js` contains the /learning denylist entry
- One-time seat note: a user's existing stale SW serves one last old navigation while the new SW installs; the second visit (and every future deploy) is permanently covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)