### PR TITLE
feat(book): language-routed web-search evidence (Naver ko + OpenRouter web) — CSE replacement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -218,6 +218,10 @@ jobs:
           OR_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OR_MODEL: ${{ secrets.OPENROUTER_MODEL }}
           COHERE_KEY: ${{ secrets.COHERE_API_KEY }}
+          # CSE — book research(STORM)/factcheck web evidence (CP458 name-only
+          # registration; key provisioning completed 2026-07-14 track).
+          GOOGLE_CSE_API_KEY: ${{ secrets.GOOGLE_CSE_API_KEY }}
+          GOOGLE_CSE_CX: ${{ vars.GOOGLE_CSE_CX }}
           ELEVEN_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           NARRATION_PREPRODUCE_ENABLED: ${{ vars.NARRATION_PREPRODUCE_ENABLED }}
           YT_SEARCH_KEY: ${{ secrets.YOUTUBE_API_KEY_SEARCH }}
@@ -316,6 +320,15 @@ jobs:
             # tuning knob (CP392 non-secret rule).
             if [ -n "${COHERE_KEY}" ]; then
               grep -q '^COHERE_API_KEY=' .env 2>/dev/null && sed -i "s|^COHERE_API_KEY=.*|COHERE_API_KEY=${COHERE_KEY}|" .env || echo "COHERE_API_KEY=${COHERE_KEY}" >> .env
+            fi
+            # Google CSE (book research/factcheck evidence). Absent = skip —
+            # graceful enabled=false stays, but fill-book now logs the
+            # degradation loudly (silent-0 class, 2026-07-14).
+            if [ -n "${GOOGLE_CSE_API_KEY}" ]; then
+              grep -q '^GOOGLE_CSE_API_KEY=' .env 2>/dev/null && sed -i "s|^GOOGLE_CSE_API_KEY=.*|GOOGLE_CSE_API_KEY=${GOOGLE_CSE_API_KEY}|" .env || echo "GOOGLE_CSE_API_KEY=${GOOGLE_CSE_API_KEY}" >> .env
+            fi
+            if [ -n "${GOOGLE_CSE_CX}" ]; then
+              grep -q '^GOOGLE_CSE_CX=' .env 2>/dev/null && sed -i "s|^GOOGLE_CSE_CX=.*|GOOGLE_CSE_CX=${GOOGLE_CSE_CX}|" .env || echo "GOOGLE_CSE_CX=${GOOGLE_CSE_CX}" >> .env
             fi
             # CP500++ CONFIG-SSOT (2026-06-16) — runtime TOGGLES removed from the
             # .env-write path. Toggle activation SSOT = docker-compose.prod.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -218,10 +218,10 @@ jobs:
           OR_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OR_MODEL: ${{ secrets.OPENROUTER_MODEL }}
           COHERE_KEY: ${{ secrets.COHERE_API_KEY }}
-          # CSE — book research(STORM)/factcheck web evidence (CP458 name-only
-          # registration; key provisioning completed 2026-07-14 track).
-          GOOGLE_CSE_API_KEY: ${{ secrets.GOOGLE_CSE_API_KEY }}
-          GOOGLE_CSE_CX: ${{ vars.GOOGLE_CSE_CX }}
+          # Naver Open API — book research/factcheck Korean evidence leg
+          # (2026-07-14 provider swap; Google CSE closed to new customers).
+          NAVER_ID: ${{ secrets.NAVER_CLIENT_ID }}
+          NAVER_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
           ELEVEN_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           NARRATION_PREPRODUCE_ENABLED: ${{ vars.NARRATION_PREPRODUCE_ENABLED }}
           YT_SEARCH_KEY: ${{ secrets.YOUTUBE_API_KEY_SEARCH }}
@@ -321,14 +321,15 @@ jobs:
             if [ -n "${COHERE_KEY}" ]; then
               grep -q '^COHERE_API_KEY=' .env 2>/dev/null && sed -i "s|^COHERE_API_KEY=.*|COHERE_API_KEY=${COHERE_KEY}|" .env || echo "COHERE_API_KEY=${COHERE_KEY}" >> .env
             fi
-            # Google CSE (book research/factcheck evidence). Absent = skip —
-            # graceful enabled=false stays, but fill-book now logs the
-            # degradation loudly (silent-0 class, 2026-07-14).
-            if [ -n "${GOOGLE_CSE_API_KEY}" ]; then
-              grep -q '^GOOGLE_CSE_API_KEY=' .env 2>/dev/null && sed -i "s|^GOOGLE_CSE_API_KEY=.*|GOOGLE_CSE_API_KEY=${GOOGLE_CSE_API_KEY}|" .env || echo "GOOGLE_CSE_API_KEY=${GOOGLE_CSE_API_KEY}" >> .env
+            # Naver Open API (book research/factcheck Korean evidence).
+            # Absent = skip — graceful naverEnabled=false, fill-book logs the
+            # degradation loudly (silent-0 class, 2026-07-14). The global leg
+            # rides OPENROUTER_API_KEY (already synced above).
+            if [ -n "${NAVER_ID}" ]; then
+              grep -q '^NAVER_CLIENT_ID=' .env 2>/dev/null && sed -i "s|^NAVER_CLIENT_ID=.*|NAVER_CLIENT_ID=${NAVER_ID}|" .env || echo "NAVER_CLIENT_ID=${NAVER_ID}" >> .env
             fi
