### PR TITLE
fix(mobile): open login on mobile — sign in then route to the dial (P0 incident)

### DIFF
--- a/frontend/src/__tests__/mobile-gate.test.ts
+++ b/frontend/src/__tests__/mobile-gate.test.ts
@@ -4,6 +4,7 @@ import { isPathAllowedOnMobile } from '@/shared/lib/mobile-gate';
 describe('mobile gate allowlist', () => {
   it.each([
     '/landing',
+    '/login',
     '/beta',
     '/pricing',
     '/templates',
@@ -17,7 +18,6 @@ describe('mobile gate allowlist', () => {
 
   it.each([
     '/',
-    '/login',
     '/mandalas',
     '/mandalas/new',
     '/mandalas/abc-123',

--- a/frontend/src/pages/login/ui/LoginPage.tsx
+++ b/frontend/src/pages/login/ui/LoginPage.tsx
@@ -18,6 +18,7 @@ import { Input } from '@/shared/ui/input';
 import { Label } from '@/shared/ui/label';
 import { useAuth } from '@/features/auth/model/useAuth';
 import { apiClient } from '@/shared/lib/api-client';
+import { isMobileDevice } from '@/shared/lib/mobile-gate';
 
 // ── SVG Brand Icons ────────────────────────────────────────
 
@@ -106,6 +107,14 @@ export default function LoginPage() {
 
   useEffect(() => {
     if (!isLoading && isLoggedIn) {
+      // Mobile users get the dial, not the desktop-only app. The mobile gate
+      // blocks app routes, so a react-router navigate to '/' would bounce to
+      // /landing; send them to the static dial via a full navigation instead
+      // (2026-07-16 incident: mobile login bounced to the landing page).
+      if (isMobileDevice()) {
+        window.location.assign('/mobile');
+        return;
+      }
       const returnTo = searchParams.get('returnTo');
       const safeReturnTo =
         returnTo && returnTo.startsWith('/') && returnTo !== '/login' ? returnTo : '/';

--- a/frontend/src/shared/lib/mobile-gate.ts
+++ b/frontend/src/shared/lib/mobile-gate.ts
@@ -11,6 +11,9 @@ export const MOBILE_GATE_MAX_WIDTH = 767;
 /** Marketing/legal surfaces that stay reachable on mobile. */
 const ALLOWED_MOBILE_PATH_PREFIXES = [
   '/landing',
+  // Mobile users must be able to sign in — after login they are routed to the
+  // mobile dial (/mobile), not the desktop-only app (2026-07-16 incident fix).
+  '/login',
   '/beta',
   '/pricing',
   '/templates',


### PR DESCRIPTION
## P0 Incident
Mobile users (iPhone + Galaxy, device-agnostic) could not log in — pressing login on the landing/app bounced back to the landing 'coming soon' banner ("모바일 화면은 준비 중입니다").

## Root cause
The closed-beta mobile gate (#1114, `shared/lib/mobile-gate.ts`) redirects any non-allowlisted app route to /landing on mobile. **`/login` was not in the allowlist**, so the login page — and the post-login `/` redirect — were both gated → bounce loop. Not a cache issue (confirmed: iPhone + Galaxy both affected; server-side login works, beta signup gate is 'open').

## Fix (James directive: open login, route mobile → dial)
- `mobile-gate.ts`: add `/login` to `ALLOWED_MOBILE_PATH_PREFIXES`.
- `LoginPage.tsx`: on `isMobileDevice()`, after login redirect to the static dial `/mobile` via full navigation (react-router navigate to '/' would re-hit the gate and bounce). Desktop unchanged.
- test: `/login` moves from gated → allowed.

## Verification
tsc 0, mobile-gate unit 20/20, production build OK. App routes stay desktop-only on mobile (unchanged) — only login is opened + routed to the dial. Post-deploy: James confirms mobile login lands on the dial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)