### PR TITLE
fix(copy): dial/mobile tagline — add possessive "내"

### DIFF
--- a/docs/guides/kakao-dial-share.md
+++ b/docs/guides/kakao-dial-share.md
@@ -15,7 +15,7 @@ https://insighta.one/dial/
 | 요소 | 값 | 바꾸려면 |
 |------|-----|---------|
 | 이미지 | `frontend/public/dial/og.png` (1200×630) | 파일 교체 후 배포 + 캐시 초기화(§3) |
-| 제목 | `og:title` — "다이얼 — 유튜브를 나만의 지식노트로" | index.html 메타 수정 |
+| 제목 | `og:title` — "다이얼 — 내 유튜브를 나만의 지식노트로" | index.html 메타 수정 |
 | 설명 | `og:description` | index.html 메타 수정 |
 
 모바일 플레이어의 48시간 게스트 링크(`insighta.one/mobile/?g=...`)도 동일 원리로 `/mobile`의 OG 메타 카드가 뜬다.

--- a/frontend/public/dial/index.html
+++ b/frontend/public/dial/index.html
@@ -3,20 +3,20 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<title>다이얼 — 유튜브를 나만의 지식노트로</title>
+<title>다이얼 — 내 유튜브를 나만의 지식노트로</title>
 <meta name="description" content="목표 한 줄이면 AI가 최적의 영상을 찾아 핵심 구간만 이어, 한 편의 지식 팟캐스트로 만들어 드립니다.">
 <link rel="icon" type="image/png" sizes="192x192" href="/mobile/icon-192.png">
 <link rel="apple-touch-icon" href="/mobile/icon-180.png">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="다이얼 — Insighta">
-<meta property="og:title" content="다이얼 — 유튜브를 나만의 지식노트로">
+<meta property="og:title" content="다이얼 — 내 유튜브를 나만의 지식노트로">
 <meta property="og:description" content="목표 한 줄이면 AI가 최적의 영상을 찾아 핵심 구간만 이어, 한 편의 지식 팟캐스트로. 지금 로그인 없이 샘플을 들어보세요.">
 <meta property="og:url" content="https://insighta.one/dial/">
 <meta property="og:image" content="https://insighta.one/dial/og.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="다이얼 — 유튜브를 나만의 지식노트로">
+<meta name="twitter:title" content="다이얼 — 내 유튜브를 나만의 지식노트로">
 <meta name="twitter:description" content="목표 한 줄이면 AI가 핵심 구간만 이어 한 편의 지식 팟캐스트로.">
 <meta name="twitter:image" content="https://insighta.one/dial/og.png">
 </head>
@@ -179,7 +179,7 @@
       <small><b>다이얼</b>Insighta · Pocket Knowledge Player</small>
     </div>
     <div class="eye">목표 한 줄 → 한 편의 지식 팟캐스트</div>
-    <h1>유튜브를<br>나만의 지식노트로.</h1>
+    <h1>내 유튜브를<br>나만의 지식노트로.</h1>
     <p class="sub">검색하고, 고르고, 건너뛰는 시간은 이제 그만.
       <b>AI가 최적의 영상을 찾아 겹침을 걷어내고 꼭 필요한 순간만 이어</b>
       한 편의 노트로 만들어 드립니다. 당신은 다이얼을 돌리기만 하세요.</p>

--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no">
 <title>다이얼 — Insighta</title>
-<meta name="description" content="유튜브를 나만의 지식노트로 — 다이얼, Insighta 플레이어">
+<meta name="description" content="내 유튜브를 나만의 지식노트로 — 다이얼, Insighta 플레이어">
 <link rel="manifest" href="/mobile/manifest.webmanifest">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="mobile-web-app-capable" content="yes">
@@ -598,7 +598,7 @@
       <div class="scr" data-s="login" id="scrLogin">
         <div class="login-scr">
           <div class="login-mark">INSIGHTA</div>
-          <div class="login-big">유튜브를<br>나만의 지식노트로.</div>
+          <div class="login-big">내 유튜브를<br>나만의 지식노트로.</div>
           <div class="login-sub" id="loginSub">로그인하면 내 만다라가 이 기계에 도착합니다</div>
           <button class="gbtn" id="bLogin">
             <svg width="16" height="16" viewBox="0 0 48 48" aria-hidden="true"><path fill="#EA4335" d="M24 9.5c3.5 0 6.6 1.2 9.1 3.6l6.8-6.8C35.8 2.4 30.3 0 24 0 14.6 0 6.5 5.4 2.6 13.2l7.9 6.2C12.4 13.5 17.7 9.5 24 9.5z"/><path fill="#4285F4" d="M46.5 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.7c-.6 3-2.3 5.5-4.8 7.2l7.7 6c4.5-4.2 6.9-10.3 6.9-17.7z"/><path fill="#FBBC05" d="M10.5 28.6a14.5 14.5 0 0 1 0-9.2l-7.9-6.2a24 24 0 0 0 0 21.6l7.9-6.2z"/><path fill="#34A853" d="M24 48c6.3 0 11.6-2.1 15.6-5.8l-7.7-6c-2.1 1.4-4.8 2.3-7.9 2.3-6.3 0-11.6-4-13.5-9.9l-7.9 6.2C6.5 42.6 14.6 48 24 48z"/></svg>


### PR DESCRIPTION
One-word copy change requested by James: the tagline "유튜브를 나만의 지식노트로." becomes "내 유튜브를 나만의 지식노트로."

Applied to every surface carrying the same tagline (no partial fixes):

| Surface | Lines |
|---------|-------|
| `frontend/public/dial/index.html` | hero `<h1>`, `<title>`, `og:title`, `twitter:title` |
| `frontend/public/mobile/index.html` | meta description, login screen headline |
| `docs/guides/kakao-dial-share.md` | og:title quote in the share guide |

## Verification (/verify PASS)
- frontend tsc `--noEmit`: pass
- vitest: 514/514 pass
- `npm run build`: pass — dist carries the new copy (dial ×4, mobile ×2)
- browser smoke (vite preview): `/`, `/dial/`, `/mobile/` → 200, new copy served on both pages

## Note
- Kakao link previews cache og tags — after deploy, refresh the cache at developers.kakao.com (see `docs/guides/kakao-dial-share.md`) for the new title to appear in shares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)