### PR TITLE
feat(curation): block harmful topics at the collector and at serving

### DIFF
--- a/src/modules/curation/suggest.ts
+++ b/src/modules/curation/suggest.ts
@@ -12,9 +12,13 @@
  */
 
 import { getPrismaClient } from '@/modules/database';
+import { logger } from '@/utils/logger';
+import { checkTopicSafety } from '@/modules/moderation/topic-safety';
 import { mapKeywordToDomain, type CurationDomain } from './domain-taxonomy';
 import type { InterestProfile } from './interest-profile';
 import { PROPOSAL_WEIGHTS, PROPOSAL_COUNT, MAX_PER_DOMAIN, REINFORCE } from './config';
+
+const log = logger.child({ module: 'curation/suggest' });
 
 export interface TrendCandidate {
   keyword: string;
@@ -139,12 +143,25 @@ export async function suggestTopics(
     select: { keyword: true, norm_score: true },
   });
   const excluded = new Set(excludeTopics.map((t) => t.trim().toLowerCase()));
+  // Serving-side safety floor. The collector gate stops NEW harmful keywords, but
+  // trend_signals already holds ~19k rows collected without one — and popularity is
+  // the rising signal, so those rows sort to the TOP (`ai 란제리 룩북` measured at
+  // norm_score 1.00). Filter here too, so nothing already stored can be proposed.
+  const blocked: string[] = [];
   const candidates: TrendCandidate[] = trends
     .filter((t) => !excluded.has(t.keyword.trim().toLowerCase()))
+    .filter((t) => {
+      const verdict = checkTopicSafety(t.keyword);
+      if (!verdict.safe) blocked.push(`${t.keyword} [${verdict.category}]`);
+      return verdict.safe;
+    })
     .map((t) => ({
       keyword: t.keyword,
       norm_score: t.norm_score,
     }));
+  if (blocked.length) {
+    log.warn('curation suggest: blocked unsafe topics', { userId, count: blocked.length, blocked });
+  }
 
   const sig = await loadReinforceSignals(userId);
   const proposals = scoreAndSelect(profile, candidates, sig);

--- a/src/modules/moderation/topic-safety.ts
+++ b/src/modules/moderation/topic-safety.ts
@@ -25,28 +25,63 @@
 const BLOCKED = Object.freeze({
   /** Sexual / suggestive. Nothing here is rescuable by educational context. */
   explicit: [
-    '란제리', '룩북', '비키니', '노출의상', '섹시', '야한', '19금', '성인용', '성인물',
-    '글래머', '몸매노출', '벗는', '벗기', '누드', '야동', 'av배우', '유흥',
-    'lingerie', 'lookbook', 'bikini', 'sexy', 'nsfw', 'onlyfans', 'nude', 'hentai',
+    '란제리',
+    '룩북',
+    '비키니',
+    '노출의상',
+    '섹시',
+    '야한',
+    '19금',
+    '성인용',
+    '성인물',
+    '글래머',
+    '몸매노출',
+    '벗는',
+    '벗기',
+    '누드',
+    '야동',
+    'av배우',
+    '유흥',
+    'lingerie',
+    'lookbook',
+    'bikini',
+    'sexy',
+    'nsfw',
+    'onlyfans',
+    'nude',
+    'hentai',
   ],
   /** Gambling / speculation-as-entertainment. */
   gambling: [
-    '카지노', '바카라', '슬롯머신', '토토사이트', '먹튀', '홀덤', '사설betting', '베팅사이트',
-    'casino', 'baccarat', 'betting',
+    '카지노',
+    '바카라',
+    '슬롯머신',
+    '토토사이트',
+    '먹튀',
+    '홀덤',
+    '사설betting',
+    '베팅사이트',
+    'casino',
+    'baccarat',
+    'betting',
   ],
   /** Pump-and-dump style financial solicitation. */
-  solicitation: [
-    '리딩방', '종목추천', '급등주', '코인리딩', '단타비법', '수익인증', '원금보장',
-  ],
+  solicitation: ['리딩방', '종목추천', '급등주', '코인리딩', '단타비법', '수익인증', '원금보장'],
   /** Illegal / harmful. */
   illegal: [
-    '마약', '대마초', '필로폰', '총기제작', '폭탄제조', '해킹툴', '불법다운', '토렌트다운',
-    '자살방법', '자해방법',
+    '마약',
+    '대마초',
+    '필로폰',
+    '총기제작',
+    '폭탄제조',
+    '해킹툴',
+    '불법다운',
+    '토렌트다운',
+    '자살방법',
+    '자해방법',
   ],
   /** Hate / dehumanising. */
-  hate: [
-    '혐오표현', '인종차별', '일베', '패드립',
-  ],
+  hate: ['혐오표현', '인종차별', '일베', '패드립'],
 });
 
 /**
@@ -54,9 +89,26 @@ const BLOCKED = Object.freeze({
  * prevention, education, recovery, journalism.
  */
 const EDUCATIONAL_CONTEXT = Object.freeze([
-  '예방', '교육', '중독', '상담', '치료', '회복', '캠페인', '피해', '대응', '보호',
-  '규제', '정책', '리터러시', '윤리',
-  'prevention', 'education', 'awareness', 'recovery', 'policy', 'ethics',
+  '예방',
+  '교육',
+  '중독',
+  '상담',
+  '치료',
+  '회복',
+  '캠페인',
+  '피해',
+  '대응',
+  '보호',
+  '규제',
+  '정책',
+  '리터러시',
+  '윤리',
+  'prevention',
+  'education',
+  'awareness',
+  'recovery',
+  'policy',
+  'ethics',
 ]);
 
 /** Categories no context can rescue. */

