### PR TITLE
feat(mobile): single-hub menu + in-app notices (Stage 1)

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -176,6 +176,11 @@
   @media (prefers-reduced-motion: reduce){ .sk,.skt{animation:none} }
 
   /* ---- MENU ---- */
+  .gearBtn{position:relative; display:grid; place-items:center; width:30px; height:30px; margin:-8px -6px;
+    border:none; background:none; color:var(--paper-sub); cursor:pointer; -webkit-tap-highlight-color:transparent}
+  .gearBtn:active{transform:scale(.92)}
+  .gearDot{position:absolute; top:4px; right:3px; width:6px; height:6px; border-radius:50%; background:var(--acc, #E8804C)}
+  .newsDot{width:6px; height:6px; border-radius:50%; background:var(--acc, #E8804C); margin-left:2px}
   .menu-list{margin-top:12px; display:flex; flex-direction:column; gap:8px}
   .mrow{display:flex; align-items:center; gap:10px; background:rgba(255,255,255,.55); border:none; width:100%;
     font-family:inherit; text-align:left; cursor:pointer; color:var(--paper-ink);
@@ -587,15 +592,16 @@
 
       <!-- 홈 -->
       <div class="scr" data-s="home" id="scrHome">
-        <div class="top"><span class="tt">내 만다라</span><span class="batt" id="sigHome"><svg class="ksig" width="15" height="15" viewBox="0 0 17 17" aria-hidden="true"><rect class="c" x="0.5" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c core" x="6.3" y="6.3" width="4.4" height="4.4" rx="1.2"/></svg></span></div>
+        <div class="top"><span class="tt">내 만다라</span><span style="display:flex;align-items:center;gap:10px;margin-left:auto"><button class="gearBtn" id="bGear" aria-label="설정"><svg width="15" height="15" viewBox="0 0 20 20" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><circle cx="10" cy="10" r="3.1"/><path d="M10 2.6v2.6M10 14.8v2.6M2.6 10h2.6M14.8 10h2.6M4.8 4.8l1.9 1.9M13.3 13.3l1.9 1.9M15.2 4.8l-1.9 1.9M6.7 13.3l-1.9 1.9"/></g></svg><span class="gearDot" id="gearDot" hidden></span></button><span class="batt" id="sigHome"><svg class="ksig" width="15" height="15" viewBox="0 0 17 17" aria-hidden="true"><rect class="c" x="0.5" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c core" x="6.3" y="6.3" width="4.4" height="4.4" rx="1.2"/></svg></span></span></div>
         <button class="goal-pill" id="bGoal"><span class="gp-plus"></span>원하는 목표 적기</button>
         <div class="rows" id="rows"><div class="skrow"><span class="sk skj"></span><span class="skm"><span class="sk" style="width:62%;height:13px"></span><span class="sk" style="width:36%;height:10px"></span></span></div><div class="skrow"><span class="sk skj"></span><span class="skm"><span class="sk" style="width:62%;height:13px"></span><span class="sk" style="width:36%;height:10px"></span></span></div><div class="skrow"><span class="sk skj"></span><span class="skm"><span class="sk" style="width:62%;height:13px"></span><span class="sk" style="width:36%;height:10px"></span></span></div></div>
       </div>
 
       <!-- MENU -->
       <div class="scr" data-s="menu" id="scrMenu">
-        <div class="top"><span class="tt">MENU</span><span class="batt" id="sigMenu"><svg class="ksig" width="15" height="15" viewBox="0 0 17 17" aria-hidden="true"><rect class="c" x="0.5" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c core" x="6.3" y="6.3" width="4.4" height="4.4" rx="1.2"/></svg></span></div>
+        <div class="top"><span class="tt">설정</span><span class="batt" id="sigMenu"><svg class="ksig" width="15" height="15" viewBox="0 0 17 17" aria-hidden="true"><rect class="c" x="0.5" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c core" x="6.3" y="6.3" width="4.4" height="4.4" rx="1.2"/></svg></span></div>
         <div class="menu-list">
+          <button class="mrow" id="bNews">새소식<span class="newsDot" id="newsDot" hidden></span><span class="sub" id="newsSub">공지 · 업데이트</span></button>
           <div class="mrow" style="cursor:default">
             컬러웨이
             <span class="ways">
@@ -609,7 +615,14 @@
           <button class="mrow" id="bFeedback">의견 보내기<span class="sub">기능 제안 · 불편 신고</span></button>
           <button class="mrow" id="bLogout">로그아웃</button>
         </div>
-        <div class="menu-note">MENU를 다시 누르면 돌아갑니다</div>
+        <div class="menu-note">MENU를 누르면 내 만다라로</div>
+      </div>
+
+      <!-- 새소식 -->
+      <div class="scr" data-s="news" id="scrNews">
+        <div class="top"><span class="tt">새소식</span></div>
+        <div class="menu-list" id="newsList"><div class="menu-note" style="margin-top:20px">아직 공지가 없어요</div></div>
+        <div class="menu-note">MENU를 누르면 내 만다라로</div>
       </div>
 
       <!-- 플레이어 -->
@@ -759,7 +772,7 @@
   }
 
   /* ================= 화면 상태 ================= */
-  var SCREENS=['login','home','menu','player'];
+  var SCREENS=['login','home','menu','news','player'];
   var scr={}; SCREENS.forEach(function(n){scr[n]=document.querySelector('.scr[data-s="'+n+'"]')});
   var cur='login';
   function bootDone(){
@@ -1675,9 +1688,9 @@
     if(wheelStole()) return;
     if(cur==='login') return;
     if(curNote&&curNote.guest&&cur==='player'){ setPlaying(false); document.body.classList.remove('clipmode'); show('login'); return; } // 게스트 = 가입 유도
+    // MENU = 언제나 "내 만다라"로 (설정 진입은 리스트의 기어 아이콘만)
     if(cur==='player'){ setPlaying(false); document.body.classList.remove('clipmode'); show('home'); renderRows(); }
-    else if(cur==='menu'){ show('home'); }
-    else{ show('menu'); }
+    else if(cur!=='home'){ show('home'); }
   };
   document.getElementById('instClose').onclick=function(){ document.getElementById('instOv').hidden=true; };
   document.getElementById('instOv').addEventListener('click',function(e){ if(e.target===this) this.hidden=true; });
@@ -1931,6 +1944,51 @@
     fetch(location.pathname,{cache:'reload'}).catch(function(){})
       .finally(function(){ location.reload(); });
   };
+  /* ── 새소식 (Stage 1: pull 피드 + 클라이언트 언리드) ── */
+  var NEWS_SEEN='insighta-news-seen'; var newsCache=null;
+  function fmtNoticeDate(iso){ try{ var d=new Date(iso); return (d.getMonth()+1)+'월 '+d.getDate()+'일'; }catch(e){ return ''; } }
+  async function fetchNews(){
+    if(newsCache) return newsCache;
+    var r=await fetch('/api/v1/app-notices?limit=20');
+    if(!r.ok) throw new Error('HTTP '+r.status);
+    var j=await r.json();
+    newsCache=(j&&j.data&&j.data.notices)||[];
+    return newsCache;
+  }
+  function newsSeenTs(){ try{ return localStorage.getItem(NEWS_SEEN)||''; }catch(e){ return ''; } }
+  function updateNewsDots(latest){
+    var unread=!!(latest&&latest>newsSeenTs());
+    document.getElementById('gearDot').hidden=!unread;
+    document.getElementById('newsDot').hidden=!unread;
+  }
+  function checkNewsUnread(){ // 부팅 시 1회 — 기어에 점만 표시 (조용히 실패)
+    fetchNews().then(function(ns){ updateNewsDots(ns[0]&&ns[0].published_at); }).catch(function(){});
+  }
+  function renderNews(ns){
+    var box=document.getElementById('newsList');
+    if(!ns.length){ box.innerHTML='<div class="menu-note" style="margin-top:20px">아직 공지가 없어요</div>'; return; }
+    box.innerHTML='';
+    ns.forEach(function(n){
+      var d=document.createElement('div');
+      d.className='mrow'; d.style.cssText='flex-direction:column;align-items:flex-start;gap:4px;cursor:default';
+      var h=document.createElement('div'); h.style.cssText='display:flex;gap:8px;align-items:baseline;width:100%';
+      var t=document.createElement('span'); t.textContent=n.title; t.style.fontWeight='700';
+      var dt=document.createElement('span'); dt.className='sub'; dt.textContent=fmtNoticeDate(n.published_at);
+      h.appendChild(t); h.appendChild(dt);
+      var b=document.createElement('div'); b.textContent=n.body;
+      b.style.cssText='font-size:11px;line-height:1.65;color:var(--paper-sub);white-space:pre-wrap';
+      d.appendChild(h); d.appendChild(b); box.appendChild(d);
+    });
+  }
+  document.getElementById('bGear').onclick=function(){ show('menu'); };
+  document.getElementById('bNews').onclick=function(){
+    show('news');
+    fetchNews().then(function(ns){
+      renderNews(ns);
+      if(ns[0]) try{ localStorage.setItem(NEWS_SEEN, ns[0].published_at); }catch(e){}
+      updateNewsDots(null); // 읽음 처리
+    }).catch(function(){ document.getElementById('newsList').innerHTML='<div class="menu-note" style="margin-top:20px">불러오지 못했어요 — 연결 확인 후 다시</div>'; });
+  };
   document.getElementById('bFeedback').onclick=function(){
     // 메일 앱으로 — 별도 서버 없이 support 공식 주소로 전달
     location.href='mailto:support@insighta.one?subject='+encodeURIComponent('다이얼 의견')
@@ -2076,7 +2134,7 @@
       }catch(e){ GUEST=null; show('login'); toast('링크를 열지 못했어요'); return; }
     }
     var tok=await freshToken();
-    if(tok){ show('home'); loadList(); wheelIntroOnce(); }
+    if(tok){ show('home'); loadList(); wheelIntroOnce(); checkNewsUnread(); }
     else { show('login'); }
   })();
 </script>

