### PR TITLE
fix(curation): connect sheet = true bottom sheet (guest-mockup grammar)

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -647,19 +647,21 @@
   .inst-x{border:none; background:none; cursor:pointer; font-family:inherit; font-size:13px; font-weight:750;
     color:var(--paper-sub); padding:9px; margin-top:2px; touch-action:manipulation}
 
-  /* YouTube connect wizard sheet [J:07-21] — bottom sheet OVER content, playback preserved behind.
-     Overlay is orthogonal to screens (body.ytsheet toggle); the back button lowers it, never navigates. */
-  #ytSheet{position:absolute; inset:0; z-index:64; display:flex; align-items:flex-end; justify-content:center;
+  /* YouTube connect wizard sheet [J:07-21] — TRUE bottom sheet (guest-mockup grammar):
+     body-level fixed overlay, card anchored to the VIEWPORT bottom (rises over the wheel),
+     compact height so the content stays visible behind; exit = quiet bottom-center link. */
+  #ytSheet{position:fixed; inset:0; z-index:80; display:flex; align-items:flex-end; justify-content:center;
     pointer-events:none; opacity:0; transition:opacity .34s var(--soft)}
   #ytSheet .yts-bd{position:absolute; inset:0; background:rgba(30,27,22,.42)}
-  #ytSheet .yts-card{position:relative; width:100%; max-width:360px; background:var(--paper-hi,#FAF6EC);
-    border-radius:22px 22px 0 0; padding:14px 22px calc(20px + var(--sab)); box-shadow:0 -14px 44px rgba(30,27,22,.30);
-    transform:translateY(103%); transition:transform .42s var(--spring); display:flex; flex-direction:column; gap:12px; text-align:center}
+  #ytSheet .yts-card{position:relative; width:100%; max-width:480px; background:var(--paper-hi,#FAF6EC);
+    border-radius:22px 22px 0 0; padding:12px 24px calc(14px + var(--sab)); box-shadow:0 -14px 44px rgba(30,27,22,.30);
+    transform:translateY(103%); transition:transform .42s var(--spring); display:flex; flex-direction:column; gap:12px;
+    text-align:center; max-height:78vh; overflow-y:auto}
   body.ytsheet #ytSheet{opacity:1; pointer-events:auto}
   body.ytsheet #ytSheet .yts-card{transform:translateY(0)}
-  #ytSheet .yts-grip{width:38px; height:4px; border-radius:99px; background:rgba(94,86,72,.22); margin:0 auto}
-  #ytSheet .yts-back{position:absolute; left:12px; top:11px; border:none; background:none; font-family:inherit;
-    font-size:12.5px; font-weight:750; color:var(--paper-sub); cursor:pointer; padding:7px; touch-action:manipulation; z-index:2}
+  #ytSheet .yts-grip{width:38px; height:4px; border-radius:99px; background:rgba(94,86,72,.22); margin:0 auto; flex:none}
+  #ytSheet .yts-exit{border:none; background:none; font-family:inherit; font-size:12.5px; font-weight:750;
+    color:var(--paper-sub); cursor:pointer; padding:10px 8px 2px; touch-action:manipulation; align-self:center}
   .yts-h{font-size:20px; font-weight:850; color:var(--paper-ink); line-height:1.35; letter-spacing:-.01em; margin-top:4px}
   .yts-h2{font-size:17px; font-weight:800; color:var(--paper-ink); line-height:1.4; margin-top:2px}
   .yts-sub{font-size:12.5px; font-weight:600; color:var(--paper-sub); line-height:1.7}
@@ -1070,41 +1072,6 @@
         </div>
       </div>
 
