### PR TITLE
feat(curation): put the weekly schedule on the KST calendar (flag-gated)

### DIFF
--- a/prisma/migrations/curation-weekday/001_weekday.sql
+++ b/prisma/migrations/curation-weekday/001_weekday.sql
@@ -1,0 +1,18 @@
+-- Weekly curation delivery weekday (KST), 2026-07-27.
+--
+-- `prisma db push` silently drops new columns on this Supabase project, so the
+-- DDL is authored here and applied by hand (local + prod) before the code merges.
+-- Applied to prod 2026-07-27 02:28Z; verified: column present, 25/25 rows weekday=1.
+--
+-- Additive and reversible: 0=Sun..6=Sat, default 1 (Monday) reproduces the
+-- delivery day every existing subscription already promised.
+-- Rollback: ALTER TABLE public.curation_subscriptions DROP COLUMN weekday;
+
+ALTER TABLE public.curation_subscriptions
+  ADD COLUMN IF NOT EXISTS weekday smallint NOT NULL DEFAULT 1;
+
+CREATE INDEX IF NOT EXISTS idx_curation_subscriptions_weekday
+  ON public.curation_subscriptions (weekday);
+
+-- PostgREST caches the schema; without this it keeps dropping the new column.
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -650,6 +650,9 @@ model curation_subscriptions {
   /// optional container mandala (kind='curation') if D1(a) is later chosen; null = standalone
   mandala_id  String?          @db.Uuid
   is_active   Boolean          @default(true)
+  /// KST delivery weekday, 0=Sun..6=Sat. Default 1 (Monday) = the shipped promise.
+  /// Raw SQL DDL: prisma/migrations/curation-weekday/001_weekday.sql (applied to prod 2026-07-27).
+  weekday     Int              @default(1) @db.SmallInt
   next_run_at DateTime?        @db.Timestamptz(6)
   last_run_at DateTime?        @db.Timestamptz(6)
   created_at  DateTime         @default(now()) @db.Timestamptz(6)

--- a/src/api/routes/curations.ts
+++ b/src/api/routes/curations.ts
@@ -19,15 +19,13 @@ import { MS_PER_DAY } from '../../utils/time-constants';
 import { suggestTopics } from '../../modules/curation/suggest';
 import { maybeTriggerProfileBuild } from '../../modules/curation/interest-profile';
 import { getAccessToken } from '../../modules/youtube/api';
+import { curationWeekKey } from '../../modules/queue/handlers/curation-weekly';
+import { isValidWeekday, nextKstWeekdayAt } from '../../utils/kst';
+import { QUEUE_CONFIG } from '../../modules/queue/types';
 
-/** ISO date (YYYY-MM-DD) of this week's Monday — curation_items.week_of key. */
-function mondayOf(d: Date): string {
-  const day = d.getUTCDay();
-  const diff = (day === 0 ? -6 : 1) - day;
-  const mon = new Date(d);
-  mon.setUTCDate(d.getUTCDate() + diff);
-  return mon.toISOString().slice(0, 10);
-}
+/** This week's snapshot key. Single source (was duplicated here and in the
+ *  weekly handler); resolves on the KST calendar once the schedule flag is on. */
+const mondayOf = (d: Date): string => curationWeekKey(d);
 
 const ALLOWED_SOURCES = new Set(['discover', 'youtube_subs', 'hybrid']);
 
@@ -157,7 +155,14 @@ export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     const rows = await prisma.curation_subscriptions.findMany({
       where: { user_id: request.user.userId, is_active: true },
       orderBy: { created_at: 'desc' },
-      select: { id: true, topic: true, source: true, last_run_at: true, next_run_at: true },
+      select: {
+        id: true,
+        topic: true,
+        source: true,
+        weekday: true,
+        last_run_at: true,
+        next_run_at: true,
+      },
     });
     // Display-dedup by normalized topic (newest wins) — legacy duplicate rows stay in
     // the DB untouched (reversible); POST now prevents new ones.
@@ -308,6 +313,41 @@ export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         data: { watched_at: new Date() },
       });
       return reply.send({ status: 'ok', data: { marked: updated.count > 0 } });
