### PR TITLE
fix(curation): tab = persistent curation list, not proposals [A]

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -155,13 +155,6 @@
   .cur-connect .t1{font-size:15px; font-weight:750; color:var(--paper-ink)}
   .cur-connect .t2{font-size:11.5px; font-weight:600; color:var(--paper-sub); line-height:1.7}
   .cur-connect .cbtn{margin-top:4px; border:none; background:var(--ui); color:#fff; font-family:inherit; font-size:13px; font-weight:800; padding:11px 22px; border-radius:12px; cursor:pointer; -webkit-tap-highlight-color:transparent; box-shadow:0 4px 10px -4px rgba(0,0,0,.3)}
-  .cur-props{flex:1; display:flex; flex-direction:column; gap:10px; padding:15px 15px 20px; overflow-y:auto}
-  .cur-props .cp-h{font-size:12px; font-weight:800; color:var(--paper-sub); letter-spacing:.02em; padding:2px 2px 3px}
-  .cur-props .cp-card{display:flex; flex-direction:column; align-items:flex-start; gap:6px; text-align:left; border:1px solid rgba(94,86,72,.14); background:rgba(255,255,255,.5); border-radius:15px; padding:13px 15px; cursor:pointer; font-family:inherit; -webkit-tap-highlight-color:transparent; transition:transform .12s ease}
-  .cur-props .cp-card:active{transform:scale(.985)}
-  .cur-props .cp-dom{font-size:10.5px; font-weight:800; color:var(--ui); background:rgba(206,95,48,.1); border-radius:8px; padding:3px 8px}
-  .cur-props .cp-t{font-size:15px; font-weight:750; color:var(--paper-ink); line-height:1.4}
-  .cur-props .cp-go{font-size:11.5px; font-weight:700; color:var(--paper-sub)}
   .cur-connect .cur-prog{width:160px; max-width:62%; height:5px; border-radius:99px; background:rgba(94,86,72,.12); overflow:hidden; margin-top:14px; position:relative}
   .cur-connect .cur-prog span{position:absolute; top:0; height:100%; width:42%; border-radius:99px; background:var(--ui); animation:curslide 1.25s cubic-bezier(.4,0,.2,1) infinite}
   @keyframes curslide{0%{left:-42%}100%{left:100%}}
@@ -753,11 +746,6 @@
     body.curdeck.cdplaying .cd-focus{flex-basis:100%; border-radius:0}
     body.curdeck.cdplaying .cd-wave{display:none}
   }
