### PR TITLE
feat(curation): thin-pool async v5 enrichment (serve-first)

### DIFF
--- a/src/modules/queue/handlers/curation-build.ts
+++ b/src/modules/queue/handlers/curation-build.ts
@@ -22,9 +22,9 @@ import { logger } from '@/utils/logger';
 import { getPrismaClient } from '@/modules/database/client';
 import { JOB_NAMES, QUEUE_CONFIG } from '../types';
 import { getJobQueue } from '../manager';
-import { runV5Executor } from '@/skills/plugins/video-discover/v5/executor';
+import { matchFromVideoPoolByCenterGoal } from '@/skills/plugins/video-discover/v3/cache-matcher';
+import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
 import { MS_PER_DAY } from '@/utils/time-constants';
-import { CURATION_PUBLISHED_AFTER_DAYS } from '@/modules/curation/config';
 
 const log = logger.child({ module: 'queue/curation-build' });
 
@@ -60,35 +60,26 @@ export async function registerCurationBuildWorker(): Promise<void> {
       return;
     }
 
-    // build-1 — discover topic → videos, mandala-free. runV5Executor takes a
-    // centerGoal STRING (no mandala). subGoals empty → v5 generates queries from
-    // centerGoal alone (B1: the empty-subGoals path is validated by one live run
-    // before flag-on). publishedAfter biases recent supply = the P0 rising signal.
-    const publishedAfter = new Date(Date.now() - CURATION_PUBLISHED_AFTER_DAYS * MS_PER_DAY)
-      .toISOString()
-      .slice(0, 10);
-    const v5 = await runV5Executor({
-      centerGoal: sub.topic,
+    // build-1/2/3 — INSTANT pool-cosine KNN (reuses add-cards Layer1,
+    // matchFromVideoPoolByCenterGoal). Embed the topic ONCE (~0.5s) → pgvector cosine
+    // on video_pool_embeddings → top-N. NO live search / candidate embed / LLM picker;
+    // runV5Executor's full pipeline (LLM×2 + search.list fanout + bulk embed) stalled
+    // the build 20s+. ~1-2s. Thin-pool niche topics → async v5 enrichment = follow-up.
+    const [centerEmbedding] = await embedBatch([sub.topic]);
+    if (!centerEmbedding) {
+      log.warn('curation build: topic embed failed', { subscriptionId, topic: sub.topic });
+      return;
+    }
+    const matches = await matchFromVideoPoolByCenterGoal({
+      centerEmbedding,
       subGoals: [],
-      focusTags: [],
-      targetLevel: '',
       language: 'ko',
-      includeEnCards: false,
-      excludeVideoIds: new Set<string>(),
-      env: process.env,
-      publishedAfter,
+      limit: QUEUE_CONFIG.CURATION_TARGET_VIDEOS,
     });
-
-    // build-2/3 — v5 already ranks by relevance (score 0-1, sorted desc) and applies
-    // trust/channel/book gating. Use that ranking DIRECTLY — no per-card relevance
-    // re-computation. The old per-card computeCardRelevance (an extra LLM call per
-    // video) stalled the build for minutes; the existing search path returns in ~6s.
-    const picked: Array<{ videoId: string; relevancePct: number }> = v5.cards
-      .slice(0, QUEUE_CONFIG.CURATION_TARGET_VIDEOS)
-      .map((card) => ({
-        videoId: card.videoId,
-        relevancePct: Math.max(1, Math.min(100, Math.round((card.score ?? 0) * 100))),
-      }));
+    const picked: Array<{ videoId: string; relevancePct: number }> = matches.map((m) => ({
+      videoId: m.videoId,
+      relevancePct: Math.max(1, Math.min(100, Math.round((m.score ?? 0) * 100))),
+    }));
 
     // build-4 — rich-summary is REUSE-ONLY for P0. video_rich_summaries is a
     // video-keyed GLOBAL table (leaks across goals), so the build never writes it
@@ -127,7 +118,7 @@ export async function registerCurationBuildWorker(): Promise<void> {
       subscriptionId,
       weekOf,
       topic: sub.topic,
-      discovered: v5.cards.length,
+      poolMatches: matches.length,
       picked: picked.length,
       belowMin: picked.length < QUEUE_CONFIG.CURATION_MIN_VIDEOS,
     });

--- a/src/modules/queue/handlers/curation-build.ts
+++ b/src/modules/queue/handlers/curation-build.ts
@@ -24,6 +24,7 @@ import { JOB_NAMES, QUEUE_CONFIG } from '../types';
 import { getJobQueue } from '../manager';
 import { matchFromVideoPoolByCenterGoal } from '@/skills/plugins/video-discover/v3/cache-matcher';
 import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
+import { runV5Executor } from '@/skills/plugins/video-discover/v5/executor';
 import { MS_PER_DAY } from '@/utils/time-constants';
 
 const log = logger.child({ module: 'queue/curation-build' });
@@ -32,6 +33,50 @@ export interface CurationBuildPayload {
   subscriptionId: string;
   /** ISO date (Monday) this build belongs to — the curation_items.week_of key. */
   weekOf: string;
+  /** Background live-search enrichment for thin-pool topics (serve-first, §fallback). */
+  deep?: boolean;
+}
+
+/**
+ * Background enrichment for thin-pool (niche) topics: the fast pool-cosine result was
+ * already served; this runs the (slow but async) live v5 search and APPENDS new videos
+ * to the week — never blocks the user. Serve-first pattern.
+ */
+async function deepEnrichCuration(
+  subscriptionId: string,
+  topic: string,
+  weekDate: Date,
+  prisma: ReturnType<typeof getPrismaClient>
+): Promise<void> {
+  const v5 = await runV5Executor({
+    centerGoal: topic,
+    subGoals: [],
+    focusTags: [],
+    targetLevel: '',
+    language: 'ko',
+    includeEnCards: false,
+    excludeVideoIds: new Set<string>(),
+    env: process.env,
+  });
+  const existing = await prisma.curation_items.findMany({
+    where: { subscription_id: subscriptionId, week_of: weekDate },
+    select: { video_id: true },
+  });
+  const room = QUEUE_CONFIG.CURATION_TARGET_VIDEOS - existing.length;
+  if (room <= 0) return;
+  const have = new Set(existing.map((e) => e.video_id));
+  const additions = v5.cards
+    .filter((c) => !have.has(c.videoId))
+    .slice(0, room)
+    .map((c, i) => ({
+      subscription_id: subscriptionId,
+      video_id: c.videoId,
+      relevance_pct: Math.max(1, Math.min(100, Math.round((c.score ?? 0) * 100))),
+      position: existing.length + i,
+      week_of: weekDate,
+    }));
+  if (additions.length) await prisma.curation_items.createMany({ data: additions });
+  log.info('curation deep enrich complete', { subscriptionId, topic, added: additions.length });
 }
 
 /** teamSize per the pg-boss trap (CP498) — explicit, low concurrency. */
@@ -57,6 +102,13 @@ export async function registerCurationBuildWorker(): Promise<void> {
     const sub = await prisma.curation_subscriptions.findUnique({ where: { id: subscriptionId } });
     if (!sub || !sub.is_active) {
       log.info('curation build skipped (missing/inactive)', { subscriptionId });
+      return;
+    }
+
+    // Background enrichment pass (thin-pool topics) — append live-search results, don't
+    // touch cadence or replace the week. The fast pool result is already live.
+    if (job.data.deep) {
+      await deepEnrichCuration(subscriptionId, sub.topic, new Date(weekOf), prisma);
       return;
     }
 
@@ -107,6 +159,16 @@ export async function registerCurationBuildWorker(): Promise<void> {
           ]
         : []),
     ]);
+
+    // Thin pool (niche topic) → enqueue a background live-search enrichment (serve-first:
+    // the fast pool result is already served; v5 appends more behind). Separate singleton
+    // key so it doesn't collide with the weekly/immediate fast build.
+    if (picked.length < QUEUE_CONFIG.CURATION_MIN_VIDEOS) {
+      await enqueueCurationBuild(
+        { subscriptionId, weekOf, deep: true },
+        { singletonKey: `${subscriptionId}:deep` }
+      );
+    }
 
     // build-6 — advance the weekly cadence.
     await prisma.curation_subscriptions.update({


### PR DESCRIPTION
Thin-pool niche topics (few pool matches) → enqueue background deep v5 build that appends more videos. Fast pool result served immediately, v5 fills behind. Supervisor-confirmed. tsc 0. 🤖 Generated with [Claude Code](https://claude.com/claude-code)