### PR TITLE
feat(curation): personalized Growth Hub curation — interest profile, suggest, build worker

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -155,6 +155,13 @@
   .cur-connect .t1{font-size:15px; font-weight:750; color:var(--paper-ink)}
   .cur-connect .t2{font-size:11.5px; font-weight:600; color:var(--paper-sub); line-height:1.7}
   .cur-connect .cbtn{margin-top:4px; border:none; background:var(--ui); color:#fff; font-family:inherit; font-size:13px; font-weight:800; padding:11px 22px; border-radius:12px; cursor:pointer; -webkit-tap-highlight-color:transparent; box-shadow:0 4px 10px -4px rgba(0,0,0,.3)}
+  .cur-props{flex:1; display:flex; flex-direction:column; gap:10px; padding:15px 15px 20px; overflow-y:auto}
+  .cur-props .cp-h{font-size:12px; font-weight:800; color:var(--paper-sub); letter-spacing:.02em; padding:2px 2px 3px}
+  .cur-props .cp-card{display:flex; flex-direction:column; align-items:flex-start; gap:6px; text-align:left; border:1px solid rgba(94,86,72,.14); background:rgba(255,255,255,.5); border-radius:15px; padding:13px 15px; cursor:pointer; font-family:inherit; -webkit-tap-highlight-color:transparent; transition:transform .12s ease}
+  .cur-props .cp-card:active{transform:scale(.985)}
+  .cur-props .cp-dom{font-size:10.5px; font-weight:800; color:var(--ui); background:rgba(206,95,48,.1); border-radius:8px; padding:3px 8px}
+  .cur-props .cp-t{font-size:15px; font-weight:750; color:var(--paper-ink); line-height:1.4}
+  .cur-props .cp-go{font-size:11.5px; font-weight:700; color:var(--paper-sub)}
   .cur-connect .cbtn:active{transform:scale(.97)}
   .rows{margin-top:10px; display:flex; flex-direction:column; gap:8px; overflow-y:auto; flex:1; min-height:0; padding-bottom:4px}
   .row{display:flex; gap:10px; align-items:center; background:rgba(255,255,255,.55); flex:none;
@@ -1277,16 +1284,96 @@
     if(t==='curation') renderCuration();
     else renderRows();   // video/note share the mandala list; click behaviour differs by homeTab
   }
-  // Curation — weekly personalized recs gated by the (existing) YouTube connection. P0 = gate shell.
-  function renderCuration(){
+  // Curation — YouTube connect gate → analyzing → 3 personalized proposals →
+  // select → async build → weekly video feed (reuses the beat player).
+  var CUR_STAR='<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3.5l1.8 4.4 4.7 1.4-3.5 3 .9 4.7L12 14.6 7.6 17l.9-4.7-3.5-3 4.7-1.4z"/></svg>';
+  function curEsc(s){ return String(s==null?'':s).replace(/[&<>"]/g,function(c){ return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]; }); }
+  var CUR_DOM_LABEL={ai_ml:'AI·기술',career:'취업·커리어',investment:'투자·경제',startup:'창업',language:'어학',exam:'시험·입시',other:'추천'};
+  // Entry point for the curation tab. Detects connection → analyzing → 3 proposals.
+  async function renderCuration(){
+    var el=document.getElementById('curBody'); if(!el) return;
+    try{
+      var r=await api('/curations/suggest');
+      if(r.status===202){ // profile building — analyze then retry
+        el.className='cur-connect';
+        el.innerHTML='<span class="cic">'+CUR_STAR+'</span><span class="t1">관심사 분석 중</span>'
+          +'<span class="t2">유튜브 활동을 살펴보고 있어요<br>잠시 후 추천이 준비돼요</span>';
+        setTimeout(function(){ if(homeTab==='curation') renderCuration(); },4000);
+        return;
+      }
+      var j=await r.json();
+      var props=(j&&j.data&&j.data.proposals)||[];
+      if(!props.length){ curConnectGate(); return; }
+      renderProposals(props);
+    }catch(e){ curConnectGate(); }   // 401/403/not-connected → connect gate
+  }
+  function curConnectGate(){
     var el=document.getElementById('curBody'); if(!el) return;
     el.className='cur-connect';
-    el.innerHTML='<span class="cic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3.5l1.8 4.4 4.7 1.4-3.5 3 .9 4.7L12 14.6 7.6 17l.9-4.7-3.5-3 4.7-1.4z"/></svg></span>'
+    el.innerHTML='<span class="cic">'+CUR_STAR+'</span>'
       +'<span class="t1">매주 나를 위한 영상</span>'
-      +'<span class="t2">유튜브 계정을 연결하면<br>매주 관심사에 맞는 영상을 큐레이션해 드려요</span>'
+      +'<span class="t2">유튜브 계정을 연결하면<br>관심사에 맞는 영상을 큐레이션해 드려요</span>'
       +'<button class="cbtn" id="bCurConnect">유튜브 연결</button>';
-    var b=document.getElementById('bCurConnect');
-    if(b) b.onclick=function(){ show('menu'); };   // connect via Settings for now; OAuth wiring is a follow-up
+    var b=document.getElementById('bCurConnect'); if(b) b.onclick=curConnect;
+  }
+  async function curConnect(){
+    try{
+      var tok=await freshToken(); if(!tok){ show('login'); return; }
+      var r=await fetch(SUPA+'/functions/v1/youtube-auth?action=auth-url',{headers:{Authorization:'Bearer '+tok,apikey:SUPA_KEY}});
+      var j=await r.json();
+      if(j&&j.authUrl){ location.href=j.authUrl; }
+    }catch(e){}
+  }
+  function renderProposals(props){
+    var el=document.getElementById('curBody'); if(!el) return;
+    el.className='cur-props';
+    var h='<div class="cp-h">이번 주 관심사</div>';
+    props.forEach(function(p){
+      h+='<button class="cp-card" data-topic="'+curEsc(p.topic)+'">'
+        +'<span class="cp-dom">'+curEsc(CUR_DOM_LABEL[p.domain]||'추천')+'</span>'
+        +'<span class="cp-t">'+curEsc(p.topic)+'</span>'
+        +'<span class="cp-go">큐레이션 받기</span></button>';
+    });
+    el.innerHTML=h;
+    [].forEach.call(el.querySelectorAll('.cp-card'),function(b){
+      b.onclick=function(){ selectCuration(b.getAttribute('data-topic')); };
+    });
+  }
+  async function selectCuration(topic){
+    var el=document.getElementById('curBody'); if(!el) return;
+    el.className='cur-connect';
+    el.innerHTML='<span class="cic">'+CUR_STAR+'</span><span class="t1">큐레이션 만드는 중</span>'
+      +'<span class="t2">'+curEsc(topic)+'<br>관련 영상을 모으고 있어요</span>';
+    try{
+      var r=await api('/curations',{method:'POST',body:JSON.stringify({topic:topic,source:'youtube_subs'})});
+      var j=await r.json(); var id=j&&j.data&&j.data.id; if(!id) throw new Error('no id');
+      pollCurationItems(id,topic,0);
+    }catch(e){ el.innerHTML='<span class="cic">'+CUR_STAR+'</span><span class="t1">잠시 후 다시 시도해주세요</span>'; }
+  }
+  async function pollCurationItems(id,topic,tries){
+    try{
+      var r=await api('/curations/'+id+'/items');
+      var j=await r.json(); var items=(j&&j.data&&j.data.items)||[];
+      if(items.length){ openCurationVideos(topic,items); return; }
+    }catch(e){}
+    if(tries<20 && homeTab==='curation'){ setTimeout(function(){ pollCurationItems(id,topic,tries+1); },3000); }
+    else{
+      var el=document.getElementById('curBody');
+      if(el) el.innerHTML='<span class="cic">'+CUR_STAR+'</span><span class="t1">영상을 모으는 중이에요</span>'
+        +'<span class="t2">잠시 후 큐레이션 탭에서 다시 확인해주세요</span>';
+    }
+  }
+  // Curation videos — reuse the beat player (same machinery as openMandalaVideos).
+  function openCurationVideos(topic,items){
+    unlockAudio();
+    document.body.classList.remove('reading'); var _rv=document.getElementById('readview'); if(_rv) _rv.hidden=true;
+    curNote={ id:null, title:topic, videoMode:true }; show('player');
+    var sh=document.getElementById('bShareNote'); if(sh) sh.hidden=true;
+    document.getElementById('pTitle').textContent=topic||'큐레이션';
+    pShowSkeleton('영상을 여는 중');
+    beats=[]; chapterOfBeat=[];
+    items.forEach(function(it){ beats.push({ t:'c', vid:it.video_id, from:0, to:99999, text:'', src:null }); chapterOfBeat.push(0); });
+    bi=0; buildRail(); setPlaying(true);
   }
   // Video tab — select a mandala → continuous watch of its videos, reusing the existing beat player.
   async function openMandalaVideos(m){

--- a/prisma/migrations/curation/002_curation_personalization.sql
+++ b/prisma/migrations/curation/002_curation_personalization.sql
@@ -1,0 +1,44 @@
+-- Curation personalization tables (Growth Hub, 2026-07-20).
+-- Design: docs/design/growth-hub-curation-personalized-2026-07-20.md (§7).
+-- prisma db push silent-fails on Supabase — apply manually to local AND prod,
+-- verify with \d public.curation_interest_profile / \d public.curation_proposals.
+--
+-- curation_interest_profile: async-built YouTube interest profile (one per user).
+--   Built off subscriptions + playlists + saved videos → extractKeywordsBatch.
+--   GET /curations/suggest reads this (never builds inline — B4 latency).
+-- curation_proposals: append-only proposal log = the reinforcement input.
+--   NO topic_affinity column anywhere — reinforce() is derived at read time by
+--   scanning this log (data-reversibility hard rule: original events only,
+--   nothing mutable to roll back). UNIQUE(user_id, week_of) dedups repeated
+--   suggest opens (one proposal row per user per week).
+-- Schema is qualified public.* (search_path-independent).
+
+CREATE TABLE IF NOT EXISTS public.curation_interest_profile (
+  user_id    uuid PRIMARY KEY,
+  -- [{ kw: string, domain: string, weight: number }] — normalized interest vector
+  profile    jsonb NOT NULL DEFAULT '[]'::jsonb,
+  -- building | ready | stale | error
+  status     varchar(12) NOT NULL DEFAULT 'building',
+  built_at   timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE public.curation_interest_profile ENABLE ROW LEVEL SECURITY;
+
+CREATE TABLE IF NOT EXISTS public.curation_proposals (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id        uuid NOT NULL,
+  -- Monday of the proposal week (dedup + reinforcement horizon)
+  week_of        date NOT NULL,
+  -- the 3 proposed topics: [{ topic, domain, score, rising, hook }]
+  proposed       jsonb NOT NULL,
+  -- which topic the user chose (null = not yet selected / abandoned)
+  selected_topic text,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, week_of)
+);
+CREATE INDEX IF NOT EXISTS idx_curation_proposals_user_id ON public.curation_proposals(user_id);
+ALTER TABLE public.curation_proposals ENABLE ROW LEVEL SECURITY;
+
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -685,6 +685,40 @@ model curation_items {
   @@schema("public")
 }
 
+/// Async-built YouTube interest profile (one per user). Read by GET /curations/suggest.
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model curation_interest_profile {
+  user_id    String   @id @db.Uuid
+  /// [{ kw, domain, weight }] — normalized interest vector from subs + playlists + saved videos
+  profile    Json     @default("[]")
+  /// building | ready | stale | error
+  status     String   @default("building") @db.VarChar(12)
+  built_at   DateTime? @db.Timestamptz(6)
+  created_at DateTime @default(now()) @db.Timestamptz(6)
+  updated_at DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+
+  @@schema("public")
+}
+
+/// Append-only proposal log = reinforcement input. No topic_affinity column; reinforce() derived at read time.
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model curation_proposals {
+  id             String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  user_id        String   @db.Uuid
+  /// Monday of the proposal week (dedup + reinforcement horizon)
+  week_of        DateTime @db.Date
+  /// the 3 proposed topics: [{ topic, domain, score, rising, hook }]
+  proposed       Json
+  /// which topic the user chose (null = not yet selected / abandoned)
+  selected_topic String?
+  created_at     DateTime @default(now()) @db.Timestamptz(6)
+  updated_at     DateTime @default(now()) @updatedAt @db.Timestamptz(6)
+
+  @@unique([user_id, week_of], map: "uq_curation_proposals_user_week")
+  @@index([user_id], map: "idx_curation_proposals_user_id")
+  @@schema("public")
+}
+
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model mandala_activity_log {
   id          String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -190,6 +190,13 @@ APPLY_FILES=(
   "prisma/migrations/app-notices/002_add_kind_cta.sql"
   "prisma/migrations/app-notices/003_seed_beta_notices.sql"
   "prisma/migrations/app-notices/004_align_cta_urls.sql"
+  # Growth Hub curation (2026-07-16 / 2026-07-20). Weekly personalized curation:
+  # 001 = curation_subscriptions + curation_items (feed, applied manually at CP521,
+  # now tracked here). 002 = curation_interest_profile (async YouTube interest vector)
+  # + curation_proposals (append-only reinforcement log). All CREATE TABLE/INDEX
+  # IF NOT EXISTS + NOTIFY pgrst — fully idempotent.
+  "prisma/migrations/curation/001_create_curation_tables.sql"
+  "prisma/migrations/curation/002_curation_personalization.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "

--- a/src/api/routes/curations.ts
+++ b/src/api/routes/curations.ts
@@ -5,17 +5,19 @@
  * feed (NO note/book_json). Create → enqueue an immediate build ("immediate", James)
  * plus the recurring weekly job refreshes it.
  *
- * NOTE: the build worker's source selection is still a scaffold — creating a
- * curation persists the subscription and enqueues a build, but the build's
- * discover source (topic → videos, mandala-independent) is D5-pending. The
- * subscription/list endpoints below are complete and safe to ship behind the
- * Growth Hub flag; the build fills in once the source path lands.
+ * Personalized flow (2026-07-20): GET /suggest returns 3 topics scored from the
+ * user's YouTube interest profile × trend pool; POST / creates the chosen curation
+ * (immediate build) and records the selection in the append-only proposal log
+ * (reinforcement). The build worker discovers a topic's videos mandala-free via
+ * runV5Executor. Design: docs/design/growth-hub-curation-personalized-2026-07-20.md.
  */
 
 import { FastifyPluginCallback } from 'fastify';
 import { getPrismaClient } from '../../modules/database';
 import { enqueueCurationBuild } from '../../modules/queue/handlers/curation-build';
 import { MS_PER_DAY } from '../../utils/time-constants';
+import { suggestTopics } from '../../modules/curation/suggest';
+import { maybeTriggerProfileBuild } from '../../modules/curation/interest-profile';
 
 /** ISO date (YYYY-MM-DD) of this week's Monday — curation_items.week_of key. */
 function mondayOf(d: Date): string {
@@ -71,10 +73,46 @@ export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       weekOf: mondayOf(now),
     });
 
+    // Reinforcement (N1): mark this topic SELECTED in the current week's proposal log
+    // if it came from a suggestion. updateMany no-ops when absent (manually typed topic)
+    // — the append-only log stays the reinforcement SSOT; nothing mutable to roll back.
+    await prisma.curation_proposals.updateMany({
+      where: { user_id: userId, week_of: new Date(mondayOf(now)) },
+      data: { selected_topic: topic },
+    });
+
     return reply.code(201).send({
       status: 'ok',
       data: { id: sub.id, topic: sub.topic, source: sub.source, buildJobId: jobId },
     });
+  });
+
+  /**
+   * GET /curations/suggest — personalized 3-topic proposals (interest × trend).
+   * Reads the async-built interest profile (never builds inline — B4). If the
+   * profile isn't ready, kicks a build off in the background and returns 202.
+   */
+  fastify.get('/suggest', { onRequest: [fastify.authenticate] }, async (request, reply) => {
+    if (!request.user || !('userId' in request.user)) {
+      return reply.code(401).send({ status: 'error', code: 'UNAUTHORIZED' });
+    }
+    const userId = request.user.userId;
+    const result = await suggestTopics(userId);
+    if (result.status === 'building') {
+      await maybeTriggerProfileBuild(userId);
+      return reply.code(202).send({ status: 'building' });
+    }
+
+    // Log the proposals (dedup by user_id + week_of) — the reinforcement input.
+    // Revisits no-op (do NOT overwrite an existing week's proposals/selection).
+    const prisma = getPrismaClient();
+    const weekOf = new Date(mondayOf(new Date()));
+    await prisma.curation_proposals.upsert({
+      where: { user_id_week_of: { user_id: userId, week_of: weekOf } },
+      create: { user_id: userId, week_of: weekOf, proposed: result.proposals as object },
+      update: {},
+    });
+    return reply.send({ status: 'ok', data: { proposals: result.proposals } });
   });
 
   /** GET /curations — list the caller's active curations. */
@@ -90,6 +128,56 @@ export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     });
     return reply.send({ status: 'ok', data: { curations: rows } });
   });
+
+  /**
+   * GET /curations/:id/items?week=YYYY-MM-DD — this curation's weekly video feed
+   * (video-only). Defaults to the latest built week. Ownership-checked.
+   */
+  fastify.get<{ Params: { id: string }; Querystring: { week?: string } }>(
+    '/:id/items',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      if (!request.user || !('userId' in request.user)) {
+        return reply.code(401).send({ status: 'error', code: 'UNAUTHORIZED' });
+      }
+      const prisma = getPrismaClient();
+      const sub = await prisma.curation_subscriptions.findUnique({
+        where: { id: request.params.id },
+        select: { user_id: true },
+      });
+      if (!sub || sub.user_id !== request.user.userId) {
+        return reply.code(404).send({ status: 'error', code: 'CURATION_NOT_FOUND' });
+      }
+
+      // Resolve the target week: explicit ?week, else the newest built snapshot.
+      let weekOf: Date | null = null;
+      if (request.query.week) {
+        const d = new Date(request.query.week);
+        if (!Number.isNaN(d.getTime())) weekOf = d;
+      }
+      if (!weekOf) {
+        const latest = await prisma.curation_items.findFirst({
+          where: { subscription_id: request.params.id },
+          orderBy: { week_of: 'desc' },
+          select: { week_of: true },
+        });
+        weekOf = latest?.week_of ?? null;
+      }
+      if (!weekOf) {
+        return reply.send({ status: 'ok', data: { week_of: null, items: [] } });
+      }
+
+      const items = await prisma.curation_items.findMany({
+        where: { subscription_id: request.params.id, week_of: weekOf },
+        orderBy: { position: 'asc' },
+        select: { video_id: true, relevance_pct: true, position: true },
+      });
+      return reply.send({
+        status: 'ok',
+        data: { week_of: weekOf.toISOString().slice(0, 10), items },
+      });
+    }
+  );
 
   fastify.log.info('curation routes registered');
   done();

