### PR TITLE
feat(admin): record whether the beta invite email actually went out

### DIFF
--- a/frontend/src/pages/admin/ui/AdminBetaCampaign.tsx
+++ b/frontend/src/pages/admin/ui/AdminBetaCampaign.tsx
@@ -178,6 +178,7 @@ export function AdminBetaCampaign() {
                   <th className="py-2 pr-4 font-medium">이메일</th>
                   <th className="py-2 pr-4 font-medium">학습 목표</th>
                   <th className="py-2 pr-4 font-medium">상태</th>
+                  <th className="py-2 pr-4 font-medium">메일</th>
                   <th className="py-2 pr-4 font-medium">신청일</th>
                   <th className="py-2 font-medium text-right">액션</th>
                 </tr>
@@ -201,6 +202,39 @@ export function AdminBetaCampaign() {
                       >
                         {a.status}
                       </span>
+                    </td>
+                    <td className="py-2.5 pr-4">
+                      {/* `status` is written before the send and the send is
+                          non-fatal, so it never proved delivery. null means the
+                          row predates this record — say so rather than guess. */}
+                      {a.status === 'pending' ? (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      ) : a.invite_email_status === 'sent' ? (
+                        <span
+                          className="text-xs px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-400"
+                          title={a.invite_email_at ?? undefined}
+                        >
+                          발송됨
+                        </span>
+                      ) : a.invite_email_status === 'failed' ? (
+                        <span
+                          className="text-xs px-2 py-0.5 rounded-full bg-red-500/15 text-red-400"
+                          title={a.invite_email_error ?? undefined}
+                        >
+                          실패
+                        </span>
+                      ) : a.invite_email_status === 'skipped' ? (
+                        <span className="text-xs px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-400">
+                          미발송
+                        </span>
+                      ) : (
+                        <span
+                          className="text-xs text-muted-foreground"
+                          title="이 컬럼이 생기기 전에 초대된 건이라 발송 여부를 알 수 없습니다"
+                        >
+                          확인 불가
+                        </span>
+                      )}
                     </td>
                     <td className="py-2.5 pr-4 text-xs text-muted-foreground">
                       {new Date(a.created_at).toLocaleDateString('ko-KR')}

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -1700,6 +1700,10 @@ class ApiClient {
       status: string;
       created_at: string;
       invited_at: string | null;
+      /** 'sent' | 'failed' | 'skipped'. null = invited before this was recorded. */
+      invite_email_status: string | null;
+      invite_email_at: string | null;
+      invite_email_error: string | null;
     }>;
     total: number;
   }> {

--- a/prisma/migrations/beta-invite-send-status/001_send_status.sql
+++ b/prisma/migrations/beta-invite-send-status/001_send_status.sql
@@ -1,0 +1,29 @@
+-- Record whether the beta invite email actually went out, 2026-07-27.
+--
+-- `status='invited'` is written BEFORE the send and the send is non-fatal, so a
+-- row claims an invitation was delivered even when SMTP refused it or the
+-- transactional-email flag was off. The admin inbox had no way to tell.
+--
+-- All three columns are nullable on purpose: rows invited before this shipped
+-- have an unknown outcome and must render as "확인 불가" rather than be assumed
+-- sent. Do not backfill them.
+--
+-- `prisma db push` silently drops new columns on this Supabase project, so the
+-- DDL is authored here and applied by hand (local + prod) before the code merges.
+--
+-- Rollback:
+--   ALTER TABLE public.beta_applications
+--     DROP COLUMN invite_email_status,
+--     DROP COLUMN invite_email_at,
+--     DROP COLUMN invite_email_error;
+
+ALTER TABLE public.beta_applications
+  ADD COLUMN IF NOT EXISTS invite_email_status varchar(10),
+  ADD COLUMN IF NOT EXISTS invite_email_at     timestamptz,
+  ADD COLUMN IF NOT EXISTS invite_email_error  text;
+
+COMMENT ON COLUMN public.beta_applications.invite_email_status IS
+  'sent | failed | skipped — outcome of the invite send. NULL = attempted before this column existed, outcome unknown.';
+
+-- PostgREST caches the schema; without this it keeps dropping the new columns.
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2723,6 +2723,14 @@ model beta_applications {
   /// Invite tickets (2026-07-15): member who spent a ticket. NULL = admin invite.
   /// Raw SQL DDL: prisma/migrations/beta/002_invited_by.sql
   invited_by String?   @db.Uuid
+  /// Outcome of the invite send: sent | failed | skipped. `status` is written
+  /// BEFORE the send and the send is non-fatal, so status alone never proved
+  /// delivery. NULL = invited before this column existed — genuinely unknown,
+  /// so render it as such instead of assuming it went out.
+  /// Raw SQL DDL: prisma/migrations/beta-invite-send-status/001_send_status.sql
+  invite_email_status String?   @db.VarChar(10)
+  invite_email_at     DateTime? @db.Timestamptz(6)
+  invite_email_error  String?
 
   @@index([status])
   @@index([invited_by])

--- a/src/api/routes/admin/beta-applications.ts
+++ b/src/api/routes/admin/beta-applications.ts
@@ -36,8 +36,19 @@ export async function adminBetaApplicationRoutes(fastify: FastifyInstance) {
       });
       // Pre-signup moment: announce the invitation, drive signup with this
       // email, and carry the onboarding guide (internally flag-gated + non-fatal).
-      await sendBetaInviteEmail(updated.email, { goal: updated.goal });
-      return reply.send({ application: updated });
+      const result = await sendBetaInviteEmail(updated.email, { goal: updated.goal });
+      // Record what actually happened. `status` above is written before the send
+      // and the send never throws, so without this the row claims an invitation
+      // went out even when SMTP refused it or the flag was off.
+      const withSend = await prisma.beta_applications.update({
+        where: { id: request.params.id },
+        data: {
+          invite_email_status: result.status,
+          invite_email_at: new Date(),
+          invite_email_error: result.status === 'failed' ? result.error.slice(0, 500) : null,
+        },
+      });
+      return reply.send({ application: withSend });
     }
   );
 }

