### PR TITLE
fix(curation): naming a social problem is not promoting it

### DIFF
--- a/src/modules/moderation/topic-safety.ts
+++ b/src/modules/moderation/topic-safety.ts
@@ -80,8 +80,15 @@ const BLOCKED = Object.freeze({
     '자살방법',
     '자해방법',
   ],
-  /** Hate / dehumanising. */
-  hate: ['혐오표현', '인종차별', '일베', '패드립'],
+  /**
+   * Hate / dehumanising. Terms here must be the SLUR OR THE ACT OF PROMOTING it,
+   * never the name of the social problem — otherwise reporting, documentary and
+   * first-hand accounts get blocked along with the abuse. `인종차별` was in this
+   * list on the first pass and took out `호주 여행 인종차별` (norm_score 0.80), a
+   * traveller describing racism they experienced. That is exactly the material a
+   * learning product should carry.
+   */
+  hate: ['혐오표현', '혐오조장', '인종차별조장', '일베', '패드립'],
 });
 
 /**

--- a/tests/smoke/topic-safety.test.ts
+++ b/tests/smoke/topic-safety.test.ts
@@ -61,6 +61,22 @@ describe('checkTopicSafety — educational carve-out', () => {
   });
 });
 
+describe('checkTopicSafety — naming a social problem is not promoting it', () => {
+  it('allows first-hand accounts and reporting', () => {
+    // measured on prod at norm_score 0.80 and wrongly blocked by the first pass:
+    // a traveller describing racism they experienced
+    expect(isTopicSafe('호주 여행 인종차별')).toBe(true);
+    expect(isTopicSafe('인종차별 다큐멘터리')).toBe(true);
+    expect(isTopicSafe('직장 내 괴롭힘 사례')).toBe(true);
+  });
+
+  it('still blocks promoting it', () => {
+    expect(isTopicSafe('혐오조장 방송')).toBe(false);
+    expect(isTopicSafe('인종차별조장')).toBe(false);
+    expect(isTopicSafe('혐오표현 모음')).toBe(false);
+  });
+});
+
 describe('checkTopicSafety — no false positives on real learning topics', () => {
   // sampled from the live top-20 of trend_signals
   const legit = [


### PR DESCRIPTION
Follow-up to #1358, found by running the deployed predicate over all 18,932 `trend_signals` rows.

**16 blocked — 15 correct, 1 wrong.**

| verdict | n | examples |
|---|---|---|
| correct (explicit) | 14 | `ai lookbook 19` (norm_score **1.00**) · `ai lookbook 치마올리기` · `ai 란제리 룩북` (1.00) · `ai bikini` |
| correct (solicitation) | 1 | `주식 종목 추천` |
| ❌ **false positive** | 1 | **`호주 여행 인종차별`** (0.80) |

`인종차별` is the *name of a social problem*, not a slur. A traveller describing racism they experienced is exactly the material a learning product should carry — the first pass blocked it alongside actual abuse.

Terms in the `hate` category must be the slur or the act of promoting it. Narrowed to `혐오표현` / `혐오조장` / `인종차별조장` / `일베` / `패드립`.

Tests pin both sides: first-hand accounts and documentary pass, promotion still blocks. 33 passing.