### PR TITLE
feat(invites): 초대권 — member-delegated beta invitations (default 2)

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -181,6 +181,24 @@
   .gearBtn:active{transform:scale(.92)}
   .gearDot{position:absolute; top:4px; right:3px; width:6px; height:6px; border-radius:50%; background:var(--acc, #E8804C)}
   .newsDot{width:6px; height:6px; border-radius:50%; background:var(--acc, #E8804C); margin-left:2px}
+  .tk{position:relative; display:flex; align-items:center; gap:10px; margin-bottom:8px;
+    background:linear-gradient(135deg, rgba(255,255,255,.75), rgba(255,255,255,.45));
+    border:1px solid rgba(0,0,0,.07); border-radius:12px; padding:11px 12px}
+  .tk::before{content:""; position:absolute; left:40px; top:6px; bottom:6px; border-left:1.5px dashed rgba(0,0,0,.13)}
+  .tk .no{flex:none; width:28px; text-align:center; font-size:13px; font-weight:900; color:var(--ui); font-variant-numeric:tabular-nums}
+  .tk .lab{font-size:11.5px; font-weight:800; color:var(--paper-ink)}
+  .tk .st{font-size:9px; color:var(--paper-sub); margin-top:2px}
+  .tk.used{opacity:.55}
+  .tk .stamp{position:absolute; right:10px; top:50%; transform:translateY(-50%) rotate(-8deg);
+    font-size:9px; font-weight:900; color:var(--ui); border:1.5px solid var(--ui); border-radius:6px; padding:2px 6px; letter-spacing:.1em}
+  .tk-inp{display:block; width:100%; box-sizing:border-box; margin:12px 0 8px; padding:11px 12px;
+    background:rgba(255,255,255,.8); border:1px solid rgba(0,0,0,.1); border-radius:11px;
+    font-family:inherit; font-size:13px; color:var(--paper-ink); -webkit-appearance:none}
+  .tk-inp::placeholder{color:var(--paper-sub)}
+  .tk-btn{display:block; width:100%; border:none; cursor:pointer; padding:12px; border-radius:11px;
+    background:var(--ui); color:#fff; font-family:inherit; font-size:13px; font-weight:800; letter-spacing:.02em}
+  .tk-btn:disabled{background:rgba(0,0,0,.14); color:rgba(255,255,255,.85)}
+  .tk-btn:active:not(:disabled){transform:scale(.98)}
   .menu-list{margin-top:12px; display:flex; flex-direction:column; gap:8px}
   .mrow{display:flex; align-items:center; gap:10px; background:rgba(255,255,255,.55); border:none; width:100%;
     font-family:inherit; text-align:left; cursor:pointer; color:var(--paper-ink);
@@ -602,6 +620,7 @@
         <div class="top"><span class="tt">설정</span><span class="batt" id="sigMenu"><svg class="ksig" width="15" height="15" viewBox="0 0 17 17" aria-hidden="true"><rect class="c" x="0.5" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c core" x="6.3" y="6.3" width="4.4" height="4.4" rx="1.2"/></svg></span></div>
         <div class="menu-list">
           <button class="mrow" id="bNews">새소식<span class="newsDot" id="newsDot" hidden></span><span class="sub" id="newsSub">공지 · 업데이트</span></button>
+          <button class="mrow" id="bInvite">초대권 사용하기<span class="sub" id="invSub">친구를 베타에 초대</span></button>
           <div class="mrow" style="cursor:default">
             컬러웨이
             <span class="ways">
@@ -622,6 +641,15 @@
       <div class="scr" data-s="news" id="scrNews">
         <div class="top"><span class="tt">새소식</span></div>
         <div class="menu-list" id="newsList"><div class="menu-note" style="margin-top:20px">아직 공지가 없어요</div></div>
+        <div class="menu-note">MENU를 누르면 내 만다라로</div>
+      </div>
+
+      <!-- 초대권 -->
+      <div class="scr" data-s="invite" id="scrInvite">
+        <div class="top"><span class="tt">초대권</span></div>
+        <div id="tkList"></div>
+        <input class="tk-inp" id="tkEmail" type="email" inputmode="email" autocomplete="off" placeholder="친구 이메일 주소">
+        <button class="tk-btn" id="tkSend">초대 메일 보내기</button>
         <div class="menu-note">MENU를 누르면 내 만다라로</div>
       </div>
 
@@ -772,7 +800,7 @@
   }
 
   /* ================= 화면 상태 ================= */
-  var SCREENS=['login','home','menu','news','player'];
+  var SCREENS=['login','home','menu','news','invite','player'];
   var scr={}; SCREENS.forEach(function(n){scr[n]=document.querySelector('.scr[data-s="'+n+'"]')});
   var cur='login';
   function bootDone(){
@@ -1980,7 +2008,58 @@
       d.appendChild(h); d.appendChild(b); box.appendChild(d);
     });
   }
-  document.getElementById('bGear').onclick=function(){ show('menu'); };
+  /* ── 초대권 (v1: 검증된 베타 초대 메일 위임, 잔여 = 파생값) ── */
+  function maskEmail(e){ var a=e.split('@'); return (a[0]||'').slice(0,3)+'***@'+(a[1]||''); }
+  function renderTickets(d){
+    var box=document.getElementById('tkList'); box.innerHTML='';
+    for(var i=0;i<d.total;i++){
+      var inv=d.invites[i];
+      var el=document.createElement('div');
+      el.className='tk'+(inv?' used':'');
+      el.innerHTML='<span class="no">'+(i+1)+'</span><span><span class="lab">베타 초대권</span><div class="st"></div></span>'
+        +(inv?'<span class="stamp"></span>':'');
+      el.querySelector('.st').textContent=inv?(maskEmail(inv.email)+' · '+(inv.joined?'가입 완료':'가입 대기')):'친구를 베타에 초대합니다';
+      if(inv) el.querySelector('.stamp').textContent=inv.joined?'가입 완료':'사용됨';
+      box.appendChild(el);
+    }
+    var left=d.remaining>0;
+    document.getElementById('tkEmail').hidden=!left;
+    var btn=document.getElementById('tkSend');
+    btn.disabled=!left;
+    btn.textContent=left?'초대 메일 보내기':'초대권을 모두 사용했어요';
+    document.getElementById('invSub').textContent=left?('남은 '+d.remaining+'장'):'모두 사용';
+  }
+  async function loadTickets(){
+    try{
+      var r=await api('/invites'); var j=await r.json();
+      if(j&&j.data) renderTickets(j.data);
+    }catch(e){ document.getElementById('tkList').innerHTML='<div class="menu-note" style="margin-top:20px">불러오지 못했어요 — 연결 확인 후 다시</div>'; }
+  }
+  document.getElementById('bInvite').onclick=function(){ show('invite'); loadTickets(); };
+  document.getElementById('tkSend').onclick=async function(){
+    var inp=document.getElementById('tkEmail'), em=(inp.value||'').trim();
+    if(!em||em.indexOf('@')<1){ toast('이메일 주소를 확인해주세요'); return; }
+    var btn=this; btn.disabled=true; btn.textContent='보내는 중…';
+    try{
+      var r=await api('/invites',{method:'POST',body:JSON.stringify({email:em})});
+      var j=await r.json();
+      inp.value='';
+      toast('초대 메일을 보냈어요'+(j&&j.data?' — 남은 '+j.data.remaining+'장':''));
+    }catch(e){
+      var msg='보내지 못했어요 — 잠시 후 다시';
+      if(e&&e.status===409) msg='이미 초대됐거나 가입한 이메일이에요';
+      if(e&&e.status===400) msg='이메일 주소를 확인해주세요';
+      toast(msg);
+    }
+    btn.disabled=false; btn.textContent='초대 메일 보내기';
+    loadTickets();
+  };
+  document.getElementById('bGear').onclick=function(){ show('menu'); loadTicketsQuiet(); };
+  function loadTicketsQuiet(){ // 설정 진입 시 잔여 장수만 미리 (조용히 실패)
+    api('/invites').then(function(r){return r.json()}).then(function(j){
+      if(j&&j.data) document.getElementById('invSub').textContent=j.data.remaining>0?('남은 '+j.data.remaining+'장'):'모두 사용';
+    }).catch(function(){});
+  }
   document.getElementById('bNews').onclick=function(){
     show('news');
     fetchNews().then(function(ns){

--- a/prisma/migrations/beta/002_invited_by.sql
+++ b/prisma/migrations/beta/002_invited_by.sql
@@ -1,0 +1,5 @@
+-- Invite tickets (2026-07-15): record which member spent a ticket on this
+-- invitation. Nullable — admin/manual invites stay NULL.
+-- Apply manually to local AND prod (prisma db push silent-fail rule).
+ALTER TABLE beta_applications ADD COLUMN IF NOT EXISTS invited_by uuid;
+CREATE INDEX IF NOT EXISTS idx_beta_applications_invited_by ON beta_applications(invited_by);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2613,8 +2613,12 @@ model beta_applications {
   status     String    @default("pending") @db.VarChar(16)
   created_at DateTime  @default(now()) @db.Timestamptz(6)
   invited_at DateTime? @db.Timestamptz(6)
+  /// Invite tickets (2026-07-15): member who spent a ticket. NULL = admin invite.
+  /// Raw SQL DDL: prisma/migrations/beta/002_invited_by.sql
+  invited_by String?   @db.Uuid
 
   @@index([status])
+  @@index([invited_by])
   @@schema("public")
 }
 

--- a/src/api/routes/invites.ts
+++ b/src/api/routes/invites.ts
@@ -1,0 +1,152 @@
+/**
+ * Invite tickets (초대권) — 2026-07-15 design (approved 시안).
+ *
+ * Each beta member may spend config.invites.defaultTickets (2) invitations.
+ * A ticket delegates the PROVEN beta-invite pipeline (beta_applications row
+ * + the field-verified invite email) to the member — no new invite system.
+ *
+ * Policy (from the approved spec):
+ * - remaining is DERIVED: default − count(invited_by = me). No counter column.
+ * - A ticket is consumed only when the email actually sends; on send failure
+ *   the row change is rolled back.
+ * - Already invited/joined addresses: no consumption, friendly error.
+ * - A pending applicant invited by a member is UPGRADED to invited (queue
+ *   jump — a legitimate ticket use).
+ */
+
+import { FastifyInstance } from 'fastify';
+import { Prisma } from '@prisma/client';
+import { getPrismaClient } from '@/modules/database/client';
+import { config } from '@/config/index';
+import { sendBetaInviteEmail } from '@/modules/email/transactional';
+import { normalizeBetaEmail } from './beta';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'routes/invites' });
+
+export interface SentInvite {
+  email: string;
+  invitedAt: Date | null;
+  joined: boolean;
+}
+
+/** Pure — unit-tested. */
+export function computeRemaining(defaultTickets: number, used: number): number {
+  return Math.max(0, Math.trunc(defaultTickets) - Math.max(0, Math.trunc(used)));
+}
+
+async function inviterDisplayName(userId: string): Promise<string | null> {
+  try {
+    const rows = await getPrismaClient().$queryRaw<Array<{ name: string | null }>>(
+      Prisma.sql`SELECT COALESCE(raw_user_meta_data->>'full_name', raw_user_meta_data->>'name') AS name
+                 FROM auth.users WHERE id = ${userId}::uuid LIMIT 1`
+    );
+    return rows[0]?.name?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function joinedEmailSet(emails: string[]): Promise<Set<string>> {
+  if (!emails.length) return new Set();
+  try {
+    const rows = await getPrismaClient().$queryRaw<Array<{ email: string }>>(
+      Prisma.sql`SELECT lower(email) AS email FROM auth.users WHERE lower(email) IN (${Prisma.join(emails)})`
+    );
+    return new Set(rows.map((r) => r.email));
+  } catch {
+    return new Set();
+  }
+}
+
+export async function inviteRoutes(fastify: FastifyInstance): Promise<void> {
+  const auth = { onRequest: [fastify.authenticate] };
+
+  // 내 초대권 현황 — 잔여 + 보낸 초대(가입 여부 포함)
+  fastify.get('/', auth, async (request, reply) => {
+    const userId = (request.user as { userId?: string } | undefined)?.userId;
+    if (!userId) return reply.code(401).send({ status: 'error', error: 'Unauthorized' });
+
+    const prisma = getPrismaClient();
+    const sent = await prisma.beta_applications.findMany({
+      where: { invited_by: userId },
+      orderBy: { invited_at: 'asc' },
+      select: { email: true, invited_at: true },
+    });
+    const joined = await joinedEmailSet(sent.map((s) => s.email.toLowerCase()));
+    const invites: SentInvite[] = sent.map((s) => ({
+      email: s.email,
+      invitedAt: s.invited_at,
+      joined: joined.has(s.email.toLowerCase()),
+    }));
+    return reply.code(200).send({
+      status: 'ok',
+      data: {
+        total: config.invites.defaultTickets,
+        remaining: computeRemaining(config.invites.defaultTickets, sent.length),
+        invites,
+      },
+    });
+  });
+
+  // 초대권 사용 — 명부 등록/승격 + 검증된 초대 메일 발송
+  fastify.post<{ Body: { email?: string } }>('/', auth, async (request, reply) => {
+    const userId = (request.user as { userId?: string } | undefined)?.userId;
+    if (!userId) return reply.code(401).send({ status: 'error', error: 'Unauthorized' });
+
+    const email = normalizeBetaEmail(request.body?.email);
+    if (!email) {
+      return reply.code(400).send({ status: 'error', code: 'INVALID_EMAIL' });
+    }
+
+    const prisma = getPrismaClient();
+    const used = await prisma.beta_applications.count({ where: { invited_by: userId } });
+    if (computeRemaining(config.invites.defaultTickets, used) <= 0) {
+      return reply.code(409).send({ status: 'error', code: 'NO_TICKETS' });
+    }
+
+    const existing = await prisma.beta_applications.findUnique({ where: { email } });
+    if (existing && existing.status === 'invited') {
+      return reply.code(409).send({ status: 'error', code: 'ALREADY_INVITED' });
+    }
+    if ((await joinedEmailSet([email])).has(email)) {
+      return reply.code(409).send({ status: 'error', code: 'ALREADY_MEMBER' });
+    }
+
+    // Register/upgrade first, then send; roll back on send failure so a
+    // ticket is only consumed by a successfully delivered invitation.
+    const prior = existing ? { status: existing.status, invited_by: existing.invited_by } : null;
+    const row = existing
+      ? await prisma.beta_applications.update({
+          where: { email },
+          data: { status: 'invited', invited_at: new Date(), invited_by: userId },
+        })
+      : await prisma.beta_applications.create({
+          data: { email, status: 'invited', invited_at: new Date(), invited_by: userId },
+        });
+
+    try {
+      const inviterName = await inviterDisplayName(userId);
+      await sendBetaInviteEmail(row.email, { goal: row.goal, inviterName });
+    } catch (err) {
+      // rollback — the ticket must not be consumed
+      if (prior) {
+        await prisma.beta_applications.update({
+          where: { email },
+          data: { status: prior.status, invited_by: prior.invited_by },
+        });
+      } else {
+        await prisma.beta_applications.deleteMany({ where: { email, invited_by: userId } });
+      }
+      log.error('invite email send failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return reply.code(502).send({ status: 'error', code: 'SEND_FAILED' });
+    }
+
+    return reply.code(200).send({
+      status: 'ok',
+      data: { remaining: computeRemaining(config.invites.defaultTickets, used + 1) },
+    });
+  });
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -20,6 +20,7 @@ import { mandalaEpisodeAudioRoutes } from './routes/mandala-episode-audio';
 import { guestNoteRoutes } from './routes/guest-share';
 import { shareLinkMintRoutes, shareLinkResolverRoutes } from './routes/share-links';
 import { appNoticeRoutes } from './routes/app-notices';
+import { inviteRoutes } from './routes/invites';
 import { imageRoutes } from './routes/images';
 import { ontologyRoutes } from './routes/ontology';
 import { searchRoutes } from './routes/search';
@@ -319,6 +320,9 @@ export async function buildServer() {
 
       // In-app notices (새소식) — public read feed for the mobile player
       await instance.register(appNoticeRoutes, { prefix: '/app-notices' });
+
+      // Invite tickets (초대권) — member-delegated beta invitations
+      await instance.register(inviteRoutes, { prefix: '/invites' });
 
       // Register image proxy routes
       await instance.register(imageRoutes, { prefix: '/images' });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -189,6 +189,9 @@ const envSchema = z.object({
   // Share v2 — public origin used to build short share URLs (/s/:code).
   PUBLIC_ORIGIN: z.string().default('https://insighta.one'),
 
+  // Invite tickets — default allowance per beta member.
+  INVITE_TICKETS_DEFAULT: z.coerce.number().default(2),
+
   // Observability Phase 2-A — ops alarm recipient (admin inbox). Empty = the
   // alarm job logs the count but sends NO email (inert until the operator sets a
   // real inbox). An email address is config, not a secret (CP392).
@@ -517,6 +520,10 @@ export const config = {
 
   share: {
     publicOrigin: env.PUBLIC_ORIGIN,
+  },
+
+  invites: {
+    defaultTickets: env.INVITE_TICKETS_DEFAULT,
   },
 
   // Observability Phase 2-A — ops alarms.

--- a/src/modules/email/templates.ts
+++ b/src/modules/email/templates.ts
@@ -116,6 +116,8 @@ export interface BetaInviteEmailParams {
   /** Learning-goal sentence from the beta application form (optional). */
   goal?: string | null;
   ctaUrl?: string;
+  /** Invite tickets (2026-07-15): member name shown as the inviter. */
+  inviterName?: string | null;
 }
 
 /**
@@ -160,7 +162,11 @@ export function buildBetaInviteEmail(params: BetaInviteEmailParams): {
     <tr><td style="padding:14px 26px 2px;text-align:center">${mascot('mascot-welcome.gif')}</td></tr>
     <tr><td style="padding:8px 30px 2px;text-align:center">
       ${heading('베타테스트에', '초대합니다')}
-      <div style="font-size:14px;color:${MUTED};margin:10px auto 0;max-width:330px;line-height:1.5">신청해 주셔서 감사해요. 자리가 준비됐어요 — 이 이메일로 로그인하면 바로 시작돼요.</div>
+      <div style="font-size:14px;color:${MUTED};margin:10px auto 0;max-width:330px;line-height:1.5">${
+        params.inviterName?.trim()
+          ? `${esc(params.inviterName.trim())}님이 초대권으로 자리를 마련했어요 — 이 이메일로 로그인하면 바로 시작돼요.`
+          : '신청해 주셔서 감사해요. 자리가 준비됐어요 — 이 이메일로 로그인하면 바로 시작돼요.'
+      }</div>
     </td></tr>
     <tr><td style="padding:4px 30px 30px">
       ${goalCard}
@@ -169,7 +175,9 @@ export function buildBetaInviteEmail(params: BetaInviteEmailParams): {
       <div style="text-align:center;font-size:12px;color:${MUTED};margin-top:16px">베타 기간 2026. 7. 13 – 8. 24 · 베타 기간에는 모든 기능이 무료예요</div>
     </td></tr>`;
   return {
-    subject: 'Insighta 클로즈드 베타에 초대합니다 — 자리가 준비됐어요',
+    subject: params.inviterName?.trim()
+      ? `${params.inviterName.trim()}님이 Insighta 베타에 초대했어요`
+      : 'Insighta 클로즈드 베타에 초대합니다 — 자리가 준비됐어요',
     html: shell(
       { label: 'INVITED', color: INDIGO },
       inner,

--- a/tests/smoke/invite-tickets.test.ts
+++ b/tests/smoke/invite-tickets.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Invite tickets (초대권) — pure derivation tests (2026-07-15).
+ * remaining is DERIVED (default − sent count), never stored.
+ */
+process.env['ENCRYPTION_SECRET'] ??=
+  'test-secret-test-secret-test-secret-test-secret-test-secret-1234';
+
+import { computeRemaining } from '@/api/routes/invites';
+
+describe('computeRemaining', () => {
+  it('starts at the default allowance', () => {
+    expect(computeRemaining(2, 0)).toBe(2);
+  });
+  it('decrements per sent invite and floors at 0', () => {
+    expect(computeRemaining(2, 1)).toBe(1);
+    expect(computeRemaining(2, 2)).toBe(0);
+    expect(computeRemaining(2, 5)).toBe(0);
+  });
+  it('ignores negative/fractional noise', () => {
+    expect(computeRemaining(2, -1)).toBe(2);
+    expect(computeRemaining(2.9, 0)).toBe(2);
+  });
+});


### PR DESCRIPTION
Implements the approved 초대권 기획·설계 시안: each beta member can spend **2 invite tickets** to bring friends into the closed beta through the **proven invite pipeline** (beta_applications + the field-verified invite email) — no new invite system.

## Policy (as approved)
- **remaining is derived**: `default(2) − count(invited_by = me)` — no counter column, cannot drift.
- Ticket consumed **only when the email actually sends**; row change rolls back on send failure.
- Already-invited / already-member addresses rejected **without consumption**.
- A pending applicant invited by a member is **upgraded** to invited (queue jump).

## Changes
- `beta_applications.invited_by uuid NULL` — raw DDL `prisma/migrations/beta/002_invited_by.sql` (local applied + verified; prod before merge). **Write-path audit**: /beta apply leaves NULL · admin mark-invited preserves · invites route sets it.
- `GET/POST /api/v1/invites` (auth). GET returns tickets + joined state (auth.users email match → '가입 완료' stamp).
- Invite email gains optional `inviterName` → subject/lede become 'OO님이 Insighta 베타에 초대했어요' (name from auth metadata; admin invites unchanged).
- Mobile 설정: **초대권 사용하기 · 남은 N장** row → ticket screen per the 시안 (perforated ticket cards, serial numbers, 사용됨/가입 완료 stamps, email input, all-used state). MENU returns to 내 만다라.
- `INVITE_TICKETS_DEFAULT` config knob (code default 2, non-secret).

## Verification
BE tsc 0 · jest invite-tickets 3/3 (+ share-links/app-notices suites green) · mobile script syntax-checked · static page + BE only. Post-deploy: unauth /invites 401, real send = James gate (본인 계정에서 테스트 이메일로 1장 사용 → 메일 수신 → 티켓 스탬프 확인; 테스트 소진분은 invited_by 행 삭제로 원복 가능).

Rollback: revert PR; column is additive/nullable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)