### PR TITLE
fix(curation): cache-first list render — no skeleton on tab re-entry

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -1532,24 +1532,35 @@
      the same text rows as the video/note tabs. Row tap opens the EXISTING week (GET
      items -> deck) — never a rebuild. Proposals live only in the connect-sheet wizard
      (first curation / "+ new"). Model fix per James + supervisor A. */
+  // Cache-first render: tab re-entry paints the last known list INSTANTLY (no
+  // skeleton) and revalidates in the background; the list only re-renders when
+  // the signature actually changed. Skeleton shows on the cold first load only.
+  var curCache=null, curRenderedSig='';
+  function curSig(subs){ return JSON.stringify((subs||[]).map(function(s){ return [s.id,s.item_count,s.watched_count,s.last_run_at,s.next_run_at,s.topic]; })); }
+  function curPaint(subs){ var sig=curSig(subs); if(sig===curRenderedSig&&Array.isArray(subs)) return; renderCurationRows(subs); curRenderedSig=sig; }
   async function renderCuration(){
     var el=document.getElementById('curBody'); if(!el) return;
-    curRowEls=[]; // non-row states (gate/skeleton/error) must not keep stale wheel targets
-    // T3 — row skeletons while loading (existing skeleton pattern)
-    el.className='cur-body';
-    el.innerHTML='<div class="rows"><div class="skrow"><span class="sk skj"></span><span class="skm"><span class="sk" style="width:62%;height:13px"></span><span class="sk" style="width:36%;height:10px"></span></span></div><div class="skrow"><span class="sk skj"></span><span class="skm"><span class="sk" style="width:62%;height:13px"></span><span class="sk" style="width:36%;height:10px"></span></span></div></div>';
+    var haveCache=Array.isArray(curCache);
+    if(haveCache){
+      curPaint(curCache); // instant — no skeleton on re-entry / revalidate
+    } else {
+      curRowEls=[]; curRenderedSig=''; // cold: skeleton, and drop stale wheel targets
+      el.className='cur-body';
+      el.innerHTML='<div class="rows"><div class="skrow"><span class="sk skj"></span><span class="skm"><span class="sk" style="width:62%;height:13px"></span><span class="sk" style="width:36%;height:10px"></span></span></div><div class="skrow"><span class="sk skj"></span><span class="skm"><span class="sk" style="width:62%;height:13px"></span><span class="sk" style="width:36%;height:10px"></span></span></div></div>';
+    }
     try{
       var r=await api('/curations');
       var j=await r.json();
       var subs=(j&&j.data&&j.data.curations)||[];
-      if(subs.length){ renderCurationRows(subs); return; }
+      if(subs.length){ curCache=subs; curPaint(subs); return; }
       // no curations yet: connected -> proposal wizard for the first one; else connect gate
       var st=await ytFetchStatus();
       if(st&&st.isConnected){
-        renderCurationRows([]);
+        curCache=[]; curPaint([]);
         if(!ytAutoRaised){ ytAutoRaised=true; openYtSheet(); ytRenderTuning(); }
-      } else curConnectGate();
+      } else { curCache=null; curRenderedSig=''; curConnectGate(); }
     }catch(e){
+      if(haveCache) return; // revalidate failure: keep the cached rows on screen
       if(e&&(e.status===401||e.status===403)){ curConnectGate(); return; }
       // T4 — inline one-liner + retry (no full-screen error)
       el.innerHTML='<div class="rows"><div class="row-empty">편성표를 불러오지 못했어요<br><button class="yts-ghost" id="curRetry" style="margin-top:6px">다시 시도</button></div></div>';
@@ -1630,8 +1641,10 @@
     b.onclick=function(ev){
       ev.stopPropagation();
       b.disabled=true; b.textContent='끊는 중…';
-      api('/curations/'+s.id,{method:'DELETE'}).then(function(){ renderCuration(); })
-        .catch(function(){ toast('끊지 못했어요 — 다시 시도해주세요'); renderCuration(); });
+      api('/curations/'+s.id,{method:'DELETE'}).then(function(){
+        if(Array.isArray(curCache)) curCache=curCache.filter(function(x){ return x.id!==s.id; }); // optimistic: no deleted-row flash
+        renderCuration();
+      }).catch(function(){ toast('끊지 못했어요 — 다시 시도해주세요'); renderCuration(); });
     };
     setTimeout(function(){ if(!b.disabled){ renderCuration(); } },4000); // auto-revert
   }


### PR DESCRIPTION
## Problem (on-device, James)
Entering the curation tab from the video/note tab re-fetched the list and flashed the loading skeleton every single time.

## Root cause
`setHomeTab('curation')` (and the menuBack/goHome home-return paths) called `renderCuration()` unconditionally, which always cleared to the skeleton then fetched `/curations`.

## Fix — cache-first render
- The last successful list is cached; re-entry paints those rows INSTANTLY (no skeleton) and revalidates `/curations` silently in the background.
- The list only re-renders when a content signature (id, item_count, watched_count, last_run_at, next_run_at, topic) actually changes — no rebuild/flicker on the common unchanged case.
- Skeleton shows on the cold first load only; a revalidate failure keeps the cached rows on screen instead of erroring over good data.
- Unsubscribe removes the row from the cache optimistically to avoid a deleted-row flash.

The silent revalidate is retained deliberately so watched-state meta ("14/20 들음") refreshes after the deck updates it.

## Verification
- node --check both scripts: pass; full-boot console 0
- In-page probe with a stubbed API: cold = 1 fetch + rows painted, no lingering skeleton; re-entry = rows stay, signature stable → zero re-render, skeleton never shown; third entry identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)