--- a/src/modules/curation/config.ts
+++ b/src/modules/curation/config.ts
@@ -1,0 +1,63 @@
+/**
+ * Curation personalization constants (Growth Hub, 2026-07-20).
+ * Design: docs/design/growth-hub-curation-personalized-2026-07-20.md (§4).
+ *
+ * Initial values are DOCUMENTED ASSUMPTIONS, not tuned. P1 exposes these via
+ * admin/URL for measured tuning (no-hardcoding hard rule: named consts, single
+ * source, flag-off = current behavior). Do NOT sprinkle these literals across
+ * modules — import from here.
+ */
+
+/** Interest-signal weights (§4). Saved playlist videos = explicit intent → outrank subs. */
+export const INTEREST_WEIGHTS = Object.freeze({
+  /** subscribed channel = passive interest */
+  sub: 0.4,
+  /** playlist-saved video = explicit intent (higher) */
+  save: 0.6,
+});
+
+/** Account-collection page caps (§2) — bound quota for power users. */
+export const COLLECT_CAPS = Object.freeze({
+  /** max subscription pages fetched (50 items/page) */
+  subscriptionPages: 4,
+  /** max playlist pages fetched */
+  playlistPages: 2,
+  /** max playlists whose items are read */
+  playlists: 15,
+  /** max item pages per playlist */
+  playlistItemPages: 1,
+  /** max saved videos whose titles are resolved via getVideosMetadata */
+  savedVideos: 100,
+});
+
+/** 3-proposal scoring weights (§4). affinity dominates so cold-start reflects the account. */
+export const PROPOSAL_WEIGHTS = Object.freeze({
+  affinity: 0.45,
+  rising: 0.3,
+  reinforce: 0.2,
+  redundancy: 0.15,
+});
+
+/** rising-signal half-life (days) for the recency component. */
+export const RISING_HALFLIFE_DAYS = 14;
+
+/** reinforcement increments derived from the proposal log (§5). α = selected, β = proposed-but-unselected. */
+export const REINFORCE = Object.freeze({
+  alpha: 0.2,
+  beta: 0.05,
+});
+
+/** number of topics proposed to the user. */
+export const PROPOSAL_COUNT = 3;
+
+/** max proposals sharing one domain (filter-bubble guard, §4). */
+export const MAX_PER_DOMAIN = 2;
+
+/** min learning_score for an extracted keyword to enter the interest profile. */
+export const KEYWORD_LEARNING_FLOOR = 0.3;
+
+/** min relevance_pct for a discovered video to enter a curation feed (off-topic drop). */
+export const CURATION_RELEVANCE_FLOOR = 40;
+
+/** recency window (days) for the discovery leg's publishedAfter — the rising bias (§4-B5). */
+export const CURATION_PUBLISHED_AFTER_DAYS = 365;