-            if [ -n "${GOOGLE_CSE_CX}" ]; then
-              grep -q '^GOOGLE_CSE_CX=' .env 2>/dev/null && sed -i "s|^GOOGLE_CSE_CX=.*|GOOGLE_CSE_CX=${GOOGLE_CSE_CX}|" .env || echo "GOOGLE_CSE_CX=${GOOGLE_CSE_CX}" >> .env
+            if [ -n "${NAVER_SECRET}" ]; then
+              grep -q '^NAVER_CLIENT_SECRET=' .env 2>/dev/null && sed -i "s|^NAVER_CLIENT_SECRET=.*|NAVER_CLIENT_SECRET=${NAVER_SECRET}|" .env || echo "NAVER_CLIENT_SECRET=${NAVER_SECRET}" >> .env
             fi
             # CP500++ CONFIG-SSOT (2026-06-16) — runtime TOGGLES removed from the
             # .env-write path. Toggle activation SSOT = docker-compose.prod.yml

--- a/docs/handoffs/web-search-provider-eval-2026-07-14.md
+++ b/docs/handoffs/web-search-provider-eval-2026-07-14.md
@@ -1,0 +1,65 @@
+# Web-Search Provider Evaluation — Book Research/Factcheck Evidence Source (2026-07-14)
+
+Context: Google CSE (the provider CP458/CP504 code targeted) is **closed to new customers, dies 2027-01-01**; its
+"entire web" option was discontinued for new engines 2026-03. Bing Web Search API died 2025-08-11. This forced a
+full provider re-evaluation. Four parallel research tracks (independent-index APIs / Google-SERP resellers /
+big-cloud+LLM-integrated / Korean-specific) ran on 2026-07-14; full agent reports preserved in session transcript.
+
+## Workload (measured from code)
+
+- Per book: research ≤6 queries (`book-research.ts MAX_GAPS=6`) + factcheck ≤24 (`fill-book.ts MAX_FACTCHECK_ATOMS=24`), each `num:3` results → **≤30 queries/book**
+- Volume: now 16 books/wk ≈ **2.1k q/mo** · growth 100 books/day ≈ **90k q/mo** (3k/day) · max 1,000 books/day ≈ **900k q/mo** (30k/day)
+- Pipeline is post-done async (background job) → latency-tolerant; batch/queued APIs acceptable
+
+## Hard requirements
+
+1. Korean quality (topics: 반려견 훈련, 라떼아트, JLPT, 재테크 …) — decisive axis
+2. Evidence storable in our DB (`references[]`, `verification`) → **provider ToS on result storage matters**
+3. Commercial use explicitly allowed; vendor continuity (two giants just exited this market)
+4. Returns URL+title+snippet (plain REST preferred)
+
+## Verdict matrix (all four tracks merged)
+
+| Provider | /1k | Korean | Storage ToS | Continuity | Verdict |
+|---|---|---|---|---|---|
+| **Naver Open API** | free 25k/day | ◎ (native verticals: 웹문서·뉴스·백과·블로그·지식iN·책) | △ 저장/캐시 금지 조항 → URL+자체 클레임 저장으로 우회 | Naver; paid path = NCP API HUB | **채택 (1순위, 한국어)** |
+| **Kakao Daum 검색** | free 50k/day (30k/vertical) | ◎ | ○ "상업적 제한 없음" 공식 답변; 캐싱은 UX 목적 | Kakao | **채택 (2순위/폴백)** |
+| **ko.wikipedia MediaWiki** | free (200 req/min w/ UA) | ○ 백과형 한정 | ◎ CC BY-SA 4.0 저장 가능 | Wikimedia | **채택 (백과 보조)** |
+| **국립국어원 우리말샘/krdict** | free 50k/day | ◎ 용어/언어 | ◎ CC BY-SA 상업 명시 | 정부 | **채택 (언어학습 팩트체크)** |
+| Perplexity Search API | $5 | ◎? SKT 협업 실증 최강(간접) | UNVERIFIED — 계약 전 확인 필수 | $18B+, 견고 | **글로벌 폴백 후보 A** |
+| DataForSEO (Standard queue) | $0.60 async | ○ Google SERP + Naver SERP 겸용 | 공급자 제한 없음(스크래핑 그레이) | 2016~, 무소송 | **글로벌 폴백 후보 B** |
+| Serper.dev | $0.75–1 | ○ gl=kr | 제한 없음(스크래핑 그레이) | 소기업, 크레딧 6개월 만료 | 예비 |
+| Tavily | $8 | △ 한국어 truncation 이슈(#29) | ZDR/SOC2 | Nebius 인수 | 보류 |
+| Exa / OpenRouter 웹플러그인 | $5–7 | ✗ 영어 중심, 한국어 미실증 | Exa ToS 재판매 제한 | $2.2B | 탈락(한국어) |
+| Brave | $5 | ✗ 취약 + 무료티어 폐지(2026-02) | ✗ **기본 저장 금지**(transient only) | Anthropic 백엔드 | **탈락** |
+| Gemini Grounding | $14(쿼리 과금) | ◎ 구글 실검색 | ✗ redirect URL 수일 만료 + 표시요건 + 30일 보관 | Google | 탈락(증거 저장 부적합) |
+| MS Bing Grounding | $14 | ○ | ✗ **저장·DB화 명문 금지** | Bing API는 사망 | **탈락(약관)** |
+| AWS AgentCore Web Search | $7 | ? 신규 인덱스 미실증 | 원시결과 반환, 제한 미발견 | GA 2026-06, us-east-1만 | 관망 |
+| SerpApi | $9+ | ○ (+Naver 전용 API) | Legal Shield(수집만) | ✗ **Google이 DMCA 제소 중**(2025-12) | 탈락(소송 당사자) |
+| Kagi / You.com / Jina / Mojeek | $12/$5/$0.5/$2.6 | ?/?/○간접/✗ | 각기 | Jina=Elastic 인수 리스크 | 예비 |
+| SearXNG 자가호스팅 | 서버비 | ○ | — | ✗ Google이 5쿼리만에 차단(fingerprinting) | 탈락(상용 부적합) |
+
+Key market facts: Google v. SerpApi (DMCA, 2025-12) pends — SERP-scraping category re-pricing risk H2 2026.
+Brave = Anthropic web_search의 백엔드(한국어 한계 공유).
+
+## Recommended architecture
+
+`src/modules/web-search/` provider-abstraction ( `searchWeb(query, opts)` 인터페이스는 기존 CSE 클라이언트와 동일 계약 ):
+
+1. **Naver Open API** — primary (웹문서+백과+뉴스+블로그 merge), free 25k/day covers growth scenario (3k/day)
+2. **Kakao Daum** — fallback + 보충, free 50k/day
+3. **ko.wikipedia + 국립국어원** — encyclopedic/terminology claims, CC-licensed (저장 무제한)
+4. 유료 글로벌 폴백(Perplexity vs DataForSEO)은 **한국어 3종 실측 후** 필요 시 결정 — 베타 볼륨에선 불필요 가능성
+
+Storage policy (Naver ToS 대응 + data-write hard rule 정합): evidence rows = **URL + title + 자체 작성 클레임 요약**.
+Naver `description` verbatim 장기 저장 금지. CC 소스(위키/국어원)만 스니펫 저장 허용.
+
+Scale path: 1,000 books/day 도달 시 Naver 25k/day 초과 → NCP API HUB 종량 전환 or 유료 폴백 확대 (그 시점 재평가).
+
+## Execution plan
+
+- Phase 1: James — developers.naver.com + developers.kakao.com 앱 등록(무료, 카드 불필요, 즉시 발급) → 키 4개
+  (NAVER_SEARCH_CLIENT_ID/SECRET Secret, KAKAO_REST_API_KEY Secret)
+- Phase 2: CC — web-search 모듈 + 실제 북 주제 50쿼리 벤치(Naver/Kakao/Wiki) → 품질 보고 → book-research/factcheck 스왑 PR
+  (+ PR #1234 재작업: GOOGLE_CSE 배선 제거, 새 키 deploy 계약 테스트 + loud-warn 유지)
+- Phase 3: 실측 기반 글로벌 폴백 결정 (필요 시)

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -28,7 +28,7 @@ import { synthesizeBookSkeleton, type BookSkeleton } from './book-skeleton';
 import { weaveChapterBody } from './book-body';
 import { researchBookGaps } from './book-research';
 import { factcheckChapterBody } from './book-factcheck';
-import { createGoogleCseClient, loadGoogleCseConfig } from '@/modules/google-cse';
+import { createWebSearchClient, loadWebSearchConfig } from '@/modules/web-search';
 import { enqueueEnrichRichSummary, enqueueNoteCvEnrich } from '@/modules/queue';
 import { enqueueRelevanceBackfillForMandala } from '@/modules/relevance/relevance-backfill-trigger';
 import { getStoredTranslation } from '@/modules/skills/rich-summary-translator';
@@ -606,16 +606,22 @@ async function enrichBookLoop2(
   mandalaId: string
 ): Promise<void> {
   const chapters = book.chapters ?? [];
-  const cseConfig = loadGoogleCseConfig();
-  const cse = createGoogleCseClient(cseConfig);
-  if (!cseConfig.enabled) {
-    // Silent-0 class (2026-07-14 incident): CSE credentials were never
-    // provisioned after CP458's name-only registration — research produced 0
-    // findings and factcheck ran without web evidence for 2 months with no
-    // signal. Degradation must be LOUD, never silent.
+  const wsConfig = loadWebSearchConfig();
+  const cse = createWebSearchClient(wsConfig);
+  if (!wsConfig.enabled) {
+    // Silent-0 class (2026-07-14 incident): the CSE credentials behind the
+    // original research/factcheck were never provisioned — 2 months of 0
+    // findings + evidence-free verdicts with no signal. Degradation must be
+    // LOUD, never silent.
     log.warn(
-      'CSE unset — book research yields 0 findings and factcheck runs WITHOUT web evidence ' +
-        '(register GOOGLE_CSE_API_KEY secret + GOOGLE_CSE_CX variable; credentials.md L163)',
+      'web-search unset — book research yields 0 findings and factcheck runs WITHOUT web ' +
+        'evidence (NAVER_CLIENT_ID/SECRET + OPENROUTER_API_KEY; credentials.md)',
+      { mandalaId }
+    );
+  } else if (!wsConfig.naverEnabled || !wsConfig.globalEnabled) {
+    log.warn(
+      `web-search partial — ${wsConfig.naverEnabled ? 'global(en/ja/zh)' : 'naver(ko)'} leg ` +
+        'unconfigured; queries in that language yield no evidence',
       { mandalaId }
     );
   }

--- a/src/modules/mandala-book/fill-book.ts
+++ b/src/modules/mandala-book/fill-book.ts
@@ -606,7 +606,19 @@ async function enrichBookLoop2(
   mandalaId: string
 ): Promise<void> {
   const chapters = book.chapters ?? [];
-  const cse = createGoogleCseClient(loadGoogleCseConfig());
+  const cseConfig = loadGoogleCseConfig();
+  const cse = createGoogleCseClient(cseConfig);
+  if (!cseConfig.enabled) {
+    // Silent-0 class (2026-07-14 incident): CSE credentials were never
+    // provisioned after CP458's name-only registration — research produced 0
+    // findings and factcheck ran without web evidence for 2 months with no
+    // signal. Degradation must be LOUD, never silent.
+    log.warn(
+      'CSE unset — book research yields 0 findings and factcheck runs WITHOUT web evidence ' +
+        '(register GOOGLE_CSE_API_KEY secret + GOOGLE_CSE_CX variable; credentials.md L163)',
+      { mandalaId }
+    );
+  }
 
   // research (loop-2-B) — web gap-fill, reference-tracked (P-2B-REF).
   try {

--- a/src/modules/web-search/client.ts
+++ b/src/modules/web-search/client.ts
@@ -1,0 +1,222 @@
+/**
+ * Language-routed web-search client — drop-in for the Google CSE client
+ * contract (`searchWeb(query, opts) → { items, totalResults, error? }`), so
+ * book-research/book-factcheck swap without call-site changes.
+ *
+ * Routing (benchmark-driven, 2026-07-14):
+ *  - query contains Hangul → Naver Open API. webkr first; when webkr comes up
+ *    short the news + encyc verticals fill in (the benchmark's failed 24%
+ *    were stats/research-flavored queries that news/academic coverage owns).
+ *  - otherwise (en/ja/zh) → OpenRouter web plugin (Exa engine): annotations
+ *    carry real page extracts + direct URLs (citable evidence).
+ *
+ * No cross-provider fallback in v1: a Korean query that Naver can't evidence
+ * is dropped, not padded with an unbenchmarked Exa-Korean result ("근거 없으면
+ * 드랍" — bad evidence is worse than none).
+ *
+ * Never throws — errors are surfaced via `.error` (mirrors CSE client).
+ */
+
+import { logger } from '@/utils/logger';
+import type { WebSearchConfig } from './config';
+
+const log = logger.child({ module: 'web-search' });
+
+export interface WebSearchItem {
+  title: string;
+  link: string;
+  snippet: string;
+  displayLink: string;
+}
+
+export interface WebSearchResult {
+  items: WebSearchItem[];
+  totalResults: number;
+  error?: string;
+}
+
+export interface SearchWebOptions {
+  /** Number of results to return. Default 3 (evidence top-k). */
+  num?: number;
+}
+
+const NAVER_BASE = 'https://openapi.naver.com/v1/search';
+/** webkr misses stats/research queries; these verticals backfill. */
+const NAVER_FALLBACK_VERTICALS = ['news', 'encyc'] as const;
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
+const TIMEOUT_MS = 10_000;
+const OPENROUTER_TIMEOUT_MS = 30_000;
+/** Evidence needs a quotable extract — drop garbled/empty plugin snippets. */
+const MIN_SNIPPET_LEN = 20;
+
+export function hasHangul(text: string): boolean {
+  return /[가-힣]/.test(text);
+}
+
+/** Strip Naver's <b> match-highlight tags + basic entities. */
+export function stripNaverMarkup(s: string): string {
+  return s
+    .replace(/<\/?b>/g, '')
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .trim();
+}
+
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return '';
+  }
+}
+
+async function fetchJsonWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number
+): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    return (await res.json()) as unknown;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface NaverRawItem {
+  title?: string;
+  link?: string;
+  description?: string;
+}
+
+/** Extract OpenRouter web-plugin url_citation annotations into items. */
+export function parseOpenRouterAnnotations(body: unknown, num: number): WebSearchItem[] {
+  const choices = (body as { choices?: Array<{ message?: { annotations?: unknown[] } }> })?.choices;
+  const annotations = choices?.[0]?.message?.annotations ?? [];
+  const items: WebSearchItem[] = [];
+  for (const a of annotations) {
+    const cite = (a as { url_citation?: { url?: string; title?: string; content?: string } })
+      .url_citation;
+    if (!cite?.url) continue;
+    const snippet = String(cite.content ?? '').trim();
+    if (snippet.length < MIN_SNIPPET_LEN) continue;
+    items.push({
+      title: String(cite.title ?? '').trim() || hostnameOf(cite.url),
+      link: cite.url,
+      snippet: snippet.slice(0, 500),
+      displayLink: hostnameOf(cite.url),
+    });
+    if (items.length >= num) break;
+  }
+  return items;
+}
+
+export function createWebSearchClient(config: WebSearchConfig) {
+  async function searchNaverVertical(vertical: string, query: string, num: number) {
+    const url = `${NAVER_BASE}/${vertical}.json?display=${num}&query=${encodeURIComponent(query)}`;
+    const json = (await fetchJsonWithTimeout(
+      url,
+      {
+        headers: {
+          'X-Naver-Client-Id': config.naverClientId,
+          'X-Naver-Client-Secret': config.naverClientSecret,
+        },
+      },
+      TIMEOUT_MS
+    )) as { items?: NaverRawItem[]; total?: number };
+    const items: WebSearchItem[] = (json.items ?? [])
+      .filter((it) => it.link)
+      .map((it) => ({
+        title: stripNaverMarkup(it.title ?? ''),
+        link: it.link ?? '',
+        snippet: stripNaverMarkup(it.description ?? ''),
+        displayLink: hostnameOf(it.link ?? ''),
+      }));
+    return { items, total: json.total ?? items.length };
+  }
+
+  async function searchNaver(query: string, num: number): Promise<WebSearchResult> {
+    try {
+      const web = await searchNaverVertical('webkr', query, num);
+      const merged = [...web.items];
+      const seen = new Set(merged.map((i) => i.link));
+      for (const vertical of NAVER_FALLBACK_VERTICALS) {
+        if (merged.length >= num) break;
+        const extra = await searchNaverVertical(vertical, query, num);
+        for (const it of extra.items) {
+          if (merged.length >= num) break;
+          if (!seen.has(it.link)) {
+            seen.add(it.link);
+            merged.push(it);
+          }
+        }
+      }
+      log.debug(`naver OK: query="${query}" count=${merged.length}`);
+      return { items: merged.slice(0, num), totalResults: web.total };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`naver search failed: ${message}`, { query });
+      return { items: [], totalResults: 0, error: `naver: ${message}` };
+    }
+  }
+
+  async function searchGlobal(query: string, num: number): Promise<WebSearchResult> {
+    try {
+      const body = await fetchJsonWithTimeout(
+        OPENROUTER_URL,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${config.openrouterApiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            model: config.openrouterWebModel,
+            plugins: [{ id: 'web', max_results: num }],
+            messages: [
+              {
+                role: 'user',
+                content: `Search the web for: ${query}\nSummarize the key facts briefly.`,
+              },
+            ],
+          }),
+        },
+        OPENROUTER_TIMEOUT_MS
+      );
+      const items = parseOpenRouterAnnotations(body, num);
+      log.debug(`openrouter-web OK: query="${query}" count=${items.length}`);
+      return { items, totalResults: items.length };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`openrouter web search failed: ${message}`, { query });
+      return { items: [], totalResults: 0, error: `openrouter-web: ${message}` };
+    }
+  }
+
+  /**
+   * CSE-contract search. Routes by query language; a leg that is not
+   * configured returns a `.error` result (caller treats as no evidence).
+   */
+  async function searchWeb(query: string, opts: SearchWebOptions = {}): Promise<WebSearchResult> {
+    const num = Math.min(Math.max(opts.num ?? 3, 1), 10);
+    if (hasHangul(query)) {
+      if (!config.naverEnabled) {
+        return { items: [], totalResults: 0, error: 'web-search: naver leg not configured' };
+      }
+      return searchNaver(query, num);
+    }
+    if (!config.globalEnabled) {
+      return { items: [], totalResults: 0, error: 'web-search: global leg not configured' };
+    }
+    return searchGlobal(query, num);
+  }
+
+  return { searchWeb };
+}

