### PR TITLE
feat(curation): watched_at — cross-device row meta (DDL) [James gate]

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -1873,7 +1873,8 @@
       else { p.unMute(); p.loadVideoById({videoId:it.video_id}); }
     }catch(e){}
     cdWarmKey[cdAct]=null; cdEndRolled=false;
-    // watch marking (server-side) wires in with the watched_at DDL (James gate); cdCtx kept.
+    // server-side watch mark (cross-device row meta) — fire-and-forget, idempotent
+    if(cdCtx&&cdCtx.subId){ api('/curations/'+cdCtx.subId+'/items/'+it.video_id+'/watched',{method:'PATCH'}).catch(function(){}); }
     cdWarmInto(1-cdAct, cdIdx+1<cdItems.length?cdIdx+1:cdIdx); // keep travel-direction neighbor warm
     cdStartPoll();
   }

--- a/prisma/migrations/curation-watched/001_watched_at.sql
+++ b/prisma/migrations/curation-watched/001_watched_at.sql
@@ -1,0 +1,6 @@
+-- Curation watch mark (redesign contract v1, P1.5 — James gate 2026-07-21).
+-- Derived-only column: NULL = unwatched this week. Same-week rebuilds preserve
+-- watched_at for retained video_ids; a new week's rows are born NULL (natural
+-- weekly reset). Reversible: DROP COLUMN restores the prior shape.
+ALTER TABLE public.curation_items
+  ADD COLUMN IF NOT EXISTS watched_at timestamptz NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -675,6 +675,12 @@ model curation_items {
   /// 0-based rank within the week's build (relevance order)
   position        Int
   bookmarked_at   DateTime?              @db.Timestamptz(6)
+  /// Derived-only watch mark (write-guard type (a): original fields untouched).
+  /// Set when playback of this item starts in the deck; NULL = unwatched.
+  /// Same-week rebuild PRESERVES watched_at for retained video_ids (see
+  /// curation-build); a NEW week's rows are born NULL = natural weekly reset.
+  /// Raw SQL DDL: prisma/migrations/curation-watched/001_watched_at.sql
+  watched_at      DateTime?              @db.Timestamptz(6)
   /// which weekly build this row belongs to (snapshot key)
   week_of         DateTime               @db.Date
   added_at        DateTime               @default(now()) @db.Timestamptz(6)

--- a/src/api/routes/curations.ts
+++ b/src/api/routes/curations.ts
@@ -175,6 +175,17 @@ export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       where: { subscription_id: { in: deduped.map((r) => r.id) } },
       _count: { video_id: true },
     });
+    const watched = await prisma.curation_items.groupBy({
+      by: ['subscription_id', 'week_of'],
+      where: { subscription_id: { in: deduped.map((r) => r.id) }, watched_at: { not: null } },
+      _count: { video_id: true },
+    });
+    const watchedBy = new Map(
+      watched.map((w) => [
+        w.subscription_id + ':' + w.week_of.toISOString().slice(0, 10),
+        w._count.video_id,
+      ])
+    );
     const latest = new Map<string, { week: string; count: number }>();
     for (const c of counts) {
       const wk = c.week_of.toISOString().slice(0, 10);
@@ -182,11 +193,15 @@ export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       if (!cur || wk > cur.week)
         latest.set(c.subscription_id, { week: wk, count: c._count.video_id });
     }
-    const withCounts = deduped.map((r) => ({
-      ...r,
-      week_of: latest.get(r.id)?.week ?? null,
-      item_count: latest.get(r.id)?.count ?? 0,
-    }));
+    const withCounts = deduped.map((r) => {
+      const l = latest.get(r.id);
+      return {
+        ...r,
+        week_of: l?.week ?? null,
+        item_count: l?.count ?? 0,
+        watched_count: l ? (watchedBy.get(r.id + ':' + l.week) ?? 0) : 0,
+      };
+    });
     return reply.send({ status: 'ok', data: { curations: withCounts } });
   });
 
@@ -260,6 +275,37 @@ export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         status: 'ok',
         data: { week_of: weekOf.toISOString().slice(0, 10), items: enriched },
       });
