### PR TITLE
fix(mobile): share settings on/off toggle switches + comment tidy

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -240,7 +240,7 @@
   .way-cream{background:radial-gradient(circle at 50% 32%, #FBFAF6 30%, #E2DDD1)}
   .way-sage{background:radial-gradient(circle at 50% 32%, #D5DECB 30%, #93A788)}
   .way-mist{background:radial-gradient(circle at 50% 32%, #D7E2EA 30%, #90A7B8)}
-  /* iOS-style on/off switch for share rows — visual only; the wheel-navigable .mrow button owns the toggle */
+  /* on/off toggle switch for share rows — visual only; the wheel-navigable .mrow button owns the toggle */
   .iosw{position:relative; flex:none; width:38px; height:22px; border-radius:22px; background:rgba(94,86,72,.28); transition:background .22s ease; pointer-events:none}
   .iosw::after{content:""; position:absolute; top:2px; left:2px; width:18px; height:18px; border-radius:50%; background:#fff; box-shadow:0 1px 3px rgba(60,45,25,.3); transition:transform .22s cubic-bezier(.3,.8,.3,1)}
   .iosw.on{background:var(--ui)}
@@ -388,7 +388,7 @@
   .go-msg{font-size:11.5px; font-weight:700; text-align:center; line-height:1.7}
   .go-msg small{display:block; font-size:9px; color:var(--paper-sub); font-weight:600}
 
-  /* ================= 클릭휠 — §1.1 + §1.1a ================= */
+  /* ================= 조그휠 — §1.1 + §1.1a ================= */
   /* [J:07-13 설치앱 판정] 휠 = 하단 고정 — 화면 공간 최우선 (정사각 필드 폐기) */
   .wheelzone{display:grid; place-items:center; flex:none; width:100%; padding-top:12px}
   .wheel{
@@ -431,7 +431,7 @@
   .wbtn svg{display:block; fill:currentColor}
   .wbtn:active{transform:scale(.86); opacity:.55} /* [A] press */
   /* [J:07-15] 정규 비율 — 아이콘을 '박스 중심 기준' % 로 배치. translate(-50%,-50%) 로 중심을 고정해
-     padding/glyph 크기와 무관하게 풀/미니/읽기 어느 크기든 4개 모두 동일 반경(iPod 링 밴드)에 안착 (d).
+     padding/glyph 크기와 무관하게 풀/미니/읽기 어느 크기든 4개 모두 동일 반경(같은 링 밴드)에 안착 (d).
      17%/83% = 중심이 휠반경의 ~0.66R (코어 0.39R ~ 가장자리 1.0R 의 링 밴드). 고정 px 폐기. */
   .wbtn.menu{top:17%; left:50%; transform:translate(-50%,-50%)} .wbtn.menu:active{transform:translate(-50%,-50%) scale(.86)}
   .wbtn.prev{left:17%; top:50%; transform:translate(-50%,-50%)} .wbtn.prev:active{transform:translate(-50%,-50%) scale(.84)}
@@ -462,7 +462,7 @@
   body.stage .device{max-width:none; max-height:none; border-radius:0; padding:0; gap:0; background:#0D0D10; box-shadow:none}
   body.stage .device::after{display:none}
   body.stage .engrave{display:none}
-  /* [J pick 07-14] C3 미니 휠 — 세로 클릭휠의 미니어처, 반투명 상주 */
+  /* [J pick 07-14] C3 미니 휠 — 세로 조그휠의 미니어처, 반투명 상주 */
   body.stage .wheelzone{display:block; position:absolute; z-index:7; width:176px; padding:0;
     right:calc(env(safe-area-inset-right, 0px) + 14px); bottom:calc(var(--sab) + 14px); left:auto; top:auto}
   /* A-기록 핸들 문법 [J:07-14]: 평시 투명 → 터치 시 저투명(시청 무방해) → 3초 머문 뒤 소멸 */
@@ -1041,7 +1041,7 @@
     }
   }catch(e){}
 
-  // share settings = wheel-navigable .mrow switch rows; center-press (or tap) toggles the iOS-style switch
+  // share settings = wheel-navigable .mrow switch rows; center-press (or tap) toggles the switch
   (function(){
     var expRow=document.getElementById('bShExpiry'), expVal=document.getElementById('shExpiryVal'), expSw=document.getElementById('shExpirySw');
     var seqRow=document.getElementById('bShSeq'), seqSw=document.getElementById('shSeqSw');
@@ -1825,7 +1825,7 @@
     setPlaying(true); // single start path — syncs body.playing / dock / mediaSession
   }
 
-  /* ================= 클릭휠 엔진 v2 — 통합 입력 레이어 → 상태기계 (iPod 각색) =================
+  /* ================= 조그휠 엔진 v2 — 통합 입력 레이어 → 상태기계 (다이얼 조작 모델) =================
      설계: 휠 위 모든 터치를 단일 핸들러가 소유(touch-action:none) → 의미 이벤트(tick/scrub/press/hold)
      방출 → 컨텍스트 상태기계(home/menu/player)가 해석. 회전 하나에 속도로 미세/거시를 얹지 않고
      '가운데 누른 채 회전=스크럽'으로 모드 분리 (실패한 조그/셔틀 대체). 멀티포인터·capture 소유로
@@ -1885,7 +1885,7 @@
         s.rotated=true; clearTimeout(s.holdT); s.acc=0; // 클릭 억제는 pointerup 에서 (시간창)
       }
       if(s.rotated){
-        // 스크럽 판정: 이 포인터가 코어에서 시작했거나, 다른 손가락이 코어를 누르고 있음 (iPod hold-center+rotate)
+        // 스크럽 판정: 이 포인터가 코어에서 시작했거나, 다른 손가락이 코어를 누르고 있음 (hold-center+rotate)
         var scrub=(s.zone==='center')||(centerId!=null&&centerId!==e.pointerId&&ptr[centerId]);
         var step=scrub?SCRUB_NOTCH:NOTCH;
         var vel=Math.abs(d)/Math.max(e.timeStamp-s.lt,1)*1000; s.lt=e.timeStamp;
@@ -1946,7 +1946,7 @@
       var items=homeItems(); if(!items.length) return;
       var nx=selIdx+dir;
       if(nx<0||nx>=items.length){ wheelRubber(dir); return; } // J4
-      selIdx=nx; updateSel(); // J5: 1노치 1행, 선택만 이동 (아이팟 메뉴)
+      selIdx=nx; updateSel(); // J5: 1노치 1행, 선택만 이동 (메뉴 이동)
     } else if(cur==='menu'){ // 설정도 조그휠 — 행 선택 이동 (홈과 동일)
       var mr=menuRows(); if(!mr.length) return;
       var nm=selMenu+dir;
@@ -1964,7 +1964,7 @@
     }
   }
 
-  /* iPod 각색: MENU 짧게=뒤로(한 단계 위), 길게=홈(엔진 holdT 처리). 설정 진입=우상단 설정 아이콘. */
+  /* MENU 짧게=뒤로(한 단계 위), 길게=홈(엔진 holdT 처리). 설정 진입=우상단 설정 아이콘. */
   // 화면 부모맵 — 하위 화면은 breadcrumb data-back 을 그대로 사용(news/invite→menu), 나머지는 명시 (h)
   function screenParent(s){
     var el=scr[s], up=el&&el.querySelector('.bc .up[data-back]');

--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -240,8 +240,11 @@
   .way-cream{background:radial-gradient(circle at 50% 32%, #FBFAF6 30%, #E2DDD1)}
   .way-sage{background:radial-gradient(circle at 50% 32%, #D5DECB 30%, #93A788)}
   .way-mist{background:radial-gradient(circle at 50% 32%, #D7E2EA 30%, #90A7B8)}
-  /* share-settings segmented control */
-  /* share settings live on wheel-navigable .mrow buttons; value shown in .sub, cycled on activation */
+  /* iOS-style on/off switch for share rows — visual only; the wheel-navigable .mrow button owns the toggle */
+  .iosw{position:relative; flex:none; width:38px; height:22px; border-radius:22px; background:rgba(94,86,72,.28); transition:background .22s ease; pointer-events:none}
+  .iosw::after{content:""; position:absolute; top:2px; left:2px; width:18px; height:18px; border-radius:50%; background:#fff; box-shadow:0 1px 3px rgba(60,45,25,.3); transition:transform .22s cubic-bezier(.3,.8,.3,1)}
+  .iosw.on{background:var(--ui)}
+  .iosw.on::after{transform:translateX(16px)}
   .menu-note{font-size:9px; color:var(--paper-sub); font-weight:600; text-align:center; margin-top:auto; padding-top:8px}
 
   /* ---- 플레이어 (세로) ---- */
@@ -757,8 +760,8 @@
           <button class="mrow" id="bNews"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 9a6 6 0 10-12 0c0 6-2.5 7.5-2.5 7.5h17S18 15 18 9"/><path d="M10.3 20a2 2 0 003.4 0"/></svg></span>새소식<span class="newsDot" id="newsDot" hidden></span><span class="sub" id="newsSub">공지 · 업데이트</span></button>
           <button class="mrow" id="bInvite"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 9V7a1.5 1.5 0 011.5-1.5h15A1.5 1.5 0 0121 7v2a3 3 0 000 6v2a1.5 1.5 0 01-1.5 1.5h-15A1.5 1.5 0 013 17v-2a3 3 0 000-6z"/><path d="M13.5 6.2v2.1M13.5 11v2M13.5 15.7V18" stroke-dasharray="1.6 2.4"/></svg></span>초대권 사용하기<span class="sub" id="invSub">친구를 베타에 초대</span></button>
           <div class="ghd">공유</div>
-          <button class="mrow" id="bShExpiry"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12M8 6.5 12 3l4 3.5"/><rect x="5" y="10" width="14" height="10" rx="2"/></svg></span>링크 유효기간<span class="sub" id="shExpiryVal">48시간</span></button>
-          <button class="mrow" id="bShSeq"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h11M4 12h16M4 17h8"/><path d="M17.5 5.5 20 8l-2.5 2.5"/></svg></span>순서대로 듣기<span class="sub" id="shSeqVal">끔</span></button>
+          <button class="mrow" id="bShExpiry" role="switch" aria-checked="true"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12M8 6.5 12 3l4 3.5"/><rect x="5" y="10" width="14" height="10" rx="2"/></svg></span>링크 유효기간<span class="sub" id="shExpiryVal">48시간</span><span class="iosw" id="shExpirySw" aria-hidden="true"></span></button>
+          <button class="mrow" id="bShSeq" role="switch" aria-checked="false"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 7h11M4 12h16M4 17h8"/><path d="M17.5 5.5 20 8l-2.5 2.5"/></svg></span>순서대로 듣기<span class="iosw" id="shSeqSw" aria-hidden="true" style="margin-left:auto"></span></button>
           <div class="ghd">앱</div>
           <div class="mrow" style="cursor:default">
             <span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" aria-hidden="true"><circle cx="7" cy="10" r="2.6"/><circle cx="15.5" cy="7.5" r="2.6"/><circle cx="14.5" cy="16" r="2.6"/></svg></span>컬러웨이
@@ -1038,12 +1041,12 @@
     }
   }catch(e){}
 
-  // share settings = wheel-navigable .mrow buttons; center-press (or tap) cycles the value shown in .sub
+  // share settings = wheel-navigable .mrow switch rows; center-press (or tap) toggles the iOS-style switch
   (function(){
-    var expRow=document.getElementById('bShExpiry'), expVal=document.getElementById('shExpiryVal');
-    var seqRow=document.getElementById('bShSeq'), seqVal=document.getElementById('shSeqVal');
-    function renderExp(){ if(expVal) expVal.textContent=(shareExpiryDays()*24)+'시간'; }
-    function renderSeq(){ if(seqVal) seqVal.textContent=shareSeqLock()?'켬':'끔'; }
+    var expRow=document.getElementById('bShExpiry'), expVal=document.getElementById('shExpiryVal'), expSw=document.getElementById('shExpirySw');
+    var seqRow=document.getElementById('bShSeq'), seqSw=document.getElementById('shSeqSw');
+    function renderExp(){ var on=shareExpiryDays()===2; if(expSw) expSw.classList.toggle('on',on); if(expVal) expVal.textContent=(shareExpiryDays()*24)+'시간'; if(expRow) expRow.setAttribute('aria-checked',on); }
+    function renderSeq(){ var on=shareSeqLock(); if(seqSw) seqSw.classList.toggle('on',on); if(seqRow) seqRow.setAttribute('aria-checked',on); }
     renderExp(); renderSeq();
     if(expRow) expRow.onclick=function(){ try{ localStorage.setItem('insighta-share-expiry', shareExpiryDays()===2?'1':'2'); }catch(e){} renderExp(); };
     if(seqRow) seqRow.onclick=function(){ try{ localStorage.setItem('insighta-share-seq', shareSeqLock()?'0':'1'); }catch(e){} renderSeq(); };


### PR DESCRIPTION
Device test: the share settings rows showed values as plain text; changed to iOS-style on/off toggle switches. Rows stay wheel-navigable (role=switch, aria-checked); center-press or tap toggles. Link expiry ON=48h(default)/OFF=24h, sequential OFF(default)/ON. shareBody carries expiresInDays + seqLock. Also normalized internal comment wording to product terms (jog wheel / dial).