### PR TITLE
fix(curation): mobile YouTube connect returns to the dial (+ progress bar, P1/P2/P3)

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -162,6 +162,10 @@
   .cur-props .cp-dom{font-size:10.5px; font-weight:800; color:var(--ui); background:rgba(206,95,48,.1); border-radius:8px; padding:3px 8px}
   .cur-props .cp-t{font-size:15px; font-weight:750; color:var(--paper-ink); line-height:1.4}
   .cur-props .cp-go{font-size:11.5px; font-weight:700; color:var(--paper-sub)}
+  .cur-connect .cur-prog{width:160px; max-width:62%; height:5px; border-radius:99px; background:rgba(94,86,72,.12); overflow:hidden; margin-top:14px; position:relative}
+  .cur-connect .cur-prog span{position:absolute; top:0; height:100%; width:42%; border-radius:99px; background:var(--ui); animation:curslide 1.25s cubic-bezier(.4,0,.2,1) infinite}
+  @keyframes curslide{0%{left:-42%}100%{left:100%}}
+  .cur-connect .cur-note{margin-top:10px; font-size:11px; font-weight:600; color:var(--acc)}
   .cur-connect .cbtn:active{transform:scale(.97)}
   .rows{margin-top:10px; display:flex; flex-direction:column; gap:8px; overflow-y:auto; flex:1; min-height:0; padding-bottom:4px}
   .row{display:flex; gap:10px; align-items:center; background:rgba(255,255,255,.55); flex:none;
@@ -1297,7 +1301,8 @@
       if(r.status===202){ // profile building — analyze then retry
         el.className='cur-connect';
         el.innerHTML='<span class="cic">'+CUR_STAR+'</span><span class="t1">관심사 분석 중</span>'
-          +'<span class="t2">유튜브 활동을 살펴보고 있어요<br>잠시 후 추천이 준비돼요</span>';
+          +'<span class="t2">유튜브 활동을 살펴보고 있어요<br>잠시 후 추천이 준비돼요</span>'
+          +'<div class="cur-prog"><span></span></div>';
         setTimeout(function(){ if(homeTab==='curation') renderCuration(); },4000);
         return;
       }
@@ -1307,22 +1312,30 @@
       renderProposals(props);
     }catch(e){ curConnectGate(); }   // 401/403/not-connected → connect gate
   }
-  function curConnectGate(){
+  function curConnectGate(note){
     var el=document.getElementById('curBody'); if(!el) return;
     el.className='cur-connect';
     el.innerHTML='<span class="cic">'+CUR_STAR+'</span>'
       +'<span class="t1">매주 나를 위한 영상</span>'
       +'<span class="t2">유튜브 계정을 연결하면<br>관심사에 맞는 영상을 큐레이션해 드려요</span>'
-      +'<button class="cbtn" id="bCurConnect">유튜브 연결</button>';
+      +'<button class="cbtn" id="bCurConnect">유튜브 연결</button>'
+      +(note?'<span class="cur-note">'+curEsc(note)+'</span>':'');
     var b=document.getElementById('bCurConnect'); if(b) b.onclick=curConnect;
   }
+  // Full-page redirect — NO popup. origin=mobile marks the state so the EF callback
+  // returns to /mobile/?youtube=connected (the dial), not the PC settings page. The
+  // app session persists in localStorage, so we come back logged in + connected.
   async function curConnect(){
+    var btn=document.getElementById('bCurConnect');
     try{
       var tok=await freshToken(); if(!tok){ show('login'); return; }
-      var r=await fetch(SUPA+'/functions/v1/youtube-auth?action=auth-url',{headers:{Authorization:'Bearer '+tok,apikey:SUPA_KEY}});
+      if(btn){ btn.disabled=true; btn.textContent='연결 중…'; }
+      var r=await fetch(SUPA+'/functions/v1/youtube-auth?action=auth-url&origin=mobile',{headers:{Authorization:'Bearer '+tok,apikey:SUPA_KEY}});
+      if(!r.ok) throw new Error('auth-url '+r.status);
       var j=await r.json();
-      if(j&&j.authUrl){ location.href=j.authUrl; }
-    }catch(e){}
+      if(!j||!j.authUrl) throw new Error('no authUrl');
+      location.href=j.authUrl;
+    }catch(e){ curConnectGate('연결에 실패했어요. 다시 시도해주세요'); }
   }
   function renderProposals(props){
     var el=document.getElementById('curBody'); if(!el) return;
@@ -1343,7 +1356,8 @@
     var el=document.getElementById('curBody'); if(!el) return;
     el.className='cur-connect';
     el.innerHTML='<span class="cic">'+CUR_STAR+'</span><span class="t1">큐레이션 만드는 중</span>'
-      +'<span class="t2">'+curEsc(topic)+'<br>관련 영상을 모으고 있어요</span>';
+      +'<span class="t2">'+curEsc(topic)+'<br>관련 영상을 모으고 있어요</span>'
+      +'<div class="cur-prog"><span></span></div>';
     try{
       var r=await api('/curations',{method:'POST',body:JSON.stringify({topic:topic,source:'youtube_subs'})});
       var j=await r.json(); var id=j&&j.data&&j.data.id; if(!id) throw new Error('no id');
@@ -2960,7 +2974,13 @@
       }catch(e){ GUEST=null; show('login'); toast('링크를 열지 못했어요'); return; }
     }
     var tok=await freshToken();
