### PR TITLE
feat(invites): v2 share-icon model — shareable links redeemed on signup

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -202,6 +202,9 @@
   .tk .no{flex:none; width:28px; text-align:center; font-size:13px; font-weight:900; color:var(--ui); font-variant-numeric:tabular-nums}
   .tk .lab{font-size:11.5px; font-weight:800; color:var(--paper-ink)}
   .tk .st{font-size:9px; color:var(--paper-sub); margin-top:2px}
+  .tk .tkshr{margin-left:auto; flex:none; width:30px; height:30px; border-radius:9px; border:none; cursor:pointer;
+    background:var(--ui); color:#fff; display:grid; place-items:center; -webkit-tap-highlight-color:transparent}
+  .tk .tkshr:active{transform:scale(.9)}
   .tk.used{opacity:.55}
   .tk .stamp{position:absolute; right:10px; top:50%; transform:translateY(-50%) rotate(-8deg);
     font-size:9px; font-weight:900; color:var(--ui); border:1.5px solid var(--ui); border-radius:6px; padding:2px 6px; letter-spacing:.1em}
@@ -678,9 +681,7 @@
       <div class="scr" data-s="invite" id="scrInvite">
         <div class="top"><span class="bc"><button class="up" data-back="menu">설정</button><span class="sep">›</span><span class="cur">초대권</span></span></div>
         <div id="tkList" style="overflow-y:auto;flex:1;min-height:0"></div>
-        <input class="tk-inp" id="tkEmail" type="email" inputmode="email" autocomplete="off" placeholder="친구 이메일 주소">
-        <button class="tk-btn" id="tkSend">초대 메일 보내기</button>
-        <div class="menu-note">MENU를 누르면 내 만다라로</div>
+        <div class="menu-note">친구가 가입하면 초대권이 사용돼요 · 그 전엔 몇 번이든 다시 보낼 수 있어요</div>
       </div>
 
       <!-- 플레이어 -->
@@ -2047,26 +2048,39 @@
       d.appendChild(h); d.appendChild(b); box.appendChild(d);
     });
   }
