### PR TITLE
fix: kakao share unfurl — proxy-safe redirects, share-token 400, timeline squish, refresh menu

### DIFF
--- a/docs/guides/kakao-dial-share.md
+++ b/docs/guides/kakao-dial-share.md
@@ -1,0 +1,55 @@
+# 다이얼(/dial) — 카카오톡 공유 가이드
+
+**Context:** `insighta.one/dial`은 정적 랜딩 페이지로, 카카오톡 공유는 **URL 붙여넣기 → OG 카드 unfurl** 방식이다 (학습페이지의 Kakao SDK 공유 버튼과는 다른 메커니즘 — 그쪽은 `docs/guides/kakao-share-setup.md`). 앱 키·SDK·개발자 콘솔 설정이 전혀 필요 없다. 카카오 스크래퍼가 페이지의 `<meta property="og:*">`를 읽어 카드를 만든다.
+
+## 1. 공유 방법
+
+카카오톡 채팅창에 URL을 붙여넣으면 끝:
+
+```
+https://insighta.one/dial/
+```
+
+카드 구성 (모두 `frontend/public/dial/index.html`의 OG 메타에서 나옴):
+
+| 요소 | 값 | 바꾸려면 |
+|------|-----|---------|
+| 이미지 | `frontend/public/dial/og.png` (1200×630) | 파일 교체 후 배포 + 캐시 초기화(§3) |
+| 제목 | `og:title` — "다이얼 — 유튜브를 나만의 지식노트로" | index.html 메타 수정 |
+| 설명 | `og:description` | index.html 메타 수정 |
+
+모바일 플레이어의 48시간 게스트 링크(`insighta.one/mobile/?g=...`)도 동일 원리로 `/mobile`의 OG 메타 카드가 뜬다.
+
+## 2. 슬래시 유무
+
+- `insighta.one/dial/` (슬래시 O) — 항상 동작.
+- `insighta.one/dial` (슬래시 X) — nginx가 `/dial/`로 301 리다이렉트. 2026-07-14 이전에는 이 리다이렉트가 내부 포트(`http://…:8081`)로 나가 카카오 스크래퍼가 도달 불가였다. `absolute_redirect off` 수정으로 해소 (nginx.conf.template).
+
+## 3. 카카오 캐시 초기화 (카드가 옛날 것으로 뜰 때)
+
+카카오는 **URL 문자열 단위로** 스크랩 결과를 수 주간 캐시한다. 배포 전에 시도했던 URL은 옛 카드(예: 베타 카드)가 계속 뜬다.
+
+1. https://developers.kakao.com 로그인 (카카오 계정)
+2. 상단 **도구 → 공유 디버거** (https://developers.kakao.com/tool/debugger/sharing)
+3. URL 입력 (`https://insighta.one/dial` — 슬래시 유무별로 각각) → **초기화** 버튼
+4. 같은 화면에서 미리보기로 새 카드 확인 → 카톡에서 재시도
+
+## 4. 배포 후 검증 체크리스트
+
+```bash
+# 1) OG 메타 존재
+curl -sL https://insighta.one/dial | grep -c 'og:image'   # ≥ 1
+
+# 2) 이미지 접근
+curl -s -o /dev/null -w "%{http_code}" https://insighta.one/dial/og.png  # 200
+
+# 3) 슬래시 없는 리다이렉트가 상대경로인지
+curl -sI https://insighta.one/dial | grep -i '^location'  # Location: /dial/
+```
+
+마지막으로 카카오톡 "나에게 보내기"로 실카드 확인.
+
+## 5. 주의
+
+- claude.ai 아티팩트 URL은 로그인 게이트라 카카오에서 카드도 내용도 안 보인다. 대외 공유물은 반드시 insighta.one 아래에 배포한다.
+- OG 이미지를 바꾸면 반드시 §3 캐시 초기화를 해야 반영된다.

--- a/frontend/nginx/nginx.conf.template
+++ b/frontend/nginx/nginx.conf.template
@@ -12,6 +12,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Directory redirects (/dial -> /dial/) must stay relative: this server
+    # sits behind a TLS proxy, so an absolute redirect leaks the internal
+    # port as http://insighta.one:8081/... — unreachable for browsers and
+    # the KakaoTalk OG scraper.
+    absolute_redirect off;
+    port_in_redirect off;
+
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;

--- a/frontend/public/dial/index.html
+++ b/frontend/public/dial/index.html
@@ -108,8 +108,9 @@
   .tl h3{font-size:16.5px; font-weight:800; letter-spacing:-.02em}
   .tl>p{font-size:13.5px; color:var(--muted); margin-top:6px; max-width:66ch}
   .band{display:flex; gap:5px; margin-top:18px; position:relative; height:36px}
-  .seg{border-radius:9px; display:grid; place-items:center;
-    font-family:var(--hel); font-size:10px; font-weight:700; letter-spacing:.12em}
+  .seg{border-radius:9px; display:grid; place-items:center; padding:0 5px;
+    font-family:var(--hel); font-size:10px; font-weight:700; letter-spacing:.12em;
+    white-space:nowrap; min-width:max-content} /* 좁은 뷰포트에서 라벨 세로 꺾임 방지 */
   .seg.n{background:#EFE7D2; color:#7A7260}
   .seg.y{background:linear-gradient(178deg,#E87B4C,#CE5F30); color:#fff}
   .seg.f{background:#5F7CAD; color:#fff}
@@ -118,6 +119,11 @@
     width:9px; height:9px; border-radius:50%; background:var(--acc)}
   .leg{display:flex; gap:18px; flex-wrap:wrap; margin-top:14px; font-size:11.5px; color:var(--muted); font-weight:600}
   .leg i{display:inline-block; width:10px; height:10px; border-radius:3px; margin-right:6px; vertical-align:-1px}
+  @media (max-width:480px){ /* 모바일: 7조각 + 간격이 한 줄에 들어가도록 축소 */
+    .tl{padding:20px 16px}
+    .band{gap:4px; height:32px}
+    .seg{font-size:9px; letter-spacing:.05em; padding:0 4px}
+  }
 
   /* ═══ 원칙 ═══ */
   .laws-sec{padding:clamp(44px,6vw,74px) 0 0}

--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -605,6 +605,7 @@
             </span>
           </div>
           <button class="mrow" id="bInstall">홈 화면에 설치<span class="sub">전체화면 앱</span></button>
+          <button class="mrow" id="bRefresh">새로고침<span class="sub">최신 버전 불러오기</span></button>
           <button class="mrow" id="bLogout">로그아웃</button>
         </div>
         <div class="menu-note">MENU를 다시 누르면 돌아갑니다</div>
@@ -745,7 +746,12 @@
   }
   async function api(path,opts){
     var tok=await freshToken(); if(!tok) throw new Error('unauthenticated');
-    opts=opts||{}; opts.headers=Object.assign({Authorization:'Bearer '+tok,'Content-Type':'application/json'},opts.headers||{});
+    opts=opts||{};
+    // Content-Type only with a body — Fastify 400s (FST_ERR_CTP_EMPTY_JSON_BODY)
+    // on bodyless POSTs that claim application/json (broke share-token mint).
+    var base={Authorization:'Bearer '+tok};
+    if(opts.body) base['Content-Type']='application/json';
+    opts.headers=Object.assign(base,opts.headers||{});
     var r=await fetch('/api/v1'+path,opts);
     if(!r.ok){ var e=new Error('HTTP '+r.status); e.status=r.status; throw e; }
     return r;
@@ -1922,6 +1928,13 @@
   /* ================= 메뉴 항목 ================= */
   document.getElementById('bLogin').onclick=loginRedirect;
   document.getElementById('bSample').onclick=function(){ openNote(SAMPLE) };
+  document.getElementById('bRefresh').onclick=function(){
+    // 설치형(standalone)엔 브라우저 새로고침 UI가 없다. cache:'reload'로
+    // HTTP 캐시를 강제 재검증해 최신 번들을 받은 뒤 리로드 (쿼리·게스트 토큰 보존).
+    toast('새로고침 중…');
+    fetch(location.pathname,{cache:'reload'}).catch(function(){})
+      .finally(function(){ location.reload(); });
+  };
   document.getElementById('bLogout').onclick=function(){
     try{localStorage.removeItem(OWN_KEY)}catch(e){}
     setPlaying(false); show('login');


### PR DESCRIPTION
Four field-reported issues from the dial/mobile share track, one deploy:

## 1. nginx: relative directory redirects (`absolute_redirect off`)
`insighta.one/dial` (no trailing slash) 301'd to `http://insighta.one:8081/dial/` — internal port, https→http downgrade, unreachable externally. KakaoTalk's OG scraper and browsers both dead-ended; Kakao fell back to the stale beta card. Same class hit `/mobile`.
**Verified in container:** `nginx -t` pass + behavioral test shows `Location: /dial/` (relative).

## 2. mobile: share-token mint 400 (`FST_ERR_CTP_EMPTY_JSON_BODY`)
`api()` claimed `Content-Type: application/json` on every request; the bodyless share-token POST got rejected by Fastify's JSON parser (prod logs: 5/5 attempts 400) → '링크를 만들지 못했어요'. Header now sent only with a body. All 8 call sites audited — the single body-carrying POST keeps the header.

## 3. landing: timeline strip crushed on phones
Segment pills had no min-width/nowrap, so 375px viewports wrapped labels vertically out of the pills (James screenshot). Fix: `white-space:nowrap` + `min-width:max-content` + a ≤480px compact tier. **Measured:** compact min-content 212px vs 303px available at 375px (91px slack; fits down to 320px SE).

## 4. mobile: 새로고침 menu item
Standalone PWA exposes no browser reload UI. New MENU row forces HTTP revalidation (`cache:'reload'`) then reloads, preserving query/guest token.

Plus `docs/guides/kakao-dial-share.md` — unfurl mechanism, Kakao cache-reset steps, post-deploy checklist.

Rollback: each commit is independently revertable; nginx change is 2 directives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)