--- a/src/modules/web-search/config.ts
+++ b/src/modules/web-search/config.ts
@@ -1,0 +1,80 @@
+/**
+ * Web-search module config — language-routed evidence source for book
+ * research/factcheck (2026-07-14 provider swap, benchmark-driven).
+ *
+ * Replaces Google CSE (closed to new customers, dies 2027-01-01). Providers
+ * chosen by a 110-query benchmark on real prod mandala titles (see
+ * docs/handoffs/web-search-provider-eval-2026-07-14.md):
+ *  - Korean queries  → Naver Open API (hit@3 76%, official-domain strength)
+ *  - en/ja/zh queries → OpenRouter web plugin (Exa) — real page extracts,
+ *    direct URLs, best citable-evidence rate (vs Gemini grounding's expiring
+ *    redirect URLs + synthesized snippets = disqualified for evidence)
+ *
+ * Unset env → that leg disabled; both unset → enabled=false (graceful,
+ * research yields 0 / factcheck runs without web evidence — fill-book logs
+ * the degradation loudly).
+ */
+
+import { z } from 'zod';
+
+const envSchema = z.object({
+  NAVER_CLIENT_ID: z.string().min(1).optional(),
+  NAVER_CLIENT_SECRET: z.string().min(1).optional(),
+  OPENROUTER_API_KEY: z.string().min(1).optional(),
+  OPENROUTER_WEB_SEARCH_MODEL: z.string().min(1).optional(),
+});
+
+export interface WebSearchConfig {
+  naverClientId: string;
+  naverClientSecret: string;
+  /** Korean leg (Naver Open API). */
+  naverEnabled: boolean;
+  openrouterApiKey: string;
+  /** Carrier model for the OpenRouter web plugin (annotations extractor). */
+  openrouterWebModel: string;
+  /** Global (en/ja/zh) leg via OpenRouter web plugin. */
+  globalEnabled: boolean;
+  /** true when at least one leg is usable. */
+  enabled: boolean;
+}
+
+const DEFAULT_WEB_MODEL = 'openai/gpt-4o-mini';
+
+export function loadWebSearchConfig(env: NodeJS.ProcessEnv = process.env): WebSearchConfig {
+  const parsed = envSchema.safeParse({
+    NAVER_CLIENT_ID: env['NAVER_CLIENT_ID'],
+    NAVER_CLIENT_SECRET: env['NAVER_CLIENT_SECRET'],
+    OPENROUTER_API_KEY: env['OPENROUTER_API_KEY'],
+    OPENROUTER_WEB_SEARCH_MODEL: env['OPENROUTER_WEB_SEARCH_MODEL'],
+  });
+
+  if (!parsed.success) {
+    return disabledConfig();
+  }
+
+  const e = parsed.data;
+  const naverEnabled = Boolean(e.NAVER_CLIENT_ID && e.NAVER_CLIENT_SECRET);
+  const globalEnabled = Boolean(e.OPENROUTER_API_KEY);
+
+  return {
+    naverClientId: e.NAVER_CLIENT_ID ?? '',
+    naverClientSecret: e.NAVER_CLIENT_SECRET ?? '',
+    naverEnabled,
+    openrouterApiKey: e.OPENROUTER_API_KEY ?? '',
+    openrouterWebModel: e.OPENROUTER_WEB_SEARCH_MODEL ?? DEFAULT_WEB_MODEL,
+    globalEnabled,
+    enabled: naverEnabled || globalEnabled,
+  };
+}
+
+function disabledConfig(): WebSearchConfig {
+  return {
+    naverClientId: '',
+    naverClientSecret: '',
+    naverEnabled: false,
+    openrouterApiKey: '',
+    openrouterWebModel: DEFAULT_WEB_MODEL,
+    globalEnabled: false,
+    enabled: false,
+  };
+}

