### PR TITLE
feat(mobile): video-tab ambient background (curation+video parity, note excluded)

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -175,6 +175,10 @@
      behind the (translucent) row cards to fill the list and cue selection. */
   #paneCuration{position:relative}
   #paneCuration>.cur-body{position:relative; z-index:1}
+  /* Video tab shares the same ambient (curation+video only; NOT note — a note is
+     a different consumption unit, so a focused-mandala color has no subject there). */
+  #paneVideo{position:relative}
+  #paneVideo>.goal-pill,#paneVideo>.rows{position:relative; z-index:1}
   .cur-amb{position:absolute; inset:-20px -20px 0; z-index:0; pointer-events:none; opacity:0;
     background-repeat:no-repeat; transition:opacity .55s var(--soft), background-image .55s var(--soft)}
   .cur-amb.on{opacity:1}
@@ -1116,6 +1120,7 @@
               <div class="cur-body" id="curBody"><div class="skrow"><span class="sk skj"></span><span class="skm"><span class="sk" style="width:62%;height:13px"></span><span class="sk" style="width:36%;height:10px"></span></span></div><div class="skrow"><span class="sk skj"></span><span class="skm"><span class="sk" style="width:62%;height:13px"></span><span class="sk" style="width:36%;height:10px"></span></span></div></div>
             </div>
             <div class="hpane" id="paneVideo">
+              <div class="cur-amb" id="vidAmb" aria-hidden="true"></div>
               <button class="goal-pill" id="bGoal"><span class="gp-plus"></span>원하는 목표 적기</button>
               <div class="rows" id="rowsV"></div>
             </div>
@@ -1589,8 +1594,17 @@
   function renderRows(){
     paintMandalaList(document.getElementById('rowsV'),'video');
     paintMandalaList(document.getElementById('rowsN'),'note');
+    setVideoAmbient();
     var active=document.getElementById(homeTab==='note'?'rowsN':'rowsV');
     var selEl=active&&active.children[selIdx]; if(selEl&&selEl.scrollIntoView) selEl.scrollIntoView({block:'nearest'});
+  }
+  // Ambient for the VIDEO tab only — the focused mandala's topic color (same
+  // pattern/values as curation). Bound to the #paneVideo DOM, so note never gets it.
+  function setVideoAmbient(){
+    var amb=document.getElementById('vidAmb'); if(!amb) return;
+    var m=homeItems()[selIdx];
+    if(m){ var c=jkColor(m.title||'?'); amb.style.backgroundImage='radial-gradient(140% 78% at 50% -6%, '+hexA(c[0],.42)+', '+hexA(c[1],.16)+' 48%, transparent 90%)'; amb.classList.add('on'); }
+    else amb.classList.remove('on');
   }
   /* ============ Home tabs (curation / video / note) [J:07-20] ============ */
   var homeTab='curation';   // default (James)
@@ -3308,6 +3322,7 @@
     for(var i=0;i<rows.children.length;i++) rows.children[i].classList.toggle('sel', i===selIdx);
     var el=rows.children[selIdx];
     if(el&&el.scrollIntoView) el.scrollIntoView({block:'nearest', behavior:reduce?'auto':'smooth'});
+    setVideoAmbient(); // wheel selection moves the mandala focus -> update the video ambient color
   }
   var suppressClickUntil=0;
   function wheelStole(){ return Date.now()<suppressClickUntil; } // 시간창(350ms): sticky 플래그 잔류 → 후속 정상 탭 삼킴 버그 제거


### PR DESCRIPTION
## Video-tab ambient (curation+video parity, note excluded) — supervisor-confirmed

James: apply the curation ambient to the video tab too. Note is excluded (a note is a different consumption unit — a focused-mandala color has no subject there; James rejected note directly).

- The video tab's mandala list gets the same focused-row topic-color ambient as curation (same radial pattern + brightened .42/.16 values), driven by the focused mandala's `jkColor(title)`.
- The ambient layer (`#vidAmb`) lives in the `#paneVideo` DOM ONLY — the note panel has no ambient layer, so there is no "not note" branch (per the supervisor's caution: bind to the video panel, don't condition on "not note"). Color follows the focused mandala; the radial stays top-anchored.

## Verification
- node --check pass; full-boot console 0; comments English-only
- Probe: `#vidAmb` present + on; color follows selIdx (운동 #9A7A38 distinct from ai/파이썬 #7C5077 — jkColor's 6-palette collisions are expected); `#paneNote` has NO ambient; paneVideo position:relative, rows z-index:1

## Done = James device
Sliding to the video tab shows the focused mandala's color as a subtle ambient (same feel as curation); note stays plain.
