### PR TITLE
feat(email): flag on — transactional emails + book-fill completion barrier

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -124,6 +124,11 @@ services:
       # T7 (matrix §11-b): consume miss → attach to in-flight precompute
       # instead of re-running discover (quota x2, 21-43s). Rollback: delete.
       - PRECOMPUTE_ATTACH_ENABLED=true
+      # CP516 package flag-on (2026-07-14, owner-approved after sample review):
+      # beta-invite email on admin mark-invited + note-ready email on the
+      # initial completion-barrier book-fill. Rollback: delete both lines.
+      - TRANSACTIONAL_EMAIL_ENABLED=true
+      - BOOK_FILL_BARRIER_ENABLED=true
       # T9 (matrix F6): deficit-cell subgoal queries carry a domain anchor
       # from the center goal ("일본어 JLPT N3" + "청취 회화"). Rollback: delete.
       - DISCOVER_SUBGOAL_ANCHOR_ENABLED=true


### PR DESCRIPTION
Owner-approved go (2026-07-14). Compose-only, 2 flags:

- `TRANSACTIONAL_EMAIL_ENABLED=true` — beta-invite email fires on admin mark-invited (applicant email); note-ready email fires on the initial completion-barrier book-fill (owner email, note-mode deep link per #1216/#1219)
- `BOOK_FILL_BARRIER_ENABLED=true` — fill once at remaining=0 (+update on ≥5 new v2) — stops the 3-4x Sonnet chapter_weave waste (CP516, supervisor-cleared)

Rollback: delete both lines, redeploy. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)