### PR TITLE
fix(curation): kill deck ghost audio (nav pauses all slots, single audio owner)

### DIFF
--- a/frontend/public/mobile/index.html
+++ b/frontend/public/mobile/index.html
@@ -2216,6 +2216,7 @@
     var idle=1-cdAct;
     if(cdWarmKey[idle]===key){ cdAct=idle; }         // warm slot has it: swap
     cdShowActive();
+    try{ var q=cdP[1-cdAct]; if(q&&q.pauseVideo) q.pauseVideo(); }catch(e){} // single audio owner: silence the slot we just left
     var p=cdP[cdAct]; if(!p||!p.loadVideoById) return;
     // A1 state machine: load (+ dark veil) ONLY on a true cold slot. A warm-buffered
     // or already-loaded slot just plays — no cdloading veil, so no black flicker on
@@ -2232,7 +2233,11 @@
     cdWarmInto(1-cdAct, cdIdx+1<cdItems.length?cdIdx+1:cdIdx); // keep travel-direction neighbor warm
     cdStartPoll();
   }
-  function cdPause(){ try{ var p=cdP[cdAct]; if(p&&p.pauseVideo) p.pauseVideo(); }catch(e){} }
+  // Nav freeze = pause EVERY slot, not just the active one. Playback focus can sit on a
+  // slot cdAct does not point to (end-of-video rolling-start plays the idle slot; a warm-swap
+  // moves cdAct while the old slot's pauseVideo() is still in flight on iOS). Pausing only
+  // cdAct let the other slot keep sounding under the hidden stage = the "ghost". Freeze both.
+  function cdPause(){ [0,1].forEach(function(i){ try{ var p=cdP[i]; if(p&&p.pauseVideo) p.pauseVideo(); }catch(e){} }); }
   function cdToggle(){
     if(!document.body.classList.contains('cdplaying')){ cdPlay(); return; }
     try{


### PR DESCRIPTION
## Kill deck ghost audio — nav pauses all slots + single audio owner (supervisor GO)

Device (James): turning the wheel to a new card hid the video on screen but the previous video kept playing underneath (ghost); focus never moved to the newly-selected card. Finger swipe worked, the wheel did not.

### Root cause
The deck runs two YouTube slots (`cdP[0]`/`cdP[1]`). `cdPause()` — the nav-entry freeze — paused only `cdAct`. But the *sounding* slot can differ from `cdAct`: the end-of-video rolling-start plays the idle slot, and a warm-swap moves `cdAct` while the old slot's `pauseVideo()` is still in flight on iOS. Whenever the sounding slot ≠ `cdAct`, nav pause missed it and the old audio survived under the `opacity:0` stage.

### Fix (two invariants)
- **Nav freeze pauses EVERY slot**, not just `cdAct` — "while browsing, nothing plays."
- **cdPlay silences the slot it just left** after the warm-swap, so exactly one player ever owns audio. The idle slot is then re-warmed muted, as before.

## Verification
- JS parse OK; boot console 0; comments English-only
- Nav-freeze probe: `cdPause()` pauses both slots (s0 + s1)
- Settle call order (spied): `old:pause → new:play → old:reload(muted)` — the old audio is killed before the slot is re-warmed muted; single audible owner throughout

## Done = James device (supervisor checklist)
1) repeated wheel taps → audio always exactly one (ghost gone), 2) card snap-lands with no straddling (motion #1329), 3) 70% commit feel.
