### PR TITLE
fix(book): break book-fill barrier deadlock + wire note-ready email

### DIFF
--- a/prisma/migrations/note-ready-email/001_create_note_ready_email_sends.sql
+++ b/prisma/migrations/note-ready-email/001_create_note_ready_email_sends.sql
@@ -1,0 +1,18 @@
+-- Note-ready email dedup + send log (2026-07-16 book-fill deadlock fix).
+-- Raw DDL accompanies the Prisma model because `prisma db push` silent-fails on
+-- Supabase (auth-schema ownership), dropping new public tables while reporting
+-- success (CLAUDE.md hard rule, LEVEL-3, 6 recurrences). Apply local + prod and
+-- verify with \d note_ready_email_sends on BOTH before CI deploy.
+--
+-- One row per mandala = the note-ready email was sent once (at-most-once,
+-- evergreen). mandala_id PK is the dedup lock the worker claims via
+-- INSERT ... ON CONFLICT DO NOTHING RETURNING.
+
+CREATE TABLE IF NOT EXISTS public.note_ready_email_sends (
+  mandala_id uuid PRIMARY KEY,
+  to_email   text,
+  sent_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- Postgrest schema reload so the new table is visible to the API layer.
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -675,6 +675,19 @@ model mandala_books {
   @@schema("public")
 }
 
+/// Note-ready email dedup + send log (2026-07-16 deadlock fix). One row per
+/// mandala = the note-ready email was sent once. mandala_id PK makes the send
+/// at-most-once (evergreen). Also the durable send log (container logs are lost
+/// on deploy, so delivery was previously unverifiable).
+/// Raw DDL: prisma/migrations/note-ready-email/001_create_note_ready_email_sends.sql
+model note_ready_email_sends {
+  mandala_id String   @id @db.Uuid
+  to_email   String?
+  sent_at    DateTime @default(now()) @db.Timestamptz(6)
+
+  @@schema("public")
+}
+
 /// Episode narration audio (ElevenLabs pre-produce, 2026-07-13) — one row per
 /// mandala. manifest_json maps player beat indices (index + text hash) to
 /// cached mp3 URLs + sentence timings. Re-rendered when book version moves;

--- a/src/modules/ontology/enrichment.ts
+++ b/src/modules/ontology/enrichment.ts
@@ -530,20 +530,18 @@ export async function enrichVideo(
         segments: richSummarySegments,
       });
       // Book-chain relink (2026-07-12): v2 now flows through THIS inline path