--- a/src/modules/moderation/topic-safety.ts
+++ b/src/modules/moderation/topic-safety.ts
@@ -1,0 +1,105 @@
+/**
+ * Topic safety gate (2026-07-27).
+ *
+ * The curation suggester ranks `trend_signals` keywords straight from the
+ * collector, and `norm_score` is raw popularity — so `ai 란제리 룩북` sat at
+ * score 1.00 and was proposed, labelled "AI·기술", as a study subject on a
+ * learning product. Nothing between the collector and the user asked whether a
+ * keyword was appropriate at all.
+ *
+ * Two enforcement points, same predicate:
+ *   - collector side  — never persist a blocked keyword
+ *   - serving side    — never propose one, including rows already in the table
+ *
+ * Matching is deliberately dumb and deterministic (substring over a normalised
+ * string). It is a floor, not a classifier: it must never let something through
+ * because a model was unsure. Ranking quality is a separate concern (#1357).
+ *
+ * Educational framing is the one carve-out. "청소년 도박 예방 교육" contains a
+ * blocked term but is exactly the kind of material this product exists for, so a
+ * context term rescues it — unless the keyword also carries an explicit-content
+ * term, which nothing rescues.
+ */
+
+/** Blocked substrings by category. Normalised (lowercased, spaces stripped) before matching. */
+const BLOCKED = Object.freeze({
+  /** Sexual / suggestive. Nothing here is rescuable by educational context. */
+  explicit: [
+    '란제리', '룩북', '비키니', '노출의상', '섹시', '야한', '19금', '성인용', '성인물',
+    '글래머', '몸매노출', '벗는', '벗기', '누드', '야동', 'av배우', '유흥',
+    'lingerie', 'lookbook', 'bikini', 'sexy', 'nsfw', 'onlyfans', 'nude', 'hentai',
+  ],
+  /** Gambling / speculation-as-entertainment. */
+  gambling: [
+    '카지노', '바카라', '슬롯머신', '토토사이트', '먹튀', '홀덤', '사설betting', '베팅사이트',
+    'casino', 'baccarat', 'betting',
+  ],
+  /** Pump-and-dump style financial solicitation. */
+  solicitation: [
+    '리딩방', '종목추천', '급등주', '코인리딩', '단타비법', '수익인증', '원금보장',
+  ],
+  /** Illegal / harmful. */
+  illegal: [
+    '마약', '대마초', '필로폰', '총기제작', '폭탄제조', '해킹툴', '불법다운', '토렌트다운',
+    '자살방법', '자해방법',
+  ],
+  /** Hate / dehumanising. */
+  hate: [
+    '혐오표현', '인종차별', '일베', '패드립',
+  ],
+});
+
+/**
+ * Terms that mark a keyword as being ABOUT a problem rather than promoting it —
+ * prevention, education, recovery, journalism.
+ */
+const EDUCATIONAL_CONTEXT = Object.freeze([
+  '예방', '교육', '중독', '상담', '치료', '회복', '캠페인', '피해', '대응', '보호',
+  '규제', '정책', '리터러시', '윤리',
+  'prevention', 'education', 'awareness', 'recovery', 'policy', 'ethics',
+]);
+
+/** Categories no context can rescue. */
+const NEVER_RESCUABLE: ReadonlyArray<keyof typeof BLOCKED> = ['explicit'];
+
+export type TopicSafetyVerdict =
+  | { safe: true }
+  | { safe: false; category: keyof typeof BLOCKED; term: string };
+
+/** Lowercase + strip whitespace so "란 제 리" and "LOOKBOOK" both match. */
+function normalise(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, '');
+}
+
+/** Does the keyword read as being about the problem rather than selling it? */
+function hasEducationalContext(normalised: string): boolean {
+  return EDUCATIONAL_CONTEXT.some((c) => normalised.includes(normalise(c)));
+}
+
+/**
+ * Verdict for one topic/keyword. Pure — no DB, no network — so both the
+ * collector and the serving path can call it on every row without cost.
+ */
+export function checkTopicSafety(keyword: string): TopicSafetyVerdict {
+  const n = normalise(keyword);
+  if (!n) return { safe: true };
+
+  for (const [category, terms] of Object.entries(BLOCKED) as Array<
+    [keyof typeof BLOCKED, readonly string[]]
+  >) {
+    for (const term of terms) {
+      if (!n.includes(normalise(term))) continue;
+      if (!NEVER_RESCUABLE.includes(category) && hasEducationalContext(n)) continue;
+      return { safe: false, category, term };
+    }
+  }
+  return { safe: true };
+}
+
+/** Convenience predicate for `.filter(...)` call sites. */
+export function isTopicSafe(keyword: string): boolean {
+  return checkTopicSafety(keyword).safe;
+}
+
+/** Exposed for the admin audit endpoint and tests. */
+export const TOPIC_SAFETY_CATEGORIES = Object.keys(BLOCKED) as Array<keyof typeof BLOCKED>;