-  /* ── 초대권 (v1: 검증된 베타 초대 메일 위임, 잔여 = 파생값) ── */
-  function maskEmail(e){ var a=e.split('@'); return (a[0]||'').slice(0,3)+'***@'+(a[1]||''); }
+  /* ── 초대권 v2 [J:07-15]: 공유 아이콘 → OS 공유 시트, 가입 시 소진 ── */
+  var _tickets=[]; // 화면 진입 시 링크 선발급 완료분 (탭 즉시 동기 공유 = iOS 제스처)
   function renderTickets(d){
+    _tickets=d.tickets||[];
     var box=document.getElementById('tkList'); box.innerHTML='';
-    for(var i=0;i<d.total;i++){
-      var inv=d.invites[i];
+    _tickets.forEach(function(t,i){
       var el=document.createElement('div');
-      el.className='tk'+(inv?' used':'');
-      el.innerHTML='<span class="no">'+(i+1)+'</span><span><span class="lab">베타 초대권</span><div class="st"></div></span>'
-        +(inv?'<span class="stamp"></span>':'');
-      el.querySelector('.st').textContent=inv?(maskEmail(inv.email)+' · '+(inv.joined?'가입 완료':'가입 대기')):'친구를 베타에 초대합니다';
-      if(inv) el.querySelector('.stamp').textContent=inv.joined?'가입 완료':'사용됨';
+      el.className='tk'+(t.redeemed?' used':'');
+      var st=t.redeemed?((t.inviteeMasked||'친구')+' · 가입 완료'):'아이콘을 눌러 어디로든 전달';
+      el.innerHTML='<span class="no">'+(i+1)+'</span><span><span class="lab">베타 초대권</span><div class="st"></div></span>';
+      el.querySelector('.st').textContent=st;
+      if(t.redeemed){ var s=document.createElement('span'); s.className='stamp'; s.textContent='가입 완료'; el.appendChild(s); }
+      else{
+        var b=document.createElement('button'); b.className='tkshr'; b.setAttribute('aria-label','초대 링크 공유');
+        b.innerHTML='<svg width="13" height="15" viewBox="0 0 15 18"><path d="M7.5 1v10M4.2 4.2 7.5 1l3.3 3.2" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/><rect x="2" y="7.4" width="11" height="9.4" rx="2" fill="none" stroke="currentColor" stroke-width="1.7"/></svg>';
+        (function(url){ b.onclick=function(e){ e.stopPropagation(); shareInvite(url); }; })(t.url);
+        el.appendChild(b);
+      }
       box.appendChild(el);
-    }
-    var left=d.remaining>0;
-    document.getElementById('tkEmail').hidden=!left;
-    var btn=document.getElementById('tkSend');
-    btn.disabled=!left;
-    btn.textContent=left?'초대 메일 보내기':'초대권을 모두 사용했어요';
-    document.getElementById('invSub').textContent=left?('남은 '+d.remaining+'장'):'모두 사용';
+    });
+    var used=_tickets.filter(function(t){return t.redeemed}).length;
+    var left=d.total-used;
+    document.getElementById('invSub').textContent=left>0?('남은 '+left+'장'):'모두 사용';
+  }
+  function shareInvite(url){
+    var data={title:'다이얼 베타 초대', text:'내 유튜브에서 필요한 정보만 — 다이얼 베타에 초대할게요.', url:url};
+    if(navigator.share){ navigator.share(data).catch(function(e){ if(!(e&&e.name==='AbortError')) copyInvite(url); }); return; }
+    copyInvite(url);
+  }
+  function copyInvite(url){
+    (navigator.clipboard?navigator.clipboard.writeText(url):Promise.reject())
+      .then(function(){ toast('초대 링크가 복사됐어요'); })
+      .catch(function(){ prompt('이 링크를 복사하세요', url); });
   }
   async function loadTickets(){
     try{
@@ -2075,24 +2089,6 @@
     }catch(e){ document.getElementById('tkList').innerHTML='<div class="menu-note" style="margin-top:20px">불러오지 못했어요 — 연결 확인 후 다시</div>'; }
   }
   document.getElementById('bInvite').onclick=function(){ show('invite'); loadTickets(); };
-  document.getElementById('tkSend').onclick=async function(){
-    var inp=document.getElementById('tkEmail'), em=(inp.value||'').trim();
-    if(!em||em.indexOf('@')<1){ toast('이메일 주소를 확인해주세요'); return; }
-    var btn=this; btn.disabled=true; btn.textContent='보내는 중…';
-    try{
-      var r=await api('/invites',{method:'POST',body:JSON.stringify({email:em})});
-      var j=await r.json();
-      inp.value='';
-      toast('초대 메일을 보냈어요'+(j&&j.data?' — 남은 '+j.data.remaining+'장':''));
-    }catch(e){
-      var msg='보내지 못했어요 — 잠시 후 다시';
-      if(e&&e.status===409) msg='이미 초대됐거나 가입한 이메일이에요';
-      if(e&&e.status===400) msg='이메일 주소를 확인해주세요';
-      toast(msg);
-    }
-    btn.disabled=false; btn.textContent='초대 메일 보내기';
-    loadTickets();
-  };
   document.getElementById('bGear').onclick=function(){ show('menu'); loadTicketsQuiet(); };
   // 브레드크럼 "설정" 세그먼트 = 한 단계 위(설정)로 [J:07-15 IA]
   Array.prototype.forEach.call(document.querySelectorAll('.bc .up[data-back]'), function(b){
@@ -2100,7 +2096,9 @@
   });
   function loadTicketsQuiet(){ // 설정 진입 시 잔여 장수만 미리 (조용히 실패)
     api('/invites').then(function(r){return r.json()}).then(function(j){
-      if(j&&j.data) document.getElementById('invSub').textContent=j.data.remaining>0?('남은 '+j.data.remaining+'장'):'모두 사용';
+      if(j&&j.data){ var used=(j.data.tickets||[]).filter(function(t){return t.redeemed}).length;
+        var left=j.data.total-used;
+        document.getElementById('invSub').textContent=left>0?('남은 '+left+'장'):'모두 사용'; }
     }).catch(function(){});
   }
   document.getElementById('bNews').onclick=function(){
@@ -2229,8 +2227,23 @@
   };
 
   /* ================= 부팅 ================= */
