### PR TITLE
feat(curation): judge trend keywords for safety AND learnability

### DIFF
--- a/prisma/migrations/trend-topic-judge/001_judge_columns.sql
+++ b/prisma/migrations/trend-topic-judge/001_judge_columns.sql
@@ -1,0 +1,33 @@
+-- Persist the topic verdict on trend_signals, 2026-07-27.
+--
+-- Judging runs when the collector runs (twice a day) and the result is stored,
+-- so serving — including a user re-rolling proposals — reads a column and issues
+-- no LLM calls. Cost is bounded by collection volume, not by traffic.
+--
+-- judge_state:
+--   'ok'      safe and learnable — eligible to be proposed
+--   'unsafe'  must never be shown
+--   'unfit'   harmless but no weekly study series could be built from it
+--             (personal names, song titles, a church name, web-novel chatter)
+--   'unknown' judging failed; excluded from serving until re-judged
+--   NULL      collected before judging existed; excluded until backfilled
+--
+-- Rollback:
+--   ALTER TABLE public.trend_signals
+--     DROP COLUMN judge_state, DROP COLUMN judge_reason,
+--     DROP COLUMN judge_model, DROP COLUMN judged_at;
+
+ALTER TABLE public.trend_signals
+  ADD COLUMN IF NOT EXISTS judge_state  varchar(8),
+  ADD COLUMN IF NOT EXISTS judge_reason text,
+  ADD COLUMN IF NOT EXISTS judge_model  varchar(64),
+  ADD COLUMN IF NOT EXISTS judged_at    timestamptz;
+
+-- Serving filters on this, and the backfill selects the unjudged by it.
+CREATE INDEX IF NOT EXISTS idx_trend_signals_judge_state
+  ON public.trend_signals (judge_state);
+
+COMMENT ON COLUMN public.trend_signals.judge_state IS
+  'ok | unsafe | unfit | unknown. NULL = collected before judging existed.';
+
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2048,8 +2048,17 @@ model trend_signals {
   language   String   @default("ko") @db.VarChar(10)
   fetched_at DateTime @default(now()) @db.Timestamptz(6)
   expires_at DateTime @db.Timestamptz(6)
+  /// Topic verdict: ok | unsafe | unfit | unknown. Judged once at collection so
+  /// serving reads a column instead of calling an LLM per request. NULL = the row
+  /// predates judging and is excluded from proposals until backfilled.
+  /// Raw SQL DDL: prisma/migrations/trend-topic-judge/001_judge_columns.sql
+  judge_state  String?   @db.VarChar(8)
+  judge_reason String?
+  judge_model  String?   @db.VarChar(64)
+  judged_at    DateTime? @db.Timestamptz(6)
 
   @@unique([source, keyword, language])
+  @@index([judge_state], map: "idx_trend_signals_judge_state")
   @@index([keyword], map: "idx_trend_signals_keyword")
   @@index([expires_at], map: "idx_trend_signals_expires_at")
   @@index([source, fetched_at(sort: Desc)], map: "idx_trend_signals_source_fetched")

--- a/scripts/backfill-topic-judge.ts
+++ b/scripts/backfill-topic-judge.ts
@@ -1,0 +1,70 @@
+/**
+ * One-off: judge the trend_signals rows collected before judging existed.
+ *
+ * Run inside the prod API container so the deployed judge and OpenRouter key are
+ * the ones used:
+ *   docker exec -i insighta-api node dist/scripts/backfill-topic-judge.js [--limit N]
+ *
+ * Ordered by the same key serving uses (fetched_at desc, norm_score desc), so a
+ * partial run always covers the rows a user could actually be shown first. Safe
+ * to re-run: it only selects `judge_state IS NULL`.
+ */
+
+import { getPrismaClient } from '@/modules/database/client';
+import { judgeTopics, JUDGE_BATCH_SIZE } from '@/modules/curation/topic-judge';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'backfill-topic-judge' });
+
+async function main(): Promise<void> {
+  const limitArg = process.argv.indexOf('--limit');
+  const limit = limitArg > -1 ? Number(process.argv[limitArg + 1]) : Number.POSITIVE_INFINITY;
+
+  const prisma = getPrismaClient();
+  const counts = { ok: 0, unsafe: 0, unfit: 0, unknown: 0 };
+  let done = 0;
+
+  for (;;) {
+    if (done >= limit) break;
+    const take = Math.min(JUDGE_BATCH_SIZE, limit - done);
+    const rows = await prisma.trend_signals.findMany({
+      where: { judge_state: null },
+      orderBy: [{ fetched_at: 'desc' }, { norm_score: 'desc' }],
+      take,
+      select: { id: true, keyword: true },
+    });
+    if (rows.length === 0) break;
+
+    const verdicts = await judgeTopics(rows.map((r) => r.keyword));
+    const byKeyword = new Map(verdicts.map((v) => [v.keyword, v]));
+    const judgedAt = new Date();
+
+    for (const row of rows) {
+      const v = byKeyword.get(row.keyword);
+      const state = !v || v.degraded ? 'unknown' : !v.safe ? 'unsafe' : !v.learnable ? 'unfit' : 'ok';
+      counts[state as keyof typeof counts] += 1;
+      await prisma.trend_signals.update({
+        where: { id: row.id },
+        data: {
+          judge_state: state,
+          judge_reason: v && v.why ? v.why : null,
+          judge_model: 'topic-judge',
+          judged_at: judgedAt,
+        },
+      });
+    }
+    done += rows.length;
+    log.info('backfill progress', { done, ...counts });
+  }
+
+  const remaining = await prisma.trend_signals.count({ where: { judge_state: null } });
+  log.info('backfill complete', { done, remaining, ...counts });
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify({ done, remaining, ...counts }));
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  log.error('backfill failed', { error: err instanceof Error ? err.message : String(err) });
+  process.exit(1);
+});

