### PR TITLE
feat(mobile): jog wheel drives 설정 too (consistent with 만다라 list)

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -231,6 +231,7 @@
     box-shadow:inset 0 0 0 1px rgba(94,86,72,.10); border-radius:12px; padding:11px 12px; font-size:12px; font-weight:750;
     transition:transform var(--snap) var(--spring); touch-action:manipulation}
   .mrow:active{transform:scale(.98)}
+  .mrow.sel{box-shadow:inset 0 0 0 1.5px var(--ui), 0 3px 8px -3px rgba(94,86,72,.4)}
   .mrow .sub{margin-left:auto; font-size:9px; color:var(--paper-sub); font-weight:600}
   .ways{display:flex; gap:8px; margin-left:auto}
   .way{width:24px; height:24px; border-radius:50%; border:none; cursor:pointer; padding:0;
@@ -934,6 +935,7 @@
     if(n===cur) return;
     scr[cur].classList.remove('active');
     cur=n; scr[cur].classList.add('active');
+    if(n==='menu'){ selMenu=0; setTimeout(updateSelMenu,0); } // 설정 진입 = 첫 행 선택 [J:07-15]
     syncStage();
   }
   function syncStage(){
@@ -1850,6 +1852,13 @@
       requestAnimationFrame(d);
     };
   })();
+  var selMenu=0;
+  function menuRows(){ return Array.prototype.filter.call(document.querySelectorAll('#scrMenu .mrow'), function(el){ return el.tagName==='BUTTON'; }); }
+  function updateSelMenu(){
+    var rows=menuRows();
+    rows.forEach(function(el,i){ el.classList.toggle('sel', i===selMenu); });
+    var el=rows[selMenu]; if(el&&el.scrollIntoView) el.scrollIntoView({block:'nearest', behavior:reduce?'auto':'smooth'});
+  }
   function updateSel(){
     var rows=document.getElementById('rows');
     for(var i=0;i<rows.children.length;i++) rows.children[i].classList.toggle('sel', i===selIdx);
@@ -1864,6 +1873,11 @@
       var nx=selIdx+dir;
       if(nx<0||nx>=items.length){ wheelRubber(dir); return; } // J4
       selIdx=nx; updateSel(); // J5: 1노치 1행, 선택만 이동 (아이팟 메뉴)
+    } else if(cur==='menu'){ // 설정도 조그휠 — 행 선택 이동 (홈과 동일)
+      var mr=menuRows(); if(!mr.length) return;
+      var nm=selMenu+dir;
+      if(nm<0||nm>=mr.length){ wheelRubber(dir); return; }
+      selMenu=nm; updateSelMenu();
     } else if(cur==='player'){
       if(finished){ // 완청 화면: 우측 = 더 진행 없음, 좌측 = 마지막 구간으로 복귀
         if(dir>0){ wheelRubber(1); return; }
@@ -1897,6 +1911,7 @@
     if(cur==='login'){ loginRedirect(); return; }
     if(cur==='home'){ var items=homeItems(); var m=items[selIdx];
       if(m){ var k=rowState(m).kind; if(k!=='making'&&k!=='loading') openNote(m); } return; }
+    if(cur==='menu'){ var mr=menuRows(); if(mr[selMenu]) mr[selMenu].click(); return; }
     if(cur==='player'){ setPlaying(!playing); }
   }
   document.getElementById('bCore').onclick=function(){ if(wheelStole()) return; corePress(); };


### PR DESCRIPTION
James: the jog wheel scrolls the 만다라 list but did nothing on 설정 — `dispatchNotch` had home + player branches but no **menu** branch, so the wheel was inert on settings.

Now settings mirrors the home list:
- Turning the wheel moves a **row selection** through the settings' actionable rows (새소식/초대권/설치/새로고침/의견/로그아웃; the 컬러웨이 sub-picker row is skipped), 1 notch = 1 row (iPod menu), rubber-band at the ends, scrollIntoView.
- **Center press activates** the selected row.
- Selection resets to the first row on entering settings.
- `.mrow.sel` highlight mirrors `.row.sel`.

Verified headless (6 rows, 2 notches → '홈 화면에 설치' selected). Static page, scripts syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)