-  /* Curation account chip (connected) — opens the manage sheet */
-  .cur-chip{align-self:flex-start; display:inline-flex; align-items:center; gap:6px; border:1px solid rgba(94,86,72,.16);
-    background:rgba(255,255,255,.5); color:var(--paper-sub); font-family:inherit; font-size:11px; font-weight:750;
-    padding:5px 11px; border-radius:99px; cursor:pointer; -webkit-tap-highlight-color:transparent; margin-bottom:2px}
-  .cur-chip:active{transform:scale(.97)}
 
   /* 배속 캡슐 — 팟캐스트 문법: 재생 화면에서 탭 = 순환 */
   .shr{border:none; background:none; cursor:pointer; touch-action:manipulation; color:var(--paper-sub);
@@ -998,6 +986,7 @@
           <button class="mrow" id="bInstall"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 11l8-7 8 7"/><path d="M6 9.5V20h12V9.5"/></svg></span>홈 화면에 설치<span class="sub">전체화면 앱</span></button>
           <button class="mrow" id="bRefresh"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 12a8 8 0 11-2.34-5.66"/><path d="M20 3v4h-4"/></svg></span>새로고침<span class="sub">최신 버전 불러오기</span></button>
           <div class="ghd">계정</div>
+          <button class="mrow" id="bYtConnect"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2.5" y="6" width="19" height="12.5" rx="3.5"/><path d="M10 9.5l4.4 2.75L10 15z" fill="currentColor" stroke="none"/></svg></span>유튜브 연결<span class="sub" id="ytConnSub">계정 연결 · 관리</span></button>
           <button class="mrow" id="bFeedback"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11a7.5 7.5 0 01-7.9 7.5c-1.3 0-2.6-.3-3.7-.9L4 19l1.5-4.3A7.5 7.5 0 1121 11z"/></svg></span>의견 보내기<span class="sub">기능 제안 · 불편 신고</span></button>
           <button class="mrow" id="bLogout"><span class="lic"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 4H6.5A1.5 1.5 0 005 5.5v13A1.5 1.5 0 006.5 20H14"/><path d="M10 12h11M18 8.8L21 12l-3 3.2"/></svg></span>로그아웃</button>
         </div>
@@ -1442,24 +1431,64 @@
   var CUR_STAR='<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3.5l1.8 4.4 4.7 1.4-3.5 3 .9 4.7L12 14.6 7.6 17l.9-4.7-3.5-3 4.7-1.4z"/></svg>';
   function curEsc(s){ return String(s==null?'':s).replace(/[&<>"]/g,function(c){ return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]; }); }
   var CUR_DOM_LABEL={ai_ml:'AI·기술',career:'취업·커리어',investment:'투자·경제',startup:'창업',language:'어학',exam:'시험·입시',other:'추천'};
-  // Entry point for the curation tab. Detects connection → analyzing → 3 proposals.
+  /* Curation tab = the caller's PERSISTENT curation list (GET /curations), rendered as
+     the same text rows as the video/note tabs. Row tap opens the EXISTING week (GET
+     items -> deck) — never a rebuild. Proposals live only in the connect-sheet wizard
+     (first curation / "+ new"). Model fix per James + supervisor A. */
   async function renderCuration(){
     var el=document.getElementById('curBody'); if(!el) return;
     try{
-      var r=await api('/curations/suggest');
-      if(r.status===202){ // profile building — analyze then retry
-        el.className='cur-connect';
-        el.innerHTML='<span class="cic">'+CUR_STAR+'</span><span class="t1">관심사 분석 중</span>'
-          +'<span class="t2">유튜브 활동을 살펴보고 있어요<br>잠시 후 추천이 준비돼요</span>'
-          +'<div class="cur-prog"><span></span></div>';
-        setTimeout(function(){ if(homeTab==='curation') renderCuration(); },4000);
-        return;
-      }
+      var r=await api('/curations');
       var j=await r.json();
-      var props=(j&&j.data&&j.data.proposals)||[];
-      if(!props.length){ curConnectGate(); return; }
-      renderProposals(props);
-    }catch(e){ curConnectGate(); }   // 401/403/not-connected → connect gate
+      var subs=(j&&j.data&&j.data.curations)||[];
+      if(subs.length){ renderCurationRows(subs); return; }
+      // no curations yet: connected -> proposal wizard for the first one; else connect gate
+      var st=await ytFetchStatus();
+      if(st&&st.isConnected){
+        renderCurationRows([]);
+        if(!ytAutoRaised){ ytAutoRaised=true; openYtSheet(); ytRenderTuning(); }
+      } else curConnectGate();
+    }catch(e){ curConnectGate(); }   // 401/403 -> connect gate
+  }
+  function curAgeLine(sub){
+    if(!sub.last_run_at) return '주간 큐레이션';
+    var d=Math.floor((Date.now()-new Date(sub.last_run_at).getTime())/86400000);
+    return '주간 큐레이션 · '+(d<=0?'오늘':d+'일 전');
+  }
+  // Same .rows/.row markup as the mandala lists (format parity is the contract).
+  function renderCurationRows(subs){
+    var el=document.getElementById('curBody'); if(!el) return;
+    el.className='cur-body';
+    el.innerHTML='<div class="rows" id="curRows"></div>';
+    var rows=document.getElementById('curRows');
+    subs.forEach(function(s){
+      var c=jkColor(s.topic||'?');
+      var d=document.createElement('div');
+      d.className='row';
+      d.innerHTML='<span class="jk" style="background:linear-gradient(150deg,'+c[0]+','+c[1]+')"><b></b></span>'
+        +'<span class="m"><span class="a"></span><span class="b"><span class="bt"></span></span></span>';
+      d.querySelector('.jk b').textContent=(s.topic||'?').trim().charAt(0);
+      d.querySelector('.a').textContent=s.topic||'(제목 없음)';
+      d.querySelector('.bt').textContent=curAgeLine(s);
+      d.addEventListener('click',function(){ openExistingCuration(s); });
+      rows.appendChild(d);
+    });
+    // "+ new curation" — same row form, opens the proposal wizard (no new screen)
+    var add=document.createElement('div');
+    add.className='row';
+    add.innerHTML='<span class="jk" style="background:rgba(94,86,72,.10)"><b style="color:var(--ui)">+</b></span>'
+      +'<span class="m"><span class="a">새 큐레이션</span><span class="b"><span class="bt">관심 주제 고르기</span></span></span>';
+    add.addEventListener('click',function(){ openYtSheet(); ytRenderTuning(); });
+    rows.appendChild(add);
+  }
+  // Open an EXISTING curation week — read-only, never triggers a rebuild.
+  async function openExistingCuration(sub){
+    try{
+      var r=await api('/curations/'+sub.id+'/items');
+      var j=await r.json(); var items=(j&&j.data&&j.data.items)||[];
+      if(items.length){ openCurationDeck(sub.topic, items); return; }
+      toast('영상을 모으는 중이에요 — 잠시 후 다시 열어주세요');
+    }catch(e){ toast('열지 못했어요 — 연결 확인 후 다시 시도해주세요'); }
   }
   // Not-connected gate (behind-content, never a dead end): slim prompt in the tab body +
   // auto-raise the connect sheet once per session. Tapping the button re-opens the sheet.
@@ -1565,9 +1594,13 @@
       if(!r.ok) return null; return await r.json();
     }catch(e){ return null; }
   }
+  // Settings-row entry: connected -> manage/disconnect state; not connected -> S1 connect.
   async function ytOpenManage(){
     openYtSheet(); ytRenderConnected(null);
-    var st=await ytFetchStatus(); ytRenderConnected(st);
+    var st=await ytFetchStatus();
+    if(st&&st.isConnected) ytRenderConnected(st); else ytRenderConnect();
+    var sub=document.getElementById('ytConnSub');
+    if(sub) sub.textContent=(st&&st.isConnected)?((st.youtubeEmail||'연결됨')+' · 관리'):'계정 연결 · 관리';
   }
   function ytRenderConnected(status){
     var b=document.getElementById('ytsBody'); if(!b) return;
@@ -1610,24 +1643,8 @@
     openYtSheet(); ytRenderTuning();
     return true;
   }
-  function renderProposals(props){
-    var el=document.getElementById('curBody'); if(!el) return;
-    el.className='cur-props';
-    // Connected → account chip (tap = manage/disconnect sheet) above this week's topics.
-    var h='<button class="cur-chip" id="curAcctChip">유튜브 연결됨 · 관리</button>';
-    h+='<div class="cp-h">이번 주 관심사</div>';
-    props.forEach(function(p){
-      h+='<button class="cp-card" data-topic="'+curEsc(p.topic)+'">'
-        +'<span class="cp-dom">'+curEsc(CUR_DOM_LABEL[p.domain]||'추천')+'</span>'
-        +'<span class="cp-t">'+curEsc(p.topic)+'</span>'
-        +'<span class="cp-go">큐레이션 받기</span></button>';
-    });
-    el.innerHTML=h;
-    var chip=document.getElementById('curAcctChip'); if(chip) chip.onclick=ytOpenManage;
-    [].forEach.call(el.querySelectorAll('.cp-card'),function(b){
-      b.onclick=function(){ selectCuration(b.getAttribute('data-topic')); };
-    });
-  }
+  // CREATE path only (from the sheet's proposal pick) — one-time build state in the tab
+  // body, then the deck. Existing curations NEVER come through here (no rebuilds).
   async function selectCuration(topic){
     var el=document.getElementById('curBody'); if(!el) return;
     el.className='cur-connect';
@@ -1638,20 +1655,16 @@
       var r=await api('/curations',{method:'POST',body:JSON.stringify({topic:topic,source:'youtube_subs'})});
       var j=await r.json(); var id=j&&j.data&&j.data.id; if(!id) throw new Error('no id');
       pollCurationItems(id,topic,0);
-    }catch(e){ el.innerHTML='<span class="cic">'+CUR_STAR+'</span><span class="t1">잠시 후 다시 시도해주세요</span>'; }
+    }catch(e){ el.innerHTML='<span class="cic">'+CUR_STAR+'</span><span class="t1">잠시 후 다시 시도해주세요</span>'; renderCuration(); }
   }
   async function pollCurationItems(id,topic,tries){
     try{
       var r=await api('/curations/'+id+'/items');
       var j=await r.json(); var items=(j&&j.data&&j.data.items)||[];
-      if(items.length){ openCurationDeck(topic,items); return; }
+      if(items.length){ renderCuration(); openCurationDeck(topic,items); return; }
     }catch(e){}
     if(tries<20 && homeTab==='curation'){ setTimeout(function(){ pollCurationItems(id,topic,tries+1); },3000); }
-    else{
-      var el=document.getElementById('curBody');
-      if(el) el.innerHTML='<span class="cic">'+CUR_STAR+'</span><span class="t1">영상을 모으는 중이에요</span>'
-        +'<span class="t2">잠시 후 큐레이션 탭에서 다시 확인해주세요</span>';
-    }
+    else{ renderCuration(); toast('영상을 모으는 중이에요 — 잠시 후 목록에서 열어주세요'); }
   }
   /* ============ Curation deck (#curDeck) [J:07-21] ============
      Port of the APPROVED design (project ef4fae07 "큐레이션 플레이어"): full-bleed
@@ -3161,6 +3174,7 @@
     }catch(e){ document.getElementById('tkList').innerHTML='<div class="menu-note" style="margin-top:20px">불러오지 못했어요 — 연결 확인 후 다시</div>'; }
   }
   document.getElementById('bInvite').onclick=function(){ show('invite'); loadTickets(); };
+  document.getElementById('bYtConnect').onclick=ytOpenManage;
   // 나브 토글 — 만다라/설정 아이콘 각각 클릭 이동 [J:07-15]
   Array.prototype.forEach.call(document.querySelectorAll('.ntb[data-nav]'), function(b){
     b.onclick=function(){ var t=b.getAttribute('data-nav'); show(t); if(t==='menu') loadTicketsQuiet(); };


### PR DESCRIPTION
## Problem (James device review)
The curation tab showed three PROPOSAL cards permanently and re-built on every
tap ("making curation" every time). Proposals are a one-time onboarding flow;
the tab must show MY curations.

## Fix (supervisor-reviewed model A)
- Tab = `GET /curations` rendered as the same text rows as video/note tabs.
- Row tap = existing week (`GET items` -> deck), zero rebuilds.
- "+ new curation" row -> proposal wizard sheet (reused, no new screen).
- Connected chip removed; settings menu gets a "YouTube connect" row
  (state + manage sheet).
- "This week's interests" label + in-tab proposal cards removed.

## Verification (local browser)
Mock list renders in row format identical to the mandala lists (jacket +
title + weekly subline), add-row present, settings row wired, JS parse OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)