--- a/src/modules/curation/domain-taxonomy.ts
+++ b/src/modules/curation/domain-taxonomy.ts
@@ -1,0 +1,171 @@
+/**
+ * Curation domain taxonomy (Growth Hub, 2026-07-20).
+ * Design: docs/design/growth-hub-curation-personalized-2026-07-20.md (§4).
+ *
+ * trend_signals.domain is null, so keyword→domain is derived by this lightweight
+ * lookup. The affinity/diversity scoring terms share this taxonomy. Substring
+ * match on the lowercased keyword; first hit wins; default = 'other'.
+ *
+ * Target audiences (James): 취준/재직 학습/직무전환/강사/대학(원)/수험/투자/창업.
+ * Content focus: fast-moving AI/ML (Claude/Codex/Gemini/Kimi/Qwen), jobs, investing, startups.
+ */
+
+export type CurationDomain =
+  | 'ai_ml'
+  | 'career'
+  | 'investment'
+  | 'startup'
+  | 'language'
+  | 'exam'
+  | 'other';
+
+export const CURATION_DOMAINS: readonly CurationDomain[] = Object.freeze([
+  'ai_ml',
+  'career',
+  'investment',
+  'startup',
+  'language',
+  'exam',
+  'other',
+]);
+
+/** Ordered rules — first matching domain wins. Patterns are lowercase substrings (ko + en). */
+const DOMAIN_RULES: ReadonlyArray<{ domain: CurationDomain; patterns: readonly string[] }> =
+  Object.freeze([
+    {
+      domain: 'ai_ml',
+      patterns: [
+        'ai',
+        '인공지능',
+        'ml',
+        '머신러닝',
+        '딥러닝',
+        'llm',
+        'gpt',
+        'claude',
+        'codex',
+        'gemini',
+        'kimi',
+        'qwen',
+        'llama',
+        'transformer',
+        '생성형',
+        '프롬프트',
+        'prompt',
+        'agent',
+        '에이전트',
+        'rag',
+        'diffusion',
+        'stable',
+        'openai',
+        'anthropic',
+        '모델',
+      ],
+    },
+    {
+      domain: 'career',
+      patterns: [
+        '취업',
+        '이직',
+        '면접',
+        '자소서',
+        '커리어',
+        '직무',
+        '취준',
+        'career',
+        'interview',
+        'resume',
+        'job',
+        '연봉',
+        '개발자',
+        '부트캠프',
+        'bootcamp',
+        '전환',
+        '포트폴리오',
+      ],
+    },
+    {
+      domain: 'investment',
+      patterns: [
+        '투자',
+        '주식',
+        '재테크',
+        '부동산',
+        '경제',
+        '금융',
+        'etf',
+        '코인',
+        '비트코인',
+        'crypto',
+        'stock',
+        'invest',
+        'finance',
+        '배당',
+        '연금',
+        '자산',
+      ],
+    },
+    {
+      domain: 'startup',
+      patterns: [
+        '창업',
+        '스타트업',
+        '사업',
+        '공모',
+        '소자본',
+        '온라인창업',
+        '부업',
+        'startup',
+        '마케팅',
+        'marketing',
+        '브랜딩',
+        '이커머스',
+        'ecommerce',
+        '수익화',
+        'saas',
+      ],
+    },
+    {
+      domain: 'language',
+      patterns: [
+        '영어',
+        '토익',
+        '토플',
+        '오픽',
+        '회화',
+        '일본어',
+        '중국어',
+        'english',
+        'toeic',
+        'ielts',
+        'language',
+        '어학',
+        '스피킹',
+      ],
+    },
+    {
+      domain: 'exam',
+      patterns: [
+        '수능',
+        '내신',
+        '공무원',
+        '자격증',
+        '기사',
+        '고시',
+        '입시',
+        'exam',
+        '수험',
+        '모의고사',
+        '검정',
+      ],
+    },
+  ]);
+
+/** Map a topic keyword to its curation domain (default 'other'). */
+export function mapKeywordToDomain(keyword: string): CurationDomain {
+  const kw = keyword.toLowerCase();
+  for (const rule of DOMAIN_RULES) {
+    if (rule.patterns.some((p) => kw.includes(p))) return rule.domain;
+  }
+  return 'other';
+}

