### PR TITLE
fix(deploy): allowlist curation-watched DDL in apply-custom-sql

### DIFF
--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -197,6 +197,9 @@ APPLY_FILES=(
   # IF NOT EXISTS + NOTIFY pgrst — fully idempotent.
   "prisma/migrations/curation/001_create_curation_tables.sql"
   "prisma/migrations/curation/002_curation_personalization.sql"
+  # curation-watched (2026-07-21): watched_at derived-only column for lineup row
+  # meta (M/N listened / weekly complete). ADD COLUMN IF NOT EXISTS = idempotent.
+  "prisma/migrations/curation-watched/001_watched_at.sql"
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "


### PR DESCRIPTION
The watched_at DDL (#1308) merged but `apply-custom-sql.sh` uses a strict allowlist and the new file was not registered — prod check confirmed the column missing. This registers `prisma/migrations/curation-watched/001_watched_at.sql` (ADD COLUMN IF NOT EXISTS = idempotent). Post-deploy prod verification will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)