### PR TITLE
fix(curation): local taxonomy keyword extraction (no LLM) — unblocks stuck analyzing

### DIFF
--- a/src/modules/curation/domain-taxonomy.ts
+++ b/src/modules/curation/domain-taxonomy.ts
@@ -169,3 +169,29 @@ export function mapKeywordToDomain(keyword: string): CurationDomain {
   }
   return 'other';
 }
+
+/**
+ * Extract interest keywords from a title by matching the taxonomy patterns —
+ * a LOCAL, LLM-free substitute for the interest-profile build (prod's LLM
+ * extractor was too slow: hundreds of titles × sequential calls stalled the
+ * "analyzing" state). Returns every matched pattern with its domain; empty when
+ * the title matches no known interest area.
+ */
+export function extractTaxonomyKeywords(
+  text: string
+): Array<{ kw: string; domain: CurationDomain }> {
+  const lower = text.toLowerCase();
+  const out: Array<{ kw: string; domain: CurationDomain }> = [];
+  const seen = new Set<string>();
+  for (const rule of DOMAIN_RULES) {
+    for (const p of rule.patterns) {
+      // Require ≥2 chars so single-letter noise (ml/ai are intentional) is bounded,
+      // and dedupe so a repeated pattern in one title counts once.
+      if (p.length >= 2 && lower.includes(p) && !seen.has(p)) {
+        seen.add(p);
+        out.push({ kw: p, domain: rule.domain });
+      }
+    }
+  }
+  return out;
+}

--- a/src/modules/curation/interest-profile.ts
+++ b/src/modules/curation/interest-profile.ts
@@ -20,14 +20,8 @@ import {
   getPlaylistItems,
   getVideosMetadata,
 } from '@/modules/youtube/api';
-import { extractKeywordsBatch } from '@/skills/plugins/trend-collector/sources/llm-extract';
-import { mapKeywordToDomain, type CurationDomain } from './domain-taxonomy';
-import {
-  INTEREST_WEIGHTS,
-  COLLECT_CAPS,
-  KEYWORD_LEARNING_FLOOR,
-  PROFILE_ERROR_RETRY_COOLDOWN_MS,
-} from './config';
+import { extractTaxonomyKeywords, type CurationDomain } from './domain-taxonomy';
+import { INTEREST_WEIGHTS, COLLECT_CAPS, PROFILE_ERROR_RETRY_COOLDOWN_MS } from './config';
 
 const log = logger.child({ module: 'curation/interest-profile' });
 
