### PR TITLE
feat(curation): turn on the KST weekly schedule

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -138,6 +138,12 @@ services:
       # Perf-monitor PR4: 15-min collapse watch + daily dead-man heartbeat
       # (mails OBSERVABILITY_ALERT_EMAIL). Rollback: delete.
       - COLLAPSE_WATCH_ENABLED=true
+      # Weekly curation schedule on the KST calendar (#1354, 2026-07-27). Off, the
+      # scan ran Sundays only while rows became due at last_run_at+7d, so the
+      # effective period measured 8-14 days and the 2026-07-26 scan built nothing.
+      # On: daily scan, due = KST weekday matches + this KST week not built yet.
+      # Rollback: delete this line (code path reverts to the Sunday scan).
+      - CURATION_SCHED_KST_ENABLED=true
       # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
       # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
       # a cell with ≥3 pool candidates drops its live search.list query → quota


### PR DESCRIPTION
Activates the #1354 code path.

**Off** (current): the scan ran Sundays only while a row became due at `last_run_at + 7d`. Two clocks that never lined up — the 2026-07-26 scan completed in 92ms with `DUE_NOW = 0` and built nothing, and the first automatic refresh for rows created 07-20..07-23 would have been 08-02.

**On**: the scan runs daily and a subscription is due when today's KST weekday matches its `weekday` column and this KST week has not been built yet.

Every existing row carries `weekday = 1` (Monday) — the delivery day they were already promised — so this changes *when the scheduler notices them*, not which day the edition arrives.

Rollback: delete the line.

Merges only after #1354 is deployed and verified on prod.