-  if(new URLSearchParams(location.search).get('invite')==='1'){
-    document.getElementById('loginSub').textContent='친구가 공유한 인사이타 — Google로 3초 만에 시작';
+  var INVITE_KEY='insighta-invite';
+  (function(){ // 초대 링크로 진입 — 코드를 로그인 왕복 전 보존 (OAuth 후 쿼리 소실)
+    var inv=new URLSearchParams(location.search).get('invite');
+    if(inv){
+      if(inv.length>=6){ try{ localStorage.setItem(INVITE_KEY, inv); }catch(e){} }
+      document.getElementById('loginSub').textContent='친구가 초대했어요 — Google로 3초 만에 시작';
+    }
+  })();
+  async function redeemPendingInvite(){ // 로그인 후 1회 리딤 (조용히)
+    var code; try{ code=localStorage.getItem(INVITE_KEY); }catch(e){}
+    if(!code) return;
+    try{ localStorage.removeItem(INVITE_KEY); }catch(e){}
+    try{
+      var r=await api('/invites/redeem',{method:'POST',body:JSON.stringify({code:code})});
+      var j=await r.json();
+      if(j&&j.data&&j.data.result==='redeemed') toast('초대로 시작했어요 — 환영해요!');
+    }catch(e){}
   }
   if(navigator.standalone===true || matchMedia('(display-mode: standalone)').matches){
     document.body.classList.add('standalone');
@@ -2256,7 +2269,7 @@
       }catch(e){ GUEST=null; show('login'); toast('링크를 열지 못했어요'); return; }
     }
     var tok=await freshToken();
-    if(tok){ show('home'); loadList(); wheelIntroOnce(); checkNewsUnread(); }
+    if(tok){ show('home'); loadList(); wheelIntroOnce(); checkNewsUnread(); redeemPendingInvite(); }
     else { show('login'); }
   })();
 </script>

