### PR TITLE
fix(mobile): reading mini-wheel more transparent (.92 → .70)

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -287,7 +287,7 @@
   body.reading .wheelzone{position:absolute; left:0; right:0; bottom:calc(var(--sab,0px) + 88px);
     z-index:40; padding:0; width:100%; pointer-events:none; place-items:center}
   body.reading .wheel{width:min(40%,168px); opacity:0; pointer-events:auto; transition:opacity .35s var(--soft)}
-  body.reading .wheel.touching,body.reading .wheel.demo,body.reading .wheel.awake,body.reading.wheelawake .wheel{opacity:.92}
+  body.reading .wheel.touching,body.reading .wheel.demo,body.reading .wheel.awake,body.reading.wheelawake .wheel{opacity:.70} /* [J:07-15] 더 투명하게 — 읽기 콘텐츠 가림 완화 */
   .rd-ch{font-size:11px; letter-spacing:.12em; font-weight:800; color:var(--paper-sub); margin:22px 2px 10px; text-transform:none}
   .rd-ch:first-child{margin-top:2px}
   .rd-note{font-size:17px; line-height:1.85; color:var(--paper-ink); margin:0 0 4px; padding:8px 10px; border-radius:10px;


### PR DESCRIPTION
James: 미니 조그휠 투명도를 더 높여 읽기 콘텐츠 가림 완화. `body.reading .wheel` 표시 상태 opacity .92 → .70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)