### PR TITLE
fix(mobile): share settings wheel-navigable (not tap-only), repositioned, + sequential on/off

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -241,9 +241,7 @@
   .way-sage{background:radial-gradient(circle at 50% 32%, #D5DECB 30%, #93A788)}
   .way-mist{background:radial-gradient(circle at 50% 32%, #D7E2EA 30%, #90A7B8)}
   /* share-settings segmented control */
-  .segset{margin-left:auto; display:inline-flex; background:rgba(94,86,72,.10); border-radius:20px; padding:2px; flex:none}
-  .segbtn{border:none; background:none; font-family:inherit; font-size:11.5px; font-weight:700; color:var(--paper-sub); padding:4px 11px; border-radius:16px; cursor:pointer; touch-action:manipulation; -webkit-tap-highlight-color:transparent}
-  .segbtn.on{background:var(--ui); color:#fff}
+  /* share settings live on wheel-navigable .mrow buttons; value shown in .sub, cycled on activation */
   .menu-note{font-size:9px; color:var(--paper-sub); font-weight:600; text-align:center; margin-top:auto; padding-top:8px}
 
   /* ---- 플레이어 (세로) ---- */
@@ -757,17 +755,12 @@
       <div class="scr" data-s="menu" id="scrMenu">
         <div class="top"><span class="tt">설정</span><div class="navtog"><button class="ntb" data-nav="home" aria-label="내 만다라"><span class="batt" id="sigMenu"><svg class="ksig" width="16" height="16" viewBox="0 0 17 17" aria-hidden="true"><rect class="c" x="0.5" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="0.5" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="12.1" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="6.3" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="12.1" width="4.4" height="4.4" rx="1.2"/><rect class="c" x="0.5" y="6.3" width="4.4" height="4.4" rx="1.2"/><rect class="c core" x="6.3" y="6.3" width="4.4" height="4.4" rx="1.2"/></svg></span></button><button class="ntb on" data-nav="menu" aria-label="설정"><svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><path d="M4 7h9M17.6 7H20"/><circle cx="15.2" cy="7" r="2.4"/><path d="M4 17h2.8M11.4 17H20"/><circle cx="8.8" cy="17" r="2.4"/></svg></button></div></div>
         <div class="menu-list">
-          <div class="ghd">공유</div>
-          <div class="mrow" style="cursor:default">
-            <span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12M8 6.5 12 3l4 3.5"/><rect x="5" y="10" width="14" height="10" rx="2"/></svg></span>링크 유효기간
-            <span class="segset" id="shExpiry">
-              <button class="segbtn" data-days="1">24시간</button>
-              <button class="segbtn on" data-days="2">48시간</button>
-            </span>
-          </div>
           <div class="ghd">소식 · 초대</div>
           <button class="mrow" id="bNews"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 9a6 6 0 10-12 0c0 6-2.5 7.5-2.5 7.5h17S18 15 18 9"/><path d="M10.3 20a2 2 0 003.4 0"/></svg></span>새소식<span class="newsDot" id="newsDot" hidden></span><span class="sub" id="newsSub">공지 · 업데이트</span></button>
           <button class="mrow" id="bInvite"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 9V7a1.5 1.5 0 011.5-1.5h15A1.5 1.5 0 0121 7v2a3 3 0 000 6v2a1.5 1.5 0 01-1.5 1.5h-15A1.5 1.5 0 013 17v-2a3 3 0 000-6z"/><path d="M13.5 6.2v2.1M13.5 11v2M13.5 15.7V18" stroke-dasharray="1.6 2.4"/></svg></span>초대권 사용하기<span class="sub" id="invSub">친구를 베타에 초대</span></button>
+          <div class="ghd">공유</div>
+          <button class="mrow" id="bShExpiry"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12M8 6.5 12 3l4 3.5"/><rect x="5" y="10" width="14" height="10" rx="2"/></svg></span>링크 유효기간<span class="sub" id="shExpiryVal">48시간</span></button>
+          <button class="mrow" id="bShSeq"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h11M4 12h16M4 17h8"/><path d="M17.5 5.5 20 8l-2.5 2.5"/></svg></span>순서대로 듣기<span class="sub" id="shSeqVal">끔</span></button>
           <div class="ghd">앱</div>
           <div class="mrow" style="cursor:default">
             <span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" aria-hidden="true"><circle cx="7" cy="10" r="2.6"/><circle cx="15.5" cy="7.5" r="2.6"/><circle cx="14.5" cy="16" r="2.6"/></svg></span>컬러웨이
@@ -1047,17 +1040,15 @@
     }
   }catch(e){}
 
-  // share-link expiry segmented control (24h/48h) — stored pref, applied at mint via shareBody()
+  // share settings = wheel-navigable .mrow buttons; center-press (or tap) cycles the value shown in .sub
   (function(){
-    var seg=document.getElementById('shExpiry'); if(!seg) return;
-    var curSel; try{ curSel=localStorage.getItem('insighta-share-expiry')==='1'?'1':'2'; }catch(e){ curSel='2'; }
-    Array.prototype.forEach.call(seg.querySelectorAll('.segbtn'),function(b){
-      b.classList.toggle('on', b.getAttribute('data-days')===curSel);
-      b.addEventListener('click',function(){
-        try{ localStorage.setItem('insighta-share-expiry', b.getAttribute('data-days')); }catch(e){}
-        Array.prototype.forEach.call(seg.querySelectorAll('.segbtn'),function(x){ x.classList.toggle('on', x===b); });
-      });
-    });
+    var expRow=document.getElementById('bShExpiry'), expVal=document.getElementById('shExpiryVal');
+    var seqRow=document.getElementById('bShSeq'), seqVal=document.getElementById('shSeqVal');
+    function renderExp(){ if(expVal) expVal.textContent=(shareExpiryDays()*24)+'시간'; }
+    function renderSeq(){ if(seqVal) seqVal.textContent=shareSeqLock()?'켬':'끔'; }
+    renderExp(); renderSeq();
+    if(expRow) expRow.onclick=function(){ try{ localStorage.setItem('insighta-share-expiry', shareExpiryDays()===2?'1':'2'); }catch(e){} renderExp(); };
+    if(seqRow) seqRow.onclick=function(){ try{ localStorage.setItem('insighta-share-seq', shareSeqLock()?'0':'1'); }catch(e){} renderSeq(); };
   })();
 
   /* ================= 이어 듣기 (C1) ================= */
@@ -2382,7 +2373,8 @@
   document.getElementById('ppBtn').onclick=function(){ if(cur==='player') setPlaying(!playing); }; // bottom-progress play/pause
   // share-link expiry preference (24h/48h), applied at mint; BE createShareLink supports expiresInDays
   function shareExpiryDays(){ try{ return localStorage.getItem('insighta-share-expiry')==='1' ? 1 : 2; }catch(e){ return 2; } }
-  function shareBody(id){ return JSON.stringify({ targetType:'note_episode', targetId:id, expiresInDays:shareExpiryDays() }); }
+  function shareSeqLock(){ try{ return localStorage.getItem('insighta-share-seq')==='1'; }catch(e){ return false; } }  // 순서대로 듣기 opt-in (guest honoring needs BE)
+  function shareBody(id){ return JSON.stringify({ targetType:'note_episode', targetId:id, expiresInDays:shareExpiryDays(), seqLock:shareSeqLock() }); }
   document.getElementById('bShareNote').onclick=function(){
     if(!curNote||curNote.sample||curNote.guest) return;
     var url=curNote._shareUrl;


### PR DESCRIPTION
Device test: the dial is wheel-first, but the earlier share setting was a tap-only segmented control at the top that the wheel skips (menuRows filters buttons). Redone as wheel-navigable .mrow button rows: link expiry (48/24h) and sequential playback on/off; center-press or tap cycles the value. shareBody carries expiresInDays + seqLock. Guest honoring of seqLock is a small follow-up BE step.