--- a/src/modules/email/transactional.ts
+++ b/src/modules/email/transactional.ts
@@ -29,48 +29,73 @@ function isTransactionalEmailEnabled(env: NodeJS.ProcessEnv = process.env): bool
   return v === 'true' || v === '1' || v === 'yes';
 }
 
-async function send(to: string, subject: string, html: string, tag: string): Promise<void> {
+/**
+ * Outcome of one send attempt. `send` used to return void, which collapsed three
+ * very different endings — delivered, refused by SMTP, and never attempted
+ * because the flag is off — into the same silence. Callers that record state
+ * (admin invite marking an application `invited`) had no way to tell them apart,
+ * so the row claimed an invitation had gone out even when nothing was sent.
+ */
+export type EmailSendResult =
+  | { status: 'sent' }
+  | { status: 'skipped'; reason: 'disabled' | 'no-recipient' }
+  | { status: 'failed'; error: string };
+
+async function send(
+  to: string,
+  subject: string,
+  html: string,
+  tag: string
+): Promise<EmailSendResult> {
   if (!isTransactionalEmailEnabled()) {
     log.info(`${tag}: transactional email disabled (TRANSACTIONAL_EMAIL_ENABLED unset) — skipped`);
-    return;
+    return { status: 'skipped', reason: 'disabled' };
   }
   if (!to) {
     log.warn(`${tag}: recipient empty — skipped`);
-    return;
+    return { status: 'skipped', reason: 'no-recipient' };
   }
   try {
     // Display name "Insighta" (not the bare noreply@ local-part).
     await transporter.sendMail({ from: `Insighta <${config.gmail.smtpFrom}>`, to, subject, html });
     log.info(`${tag}: sent to ${to}`);
+    return { status: 'sent' };
   } catch (err) {
-    log.warn(
-      `${tag}: send failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`
-    );
+    const error = err instanceof Error ? err.message : String(err);
+    log.warn(`${tag}: send failed (non-fatal): ${error}`);
+    // Still non-fatal to the caller — the result is returned, not thrown.
+    return { status: 'failed', error };
   }
 }
 
-export async function sendWelcomeEmail(to: string, params: WelcomeEmailParams): Promise<void> {
+export async function sendWelcomeEmail(
+  to: string,
+  params: WelcomeEmailParams
+): Promise<EmailSendResult> {
   const { subject, html } = buildWelcomeEmail(params);
-  await send(to, subject, html, 'welcome-email');
+  return send(to, subject, html, 'welcome-email');
 }
 
 export async function sendBetaInviteEmail(
   to: string,
   params: BetaInviteEmailParams
-): Promise<void> {
+): Promise<EmailSendResult> {
   const { subject, html } = buildBetaInviteEmail(params);
-  await send(to, subject, html, 'beta-invite-email');
+  return send(to, subject, html, 'beta-invite-email');
 }
 
-export async function sendNoteReadyEmail(to: string, params: NoteReadyEmailParams): Promise<void> {
+export async function sendNoteReadyEmail(
+  to: string,
+  params: NoteReadyEmailParams
+): Promise<EmailSendResult> {
   const { subject, html } = buildNoteReadyEmail(params);
-  await send(to, subject, html, 'note-ready-email');
+  return send(to, subject, html, 'note-ready-email');
 }
 
 export async function sendProUpgradeEmail(
   to: string,
   params: ProUpgradeEmailParams
-): Promise<void> {
+): Promise<EmailSendResult> {
   const { subject, html } = buildProUpgradeEmail(params);
-  await send(to, subject, html, 'pro-upgrade-email');
+  return send(to, subject, html, 'pro-upgrade-email');
 }


### PR DESCRIPTION
`status='invited'` never proved delivery.

It is written **before** the send, and `send()` returned `Promise<void>` while swallowing all three endings — delivered, refused by SMTP, and never attempted because `TRANSACTIONAL_EMAIL_ENABLED` is off. The admin inbox showed the same chip either way, so answering "did the invite go out?" meant grepping `/app/logs` on prod (which is exactly what I had to do for bobcho83@gmail.com today).

## Changes

- `send()` returns `EmailSendResult` (`sent` | `skipped{reason}` | `failed{error}`) and every wrapper propagates it. **Still non-fatal** — the result is returned, never thrown.
- `mark-invited` writes the outcome to `invite_email_status` / `_at` / `_error`.
- Admin table gains a **메일** column: 발송됨 / 실패 (hover shows the error) / 미발송.

## Rows that predate this

They render **확인 불가**, not 발송됨. The three existing `invited` rows have a genuinely unknown outcome and are left `NULL` — backfilling them would be inventing a fact.

## DDL

Applied to prod 2026-07-27 and verified before merge, per the `prisma db push` silent-fail rule:

```
invite_email_status  varchar(10)  nullable
invite_email_at      timestamptz  nullable
invite_email_error   text         nullable
existing rows: 3 invited, 0 with a send status
```

BE `tsc` 0, FE `tsc` 0.