### PR TITLE
feat(curation): enforce the curation quota (free 1 / pro 5)

### DIFF
--- a/src/api/routes/curations.ts
+++ b/src/api/routes/curations.ts
@@ -20,6 +20,7 @@ import { suggestTopics } from '../../modules/curation/suggest';
 import { maybeTriggerProfileBuild } from '../../modules/curation/interest-profile';
 import { getAccessToken } from '../../modules/youtube/api';
 import { curationWeekKey } from '../../modules/queue/handlers/curation-weekly';
+import { getCurationLimit, type Tier } from '../../config/quota';
 import { isValidWeekday, nextKstWeekdayAt } from '../../utils/kst';
 import { QUEUE_CONFIG } from '../../modules/queue/types';
 
@@ -28,6 +29,33 @@ import { QUEUE_CONFIG } from '../../modules/queue/types';
 const mondayOf = (d: Date): string => curationWeekKey(d);
 
 const ALLOWED_SOURCES = new Set(['discover', 'youtube_subs', 'hybrid']);
+
+/**
+ * Tier for the curation quota. An approved beta application counts as pro for
+ * the duration of the closed beta — the testers were invited to exercise the
+ * product, so holding them to the free ceiling defeats the point. Redeeming an
+ * invite ticket does not: `invited_by` non-null means a member spent a ticket on
+ * them, which is a signup path, not a plan.
+ */
+async function resolveCurationTier(
+  prisma: ReturnType<typeof getPrismaClient>,
+  userId: string
+): Promise<Tier> {
+  const sub = await prisma.user_subscriptions.findUnique({
+    where: { user_id: userId },
+    select: { tier: true },
+  });
+  const tier = (sub?.tier ?? 'free') as Tier;
+  if (tier !== 'free') return tier;
+
+  const user = await prisma.users.findUnique({ where: { id: userId }, select: { email: true } });
+  if (!user?.email) return 'free';
+  const approved = await prisma.beta_applications.findFirst({
+    where: { email: user.email, status: { in: ['invited', 'joined'] }, invited_by: null },
+    select: { id: true },
+  });
+  return approved ? 'pro' : 'free';
+}
 
 export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
   /** POST /curations — create a weekly curation subscription + immediate build. */