--- a/src/modules/curation/interest-profile.ts
+++ b/src/modules/curation/interest-profile.ts
@@ -1,0 +1,239 @@
+/**
+ * Curation interest profile — account signal collection + analysis (Growth Hub, 2026-07-20).
+ * Design: docs/design/growth-hub-curation-personalized-2026-07-20.md (§2, §4, §8-B4).
+ *
+ * Collects the AVAILABLE YouTube personal signals (subscriptions + playlists +
+ * saved playlist videos — watch history is NOT exposed by the Data API) and
+ * derives a normalized interest vector [{kw, domain, weight}] via the existing
+ * keyword extractor. Saved videos = explicit intent → outweigh subscriptions.
+ *
+ * Runs as an ASYNC job (never inside GET /curations/suggest — B4 latency), and
+ * persists to curation_interest_profile (status building→ready). extractKeywordsBatch
+ * hits an LLM (production-serving path); tests inject a mock via deps.
+ */
+
+import { logger } from '@/utils/logger';
+import { getPrismaClient } from '@/modules/database';
+import {
+  getUserSubscriptions,
+  getUserPlaylists,
+  getPlaylistItems,
+  getVideosMetadata,
+} from '@/modules/youtube/api';
+import { extractKeywordsBatch } from '@/skills/plugins/trend-collector/sources/llm-extract';
+import { mapKeywordToDomain, type CurationDomain } from './domain-taxonomy';
+import { INTEREST_WEIGHTS, COLLECT_CAPS, KEYWORD_LEARNING_FLOOR } from './config';
+
+const log = logger.child({ module: 'curation/interest-profile' });
+
+export interface InterestKeyword {
+  kw: string;
+  domain: CurationDomain;
+  /** normalized [0,1] interest strength */
+  weight: number;
+}
+export type InterestProfile = InterestKeyword[];
+
+/** Titles collected from the account, tagged with their source weight. */
+export interface AccountSignals {
+  /** title → source weight (sub vs save); dedup keeps the strongest source */
+  titleWeights: Map<string, number>;
+  counts: { subscriptions: number; playlists: number; savedVideos: number };
+}
+
+/** Injectable deps — real YouTube/LLM/DB by default, mocked in tests. */
+export interface InterestProfileDeps {
+  getUserSubscriptions: typeof getUserSubscriptions;
+  getUserPlaylists: typeof getUserPlaylists;
+  getPlaylistItems: typeof getPlaylistItems;
+  getVideosMetadata: typeof getVideosMetadata;
+  extractKeywordsBatch: typeof extractKeywordsBatch;
+}
+
+const defaultDeps: InterestProfileDeps = {
+  getUserSubscriptions,
+  getUserPlaylists,
+  getPlaylistItems,
+  getVideosMetadata,
+  extractKeywordsBatch,
+};
+
+/** Merge a title at `weight`, keeping the stronger source if it repeats. */
+function addTitle(map: Map<string, number>, title: string, weight: number): void {
+  const t = title.trim();
+  if (t.length < 2) return;
+  const prev = map.get(t);
+  if (prev === undefined || weight > prev) map.set(t, weight);
+}
+
+/**
+ * Collect the account's available interest titles, page-capped for quota safety.
+ * Subscriptions + playlist labels → sub weight; saved playlist videos → save weight.
+ */
+export async function collectAccountSignals(
+  userId: string,
+  deps: InterestProfileDeps = defaultDeps
+): Promise<AccountSignals> {
+  const titleWeights = new Map<string, number>();
+  let subCount = 0;
+  let plCount = 0;
+  let savedCount = 0;
+
+  // Subscriptions (channel titles + descriptions) — passive interest.
+  let pageToken: string | undefined;
+  for (let page = 0; page < COLLECT_CAPS.subscriptionPages; page++) {
+    const res = await deps.getUserSubscriptions(userId, pageToken);
+    for (const s of res.items) {
+      subCount++;
+      addTitle(titleWeights, s.title, INTEREST_WEIGHTS.sub);
+      if (s.description) addTitle(titleWeights, s.description.slice(0, 120), INTEREST_WEIGHTS.sub);
+    }
+    if (!res.nextPageToken) break;
+    pageToken = res.nextPageToken;
+  }
+
+  // Playlists — labels (sub weight) + collect their saved videos (save weight).
+  const playlistIds: string[] = [];
+  pageToken = undefined;
+  for (let page = 0; page < COLLECT_CAPS.playlistPages; page++) {
+    const res = await deps.getUserPlaylists(userId, pageToken);
+    for (const p of res.items) {
+      plCount++;
+      addTitle(titleWeights, p.title, INTEREST_WEIGHTS.sub);
+      if (p.playlistId && playlistIds.length < COLLECT_CAPS.playlists)
+        playlistIds.push(p.playlistId);
+    }
+    if (!res.nextPageToken) break;
+    pageToken = res.nextPageToken;
+  }
+
+  // Saved videos inside playlists — explicit intent (save weight). Cap total.
+  const savedVideoIds: string[] = [];
+  for (const playlistId of playlistIds) {
+    let plToken: string | undefined;
+    for (let page = 0; page < COLLECT_CAPS.playlistItemPages; page++) {
+      const res = await deps.getPlaylistItems(userId, playlistId, plToken);
+      for (const it of res.items) {
+        if (it.videoId && savedVideoIds.length < COLLECT_CAPS.savedVideos) {
+          savedVideoIds.push(it.videoId);
+        }
+      }
+      if (!res.nextPageToken || savedVideoIds.length >= COLLECT_CAPS.savedVideos) break;
+      plToken = res.nextPageToken;
+    }
+    if (savedVideoIds.length >= COLLECT_CAPS.savedVideos) break;
+  }
+  if (savedVideoIds.length > 0) {
+    const metas = await deps.getVideosMetadata(userId, savedVideoIds);
+    for (const m of metas) {
+      savedCount++;
+      addTitle(titleWeights, m.title, INTEREST_WEIGHTS.save);
+    }
+  }
+
+  return {
+    titleWeights,
+    counts: { subscriptions: subCount, playlists: plCount, savedVideos: savedCount },
+  };
+}
+
+/**
+ * Build the normalized interest vector from collected signals.
+ * extractKeywordsBatch → aggregate per-keyword weight (by source) → learning gate
+ * → domain tag → normalize to [0,1]. Pure over `deps`, so unit-testable.
+ */
+export async function buildInterestProfile(
+  userId: string,
+  deps: InterestProfileDeps = defaultDeps
+): Promise<InterestProfile> {
+  const signals = await collectAccountSignals(userId, deps);
+  const titles = [...signals.titleWeights.keys()];
+  if (titles.length === 0) return [];
+
+  const extracted = await deps.extractKeywordsBatch({ titles });
+
+  // kw → accumulated raw weight (source weight × per-title keywords, learning-gated).
+  const raw = new Map<string, number>();
+  for (const r of extracted) {
+    if (r.learning_score < KEYWORD_LEARNING_FLOOR) continue;
+    const w = signals.titleWeights.get(r.title) ?? INTEREST_WEIGHTS.sub;
+    for (const kw of r.keywords) {
+      const key = kw.trim().toLowerCase();
+      if (key.length < 2) continue;
+      raw.set(key, (raw.get(key) ?? 0) + w);
+    }
+  }
+  if (raw.size === 0) return [];
+
+  const max = Math.max(...raw.values());
+  const profile: InterestProfile = [...raw.entries()]
+    .map(([kw, weight]) => ({
+      kw,
+      domain: mapKeywordToDomain(kw),
+      weight: Math.round((weight / max) * 100) / 100,
+    }))
+    .sort((a, b) => b.weight - a.weight);
+
+  log.info('interest profile built', {
+    userId,
+    ...signals.counts,
+    keywords: profile.length,
+  });
+  return profile;
+}
+
+/** Upsert the profile row (status ready + built_at). */
+export async function persistInterestProfile(
+  userId: string,
+  profile: InterestProfile,
+  status: 'ready' | 'error' = 'ready'
+): Promise<void> {
+  const prisma = getPrismaClient();
+  const now = new Date();
+  await prisma.curation_interest_profile.upsert({
+    where: { user_id: userId },
+    create: { user_id: userId, profile: profile as unknown as object, status, built_at: now },
+    update: { profile: profile as unknown as object, status, built_at: now },
+  });
+}
+
+/**
+ * Kick off a profile build IF one isn't already ready/in-flight (fire-and-forget).
+ * Called from GET /curations/suggest when the profile is not ready — the build
+ * itself is async so the GET stays fast (B4). Idempotent-ish: skips if 'building'
+ * or 'ready'. The proper trigger is YouTube-connect; this is the first-suggest fallback.
+ */
+export async function maybeTriggerProfileBuild(
+  userId: string,
+  deps: InterestProfileDeps = defaultDeps
+): Promise<void> {
+  const prisma = getPrismaClient();
+  const row = await prisma.curation_interest_profile.findUnique({ where: { user_id: userId } });
+  if (row && (row.status === 'building' || row.status === 'ready')) return;
+  // mark building first so concurrent suggests don't double-fire, then run detached.
+  await prisma.curation_interest_profile.upsert({
+    where: { user_id: userId },
+    create: { user_id: userId, profile: [], status: 'building' },
+    update: { status: 'building' },
+  });
+  void buildAndPersistInterestProfile(userId, deps).catch(() => undefined);
+}
+
+/**
+ * Full async job: mark building → build → persist ready (or error).
+ * Triggered at YouTube connect (or first suggest). Never called inside a GET.
+ */
+export async function buildAndPersistInterestProfile(
+  userId: string,
+  deps: InterestProfileDeps = defaultDeps
+): Promise<InterestProfile> {
+  try {
+    const profile = await buildInterestProfile(userId, deps);
+    await persistInterestProfile(userId, profile, 'ready');
+    return profile;
+  } catch (err) {
+    log.error('interest profile build failed', { userId, err });
+    await persistInterestProfile(userId, [], 'error').catch(() => undefined);
+    throw err;
+  }
+}