-      <!-- Curation deck [J:07-21] — full-bleed player, approved-design port (filmstrip + wave + wheel) -->
-      <div id="curDeck" aria-hidden="true">
-        <div class="cd-top">
-          <button class="cd-back" id="cdBack" type="button">← 큐레이션</button>
-          <span class="cd-title" id="cdTitle"></span>
-          <span class="cd-count num" id="cdCount"></span>
-        </div>
-        <div class="cd-strip" id="cdStrip">
-          <div class="cd-card cd-side" id="cdPrev"></div>
-          <div class="cd-card cd-focus" id="cdFocus">
-            <div class="cd-yt off" id="cdYt"></div>
-            <button class="cd-play" id="cdPlayBtn" type="button" aria-label="재생"><svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5.5v13l11-6.5z"/></svg></button>
-            <div class="cd-meta"><span class="cd-vt" id="cdVt"></span><span class="cd-vs" id="cdVs"></span></div>
-            <svg class="cd-wave" id="cdWave" viewBox="0 0 100 26" preserveAspectRatio="none" aria-hidden="true"></svg>
-          </div>
-          <div class="cd-card cd-side" id="cdNext"></div>
-        </div>
-        <div class="cd-wheel" id="cdWheel">
-          <button class="cd-w-menu" id="cdWMenu" type="button">MENU</button>
-          <button class="cd-w-prev" id="cdWPrev" type="button" aria-label="이전"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.5 5.5v13l-8-6.5zM10 5.5v13l-8-6.5z"/></svg></button>
-          <button class="cd-w-next" id="cdWNext" type="button" aria-label="다음"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5.5 5.5v13l8-6.5zM14 5.5v13l8-6.5z"/></svg></button>
-          <button class="cd-w-center" id="cdWCenter" type="button" aria-label="재생/일시정지"><svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path id="cdWCIcon" d="M8 5.5v13l11-6.5z"/></svg></button>
-        </div>
-      </div>
-
-      <!-- YouTube connect wizard sheet [J:07-21] — overlay over content, playback preserved, back returns -->
-      <div id="ytSheet" aria-hidden="true">
-        <div class="yts-bd" id="ytsBd"></div>
-        <div class="yts-card" role="dialog" aria-modal="true" aria-label="유튜브 연결">
-          <button class="yts-back" id="ytsBack" type="button">← 계속 보기</button>
-          <div class="yts-grip"></div>
-          <div id="ytsBody"></div>
-        </div>
-      </div>
-
       <!-- 목표 입력 -->
       <div class="goal-ov" id="goalOv">
         <div class="go-title" id="goTitle">무엇을 배우고 싶나요?</div>
@@ -1140,6 +1107,43 @@
     <div class="engrave">INSIGHTA</div>
   </div>
 
+
+  <!-- Curation deck [J:07-21] — full-bleed player, approved-design port (filmstrip + wave + wheel).
+       Body-level so it truly covers the viewport (never trapped inside the screen area). -->
+  <div id="curDeck" aria-hidden="true">
+    <div class="cd-top">
+      <button class="cd-back" id="cdBack" type="button">← 큐레이션</button>
+      <span class="cd-title" id="cdTitle"></span>
+      <span class="cd-count num" id="cdCount"></span>
+    </div>
+    <div class="cd-strip" id="cdStrip">
+      <div class="cd-card cd-side" id="cdPrev"></div>
+      <div class="cd-card cd-focus" id="cdFocus">
+        <div class="cd-yt off" id="cdYt"></div>
+        <button class="cd-play" id="cdPlayBtn" type="button" aria-label="재생"><svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5.5v13l11-6.5z"/></svg></button>
+        <div class="cd-meta"><span class="cd-vt" id="cdVt"></span><span class="cd-vs" id="cdVs"></span></div>
+        <svg class="cd-wave" id="cdWave" viewBox="0 0 100 26" preserveAspectRatio="none" aria-hidden="true"></svg>
+      </div>
+      <div class="cd-card cd-side" id="cdNext"></div>
+    </div>
+    <div class="cd-wheel" id="cdWheel">
+      <button class="cd-w-menu" id="cdWMenu" type="button">MENU</button>
+      <button class="cd-w-prev" id="cdWPrev" type="button" aria-label="이전"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.5 5.5v13l-8-6.5zM10 5.5v13l-8-6.5z"/></svg></button>
+      <button class="cd-w-next" id="cdWNext" type="button" aria-label="다음"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5.5 5.5v13l8-6.5zM14 5.5v13l8-6.5z"/></svg></button>
+      <button class="cd-w-center" id="cdWCenter" type="button" aria-label="재생/일시정지"><svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path id="cdWCIcon" d="M8 5.5v13l11-6.5z"/></svg></button>
+    </div>
+  </div>
+
+  <!-- YouTube connect wizard sheet [J:07-21] — TRUE bottom sheet: body-level, rises from the
+       viewport bottom over everything (wheel included); quiet exit link at the bottom center. -->
+  <div id="ytSheet" aria-hidden="true">
+    <div class="yts-bd" id="ytsBd"></div>
+    <div class="yts-card" role="dialog" aria-modal="true" aria-label="유튜브 연결">
+      <div class="yts-grip"></div>
+      <div id="ytsBody"></div>
+      <button class="yts-exit" id="ytsBack" type="button">← 계속 보기</button>
+    </div>
+  </div>
 
   <div class="toast" id="toast"></div>
 
