### PR TITLE
feat(share): Phase 2 — learning-page share menu mints short links

### DIFF
--- a/frontend/src/features/learning-share/ui/LearningShareMenu.tsx
+++ b/frontend/src/features/learning-share/ui/LearningShareMenu.tsx
@@ -103,10 +103,24 @@ export function LearningShareMenu({ mandalaId, videoId }: LearningShareMenuProps
     staleTime: 5 * 60_000,
   });
 
+  // Share v2 — mint a short link (insighta.one/s/CODE) when the popover
+  // opens; the BE reuses a live link so repeated opens don't pile up rows.
+  // The legacy /og/learning URL stays as fallback if the mint fails.
+  const shortLinkQuery = useQuery({
+    queryKey: ['learning-share-short', mandalaId, videoId],
+    queryFn: () =>
+      apiClient.mintShortLink({ targetType: 'learning_video', targetId: mandalaId, videoId }),
+    enabled: open && Boolean(mandalaId) && Boolean(videoId),
+    staleTime: 5 * 60_000,
+    retry: 1,
+  });
+
   const previewTitle = ogQuery.data?.title ?? '';
   const previewDescription = ogQuery.data?.description ?? '';
   const previewThumbnail = ogQuery.data?.thumbnail ?? '';
-  const shareUrl = buildShareUrl({ origin: window.location.origin, mandalaId, videoId });
+  const shareUrl =
+    shortLinkQuery.data?.data?.url ??
+    buildShareUrl({ origin: window.location.origin, mandalaId, videoId });
 
   // Outbound share text — used as the tweet body / Naver share title.
   // Priority: BE-resolved description (AI summary first sentence) >

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1153,6 +1153,24 @@ class ApiClient {
    * single source of truth for the FE share-menu preview card so what the
    * user sees matches the SNS-rendered card byte-for-byte. CP454+.
    */
+  /**
+   * Share v2 — mint a short link (insighta.one/s/CODE). One backbone for
+   * every share surface; BE reuses a live link for the same target+mode.
+   */
+  async mintShortLink(input: {
+    targetType: 'note_episode' | 'learning_video' | 'mandala';
+    targetId: string;
+    videoId?: string;
+  }): Promise<{
+    status: string;
+    data: { code: string; url: string; expiresAt: string | null };
+  }> {
+    return this.request('/share-links', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+
   async getLearningShareOgMeta(
     mandalaId: string,
     videoId: string

--- a/src/api/routes/og.ts
+++ b/src/api/routes/og.ts
@@ -53,7 +53,7 @@ const OG_DEFAULTS = {
 /** Resolve title / description / thumbnail / spaPath for a learning share
  *  target. Same logic feeds both the HTML response (SNS bot) and the
  *  `?format=json` response (FE preview card) so the two stay drift-free. */
-async function resolveOgMeta(
+export async function resolveOgMeta(
   mandalaId: string,
   videoId: string
 ): Promise<{ title: string; description: string; thumbnail: string; spaPath: string }> {

--- a/src/api/routes/share-links.ts
+++ b/src/api/routes/share-links.ts
@@ -22,6 +22,7 @@ import {
   type ShareMode,
   type ShareTargetType,
 } from '@/modules/share-links/manager';
+import { resolveOgMeta } from './og';
 
 function escapeHtml(s: string): string {
   return s
@@ -157,7 +158,7 @@ export async function shareLinkResolverRoutes(fastify: FastifyInstance): Promise
         .header('Content-Type', 'text/html; charset=utf-8')
         // Short cache: bots re-scrape fresh cards; humans redirect instantly.
         .header('Cache-Control', 'public, max-age=300')
-        .send(ogPage({ ...meta, image: brandImage, pageUrl }))
+        .send(ogPage({ image: brandImage, ...meta, pageUrl }))
     );
   });
 }
@@ -165,7 +166,7 @@ export async function shareLinkResolverRoutes(fastify: FastifyInstance): Promise
 async function targetMeta(
   row: ShareLinkRow,
   origin: string
-): Promise<{ title: string; description: string; redirectTo: string }> {
+): Promise<{ title: string; description: string; redirectTo: string; image?: string }> {
   const prisma = getPrismaClient();
   const mandala = await prisma.user_mandalas.findFirst({
     where: { id: row.target_id },
@@ -180,12 +181,24 @@ async function targetMeta(
         description: '가입 없이 48시간 무료 청취 · AI가 유튜브 핵심 구간만 이어 만든 지식 팟캐스트',
         redirectTo: `${origin}/mobile/?s=${encodeURIComponent(row.code)}`,
       };
-    case 'learning_video': // Phase 2 — minted by the learning-page share menu
+    case 'learning_video': {
+      // Card parity with the legacy /og/learning route: video title,
+      // AI one-liner, real thumbnail (og.ts is the single resolver).
+      if (row.video_id) {
+        const og = await resolveOgMeta(row.target_id, row.video_id);
+        return {
+          title: og.title,
+          description: og.description,
+          image: og.thumbnail,
+          redirectTo: `${origin}${og.spaPath}`,
+        };
+      }
       return {
         title: `${noteTitle} — Insighta`,
         description: 'AI가 고른 유튜브 핵심 구간으로 배우는 나만의 커리큘럼',
         redirectTo: `${origin}/learning/${row.target_id}/${row.video_id ?? ''}`,
       };
+    }
     case 'mandala': // Phase 3 — recipient page lands here
     default:
       return {


### PR DESCRIPTION
Phase 2 of the share-v2 design (docs/design/share-v2-2026-07-14.md). The learning-page share menu now shares `insighta.one/s/CODE` (~31 chars) instead of the 71+-char `/og/learning/{uuid}/{videoId}` URL.

## Changes
- **apiClient.mintShortLink** → `POST /api/v1/share-links` (envelope pattern; URL-contract test stays green).
- **LearningShareMenu**: lazily mints a short link when the popover opens (React Query, 5-min staleTime, BE dedupes live links). All four channels — copy / X / Naver / Kakao — pick the short URL reactively; if the mint fails the legacy `/og/learning` URL is the automatic fallback, so sharing can never regress below today's behavior.
- **Resolver card parity**: `og.ts`'s `resolveOgMeta` is exported and reused for `learning_video` targets, so the short-link card carries the video title, AI one-liner, and real thumbnail — byte-for-byte the same meta as the legacy card.

## Not in this PR
- Kakao SDK activation still needs `VITE_KAKAO_JS_KEY` (operator console action — docs/guides/kakao-share-setup.md). The Kakao button stays in its existing disabled state until then.

## Verification
BE tsc 0 · FE tsc 0 · vitest 514/514 · prod build OK · dev-server smoke 200/200 (`/`, `/mandalas/new`) with zero vite errors. Post-deploy: mint→resolve round-trip on prod with a real account link.

Rollback: revert PR — resolver keeps serving existing /s/ links; menu falls back to legacy URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)