-    if(tok){ show('home'); loadList(); renderCuration(); wheelIntroOnce(); checkNewsUnread(); redeemPendingInvite(); }
+    // Return from YouTube OAuth (EF callback → /mobile/?youtube=connected|error). Clean
+    // the param; renderCuration() below re-checks (connected→analyzing, error→gate via P1).
+    var ytParam=new URLSearchParams(location.search).get('youtube');
+    if(ytParam) history.replaceState(null,'',location.pathname);
+    if(tok){ show('home'); loadList(); renderCuration(); wheelIntroOnce(); checkNewsUnread(); redeemPendingInvite();
+      if(ytParam==='connected') toast('유튜브 계정을 연결했어요');
+      else if(ytParam==='error') toast('유튜브 연결에 실패했어요. 다시 시도해주세요'); }
     else { show('login'); }
   })();
 </script>

--- a/src/api/routes/curations.ts
+++ b/src/api/routes/curations.ts
@@ -18,6 +18,7 @@ import { enqueueCurationBuild } from '../../modules/queue/handlers/curation-buil
 import { MS_PER_DAY } from '../../utils/time-constants';
 import { suggestTopics } from '../../modules/curation/suggest';
 import { maybeTriggerProfileBuild } from '../../modules/curation/interest-profile';
+import { getAccessToken } from '../../modules/youtube/api';
 
 /** ISO date (YYYY-MM-DD) of this week's Monday — curation_items.week_of key. */
 function mondayOf(d: Date): string {
@@ -99,6 +100,13 @@ export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     const userId = request.user.userId;
     const result = await suggestTopics(userId);
     if (result.status === 'building') {
+      // Not connected (no YouTube token) → return empty so the FE shows the connect
+      // gate, instead of spinning "analyzing" forever and re-firing a doomed build
+      // every poll (P1: getUserSubscriptions throws YOUTUBE_NOT_CONNECTED for token-less users).
+      const connected = (await getAccessToken(userId)) !== null;
+      if (!connected) {
+        return reply.send({ status: 'ok', data: { proposals: [] } });
+      }
       await maybeTriggerProfileBuild(userId);
       return reply.code(202).send({ status: 'building' });
     }

--- a/src/modules/curation/config.ts
+++ b/src/modules/curation/config.ts
@@ -61,3 +61,7 @@ export const CURATION_RELEVANCE_FLOOR = 40;
 
 /** recency window (days) for the discovery leg's publishedAfter — the rising bias (§4-B5). */
 export const CURATION_PUBLISHED_AFTER_DAYS = 365;
+
+/** cooldown before re-attempting a failed interest-profile build — avoids the
+ * suggest poll re-firing a doomed build every few seconds (P1). */
+export const PROFILE_ERROR_RETRY_COOLDOWN_MS = 5 * 60 * 1000;

--- a/src/modules/curation/interest-profile.ts
+++ b/src/modules/curation/interest-profile.ts
@@ -22,7 +22,12 @@ import {
 } from '@/modules/youtube/api';
 import { extractKeywordsBatch } from '@/skills/plugins/trend-collector/sources/llm-extract';
 import { mapKeywordToDomain, type CurationDomain } from './domain-taxonomy';
-import { INTEREST_WEIGHTS, COLLECT_CAPS, KEYWORD_LEARNING_FLOOR } from './config';
+import {
+  INTEREST_WEIGHTS,
+  COLLECT_CAPS,
+  KEYWORD_LEARNING_FLOOR,
+  PROFILE_ERROR_RETRY_COOLDOWN_MS,
+} from './config';
 
 const log = logger.child({ module: 'curation/interest-profile' });
 
@@ -210,6 +215,16 @@ export async function maybeTriggerProfileBuild(
   const prisma = getPrismaClient();
   const row = await prisma.curation_interest_profile.findUnique({ where: { user_id: userId } });
   if (row && (row.status === 'building' || row.status === 'ready')) return;
+  // Back off on a recently-errored build — otherwise every suggest poll re-fires a
+  // doomed build (P1: token-less users, or a transient YouTube/LLM failure).
+  if (
+    row &&
+    row.status === 'error' &&
+    row.built_at &&
+    Date.now() - row.built_at.getTime() < PROFILE_ERROR_RETRY_COOLDOWN_MS
+  ) {
+    return;
+  }
   // mark building first so concurrent suggests don't double-fire, then run detached.
   await prisma.curation_interest_profile.upsert({
     where: { user_id: userId },

--- a/supabase/functions/youtube-auth/index.ts
+++ b/supabase/functions/youtube-auth/index.ts
@@ -27,7 +27,7 @@ async function signState(nonce: string, userId: string, secret: string): Promise
   return `${nonce}:${userId}:${sig}`;
 }
 
-async function verifyState(state: string, secret: string): Promise<{ valid: boolean; userId?: string }> {
+async function verifyState(state: string, secret: string): Promise<{ valid: boolean; userId?: string; nonce?: string }> {
   const parts = state.split(':');
   if (parts.length < 3) return { valid: false };
   const [nonce, userId, sig] = [parts[0], parts[1], parts.slice(2).join(':')];
@@ -38,7 +38,7 @@ async function verifyState(state: string, secret: string): Promise<{ valid: bool
   // Reconstruct signature bytes from base64
   const sigBytes = Uint8Array.from(atob(sig), c => c.charCodeAt(0));
   const valid = await crypto.subtle.verify('HMAC', key, sigBytes, encoder.encode(`${nonce}:${userId}`));
-  return { valid, userId: valid ? userId : undefined };
+  return { valid, userId: valid ? userId : undefined, nonce: valid ? nonce : undefined };
 }
 
 // YouTube OAuth 2.0 endpoints
@@ -88,8 +88,10 @@ Deno.serve(async (req) => {
   try {
     switch (action) {
       case 'auth-url': {
-        // Generate OAuth authorization URL
-        const state = crypto.randomUUID();
+        // Generate OAuth authorization URL. origin=mobile marks the (HMAC-signed)
+        // state so the callback returns to /mobile/ instead of the PC /settings page.
+        const isMobile = url.searchParams.get('origin') === 'mobile';
+        const state = (isMobile ? 'm_' : '') + crypto.randomUUID();
 
         // Get user from authorization header
         const authHeader = req.headers.get('Authorization');
@@ -139,28 +141,36 @@ Deno.serve(async (req) => {
         const state = url.searchParams.get('state');
         const error = url.searchParams.get('error');
 
+        // Mobile connects (state nonce 'm_…') must be sent BACK to the dial on every
+        // exit — a raw JSON error page would strand them on supabase.co (the incident
+        // class this flow fixes). Checking the prefix unverified only picks between two
+        // of our own error pages, so it leaks nothing.
+        const frontendOrigin = Deno.env.get('FRONTEND_URL') || 'https://insighta.one';
+        const isMobileState = (state || '').startsWith('m_');
+        const errExit = (msg: string) =>
+          isMobileState
+            ? new Response(null, {
+                status: 302,
+                headers: { 'Location': `${frontendOrigin}/mobile/?youtube=error`, 'Cache-Control': 'no-store' },
+              })
+            : new Response(
+                JSON.stringify({ error: msg }),
+                { status: 400, headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' } }
+              );
+
         if (error) {
           console.error('OAuth error:', error);
-          return new Response(
-            JSON.stringify({ error: `OAuth error: ${error}` }),
-            { status: 400, headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' } }
-          );
+          return errExit(`OAuth error: ${error}`);
         }
 
         if (!code || !state) {
-          return new Response(
-            JSON.stringify({ error: 'Missing code or state parameter' }),
-            { status: 400, headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' } }
-          );
+          return errExit('Missing code or state parameter');
         }
 
         // Verify HMAC-signed state to prevent CSRF
-        const { valid, userId } = await verifyState(state, supabaseServiceKey);
+        const { valid, userId, nonce } = await verifyState(state, supabaseServiceKey);
         if (!valid || !userId) {
-          return new Response(
-            JSON.stringify({ error: 'Invalid or tampered state parameter' }),
-            { status: 400, headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' } }
-          );
+          return errExit('Invalid or tampered state parameter');
         }
 
         // Exchange code for tokens
@@ -181,10 +191,7 @@ Deno.serve(async (req) => {
         if (!tokenResponse.ok) {
           const errorText = await tokenResponse.text();
           console.error('Token exchange failed:', errorText);
-          return new Response(
-            JSON.stringify({ error: 'Failed to exchange code for tokens' }),
-            { status: 400, headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' } }
-          );
+          return errExit('Failed to exchange code for tokens');
         }
 
         const tokens: TokenResponse = await tokenResponse.json();
@@ -222,20 +229,21 @@ Deno.serve(async (req) => {
 
         if (upsertError) {
           console.error('Failed to save tokens:', upsertError);
-          return new Response(
-            JSON.stringify({ error: 'Failed to save authentication' }),
-            { status: 500, headers: { ...getCorsHeaders(req), 'Content-Type': 'application/json' } }
-          );
+          return errExit('Failed to save authentication');
         }
 
         // Redirect to frontend — let the app handle popup close + UI refresh.
         // Supabase Edge Functions gateway doesn't reliably pass Content-Type: text/html,
         // so returning HTML directly causes source code to display instead of rendering.
-        const frontendOrigin = Deno.env.get('FRONTEND_URL') || 'https://insighta.one';
+        // Mobile-initiated connects (state nonce prefixed 'm_') return to the dial;
+        // PC connects keep the settings page + its popup postMessage close path.
+        const dest = (nonce || '').startsWith('m_')
+          ? `${frontendOrigin}/mobile/?youtube=connected`
+          : `${frontendOrigin}/settings?tab=services&youtube=connected`;
         return new Response(null, {
           status: 302,
           headers: {
-            'Location': `${frontendOrigin}/settings?tab=services&youtube=connected`,
+            'Location': dest,
             'Cache-Control': 'no-store',
           },
         });


### PR DESCRIPTION
## Incident fix
Login-loop: mobile used a full-page redirect but the EF callback 302'd to the PC `/settings` page, ejecting mobile users to the desktop landing.

## Changes
- **Mobile** (`frontend/public/mobile/index.html`): NO popup. Full-page redirect with `origin=mobile` marker; boot detects `/mobile/?youtube=connected|error` → toast, dial stays put. Progress bar on analyzing/building states.
- **EF** (`supabase/functions/youtube-auth`): state nonce carries an HMAC-signed `m_` mobile flag; callback returns to `/mobile/` for mobile (PC keeps `/settings`); error paths redirect mobile to `/mobile/?youtube=error` instead of a raw JSON page.
- **P1** (`suggest` route + interest-profile): not-connected users get an empty response → the connect gate, instead of infinite "analyzing" + a doomed build re-firing every poll; errored builds back off.
- **P3**: `verifyState` return type includes `nonce`.

## Verification
- BE `tsc` 0, curation jest 7/7, mobile JS syntax OK, hardcode-audit at baseline.
- Fable supervisor scenario review: SHIP-WITH-FIXES → all applied.
- Live browser test after deploy (OAuth is untestable locally).

Follow-up (local-only): sync the local EF dispatcher per the dual-EF rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)