+    }
+  );
+
+  /**
+   * PATCH /curations/weekday — set the KST delivery day for ALL of the caller's
+   * active curations (one dial, not per-topic: "my edition arrives on <day>").
+   * next_run_at is display-only under the KST schedule, so it is realigned here
+   * to keep the list copy honest.
+   */
+  fastify.patch<{ Body: { weekday?: unknown } }>(
+    '/weekday',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      if (!request.user || !('userId' in request.user)) {
+        return reply.code(401).send({ status: 'error', code: 'UNAUTHORIZED' });
+      }
+      const weekday = (request.body ?? {}).weekday;
+      if (!isValidWeekday(weekday)) {
+        return reply.code(400).send({ status: 'error', code: 'INVALID_WEEKDAY' });
+      }
+      const prisma = getPrismaClient();
+      const nextRun = nextKstWeekdayAt(
+        weekday,
+        new Date(),
+        QUEUE_CONFIG.CURATION_DELIVERY_HOUR_KST,
+        QUEUE_CONFIG.CURATION_DELIVERY_MINUTE_KST
+      );
+      const updated = await prisma.curation_subscriptions.updateMany({
+        where: { user_id: request.user.userId, is_active: true },
+        data: { weekday, next_run_at: nextRun },
+      });
+      return reply.send({
+        status: 'ok',
+        data: { weekday, updated: updated.count, nextRunAt: nextRun.toISOString() },
+      });
     }
   );
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -250,6 +250,16 @@ const envSchema = z.object({
     .preprocess((v) => String(v).toLowerCase() !== 'false', z.boolean())
     .default(true),
 
+  // Weekly curation schedule on the KST calendar (2026-07-27). Off (default) keeps
+  // the shipped behaviour exactly: a Sunday-only scan plus `last_run_at + 7d` as the
+  // due time, which measured an 8-14 day effective period and built nothing on
+  // 2026-07-26. On: the scan runs daily and a subscription is due when today's KST
+  // weekday matches its `weekday` column and this KST week has not been built.
+  // Rollback is a config flip, not a revert.
+  CURATION_SCHED_KST_ENABLED: z
+    .preprocess((v) => String(v).toLowerCase() === 'true', z.boolean())
+    .default(false),
+
   // CP512 — metadata REFRESH for active rows (videos.list re-fetch, keeps served
   // rows ToS-compliant AND titled). Default true; set 'false' to pause refresh
   // (scrub still only touches inactive rows, so active rows just stop aging-out).
@@ -455,6 +465,11 @@ export const config = {
   // Observability Phase 1 — search trail log (search_trace + candidates).
   searchTrace: {
     enabled: env.SEARCH_TRACE_ENABLED,
+  },
+
+  // Weekly curation schedule — KST calendar instead of UTC wall-clock (2026-07-27).
+  curationSchedule: {
+    kstEnabled: env.CURATION_SCHED_KST_ENABLED,
   },
 
   // video_pool ToS hygiene cron (CP494).

--- a/src/modules/queue/handlers/curation-build.ts
+++ b/src/modules/queue/handlers/curation-build.ts
@@ -26,6 +26,8 @@ import { matchFromVideoPoolByCenterGoal } from '@/skills/plugins/video-discover/
 import { embedBatch } from '@/skills/plugins/iks-scorer/embedding';
 import { runV5Executor } from '@/skills/plugins/video-discover/v5/executor';
 import { MS_PER_DAY } from '@/utils/time-constants';
+import { config } from '../../../config';
+import { nextKstWeekdayAt } from '@/utils/kst';
 
 const log = logger.child({ module: 'queue/curation-build' });
 
@@ -182,10 +184,24 @@ export async function registerCurationBuildWorker(): Promise<void> {
       );
     }
 
-    // build-6 — advance the weekly cadence.
+    // build-6 — advance the cadence. Under the KST schedule `next_run_at` is
+    // DISPLAY-ONLY (the weekday column + last_run_at decide what is due), so it is
+    // pinned to the next delivery slot instead of "now + 7d", which drifted to
+    // whatever time the build happened to run.
+    const doneAt = new Date();
     await prisma.curation_subscriptions.update({
       where: { id: subscriptionId },
-      data: { last_run_at: new Date(), next_run_at: new Date(Date.now() + 7 * MS_PER_DAY) },
+      data: {
+        last_run_at: doneAt,
+        next_run_at: config.curationSchedule.kstEnabled
+          ? nextKstWeekdayAt(
+              sub.weekday,
+              doneAt,
+              QUEUE_CONFIG.CURATION_DELIVERY_HOUR_KST,
+              QUEUE_CONFIG.CURATION_DELIVERY_MINUTE_KST
+            )
+          : new Date(doneAt.getTime() + 7 * MS_PER_DAY),
+      },
     });
 
     log.info('curation build complete', {

--- a/src/modules/queue/handlers/curation-weekly.ts
+++ b/src/modules/queue/handlers/curation-weekly.ts
@@ -1,47 +1,83 @@
 /**
- * Weekly curation scheduler (Growth Hub, 2026-07-16). SCAFFOLD.
+ * Weekly curation scheduler (Growth Hub, 2026-07-16).
  *
  * boss.schedule cron scan (same pattern as batch-scan / collapse-watch /
- * key-alarm): find due subscriptions (is_active AND next_run_at <= now) and fan
- * out one CURATION_BUILD each (singletonKey per subscription dedups).
+ * key-alarm): find due subscriptions and fan out one CURATION_BUILD each
+ * (singletonKey per subscription dedups).
  *
  * "immediate" (James): a NEW subscription enqueues CURATION_BUILD immediately at
  * create time (see subscription create route, separate) — this weekly job is
  * the recurring refresh, not the first build.
+ *
+ * Due semantics depend on `curationSchedule.kstEnabled` (2026-07-27):
+ *
+ *   off (shipped behaviour) — scan Sundays only, due = next_run_at <= now.
+ *     The scan and the due time are two different clocks, so a due time landing
+ *     between scans waits for the next one (measured effective period 8-14 days).
+ *     The 2026-07-26 scan ran in 92ms, found 0 due rows and built nothing.
+ *
+ *   on — scan daily, due = today's KST weekday matches the subscription's
+ *     `weekday` AND this KST week has not been built yet. No time arithmetic, so
+ *     nothing drifts; any chosen weekday fires exactly once a week.
  */
 
 import { logger } from '@/utils/logger';
 import { getPrismaClient } from '@/modules/database/client';
+import { config } from '../../../config';
+import { kstDow, kstWeekStart, kstWeekStartInstant, utcWeekStart } from '@/utils/kst';
 import { JOB_NAMES, QUEUE_CONFIG } from '../types';
 import { getJobQueue } from '../manager';
 import { enqueueCurationBuild } from './curation-build';
 
 const log = logger.child({ module: 'queue/curation-weekly' });
 
-/** ISO date (YYYY-MM-DD) of the Monday of `d`'s week — the week_of snapshot key. */
-function mondayOf(d: Date): string {
-  const day = d.getUTCDay(); // 0=Sun..6=Sat
-  const diff = (day === 0 ? -6 : 1) - day; // back to Monday
-  const mon = new Date(d);
-  mon.setUTCDate(d.getUTCDate() + diff);
-  return mon.toISOString().slice(0, 10);
+/** Week snapshot key for a build starting now. */
+export function curationWeekKey(now: Date): string {
+  return config.curationSchedule.kstEnabled ? kstWeekStart(now) : utcWeekStart(now);
+}
+
+/** Subscriptions that should be refreshed at `now`. Exported for unit tests. */
+export async function findDueSubscriptions(
+  prisma: ReturnType<typeof getPrismaClient>,
+  now: Date
+): Promise<Array<{ id: string }>> {
+  if (!config.curationSchedule.kstEnabled) {
+    return prisma.curation_subscriptions.findMany({
+      where: { is_active: true, next_run_at: { lte: now } },
+      select: { id: true },
+    });
+  }
+  // Calendar-driven: right weekday, and this KST week not built yet.
+  return prisma.curation_subscriptions.findMany({
+    where: {
+      is_active: true,
+      weekday: kstDow(now),
+      OR: [{ last_run_at: null }, { last_run_at: { lt: kstWeekStartInstant(now) } }],
+    },
+    select: { id: true },
+  });
 }
 
 export async function registerCurationWeeklyWorker(): Promise<void> {
   const boss = getJobQueue().getInstance();
-  await boss.schedule(JOB_NAMES.CURATION_WEEKLY, QUEUE_CONFIG.CURATION_WEEKLY_CRON);
+  const cron = config.curationSchedule.kstEnabled
+    ? QUEUE_CONFIG.CURATION_DAILY_CRON
+    : QUEUE_CONFIG.CURATION_WEEKLY_CRON;
+  await boss.schedule(JOB_NAMES.CURATION_WEEKLY, cron);
 
   await boss.work(JOB_NAMES.CURATION_WEEKLY, async () => {
     const prisma = getPrismaClient();
     const now = new Date();
-    const due = await prisma.curation_subscriptions.findMany({
-      where: { is_active: true, next_run_at: { lte: now } },
-      select: { id: true },
-    });
-    const weekOf = mondayOf(now);
+    const due = await findDueSubscriptions(prisma, now);
+    const weekOf = curationWeekKey(now);
     for (const sub of due) {
       await enqueueCurationBuild({ subscriptionId: sub.id, weekOf });
     }
-    log.info('curation weekly scan', { due: due.length, weekOf });
+    log.info('curation weekly scan', {
+      due: due.length,
+      weekOf,
+      mode: config.curationSchedule.kstEnabled ? 'kst' : 'legacy',
+      kstDow: kstDow(now),
+    });
   });
 }

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -488,8 +488,15 @@ export const QUEUE_CONFIG = {
   MANDALA_PIPELINE_WATCHDOG_CRON: '*/10 * * * *',
   /** A pipeline run stuck at status=running past this age is treated orphaned. */
   MANDALA_PIPELINE_STALE_MINUTES: 10,
-  /** Weekly curation scan: Mondays 08:17 KST (Sun 23:17 UTC), off-minute. */
+  /** Legacy weekly curation scan: Mondays 08:17 KST (Sun 23:17 UTC), off-minute.
+   *  Used when CURATION_SCHED_KST_ENABLED is off. */
   CURATION_WEEKLY_CRON: '17 23 * * 0',
+  /** KST-calendar scan: every day 08:17 KST (23:17 UTC). The weekday filter lives
+   *  in the handler, so any delivery day fires exactly once a week. */
+  CURATION_DAILY_CRON: '17 23 * * *',
+  /** Delivery slot in KST — keeps next_run_at (display-only) on the same clock. */
+  CURATION_DELIVERY_HOUR_KST: 8,
+  CURATION_DELIVERY_MINUTE_KST: 17,
   /** Weekly curation build — a full week's feed = 15~20 videos (James 2026-07-17).
    *  Build aims for TARGET; ships if it can gather at least MIN after passesBookGate. */
   CURATION_MIN_VIDEOS: 15,

--- a/src/utils/kst.ts
+++ b/src/utils/kst.ts
@@ -1,0 +1,91 @@
+/**
+ * KST calendar helpers for the weekly curation schedule.
+ *
+ * The product promise is a KST weekday ("your new edition arrives Monday
+ * morning"), but the scheduler used UTC wall-clock arithmetic. The two never
+ * lined up, which produced two defects measured on prod 2026-07-27:
+ *
+ *  - The weekly scan ran once a week (Sun 23:17 UTC) while a subscription became
+ *    due at `last_run_at + 7d` — an arbitrary time of day. A due time that landed
+ *    anywhere between scans waited for the NEXT one, so the effective period was
+ *    8-14 days, not 7. On 2026-07-26 the scan found 0 due rows and built nothing.
+ *  - `mondayOf()` resolved the week key in UTC, so at the scan moment (Sunday
+ *    23:17 UTC = Monday 08:17 KST) it returned the PREVIOUS Monday. A Monday
+ *    morning build would have replaced last week's snapshot instead of opening a
+ *    new week.
+ *
+ * The fix is to stop doing time arithmetic for scheduling and ask the KST
+ * calendar instead: a subscription is due when today's KST weekday matches the
+ * one the user picked and this KST week has not been built yet.
+ */
+
+import { MS_PER_HOUR, MS_PER_DAY } from './time-constants';
+
+/** KST is a fixed offset — no DST, so a constant shift is exact. */
+export const KST_OFFSET_HOURS = 9;
+const KST_OFFSET_MS = KST_OFFSET_HOURS * MS_PER_HOUR;
+
+/** `d` shifted into KST, so the getUTC* accessors read as KST wall-clock. */
+function toKst(d: Date): Date {
+  return new Date(d.getTime() + KST_OFFSET_MS);
+}
+
+/** KST day of week: 0=Sun .. 6=Sat. */
+export function kstDow(d: Date): number {
+  return toKst(d).getUTCDay();
+}
+
+/** ISO date (YYYY-MM-DD) of the Monday that starts `d`'s KST week. */
+export function kstWeekStart(d: Date): string {
+  const k = toKst(d);
+  const day = k.getUTCDay();
+  const backToMonday = (day === 0 ? -6 : 1) - day;
+  const mon = new Date(k.getTime() + backToMonday * MS_PER_DAY);
+  return mon.toISOString().slice(0, 10);
+}
+
+/** Instant (UTC) of 00:00 KST on the Monday that starts `d`'s KST week. */
+export function kstWeekStartInstant(d: Date): Date {
+  return new Date(new Date(kstWeekStart(d) + 'T00:00:00Z').getTime() - KST_OFFSET_MS);
+}
+
+/**
+ * ISO date (YYYY-MM-DD) of the Monday of `d`'s week in UTC — the pre-fix key.
+ * Kept so the flag-off path reproduces the old behaviour exactly, and so the
+ * two copies that used to live in curations.ts and curation-weekly.ts have one
+ * home (no-hardcoding rule: one source, not a re-declaration per module).
+ */
+export function utcWeekStart(d: Date): string {
+  const day = d.getUTCDay();
+  const backToMonday = (day === 0 ? -6 : 1) - day;
+  const mon = new Date(d);
+  mon.setUTCDate(d.getUTCDate() + backToMonday);
+  return mon.toISOString().slice(0, 10);
+}
+
+/**
+ * Next occurrence of `weekday` (0=Sun..6=Sat) at `hourKst`:`minuteKst` KST,
+ * strictly after `from`. Used to keep `next_run_at` meaningful for display —
+ * it is no longer what makes a subscription due.
+ */
+export function nextKstWeekdayAt(
+  weekday: number,
+  from: Date,
+  hourKst: number,
+  minuteKst: number
+): Date {
+  const k = toKst(from);
+  const days = (weekday - k.getUTCDay() + 7) % 7;
+  const candidate = new Date(k.getTime() + days * MS_PER_DAY);
+  candidate.setUTCHours(hourKst, minuteKst, 0, 0);
+  // same weekday but the slot already passed today -> next week
+  if (candidate.getTime() <= k.getTime()) {
+    candidate.setTime(candidate.getTime() + 7 * MS_PER_DAY);
+  }
+  return new Date(candidate.getTime() - KST_OFFSET_MS);
+}
+
+/** Valid weekday column values (0=Sun..6=Sat). */
+export function isValidWeekday(v: unknown): v is number {
+  return typeof v === 'number' && Number.isInteger(v) && v >= 0 && v <= 6;
+}

--- a/tests/smoke/kst-schedule.test.ts
+++ b/tests/smoke/kst-schedule.test.ts
@@ -1,0 +1,127 @@
+/**
+ * KST calendar helpers for the weekly curation schedule (2026-07-27).
+ *
+ * These lock the two boundaries the UTC implementation got wrong:
+ *  - 15:00 UTC is midnight KST, so the KST day flips there, not at 00:00 UTC.
+ *  - At the Monday-morning-KST scan (Sun 23:17 UTC) the week key must be THIS
+ *    Monday. The old UTC helper returned the PREVIOUS Monday, which would have
+ *    made a Monday build overwrite last week's snapshot.
+ */
+
+import {
+  kstDow,
+  kstWeekStart,
+  kstWeekStartInstant,
+  utcWeekStart,
+  nextKstWeekdayAt,
+  isValidWeekday,
+} from '../../src/utils/kst';
+
+describe('kstDow', () => {
+  it('flips the day at 15:00 UTC (KST midnight), not at 00:00 UTC', () => {
+    // 2026-07-27 is a Monday. 14:59Z is still Monday 23:59 KST.
+    expect(kstDow(new Date('2026-07-27T14:59:59Z'))).toBe(1);
+    // 15:00Z is Tuesday 00:00 KST.
+    expect(kstDow(new Date('2026-07-27T15:00:00Z'))).toBe(2);
+  });
+
+  it('reads the scan moment (Sun 23:17 UTC) as Monday in KST', () => {
+    expect(kstDow(new Date('2026-07-26T23:17:03Z'))).toBe(1);
+  });
+
+  it('covers every weekday', () => {
+    // 2026-07-26 is a Sunday; walk a full KST week from Monday 00:00 KST.
+    const monday = new Date('2026-07-26T15:00:00Z'); // Mon 00:00 KST
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(monday.getTime() + i * 24 * 60 * 60 * 1000);
+      expect(kstDow(d)).toBe((1 + i) % 7);
+    }
+  });
+});
+
+describe('kstWeekStart', () => {
+  it('returns THIS Monday at the scan moment — the defect the UTC helper had', () => {
+    const scan = new Date('2026-07-26T23:17:03Z'); // Mon 08:17 KST
+    expect(kstWeekStart(scan)).toBe('2026-07-27');
+    // the shipped UTC helper resolved the same instant to the previous week
+    expect(utcWeekStart(scan)).toBe('2026-07-20');
+  });
+
+  it('holds the same key across a whole KST week', () => {
+    const monday = new Date('2026-07-26T15:00:00Z'); // Mon 00:00 KST
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(monday.getTime() + i * 24 * 60 * 60 * 1000);
+      expect(kstWeekStart(d)).toBe('2026-07-27');
+    }
+    // one minute into the next KST week
+    expect(kstWeekStart(new Date('2026-08-02T15:00:00Z'))).toBe('2026-08-03');
+  });
+
+  it('treats Sunday as the END of the KST week, not the start', () => {
+    // Sunday 2026-08-02 12:00 KST
+    expect(kstWeekStart(new Date('2026-08-02T03:00:00Z'))).toBe('2026-07-27');
+  });
+});
+
+describe('kstWeekStartInstant', () => {
+  it('is 00:00 KST = 15:00 UTC the previous day', () => {
+    const inst = kstWeekStartInstant(new Date('2026-07-27T02:00:00Z'));
+    expect(inst.toISOString()).toBe('2026-07-26T15:00:00.000Z');
+  });
+
+  it('makes "built this week already" comparable', () => {
+    const now = new Date('2026-07-27T02:00:00Z');
+    const start = kstWeekStartInstant(now);
+    const lastWeeksRun = new Date('2026-07-20T05:00:00Z');
+    const thisWeeksRun = new Date('2026-07-27T01:00:00Z');
+    expect(lastWeeksRun < start).toBe(true); // due
+    expect(thisWeeksRun < start).toBe(false); // already built
+  });
+});
+
+describe('nextKstWeekdayAt', () => {
+  const H = 8;
+  const M = 17;
+
+  it('lands on the requested weekday at the delivery slot, in KST', () => {
+    const from = new Date('2026-07-27T02:00:00Z'); // Mon 11:00 KST
+    const next = nextKstWeekdayAt(3, from, H, M); // Wednesday
+    expect(kstDow(next)).toBe(3);
+    // 08:17 KST == 23:17 UTC the previous day
+    expect(next.toISOString()).toBe('2026-07-28T23:17:00.000Z');
+  });
+
+  it('rolls to next week when today is the day but the slot has passed', () => {
+    const from = new Date('2026-07-27T02:00:00Z'); // Mon 11:00 KST, past 08:17
+    const next = nextKstWeekdayAt(1, from, H, M);
+    expect(kstDow(next)).toBe(1);
+    expect(kstWeekStart(next)).toBe('2026-08-03');
+  });
+
+  it('stays today when the slot is still ahead', () => {
+    const from = new Date('2026-07-26T22:00:00Z'); // Mon 07:00 KST, before 08:17
+    const next = nextKstWeekdayAt(1, from, H, M);
+    expect(next.toISOString()).toBe('2026-07-26T23:17:00.000Z');
+  });
+
+  it('always produces a future instant for every weekday', () => {
+    const from = new Date('2026-07-27T02:00:00Z');
+    for (let w = 0; w < 7; w++) {
+      const next = nextKstWeekdayAt(w, from, H, M);
+      expect(next.getTime()).toBeGreaterThan(from.getTime());
+      expect(kstDow(next)).toBe(w);
+    }
+  });
+});
+
+describe('isValidWeekday', () => {
+  it('accepts 0..6 only', () => {
+    for (let i = 0; i <= 6; i++) expect(isValidWeekday(i)).toBe(true);
+    expect(isValidWeekday(-1)).toBe(false);
+    expect(isValidWeekday(7)).toBe(false);
+    expect(isValidWeekday(1.5)).toBe(false);
+    expect(isValidWeekday('1')).toBe(false);
+    expect(isValidWeekday(null)).toBe(false);
+    expect(isValidWeekday(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

The product promise is a KST weekday, but the scheduler did UTC wall-clock arithmetic. Measured on prod 2026-07-27:

```
curation-weekly  2026-07-26 23:17:03.036 -> .128Z  completed (92ms) x1
curation-build   last run 2026-07-23   (no build after the weekly scan)
DUE_NOW = 0      min(next_run_at) 2026-07-27 14:53Z > scan time
curation_items   one week only: 2026-07-20, 401 rows
```

The cron fired. It just found nothing due.

## Two defects, one root

1. **Effective period was 8-14 days, not 7.** The scan ran weekly (Sun 23:17 UTC) while a row became due at `last_run_at + 7d` — an arbitrary instant. A due time landing between scans waited for the next scan.
2. **A Monday build would have overwritten last week.** `mondayOf()` resolved the week key in UTC, so at the scan moment it returned the previous Monday: `mondayOf('2026-07-26T23:17Z') === '2026-07-20'`. Fixing (1) alone would have made the build delete and rewrite the previous snapshot, carrying `watched_at` over and erasing the weekly reset.

## Fix

Stop doing time arithmetic for scheduling; ask the KST calendar:

```
due = is_active
  AND weekday = kstDow(now)
  AND (last_run_at IS NULL OR last_run_at < kstWeekStart(now))
```

With a daily scan, any chosen weekday fires exactly once a week and nothing drifts. `next_run_at` becomes display-only, pinned to the next delivery slot.

## Changes

- `src/utils/kst.ts` — `kstDow` / `kstWeekStart` / `kstWeekStartInstant` / `utcWeekStart` / `nextKstWeekdayAt` / `isValidWeekday`
- Removed the duplicated `mondayOf()` (it lived in both `curations.ts` and `curation-weekly.ts`) — one source now
- `weekday smallint` column, default 1 (Monday) = the day every existing row already promised. Raw DDL applied to prod 2026-07-27, verified 25/25 rows
- `PATCH /curations/weekday`; `GET /curations` returns `weekday`
- `CURATION_SCHED_KST_ENABLED` defaults **false** — cron stays Sunday-only and the due clause stays `next_run_at`, i.e. current behaviour. Rollback is a config flip

## Verification

- `tsc` 0
- 13 new unit tests, all passing — they lock the boundaries the UTC version got wrong: the KST day flips at 15:00 UTC, the scan moment resolves to *this* Monday, Sunday ends the KST week, `nextKstWeekdayAt` lands correctly for all 7 weekdays
- `tests/smoke/curation-{suggest,interest-profile}` fail identically on a clean `origin/main` worktree (local env, not this change)

## Notes

- DDL force-added: `prisma/migrations/*` is gitignored with a per-directory allowlist, and the existing curation DDLs are tracked the same way
- Flag-on is a follow-up compose change, after this deploys and is verified