### PR TITLE
feat(quota): raise tier limits — cards 300/2000, richSummaries 50/1000

### DIFF
--- a/src/config/quota.ts
+++ b/src/config/quota.ts
@@ -78,9 +78,9 @@ export interface TierLimitConfig {
 export const TIER_LIMITS: Record<Tier, TierLimitConfig> = {
   free: {
     mandalas: 3,
-    cards: 150,
+    cards: 300,
     aiSummaries: 150,
-    richSummaries: 30,
+    richSummaries: 50,
     weeklyReports: 10,
     skills: {
       newsletter: {
@@ -117,9 +117,9 @@ export const TIER_LIMITS: Record<Tier, TierLimitConfig> = {
   },
   pro: {
     mandalas: 20,
-    cards: 1_000,
+    cards: 2_000,
     aiSummaries: 1_000,
-    richSummaries: 200,
+    richSummaries: 1_000,
     weeklyReports: null,
     skills: {
       newsletter: {

--- a/src/modules/skills/rich-summary-quota.ts
+++ b/src/modules/skills/rich-summary-quota.ts
@@ -2,8 +2,8 @@
  * Rich Summary quota (CP423).
  *
  * Per-tier monthly limits for rich summary generation:
- *   free      → 30 / month
- *   pro       → 200 / month
+ *   free      → 50 / month
+ *   pro       → 1000 / month
  *   lifetime  → unlimited
  *   admin     → unlimited
  *

--- a/tests/smoke/billing/plan-catalog.test.ts
+++ b/tests/smoke/billing/plan-catalog.test.ts
@@ -20,7 +20,7 @@ describe('plan-catalog', () => {
     expect(found).not.toBeNull();
     expect(found?.planCode).toBe('pro_monthly');
     expect(found?.tier).toBe('pro');
-    expect(found?.cardLimit).toBe(1000);
+    expect(found?.cardLimit).toBe(2000);
     expect(found?.mandalaLimit).toBe(20);
   });
 
@@ -30,7 +30,7 @@ describe('plan-catalog', () => {
     expect(found).not.toBeNull();
     expect(found?.planCode).toBe('pro_yearly');
     expect(found?.tier).toBe('pro');
-    expect(found?.cardLimit).toBe(1000);
+    expect(found?.cardLimit).toBe(2000);
     expect(found?.mandalaLimit).toBe(20);
   });
 

--- a/tests/unit/modules/rich-summary-quota.test.ts
+++ b/tests/unit/modules/rich-summary-quota.test.ts
@@ -29,11 +29,11 @@ function mockPrisma(opts: { tier?: string | null | undefined; usedThisMonth: num
 }
 
 describe('TIER_LIMITS.richSummaries values (CP423 spec)', () => {
-  it('free = 30', () => {
-    expect(TIER_LIMITS.free.richSummaries).toBe(30);
+  it('free = 50', () => {
+    expect(TIER_LIMITS.free.richSummaries).toBe(50);
   });
-  it('pro = 200', () => {
-    expect(TIER_LIMITS.pro.richSummaries).toBe(200);
+  it('pro = 1000', () => {
+    expect(TIER_LIMITS.pro.richSummaries).toBe(1_000);
   });
   it('lifetime = unlimited (null)', () => {
     expect(TIER_LIMITS.lifetime.richSummaries).toBeNull();
@@ -46,27 +46,27 @@ describe('TIER_LIMITS.richSummaries values (CP423 spec)', () => {
 describe('assertRichSummaryQuota', () => {
   const uid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 
-  it('free tier: passes when used=29 (under limit 30)', async () => {
-    const p = mockPrisma({ tier: 'free', usedThisMonth: 29 });
+  it('free tier: passes when used=49 (under limit 50)', async () => {
+    const p = mockPrisma({ tier: 'free', usedThisMonth: 49 });
     const r = await assertRichSummaryQuota(p as any, uid);
-    expect(r).toEqual({ tier: 'free', used: 29, limit: 30 });
+    expect(r).toEqual({ tier: 'free', used: 49, limit: 50 });
   });
 
-  it('free tier: throws at used=30 (at limit)', async () => {
-    const p = mockPrisma({ tier: 'free', usedThisMonth: 30 });
+  it('free tier: throws at used=50 (at limit)', async () => {
+    const p = mockPrisma({ tier: 'free', usedThisMonth: 50 });
     await expect(assertRichSummaryQuota(p as any, uid)).rejects.toThrow(
       RichSummaryQuotaExceededError
     );
   });
 
-  it('pro tier: passes at used=199', async () => {
-    const p = mockPrisma({ tier: 'pro', usedThisMonth: 199 });
+  it('pro tier: passes at used=999', async () => {
+    const p = mockPrisma({ tier: 'pro', usedThisMonth: 999 });
     const r = await assertRichSummaryQuota(p as any, uid);
-    expect(r).toEqual({ tier: 'pro', used: 199, limit: 200 });
+    expect(r).toEqual({ tier: 'pro', used: 999, limit: 1_000 });
   });
 
-  it('pro tier: throws at used=200', async () => {
-    const p = mockPrisma({ tier: 'pro', usedThisMonth: 200 });
+  it('pro tier: throws at used=1000', async () => {
+    const p = mockPrisma({ tier: 'pro', usedThisMonth: 1_000 });
     await expect(assertRichSummaryQuota(p as any, uid)).rejects.toThrow(
       RichSummaryQuotaExceededError
     );
@@ -90,7 +90,7 @@ describe('assertRichSummaryQuota', () => {
     const p = mockPrisma({ tier: undefined, usedThisMonth: 5 });
     const r = await assertRichSummaryQuota(p as any, uid);
     expect(r.tier).toBe('free');
-    expect(r.limit).toBe(30);
+    expect(r.limit).toBe(50);
   });
 
   it('defaults to free when tier column is null', async () => {
@@ -106,7 +106,7 @@ describe('assertRichSummaryQuota', () => {
   });
 
   it('thrown error carries tier/used/limit in details', async () => {
-    const p = mockPrisma({ tier: 'free', usedThisMonth: 30 });
+    const p = mockPrisma({ tier: 'free', usedThisMonth: 50 });
     try {
       await assertRichSummaryQuota(p as any, uid);
       fail('expected throw');
@@ -114,7 +114,7 @@ describe('assertRichSummaryQuota', () => {
       const e = err as RichSummaryQuotaExceededError;
       expect(e.code).toBe('RICH_SUMMARY_QUOTA_EXCEEDED');
       expect(e.statusCode).toBe(429);
-      expect(e.details).toMatchObject({ userId: uid, tier: 'free', used: 30, limit: 30 });
+      expect(e.details).toMatchObject({ userId: uid, tier: 'free', used: 50, limit: 50 });
     }
   });
 });

--- a/tests/unit/modules/skill-schema.test.ts
+++ b/tests/unit/modules/skill-schema.test.ts
@@ -95,9 +95,9 @@ describe('TIER_LIMITS.skills', () => {
 
   it('existing resource limits are unchanged', () => {
     expect(TIER_LIMITS.free.mandalas).toBe(3);
-    expect(TIER_LIMITS.free.cards).toBe(150);
+    expect(TIER_LIMITS.free.cards).toBe(300);
     expect(TIER_LIMITS.pro.mandalas).toBe(20);
-    expect(TIER_LIMITS.pro.cards).toBe(1_000);
+    expect(TIER_LIMITS.pro.cards).toBe(2_000);
     expect(TIER_LIMITS.lifetime.mandalas).toBeNull();
     expect(TIER_LIMITS.admin.cards).toBeNull();
   });


### PR DESCRIPTION
James-approved tier/cost structure (2026-07-23).

## 변경 (quota.ts — 집행 SSOT)
| | Free | Pro | Lifetime |
|---|---|---|---|
| cards | 150 → **300** | 1,000 → **2,000** | ∞ (유지) |
| richSummaries/월 | 30 → **50** | 200 → **1,000** | ∞ (유지) |
| mandalas | 3 (유지) | 20 (유지) | ∞ |

- **mandalas 유지**: "총 25(일반20+큐레이션5)"의 큐레이션 별도 카운트는 코드에 아직 없음(진행 중 curation 기능은 UI/UX). 이 config 변경 범위 밖 → 수동 3/20 유지.

## 비용 모델 (근거)
- rich-summary **캐시 히트는 quota 카운트 X + 비용 $0** (풀 재사용, `rich-summary-quota.ts` short-circuit).
- 실측 순생성 비용 = **$0.052/summary** (prod `llm_call_logs`, Sonnet). 상한 = 어뷰징 천장. 총비용은 풀 히트율(잘 설계된 주제 유도 + 주간 분석) + 모델 swap(`RICH_SUMMARY_V2_MODEL` env)으로 관리.

## 검증
- backend tsc clean · 관련 테스트 28/28 pass (rich-summary-quota 시나리오 새 한도로 갱신, skill-schema, pro-upgrade-email).

## 범위 밖 (follow-up)
- 죽은 config(aiSummaries/weeklyReports — 집행 0) 제거: trivial cleanup.
- 가격 카피(ko/en.json) 정합: 큐레이션 총량 확정 + James 문구 검수 후.
- 큐레이션 만다라 별도 한도(Free1/Pro5): curation 기능 트랙에서 배선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)