### PR TITLE
fix(mobile): progress bar collapsed next to play button (#1268 regression)

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -321,6 +321,7 @@
   .ptrack{flex:none; margin-top:10px}
   /* [J:07-16] play/pause embedded at left of bottom progress (option C) — shared by basic+reading; replaces top mute icon */
   .ptrack .prow{display:flex; align-items:center; gap:10px}
+  .ptrack .prow .chapters{flex:1; min-width:0}  /* fill row — without this the bar collapses next to the play button */
   .ppbtn{flex:none; width:26px; height:26px; border-radius:50%; border:none; background:rgba(206,95,48,.12);
     display:grid; place-items:center; cursor:pointer; touch-action:manipulation; -webkit-tap-highlight-color:transparent;
     transition:transform .12s ease}


### PR DESCRIPTION
#1268 play/pause 추가 시 chapters를 flex .prow로 감쌌으나 .chapters에 flex-grow가 없어 collapse(점만 보임). `flex:1;min-width:0` 추가로 바가 행을 채움. 검증: chapW=322px(=prow358-ppBtn26-gap10).