--- a/src/modules/web-search/index.ts
+++ b/src/modules/web-search/index.ts
@@ -1,0 +1,10 @@
+export { loadWebSearchConfig, type WebSearchConfig } from './config';
+export {
+  createWebSearchClient,
+  hasHangul,
+  stripNaverMarkup,
+  parseOpenRouterAnnotations,
+  type WebSearchItem,
+  type WebSearchResult,
+  type SearchWebOptions,
+} from './client';

--- a/tests/smoke/deploy-env-contract.test.ts
+++ b/tests/smoke/deploy-env-contract.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Deploy env-injection contract (regression, 2026-07-14 CSE silent-0).
+ *
+ * Failure class: a config module reads an env var, but deploy.yml never
+ * writes it to the EC2 .env — the feature silently degrades for months
+ * (GOOGLE_CSE_* was name-registered at CP458, code shipped at CP504, yet
+ * research yielded 0 findings and factcheck ran without web evidence
+ * because the credentials were never injected anywhere).
+ *
+ * This test pins the contract: every env var listed here MUST have a
+ * sync line in deploy.yml's .env-write block.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const DEPLOY_YML = path.join(__dirname, '../../.github/workflows/deploy.yml');
+
+// Env vars whose ONLY production injection path is the deploy.yml .env sync.
+const ENV_SYNCED_VARS = [
+  'OPENROUTER_API_KEY',
+  'COHERE_API_KEY',
+  'GOOGLE_CSE_API_KEY',
+  'GOOGLE_CSE_CX',
+];
+
+describe('deploy.yml env-injection contract', () => {
+  const yml = fs.readFileSync(DEPLOY_YML, 'utf-8');
+
+  it.each(ENV_SYNCED_VARS)('%s has a .env sync line', (name) => {
+    // The idempotent sync pattern: grep -q '^NAME=' .env ... || echo "NAME=..." >> .env
+    expect(yml).toMatch(new RegExp(`\\^${name}=`));
+    expect(yml).toContain(`${name}=`);
+  });
+});