+    }
+  );
+
+  /**
+   * PATCH /curations/:id/items/:videoId/watched — mark this week's item watched
+   * (watched_at=now, idempotent: an existing mark is kept). Ownership-checked.
+   */
+  fastify.patch<{ Params: { id: string; videoId: string } }>(
+    '/:id/items/:videoId/watched',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      if (!request.user || !('userId' in request.user)) {
+        return reply.code(401).send({ status: 'error', code: 'UNAUTHORIZED' });
+      }
+      const prisma = getPrismaClient();
+      const sub = await prisma.curation_subscriptions.findUnique({
+        where: { id: request.params.id },
+        select: { user_id: true },
+      });
+      if (!sub || sub.user_id !== request.user.userId) {
+        return reply.code(404).send({ status: 'error', code: 'CURATION_NOT_FOUND' });
+      }
+      const updated = await prisma.curation_items.updateMany({
+        where: {
+          subscription_id: request.params.id,
+          video_id: request.params.videoId,
+          watched_at: null,
+        },
+        data: { watched_at: new Date() },
+      });
+      return reply.send({ status: 'ok', data: { marked: updated.count > 0 } });
     }
   );
 

--- a/src/modules/queue/handlers/curation-build.ts
+++ b/src/modules/queue/handlers/curation-build.ts
@@ -140,7 +140,18 @@ export async function registerCurationBuildWorker(): Promise<void> {
 
     // build-5 — snapshot this week's items. Replace THIS week only (idempotent
     // re-run); prior weeks are kept (data-reversibility). No mandala_books touched.
+    // Same-week rebuild PRESERVES watched_at for retained video_ids (supervisor
+    // caveat: delete-recreate must not turn "in progress" back into "new") — a
+    // NEW week's rows are born NULL, which is the intended weekly reset.
     const weekDate = new Date(weekOf);
+    const prevWatched = new Map(
+      (
+        await prisma.curation_items.findMany({
+          where: { subscription_id: subscriptionId, week_of: weekDate, watched_at: { not: null } },
+          select: { video_id: true, watched_at: true },
+        })
+      ).map((r) => [r.video_id, r.watched_at])
+    );
     await prisma.$transaction([
       prisma.curation_items.deleteMany({
         where: { subscription_id: subscriptionId, week_of: weekDate },
@@ -154,6 +165,7 @@ export async function registerCurationBuildWorker(): Promise<void> {
                 relevance_pct: p.relevancePct,
                 position: i,
                 week_of: weekDate,
+                watched_at: prevWatched.get(p.videoId) ?? null,
               })),
             }),
           ]


### PR DESCRIPTION
## What (James-approved DDL gate — "go")
`curation_items.watched_at timestamptz NULL` — the watch mark that completes
the lineup row meta (**M/N listened / weekly complete**), cross-device.

## Preservation policy (supervisor caveat, stated explicitly)
- **Same-week rebuild preserves `watched_at`** for retained `video_id`s (the
  build reads existing marks before delete-recreate and carries them over) —
  "in progress" never turns back into "new".
- A **new week's rows are born NULL** = the intended weekly reset.

## Changes
- Raw SQL DDL: `prisma/migrations/curation-watched/001_watched_at.sql`
  (force-added per manual-DDL convention). **Applied + verified on local DB
  first** (`\d` confirms) per DB work order; prod applies via the deploy
  pipeline's schema sync.
- Prisma schema + build-worker preservation.
- `PATCH /curations/:id/items/:videoId/watched` (idempotent, ownership-checked).
- `GET /curations` returns `watched_count`; the FE row meta is already
  forward-compatible and activates M/N + complete automatically.
- FE deck marks watch on play start (fire-and-forget).

## Rejected alternatives (recorded)
localStorage (per-device drift breaks lineup trust); `UserVideoState` reuse
(`videoId` is an internal UUID — forcing `youtube_videos` rows would leak
cards across surfaces).

## Verification
Local DDL applied + `\d` verified; `tsc` 0; lint clean; JS parse OK.
Post-deploy: prod `\d` check via deploy verify step + device pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)