@@ -52,7 +46,6 @@ export interface InterestProfileDeps {
   getUserPlaylists: typeof getUserPlaylists;
   getPlaylistItems: typeof getPlaylistItems;
   getVideosMetadata: typeof getVideosMetadata;
-  extractKeywordsBatch: typeof extractKeywordsBatch;
 }
 
 const defaultDeps: InterestProfileDeps = {
@@ -60,7 +53,6 @@ const defaultDeps: InterestProfileDeps = {
   getUserPlaylists,
   getPlaylistItems,
   getVideosMetadata,
-  extractKeywordsBatch,
 };
 
 /** Merge a title at `weight`, keeping the stronger source if it repeats. */
@@ -152,30 +144,25 @@ export async function buildInterestProfile(
   deps: InterestProfileDeps = defaultDeps
 ): Promise<InterestProfile> {
   const signals = await collectAccountSignals(userId, deps);
-  const titles = [...signals.titleWeights.keys()];
-  if (titles.length === 0) return [];
+  if (signals.titleWeights.size === 0) return [];
 
-  const extracted = await deps.extractKeywordsBatch({ titles });
-
-  // kw → accumulated raw weight (source weight × per-title keywords, learning-gated).
-  const raw = new Map<string, number>();
-  for (const r of extracted) {
-    if (r.learning_score < KEYWORD_LEARNING_FLOOR) continue;
-    const w = signals.titleWeights.get(r.title) ?? INTEREST_WEIGHTS.sub;
-    for (const kw of r.keywords) {
-      const key = kw.trim().toLowerCase();
-      if (key.length < 2) continue;
-      raw.set(key, (raw.get(key) ?? 0) + w);
+  // LOCAL taxonomy extraction (no LLM) — the prod LLM extractor stalled the build
+  // (hundreds of titles × sequential qwen calls). kw → accumulated source weight + domain.
+  const raw = new Map<string, { weight: number; domain: CurationDomain }>();
+  for (const [title, w] of signals.titleWeights) {
+    for (const { kw, domain } of extractTaxonomyKeywords(title)) {
+      const prev = raw.get(kw);
+      raw.set(kw, { weight: (prev?.weight ?? 0) + w, domain });
     }
   }
   if (raw.size === 0) return [];
 
-  const max = Math.max(...raw.values());
+  const max = Math.max(...[...raw.values()].map((v) => v.weight));
   const profile: InterestProfile = [...raw.entries()]
-    .map(([kw, weight]) => ({
+    .map(([kw, v]) => ({
       kw,
-      domain: mapKeywordToDomain(kw),
-      weight: Math.round((weight / max) * 100) / 100,
+      domain: v.domain,
+      weight: Math.round((v.weight / max) * 100) / 100,
     }))
     .sort((a, b) => b.weight - a.weight);
 

--- a/tests/smoke/curation-interest-profile.test.ts
+++ b/tests/smoke/curation-interest-profile.test.ts
@@ -2,9 +2,9 @@
  * Curation interest-profile analysis — unit tests (Growth Hub, 2026-07-20).
  * Design: docs/design/growth-hub-curation-personalized-2026-07-20.md (§2, §4).
  *
- * Deps are injected mocks — NO real YouTube/LLM calls. Verifies the analysis
- * algorithm: source weighting (saved > sub), learning gate, domain tagging,
- * normalization.
+ * Deps are injected mocks — NO real YouTube calls. Keyword extraction is LOCAL
+ * (taxonomy match, no LLM). Verifies source weighting (saved > sub), domain
+ * tagging, and normalization.
  */
 
 import {
@@ -12,12 +12,12 @@ import {
   buildInterestProfile,
   type InterestProfileDeps,
 } from '@/modules/curation/interest-profile';
-import { mapKeywordToDomain } from '@/modules/curation/domain-taxonomy';
-import { INTEREST_WEIGHTS, KEYWORD_LEARNING_FLOOR } from '@/modules/curation/config';
+import { mapKeywordToDomain, extractTaxonomyKeywords } from '@/modules/curation/domain-taxonomy';
+import { INTEREST_WEIGHTS } from '@/modules/curation/config';
 
 /** Build a deps mock from fixed fixtures. */
 function makeDeps(over: Partial<InterestProfileDeps> = {}): InterestProfileDeps {
-  const deps: InterestProfileDeps = {
+  return {
     getUserSubscriptions: async () =>
       ({
         items: [{ channelId: 'c1', title: 'Two Minute Papers — AI 논문', description: '' }],
@@ -32,34 +32,32 @@ function makeDeps(over: Partial<InterestProfileDeps> = {}): InterestProfileDeps 
       ({ items: [{ videoId: 'v1', position: 0 }], totalResults: 1 }) as any,
     getVideosMetadata: async () =>
       [{ videoId: 'v1', title: 'ETF 배당 투자 전략', description: '', channelId: 'c9' }] as any,
-    extractKeywordsBatch: async ({ titles }) =>
-      titles.map((title) => {
-        if (title.includes('AI')) return { title, keywords: ['ai 논문'], learning_score: 0.9 };
-        if (title.includes('주식')) return { title, keywords: ['주식 투자'], learning_score: 0.8 };
-        if (title.includes('ETF')) return { title, keywords: ['etf 투자'], learning_score: 0.85 };
-        return { title, keywords: ['잡담'], learning_score: 0.1 }; // below floor
-      }),
     ...over,
   };
-  return deps;
 }
 
 describe('mapKeywordToDomain', () => {
   it('maps AI/ML, investment, career, and defaults to other', () => {
     expect(mapKeywordToDomain('Claude 모델')).toBe('ai_ml');
-    expect(mapKeywordToDomain('ai 논문')).toBe('ai_ml');
     expect(mapKeywordToDomain('ETF 투자')).toBe('investment');
     expect(mapKeywordToDomain('면접 준비')).toBe('career');
     expect(mapKeywordToDomain('바이올린 연주')).toBe('other');
   });
 });
 
+describe('extractTaxonomyKeywords', () => {
+  it('extracts matched patterns with domains; empty for unknown areas', () => {
+    const ai = extractTaxonomyKeywords('MCP 기반 AI 에이전트 개발');
+    expect(ai.map((k) => k.kw)).toEqual(expect.arrayContaining(['ai']));
+    expect(ai.find((k) => k.kw === 'ai')?.domain).toBe('ai_ml');
+    expect(extractTaxonomyKeywords('오늘 점심 뭐먹지')).toHaveLength(0);
+  });
+});
+
 describe('collectAccountSignals', () => {
   it('tags saved videos with save weight and subs with sub weight', async () => {
     const signals = await collectAccountSignals('u1', makeDeps());
-    // subscription channel title → sub weight
     expect(signals.titleWeights.get('Two Minute Papers — AI 논문')).toBe(INTEREST_WEIGHTS.sub);
-    // saved video title → save weight (stronger)
     expect(signals.titleWeights.get('ETF 배당 투자 전략')).toBe(INTEREST_WEIGHTS.save);
     expect(signals.counts.savedVideos).toBe(1);
   });
@@ -69,41 +67,29 @@ describe('buildInterestProfile', () => {
   it('produces a normalized, domain-tagged profile; saved-video keyword outranks sub', async () => {
     const profile = await buildInterestProfile('u1', makeDeps());
     const kws = profile.map((p) => p.kw);
-    expect(kws).toContain('ai 논문');
-    expect(kws).toContain('etf 투자');
+    expect(kws).toContain('ai'); // from the subscription (sub weight)
+    expect(kws).toContain('etf'); // from the saved video (save weight)
 
-    // normalization: top weight is exactly 1.0
-    expect(Math.max(...profile.map((p) => p.weight))).toBe(1);
+    expect(Math.max(...profile.map((p) => p.weight))).toBe(1); // normalized
 
-    // domain tagging
-    const etf = profile.find((p) => p.kw === 'etf 투자');
+    const etf = profile.find((p) => p.kw === 'etf');
+    const ai = profile.find((p) => p.kw === 'ai');
     expect(etf?.domain).toBe('investment');
-    const ai = profile.find((p) => p.kw === 'ai 논문');
     expect(ai?.domain).toBe('ai_ml');
-
-    // saved-video (save weight 0.6) keyword outranks subscription (sub weight 0.4) keyword
-    const aiW = ai!.weight;
-    const etfW = etf!.weight;
-    expect(etfW).toBeGreaterThan(aiW);
+    // saved-video keyword (save 0.6) outranks subscription keyword (sub 0.4)
+    expect(etf!.weight).toBeGreaterThan(ai!.weight);
   });
 
-  it('drops keywords below the learning floor', async () => {
+  it('returns empty when nothing matches the taxonomy', async () => {
     const deps = makeDeps({
       getUserSubscriptions: async () =>
         ({
-          items: [{ channelId: 'c', title: '먹방 브이로그', description: '' }],
+          items: [{ channelId: 'c', title: '오늘의 브이로그', description: '' }],
           totalResults: 1,
         }) as any,
       getUserPlaylists: async () => ({ items: [], totalResults: 0 }) as any,
       getVideosMetadata: async () => [] as any,
-      extractKeywordsBatch: async ({ titles }) =>
-        titles.map((title) => ({
-          title,
-          keywords: ['잡담'],
-          learning_score: KEYWORD_LEARNING_FLOOR - 0.1,
-        })),
     });
-    const profile = await buildInterestProfile('u1', deps);
-    expect(profile).toHaveLength(0);
+    expect(await buildInterestProfile('u1', deps)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
The interest-profile build called an LLM (qwen3-30b via OpenRouter) over hundreds of account titles in sequential 5-title chunks (100-200s+), so the mobile curation tab stayed stuck on 'analyzing' and never showed the 3 proposals (confirmed via prod logs + live browser test). Replaced with a local taxonomy-pattern extractor — instant, no external LLM dependency. Domain-based proposals unaffected. tsc 0, jest 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)