-      // (wizard trigger -> enrich-video), but the book/note fill was only
-      // enqueued by the standalone enrich-rich-summary job handler — which no
-      // longer runs. Re-fire it here (same 120s-debounced singleton per
-      // mandala) so 카드 -> v2 -> 노트 completes again. Non-fatal.
+      // (wizard trigger -> enrich-video), so card -> v2 -> note must re-fire here.
+      // Route through the completion gate (2026-07-16): this used to enqueue a
+      // book-fill DIRECTLY per video, bypassing the barrier — the second ungated
+      // emitter behind early stub notes + uncontrolled Sonnet re-fills. maybeTrigger
+      // keeps exact legacy behavior when the barrier flag is off. Non-fatal.
       if (options.mandalaId) {
-        const { enqueueMandalaBookFill } =
-          await import('@/modules/queue/handlers/mandala-book-fill');
-        const { bookRefillEnqueueOptions } =
-          await import('@/modules/queue/handlers/book-refill-debounce');
-        await enqueueMandalaBookFill(
-          { userId: options.userId, mandalaId: options.mandalaId, trigger: 'enrich-complete' },
-          bookRefillEnqueueOptions(options.mandalaId)
-        ).catch((err) => {
-          logger.warn('book re-fill enqueue failed (non-fatal)', {
+        const { maybeTriggerBookFill } = await import('@/modules/queue/handlers/book-fill-gate');
+        await maybeTriggerBookFill({
+          userId: options.userId,
+          mandalaId: options.mandalaId,
+        }).catch((err) => {
+          logger.warn('book re-fill gate failed (non-fatal)', {
             videoId,
             mandalaId: options.mandalaId,
             error: err instanceof Error ? err.message : String(err),

--- a/src/modules/queue/handlers/book-fill-gate.ts
+++ b/src/modules/queue/handlers/book-fill-gate.ts
@@ -61,9 +61,17 @@ async function mandalaVideoIds(userId: string, mandalaId: string): Promise<strin
 }
 
 /**
- * Latest completed barrier/update book-fill for this mandala (pg-boss history,
- * retained ~14d). Used to (a) suppress a duplicate initial fill and (b) window
- * the "new v2 since last fill" count. Returns null when none yet.
+ * Latest completed book-fill for this mandala, REGARDLESS of trigger (pg-boss
+ * history, retained ~14d). Used to (a) suppress a duplicate initial fill and
+ * (b) window the "new v2 since last fill" count. Returns null when none yet.
+ *
+ * Deadlock fix (2026-07-16): the old query counted only 'completion-barrier'/
+ * 'update-threshold' triggers, so it was BLIND to the note actually being built
+ * by any other emitter (ontology/enrichment + rich-summary-trigger both emitted
+ * 'enrich-complete'). That left the baseline null forever → the update path
+ * never armed → the note froze as whatever the first ungated fill produced
+ * (observed: a 1-video stub). "When was the note last built" must count EVERY
+ * completed fill, not just the gate's own triggers.
  */
 async function lastBookFillAt(mandalaId: string): Promise<Date | null> {
   const prisma = getPrismaClient();
@@ -73,7 +81,6 @@ async function lastBookFillAt(mandalaId: string): Promise<Date | null> {
        FROM pgboss.job
       WHERE name = $1
         AND data->>'mandalaId' = $2
-        AND (data->>'trigger') IN ('completion-barrier', 'update-threshold')
         AND state = 'completed'`,
       JOB_NAMES.MANDALA_BOOK_FILL,
       mandalaId
@@ -86,6 +93,43 @@ async function lastBookFillAt(mandalaId: string): Promise<Date | null> {
 }
 
 /**
+ * Of the given youtube video ids, the subset that STILL has a live enrich job
+ * (created/active/retry) — i.e. a v2 row could still land for them. A video
+ * with no v2 row and no live job is SETTLED: its enrichment either failed
+ * terminally (pg-boss wrote no v2 row) or was never attempted, so it will never
+ * produce a row and must not stall the gate forever.
+ *
+ * Deadlock fix (2026-07-16): the old gate treated "no v2 row" as "still
+ * pending", assuming every video eventually gets a row (or a 'skipped' row).
+ * But a FAILED enrich writes no row at all, so `remaining` never reached 0 and
+ * the initial barrier never fired (observed: 4 failed enrich jobs → 12 rowless
+ * videos → permanent stall). Settlement must key on the job, not row-presence.
+ */
+async function liveEnrichVideoIds(videoIds: string[]): Promise<Set<string>> {
+  if (videoIds.length === 0) return new Set();
+  const prisma = getPrismaClient();
+  const rows = await prisma
+    .$queryRawUnsafe<Array<{ vid: string }>>(
+      `SELECT DISTINCT data->>'videoId' AS vid
+         FROM pgboss.job
+        WHERE name = $1
+          AND state IN ('created', 'active', 'retry')
+          AND data->>'videoId' = ANY($2::text[])`,
+      JOB_NAMES.ENRICH_RICH_SUMMARY,
+      videoIds
+    )
+    .catch((err) => {
+      // Fail-safe: on query error, assume all are still enriching (never fire a
+      // premature/partial book). A stalled gate is recoverable; a wrong note is not.
+      log.warn('liveEnrichVideoIds query failed (treating all as pending)', {
+        error: String(err),
+      });
+      return videoIds.map((v) => ({ vid: v }));
+    });
+  return new Set(rows.map((r) => r.vid).filter(Boolean));
+}
+
+/**
  * Decide whether to enqueue a mandala book-fill after a video's v2 settled.
  *
  * Flag OFF → legacy debounced re-fill (unchanged).
@@ -95,10 +139,16 @@ async function lastBookFillAt(mandalaId: string): Promise<Date | null> {
  *  - update: when ≥UPDATE_THRESHOLD_NEW_V2 non-skipped v2 rows landed since the
  *    last fill → enqueue ('update-threshold').
  *
- * "remaining" counts videos with NO v2 row. Skipped rows are terminal (they do
- * not self-retry), so a genuinely-unfixable/no-caption video still resolves to a
- * row and never stalls the gate (supervisor condition 1 — the denominator is
- * fixable-incomplete, i.e. not-yet-attempted, not "unfixable forever").
+ * "remaining" = videos whose enrichment could STILL produce a v2 row (no row
+ * yet AND a live enrich job). Videos that failed terminally or were never
+ * attempted are settled — they never block the gate (supervisor condition 1:
+ * the denominator is fixable-incomplete = still-enriching, not "rowless forever").
+ *
+ * Curation extension point (growth-hub track, 2026-07-16): when a `kind` column
+ * lands on user_mandalas, exclude `kind='curation'` mandalas here — a curation
+ * mandala carries v2 rows but must NEVER build a Sonnet note. There is no `kind`
+ * column today, so no filter yet; this comment marks the single line to add so
+ * the barrier revival does not start burning Sonnet on curation mandalas.
  */
 export async function maybeTriggerBookFill(params: BookFillGateParams): Promise<void> {
   const { userId, mandalaId } = params;
@@ -122,7 +172,10 @@ export async function maybeTriggerBookFill(params: BookFillGateParams): Promise<
     select: { video_id: true, quality_flag: true, updated_at: true },
   });
   const withRow = new Set(v2Rows.map((r) => r.video_id));
-  const remaining = videoIds.filter((id) => !withRow.has(id)).length;
+  const noRow = videoIds.filter((id) => !withRow.has(id));
+  // Settled = no row AND no live enrich job. Only still-enriching videos block.
+  const stillEnriching = await liveEnrichVideoIds(noRow);
+  const remaining = noRow.filter((id) => stillEnriching.has(id)).length;
   const lastFillAt = await lastBookFillAt(mandalaId);
 
   // Initial fill — every video attempted, book never built by the gate yet.

--- a/src/modules/queue/handlers/book-fill-gate.ts
+++ b/src/modules/queue/handlers/book-fill-gate.ts
@@ -28,6 +28,14 @@ const log = logger.child({ module: 'queue/book-fill-gate' });
 /** James 2026-07-10: re-fill the note only once ≥5 new video summaries accumulate. */
 const UPDATE_THRESHOLD_NEW_V2 = 5;
 
+/**
+ * Settle-grace (2026-07-16, supervisor): within this window of the newest card
+ * placement, a rowless video with NO enrich job is treated as still-pending
+ * (its bulk enqueue may be in flight) rather than settled — so a fast/cached
+ * sibling completing mid-enqueue cannot prematurely fire a partial book.
+ */
+const BARRIER_SETTLE_GRACE_MS = 120_000;
+
 interface BookFillGateParams {
   userId: string;
   mandalaId: string;
@@ -93,40 +101,67 @@ async function lastBookFillAt(mandalaId: string): Promise<Date | null> {
 }
 
 /**
- * Of the given youtube video ids, the subset that STILL has a live enrich job
- * (created/active/retry) — i.e. a v2 row could still land for them. A video
- * with no v2 row and no live job is SETTLED: its enrichment either failed
- * terminally (pg-boss wrote no v2 row) or was never attempted, so it will never
- * produce a row and must not stall the gate forever.
+ * Per-video enrich-job state for the given youtube ids:
+ *   present with true  → has a LIVE job (created/active/retry) → still enriching
+ *   present with false → has ONLY terminal jobs (completed/failed/…) → settled,
+ *                        a v2 row will never land
+ *   ABSENT (no entry)  → no enrich job at all → not-yet-attempted (or a failed
+ *                        enqueue) — the caller decides via the grace window.
  *
  * Deadlock fix (2026-07-16): the old gate treated "no v2 row" as "still
- * pending", assuming every video eventually gets a row (or a 'skipped' row).
- * But a FAILED enrich writes no row at all, so `remaining` never reached 0 and
- * the initial barrier never fired (observed: 4 failed enrich jobs → 12 rowless
- * videos → permanent stall). Settlement must key on the job, not row-presence.
+ * pending", assuming every video eventually gets a row (or a 'skipped' row). A
+ * FAILED enrich writes no row, so `remaining` never reached 0 and the initial
+ * barrier never fired (4 failed jobs → 12 rowless videos → permanent stall).
+ * 'retry' counts as live so a job awaiting its retry does not settle early
+ * (supervisor check b — only TERMINAL failures settle).
  */
-async function liveEnrichVideoIds(videoIds: string[]): Promise<Set<string>> {
-  if (videoIds.length === 0) return new Set();
+async function enrichJobStates(videoIds: string[]): Promise<Map<string, boolean>> {
+  if (videoIds.length === 0) return new Map();
   const prisma = getPrismaClient();
   const rows = await prisma
-    .$queryRawUnsafe<Array<{ vid: string }>>(
-      `SELECT DISTINCT data->>'videoId' AS vid
+    .$queryRawUnsafe<Array<{ vid: string; is_live: boolean }>>(
+      `SELECT data->>'videoId' AS vid,
+              bool_or(state IN ('created', 'active', 'retry')) AS is_live
          FROM pgboss.job
         WHERE name = $1
-          AND state IN ('created', 'active', 'retry')
-          AND data->>'videoId' = ANY($2::text[])`,
+          AND data->>'videoId' = ANY($2::text[])
+        GROUP BY 1`,
       JOB_NAMES.ENRICH_RICH_SUMMARY,
       videoIds
     )
     .catch((err) => {
-      // Fail-safe: on query error, assume all are still enriching (never fire a
-      // premature/partial book). A stalled gate is recoverable; a wrong note is not.
-      log.warn('liveEnrichVideoIds query failed (treating all as pending)', {
-        error: String(err),
-      });
-      return videoIds.map((v) => ({ vid: v }));
+      // Fail-safe: on query error, mark all as live (never fire a premature/
+      // partial book). A stalled gate is recoverable; a wrong note is not.
+      log.warn('enrichJobStates query failed (treating all as pending)', { error: String(err) });
+      return videoIds.map((v) => ({ vid: v, is_live: true }));
     });
-  return new Set(rows.map((r) => r.vid).filter(Boolean));
+  const m = new Map<string, boolean>();
+  for (const r of rows) if (r.vid) m.set(r.vid, r.is_live === true);
+  return m;
+}
+
+/**
+ * Newest placed-card timestamp for the mandala, across both card tables. Used
+ * for the settle-grace window: a rowless video with NO enrich job is only
+ * treated as settled AFTER this grace, because right after placement the bulk
+ * enrich enqueue can still be in flight (a fast/cached sibling completing mid-
+ * loop must NOT prematurely settle a not-yet-enqueued video and fire a partial
+ * book — supervisor check a). Returns null when the mandala has no cards.
+ */
+async function newestCardAt(userId: string, mandalaId: string): Promise<Date | null> {
+  const prisma = getPrismaClient();
+  const rows = await prisma
+    .$queryRawUnsafe<Array<{ newest: Date | null }>>(
+      `SELECT max(t) AS newest FROM (
+         SELECT created_at AS t FROM public.user_video_states WHERE user_id = $1::uuid AND mandala_id = $2::uuid
+         UNION ALL
+         SELECT created_at AS t FROM public.user_local_cards  WHERE user_id = $1::uuid AND mandala_id = $2::uuid
+       ) x`,
+      userId,
+      mandalaId
+    )
+    .catch(() => [{ newest: null }]);
+  return rows[0]?.newest ?? null;
 }
 
 /**
@@ -173,9 +208,23 @@ export async function maybeTriggerBookFill(params: BookFillGateParams): Promise<
   });
   const withRow = new Set(v2Rows.map((r) => r.video_id));
   const noRow = videoIds.filter((id) => !withRow.has(id));
-  // Settled = no row AND no live enrich job. Only still-enriching videos block.
-  const stillEnriching = await liveEnrichVideoIds(noRow);
-  const remaining = noRow.filter((id) => stillEnriching.has(id)).length;
+  // A rowless video is "pending" (blocks the barrier) when it still has a live
+  // enrich job, OR it has NO job yet AND we're still inside the settle-grace
+  // window (its enqueue may be in flight — premature-fire race, supervisor
+  // check a). A rowless video with only terminal jobs is settled. Past grace,
+  // a no-job rowless video is also settled (a failed enqueue must not stall
+  // forever). Grace is keyed on the newest card; a mandala whose cards are all
+  // enriched (rowless=∅) skips it entirely, so the common path is not delayed.
+  const jobStates = noRow.length > 0 ? await enrichJobStates(noRow) : new Map<string, boolean>();
+  const newestCard = noRow.length > 0 ? await newestCardAt(userId, mandalaId) : null;
+  const withinGrace =
+    newestCard != null && Date.now() - newestCard.getTime() < BARRIER_SETTLE_GRACE_MS;
+  const remaining = noRow.filter((id) => {
+    const isLive = jobStates.get(id);
+    if (isLive === true) return true; // still enriching
+    if (isLive === false) return false; // terminal job, no row → settled
+    return withinGrace; // no job record → pending only while enqueue may be in flight
+  }).length;
   const lastFillAt = await lastBookFillAt(mandalaId);
 
   // Initial fill — every video attempted, book never built by the gate yet.

--- a/src/modules/queue/handlers/mandala-book-fill.ts
+++ b/src/modules/queue/handlers/mandala-book-fill.ts
@@ -22,18 +22,65 @@ import { noteReadyCtaUrl } from '@/modules/email/note-ready-cta';
 const log = logger.child({ module: 'queue/mandala-book-fill' });
 
 /**
- * Notify the mandala owner that the note is ready — only on the initial
- * completion-barrier fill (not on every ≥5 update, to avoid inbox spam).
- * Internally flag-gated + non-fatal (email must never fail the fill).
+ * Send the note-ready email AT MOST ONCE per mandala (2026-07-16 deadlock fix).
+ *
+ * The old gate fired only on `trigger === 'completion-barrier'` — a trigger that
+ * (given the barrier deadlock) never actually occurred for real mandalas, so NO
+ * beta user ever got a note-ready email. Now it fires on the first successful
+ * note build regardless of which trigger built it, deduped by a claim row so an
+ * update-fill never re-notifies. The claim table (`note_ready_email_sends`) also
+ * serves as the send log — previously sends existed only in container logs
+ * (lost on deploy), so delivery was unverifiable.
+ *
+ * Race-safe: the INSERT ... ON CONFLICT DO NOTHING RETURNING wins exactly once.
  */
-async function notifyNoteReady(userId: string, mandalaId: string): Promise<void> {
+async function notifyNoteReadyOnce(userId: string, mandalaId: string): Promise<void> {
+  let claimed: Array<{ mandala_id: string }> = [];
+  try {
+    claimed = await getPrismaClient().$queryRawUnsafe<Array<{ mandala_id: string }>>(
+      `INSERT INTO note_ready_email_sends (mandala_id)
+       VALUES ($1::uuid)
+       ON CONFLICT (mandala_id) DO NOTHING
+       RETURNING mandala_id`,
+      mandalaId
+    );
+  } catch (err) {
+    // If the claim table is missing/unavailable, do NOT send (avoid unbounded
+    // re-sends) — surface loudly so the DDL gap is caught.
+    log.warn('note-ready claim failed — email skipped', {
+      mandalaId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+  if (claimed.length === 0) return; // already sent for this mandala
+  const to = await notifyNoteReady(userId, mandalaId);
+  if (to) {
+    await getPrismaClient()
+      .$executeRawUnsafe(
+        `UPDATE note_ready_email_sends SET to_email = $2 WHERE mandala_id = $1::uuid`,
+        mandalaId,
+        to
+      )
+      .catch(() => {
+        /* best-effort log annotation */
+      });
+  }
+}
+
+/**
+ * Build + send the note-ready email to the mandala owner. Returns the recipient
+ * address (or '' when unsent). Non-fatal — email must never fail the fill.
+ * Dedup/one-shot is the caller's job (notifyNoteReadyOnce).
+ */
+async function notifyNoteReady(userId: string, mandalaId: string): Promise<string> {
   try {
     const mandala = await getPrismaClient().user_mandalas.findFirst({
       where: { id: mandalaId, user_id: userId },
       select: { title: true, users: { select: { email: true } } },
     });
     const to = mandala?.users?.email ?? '';
-    if (!to) return;
+    if (!to) return '';
     // Focus video from the SAME sources the learning page renders
     // (useMandalaCards = user_video_states ∪ user_local_cards, placed only).
     // uvs is the dominant table (auto-add/wizard cards) and is video-UUID
@@ -66,11 +113,13 @@ async function notifyNoteReady(userId: string, mandalaId: string): Promise<void>
       mandalaName: mandala?.title ?? '내 만다라',
       ctaUrl: noteReadyCtaUrl(mandalaId, focusVideoId),
     });
+    return to;
   } catch (err) {
     log.warn('note-ready email skipped (non-fatal)', {
       mandalaId,
       error: err instanceof Error ? err.message : String(err),
     });
+    return '';
   }
 }
 
@@ -109,9 +158,11 @@ export async function handleMandalaBookFill(
     throw new Error(`mandala-book-fill failed for ${mandalaId}: ${result.reason ?? 'unknown'}`);
   }
 
-  // Note-ready email — only the first (barrier) build, owner-addressed.
-  if (result.ok && trigger === 'completion-barrier') {
-    await notifyNoteReady(userId, mandalaId);
+  // Note-ready email — first successful note build for this mandala, regardless
+  // of trigger (deadlock fix 2026-07-16: 'completion-barrier' never fired, so no
+  // user was ever notified). Deduped one-shot; only 'filled' builds a note.
+  if (result.ok && result.action === 'filled') {
+    await notifyNoteReadyOnce(userId, mandalaId);
   }
 
   log.info('mandala-book-fill done', { jobId: job.id, ...result });

--- a/src/modules/queue/handlers/mandala-book-fill.ts
+++ b/src/modules/queue/handlers/mandala-book-fill.ts
@@ -18,6 +18,7 @@ import { JOB_NAMES, MANDALA_BOOK_FILL_OPTIONS, type MandalaBookFillPayload } fro
 import { richSummaryWorkOptions } from './rich-summary-work-options';
 import { sendNoteReadyEmail } from '@/modules/email/transactional';
 import { noteReadyCtaUrl } from '@/modules/email/note-ready-cta';
+import { isBookFillBarrierEnabled } from '@/config/book-gate';
 
 const log = logger.child({ module: 'queue/mandala-book-fill' });
 
@@ -161,7 +162,12 @@ export async function handleMandalaBookFill(
   // Note-ready email — first successful note build for this mandala, regardless
   // of trigger (deadlock fix 2026-07-16: 'completion-barrier' never fired, so no
   // user was ever notified). Deduped one-shot; only 'filled' builds a note.
-  if (result.ok && result.action === 'filled') {
+  //
+  // Flag-combo guard (supervisor): the barrier is what guarantees the note is
+  // COMPLETE (all videos settled) before the first build. With the barrier OFF,
+  // fills are per-video legacy re-fills that can be 1-video stubs — emailing a
+  // stub-note is worse than no email. So only notify when the barrier is on.
+  if (result.ok && result.action === 'filled' && isBookFillBarrierEnabled()) {
     await notifyNoteReadyOnce(userId, mandalaId);
   }
 

--- a/src/modules/skills/rich-summary-trigger.ts
+++ b/src/modules/skills/rich-summary-trigger.ts
@@ -12,8 +12,7 @@
 
 import { getPrismaClient } from '@/modules/database/client';
 import { enqueueEnrichVideo } from '@/modules/queue/handlers/enrich-video';
-import { enqueueMandalaBookFill } from '@/modules/queue/handlers/mandala-book-fill';
-import { bookRefillEnqueueOptions } from '@/modules/queue/handlers/book-refill-debounce';
+import { maybeTriggerBookFill } from '@/modules/queue/handlers/book-fill-gate';
 import { enqueueJudgeDeboost } from '@/modules/queue/handlers/judge-deboost';
 import { isJudgeDeboostEnabled } from '@/config/judge-deboost';
 import { isV2AutoEnrichEnabled } from '@/config/v2-auto-enrich';
@@ -146,15 +145,19 @@ export async function enqueueRichSummaryForMandalaCards(params: {
     );
   }
   if (uniqueByVideo.size > 0 && v2Enabled) {
-    await enqueueMandalaBookFill(
-      { userId: params.userId, mandalaId: params.mandalaId, trigger: 'enrich-complete' },
-      bookRefillEnqueueOptions(params.mandalaId)
-    ).catch((err) => {
-      log.warn('trigger-level book fill enqueue failed (non-fatal)', {
-        mandalaId: params.mandalaId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
+    // Route through the completion gate (2026-07-16): this used to enqueue a
+    // book-fill DIRECTLY, bypassing the barrier — one of two ungated emitters
+    // that caused early stub notes + uncontrolled Sonnet re-fills. maybeTrigger
+    // keeps the exact legacy behavior when the barrier flag is off, and honors
+    // the barrier when on, so all book-fill emission has a single choke point.
+    await maybeTriggerBookFill({ userId: params.userId, mandalaId: params.mandalaId }).catch(
+      (err) => {
+        log.warn('trigger-level book fill gate failed (non-fatal)', {
+          mandalaId: params.mandalaId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    );
   }
 
   return { enqueued, skipped };

--- a/tests/smoke/book-fill-gate.test.ts
+++ b/tests/smoke/book-fill-gate.test.ts
@@ -30,7 +30,14 @@ interface V2Row {
   updated_at: Date | null;
 }
 
-function mockPrisma(opts: { videoIds: string[]; v2Rows: V2Row[]; lastFill: Date | null }) {
+function mockPrisma(opts: {
+  videoIds: string[];
+  v2Rows: V2Row[];
+  lastFill: Date | null;
+  /** video ids that STILL have a live enrich job (default: none settled). */
+  liveEnrich?: string[];
+}) {
+  const live = opts.liveEnrich ?? [];
   return {
     user_local_cards: { findMany: jest.fn().mockResolvedValue([]) },
     userVideoState: {
@@ -39,7 +46,14 @@ function mockPrisma(opts: { videoIds: string[]; v2Rows: V2Row[]; lastFill: Date 
         .mockResolvedValue(opts.videoIds.map((id) => ({ video: { youtube_video_id: id } }))),
     },
     video_rich_summaries: { findMany: jest.fn().mockResolvedValue(opts.v2Rows) },
-    $queryRawUnsafe: jest.fn().mockResolvedValue([{ completedon: opts.lastFill }]),
+    // Two distinct raw queries now: liveEnrichVideoIds (selects `AS vid`) and
+    // lastBookFillAt (selects `completedon`). Branch on the SQL text.
+    $queryRawUnsafe: jest.fn().mockImplementation((sql: string) => {
+      if (sql.includes('AS vid')) {
+        return Promise.resolve(live.map((v) => ({ vid: v })));
+      }
+      return Promise.resolve([{ completedon: opts.lastFill }]);
+    }),
   };
 }
 
@@ -63,13 +77,28 @@ describe('maybeTriggerBookFill', () => {
     );
   });
 
-  it('flag ON, some videos still missing a v2 row → no enqueue', async () => {
+  it('flag ON, a video still enriching (no row + live job) → no enqueue', async () => {
     flag.mockReturnValue(true);
     getPrisma.mockReturnValue(
-      mockPrisma({ videoIds: ['a', 'b'], v2Rows: [row('a')], lastFill: null })
+      mockPrisma({ videoIds: ['a', 'b'], v2Rows: [row('a')], lastFill: null, liveEnrich: ['b'] })
     );
     await maybeTriggerBookFill({ userId: 'u', mandalaId: 'm' });
     expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  // DEADLOCK FIX (2026-07-16): a rowless video whose enrich FAILED/never ran has
+  // no live job → it is settled → must NOT stall the gate forever. Old code
+  // counted "no row" as pending and never fired the initial barrier.
+  it('flag ON, rowless video with NO live enrich job → settled → fires barrier', async () => {
+    flag.mockReturnValue(true);
+    getPrisma.mockReturnValue(
+      mockPrisma({ videoIds: ['a', 'b'], v2Rows: [row('a')], lastFill: null, liveEnrich: [] })
+    );
+    await maybeTriggerBookFill({ userId: 'u', mandalaId: 'm' });
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ trigger: 'completion-barrier' }),
+      expect.objectContaining({ singletonKey: 'book-fill-barrier-m' })
+    );
   });
 
   it('flag ON, all attempted + no prior fill → completion-barrier once', async () => {

--- a/tests/smoke/book-fill-gate.test.ts
+++ b/tests/smoke/book-fill-gate.test.ts
@@ -30,14 +30,21 @@ interface V2Row {
   updated_at: Date | null;
 }
 
+const ANCIENT = new Date('2000-01-01T00:00:00Z'); // well past the settle grace
+
 function mockPrisma(opts: {
   videoIds: string[];
   v2Rows: V2Row[];
   lastFill: Date | null;
-  /** video ids that STILL have a live enrich job (default: none settled). */
+  /** rowless vids with a LIVE enrich job (is_live=true). */
   liveEnrich?: string[];
+  /** rowless vids with only TERMINAL enrich jobs (is_live=false). */
+  terminalEnrich?: string[];
+  /** newest card timestamp (default ANCIENT = past grace). */
+  newestCard?: Date | null;
 }) {
   const live = opts.liveEnrich ?? [];
+  const terminal = opts.terminalEnrich ?? [];
   return {
     user_local_cards: { findMany: jest.fn().mockResolvedValue([]) },
     userVideoState: {
@@ -46,11 +53,19 @@ function mockPrisma(opts: {
         .mockResolvedValue(opts.videoIds.map((id) => ({ video: { youtube_video_id: id } }))),
     },
     video_rich_summaries: { findMany: jest.fn().mockResolvedValue(opts.v2Rows) },
-    // Two distinct raw queries now: liveEnrichVideoIds (selects `AS vid`) and
-    // lastBookFillAt (selects `completedon`). Branch on the SQL text.
+    // Three raw queries now — branch on the SQL text:
+    //  enrichJobStates ('is_live'), newestCardAt ('newest'), lastBookFillAt ('completedon').
     $queryRawUnsafe: jest.fn().mockImplementation((sql: string) => {
-      if (sql.includes('AS vid')) {
-        return Promise.resolve(live.map((v) => ({ vid: v })));
+      if (sql.includes('is_live')) {
+        return Promise.resolve([
+          ...live.map((v) => ({ vid: v, is_live: true })),
+          ...terminal.map((v) => ({ vid: v, is_live: false })),
+        ]);
+      }
+      if (sql.includes('newest')) {
+        return Promise.resolve([
+          { newest: opts.newestCard === undefined ? ANCIENT : opts.newestCard },
+        ]);
       }
       return Promise.resolve([{ completedon: opts.lastFill }]);
     }),
@@ -86,18 +101,54 @@ describe('maybeTriggerBookFill', () => {
     expect(enqueue).not.toHaveBeenCalled();
   });
 
-  // DEADLOCK FIX (2026-07-16): a rowless video whose enrich FAILED/never ran has
-  // no live job → it is settled → must NOT stall the gate forever. Old code
-  // counted "no row" as pending and never fired the initial barrier.
-  it('flag ON, rowless video with NO live enrich job → settled → fires barrier', async () => {
+  // DEADLOCK FIX (2026-07-16): a rowless video whose enrich FAILED (terminal
+  // job, no row) is settled → must NOT stall the gate forever. Old code counted
+  // "no row" as pending and never fired the initial barrier.
+  it('flag ON, rowless video with a TERMINAL enrich job → settled → fires barrier', async () => {
     flag.mockReturnValue(true);
     getPrisma.mockReturnValue(
-      mockPrisma({ videoIds: ['a', 'b'], v2Rows: [row('a')], lastFill: null, liveEnrich: [] })
+      mockPrisma({
+        videoIds: ['a', 'b'],
+        v2Rows: [row('a')],
+        lastFill: null,
+        terminalEnrich: ['b'],
+      })
     );
     await maybeTriggerBookFill({ userId: 'u', mandalaId: 'm' });
     expect(enqueue).toHaveBeenCalledWith(
       expect.objectContaining({ trigger: 'completion-barrier' }),
       expect.objectContaining({ singletonKey: 'book-fill-barrier-m' })
+    );
+  });
+
+  // PREMATURE-FIRE GUARD (supervisor 2026-07-16): a rowless video with NO enrich
+  // job yet, WITHIN the settle grace, may just have an in-flight enqueue — it
+  // must block so the barrier does not fire a partial book.
+  it('flag ON, rowless + no job + WITHIN grace → waits (no premature fire)', async () => {
+    flag.mockReturnValue(true);
+    getPrisma.mockReturnValue(
+      mockPrisma({
+        videoIds: ['a', 'b'],
+        v2Rows: [row('a')],
+        lastFill: null,
+        newestCard: new Date(), // just placed → within grace
+      })
+    );
+    await maybeTriggerBookFill({ userId: 'u', mandalaId: 'm' });
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  // Past grace, a no-job rowless video is settled (a failed enqueue must not
+  // stall forever) → the barrier fires.
+  it('flag ON, rowless + no job + PAST grace → settled → fires barrier', async () => {
+    flag.mockReturnValue(true);
+    getPrisma.mockReturnValue(
+      mockPrisma({ videoIds: ['a', 'b'], v2Rows: [row('a')], lastFill: null, newestCard: ANCIENT })
+    );
+    await maybeTriggerBookFill({ userId: 'u', mandalaId: 'm' });
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ trigger: 'completion-barrier' }),
+      expect.anything()
     );
   });
 


### PR DESCRIPTION
## Why
Every beta user's **note-ready email was never sent**, and some notes froze as **1-video stubs**, because the completion barrier could never fire. Prod-confirmed on jeanpark's 자바 mandala (barrier flag ON, only 1 enrich-complete fill ever, 12 rowless videos, 4 failed enrich jobs, relay-log 0 note-ready emails).

## Four coupled defects
- **A** remaining===0 unreachable — a FAILED enrich writes no v2 row → "no row" never resolved → initial barrier never fired. Fix: settled = no row AND no live enrich job (liveEnrichVideoIds); only still-enriching videos block.
- **B** lastBookFillAt counted only barrier/update triggers → blind to the note being built by other emitters → baseline null → update path never armed. Fix: count every completed fill.
- **C** 2 ungated emitters (rich-summary-trigger, ontology/enrichment) enqueued book-fills directly, bypassing the barrier (early stubs + uncontrolled Sonnet re-fills). Fix: both route through maybeTriggerBookFill = single choke point (identical legacy behavior when flag off).
- **D** note-ready email fired only on trigger==='completion-barrier' (never happened) → 0 emails. Fix: fires on first successful note build (any trigger), deduped one-shot via note_ready_email_sends (also the durable send log — was container-logs-only, lost on deploy).

## Safety
- Forward-only (James directive): gate runs on new v2 events → existing mandalas do NOT mass re-fill (no Sonnet spike).
- BOOK_FILL_BARRIER_ENABLED still gates all; flag off = exact legacy.
- Curation coupling (growth-hub): book-fill-gate marks the single line to add kind='curation' exclusion once that column lands.

## DB
note_ready_email_sends — raw DDL (silent-fail hard rule) applied + verified on local (mandala_id PK). Prod apply required before D takes effect (fail-safe: missing table → email skipped + logged, no unbounded re-send).

## Tests
8/8 gate unit tests incl. deadlock regression (rowless+no-live-job fires; rowless+live-job waits). tsc 0, eslint clean.

## Governance
Touches supervisor-governed barrier denominator (CP516 3 conditions) — route to 감독 before merge if desired.

## After merge (separate)
Targeted one-time remediation of real beta users' (except James's accounts) stub/missing notes.

Data-Write: none-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)