--- a/prisma/migrations/app-notices/001_create_app_notices.sql
+++ b/prisma/migrations/app-notices/001_create_app_notices.sql
@@ -1,0 +1,12 @@
+-- In-app notices for the dial mobile player (2026-07-15).
+-- prisma db push silent-fails on Supabase — apply manually to local AND
+-- prod, verify with \d app_notices.
+CREATE TABLE IF NOT EXISTS app_notices (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title        varchar(120) NOT NULL,
+  body         text NOT NULL,
+  published_at timestamptz NOT NULL DEFAULT now(),
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_app_notices_published ON app_notices(published_at);
+ALTER TABLE app_notices ENABLE ROW LEVEL SECURITY;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2638,3 +2638,18 @@ model share_links {
   @@index([created_by])
   @@schema("public")
 }
+
+/// In-app notices for the dial mobile player (2026-07-15): pull-based
+/// 새소식 feed — public read, admin publish. Unread state lives client-side
+/// (localStorage latest-seen timestamp).
+/// Raw SQL DDL: prisma/migrations/app-notices/001_create_app_notices.sql
+model app_notices {
+  id           String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  title        String    @db.VarChar(120)
+  body         String
+  published_at DateTime  @default(now()) @db.Timestamptz(6)
+  created_at   DateTime  @default(now()) @db.Timestamptz(6)
+
+  @@index([published_at])
+  @@schema("public")
+}

--- a/src/api/routes/admin/index.ts
+++ b/src/api/routes/admin/index.ts
@@ -7,6 +7,7 @@ import { adminPromotionRoutes } from './promotions';
 import { adminAuditRoutes } from './audit';
 import { adminChannelBlocklistRoutes } from './channel-blocklist';
 import { adminBetaApplicationRoutes } from './beta-applications';
+import { adminNoticeRoutes } from './notices';
 import { adminPerformanceRoutes } from './performance';
 import { adminRedemptionRoutes, adminBulkRoutes } from './redemption';
 // Stripe scaffold moved to payments.legacy.ts on 2026-05-13 (superseded by
@@ -53,6 +54,7 @@ export async function adminRoutes(fastify: FastifyInstance) {
   await fastify.register(adminAuditRoutes, { prefix: '/audit-log' });
   await fastify.register(adminChannelBlocklistRoutes, { prefix: '/channel-blocklist' });
   await fastify.register(adminBetaApplicationRoutes);
+  await fastify.register(adminNoticeRoutes);
   await fastify.register(adminAnalyticsRoutes, { prefix: '/analytics' });
   await fastify.register(adminContentRoutes, { prefix: '/content' });
   await fastify.register(adminReportRoutes, { prefix: '/reports' });

--- a/src/api/routes/admin/notices.ts
+++ b/src/api/routes/admin/notices.ts
@@ -1,0 +1,36 @@
+import { FastifyInstance } from 'fastify';
+import { getPrismaClient } from '../../../modules/database/client';
+
+/**
+ * Admin — publish/delete in-app notices (새소식) shown in the dial mobile
+ * player. Admin-gated per the hard rule for new admin routes.
+ */
+export async function adminNoticeRoutes(fastify: FastifyInstance) {
+  const adminAuth = { onRequest: [fastify.authenticate, fastify.authenticateAdmin] };
+
+  fastify.post<{ Body: { title?: string; body?: string } }>(
+    '/notices',
+    adminAuth,
+    async (request, reply) => {
+      const { title, body } = request.body ?? {};
+      if (!title?.trim() || title.length > 120 || !body?.trim()) {
+        return reply.code(400).send({ status: 'error', error: 'title (≤120) and body required' });
+      }
+      const row = await getPrismaClient().app_notices.create({
+        data: { title: title.trim(), body: body.trim() },
+      });
+      return reply
+        .code(200)
+        .send({ status: 'ok', data: { id: row.id, publishedAt: row.published_at } });
+    }
+  );
+
+  fastify.delete<{ Params: { id: string } }>('/notices/:id', adminAuth, async (request, reply) => {
+    const { id } = request.params;
+    if (!/^[0-9a-f-]{36}$/i.test(id)) {
+      return reply.code(400).send({ status: 'error', error: 'invalid id' });
+    }
+    await getPrismaClient().app_notices.deleteMany({ where: { id } });
+    return reply.code(200).send({ status: 'ok' });
+  });
+}

--- a/src/api/routes/app-notices.ts
+++ b/src/api/routes/app-notices.ts
@@ -1,0 +1,34 @@
+/**
+ * In-app notices (새소식) — public read feed for the dial mobile player
+ * (2026-07-15, Stage 1 of 공지/새소식 전달; Stage 2 = Web Push, separate
+ * design). Publishing is admin-only (src/api/routes/admin/notices.ts).
+ *
+ * Unread state is client-side: the player stores the newest published_at
+ * it has shown and compares against this feed.
+ */
+
+import { FastifyInstance } from 'fastify';
+import { getPrismaClient } from '@/modules/database/client';
+
+const MAX_NOTICES = 20;
+
+/** Pure clamp for the public feed's limit param — unit-tested. */
+export function clampNoticeLimit(raw: unknown): number {
+  const n = Number(raw ?? MAX_NOTICES);
+  return Number.isFinite(n) ? Math.min(Math.max(1, Math.trunc(n)), MAX_NOTICES) : MAX_NOTICES;
+}
+
+export async function appNoticeRoutes(fastify: FastifyInstance): Promise<void> {
+  fastify.get<{ Querystring: { limit?: string } }>('/', async (request, reply) => {
+    const limit = clampNoticeLimit(request.query.limit);
+
+    const rows = await getPrismaClient().app_notices.findMany({
+      orderBy: { published_at: 'desc' },
+      take: limit,
+      select: { id: true, title: true, body: true, published_at: true },
+    });
+    return reply
+      .header('Cache-Control', 'public, max-age=60')
+      .send({ status: 'ok', data: { notices: rows } });
+  });
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -19,6 +19,7 @@ import { mandalaRoutes } from './routes/mandalas';
 import { mandalaEpisodeAudioRoutes } from './routes/mandala-episode-audio';
 import { guestNoteRoutes } from './routes/guest-share';
 import { shareLinkMintRoutes, shareLinkResolverRoutes } from './routes/share-links';
+import { appNoticeRoutes } from './routes/app-notices';
 import { imageRoutes } from './routes/images';
 import { ontologyRoutes } from './routes/ontology';
 import { searchRoutes } from './routes/search';
@@ -315,6 +316,9 @@ export async function buildServer() {
       await instance.register(shareLinkMintRoutes, { prefix: '/share-links' });
       await instance.register(shareLinkResolverRoutes, { prefix: '/s' });
       await instance.register(guestNoteRoutes, { prefix: '/guest' });
+
+      // In-app notices (새소식) — public read feed for the mobile player
+      await instance.register(appNoticeRoutes, { prefix: '/app-notices' });
 
       // Register image proxy routes
       await instance.register(imageRoutes, { prefix: '/images' });

--- a/tests/smoke/app-notices.test.ts
+++ b/tests/smoke/app-notices.test.ts
@@ -1,0 +1,20 @@
+/**
+ * In-app notices (새소식) — public feed limit clamp (2026-07-15).
+ */
+process.env['ENCRYPTION_SECRET'] ??=
+  'test-secret-test-secret-test-secret-test-secret-test-secret-1234';
+
+import { clampNoticeLimit } from '@/api/routes/app-notices';
+
+describe('clampNoticeLimit', () => {
+  it('defaults to 20 when absent or garbage', () => {
+    expect(clampNoticeLimit(undefined)).toBe(20);
+    expect(clampNoticeLimit('abc')).toBe(20);
+  });
+  it('clamps to [1, 20] and truncates', () => {
+    expect(clampNoticeLimit('0')).toBe(1);
+    expect(clampNoticeLimit('-5')).toBe(1);
+    expect(clampNoticeLimit('7.9')).toBe(7);
+    expect(clampNoticeLimit('999')).toBe(20);
+  });
+});


### PR DESCRIPTION
Implements James's menu design + Stage 1 of 공지/새소식 delivery.

## Menu — one hub, one button meaning
The same MENU button used to route to different screens depending on context (player→settings, settings→list), which made 'where does MENU go?' unanswerable. Now:
- **내 만다라 list is the only hub.** Settings entry is a **gear icon** in the list's top bar (hand-drawn stroke SVG, 30px tap target — no emoji per brand rule).
- **Wheel MENU means one thing everywhere: back to 내 만다라** (player→list, settings→list, news→list). Guest player→login nudge unchanged.
- The old MENU screen is retitled **설정** and reached only via the gear.

## 새소식 (in-app notices, Stage 1)
- `app_notices` table — raw DDL at `prisma/migrations/app-notices/001_create_app_notices.sql` (applied + \d-verified on local; prod before merge).
- `GET /api/v1/app-notices` — public feed (60s cache; limit clamp unit-tested).
- `POST/DELETE /api/v1/admin/notices` — **admin-gated** (`authenticate + authenticateAdmin`, per the admin-route hard rule; unauth 401 verified on prod post-deploy before done-report).
- 설정 gains a **새소식** row; an **unread dot** shows on the gear and the row when a notice is newer than the client's latest-seen timestamp; opening the list clears it.
- Stage 2 (Web Push for installed PWAs) is a separate design — not in this PR.

## Verification
BE tsc 0 · jest (share-links + app-notices) 10/10 · mobile main script syntax-checked · static page + BE only (no frontend/src). Post-deploy: public feed 200, admin 401 unauth, real-device menu flow = James gate.

Rollback: revert PR; table is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)