### PR TITLE
feat(curation): deck rework — mockup parity + warm pre-roll engine [B+C']

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -687,63 +687,70 @@
   .yts-tune-t{font-size:13.5px; font-weight:700; color:var(--paper-ink)}
   @media (prefers-reduced-motion:reduce){ .yts-dial{animation:none} #ytSheet .yts-card{transition-duration:.001s} }
   /* Curation deck [J:07-21] — full-bleed dark player, port of the approved design
-     (project ef4fae07: vertical 3-card filmstrip + relevance curve + floating jog wheel). */
+     (project ef4fae07 + James device screenshots as the numeric contract):
+       - all THREE cards fully inside the viewport: prev 24% / focus 42% / next 24%
+         of the strip height (mockup shows near-equal thirds, focus slightly larger)
+       - relevance wave lives INSIDE the focus card, ALWAYS visible (playing too)
+       - core/full toggle in the header (mockup 핵심만/전체)
+       - jog wheel = the EXISTING #wheel floating-mini mode (reading/stage pattern),
+         NOT a bespoke widget. */
   #curDeck{position:fixed; inset:0; z-index:70; background:#12100E; display:none; flex-direction:column;
-    padding:calc(var(--sat) + 10px) 14px calc(var(--sab) + 12px); color:#EDE7DC; overflow:hidden}
+    padding:calc(var(--sat) + 8px) 14px calc(var(--sab) + 10px); color:#EDE7DC; overflow:hidden}
   body.curdeck #curDeck{display:flex}
-  .cd-top{display:flex; align-items:center; gap:10px; padding:2px 4px 8px}
+  .cd-top{display:flex; align-items:center; gap:8px; padding:2px 4px 8px}
   .cd-back{border:none; background:none; color:#B8AE9E; font-family:inherit; font-size:13px; font-weight:750;
-    cursor:pointer; padding:7px; touch-action:manipulation; flex:none}
-  .cd-title{flex:1; text-align:center; font-size:14.5px; font-weight:800; color:#EDE7DC;
+    cursor:pointer; padding:7px 4px; touch-action:manipulation; flex:none}
+  .cd-title{flex:1; text-align:center; font-size:14px; font-weight:800; color:#EDE7DC; min-width:0;
     white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
-  .cd-count{flex:none; font-size:11px; font-weight:700; color:#8F887A; letter-spacing:.14em; min-width:44px; text-align:right}
-  .cd-strip{flex:1; min-height:0; position:relative; display:flex; flex-direction:column; gap:10px;
-    align-items:stretch; justify-content:center}
-  .cd-card{position:relative; border-radius:18px; overflow:hidden; background:#1E1B17 center/cover no-repeat;
-    flex:none; transition:flex-basis .35s var(--soft), opacity .35s, transform .35s var(--soft);
-    -webkit-tap-highlight-color:transparent}
+  .cd-mode{flex:none; display:inline-flex; border:1px solid rgba(237,231,220,.22); border-radius:99px; overflow:hidden}
+  .cd-mode button{border:none; background:none; color:#8F887A; font-family:inherit; font-size:10.5px; font-weight:800;
+    padding:4px 9px; cursor:pointer; touch-action:manipulation}
+  .cd-mode button.on{background:var(--acc); color:#fff}
+  .cd-mode.disabled{opacity:.35; pointer-events:none}
+  .cd-count{flex:none; font-size:10.5px; font-weight:700; color:#8F887A; letter-spacing:.12em; text-align:right}
+  .cd-strip{flex:1; min-height:0; position:relative; display:flex; flex-direction:column; gap:8px; align-items:stretch}
+  .cd-card{position:relative; border-radius:16px; overflow:hidden; background:#1E1B17 center/cover no-repeat;
+    min-height:0; transition:flex .35s var(--soft), opacity .35s; -webkit-tap-highlight-color:transparent}
   .cd-card::after{content:''; position:absolute; inset:0;
-    background:linear-gradient(180deg, rgba(10,9,8,.18), rgba(10,9,8,.62) 78%)}
-  .cd-side{flex-basis:15%; opacity:.5; cursor:pointer}
-  .cd-side.empty{opacity:.14; cursor:default; background:#181512}
-  .cd-focus{flex-basis:62%; opacity:1; box-shadow:0 16px 44px rgba(0,0,0,.5)}
-  .cd-meta{position:absolute; left:16px; right:16px; bottom:34px; z-index:2; display:flex; flex-direction:column; gap:3px}
-  .cd-vt{font-size:16.5px; font-weight:850; color:#F5F2EC; line-height:1.35;
-    display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden}
-  .cd-vs{font-size:11px; font-weight:650; color:#B8AE9E}
+    background:linear-gradient(180deg, rgba(10,9,8,.15), rgba(10,9,8,.58) 80%)}
+  /* numeric contract: 24 / 42 / 24 — three full cards, no viewport overflow */
+  .cd-side{flex:24 1 0; opacity:.55; cursor:pointer}
+  .cd-side.empty{opacity:.12; cursor:default; background:#181512}
+  .cd-focus{flex:42 1 0; opacity:1; box-shadow:0 14px 40px rgba(0,0,0,.5)}
+  /* compact one-line meta (poster state only) — the embed shows its own header while playing */
+  .cd-meta{position:absolute; left:14px; right:14px; bottom:30px; z-index:2; display:flex; flex-direction:column; gap:2px}
+  .cd-vt{font-size:14.5px; font-weight:800; color:#F5F2EC; line-height:1.3;
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
+  .cd-vs{font-size:10.5px; font-weight:650; color:#B8AE9E; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
   .cd-vs .rel{color:#E8A76B; font-weight:800}
-  .cd-wave{position:absolute; left:12px; right:12px; bottom:12px; z-index:2; height:26px; width:calc(100% - 24px)}
-  .cd-wave polyline{fill:none; stroke-width:1.6}
-  .cd-wave .w-all{stroke:rgba(237,231,220,.28)}
+  /* relevance wave — ALWAYS visible inside the focus card (mockup contract) */
+  .cd-wave{position:absolute; left:12px; right:12px; bottom:8px; z-index:3; height:24px; width:calc(100% - 24px);
+    pointer-events:none}
+  .cd-wave polyline{fill:none; stroke-width:2.2; stroke-linecap:round; stroke-linejoin:round}
+  .cd-wave .w-all{stroke:rgba(237,231,220,.30)}
   .cd-wave .w-done{stroke:#E0703F}
   .cd-wave circle{fill:#F5D48A}
   .cd-side .cd-meta,.cd-side .cd-wave{display:none}
   .cd-yt{position:absolute; inset:0; z-index:1}
-  .cd-yt.off{display:none}
+  .cd-yt.off{visibility:hidden}
   .cd-play{position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); z-index:2;
-    width:58px; height:58px; border-radius:50%; border:none; cursor:pointer;
+    width:56px; height:56px; border-radius:50%; border:none; cursor:pointer;
     background:rgba(245,242,236,.92); color:#2C2925; display:grid; place-items:center;
     box-shadow:0 8px 24px rgba(0,0,0,.4); touch-action:manipulation}
   .cd-play:active{transform:translate(-50%,-50%) scale(.94)}
   body.cdplaying .cd-play{display:none}
   body.cdplaying .cd-focus .cd-meta{display:none}
-  /* Floating jog wheel — all controls live (MENU=back, sides=prev/next, center=play/pause) */
-  .cd-wheel{position:absolute; right:16px; bottom:calc(var(--sab) + 16px); z-index:5; width:104px; height:104px;
-    border-radius:50%; background:rgba(245,242,236,.94); box-shadow:0 10px 30px rgba(0,0,0,.45)}
-  .cd-wheel button{position:absolute; border:none; background:none; cursor:pointer; font-family:inherit;
-    color:#837D72; touch-action:manipulation; padding:6px; -webkit-tap-highlight-color:transparent}
-  .cd-w-menu{top:2px; left:50%; transform:translateX(-50%); font-size:8.5px; font-weight:800; letter-spacing:.18em}
-  .cd-w-prev{left:4px; top:50%; transform:translateY(-50%)}
-  .cd-w-next{right:4px; top:50%; transform:translateY(-50%)}
-  .cd-w-center{left:50%; top:50%; transform:translate(-50%,-50%); width:44px; height:44px; border-radius:50%;
-    background:var(--acc); color:#fff; display:grid; place-items:center; box-shadow:inset 0 1px 3px rgba(0,0,0,.2)}
-  .cd-w-center:active{transform:translate(-50%,-50%) scale(.93)}
+  /* jog wheel = existing #wheel in floating-mini mode (same machinery as reading/stage) */
+  body.curdeck .wheelzone{position:fixed; left:auto; right:6px; top:auto; bottom:calc(var(--sab) + 40px);
+    width:min(46%,190px); z-index:76; padding:0; pointer-events:none}
+  body.curdeck .wheel{width:100%; opacity:0; pointer-events:auto; transition:opacity .35s var(--soft)}
+  body.curdeck .wheel.touching,body.curdeck .wheel.demo,body.curdeck .wheel.awake,body.curdeck.wheelawake .wheel{opacity:.72}
   /* Landscape = the mockup's fullscreen contract: focus card fills the viewport */
   @media (orientation:landscape){
     body.curdeck.cdplaying #curDeck{padding:0}
     body.curdeck.cdplaying .cd-top,body.curdeck.cdplaying .cd-side{display:none}
     body.curdeck.cdplaying .cd-strip{gap:0}
-    body.curdeck.cdplaying .cd-focus{flex-basis:100%; border-radius:0}
+    body.curdeck.cdplaying .cd-focus{flex:100 1 0; border-radius:0}
     body.curdeck.cdplaying .cd-wave{display:none}
   }
 
@@ -1103,23 +1110,19 @@
     <div class="cd-top">
       <button class="cd-back" id="cdBack" type="button">← 큐레이션</button>
       <span class="cd-title" id="cdTitle"></span>
+      <span class="cd-mode" id="cdMode"><button id="cdModeCore" type="button" class="on">핵심만</button><button id="cdModeFull" type="button">전체</button></span>
       <span class="cd-count num" id="cdCount"></span>
     </div>
     <div class="cd-strip" id="cdStrip">
       <div class="cd-card cd-side" id="cdPrev"></div>
       <div class="cd-card cd-focus" id="cdFocus">
-        <div class="cd-yt off" id="cdYt"></div>
+        <div class="cd-yt off" id="cdYtA"></div>
+        <div class="cd-yt off" id="cdYtB"></div>
         <button class="cd-play" id="cdPlayBtn" type="button" aria-label="재생"><svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5.5v13l11-6.5z"/></svg></button>
         <div class="cd-meta"><span class="cd-vt" id="cdVt"></span><span class="cd-vs" id="cdVs"></span></div>
         <svg class="cd-wave" id="cdWave" viewBox="0 0 100 26" preserveAspectRatio="none" aria-hidden="true"></svg>
       </div>
       <div class="cd-card cd-side" id="cdNext"></div>
-    </div>
-    <div class="cd-wheel" id="cdWheel">
-      <button class="cd-w-menu" id="cdWMenu" type="button">MENU</button>
-      <button class="cd-w-prev" id="cdWPrev" type="button" aria-label="이전"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.5 5.5v13l-8-6.5zM10 5.5v13l-8-6.5z"/></svg></button>
-      <button class="cd-w-next" id="cdWNext" type="button" aria-label="다음"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5.5 5.5v13l8-6.5zM14 5.5v13l8-6.5z"/></svg></button>
-      <button class="cd-w-center" id="cdWCenter" type="button" aria-label="재생/일시정지"><svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path id="cdWCIcon" d="M8 5.5v13l11-6.5z"/></svg></button>
     </div>
   </div>
 
@@ -1666,24 +1669,65 @@
     if(tries<20 && homeTab==='curation'){ setTimeout(function(){ pollCurationItems(id,topic,tries+1); },3000); }
     else{ renderCuration(); toast('영상을 모으는 중이에요 — 잠시 후 목록에서 열어주세요'); }
   }
-  /* ============ Curation deck (#curDeck) [J:07-21] ============
-     Port of the APPROVED design (project ef4fae07 "큐레이션 플레이어"): full-bleed
-     dark player, vertical 3-card filmstrip (prev/focus/next), relevance wave with
-     journey marker, floating jog wheel, ended -> auto-advance (lean-back loop).
-     The old note/beat-player reuse (openCurationVideos, to:99999 fake durations)
-     is REMOVED — the deck owns its own YT.Player and uses real pool metadata. */
-  var cdItems=[], cdIdx=0, cdTopic='', cdPlayer=null, cdPlayerReady=false, cdWantPlay=false;
+  /* ============ Curation deck — WARM PRE-ROLL dual-player engine [B+C'] ============
+     Seamless-consumption contract (James): transition <= 0.3s / imperceptible,
+     benchmark = the YouTube app. cueVideoById does NOT buffer media, so warm =
+     mute -> play -> (PLAYING) -> pause on the idle slot; advance = visibility swap
+     + seek + unmute. ~2s before ended the idle slot resumes muted -> zero-gap
+     auto-advance. iOS/low-power: if warm play never reaches PLAYING, quiet cue
+     fallback (poster stays, no spinner). Core mode plays rich-summary sections
+     sequentially (shared segCache); videos without sections disable the toggle.
+     Beat-player pair is released on deck entry (memory, supervisor caveat). */
+  var cdItems=[], cdIdx=0, cdTopic='';
+  var cdP=[null,null], cdAct=0, cdWarmKey=[null,null], cdWarmT=[null,null];
+  var cdReadySlots=[false,false], cdPendingWarm=[null,null];
+  var cdMode='core', cdSegIdx=0, cdPollT=null, cdEndRolled=false;
+  function cdEl(i){ return document.getElementById(i===0?'cdYtA':'cdYtB'); }
+  function cdSlotOf(p){ return p===cdP[0]?0:1; }
+  function cdSecs(it){ var e=segCache[it.video_id]; return (e&&e.sections)||null; }
+  async function cdFetchSegs(vid){
+    if(vid in segCache) return (segCache[vid].sections||[]);
+    var entry={sections:[],credit:null};
+    try{
+      var r=await api('/videos/'+vid+'/rich-summary');
+      var j=await r.json();
+      entry.sections=(j.data&&j.data.segments&&j.data.segments.sections)||[];
+      entry.credit=(j.data&&j.data.oneLiner)||null;
+    }catch(e){}
+    segCache[vid]=entry; return entry.sections;
+  }
+  // Playback bounds for an item under the current mode (core = section window).
+  function cdBounds(it, segIdx){
+    var ss=cdSecs(it);
+    if(cdMode==='core'&&ss&&ss.length){
+      var s=ss[Math.min(segIdx||0, ss.length-1)];
+      if(typeof s.from_sec==='number'&&s.to_sec>s.from_sec) return {start:s.from_sec, end:s.to_sec, segs:ss.length};
+    }
+    return {start:0, end:null, segs:0};
+  }
   function openCurationDeck(topic, items){
     unlockAudio();
-    cdTopic=topic||'큐레이션'; cdItems=items||[]; cdIdx=0; cdWantPlay=false;
+    cdTopic=topic||'큐레이션'; cdItems=items||[]; cdIdx=0; cdSegIdx=0; cdEndRolled=false;
     document.getElementById('cdTitle').textContent=cdTopic;
     document.body.classList.add('curdeck');
+    // release the note/beat player pair — never two dual-player pairs alive (memory)
+    try{ ytP.forEach(function(p){ if(p&&p.stopVideo) p.stopVideo(); }); }catch(e){}
+    cdEnsurePlayers();               // inside the row-tap gesture: prime allowed
+    cdPrefetchSegs();
     cdRender();
+    cdWarmInto(1-cdAct, cdIdx);      // warm the FIRST video before the user taps play
   }
   function closeCurationDeck(){
-    cdPause(); document.body.classList.remove('curdeck','cdplaying');
-    var w=document.getElementById('cdYt'); if(w) w.classList.add('off');
+    cdStopPoll();
+    try{ cdP.forEach(function(p){ if(p&&p.stopVideo) p.stopVideo(); }); }catch(e){}
+    cdWarmKey=[null,null];
+    document.body.classList.remove('curdeck','cdplaying');
+    [0,1].forEach(function(i){ var w=cdEl(i); if(w) w.classList.add('off'); });
     setHomeTab('curation');
+  }
+  // Prefetch sections for the first few items so core-mode bounds are ready pre-warm.
+  function cdPrefetchSegs(){
+    cdItems.slice(0,4).forEach(function(it){ cdFetchSegs(it.video_id).then(function(){ if(cdItems[cdIdx]===it) cdSyncModeUI(); }); });
   }
   function cdThumb(it){ return (it&&it.thumbnail)||('https://i.ytimg.com/vi/'+(it?it.video_id:'')+'/hqdefault.jpg'); }
   function cdRender(){
@@ -1703,61 +1747,159 @@
       '<span class="rel">'+(cur.relevance_pct!=null?(cur.relevance_pct+'%'):'')+'</span>'
       +(bits.length?(' · '+curEsc(bits.join(' · '))):'');
     document.getElementById('cdCount').textContent=(cdIdx+1)+' / '+n;
-    cdDrawWave();
-    // keep the iframe only on the focus card while playing; paused nav shows posters
-    if(document.body.classList.contains('cdplaying')) cdLoadCurrent(true);
+    cdDrawWave(); cdSyncModeUI();
+  }
+  function cdSyncModeUI(){
+    var it=cdItems[cdIdx]; if(!it) return;
+    var ss=cdSecs(it);
+    var wrap=document.getElementById('cdMode');
+    var hasCore=!!(ss&&ss.length);
+    wrap.classList.toggle('disabled', !hasCore);
+    if(!hasCore&&cdMode==='core'){ /* honest disable: this video plays full */ }
+    document.getElementById('cdModeCore').classList.toggle('on', cdMode==='core'&&hasCore);
+    document.getElementById('cdModeFull').classList.toggle('on', cdMode==='full'||!hasCore);
   }
   // Relevance journey: one point per card (y=relevance), done-portion + marker in accent.
   function cdDrawWave(){
     var svg=document.getElementById('cdWave'); if(!svg) return;
     var n=cdItems.length; if(n<1){ svg.innerHTML=''; return; }
     function pt(i){ var x=n===1?50:(i/(n-1))*100; var pct=cdItems[i].relevance_pct||0;
-      return x.toFixed(1)+','+(23-(pct/100)*18).toFixed(1); }
+      return x.toFixed(1)+','+(22-(pct/100)*17).toFixed(1); }
     var all=[], done=[];
     for(var i=0;i<n;i++){ all.push(pt(i)); if(i<=cdIdx) done.push(pt(i)); }
     var mk=pt(cdIdx).split(',');
     svg.innerHTML='<polyline class="w-all" points="'+all.join(' ')+'"/>'
       +'<polyline class="w-done" points="'+done.join(' ')+'"/>'
-      +'<circle cx="'+mk[0]+'" cy="'+mk[1]+'" r="2.2"/>';
+      +'<circle cx="'+mk[0]+'" cy="'+mk[1]+'" r="2.4"/>';
   }
-  function cdEnsurePlayer(){
-    if(cdPlayer||!window.YT||!YT.Player) return;
-    cdPlayer=new YT.Player('cdYt',{
-      width:'100%', height:'100%', videoId:cdItems[cdIdx].video_id,
-      playerVars:{playsinline:1, rel:0, modestbranding:1, controls:1, fs:1, autoplay:1},
-      events:{
-        onReady:function(){ cdPlayerReady=true; if(cdWantPlay){ try{cdPlayer.playVideo()}catch(e){} } },
-        onStateChange:function(ev){
-          if(ev.data===0){ // ended -> lean-back auto-advance
-            if(cdIdx<cdItems.length-1){ cdIdx++; cdRender(); }
-            else { cdPause(); }
-          }
-          var ic=document.getElementById('cdWCIcon');
-          if(ic) ic.setAttribute('d', ev.data===1 ? 'M7 5h3.5v14H7zM13.5 5H17v14h-3.5z' : 'M8 5.5v13l11-6.5z');
+  function cdEnsurePlayers(){
+    if(!window.YT||!YT.Player) return;
+    [0,1].forEach(function(i){
+      if(cdP[i]) return;
+      cdP[i]=new YT.Player(i===0?'cdYtA':'cdYtB',{
+        width:'100%', height:'100%', videoId:'',
+        playerVars:{playsinline:1, rel:0, modestbranding:1, controls:1, fs:1},
+        events:{
+          onReady:(function(slot){ return function(){
+            cdReadySlots[slot]=true;
+            if(cdPendingWarm[slot]!=null){ var ix=cdPendingWarm[slot]; cdPendingWarm[slot]=null; cdWarmInto(slot, ix); }
+          }; })(i),
+          onStateChange:(function(slot){ return function(ev){ cdOnState(slot, ev.data); }; })(i)
         }
-      }
+      });
     });
   }
-  function cdLoadCurrent(play){
-    var w=document.getElementById('cdYt'); if(w) w.classList.remove('off');
-    if(!cdPlayer){ cdWantPlay=!!play; cdEnsurePlayer(); return; }
-    try{ if(play) cdPlayer.loadVideoById(cdItems[cdIdx].video_id); else cdPlayer.cueVideoById(cdItems[cdIdx].video_id); }catch(e){}
+  function cdOnState(slot, st){
+    if(slot!==cdAct){
+      // idle slot warming: reached PLAYING => buffered => pause & mark warm
+      if(st===1 && cdWarmKey[slot]==='warming'){ try{cdP[slot].pauseVideo();}catch(e){} cdWarmKey[slot]=cdP[slot].__warmTarget||null; }
+      return;
+    }
+    if(st===0){ cdEnded(); }
   }
+  // Warm an item into a slot: muted load -> PLAYING -> pause. Quiet cue fallback (iOS/low-power).
+  // Before the slot's onReady, park the request (cdPendingWarm) — never silently skip.
+  function cdWarmInto(slot, itemIdx){
+    if(!cdReadySlots[slot]){ cdPendingWarm[slot]=itemIdx; return; }
+    var it=cdItems[itemIdx]; if(!it||!cdP[slot]||!cdP[slot].loadVideoById) return;
+    var b=cdBounds(it, 0);
+    var key=it.video_id+':'+b.start;
+    if(cdWarmKey[slot]===key) return;
+    clearTimeout(cdWarmT[slot]);
+    cdP[slot].__warmTarget=key;
+    cdWarmKey[slot]='warming';
+    try{
+      cdP[slot].mute();
+      cdP[slot].loadVideoById(b.end!=null?{videoId:it.video_id,startSeconds:b.start,endSeconds:b.end}:{videoId:it.video_id,startSeconds:b.start});
+    }catch(e){ cdWarmKey[slot]=null; return; }
+    cdWarmT[slot]=setTimeout(function(){
+      if(cdWarmKey[slot]==='warming'){ // never reached PLAYING: quiet cue fallback, poster stays
+        try{ cdP[slot].cueVideoById(b.end!=null?{videoId:it.video_id,startSeconds:b.start,endSeconds:b.end}:{videoId:it.video_id,startSeconds:b.start}); }catch(e){}
+        cdWarmKey[slot]=null;
+      }
+    },3500);
+  }
+  // Show only the active slot's iframe inside the focus card.
+  function cdShowActive(){
+    [0,1].forEach(function(i){ var w=cdEl(i); if(w) w.classList.toggle('off', i!==cdAct); });
+  }
+  // Start/resume playback of the current item on the active slot.
   function cdPlay(){
     document.body.classList.add('cdplaying');
-    cdLoadCurrent(true);
+    cdEnsurePlayers();
+    var it=cdItems[cdIdx]; if(!it) return;
+    var b=cdBounds(it, cdSegIdx);
+    var key=it.video_id+':'+b.start;
+    var idle=1-cdAct;
+    if(cdWarmKey[idle]===key){ cdAct=idle; }         // warm slot has it: swap
+    cdShowActive();
+    var p=cdP[cdAct]; if(!p||!p.loadVideoById) return;
+    try{
+      if(cdWarmKey[cdAct]===key){ p.seekTo(b.start,true); p.unMute(); p.playVideo(); } // <=0.3s
+      else { p.unMute(); p.loadVideoById(b.end!=null?{videoId:it.video_id,startSeconds:b.start,endSeconds:b.end}:{videoId:it.video_id,startSeconds:b.start}); }
+    }catch(e){}
+    cdWarmKey[cdAct]=null; cdEndRolled=false;
+    cdWarmInto(1-cdAct, cdIdx+1<cdItems.length?cdIdx+1:cdIdx); // keep travel-direction neighbor warm
+    cdStartPoll();
   }
-  function cdPause(){ try{ if(cdPlayer&&cdPlayer.pauseVideo) cdPlayer.pauseVideo(); }catch(e){} }
+  function cdPause(){ try{ var p=cdP[cdAct]; if(p&&p.pauseVideo) p.pauseVideo(); }catch(e){} }
   function cdToggle(){
     if(!document.body.classList.contains('cdplaying')){ cdPlay(); return; }
     try{
-      var st=cdPlayer&&cdPlayer.getPlayerState?cdPlayer.getPlayerState():-1;
-      if(st===1) cdPlayer.pauseVideo(); else cdPlayer.playVideo();
+      var p=cdP[cdAct]; var st=p&&p.getPlayerState?p.getPlayerState():-1;
+      if(st===1) p.pauseVideo(); else p.playVideo();
     }catch(e){}
   }
-  function cdNav(d){
+  // ~2s before the end, resume the warmed idle slot muted => zero-gap handoff at ended.
+  function cdStartPoll(){
+    cdStopPoll();
+    cdPollT=setInterval(function(){
+      try{
+        var p=cdP[cdAct]; if(!p||!p.getCurrentTime) return;
+        var it=cdItems[cdIdx]; if(!it) return;
+        var b=cdBounds(it, cdSegIdx);
+        var end=(b.end!=null)?b.end:(p.getDuration()||0);
+        if(!end) return;
+        var rem=end-p.getCurrentTime();
+        if(rem<2&&!cdEndRolled){
+          cdEndRolled=true;
+          var idle=1-cdAct;
+          if(cdWarmKey[idle]&&cdWarmKey[idle]!=='warming'){ try{ cdP[idle].playVideo(); }catch(e){} } // rolling start (muted)
+        }
+      }catch(e){}
+    },500);
+  }
+  function cdStopPoll(){ if(cdPollT){ clearInterval(cdPollT); cdPollT=null; } }
+  // Ended on the active slot: next section (core) or next video — swap path, no spinner.
+  function cdEnded(){
+    var it=cdItems[cdIdx]; if(!it) return;
+    var ss=cdSecs(it);
+    if(cdMode==='core'&&ss&&ss.length&&cdSegIdx<ss.length-1){
+      cdSegIdx++;
+      var b=cdBounds(it, cdSegIdx);
+      try{ cdP[cdAct].loadVideoById({videoId:it.video_id,startSeconds:b.start,endSeconds:b.end}); }catch(e){}
+      return;
+    }
+    if(cdIdx<cdItems.length-1){ cdAdvance(1,true); } else { cdStopPoll(); }
+  }
+  // Advance the deck. auto/playing => seamless swap into the warmed slot.
+  function cdAdvance(d, keepPlaying){
     var ni=cdIdx+d; if(ni<0||ni>=cdItems.length) return;
-    cdIdx=ni; cdRender();
+    cdIdx=ni; cdSegIdx=0; cdEndRolled=false;
+    cdRender();
+    if(keepPlaying||document.body.classList.contains('cdplaying')) cdPlay();
+  }
+  function cdNav(d){
+    if(document.body.classList.contains('cdplaying')){ cdAdvance(d,true); return; }
+    var ni=cdIdx+d; if(ni<0||ni>=cdItems.length) return;
+    cdIdx=ni; cdSegIdx=0; cdRender();
+    cdWarmInto(1-cdAct, cdIdx); // keep the new focus warm for an instant play tap
+  }
+  function cdSetMode(m){
+    if(cdMode===m) return;
+    cdMode=m; cdSegIdx=0; cdWarmKey=[null,null]; cdSyncModeUI();
+    if(document.body.classList.contains('cdplaying')) cdPlay(); // reload under new bounds
+    else cdWarmInto(1-cdAct, cdIdx);
   }
   // Video tab — select a mandala → continuous watch of its videos, reusing the existing beat player.
   async function openMandalaVideos(m){
@@ -2597,7 +2739,7 @@
       ptr[e.pointerId]=s; touchN++;
       if(zone==='center') centerId=e.pointerId;
       visAngle=p.a; wheel.classList.add('touching');
-      if(document.body.classList.contains('stage')||document.body.classList.contains('reading')) wheelAwake(); // 플로팅 휠 = 터치 시 표시 (e)
+      if(document.body.classList.contains('stage')||document.body.classList.contains('reading')||document.body.classList.contains('curdeck')) wheelAwake(); // 플로팅 휠 = 터치 시 표시 (e)
       // 롱프레스: MENU 길게 = 홈 (회전 없이 유지 시)
       s.holdT=setTimeout(function(){
         if(s.rotated) return;
@@ -2643,7 +2785,7 @@
         delete ptr[e.pointerId]; touchN=Math.max(0,touchN-1);
         if(touchN===0){ wheel.classList.remove('touching');
           if(navHold.active) navEnd(); // fingers up -> settle: resume (or stay paused) per start state
-          if(document.body.classList.contains('stage')||document.body.classList.contains('reading')) wheelSleep(); } // float wheel hides 3s after release
+          if(document.body.classList.contains('stage')||document.body.classList.contains('reading')||document.body.classList.contains('curdeck')) wheelSleep(); } // float wheel hides 3s after release
         kickFrame();
       });
     });
@@ -2680,6 +2822,7 @@
   var suppressClickUntil=0;
   function wheelStole(){ return Date.now()<suppressClickUntil; } // 시간창(350ms): sticky 플래그 잔류 → 후속 정상 탭 삼킴 버그 제거
   function dispatchNotch(dir){
+    if(document.body.classList.contains('curdeck')){ cdNav(dir); return; } // deck: 1 detent = 1 card
     if(cur==='home'){
       var items=homeItems(); if(!items.length) return;
       var nx=selIdx+dir;
@@ -2715,6 +2858,7 @@
     return ({menu:'home', player:'home'})[s]||null;
   }
   function menuBack(){
+    if(document.body.classList.contains('curdeck')){ closeCurationDeck(); return; } // deck MENU = back to tab
     if(cur==='login') return;
     if(curNote&&curNote.guest&&cur==='player'){ setPlaying(false); document.body.classList.remove('clipmode'); show('login'); return; } // 게스트 = 가입 유도
     var parent=screenParent(cur);
@@ -2757,18 +2901,17 @@
   (function(){ var bk=document.getElementById('ytsBack'), bd=document.getElementById('ytsBd');
     if(bk) bk.onclick=closeYtSheet; if(bd) bd.onclick=closeYtSheet; })();
   // Curation deck controls — every visible control is live (no dead controls).
+  // Wheel bindings (rotate/center/MENU) live in the EXISTING #wheel dispatcher.
   (function(){
     var g=function(id){ return document.getElementById(id); };
     if(!g('curDeck')) return;
     g('cdBack').onclick=closeCurationDeck;
-    g('cdWMenu').onclick=closeCurationDeck;
-    g('cdWPrev').onclick=function(){ cdNav(-1); };
-    g('cdWNext').onclick=function(){ cdNav(1); };
-    g('cdWCenter').onclick=cdToggle;
     g('cdPlayBtn').onclick=function(e){ e.stopPropagation(); cdPlay(); };
     g('cdPrev').onclick=function(){ cdNav(-1); };
     g('cdNext').onclick=function(){ cdNav(1); };
-    // vertical swipe on the strip = prev/next (same grammar as wheel taps)
+    g('cdModeCore').onclick=function(){ cdSetMode('core'); };
+    g('cdModeFull').onclick=function(){ cdSetMode('full'); };
+    // vertical swipe on the strip = prev/next (same grammar as wheel rotation)
     var sy=null;
     g('cdStrip').addEventListener('touchstart',function(e){ sy=e.touches[0].clientY; },{passive:true});
     g('cdStrip').addEventListener('touchend',function(e){
@@ -2788,9 +2931,12 @@
     if(cur==='menu'){ var mr=menuRows(); if(mr[selMenu]) mr[selMenu].click(); return; }
     if(cur==='player'){ setPlaying(!playing); }
   }
-  document.getElementById('bCore').onclick=function(){ if(wheelStole()) return; corePress(); };
+  document.getElementById('bCore').onclick=function(){ if(wheelStole()) return;
+    if(document.body.classList.contains('curdeck')){ cdToggle(); return; }
+    corePress(); };
   document.getElementById('bPlay').onclick=function(){
     if(wheelStole()) return;
+    if(document.body.classList.contains('curdeck')){ cdToggle(); return; }
     if(cur==='player'){ setPlaying(!playing); }
     else if(cur==='home'){ corePress(); }
   };
@@ -2825,7 +2971,7 @@
   }
   (function(){
     var wz=document.querySelector('.wheelzone'); if(!wz) return;
-    wz.addEventListener('pointerdown',function(){ if(document.body.classList.contains('stage')) wheelAwake(); });
+    wz.addEventListener('pointerdown',function(){ if(document.body.classList.contains('stage')||document.body.classList.contains('curdeck')) wheelAwake(); });
     ['pointerup','pointercancel'].forEach(function(ev){
       wz.addEventListener(ev,function(){ if(document.body.classList.contains('stage')) wheelSleep(); });
     });


### PR DESCRIPTION
## B. Mockup parity (supervisor-reviewed; numeric contract in spec comments)
- All **three cards fully visible**: prev 24 / focus 42 / next 24 of the strip.
- Compact one-line meta on the poster only (no duplicate title over the embed's
  own header).
- **Relevance wave always visible** inside the focus card (playing included).
- **core/full toggle** in the header — core plays rich-summary sections
  sequentially; videos without sections disable the toggle (honest state).
- Bespoke mini wheel **removed** — the jog wheel is the existing `#wheel` in a
  floating-mini mode (reading/stage pattern): rotate = 1 detent 1 card,
  center = play/pause, MENU = back. One dispatcher, no duplicated gesture code.

## C'. Seamless consumption (target ≤ 0.3s, benchmark = YouTube app)
- **Dual-player warm pre-roll**: `cueVideoById` does not buffer media, so the
  idle slot warms via mute → play → (PLAYING) → pause; advance = swap + seek +
  unmute.
- ~2s before ended, the idle slot resumes muted → **zero-gap auto-advance**.
- First video warms on deck open (inside the row-tap gesture).
- iOS/low-power fallback: warm play that never reaches PLAYING quietly cues
  (poster stays, no spinner) — this path was exercised end-to-end locally.
- Beat-player pair released on deck entry (memory; supervisor caveat).

## Verification (local browser 400x860)
3-card layout inside viewport (172/300/172 px), dual players created,
onReady-parked warm requests, playback enter, nav swap path, 500ms end-roll
poll, toggle disable state, wave render. JS parse OK.

**Device pass (James):** transition feel (≤0.3s swap / zero-gap ended),
core/full toggle, wheel rotate/center/MENU in deck, landscape fullscreen.
**Observation item:** whether muted warm play pollutes YouTube watch history
(supervisor: record as trade-off if seen — James decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)