@@ -66,6 +94,20 @@ export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       return reply.send({
         status: 'ok',
         data: { id: dup.id, topic: dup.topic, source: dup.source, buildJobId: null },
+      });
+    }
+
+    // Quota. Counted by DISTINCT normalised topic, never by row: prod holds
+    // legacy duplicates (one account has 21 active rows for 5 topics), and a row
+    // count would lock those users out on the spot.
+    const tier = await resolveCurationTier(prisma, userId);
+    const limit = getCurationLimit(tier);
+    const distinctTopics = new Set(allActive.map((s) => norm(s.topic))).size;
+    if (distinctTopics >= limit) {
+      return reply.code(403).send({
+        status: 'error',
+        code: 'QUOTA_EXCEEDED',
+        data: { tier, limit, current: distinctTopics },
       });
     }
     const sub = await prisma.curation_subscriptions.create({

--- a/src/config/quota.ts
+++ b/src/config/quota.ts
@@ -62,6 +62,10 @@ export interface SkillLimits {
 /** Resource limits shape per tier */
 export interface TierLimitConfig {
   mandalas: number | null;
+  /** Weekly curation subscriptions. Counted by DISTINCT normalised topic, not by
+   *  row: legacy duplicates exist in prod (one account holds 21 active rows for
+   *  5 topics), so a row count would lock those users out immediately. */
+  curations: number | null;
   cards: number | null;
   aiSummaries: number | null;
   /**
@@ -78,6 +82,7 @@ export interface TierLimitConfig {
 export const TIER_LIMITS: Record<Tier, TierLimitConfig> = {
   free: {
     mandalas: 3,
+    curations: 1,
     cards: 150,
     aiSummaries: 150,
     richSummaries: 30,
@@ -117,6 +122,7 @@ export const TIER_LIMITS: Record<Tier, TierLimitConfig> = {
   },
   pro: {
     mandalas: 20,
+    curations: 5,
     cards: 1_000,
     aiSummaries: 1_000,
     richSummaries: 200,
@@ -156,6 +162,7 @@ export const TIER_LIMITS: Record<Tier, TierLimitConfig> = {
   },
   lifetime: {
     mandalas: null,
+    curations: null,
     cards: null,
     aiSummaries: null,
     richSummaries: null,
@@ -179,6 +186,7 @@ export const TIER_LIMITS: Record<Tier, TierLimitConfig> = {
   },
   admin: {
     mandalas: null,
+    curations: null,
     cards: null,
     aiSummaries: null,
     richSummaries: null,
@@ -221,6 +229,11 @@ export function getMandalaLimit(tier: Tier): number {
 /** Helper: get cards limit for a tier (returns Infinity for unlimited) */
 export function getCardsLimit(tier: Tier): number {
   return TIER_LIMITS[tier].cards ?? Infinity;
+}
+
+/** Helper: get curation limit for a tier (returns Infinity for unlimited) */
+export function getCurationLimit(tier: Tier): number {
+  return TIER_LIMITS[tier].curations ?? Infinity;
 }
 
 /** Helper: get rate limit max for a tier (returns 0 to indicate unlimited) */

--- a/tests/smoke/curation-quota.test.ts
+++ b/tests/smoke/curation-quota.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Curation quota limits.
+ *
+ * The counting rule is the part worth pinning: prod holds legacy duplicate
+ * subscriptions (one account has 21 active rows for 5 distinct topics), so a
+ * row-based count would put that account over any ceiling immediately.
+ */
+
+import { getCurationLimit, TIER_LIMITS } from '../../src/config/quota';
+
+describe('curation limits per tier', () => {
+  it('is 1 for free and 5 for pro', () => {
+    expect(TIER_LIMITS.free.curations).toBe(1);
+    expect(TIER_LIMITS.pro.curations).toBe(5);
+  });
+
+  it('is unlimited for lifetime and admin', () => {
+    expect(TIER_LIMITS.lifetime.curations).toBeNull();
+    expect(TIER_LIMITS.admin.curations).toBeNull();
+    expect(getCurationLimit('lifetime')).toBe(Infinity);
+    expect(getCurationLimit('admin')).toBe(Infinity);
+  });
+
+  it('resolves to a comparable number for every tier', () => {
+    expect(getCurationLimit('free')).toBe(1);
+    expect(getCurationLimit('pro')).toBe(5);
+  });
+});
+
+describe('counting rule', () => {
+  const norm = (s: string) => s.trim().toLowerCase();
+  const distinct = (rows: Array<{ topic: string }>) => new Set(rows.map((r) => norm(r.topic))).size;
+
+  it('counts distinct normalised topics, not rows', () => {
+    // shape taken from prod: 21 active rows, 5 real topics
+    const rows = [
+      ...Array.from({ length: 12 }, () => ({ topic: '파이썬' })),
+      ...Array.from({ length: 5 }, () => ({ topic: '호흡법' })),
+      { topic: 'ai 에이전트' },
+      { topic: 'ai 에이전트' },
+      { topic: 'Claude 코드' },
+      { topic: '수능 100일 2등급 올리기' },
+    ];
+    expect(rows).toHaveLength(21);
+    expect(distinct(rows)).toBe(5);
+  });
+
+  it('treats case and surrounding space as the same topic', () => {
+    expect(distinct([{ topic: 'Claude 코드' }, { topic: '  claude 코드 ' }])).toBe(1);
+  });
+
+  it('lets a pro user with legacy duplicates still be under the ceiling', () => {
+    const rows = Array.from({ length: 21 }, (_, i) => ({
+      topic: ['파이썬', '호흡법', 'ai 에이전트', 'Claude 코드', '수능'][i % 5] as string,
+    }));
+    expect(distinct(rows) >= getCurationLimit('pro')).toBe(true); // exactly at the ceiling
+    expect(distinct(rows)).toBe(5);
+    // and would have been 21 under a row count — four times over
+    expect(rows.length > getCurationLimit('pro')).toBe(true);
+  });
+
+  it('blocks a free user at their second distinct topic', () => {
+    const existing = [{ topic: '파이썬' }];
+    expect(distinct(existing) >= getCurationLimit('free')).toBe(true);
+  });
+});


### PR DESCRIPTION
Decided a while back, never implemented — `POST /curations` had no ceiling at all.

## Counting rule is the load-bearing part

By **distinct normalised topic**, never by row. Prod holds legacy duplicates from before the dedup landed:

```
one account:  21 active rows  →  5 real topics
              파이썬 x12 · 호흡법 x5 · ai 에이전트 x2 · Claude 코드 · 수능
```

A row count would put that account **four times over the pro ceiling** and lock it out on the spot.

## Beta testers

An approved beta application counts as **pro** for the closed beta — testers were invited to exercise the product, so holding them to a single curation defeats the point.

Redeeming an invite ticket does **not** qualify: `invited_by` non-null means a member spent a ticket on them, which is a signup path, not a plan.

## Limits

| tier | curations |
|---|---|
| free | 1 |
| pro | 5 |
| lifetime / admin | unlimited |

Over the ceiling returns `403 QUOTA_EXCEEDED` with `{ tier, limit, current }` so the client can name the number instead of guessing.

## Verification

`tsc` 0. 7 unit tests, most of them on the counting rule using the actual prod row shape.