--- a/prisma/migrations/invite-links/001_create_invite_links.sql
+++ b/prisma/migrations/invite-links/001_create_invite_links.sql
@@ -1,0 +1,13 @@
+-- Invite tickets v2 (2026-07-15). Apply to local AND prod (prisma db push
+-- silent-fail rule), verify with \d invite_links.
+CREATE TABLE IF NOT EXISTS invite_links (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code        varchar(16) UNIQUE NOT NULL,
+  inviter_id  uuid NOT NULL,
+  invitee_id  uuid,
+  redeemed_at timestamptz,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_invite_links_inviter ON invite_links(inviter_id);
+CREATE INDEX IF NOT EXISTS idx_invite_links_invitee ON invite_links(invitee_id);
+ALTER TABLE invite_links ENABLE ROW LEVEL SECURITY;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2657,3 +2657,21 @@ model app_notices {
   @@index([published_at])
   @@schema("public")
 }
+
+/// Invite tickets v2 (2026-07-15): each member gets N shareable invite links
+/// (nanoid code, resolved via /s/:code). Consumed when someone signs up
+/// through the link (redeemed), not when shared — so a link can be re-shared
+/// until it lands a signup.
+/// Raw SQL DDL: prisma/migrations/invite-links/001_create_invite_links.sql
+model invite_links {
+  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  code        String    @unique @db.VarChar(16)
+  inviter_id  String    @db.Uuid
+  invitee_id  String?   @db.Uuid
+  redeemed_at DateTime? @db.Timestamptz(6)
+  created_at  DateTime  @default(now()) @db.Timestamptz(6)
+
+  @@index([inviter_id])
+  @@index([invitee_id])
+  @@schema("public")
+}

--- a/src/api/routes/invites.ts
+++ b/src/api/routes/invites.ts
@@ -1,152 +1,42 @@
 /**
- * Invite tickets (초대권) — 2026-07-15 design (approved 시안).
+ * Invite tickets v2 routes (2026-07-15) — shareable links, redeemed on signup.
  *
- * Each beta member may spend config.invites.defaultTickets (2) invitations.
- * A ticket delegates the PROVEN beta-invite pipeline (beta_applications row
- * + the field-verified invite email) to the member — no new invite system.
+ * GET  /api/v1/invites          — my tickets (mints missing open slots)
+ * POST /api/v1/invites/redeem   — redeem a code for the current (new) user
  *
- * Policy (from the approved spec):
- * - remaining is DERIVED: default − count(invited_by = me). No counter column.
- * - A ticket is consumed only when the email actually sends; on send failure
- *   the row change is rolled back.
- * - Already invited/joined addresses: no consumption, friendly error.
- * - A pending applicant invited by a member is UPGRADED to invited (queue
- *   jump — a legitimate ticket use).
+ * Supersedes the v1 email-input mint. Links resolve through /s/:code
+ * (invite branch in share-links.ts).
  */
 
 import { FastifyInstance } from 'fastify';
-import { Prisma } from '@prisma/client';
-import { getPrismaClient } from '@/modules/database/client';
-import { config } from '@/config/index';
-import { sendBetaInviteEmail } from '@/modules/email/transactional';
-import { normalizeBetaEmail } from './beta';
+import { listTickets, redeemInvite } from '@/modules/invites/manager';
 import { logger } from '@/utils/logger';
 
 const log = logger.child({ module: 'routes/invites' });
 
-export interface SentInvite {
-  email: string;
-  invitedAt: Date | null;
-  joined: boolean;
-}
-
-/** Pure — unit-tested. */
-export function computeRemaining(defaultTickets: number, used: number): number {
-  return Math.max(0, Math.trunc(defaultTickets) - Math.max(0, Math.trunc(used)));
-}
-
-async function inviterDisplayName(userId: string): Promise<string | null> {
-  try {
-    const rows = await getPrismaClient().$queryRaw<Array<{ name: string | null }>>(
-      Prisma.sql`SELECT COALESCE(raw_user_meta_data->>'full_name', raw_user_meta_data->>'name') AS name
-                 FROM auth.users WHERE id = ${userId}::uuid LIMIT 1`
-    );
-    return rows[0]?.name?.trim() || null;
-  } catch {
-    return null;
-  }
-}
-
-async function joinedEmailSet(emails: string[]): Promise<Set<string>> {
-  if (!emails.length) return new Set();
-  try {
-    const rows = await getPrismaClient().$queryRaw<Array<{ email: string }>>(
-      Prisma.sql`SELECT lower(email) AS email FROM auth.users WHERE lower(email) IN (${Prisma.join(emails)})`
-    );
-    return new Set(rows.map((r) => r.email));
-  } catch {
-    return new Set();
-  }
-}
-
 export async function inviteRoutes(fastify: FastifyInstance): Promise<void> {
   const auth = { onRequest: [fastify.authenticate] };
 
-  // 내 초대권 현황 — 잔여 + 보낸 초대(가입 여부 포함)
   fastify.get('/', auth, async (request, reply) => {
     const userId = (request.user as { userId?: string } | undefined)?.userId;
     if (!userId) return reply.code(401).send({ status: 'error', error: 'Unauthorized' });
-
-    const prisma = getPrismaClient();
-    const sent = await prisma.beta_applications.findMany({
-      where: { invited_by: userId },
-      orderBy: { invited_at: 'asc' },
-      select: { email: true, invited_at: true },
-    });
-    const joined = await joinedEmailSet(sent.map((s) => s.email.toLowerCase()));
-    const invites: SentInvite[] = sent.map((s) => ({
-      email: s.email,
-      invitedAt: s.invited_at,
-      joined: joined.has(s.email.toLowerCase()),
-    }));
-    return reply.code(200).send({
-      status: 'ok',
-      data: {
-        total: config.invites.defaultTickets,
-        remaining: computeRemaining(config.invites.defaultTickets, sent.length),
-        invites,
-      },
-    });
+    const data = await listTickets(userId);
+    return reply.code(200).send({ status: 'ok', data });
   });
 
-  // 초대권 사용 — 명부 등록/승격 + 검증된 초대 메일 발송
-  fastify.post<{ Body: { email?: string } }>('/', auth, async (request, reply) => {
+  fastify.post<{ Body: { code?: string } }>('/redeem', auth, async (request, reply) => {
     const userId = (request.user as { userId?: string } | undefined)?.userId;
     if (!userId) return reply.code(401).send({ status: 'error', error: 'Unauthorized' });
 
-    const email = normalizeBetaEmail(request.body?.email);
-    if (!email) {
-      return reply.code(400).send({ status: 'error', code: 'INVALID_EMAIL' });
-    }
+    const code = (request.body?.code ?? '').trim();
+    if (!code) return reply.code(400).send({ status: 'error', code: 'INVALID_CODE' });
 
-    const prisma = getPrismaClient();
-    const used = await prisma.beta_applications.count({ where: { invited_by: userId } });
-    if (computeRemaining(config.invites.defaultTickets, used) <= 0) {
-      return reply.code(409).send({ status: 'error', code: 'NO_TICKETS' });
+    const result = await redeemInvite(code, userId);
+    // 'self'/'already'/'used'/'invalid' are all non-fatal — the client just
+    // proceeds; only a genuine redeem records the relationship.
+    if (result === 'redeemed') {
+      log.info('invite redeemed', { code, inviteeId: userId });
     }
-
-    const existing = await prisma.beta_applications.findUnique({ where: { email } });
-    if (existing && existing.status === 'invited') {
-      return reply.code(409).send({ status: 'error', code: 'ALREADY_INVITED' });
-    }
-    if ((await joinedEmailSet([email])).has(email)) {
-      return reply.code(409).send({ status: 'error', code: 'ALREADY_MEMBER' });
-    }
-
-    // Register/upgrade first, then send; roll back on send failure so a
-    // ticket is only consumed by a successfully delivered invitation.
-    const prior = existing ? { status: existing.status, invited_by: existing.invited_by } : null;
-    const row = existing
-      ? await prisma.beta_applications.update({
-          where: { email },
-          data: { status: 'invited', invited_at: new Date(), invited_by: userId },
-        })
-      : await prisma.beta_applications.create({
-          data: { email, status: 'invited', invited_at: new Date(), invited_by: userId },
-        });
-
-    try {
-      const inviterName = await inviterDisplayName(userId);
-      await sendBetaInviteEmail(row.email, { goal: row.goal, inviterName });
-    } catch (err) {
-      // rollback — the ticket must not be consumed
-      if (prior) {
-        await prisma.beta_applications.update({
-          where: { email },
-          data: { status: prior.status, invited_by: prior.invited_by },
-        });
-      } else {
-        await prisma.beta_applications.deleteMany({ where: { email, invited_by: userId } });
-      }
-      log.error('invite email send failed', {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return reply.code(502).send({ status: 'error', code: 'SEND_FAILED' });
-    }
-
-    return reply.code(200).send({
-      status: 'ok',
-      data: { remaining: computeRemaining(config.invites.defaultTickets, used + 1) },
-    });
+    return reply.code(200).send({ status: 'ok', data: { result } });
   });
 }

--- a/src/api/routes/share-links.ts
+++ b/src/api/routes/share-links.ts
@@ -23,6 +23,7 @@ import {
   type ShareTargetType,
 } from '@/modules/share-links/manager';
 import { resolveOgMeta } from './og';
+import { inviteInviterId, inviterName } from '@/modules/invites/manager';
 
 function escapeHtml(s: string): string {
   return s
@@ -136,6 +137,26 @@ export async function shareLinkResolverRoutes(fastify: FastifyInstance): Promise
     const origin = config.share.publicOrigin;
     const pageUrl = `${origin}/s/${encodeURIComponent(request.params.code)}`;
     const brandImage = `${origin}/dial/og.png`;
+
+    // Invite links live in invite_links (v2). Check them first.
+    const inviterId = await inviteInviterId(request.params.code);
+    if (inviterId) {
+      const name = await inviterName(inviterId);
+      const who = name ? `${name}님이` : '친구가';
+      return reply
+        .header('Content-Type', 'text/html; charset=utf-8')
+        .header('Cache-Control', 'no-store')
+        .send(
+          ogPage({
+            title: `${who} 다이얼 베타에 초대했어요`,
+            description:
+              '내 유튜브에서 필요한 정보만 — 초대로 클로즈드 베타에 바로 참여할 수 있어요.',
+            image: brandImage,
+            pageUrl,
+            redirectTo: `${origin}/mobile/?invite=${encodeURIComponent(request.params.code)}`,
+          })
+        );
+    }
 
     const { state, row } = await resolveShareLink(request.params.code);
 

--- a/src/modules/invites/manager.ts
+++ b/src/modules/invites/manager.ts
@@ -1,0 +1,152 @@
+/**
+ * Invite tickets v2 — shareable invite links (2026-07-15 approved design).
+ *
+ * Each member gets config.invites.defaultTickets (2) invite LINKS. A link is
+ * shared via the OS share sheet (any channel) and consumed only when someone
+ * SIGNS UP through it (redeemed) — so an unredeemed link can be re-shared
+ * freely until it lands a signup. Resolved through the /s/:code backbone.
+ *
+ * Supersedes the v1 email-input flow (docs/design invite v2 시안).
+ */
+
+import { customAlphabet } from 'nanoid';
+import { getPrismaClient } from '@/modules/database/client';
+import { config } from '@/config/index';
+
+const CODE_ALPHABET = '23456789abcdefghjkmnpqrstuvwxyzABCDEFGHJKMNPQRSTUVWXYZ';
+const CODE_LENGTH = 8;
+const genCode = customAlphabet(CODE_ALPHABET, CODE_LENGTH);
+
+export function isValidInviteCode(code: string): boolean {
+  return code.length === CODE_LENGTH && [...code].every((c) => CODE_ALPHABET.includes(c));
+}
+
+export interface InviteTicket {
+  code: string;
+  url: string;
+  redeemed: boolean;
+  inviteeMasked: string | null;
+  redeemedAt: Date | null;
+}
+
+function shortUrl(code: string): string {
+  return `${config.share.publicOrigin}/s/${code}`;
+}
+
+/**
+ * Return the member's invite tickets, minting missing open slots so the user
+ * always has `defaultTickets` links total (open + redeemed).
+ */
+export async function listTickets(
+  userId: string
+): Promise<{ total: number; tickets: InviteTicket[] }> {
+  const prisma = getPrismaClient();
+  const total = config.invites.defaultTickets;
+
+  const existing = await prisma.invite_links.findMany({
+    where: { inviter_id: userId },
+    orderBy: { created_at: 'asc' },
+  });
+
+  // Top up open slots so the user always sees `total` tickets.
+  const missing = total - existing.length;
+  if (missing > 0) {
+    for (let i = 0; i < missing; i++) {
+      await prisma.invite_links.create({ data: { code: genCode(), inviter_id: userId } });
+    }
+    return listTickets(userId); // re-read once, now full
+  }
+
+  // Resolve invitee display (masked email) for redeemed links.
+  const inviteeIds = existing.map((r) => r.invitee_id).filter((v): v is string => !!v);
+  const emails = await inviteeEmails(inviteeIds);
+
+  const tickets: InviteTicket[] = existing.slice(0, total).map((r) => ({
+    code: r.code,
+    url: shortUrl(r.code),
+    redeemed: !!r.redeemed_at,
+    inviteeMasked: r.invitee_id ? maskEmail(emails.get(r.invitee_id)) : null,
+    redeemedAt: r.redeemed_at,
+  }));
+  return { total, tickets };
+}
+
+/** Inviter display name for the invite landing card. */
+export async function inviterName(userId: string): Promise<string | null> {
+  const map = await inviterNames([userId]);
+  return map.get(userId) ?? null;
+}
+
+export async function inviterNames(ids: string[]): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  if (!ids.length) return out;
+  try {
+    const { Prisma } = await import('@prisma/client');
+    const rows = await getPrismaClient().$queryRaw<Array<{ id: string; name: string | null }>>(
+      Prisma.sql`SELECT id::text AS id, COALESCE(raw_user_meta_data->>'full_name', raw_user_meta_data->>'name') AS name
+                 FROM auth.users WHERE id IN (${Prisma.join(ids)})`
+    );
+    for (const r of rows) if (r.name?.trim()) out.set(r.id, r.name.trim());
+  } catch {
+    /* auth schema unreadable — fall back to null names */
+  }
+  return out;
+}
+
+async function inviteeEmails(ids: string[]): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  if (!ids.length) return out;
+  try {
+    const { Prisma } = await import('@prisma/client');
+    const rows = await getPrismaClient().$queryRaw<Array<{ id: string; email: string }>>(
+      Prisma.sql`SELECT id::text AS id, email FROM auth.users WHERE id IN (${Prisma.join(ids)})`
+    );
+    for (const r of rows) out.set(r.id, r.email);
+  } catch {
+    /* ignore */
+  }
+  return out;
+}
+
+function maskEmail(email: string | undefined): string | null {
+  if (!email) return null;
+  const [u, d] = email.split('@');
+  return `${(u || '').slice(0, 3)}***@${d || ''}`;
+}
+
+export type RedeemResult = 'redeemed' | 'already' | 'self' | 'invalid' | 'used';
+
+/**
+ * Redeem an invite code for a freshly signed-up user. Idempotent per invitee:
+ * a user can only ever be the invitee of one link.
+ */
+export async function redeemInvite(code: string, inviteeId: string): Promise<RedeemResult> {
+  if (!isValidInviteCode(code)) return 'invalid';
+  const prisma = getPrismaClient();
+
+  const link = await prisma.invite_links.findUnique({ where: { code } });
+  if (!link) return 'invalid';
+  if (link.inviter_id === inviteeId) return 'self';
+  if (link.redeemed_at) return 'used';
+
+  // Has this user already been invited (via any link)? Then no-op.
+  const priorAsInvitee = await prisma.invite_links.findFirst({ where: { invitee_id: inviteeId } });
+  if (priorAsInvitee) return 'already';
+
+  await prisma.invite_links.update({
+    where: { code },
+    data: { invitee_id: inviteeId, redeemed_at: new Date() },
+  });
+  return 'redeemed';
+}
+
+/** For the /s/:code resolver — is this code an invite link? Returns inviter id or null. */
+export async function inviteInviterId(code: string): Promise<string | null> {
+  if (!isValidInviteCode(code)) return null;
+  const link = await getPrismaClient().invite_links.findUnique({
+    where: { code },
+    select: { inviter_id: true, redeemed_at: true },
+  });
+  if (!link || link.redeemed_at) return null;
+  return link.inviter_id;
+}

--- a/tests/smoke/invite-tickets.test.ts
+++ b/tests/smoke/invite-tickets.test.ts
@@ -1,23 +1,21 @@
 /**
- * Invite tickets (초대권) — pure derivation tests (2026-07-15).
- * remaining is DERIVED (default − sent count), never stored.
+ * Invite tickets v2 — pure code validation (2026-07-15).
+ * (v1 computeRemaining retired with the email-delegation flow.)
  */
 process.env['ENCRYPTION_SECRET'] ??=
   'test-secret-test-secret-test-secret-test-secret-test-secret-1234';
 
-import { computeRemaining } from '@/api/routes/invites';
+import { isValidInviteCode } from '@/modules/invites/manager';
 
-describe('computeRemaining', () => {
-  it('starts at the default allowance', () => {
-    expect(computeRemaining(2, 0)).toBe(2);
+describe('isValidInviteCode', () => {
+  it('accepts an 8-char unambiguous-alphabet code', () => {
+    expect(isValidInviteCode('aB3xYz9k')).toBe(true);
   });
-  it('decrements per sent invite and floors at 0', () => {
-    expect(computeRemaining(2, 1)).toBe(1);
-    expect(computeRemaining(2, 2)).toBe(0);
-    expect(computeRemaining(2, 5)).toBe(0);
-  });
-  it('ignores negative/fractional noise', () => {
-    expect(computeRemaining(2, -1)).toBe(2);
-    expect(computeRemaining(2.9, 0)).toBe(2);
+  it('rejects wrong length and ambiguous/forbidden chars', () => {
+    expect(isValidInviteCode('short')).toBe(false);
+    expect(isValidInviteCode('aB3xYz9kX')).toBe(false);
+    expect(isValidInviteCode('aB3xYz0O')).toBe(false); // 0/O excluded
+    expect(isValidInviteCode('')).toBe(false);
+    expect(isValidInviteCode('1')).toBe(false);
   });
 });


### PR DESCRIPTION
Replaces the v1 email-input invite flow with the approved **share-icon model**.

## Model
Each member gets **2 invite links** (`invite_links` table, nanoid code, resolved via `/s/:code`). A link is shared through the **OS share sheet** (kakao/message/mail/copy) and **consumed only when someone signs up through it** (redeemed) — not when shared. So an unredeemed link can be re-shared until it lands a signup; nothing is wasted on ignored invites.

## Changes
- `invite_links` table — raw DDL `prisma/migrations/invite-links/001_*.sql` (local applied + \d-verified; prod before merge).
- `src/modules/invites/manager` — `listTickets` (tops up open slots to 2), `redeemInvite` (idempotent per invitee; rejects self/used/already), `inviteInviterId`/`inviterName` for the landing card.
- `GET /api/v1/invites` (tickets + redeemed/invitee state) · `POST /api/v1/invites/redeem` (auth). **Email POST removed.**
- `/s/:code` resolver: invite branch → OG card **'OO님이 다이얼 베타에 초대했어요'** → redirect to `/mobile/?invite=CODE`.
- Mobile 초대권 screen: ticket cards with a **share icon → OS share sheet** (navigator.share, synchronous, clipboard fallback) — no keyboard/email. Redeemed tickets show a **가입 완료** stamp + masked invitee.
- **Redemption**: the code is stashed in localStorage before the Google OAuth round-trip (query is lost across redirect) and redeemed once on the next authenticated boot.

## Verification
BE tsc 0 · jest invite+share 10/10 · mobile script syntax-checked · invite screen rendered (open ticket = share icon, redeemed = 가입 완료 stamp). Post-deploy: unauth /invites 401, /s/\<invite\> → landing card. Real-device E2E (share → other account signs up → stamp) = James gate.

Note: builds on IA redesign (#1251) breadcrumb. Pro-grant for invitees is a follow-up (beta members already get it).

Rollback: revert; table additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)