@@ -1480,7 +1484,8 @@
      the redirect round-trip is sealed FE-side via a sessionStorage snapshot.
      Design: supervisor 0709 (Fable 5), guest-sheet pattern. */
   var YTS_SNAP='insighta-yt-wizard-snap';
-  var YT_GOOGLE_SVG='<svg width="16" height="16" viewBox="0 0 48 48" aria-hidden="true"><path fill="#EA4335" d="M24 9.5c3.5 0 6.6 1.2 9.1 3.6l6.8-6.8C35.8 2.4 30.3 0 24 0 14.6 0 6.5 5.4 2.6 13.2l7.9 6.2C12.4 13.5 17.7 9.5 24 9.5z"/><path fill="#4285F4" d="M46.5 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.7c-.6 3-2.3 5.5-4.8 7.2l7.7 6c4.5-4.2 6.9-10.3 6.9-17.7z"/><path fill="#FBBC05" d="M10.5 28.6a14.5 14.5 0 0 1 0-9.2l-7.9-6.2a24 24 0 0 0 0 21.6l7.9-6.2z"/><path fill="#34A853" d="M24 48c6.3 0 11.6-2.1 15.6-5.8l-7.7-6c-2.1 1.4-4.8 2.3-7.9 2.3-6.3 0-11.6-4-13.5-9.9l-7.9 6.2C6.5 42.6 14.6 48 24 48z"/></svg>';
+  // YouTube play glyph — the G logo pairs only with Google sign-in copy, not a YouTube connect CTA.
+  var YT_TUBE_SVG='<svg width="17" height="17" viewBox="0 0 24 24" aria-hidden="true"><rect x="1.5" y="4.5" width="21" height="15" rx="4" fill="#FF0000"/><path d="M10 9l5.2 3L10 15z" fill="#fff"/></svg>';
   function openYtSheet(){ document.body.classList.add('ytsheet'); var s=document.getElementById('ytSheet'); if(s) s.setAttribute('aria-hidden','false'); }
   function closeYtSheet(){ document.body.classList.remove('ytsheet'); var s=document.getElementById('ytSheet'); if(s) s.setAttribute('aria-hidden','true'); }
 
@@ -1489,7 +1494,7 @@
     var b=document.getElementById('ytsBody'); if(!b) return;
     b.innerHTML='<div class="yts-h">보던 유튜브가,<br>나만의 목표 지도로</div>'
       +'<div class="yts-sub">자주 머무는 주제 세 갈래를<br>다이얼에 맞춰 드려요.</div>'
-      +'<button class="yts-cta" id="ytsGo">'+YT_GOOGLE_SVG+'<span>유튜브 연결하기</span></button>'
+      +'<button class="yts-cta" id="ytsGo">'+YT_TUBE_SVG+'<span>유튜브 연결하기</span></button>'
       +'<div class="yts-safe">나중에 연결해도 괜찮아요</div>';
     var g=document.getElementById('ytsGo'); if(g) g.onclick=ytHandoff;
   }


### PR DESCRIPTION
## Problem (James review)
The connect sheet ruined the approved design: it was rendered inside the
screen area (`.epaper`, `position:absolute`), so it floated mid-device and
cut off above the jog wheel — a levitating card, not a bottom sheet. It also
paired the Google G logo with a YouTube-connect CTA, and put the exit link
top-left like a page header.

## Fix — restore the guest-mockup grammar
- `#ytSheet` (and `#curDeck`, defensively) moved to **body level**; the sheet
  is `position:fixed` and rises from the **viewport bottom**, over the wheel.
- Exit = quiet **bottom-center** "← 계속 보기" text link; grip stays top.
- CTA icon: Google G → **YouTube play glyph** (G pairs only with Google
  sign-in copy).
- Compact card (content height, max 78vh scroll) so content behind stays
  visible; backdrop dims the whole device.

## Verification (local browser, 400x860)
Card bottom == viewport bottom (717/717), exit at bottom center, YouTube
glyph CTA renders, content visible + dimmed behind. JS parse OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)