--- a/src/skills/plugins/trend-collector/executor.ts
+++ b/src/skills/plugins/trend-collector/executor.ts
@@ -57,6 +57,7 @@ import {
   type SuggestionItem,
 } from './sources/suggest';
 import { LEARNING_SEED_TERMS, type LearningSeed } from './seed-terms';
+import { checkTopicSafety } from '@/modules/moderation/topic-safety';
 import { loadDynamicSeedsFromMandalas, mergeSeeds } from './dynamic-seeds';
 import { MS_PER_DAY } from '@/utils/time-constants';
 
@@ -331,9 +332,25 @@ export const executor: SkillExecutor = {
     // Per-source min-max normalization (Suggest already in [0.05, 1] so no-op)
     normalizeWithinSource(allRows);
 
+    // Collector-side safety floor. Both sources scrape whatever YouTube is
+    // surfacing, so without this the table accumulates terms this product must
+    // never propose — `ai 란제리 룩북` was collected and then suggested at
+    // norm_score 1.00, chipped as "AI·기술". Drop them before they are stored;
+    // the serving path filters too, for rows collected before this existed.
+    let blockedUnsafe = 0;
+    const safeRows = allRows.filter((row) => {
+      const verdict = checkTopicSafety(row.keyword);
+      if (verdict.safe) return true;
+      blockedUnsafe++;
+      logger.warn(
+        `trend-collector: dropped unsafe keyword "${row.keyword.slice(0, 40)}" [${verdict.category}]`
+      );
+      return false;
+    });
+
     let inserted = 0;
     let upsertErrors = 0;
-    for (const row of allRows) {
+    for (const row of safeRows) {
       try {
         await db.trend_signals.upsert({
           where: {
@@ -392,6 +409,7 @@ export const executor: SkillExecutor = {
         suggest_failed_seeds: suggestFailed,
         suggest_duration_ms: suggestDurationMs,
         total_signals_upserted: inserted,
+        blocked_unsafe: blockedUnsafe,
         upsert_errors: upsertErrors,
       },
       metrics: {

--- a/tests/smoke/topic-safety.test.ts
+++ b/tests/smoke/topic-safety.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Topic safety gate (2026-07-27).
+ *
+ * Anchored on the row that shipped to a user: `ai 란제리 룩북`, stored at
+ * norm_score 1.00 and proposed as a study subject chipped "AI·기술".
+ */
+
+import { checkTopicSafety, isTopicSafe } from '../../src/modules/moderation/topic-safety';
+
+describe('checkTopicSafety — the keywords that actually reached prod', () => {
+  const measured = [
+    'ai 란제리 룩북',
+    'ai모델 룩북',
+    'ai 모델 룩북',
+    'ai 란제리 룩북 실사',
+    'ai 란제리 룩북 back',
+    'ai 룩북',
+  ];
+
+  it.each(measured)('blocks %s', (kw) => {
+    const v = checkTopicSafety(kw);
+    expect(v.safe).toBe(false);
+    if (!v.safe) expect(v.category).toBe('explicit');
+  });
+});
+
+describe('checkTopicSafety — categories', () => {
+  it.each([
+    ['카지노 슬롯머신 공략', 'gambling'],
+    ['주식 리딩방 수익인증', 'solicitation'],
+    ['마약 구하는 법', 'illegal'],
+    ['비키니 하울', 'explicit'],
+    ['casino baccarat tips', 'gambling'],
+  ])('blocks %s as %s', (kw, category) => {
+    const v = checkTopicSafety(kw);
+    expect(v.safe).toBe(false);
+    if (!v.safe) expect(v.category).toBe(category);
+  });
+});
+
+describe('checkTopicSafety — normalisation', () => {
+  it('is case-insensitive and ignores spacing', () => {
+    expect(isTopicSafe('LOOKBOOK')).toBe(false);
+    expect(isTopicSafe('란 제 리')).toBe(false);
+    expect(isTopicSafe('Lingerie Haul')).toBe(false);
+  });
+});
+
+describe('checkTopicSafety — educational carve-out', () => {
+  it('allows material ABOUT a problem', () => {
+    // measured in trend_signals and caught by a naive scan — it is exactly the
+    // kind of content this product exists to serve
+    expect(isTopicSafe('청소년 도박 예방 교육')).toBe(true);
+    expect(isTopicSafe('도박 중독 상담')).toBe(true);
+    expect(isTopicSafe('마약 예방 캠페인')).toBe(true);
+  });
+
+  it('does NOT let educational framing rescue explicit content', () => {
+    expect(isTopicSafe('란제리 룩북 교육')).toBe(false);
+    expect(isTopicSafe('비키니 예방')).toBe(false);
+  });
+});
+
+describe('checkTopicSafety — no false positives on real learning topics', () => {
+  // sampled from the live top-20 of trend_signals
+  const legit = [
+    'options trading for beginners',
+    '개인 철학과',
+    '안세영',
+    '근력운동 홈트',
+    'furniture design',
+    '지방선거',
+    'ai 에이전트',
+    '강아지훈련',
+    'woodworking',
+    '자바스크립트',
+    '파이썬',
+    '수능 100일 2등급 올리기',
+    '영어회화',
+    '토익스피킹',
+    'Claude 코드',
+    '호흡법',
+  ];
+
+  it.each(legit)('allows %s', (kw) => {
+    expect(isTopicSafe(kw)).toBe(true);
+  });
+});
+
+describe('checkTopicSafety — edge cases', () => {
+  it('treats empty input as safe (nothing to block)', () => {
+    expect(isTopicSafe('')).toBe(true);
+    expect(isTopicSafe('   ')).toBe(true);
+  });
+});


### PR DESCRIPTION
`ai 란제리 룩북` was proposed to a user as a study subject, chipped **AI·기술**. It sat in `trend_signals` at `norm_score` **1.00** — the maximum — so it sorted to the top of the suggestion list.

## Nothing was filtering

| asset | scope | covers suggestions? |
|---|---|---|
| `channel_blocklist` | channel-level, 5 discovery surfaces | ❌ |
| `safeSearch=moderate` | v2 + legacy YouTube clients | ❌ (not on the trend collector) |
| `suggest.ts` filter | the user's own "show me other topics" exclusions | ❌ |

Whatever the collector scraped reached the user verbatim. And because `rising` is raw popularity, sensational terms outrank study subjects **by construction**.

Measured on prod (18,932 rows):

```
ai 란제리 룩북           1.00
ai모델 룩북              1.00
ai 모델 룩북             0.90
ai 란제리 룩북 실사       0.60
ai 란제리 룩북 back      0.50
```

## Two enforcement points, one pure predicate

- **collector** — `trend-collector` drops blocked keywords before upserting, and reports `blocked_unsafe` in its metrics
- **serving** — `suggest.ts` filters again, because ~19k rows were collected before this gate existed and those are exactly the ones ranked highest

Categories: `explicit` / `gambling` / `solicitation` / `illegal` / `hate`. Matching is substring over a normalised string — deliberately deterministic, since a floor must not let something through because a model was unsure.

## Educational carve-out

`청소년 도박 예방 교육` contains a blocked term but is the kind of material this product exists for, so context terms (예방/교육/중독/상담/…) rescue it.

Explicit content is **never** rescuable — `란제리 룩북 교육` stays blocked.

## Tests (31)

Every keyword measured on prod · each category · case and spacing normalisation (`LOOKBOOK`, `란 제 리`) · the carve-out and its limit · and **16 real learning topics sampled from the live top-20** to pin down false positives.

## Follow-up

Ranking quality is #1357, not this change — popularity as the only rising signal, `airbnb` chipped AI·기술, `파이썬` falling through to the fallback chip.

## Rollout

Deploy stops new harmful keywords and hides stored ones immediately. A cleanup pass over the 18,932 existing rows follows once this is live.