### PR TITLE
feat(mobile): reading mode P2a — voice toggle (silent reading)

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -273,6 +273,12 @@
     color:var(--paper-sub); cursor:pointer; -webkit-tap-highlight-color:transparent; border-radius:9px}
   .rdtog:active{transform:scale(.9)}
   body.reading .rdtog{color:var(--ui); background:rgba(94,86,72,.12)}
+  #bVoice{display:none}
+  body.reading #bVoice{display:grid; background:none; color:var(--paper-sub)}
+  #bVoice .v-off{display:none}
+  body:not(.playing) #bVoice .v-on{display:none}
+  body:not(.playing) #bVoice .v-off{display:block; color:var(--paper-sub)}
+  body.playing.reading #bVoice{color:var(--ui)}
   .readview{flex:1; min-height:0; overflow-y:auto; margin-top:10px; padding-bottom:24px; display:none}
   body.reading .readview{display:block}
   body.stage .rdtog,body.stage .readview{display:none !important}
@@ -767,7 +773,7 @@
 
       <!-- 플레이어 -->
       <div class="scr" data-s="player" id="scrPlayer">
-        <div class="top"><span class="tt" id="pTitle">노트</span><button class="rdtog" id="bRead" aria-label="읽기 모드"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5.5A2 2 0 016 4h5v15H6a2 2 0 00-2 1.5zM20 5.5A2 2 0 0018 4h-5v15h5a2 2 0 012 1.5z"/></svg></button><button class="shr" id="bShareNote" aria-label="이 노트 공유" hidden><svg width="13" height="16" viewBox="0 0 15 18"><path d="M7.5 1v10M4.2 4.2 7.5 1l3.3 3.2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><rect x="2" y="7.4" width="11" height="9.4" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></button><span class="batt" id="sigPlay"><svg class="ksig" width="15" height="15" viewBox="0 0 17 17" aria-hidden="true"><rect class="c" x="0.5" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c core" x="6.3" y="6.3" width="4.4" height="4.4" rx="1.2"/></svg></span></div>
+        <div class="top"><span class="tt" id="pTitle">노트</span><button class="rdtog" id="bRead" aria-label="읽기 모드"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5.5A2 2 0 016 4h5v15H6a2 2 0 00-2 1.5zM20 5.5A2 2 0 0018 4h-5v15h5a2 2 0 012 1.5z"/></svg></button><button class="rdtog voicebtn" id="bVoice" aria-label="소리 켜기/끄기"><svg class="v-on" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5 6 9H3v6h3l5 4z"/><path d="M15.5 8.5a5 5 0 010 7M18.5 6a9 9 0 010 12"/></svg><svg class="v-off" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M11 5 6 9H3v6h3l5 4z"/><path d="M22 9l-6 6M16 9l6 6"/></svg></button><button class="shr" id="bShareNote" aria-label="이 노트 공유" hidden><svg width="13" height="16" viewBox="0 0 15 18"><path d="M7.5 1v10M4.2 4.2 7.5 1l3.3 3.2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><rect x="2" y="7.4" width="11" height="9.4" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></button><span class="batt" id="sigPlay"><svg class="ksig" width="15" height="15" viewBox="0 0 17 17" aria-hidden="true"><rect class="c" x="0.5" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c core" x="6.3" y="6.3" width="4.4" height="4.4" rx="1.2"/></svg></span></div>
         <div class="player-state" id="pState">
           <div class="pulse"></div>
           <div class="big" id="pStateBig">노트를 여는 중…</div>
@@ -1720,6 +1726,7 @@
   function setPlaying(on){
     if(on){ unlockAudio(); finished=false; }
     playing=on; setCharging(on);
+    document.body.classList.toggle('playing', on); // 보이스 아이콘
     if(on){ acquireWake(); runBeat(); }
     else{ stopSpeech(); stopClip(); releaseWake();
       if(document.body.classList.contains('clipmode')) veilHold(true); }
@@ -2253,6 +2260,7 @@
     setPlaying(false); show('login');
   };
   document.getElementById('bRead').onclick=toggleReading;
+  document.getElementById('bVoice').onclick=function(){ setPlaying(!playing); }; // 소리 켜기/끄기 = 재생/정지
   document.getElementById('bShareNote').onclick=function(){
     if(!curNote||curNote.sample||curNote.guest) return;
     var url=curNote._shareUrl;


### PR DESCRIPTION
Reading mode gains a **소리 켜기/끄기** button (James: 'PC 읽기 모드 = 보이스를 끌 수 있는 것').

- **Off** = silent — scroll and read at your own pace. **On** = audio plays from the current atom with highlight follow.
- Reuses `setPlaying` (off = stopSpeech/stopClip, on = runBeat); tapping an atom already resumes voice. Speaker icon reflects play state via a `body.playing` class (shown only in reading mode).

Verified headless (reading mode: button visible, muted-speaker icon when paused, wired). Static page, scripts syntax-checked.

Next: atom scrub bar + jog/shuttle wheel (velocity macro↔micro) as one seek component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)