### PR TITLE
fix(mobile): notice banners clipped + unscrollable in the short news panel

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -647,7 +647,7 @@
 
   /* ── 새소식 애니메이션 배너 (closed_beta / dial_launch) — CTA 전환 표면 ── */
   #newsList{--nb-berry:#8E7DE4; --nb-berry-mid:#6E5DC8; --nb-berry-lo:#5A4BB0}
-  .nb-card{position:relative; border-radius:18px; overflow:hidden; contain:layout paint style;
+  .nb-card{position:relative; flex:none; border-radius:18px; overflow:hidden; contain:layout paint;
     opacity:0; transform:translateY(14px); animation:nbIn .6s cubic-bezier(.2,.8,.2,1) forwards;
     cursor:pointer; -webkit-tap-highlight-color:transparent; touch-action:manipulation}
   .nb-card:active{transform:scale(.986)}


### PR DESCRIPTION
Device report: banners cut off (pills/CTA/mascot/body clipped), animations not visible, feed would not scroll.

Root cause: .nb-card are flex children of the flex-column #newsList; default flex-shrink:1 compressed them to fit the short panel (~431px), and contain:paint clipped the overflow — content cut AND no list overflow so nothing to scroll. Animated elements sat in the clipped region.

Fix: .nb-card{flex:none} — natural height (~230/240px), list overflows and scrolls, full card + animations show. Verified at 390x844: beta card full, scroll reveals dial CTA, nbIn/nbBreathe/nbBob running.