### PR TITLE
feat(mobile): real YouTube thumbnails on reading-mode clip cards

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -294,8 +294,9 @@
     background:rgba(255,255,255,.55); box-shadow:inset 0 0 0 1px rgba(94,86,72,.1); cursor:pointer}
   .rd-clip:active{transform:scale(.99)}
   .rd-clip.on{box-shadow:inset 0 0 0 2px var(--ui)}
-  .rd-clip .th{flex:none; width:52px; height:32px; border-radius:7px; background:linear-gradient(140deg,#2c2c34,#101014); position:relative; overflow:hidden}
-  .rd-clip .th::after{content:""; position:absolute; inset:0; margin:auto; width:0; height:0; border-left:9px solid rgba(255,255,255,.92); border-top:6px solid transparent; border-bottom:6px solid transparent; margin-left:22px}
+  .rd-clip .th{flex:none; width:56px; height:34px; border-radius:7px; background:#101014 center/cover no-repeat; position:relative; overflow:hidden}
+  .rd-clip .th::before{content:""; position:absolute; inset:0; background:rgba(0,0,0,.28)}
+  .rd-clip .th::after{content:""; position:absolute; inset:0; margin:auto; width:0; height:0; border-left:9px solid rgba(255,255,255,.95); border-top:6px solid transparent; border-bottom:6px solid transparent; filter:drop-shadow(0 1px 2px rgba(0,0,0,.5))}
   .rd-clip .m{min-width:0}
   .rd-clip .t1{font-size:13px; font-weight:750; color:var(--paper-ink); white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
   .rd-clip .t2{font-size:10px; color:var(--paper-sub); margin-top:2px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
@@ -1217,7 +1218,7 @@
         var txt=stripMd(b.text||''); if(!txt) continue;
         html+='<p class="rd-note" data-bi="'+i+'">'+esc(txt)+'</p>';
       } else if(b.t==='c'){
-        html+='<div class="rd-clip" data-bi="'+i+'"><span class="th"></span><span class="m">'
+        html+='<div class="rd-clip" data-bi="'+i+'"><span class="th" style="background-image:url(https://i.ytimg.com/vi/'+esc(b.vid)+'/mqdefault.jpg)"></span><span class="m">'
           +'<span class="t1">'+esc(b.text||'유튜브 핵심 구간')+'</span>'
           +'<span class="t2">'+esc(b.src||'유튜브 영상')+'</span></span></div>';
       }


### PR DESCRIPTION
The reading view's clip cards showed a flat gray gradient placeholder. Now each shows the **actual video thumbnail** (`i.ytimg.com/vi/<id>/mqdefault.jpg`) with a play-triangle + darkening scrim — the cards read as real video entries and give visual context while scrolling the note.

Safe precursor to **in-view muted autoplay (P2c-2)** — that needs per-card YT iframe lifecycle (mount on intersection, unmount on exit, one at a time) + device testing (autoplay policy, iOS, perf), so it comes as a careful follow-up.

Verified headless (sample note): real thumbnails render on both clip cards. Static page only, scripts syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)