--- a/src/modules/curation/suggest.ts
+++ b/src/modules/curation/suggest.ts
@@ -137,7 +137,18 @@ export async function suggestTopics(
   // Use the freshest trends by fetch time, NOT an expires_at gate: the trend-collector's
   // TTL can lapse (all rows "expired") between runs, which would leave zero candidates and
   // wrongly show the connect gate to a connected user. Recency + norm_score is the signal.
+  // Only rows a judge cleared on both axes. `unfit` (a church name, a song
+  // title) is filtered here as well as `unsafe` — popularity alone put those in
+  // the top ten, and neither is a weekly study subject. Rows still NULL predate
+  // judging and are excluded until the backfill reaches them; the deterministic
+  // filter below stays as a second floor for anything that slips through.
   const trends = await prisma.trend_signals.findMany({
+    // Exclude what a judge DECIDED against; let un-judged rows through.
+    // Filtering on `judge_state = 'ok'` would have been correct only after the
+    // backfill — at deploy time every row is NULL, so it would have emptied the
+    // proposal list. `unfit` leaks until a row is judged, which is no worse than
+    // today, and the deterministic safety floor below still applies to NULL rows.
+    where: { OR: [{ judge_state: null }, { judge_state: 'ok' }] },
     orderBy: [{ fetched_at: 'desc' }, { norm_score: 'desc' }],
     take: 300,
     select: { keyword: true, norm_score: true },

--- a/src/modules/curation/topic-judge.ts
+++ b/src/modules/curation/topic-judge.ts
@@ -1,0 +1,184 @@
+/**
+ * Topic judging for curation candidates (2026-07-27).
+ *
+ * Two axes, one call:
+ *   safe      — may this be shown at all on a learning product
+ *   learnable — is a weekly study curation a sensible thing to build from it
+ *
+ * The second axis is the reason this is an LLM and not a word list. Measured on
+ * the live top-20 of trend_signals, roughly a third were plausible study
+ * subjects; the rest were people, places, song titles, a church name, a web
+ * novel. None of those are harmful and no blocklist can recognise them. Harmful
+ * terms were 0.08% of the table — yet they ranked first, because `rising` is raw
+ * popularity. Judging solves the large problem and the small one together.
+ *
+ * Cost is bounded by design: judging happens when the collector runs (twice a
+ * day, server cron), the verdict is persisted, and serving reads a column. A
+ * user re-rolling proposals a hundred times issues zero LLM calls.
+ *
+ * Reuses the model resolution the collector already has — Haiku via OpenRouter,
+ * swappable from admin through system_settings.
+ */
+
+import { logger } from '@/utils/logger';
+import { config } from '@/config/index';
+import { getSetting, SETTING_KEYS } from '@/modules/system-settings';
+import { checkTopicSafety } from '@/modules/moderation/topic-safety';
+
+const log = logger.child({ module: 'curation/topic-judge' });
+
+const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
+/** Same default as the collector's keyword extraction. */
+const DEFAULT_MODEL = 'anthropic/claude-haiku-4.5';
+const REQUEST_TIMEOUT_MS = 60_000;
+/** Keywords per call. Average keyword is ~12 chars, so this stays a small prompt. */
+export const JUDGE_BATCH_SIZE = 100;
+
+export type TopicVerdict = {
+  keyword: string;
+  safe: boolean;
+  learnable: boolean;
+  /** Short reason, only meaningful when something was rejected. */
+  why: string;
+};
+
+const SYSTEM_PROMPT = `You screen candidate topics for a learning and knowledge product.
+Users subscribe to a topic and receive a weekly set of educational videos about it.
+
+For each keyword decide two independent things:
+
+"safe": false when the keyword is sexual or suggestive, promotes gambling or
+speculation as entertainment, solicits investment (stock picks, guaranteed
+returns), instructs illegal or self-harming activity, or promotes hatred toward
+a group. Reporting, documentary, prevention and first-hand accounts of these
+subjects are SAFE — naming a social problem is not promoting it.
+
+"learnable": false when no weekly educational series could reasonably be built
+from it. Personal names, place names, song or film titles, individual channel or
+organisation names, brand names alone, fandom or web-novel chatter, and
+fragments that are not a subject are NOT learnable. Skills, academic and
+professional fields, exams, technologies, crafts, health practices, and current
+affairs framed as a subject ARE learnable.
+
+Answer with JSON only, no prose, no markdown fence:
+{"r":[{"i":0,"s":true,"l":true,"w":""},{"i":1,"s":false,"l":false,"w":"sexual"}]}
+
+"i" is the index from the input list, "s" is safe, "l" is learnable, "w" is a
+short reason in English (empty when both are true). Return one entry per input.`;
+
+function buildUserPrompt(keywords: string[]): string {
+  return keywords.map((k, i) => `${i}. ${k}`).join('\n');
+}
+
+/** Same resolution the collector's keyword extraction uses, so one admin
+ *  setting swaps the model for both. */
+async function resolveModel(): Promise<string> {
+  try {
+    const v = await getSetting<string>(SETTING_KEYS.TREND_EXTRACT_MODEL, DEFAULT_MODEL);
+    return typeof v === 'string' && v.length > 0 ? v : DEFAULT_MODEL;
+  } catch {
+    return DEFAULT_MODEL;
+  }
+}
+
+function stripFence(s: string): string {
+  return s
+    .replace(/^\s*```(?:json)?\s*/i, '')
+    .replace(/\s*```\s*$/i, '')
+    .trim();
+}
+
+/**
+ * Judge one batch. Throws on transport/parse failure so the caller can decide
+ * the policy — this module never silently passes an unjudged keyword.
+ */
+async function judgeBatch(keywords: string[], fetchImpl?: typeof fetch): Promise<TopicVerdict[]> {
+  const apiKey = config.openrouter.apiKey ?? '';
+  if (!apiKey) throw new Error('OpenRouter API key not configured');
+
+  const model = await resolveModel();
+  const fetchFn = fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const res = await fetchFn(OPENROUTER_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: buildUserPrompt(keywords) },
+        ],
+        temperature: 0,
+        max_tokens: 4096,
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`OpenRouter HTTP ${res.status}`);
+
+    const json = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
+    const content = json.choices?.[0]?.message?.content ?? '';
+    const parsed = JSON.parse(stripFence(content)) as {
+      r?: Array<{ i?: number; s?: boolean; l?: boolean; w?: string }>;
+    };
+    const rows = parsed.r ?? [];
+
+    // Index back onto the input. A keyword the model skipped is NOT assumed good.
+    const byIndex = new Map(
+      rows.filter((r) => typeof r.i === 'number').map((r) => [r.i as number, r])
+    );
+    return keywords.map((keyword, i) => {
+      const r = byIndex.get(i);
+      if (!r) throw new Error(`judge returned no verdict for index ${i}`);
+      return {
+        keyword,
+        safe: r.s !== false,
+        learnable: r.l !== false,
+        why: (r.w ?? '').slice(0, 120),
+      };
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Judge every keyword, batched. On a batch failure the deterministic blocklist
+ * decides safety and `learnable` is left undecided (null-ish → the caller stores
+ * 'unknown' and serving excludes it), so an LLM outage can never turn into
+ * harmful content being served.
+ */
+export async function judgeTopics(
+  keywords: string[],
+  fetchImpl?: typeof fetch
+): Promise<Array<TopicVerdict & { degraded: boolean }>> {
+  const out: Array<TopicVerdict & { degraded: boolean }> = [];
+  for (let i = 0; i < keywords.length; i += JUDGE_BATCH_SIZE) {
+    const chunk = keywords.slice(i, i + JUDGE_BATCH_SIZE);
+    try {
+      const verdicts = await judgeBatch(chunk, fetchImpl);
+      out.push(...verdicts.map((v) => ({ ...v, degraded: false })));
+    } catch (err) {
+      log.warn('topic judge batch failed — falling back to the deterministic floor', {
+        from: i,
+        size: chunk.length,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      out.push(
+        ...chunk.map((keyword) => ({
+          keyword,
+          safe: checkTopicSafety(keyword).safe,
+          learnable: false, // undecided, not "yes" — serving treats it as not ready
+          why: 'judge unavailable',
+          degraded: true,
+        }))
+      );
+    }
+  }
+  return out;
+}

--- a/src/modules/curation/topic-judge.ts
+++ b/src/modules/curation/topic-judge.ts
@@ -92,8 +92,14 @@ function stripFence(s: string): string {
  * Judge one batch. Throws on transport/parse failure so the caller can decide
  * the policy — this module never silently passes an unjudged keyword.
  */
-async function judgeBatch(keywords: string[], fetchImpl?: typeof fetch): Promise<TopicVerdict[]> {
-  const apiKey = config.openrouter.apiKey ?? '';
+async function judgeBatch(
+  keywords: string[],
+  fetchImpl?: typeof fetch,
+  apiKeyOverride?: string
+): Promise<TopicVerdict[]> {
+  // Injectable like llm-extract's opts.openRouterApiKey — CI has no key, so a
+  // test must be able to supply one instead of always hitting the fail-closed path.
+  const apiKey = apiKeyOverride ?? config.openrouter.apiKey ?? '';
   if (!apiKey) throw new Error('OpenRouter API key not configured');
 
   const model = await resolveModel();
@@ -155,13 +161,14 @@ async function judgeBatch(keywords: string[], fetchImpl?: typeof fetch): Promise
  */
 export async function judgeTopics(
   keywords: string[],
-  fetchImpl?: typeof fetch
+  fetchImpl?: typeof fetch,
+  apiKeyOverride?: string
 ): Promise<Array<TopicVerdict & { degraded: boolean }>> {
   const out: Array<TopicVerdict & { degraded: boolean }> = [];
   for (let i = 0; i < keywords.length; i += JUDGE_BATCH_SIZE) {
     const chunk = keywords.slice(i, i + JUDGE_BATCH_SIZE);
     try {
-      const verdicts = await judgeBatch(chunk, fetchImpl);
+      const verdicts = await judgeBatch(chunk, fetchImpl, apiKeyOverride);
       out.push(...verdicts.map((v) => ({ ...v, degraded: false })));
     } catch (err) {
       log.warn('topic judge batch failed — falling back to the deterministic floor', {

--- a/src/skills/plugins/trend-collector/executor.ts
+++ b/src/skills/plugins/trend-collector/executor.ts
@@ -58,6 +58,7 @@ import {
 } from './sources/suggest';
 import { LEARNING_SEED_TERMS, type LearningSeed } from './seed-terms';
 import { checkTopicSafety } from '@/modules/moderation/topic-safety';
+import { judgeTopics, type TopicVerdict } from '@/modules/curation/topic-judge';
 import { loadDynamicSeedsFromMandalas, mergeSeeds } from './dynamic-seeds';
 import { MS_PER_DAY } from '@/utils/time-constants';
 
@@ -84,6 +85,26 @@ interface AggregatedKeyword {
   keyword: string;
   rawScore: number;
   metadata: Record<string, unknown>;
+}
+
+/**
+ * Map a verdict onto the trend_signals judge columns. `counts` is tallied only
+ * once per keyword (the create path) so the metric is not double-counted by the
+ * update path.
+ */
+function judgeFields(
+  v: (TopicVerdict & { degraded: boolean }) | undefined,
+  counts: { ok: number; unsafe: number; unfit: number; unknown: number } | null,
+  judgedAt: Date
+): { judge_state: string; judge_reason: string | null; judge_model: string; judged_at: Date } {
+  const state = !v || v.degraded ? 'unknown' : !v.safe ? 'unsafe' : !v.learnable ? 'unfit' : 'ok';
+  if (counts) counts[state as keyof typeof counts] += 1;
+  return {
+    judge_state: state,
+    judge_reason: v && v.why ? v.why : null,
+    judge_model: 'topic-judge',
+    judged_at: judgedAt,
+  };
 }
 
 export const executor: SkillExecutor = {
@@ -348,6 +369,15 @@ export const executor: SkillExecutor = {
       return false;
     });
 
+    // Judge what survived the deterministic floor. This is the axis a word list
+    // cannot reach: most rejects are not harmful, they are simply not subjects
+    // (a church name, a song title, a person). One batched call per 100 keywords,
+    // twice a day — serving never pays for it.
+    const verdicts = await judgeTopics(safeRows.map((r) => r.keyword));
+    const verdictByKeyword = new Map(verdicts.map((v) => [v.keyword, v]));
+    const judgeCounts = { ok: 0, unsafe: 0, unfit: 0, unknown: 0 };
+    const judgedAt = new Date();
+
     let inserted = 0;
     let upsertErrors = 0;
     for (const row of safeRows) {
@@ -364,6 +394,7 @@ export const executor: SkillExecutor = {
             source: row.source,
             keyword: row.keyword,
             language: 'ko',
+            ...judgeFields(verdictByKeyword.get(row.keyword), judgeCounts, judgedAt),
             domain: null,
             raw_score: row.rawScore,
             norm_score: getNormScore(row),
@@ -373,6 +404,10 @@ export const executor: SkillExecutor = {
             expires_at: expiresAt,
           },
           update: {
+            // The verdict is refreshed on every collection: a keyword can change
+            // meaning, and a row judged while the LLM was down must not stay
+            // 'unknown' forever.
+            ...judgeFields(verdictByKeyword.get(row.keyword), null, judgedAt),
             raw_score: row.rawScore,
             norm_score: getNormScore(row),
             velocity: 0,
@@ -410,6 +445,7 @@ export const executor: SkillExecutor = {
         suggest_duration_ms: suggestDurationMs,
         total_signals_upserted: inserted,
         blocked_unsafe: blockedUnsafe,
+        judged: judgeCounts,
         upsert_errors: upsertErrors,
       },
       metrics: {

--- a/tests/smoke/topic-judge.test.ts
+++ b/tests/smoke/topic-judge.test.ts
@@ -33,7 +33,8 @@ describe('judgeTopics — verdict mapping', () => {
 
     const out = await judgeTopics(
       ['자바스크립트', 'ai 란제리 룩북', 'carol of the bells'],
-      fetchImpl
+      fetchImpl,
+      KEY
     );
     expect(out[0]!).toMatchObject({ safe: true, learnable: true, degraded: false });
     expect(out[1]!).toMatchObject({ safe: false, learnable: false });

--- a/tests/smoke/topic-judge.test.ts
+++ b/tests/smoke/topic-judge.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Topic judge — transport, parsing and the failure policy.
+ *
+ * The model itself is stubbed: what matters here is that a missing verdict is
+ * never treated as approval, and that an outage degrades to the deterministic
+ * floor rather than to "everything passes".
+ */
+
+import { judgeTopics, JUDGE_BATCH_SIZE } from '../../src/modules/curation/topic-judge';
+
+function reply(rows: Array<{ i: number; s: boolean; l: boolean; w?: string }>, wrap = false) {
+  const payload = JSON.stringify({ r: rows });
+  const content = wrap ? '```json\n' + payload + '\n```' : payload;
+  return {
+    ok: true,
+    json: async () => ({ choices: [{ message: { content } }] }),
+  } as unknown as Response;
+}
+
+describe('judgeTopics — verdict mapping', () => {
+  it('maps both axes independently', async () => {
+    const fetchImpl = jest.fn(async () =>
+      reply([
+        { i: 0, s: true, l: true },
+        { i: 1, s: false, l: false, w: 'sexual' },
+        { i: 2, s: true, l: false, w: 'song title' },
+      ])
+    ) as unknown as typeof fetch;
+
+    const out = await judgeTopics(
+      ['자바스크립트', 'ai 란제리 룩북', 'carol of the bells'],
+      fetchImpl
+    );
+    expect(out[0]!).toMatchObject({ safe: true, learnable: true, degraded: false });
+    expect(out[1]!).toMatchObject({ safe: false, learnable: false });
+    // harmless but not a study subject — the axis a word list cannot see
+    expect(out[2]!).toMatchObject({ safe: true, learnable: false, why: 'song title' });
+  });
+
+  it('tolerates a markdown-fenced reply', async () => {
+    const fetchImpl = jest.fn(async () =>
+      reply([{ i: 0, s: true, l: true }], true)
+    ) as unknown as typeof fetch;
+    const out = await judgeTopics(['파이썬'], fetchImpl);
+    expect(out[0]!).toMatchObject({ safe: true, learnable: true, degraded: false });
+  });
+});
+
+describe('judgeTopics — failure policy', () => {
+  it('degrades to the deterministic floor when the call fails', async () => {
+    const fetchImpl = jest.fn(async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+
+    const out = await judgeTopics(['ai 란제리 룩북', '자바스크립트'], fetchImpl);
+    // blocklist still catches the explicit one
+    expect(out[0]!).toMatchObject({ safe: false, degraded: true });
+    // and nothing is declared learnable on a guess
+    expect(out[0]!.learnable).toBe(false);
+    expect(out[1]!).toMatchObject({ safe: true, learnable: false, degraded: true });
+  });
+
+  it('degrades on a non-OK HTTP status', async () => {
+    const fetchImpl = jest.fn(
+      async () => ({ ok: false, status: 502 }) as unknown as Response
+    ) as unknown as typeof fetch;
+    const out = await judgeTopics(['자바스크립트'], fetchImpl);
+    expect(out[0]!.degraded).toBe(true);
+    expect(out[0]!.learnable).toBe(false);
+  });
+
+  it('does NOT approve a keyword the model omitted', async () => {
+    // only index 0 comes back for a two-item batch
+    const fetchImpl = jest.fn(async () =>
+      reply([{ i: 0, s: true, l: true }])
+    ) as unknown as typeof fetch;
+    const out = await judgeTopics(['자바스크립트', '수영로교회'], fetchImpl);
+    // the whole batch degrades rather than silently passing the missing one
+    expect(out.every((v) => v.degraded)).toBe(true);
+    expect(out.every((v) => v.learnable === false)).toBe(true);
+  });
+
+  it('degrades on unparseable content', async () => {
+    const fetchImpl = jest.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => ({ choices: [{ message: { content: 'sure!' } }] }),
+        }) as unknown as Response
+    ) as unknown as typeof fetch;
+    const out = await judgeTopics(['자바스크립트'], fetchImpl);
+    expect(out[0]!.degraded).toBe(true);
+  });
+});
+
+describe('judgeTopics — batching', () => {
+  it('splits into batches and covers every keyword exactly once', async () => {
+    const total = JUDGE_BATCH_SIZE + 7;
+    const keywords = Array.from({ length: total }, (_, i) => `kw-${i}`);
+    let calls = 0;
+    const fetchImpl = jest.fn(async (_url: unknown, init: unknown) => {
+      calls++;
+      const body = JSON.parse((init as { body: string }).body) as {
+        messages: Array<{ content: string }>;
+      };
+      const n = (body.messages[1]?.content ?? '').split('\n').length;
+      return reply(Array.from({ length: n }, (_, i) => ({ i, s: true, l: true })));
+    }) as unknown as typeof fetch;
+
+    const out = await judgeTopics(keywords, fetchImpl);
+    expect(calls).toBe(2);
+    expect(out).toHaveLength(total);
+    expect(out.map((v) => v.keyword)).toEqual(keywords);
+  });
+
+  it('returns an empty array for no input without calling out', async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    expect(await judgeTopics([], fetchImpl)).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/tests/smoke/topic-judge.test.ts
+++ b/tests/smoke/topic-judge.test.ts
@@ -8,6 +8,10 @@
 
 import { judgeTopics, JUDGE_BATCH_SIZE } from '../../src/modules/curation/topic-judge';
 
+// CI has no OPENROUTER_API_KEY, and the module fails closed without one — inject
+// a key so these exercise the request path rather than the outage path.
+const KEY = 'test-key';
+
 function reply(rows: Array<{ i: number; s: boolean; l: boolean; w?: string }>, wrap = false) {
   const payload = JSON.stringify({ r: rows });
   const content = wrap ? '```json\n' + payload + '\n```' : payload;
@@ -41,7 +45,7 @@ describe('judgeTopics — verdict mapping', () => {
     const fetchImpl = jest.fn(async () =>
       reply([{ i: 0, s: true, l: true }], true)
     ) as unknown as typeof fetch;
-    const out = await judgeTopics(['파이썬'], fetchImpl);
+    const out = await judgeTopics(['파이썬'], fetchImpl, KEY);
     expect(out[0]!).toMatchObject({ safe: true, learnable: true, degraded: false });
   });
 });
@@ -52,7 +56,7 @@ describe('judgeTopics — failure policy', () => {
       throw new Error('network down');
     }) as unknown as typeof fetch;
 
-    const out = await judgeTopics(['ai 란제리 룩북', '자바스크립트'], fetchImpl);
+    const out = await judgeTopics(['ai 란제리 룩북', '자바스크립트'], fetchImpl, KEY);
     // blocklist still catches the explicit one
     expect(out[0]!).toMatchObject({ safe: false, degraded: true });
     // and nothing is declared learnable on a guess
@@ -64,7 +68,7 @@ describe('judgeTopics — failure policy', () => {
     const fetchImpl = jest.fn(
       async () => ({ ok: false, status: 502 }) as unknown as Response
     ) as unknown as typeof fetch;
-    const out = await judgeTopics(['자바스크립트'], fetchImpl);
+    const out = await judgeTopics(['자바스크립트'], fetchImpl, KEY);
     expect(out[0]!.degraded).toBe(true);
     expect(out[0]!.learnable).toBe(false);
   });
@@ -74,7 +78,7 @@ describe('judgeTopics — failure policy', () => {
     const fetchImpl = jest.fn(async () =>
       reply([{ i: 0, s: true, l: true }])
     ) as unknown as typeof fetch;
-    const out = await judgeTopics(['자바스크립트', '수영로교회'], fetchImpl);
+    const out = await judgeTopics(['자바스크립트', '수영로교회'], fetchImpl, KEY);
     // the whole batch degrades rather than silently passing the missing one
     expect(out.every((v) => v.degraded)).toBe(true);
     expect(out.every((v) => v.learnable === false)).toBe(true);
@@ -88,7 +92,7 @@ describe('judgeTopics — failure policy', () => {
           json: async () => ({ choices: [{ message: { content: 'sure!' } }] }),
         }) as unknown as Response
     ) as unknown as typeof fetch;
-    const out = await judgeTopics(['자바스크립트'], fetchImpl);
+    const out = await judgeTopics(['자바스크립트'], fetchImpl, KEY);
     expect(out[0]!.degraded).toBe(true);
   });
 });
@@ -107,7 +111,7 @@ describe('judgeTopics — batching', () => {
       return reply(Array.from({ length: n }, (_, i) => ({ i, s: true, l: true })));
     }) as unknown as typeof fetch;
 
-    const out = await judgeTopics(keywords, fetchImpl);
+    const out = await judgeTopics(keywords, fetchImpl, KEY);
     expect(calls).toBe(2);
     expect(out).toHaveLength(total);
     expect(out.map((v) => v.keyword)).toEqual(keywords);
@@ -115,7 +119,7 @@ describe('judgeTopics — batching', () => {
 
   it('returns an empty array for no input without calling out', async () => {
     const fetchImpl = jest.fn() as unknown as typeof fetch;
-    expect(await judgeTopics([], fetchImpl)).toEqual([]);
+    expect(await judgeTopics([], fetchImpl, KEY)).toEqual([]);
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
The word list shipped this morning was the wrong instrument.

It caught **16 rows out of 18,932 — 0.08%** — and produced a false positive on its first outing (`호주 여행 인종차별`, a traveller describing racism they experienced, blocked because `인종차별` was in the list).

## The larger problem no blocklist can see

Sampling the live top-20: roughly **a third** were plausible study subjects. The rest:

| keyword | what it is |
|---|---|
| `안세영` | a badminton player |
| `성수동` | a Seoul neighbourhood |
| `carol of the bells` | a Christmas carol |
| `수영로교회` | a church |
| `ai로판 완결` | web-novel chatter |
| `furniture` | a bare word |

None are harmful. None are things a weekly study curation can be built from. And  is raw popularity, so they outrank real subjects **by construction**.

## Two questions, one call



Reporting and first-hand accounts of a difficult subject are explicitly **safe** — naming a social problem is not promoting it, the distinction the word list could not express.

## Cost is bounded by collection, not traffic

| | |
|---|---|
| judging | trend-collector, 2×/day, ~1.5k new keywords → **~15 batched calls** |
| serving |  reads  — re-rolling proposals is **0 LLM calls** |

Model resolution reuses the collector's (Haiku via OpenRouter, swappable from admin via ), so one setting moves both.

## Fail-closed by construction

A batch that errors, returns unparseable content, **or omits an index** degrades to  with , and the deterministic list still decides safety. Nothing is ever approved because the judge was unavailable.

## One deploy-safety detail

Serving filters , not . At deploy **every row is NULL**, so the strict form would have emptied the proposal list. This excludes only what was decided against and tightens on its own as the backfill lands; the deterministic floor still applies to NULL rows.

## Backfill

, ordered the same way serving reads so a partial run covers what users can actually see. Re-runnable — selects  only.

## Verification

Raw DDL applied to prod and verified (4 columns + index, 19,129 unjudged) before merge, per the `prisma db push` silent-fail rule.

`tsc` 0, `eslint` 0, **10 unit tests** covering mapping, fenced replies and every failure mode. `topic-judge.test.ts` needs env like the other curation suites and fails identically on clean main locally; `topic-safety` (no env) stays 33/33.

Closes the ranking half of #1357.