--- a/src/modules/curation/suggest.ts
+++ b/src/modules/curation/suggest.ts
@@ -1,0 +1,160 @@
+/**
+ * Curation 3-topic suggestion — interest × trend scoring (Growth Hub, 2026-07-20).
+ * Design: docs/design/growth-hub-curation-personalized-2026-07-20.md (§4, §8).
+ *
+ * score(t) = w1·affinity(t, profile) + w2·rising(t) + w3·reinforce(t, user)
+ * with a hard max-per-domain cap standing in for the w4·redundancy term (P0).
+ * rising = trend_signals.norm_score (suggest-rank proxy — B5; velocity=P1).
+ * reinforce is DERIVED from the append-only curation_proposals log (N1).
+ *
+ * The pure scorer `scoreAndSelect` has no DB/LLM — unit-tested directly.
+ * `suggestTopics` wraps it with the DB reads.
+ */
+
+import { getPrismaClient } from '@/modules/database';
+import { mapKeywordToDomain, type CurationDomain } from './domain-taxonomy';
+import type { InterestProfile } from './interest-profile';
+import { PROPOSAL_WEIGHTS, PROPOSAL_COUNT, MAX_PER_DOMAIN, REINFORCE } from './config';
+
+export interface TrendCandidate {
+  keyword: string;
+  /** trend_signals.norm_score in [0,1] — the rising proxy (P0). */
+  norm_score: number;
+}
+
+/** Domain-level reinforcement counts derived from the proposal log. */
+export interface ReinforceSignals {
+  /** domain → # of past weeks the user SELECTED a topic in this domain */
+  selected: Map<CurationDomain, number>;
+  /** domain → # of past weeks a topic in this domain was proposed but NOT selected */
+  unselected: Map<CurationDomain, number>;
+}
+
+export interface TopicProposal {
+  topic: string;
+  domain: CurationDomain;
+  /** final blended score (higher = better) */
+  score: number;
+  /** rising component [0,1], surfaced for UI/telemetry */
+  rising: number;
+}
+
+/** Token overlap: does the candidate keyword relate to a profile keyword? */
+function tokenMatch(candidate: string, profileKw: string): boolean {
+  const c = candidate.toLowerCase();
+  const p = profileKw.toLowerCase();
+  if (c.includes(p) || p.includes(c)) return true;
+  const pTokens = p.split(/\s+/).filter((t) => t.length >= 2);
+  return pTokens.some((t) => c.includes(t));
+}
+
+/** affinity(t, profile) ∈ [0,1] — profile-weighted token/domain overlap, capped. */
+function affinity(keyword: string, domain: CurationDomain, profile: InterestProfile): number {
+  let acc = 0;
+  for (const p of profile) {
+    if (tokenMatch(keyword, p.kw)) acc += p.weight;
+    else if (p.domain === domain) acc += p.weight * 0.3; // weaker domain-level match
+  }
+  return Math.min(1, acc);
+}
+
+/** reinforce(t, user) ∈ roughly [-β·k, +α·k] — from the proposal log (N1). */
+function reinforce(domain: CurationDomain, sig: ReinforceSignals): number {
+  const sel = sig.selected.get(domain) ?? 0;
+  const un = sig.unselected.get(domain) ?? 0;
+  return REINFORCE.alpha * sel - REINFORCE.beta * un;
+}
+
+/**
+ * Pure scorer: rank candidates and pick PROPOSAL_COUNT with domain diversity
+ * (≤ MAX_PER_DOMAIN per domain = the redundancy guard). No DB, no LLM.
+ */
+export function scoreAndSelect(
+  profile: InterestProfile,
+  candidates: TrendCandidate[],
+  sig: ReinforceSignals
+): TopicProposal[] {
+  const scored: TopicProposal[] = candidates.map((c) => {
+    const domain = mapKeywordToDomain(c.keyword);
+    const aff = affinity(c.keyword, domain, profile);
+    const rising = Math.max(0, Math.min(1, c.norm_score));
+    const rein = reinforce(domain, sig);
+    const score =
+      PROPOSAL_WEIGHTS.affinity * aff +
+      PROPOSAL_WEIGHTS.rising * rising +
+      PROPOSAL_WEIGHTS.reinforce * rein;
+    return { topic: c.keyword, domain, score: Math.round(score * 1000) / 1000, rising };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+
+  const picked: TopicProposal[] = [];
+  const perDomain = new Map<CurationDomain, number>();
+  for (const s of scored) {
+    if (picked.length >= PROPOSAL_COUNT) break;
+    const n = perDomain.get(s.domain) ?? 0;
+    if (n >= MAX_PER_DOMAIN) continue; // redundancy guard
+    perDomain.set(s.domain, n + 1);
+    picked.push(s);
+  }
+  // If diversity cap starved the list (few domains), backfill by score.
+  if (picked.length < PROPOSAL_COUNT) {
+    for (const s of scored) {
+      if (picked.length >= PROPOSAL_COUNT) break;
+      if (!picked.includes(s)) picked.push(s);
+    }
+  }
+  return picked;
+}
+
+export type SuggestResult =
+  | { status: 'building' }
+  | { status: 'ready'; proposals: TopicProposal[] };
+
+/** Read interest profile → fresh trends → reinforcement → 3 proposals. */
+export async function suggestTopics(userId: string): Promise<SuggestResult> {
+  const prisma = getPrismaClient();
+
+  const profileRow = await prisma.curation_interest_profile.findUnique({
+    where: { user_id: userId },
+  });
+  if (!profileRow || profileRow.status !== 'ready') {
+    return { status: 'building' };
+  }
+  const profile = (profileRow.profile as unknown as InterestProfile) ?? [];
+
+  const now = new Date();
+  const trends = await prisma.trend_signals.findMany({
+    where: { expires_at: { gt: now } },
+    orderBy: { norm_score: 'desc' },
+    take: 200,
+    select: { keyword: true, norm_score: true },
+  });
+  const candidates: TrendCandidate[] = trends.map((t) => ({
+    keyword: t.keyword,
+    norm_score: t.norm_score,
+  }));
+
+  const sig = await loadReinforceSignals(userId);
+  const proposals = scoreAndSelect(profile, candidates, sig);
+  return { status: 'ready', proposals };
+}
+
+/** Derive domain-level reinforcement from the append-only proposal log (N1). */
+export async function loadReinforceSignals(userId: string): Promise<ReinforceSignals> {
+  const prisma = getPrismaClient();
+  const rows = await prisma.curation_proposals.findMany({
+    where: { user_id: userId },
+    select: { proposed: true, selected_topic: true },
+  });
+  const selected = new Map<CurationDomain, number>();
+  const unselected = new Map<CurationDomain, number>();
+  for (const r of rows) {
+    const proposed = (r.proposed as unknown as TopicProposal[]) ?? [];
+    for (const p of proposed) {
+      const bucket = r.selected_topic && p.topic === r.selected_topic ? selected : unselected;
+      bucket.set(p.domain, (bucket.get(p.domain) ?? 0) + 1);
+    }
+  }
+  return { selected, unselected };
+}

--- a/src/modules/queue/handlers/curation-build.ts
+++ b/src/modules/queue/handlers/curation-build.ts
@@ -1,27 +1,31 @@
 /**
- * Weekly curation build — durable worker (Growth Hub, 2026-07-16). SCAFFOLD.
+ * Weekly curation build — durable worker (Growth Hub, 2026-07-20).
+ * Design: docs/design/growth-hub-curation-personalized-2026-07-20.md (§6).
  *
- * Flow (all reused parts, no note/book_json/Sonnet):
- *   subscription → discover candidates (by source) → compute-card-relevance
- *   → passesBookGate (off-topic drop) → pick CURATION_TARGET_VIDEOS by relevance
- *   → ensure rich_summary v2 (segment relevance_pct is INLINE → useHighlightReel
- *   works, no separate backfill) → write curation_items with a week_of snapshot
- *   (D2: snapshot not overwrite — data-reversibility hard rule).
+ * Flow (video-only, no note/book_json):
+ *   subscription → runV5Executor(centerGoal=topic, mandala-free) → computeCardRelevance
+ *   per card (centerGoal=topic) → relevance floor (off-topic drop) → top TARGET
+ *   → write curation_items with a week_of snapshot (replace this week only —
+ *   data-reversibility hard rule).
  *
- * SEPARATE from mandala_books → never touches book-fill-gate (no barrier risk).
- *
- * The step bodies are TODO on purpose: each wires an existing module
- * (video-discover executor / relevance/compute-card-relevance / config/book-gate
- * passesBookGate / enrich-rich-summary) whose interface must be read before use
- * (CLAUDE.md read-source-before-guessing). Left for a fresh session to implement against
- * the real signatures rather than guessed ones.
+ * P0 scope decisions (§6):
+ *   - Discovery = runV5Executor with empty subGoals (B1: validated by one live run
+ *     before flag-on). Legacy video-discover/executor needs a mandala → unusable.
+ *   - rich_summary is REUSE-ONLY: video_rich_summaries is a video-keyed GLOBAL table
+ *     (leaks across goals), so this build NEVER writes it (B2). Existing segments =
+ *     core clips; absent = full-video playback (N4). Generation-if-absent = P1.
+ *   - SEPARATE from mandala_books → never touches book-fill-gate (no barrier risk).
  */
 
 import type PgBoss from 'pg-boss';
 import { logger } from '@/utils/logger';
 import { getPrismaClient } from '@/modules/database/client';
-import { JOB_NAMES } from '../types';
+import { JOB_NAMES, QUEUE_CONFIG } from '../types';
 import { getJobQueue } from '../manager';
+import { runV5Executor } from '@/skills/plugins/video-discover/v5/executor';
+import { computeCardRelevance } from '@/modules/relevance/compute-card-relevance';
+import { MS_PER_DAY } from '@/utils/time-constants';
+import { CURATION_RELEVANCE_FLOOR, CURATION_PUBLISHED_AFTER_DAYS } from '@/modules/curation/config';
 
 const log = logger.child({ module: 'queue/curation-build' });
 
@@ -57,25 +61,85 @@ export async function registerCurationBuildWorker(): Promise<void> {
       return;
     }
 
-    // Build pipeline — see design doc §12. Relevance depends on a centerGoal STRING,
-    // not a mandala object: computeCardRelevance takes input.centerGoal directly
-    // (compute-card-relevance.ts:88), so passing sub.topic AS the center goal reuses
-    // the whole relevance path — NO mandala needed. (Earlier "blocker / create a
-    // curation mandala" note was wrong.)
-    //
-    // TODO(build-1) discover: topic → videos (video-discover topic leg / video_pool), by sub.source.
-    // TODO(build-2) computeCardRelevance({ centerGoal: sub.topic, title, ... }) → relevance_pct.
-    // TODO(build-3) pick top by relevance, MIN 15 ~ TARGET 20 (floor at MIN).
-    // TODO(build-4) rich_summary v2 with centerGoal=topic (segment relevance_pct → useHighlightReel).
-    //   §12.3: enrich-rich-summary needs a centerGoal-direct path (currently mandalaId→lookup).
-    // TODO(build-5) write curation_items { subscription_id, video_id, relevance_pct, position, week_of }
-    //   (snapshot; keep prior weeks). No mandala_books → book-fill-gate untouched (no barrier risk).
-    // TODO(build-6) sub.last_run_at = now, next_run_at += 7d. notify (D3 — email reuse candidate).
+    // build-1 — discover topic → videos, mandala-free. runV5Executor takes a
+    // centerGoal STRING (no mandala). subGoals empty → v5 generates queries from
+    // centerGoal alone (B1: the empty-subGoals path is validated by one live run
+    // before flag-on). publishedAfter biases recent supply = the P0 rising signal.
+    const publishedAfter = new Date(Date.now() - CURATION_PUBLISHED_AFTER_DAYS * MS_PER_DAY)
+      .toISOString()
+      .slice(0, 10);
+    const v5 = await runV5Executor({
+      centerGoal: sub.topic,
+      subGoals: [],
+      focusTags: [],
+      targetLevel: '',
+      language: 'ko',
+      includeEnCards: false,
+      excludeVideoIds: new Set<string>(),
+      env: process.env,
+      publishedAfter,
+    });
 
-    log.info('curation build (SCAFFOLD — steps TODO)', {
+    // build-2/3 — relevance per card (centerGoal=topic) → off-topic floor → rank → TARGET.
+    // v5 already applies trust/channel/book gating, so this floor is the topic-fit cut.
+    const scored: Array<{ videoId: string; relevancePct: number }> = [];
+    for (const card of v5.cards) {
+      try {
+        const r = await computeCardRelevance({
+          videoId: card.videoId,
+          title: card.title,
+          centerGoal: sub.topic,
+        });
+        if (r.ok && r.relevancePct >= CURATION_RELEVANCE_FLOOR) {
+          scored.push({ videoId: card.videoId, relevancePct: r.relevancePct });
+        }
+      } catch (err) {
+        log.warn('curation relevance failed', { subscriptionId, videoId: card.videoId, err });
+      }
+    }
+    scored.sort((a, b) => b.relevancePct - a.relevancePct);
+    const picked = scored.slice(0, QUEUE_CONFIG.CURATION_TARGET_VIDEOS);
+
+    // build-4 — rich-summary is REUSE-ONLY for P0. video_rich_summaries is a
+    // video-keyed GLOBAL table (leaks across goals), so the build never writes it
+    // (B2): existing segments serve as core clips, absent → full-video playback
+    // (N4). centerGoal-direct generation-if-absent = P1.
+
+    // build-5 — snapshot this week's items. Replace THIS week only (idempotent
+    // re-run); prior weeks are kept (data-reversibility). No mandala_books touched.
+    const weekDate = new Date(weekOf);
+    await prisma.$transaction([
+      prisma.curation_items.deleteMany({
+        where: { subscription_id: subscriptionId, week_of: weekDate },
+      }),
+      ...(picked.length
+        ? [
+            prisma.curation_items.createMany({
+              data: picked.map((p, i) => ({
+                subscription_id: subscriptionId,
+                video_id: p.videoId,
+                relevance_pct: p.relevancePct,
+                position: i,
+                week_of: weekDate,
+              })),
+            }),
+          ]
+        : []),
+    ]);
+
+    // build-6 — advance the weekly cadence.
+    await prisma.curation_subscriptions.update({
+      where: { id: subscriptionId },
+      data: { last_run_at: new Date(), next_run_at: new Date(Date.now() + 7 * MS_PER_DAY) },
+    });
+
+    log.info('curation build complete', {
       subscriptionId,
       weekOf,
       topic: sub.topic,
+      discovered: v5.cards.length,
+      picked: picked.length,
+      belowMin: picked.length < QUEUE_CONFIG.CURATION_MIN_VIDEOS,
     });
   });
 }

--- a/tests/smoke/curation-interest-profile.test.ts
+++ b/tests/smoke/curation-interest-profile.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Curation interest-profile analysis — unit tests (Growth Hub, 2026-07-20).
+ * Design: docs/design/growth-hub-curation-personalized-2026-07-20.md (§2, §4).
+ *
+ * Deps are injected mocks — NO real YouTube/LLM calls. Verifies the analysis
+ * algorithm: source weighting (saved > sub), learning gate, domain tagging,
+ * normalization.
+ */
+
+import {
+  collectAccountSignals,
+  buildInterestProfile,
+  type InterestProfileDeps,
+} from '@/modules/curation/interest-profile';
+import { mapKeywordToDomain } from '@/modules/curation/domain-taxonomy';
+import { INTEREST_WEIGHTS, KEYWORD_LEARNING_FLOOR } from '@/modules/curation/config';
+
+/** Build a deps mock from fixed fixtures. */
+function makeDeps(over: Partial<InterestProfileDeps> = {}): InterestProfileDeps {
+  const deps: InterestProfileDeps = {
+    getUserSubscriptions: async () =>
+      ({
+        items: [{ channelId: 'c1', title: 'Two Minute Papers — AI 논문', description: '' }],
+        totalResults: 1,
+      }) as any,
+    getUserPlaylists: async () =>
+      ({
+        items: [{ playlistId: 'pl1', title: '주식 투자 공부', description: '' }],
+        totalResults: 1,
+      }) as any,
+    getPlaylistItems: async () =>
+      ({ items: [{ videoId: 'v1', position: 0 }], totalResults: 1 }) as any,
+    getVideosMetadata: async () =>
+      [{ videoId: 'v1', title: 'ETF 배당 투자 전략', description: '', channelId: 'c9' }] as any,
+    extractKeywordsBatch: async ({ titles }) =>
+      titles.map((title) => {
+        if (title.includes('AI')) return { title, keywords: ['ai 논문'], learning_score: 0.9 };
+        if (title.includes('주식')) return { title, keywords: ['주식 투자'], learning_score: 0.8 };
+        if (title.includes('ETF')) return { title, keywords: ['etf 투자'], learning_score: 0.85 };
+        return { title, keywords: ['잡담'], learning_score: 0.1 }; // below floor
+      }),
+    ...over,
+  };
+  return deps;
+}
+
+describe('mapKeywordToDomain', () => {
+  it('maps AI/ML, investment, career, and defaults to other', () => {
+    expect(mapKeywordToDomain('Claude 모델')).toBe('ai_ml');
+    expect(mapKeywordToDomain('ai 논문')).toBe('ai_ml');
+    expect(mapKeywordToDomain('ETF 투자')).toBe('investment');
+    expect(mapKeywordToDomain('면접 준비')).toBe('career');
+    expect(mapKeywordToDomain('바이올린 연주')).toBe('other');
+  });
+});
+
+describe('collectAccountSignals', () => {
+  it('tags saved videos with save weight and subs with sub weight', async () => {
+    const signals = await collectAccountSignals('u1', makeDeps());
+    // subscription channel title → sub weight
+    expect(signals.titleWeights.get('Two Minute Papers — AI 논문')).toBe(INTEREST_WEIGHTS.sub);
+    // saved video title → save weight (stronger)
+    expect(signals.titleWeights.get('ETF 배당 투자 전략')).toBe(INTEREST_WEIGHTS.save);
+    expect(signals.counts.savedVideos).toBe(1);
+  });
+});
+
+describe('buildInterestProfile', () => {
+  it('produces a normalized, domain-tagged profile; saved-video keyword outranks sub', async () => {
+    const profile = await buildInterestProfile('u1', makeDeps());
+    const kws = profile.map((p) => p.kw);
+    expect(kws).toContain('ai 논문');
+    expect(kws).toContain('etf 투자');
+
+    // normalization: top weight is exactly 1.0
+    expect(Math.max(...profile.map((p) => p.weight))).toBe(1);
+
+    // domain tagging
+    const etf = profile.find((p) => p.kw === 'etf 투자');
+    expect(etf?.domain).toBe('investment');
+    const ai = profile.find((p) => p.kw === 'ai 논문');
+    expect(ai?.domain).toBe('ai_ml');
+
+    // saved-video (save weight 0.6) keyword outranks subscription (sub weight 0.4) keyword
+    const aiW = ai!.weight;
+    const etfW = etf!.weight;
+    expect(etfW).toBeGreaterThan(aiW);
+  });
+
+  it('drops keywords below the learning floor', async () => {
+    const deps = makeDeps({
+      getUserSubscriptions: async () =>
+        ({
+          items: [{ channelId: 'c', title: '먹방 브이로그', description: '' }],
+          totalResults: 1,
+        }) as any,
+      getUserPlaylists: async () => ({ items: [], totalResults: 0 }) as any,
+      getVideosMetadata: async () => [] as any,
+      extractKeywordsBatch: async ({ titles }) =>
+        titles.map((title) => ({
+          title,
+          keywords: ['잡담'],
+          learning_score: KEYWORD_LEARNING_FLOOR - 0.1,
+        })),
+    });
+    const profile = await buildInterestProfile('u1', deps);
+    expect(profile).toHaveLength(0);
+  });
+});

--- a/tests/smoke/curation-suggest.test.ts
+++ b/tests/smoke/curation-suggest.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Curation 3-topic suggestion — pure scorer unit tests (Growth Hub, 2026-07-20).
+ * Design: docs/design/growth-hub-curation-personalized-2026-07-20.md (§4).
+ *
+ * Tests scoreAndSelect directly (no DB/LLM): affinity+rising ranking, domain
+ * diversity cap (redundancy guard), reinforcement boost.
+ */
+
+import {
+  scoreAndSelect,
+  type TrendCandidate,
+  type ReinforceSignals,
+} from '@/modules/curation/suggest';
+import type { InterestProfile } from '@/modules/curation/interest-profile';
+import type { CurationDomain } from '@/modules/curation/domain-taxonomy';
+
+const emptySignals: ReinforceSignals = { selected: new Map(), unselected: new Map() };
+
+describe('scoreAndSelect', () => {
+  it('ranks a profile-matching + rising topic above an unrelated one', () => {
+    const profile: InterestProfile = [{ kw: 'claude', domain: 'ai_ml', weight: 1 }];
+    const candidates: TrendCandidate[] = [
+      { keyword: 'claude 코드', norm_score: 0.9 }, // matches profile + high rising
+      { keyword: '바이올린 레슨', norm_score: 0.4 }, // unrelated
+    ];
+    const out = scoreAndSelect(profile, candidates, emptySignals);
+    expect(out).toHaveLength(2);
+    expect(out[0]!.topic).toBe('claude 코드');
+    expect(out[0]!.domain).toBe('ai_ml');
+    expect(out[0]!.score).toBeGreaterThan(out[1]!.score);
+  });
+
+  it('enforces the max-per-domain diversity cap (redundancy guard)', () => {
+    const profile: InterestProfile = [{ kw: 'ai', domain: 'ai_ml', weight: 1 }];
+    // 4 AI topics + 1 investment; cap = 2 per domain → result must include the investment one.
+    const candidates: TrendCandidate[] = [
+      { keyword: 'ai 뉴스', norm_score: 0.95 },
+      { keyword: 'llm 튜토리얼', norm_score: 0.9 },
+      { keyword: 'gpt 활용', norm_score: 0.85 },
+      { keyword: 'gemini 소식', norm_score: 0.8 },
+      { keyword: 'etf 투자', norm_score: 0.5 },
+    ];
+    const out = scoreAndSelect(profile, candidates, emptySignals);
+    expect(out).toHaveLength(3);
+    const aiCount = out.filter((p) => p.domain === 'ai_ml').length;
+    expect(aiCount).toBeLessThanOrEqual(2);
+    expect(out.some((p) => p.domain === 'investment')).toBe(true);
+  });
+
+  it('reinforcement boosts a previously selected domain', () => {
+    const profile: InterestProfile = [];
+    const candidates: TrendCandidate[] = [
+      { keyword: '창업 아이디어', norm_score: 0.6 },
+      { keyword: '주식 분석', norm_score: 0.6 },
+    ];
+    const startupSelected: ReinforceSignals = {
+      selected: new Map<CurationDomain, number>([['startup', 3]]),
+      unselected: new Map(),
+    };
+    const out = scoreAndSelect(profile, candidates, startupSelected);
+    expect(out[0]!.domain).toBe('startup'); // reinforcement tips the equal-rising tie
+  });
+});


### PR DESCRIPTION
## What

Personalized Growth Hub curation on the mobile dial player: read the user's YouTube account → propose 3 trend-aware topics → select → weekly curated video feed → selection reinforces future proposals.

## Backend
- **Migration** (`prisma/migrations/curation/002`): `curation_interest_profile` (async YouTube interest vector) + `curation_proposals` (append-only reinforcement log). Registered in `apply-custom-sql.sh` (idempotent).
- **Interest profile** (`src/modules/curation/interest-profile.ts`): collect subscriptions + playlists + saved videos → `extractKeywordsBatch` → weighted, domain-tagged vector. Async job (never inside a GET). Saved videos outweigh subscriptions.
- **Suggest** (`GET /curations/suggest`): interest × trend scoring — affinity + rising (suggest-rank proxy) + reinforce (derived from the proposal log) with a domain-diversity cap. 202 while the profile builds.
- **Reinforcement** (`POST /curations`): records the selection in the append-only log (nothing mutable → rollback-safe).
- **Build worker** (`curation-build.ts`): `runV5Executor` (mandala-free topic) → `computeCardRelevance` → relevance floor → weekly `curation_items` snapshot. rich-summary is **reuse-only** (never writes the video-keyed global table).
- **Read** (`GET /curations/:id/items`): weekly video feed.

## Frontend (mobile only)
- `frontend/public/mobile/index.html` curation tab: YouTube connect gate → "analyzing" → 3 proposal cards (cream/paper) → select → async build → **reuses the existing beat player** (no parallel structures).

## Verification
- BE: `tsc` clean, 7 unit tests (interest-profile + suggest scorer), routes + workers registered and live-verified locally (401/200).
- FE: `tsc` + build clean; mobile JS syntax-checked. Full curation UI is auth-gated → browser E2E happens post-deploy with a YouTube-connected account.
- hardcode-audit at baseline, eslint clean.

Design: `docs/design/growth-hub-curation-personalized-2026-07-20.md` (Fable supervisor review: GO after resolving 6 blockers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)