### PR TITLE
fix(mobile): beta notice CTA -> beta signup page + keep CTA text on one line

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -654,7 +654,7 @@
   @keyframes nbIn{to{opacity:1; transform:none}}
   .nb-body{position:relative; color:#fff}
   .nb-eyebrow{font-size:9.5px; font-weight:800; letter-spacing:.2em; opacity:.85}
-  .nb-cta{display:inline-flex; align-items:center; gap:6px; margin-top:15px; position:relative; z-index:2;
+  .nb-cta{display:inline-flex; align-items:center; gap:6px; margin-top:15px; position:relative; z-index:2; white-space:nowrap;
     background:#fff; border-radius:99px; padding:10px 17px; font-size:12.5px; font-weight:900; box-shadow:0 4px 12px -4px rgba(0,0,0,.28)}
   .nb-cta svg{width:13px; height:13px}
   /* beta */
@@ -2390,8 +2390,8 @@
     tick(); _newsTimers.push(setInterval(tick,1000));
   }
   function nbCTA(n){ var u=n&&n.cta_url; if(!u) return;
-    if(/^https?:/i.test(u)) return;                       // internal routes only (no external nav)
-    if(u==='invite'){ show('invite'); if(typeof loadTickets==='function') loadTickets(); return; }
+    if(/^https:\/\/(www\.)?insighta\.one\//i.test(u)){ location.href=u; return; } // admin-set external page (e.g. /beta/)
+    if(/^https?:/i.test(u)) return;                       // block other external
     if(u==='/mobile/'||u==='/mobile'||u==='home'){ show('home'); return; }
     location.href=u;
   }

--- a/prisma/migrations/app-notices/003_seed_beta_notices.sql
+++ b/prisma/migrations/app-notices/003_seed_beta_notices.sql
@@ -4,7 +4,7 @@
 INSERT INTO app_notices (title, body, kind, event_at, cta_label, cta_url, published_at)
 SELECT '클로즈드 베타가 열렸어요',
        '지금, 초대받은 분들만 · 6주 무료로 Pro 전 기능을 써보세요.',
-       'closed_beta', TIMESTAMPTZ '2026-08-24 23:59:59+09', '지금 참여하기', 'invite', now()
+       'closed_beta', TIMESTAMPTZ '2026-08-24 23:59:59+09', '지금 참여하기', 'https://insighta.one/beta/', now()
 WHERE NOT EXISTS (SELECT 1 FROM app_notices WHERE kind = 'closed_beta');
 
 INSERT INTO app_notices (title, body, kind, cta_label, cta_url, published_at)

--- a/prisma/migrations/app-notices/004_align_cta_urls.sql
+++ b/prisma/migrations/app-notices/004_align_cta_urls.sql
@@ -1,5 +1,5 @@
--- Point the two launch notices at in-app CTA destinations (2026-07-16):
--- closed_beta -> invite screen (beta growth), dial_launch -> home. Idempotent
+-- Point the launch notices at their CTA destinations (2026-07-16):
+-- closed_beta -> the beta signup page, dial_launch -> home. Idempotent
 -- (IS DISTINCT FROM guard makes re-application a no-op).
-UPDATE app_notices SET cta_url = 'invite' WHERE kind = 'closed_beta' AND cta_url IS DISTINCT FROM 'invite';
-UPDATE app_notices SET cta_url = 'home'   WHERE kind = 'dial_launch' AND cta_url IS DISTINCT FROM 'home';
+UPDATE app_notices SET cta_url = 'https://insighta.one/beta/' WHERE kind = 'closed_beta' AND cta_url IS DISTINCT FROM 'https://insighta.one/beta/';
+UPDATE app_notices SET cta_url = 'home' WHERE kind = 'dial_launch' AND cta_url IS DISTINCT FROM 'home';


### PR DESCRIPTION
Device feedback: the beta banner CTA '지금 참여하기' must open the beta signup page (https://insighta.one/beta/, verified 200), not the in-app invite screen; and the dial CTA '지금 들어보기' wrapped to two lines (squished).

- nbCTA: allow navigation to https://insighta.one/* (admin-set cta_url); other external blocked; dropped the unused 'invite' route.
- .nb-cta: white-space:nowrap (single-line label).
- Migration 004 + seed 003: closed_beta cta_url -> https://insighta.one/beta/ (idempotent); dial_launch stays 'home'.

Verified at 390x844: dial CTA one line, beta routes to the external nav branch, no console errors.