--- a/tests/smoke/deploy-env-contract.test.ts
+++ b/tests/smoke/deploy-env-contract.test.ts
@@ -5,7 +5,8 @@
  * writes it to the EC2 .env — the feature silently degrades for months
  * (GOOGLE_CSE_* was name-registered at CP458, code shipped at CP504, yet
  * research yielded 0 findings and factcheck ran without web evidence
- * because the credentials were never injected anywhere).
+ * because the credentials were never injected anywhere; 2026-07-14 the
+ * evidence source moved to Naver + the OpenRouter web plugin).
  *
  * This test pins the contract: every env var listed here MUST have a
  * sync line in deploy.yml's .env-write block.
@@ -19,8 +20,8 @@ const DEPLOY_YML = path.join(__dirname, '../../.github/workflows/deploy.yml');
 const ENV_SYNCED_VARS = [
   'OPENROUTER_API_KEY',
   'COHERE_API_KEY',
-  'GOOGLE_CSE_API_KEY',
-  'GOOGLE_CSE_CX',
+  'NAVER_CLIENT_ID',
+  'NAVER_CLIENT_SECRET',
 ];
 
 describe('deploy.yml env-injection contract', () => {

--- a/tests/smoke/web-search.test.ts
+++ b/tests/smoke/web-search.test.ts
@@ -1,0 +1,120 @@
+/**
+ * web-search module — routing/parsing/disabled-graceful unit tests
+ * (2026-07-14 provider swap: Naver ko leg + OpenRouter web plugin global leg).
+ */
+import { loadWebSearchConfig } from '../../src/modules/web-search/config';
+import {
+  createWebSearchClient,
+  hasHangul,
+  stripNaverMarkup,
+  parseOpenRouterAnnotations,
+} from '../../src/modules/web-search/client';
+
+describe('loadWebSearchConfig', () => {
+  it('disabled when nothing is set', () => {
+    const c = loadWebSearchConfig({} as NodeJS.ProcessEnv);
+    expect(c.enabled).toBe(false);
+    expect(c.naverEnabled).toBe(false);
+    expect(c.globalEnabled).toBe(false);
+  });
+
+  it('naver leg needs BOTH id and secret', () => {
+    const c = loadWebSearchConfig({ NAVER_CLIENT_ID: 'x' } as NodeJS.ProcessEnv);
+    expect(c.naverEnabled).toBe(false);
+    const c2 = loadWebSearchConfig({
+      NAVER_CLIENT_ID: 'x',
+      NAVER_CLIENT_SECRET: 'y',
+    } as NodeJS.ProcessEnv);
+    expect(c2.naverEnabled).toBe(true);
+    expect(c2.enabled).toBe(true);
+  });
+
+  it('global leg rides OPENROUTER_API_KEY with a default carrier model', () => {
+    const c = loadWebSearchConfig({ OPENROUTER_API_KEY: 'k' } as NodeJS.ProcessEnv);
+    expect(c.globalEnabled).toBe(true);
+    expect(c.openrouterWebModel).toBe('openai/gpt-4o-mini');
+  });
+});
+
+describe('hasHangul routing predicate', () => {
+  it.each([
+    ['마라톤 풀코스 훈련', true],
+    ['JLPT N2 공부 시간', true],
+    ['JLPT N2 study hours', false],
+    ['HSK 4级 词汇量', false],
+    ['しまなみ海道 サイクリング', false],
+  ])('%s → %s', (q, expected) => {
+    expect(hasHangul(q)).toBe(expected);
+  });
+});
+
+describe('stripNaverMarkup', () => {
+  it('removes highlight tags and entities', () => {
+    expect(stripNaverMarkup('<b>라떼 아트</b> &amp; 우유 &quot;스티밍&quot;')).toBe(
+      '라떼 아트 & 우유 "스티밍"'
+    );
+  });
+});
+
+describe('parseOpenRouterAnnotations', () => {
+  const body = {
+    choices: [
+      {
+        message: {
+          annotations: [
+            {
+              type: 'url_citation',
+              url_citation: {
+                url: 'https://example.com/a',
+                title: 'A',
+                content: 'a'.repeat(50),
+              },
+            },
+            // dropped: garbled/empty snippet is not evidence
+            { type: 'url_citation', url_citation: { url: 'https://example.com/b', content: 'e' } },
+            {
+              type: 'url_citation',
+              url_citation: { url: 'https://example.com/c', content: 'c'.repeat(30) },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  it('extracts direct URLs, drops sub-minimum snippets, caps at num', () => {
+    const items = parseOpenRouterAnnotations(body, 3);
+    expect(items.map((i) => i.link)).toEqual(['https://example.com/a', 'https://example.com/c']);
+    expect(items[0]?.displayLink).toBe('example.com');
+    // title fallback = hostname when absent
+    expect(items[1]?.title).toBe('example.com');
+  });
+
+  it('tolerates malformed bodies', () => {
+    expect(parseOpenRouterAnnotations({}, 3)).toEqual([]);
+    expect(parseOpenRouterAnnotations(null, 3)).toEqual([]);
+  });
+});
+
+describe('createWebSearchClient routing (no network — unconfigured legs error out)', () => {
+  it('Korean query without naver leg → error result, never throws', async () => {
+    const client = createWebSearchClient(
+      loadWebSearchConfig({ OPENROUTER_API_KEY: 'k' } as NodeJS.ProcessEnv)
+    );
+    const r = await client.searchWeb('마라톤 훈련');
+    expect(r.items).toEqual([]);
+    expect(r.error).toContain('naver leg not configured');
+  });
+
+  it('global query without openrouter leg → error result, never throws', async () => {
+    const client = createWebSearchClient(
+      loadWebSearchConfig({
+        NAVER_CLIENT_ID: 'x',
+        NAVER_CLIENT_SECRET: 'y',
+      } as NodeJS.ProcessEnv)
+    );
+    const r = await client.searchWeb('JLPT N2 study hours');
+    expect(r.items).toEqual([]);
+    expect(r.error).toContain('global leg not configured');
+  });
+});


### PR DESCRIPTION
## Why (root cause chain)

1. **Silent-0 incident**: book research produced 0 findings / 16 books and factcheck recorded 336 verdicts — ALL UNVERIFIABLE with 0 evidence URLs, because GOOGLE_CSE credentials were never provisioned end-to-end (name-only registration at CP458, code shipped flag-ON at CP504, graceful degrade silenced it).
2. **Google CSE is a dead end**: closed to new customers, service ends 2027-01-01, entire-web option removed for new engines 2026-03 (verified against official docs + live 403 probes).

## Provider decision (benchmark-driven)

4 parallel research tracks (25+ providers) + a **110-query benchmark on real prod mandala titles** (50 ko × Naver, 50 en + 10 ja/zh × Gemini grounding vs OpenRouter web plugin), graded exhaustively:

| Leg | Winner | Evidence |
|---|---|---|
| ko | **Naver Open API** | hit@3 76%, p50 319ms, official-domain strength; failed band (stats/research queries) covered by news+encyc vertical backfill |
| en | **OpenRouter web plugin (Exa)** | citable-relevant 87% vs Gemini's effective 79% (11.3% of Gemini URLs are expiring vertexaisearch redirects; snippets are LLM-synthesized, decoupled from pages) — real page extracts + direct URLs, higher-authority domains |
| ja/zh | **OpenRouter** | surfaced official primary sources (jlpt.jp, chinesetest.cn); zero unresolvable URLs |

Full evaluation: docs/handoffs/web-search-provider-eval-2026-07-14.md. Cost: ko leg free (25k/day quota), global leg ~$5/1k on the existing OpenRouter account (~$5/mo at current volume).

## Changes

1. **src/modules/web-search/** — language-routed client implementing the exact CSE searchWeb contract (research/factcheck swap without call-site changes). Hangul → Naver (webkr + news/encyc backfill, dedup); else → OpenRouter web plugin (min-snippet guard). No cross-provider fallback in v1.
2. **fill-book.ts** — swaps to createWebSearchClient; loud warn when legs are unset/partial.
3. **deploy.yml** — NAVER_CLIENT_ID/SECRET .env sync (secrets registered 2026-07-14, verified live via webkr 200 probe). Global leg rides existing OPENROUTER_API_KEY sync.
4. **tests** — contract test tracks NAVER_*; 13 new unit tests.

src/modules/google-cse/ stays for the internal PoC route only; the book pipeline no longer references it.

## Verification

- tsc 0 errors; jest 13/13
- Post-merge: regenerate 1 ko + 1 en book → verify references[]/chapter.research[] > 0 and factcheck verdicts carry evidence URLs

Data-Write: none-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)