### PR TITLE
fix(curation): CI green — await boss.work + MS_PER_DAY constant

### DIFF
--- a/src/api/routes/curations.ts
+++ b/src/api/routes/curations.ts
@@ -15,6 +15,7 @@
 import { FastifyPluginCallback } from 'fastify';
 import { getPrismaClient } from '../../modules/database';
 import { enqueueCurationBuild } from '../../modules/queue/handlers/curation-build';
+import { MS_PER_DAY } from '../../utils/time-constants';
 
 /** ISO date (YYYY-MM-DD) of this week's Monday — curation_items.week_of key. */
 function mondayOf(d: Date): string {
@@ -60,7 +61,7 @@ export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         mandala_id: mandalaId,
         is_active: true,
         // recurring weekly refresh starts a week out; the FIRST build runs now.
-        next_run_at: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000),
+        next_run_at: new Date(now.getTime() + 7 * MS_PER_DAY),
       },
     });
 

--- a/src/modules/queue/handlers/curation-build.ts
+++ b/src/modules/queue/handlers/curation-build.ts
@@ -48,7 +48,7 @@ export async function enqueueCurationBuild(
 
 export async function registerCurationBuildWorker(): Promise<void> {
   const boss = getJobQueue().getInstance();
-  boss.work<CurationBuildPayload>(JOB_NAMES.CURATION_BUILD, WORKER, async (job) => {
+  await boss.work<CurationBuildPayload>(JOB_NAMES.CURATION_BUILD, WORKER, async (job) => {
     const { subscriptionId, weekOf } = job.data;
     const prisma = getPrismaClient();
     const sub = await prisma.curation_subscriptions.findUnique({ where: { id: subscriptionId } });
@@ -72,6 +72,10 @@ export async function registerCurationBuildWorker(): Promise<void> {
     //   (snapshot; keep prior weeks). No mandala_books → book-fill-gate untouched (no barrier risk).
     // TODO(build-6) sub.last_run_at = now, next_run_at += 7d. notify (D3 — email reuse candidate).
 
-    log.info('curation build (SCAFFOLD — steps TODO)', { subscriptionId, weekOf, topic: sub.topic });
+    log.info('curation build (SCAFFOLD — steps TODO)', {
+      subscriptionId,
+      weekOf,
+      topic: sub.topic,
+    });
   });
 }

--- a/src/modules/queue/handlers/curation-weekly.ts
+++ b/src/modules/queue/handlers/curation-weekly.ts
@@ -31,7 +31,7 @@ export async function registerCurationWeeklyWorker(): Promise<void> {
   const boss = getJobQueue().getInstance();
   await boss.schedule(JOB_NAMES.CURATION_WEEKLY, QUEUE_CONFIG.CURATION_WEEKLY_CRON);
 
-  boss.work(JOB_NAMES.CURATION_WEEKLY, async () => {
+  await boss.work(JOB_NAMES.CURATION_WEEKLY, async () => {
     const prisma = getPrismaClient();
     const now = new Date();
     const due = await prisma.curation_subscriptions.findMany({


### PR DESCRIPTION
Fixes the Lint + Hardcode Audit CI failures from the #1289 merge.

- **lint**: `await` the `boss.work()` registrations in `curation-build.ts` / `curation-weekly.ts` (were floating promises) + prettier reflow.
- **hardcode-audit**: use `MS_PER_DAY` (utils/time-constants) instead of the raw `7*24*60*60*1000` literal in `curations.ts`.

Verified locally: lint 0 errors, hardcode-audit PASS, tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)