### PR TITLE
feat(mobile): wire notice CTAs to in-app destinations (beta->invite, dial->home)

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -2379,6 +2379,7 @@
   }
   function nbCTA(n){ var u=n&&n.cta_url; if(!u) return;
     if(/^https?:/i.test(u)) return;                       // internal routes only (no external nav)
+    if(u==='invite'){ show('invite'); if(typeof loadTickets==='function') loadTickets(); return; }
     if(u==='/mobile/'||u==='/mobile'||u==='home'){ show('home'); return; }
     location.href=u;
   }

--- a/prisma/migrations/app-notices/003_seed_beta_notices.sql
+++ b/prisma/migrations/app-notices/003_seed_beta_notices.sql
@@ -4,11 +4,11 @@
 INSERT INTO app_notices (title, body, kind, event_at, cta_label, cta_url, published_at)
 SELECT '클로즈드 베타가 열렸어요',
        '지금, 초대받은 분들만 · 6주 무료로 Pro 전 기능을 써보세요.',
-       'closed_beta', TIMESTAMPTZ '2026-08-24 23:59:59+09', '지금 참여하기', '/mobile/', now()
+       'closed_beta', TIMESTAMPTZ '2026-08-24 23:59:59+09', '지금 참여하기', 'invite', now()
 WHERE NOT EXISTS (SELECT 1 FROM app_notices WHERE kind = 'closed_beta');
 
 INSERT INTO app_notices (title, body, kind, cta_label, cta_url, published_at)
 SELECT E'다이얼,\n이제 손 안에',
        '유튜브는 보던 대로 보세요. 인사이타가 매주 한 편의 지식노트로 정리해 드려요.',
-       'dial_launch', '지금 들어보기', '/mobile/', now() - interval '1 minute'
+       'dial_launch', '지금 들어보기', 'home', now() - interval '1 minute'
 WHERE NOT EXISTS (SELECT 1 FROM app_notices WHERE kind = 'dial_launch');

--- a/prisma/migrations/app-notices/004_align_cta_urls.sql
+++ b/prisma/migrations/app-notices/004_align_cta_urls.sql
@@ -1,0 +1,5 @@
+-- Point the two launch notices at in-app CTA destinations (2026-07-16):
+-- closed_beta -> invite screen (beta growth), dial_launch -> home. Idempotent
+-- (IS DISTINCT FROM guard makes re-application a no-op).
+UPDATE app_notices SET cta_url = 'invite' WHERE kind = 'closed_beta' AND cta_url IS DISTINCT FROM 'invite';
+UPDATE app_notices SET cta_url = 'home'   WHERE kind = 'dial_launch' AND cta_url IS DISTINCT FROM 'home';

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -189,6 +189,7 @@ APPLY_FILES=(
   "prisma/migrations/app-notices/001_create_app_notices.sql"
   "prisma/migrations/app-notices/002_add_kind_cta.sql"
   "prisma/migrations/app-notices/003_seed_beta_notices.sql"
+  "prisma/migrations/app-notices/004_align_cta_urls.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "


### PR DESCRIPTION
Banner CTAs previously all went to /mobile/ (home). Now routed to meaningful in-app destinations: closed_beta '지금 참여하기' -> invite screen (beta growth), dial_launch '지금 들어보기' -> home.

- FE nbCTA gains an 'invite' route (show('invite') + loadTickets).
- Migration 004 aligns existing prod rows' cta_url (idempotent, IS DISTINCT FROM guard); seed 003 aligned for fresh installs; 004 in apply-custom-sql allowlist.

Verified: beta CTA -> invite screen, dial CTA -> home, no console errors.