### PR TITLE
fix(narration): markdown callout tokens no longer displayed or spoken

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -938,6 +938,7 @@
   function stripMd(s){
     return String(s||'')
       .replace(/```[\s\S]*?```/g,' ').replace(/\|[^\n]*\|/g,' ')
+      .replace(/\[!\w+\]\s*/g,'') // 콜아웃([!warning] 등) 낭독·표시 금지 — BE sentences.ts와 패리티
       .replace(/[#>*_`~]|\[(.*?)\]\(.*?\)/g,'$1').replace(/\s+/g,' ').trim();
   }
   function sentences(s){

--- a/src/api/routes/mandala-episode-audio.ts
+++ b/src/api/routes/mandala-episode-audio.ts
@@ -19,7 +19,7 @@ import { getPrismaClient } from '@/modules/database/client';
 import { config } from '@/config/index';
 import { logger } from '@/utils/logger';
 import { enqueueEpisodeNarrationRender } from '@/modules/queue/handlers/episode-narration-render';
-import type { EpisodeManifest } from '@/modules/narration/render-episode';
+import { MANIFEST_V, type EpisodeManifest } from '@/modules/narration/render-episode';
 
 const log = logger.child({ module: 'routes/mandala-episode-audio' });
 
@@ -71,7 +71,11 @@ export async function mandalaEpisodeAudioRoutes(fastify: FastifyInstance): Promi
       );
       const row = rows[0];
 
-      if (row?.status === 'ready' && row.book_version === bookVersion) {
+      if (
+        row?.status === 'ready' &&
+        row.book_version === bookVersion &&
+        row.manifest_json?.v === MANIFEST_V
+      ) {
         return reply.code(200).send({
           status: 'ok',
           data: { enabled: true, status: 'ready', manifest: row.manifest_json },

--- a/src/modules/narration/render-episode.ts
+++ b/src/modules/narration/render-episode.ts
@@ -35,8 +35,11 @@ export interface ManifestBeat {
   s: number[];
 }
 
+/** 전처리 규칙이 바뀌면 범프 — 스테일 매니페스트가 lazy 재렌더된다 */
+export const MANIFEST_V = 2 as const;
+
 export interface EpisodeManifest {
-  v: 1;
+  v: number;
   host: NarrationHost;
   voiceId: string;
   tempo: number;
@@ -117,7 +120,11 @@ export async function renderEpisodeNarration(mandalaId: string): Promise<RenderR
       : classifyHost(mandala.title ?? '', mandala.domain);
   const preset = HOSTS[host];
 
-  if (existing?.status === 'ready' && existing.book_version === bookVersion) {
+  if (
+    existing?.status === 'ready' &&
+    existing.book_version === bookVersion &&
+    existing.manifest_json?.v === MANIFEST_V
+  ) {
     return { ok: true, action: 'fresh' };
   }
 
@@ -146,7 +153,7 @@ export async function renderEpisodeNarration(mandalaId: string): Promise<RenderR
     (existing?.manifest_json?.beats ?? []).map((m) => [`${m.i}:${m.h}`, m])
   );
   const manifest: EpisodeManifest = {
-    v: 1,
+    v: MANIFEST_V,
     host,
     voiceId: preset.voiceId,
     tempo: NARRATION_TEMPO,

--- a/src/modules/narration/sentences.ts
+++ b/src/modules/narration/sentences.ts
@@ -12,6 +12,7 @@ export function stripMd(s: unknown): string {
   return String(s ?? '')
     .replace(/```[\s\S]*?```/g, ' ')
     .replace(/\|[^\n]*\|/g, ' ')
+    .replace(/\[!\w+\]\s*/g, '') // 마크다운 콜아웃([!warning] 등) — 낭독·표시 금지
     .replace(/[#>*_`~]|\[(.*?)\]\(.*?\)/g, '$1')
     .replace(/\s+/g, ' ')
     .trim();

--- a/tests/smoke/narration.test.ts
+++ b/tests/smoke/narration.test.ts
@@ -25,6 +25,11 @@ describe('narration sentences (player parity)', () => {
     expect(stripMd('## 제목\n**굵게** [링크](http://x)와 `코드`')).toBe('제목 굵게 링크와 코드');
   });
 
+  it('strips markdown callout tokens ([!warning] 등) — 낭독 금지', () => {
+    expect(stripMd('> [!warning] 이 구간은 주의가 필요하다.')).toBe('이 구간은 주의가 필요하다.');
+    expect(stripMd('[!note]핵심 요약입니다.')).toBe('핵심 요약입니다.');
+  });
+
   it('filters fragments of length <= 1', () => {
     expect(sentences('가. 나머지는 유지됩니다.')).toEqual(['가.', '나머지는 유지됩니다.']);
     expect(sentences('.')).toEqual([]);


### PR DESCRIPTION
[!warning]-style callout markers from book narratives leaked into the
read-along text and the ElevenLabs narration (James device report).

- stripMd strips [!word] tokens on BOTH sides of the parity contract
  (player + BE sentence splitter), fixture pinned
- Manifest version bumped to 2 with version-aware freshness in the
  renderer and route: already-rendered episodes lazily re-render on
  next open, and only beats whose text hash changed re-bill — clean
  beats are reused from the prior manifest

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
