### PR TITLE
hotfix(curation): remove stale cdPrev wiring — prod boot crash

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -2996,8 +2996,8 @@
     g('cdFinList').onclick=closeCurationDeck;                    // D4: back to the lineup
     g('cdFinReplay').onclick=function(){ document.body.classList.remove('cdfin'); cdIdx=0; cdRender(); cdPlay(); };
     g('cdPlayBtn').onclick=function(e){ e.stopPropagation(); cdPlay(); };
-    g('cdPrev').onclick=function(){ cdNav(-1); };
     g('cdNext').onclick=function(){ cdNav(1); };
+    g('cdNext2').onclick=function(){ cdNav(2); };
     // vertical swipe on the strip = prev/next (same grammar as wheel rotation)
     var sy=null;
     g('cdStrip').addEventListener('touchstart',function(e){ sy=e.touches[0].clientY; },{passive:true});


### PR DESCRIPTION
Prod incident (James-reported: mobile page dead). P2 removed the cdPrev element but its onclick wiring survived → TypeError on null at boot killed the top-level script (all later wiring + boot IIFE). Fix: wire cdNext/cdNext2. Verified: full-boot console 0, booted flag set, post-crash-site wiring alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)