### PR TITLE
feat(curation): curation_channels table (channel-based curation, P1)

### DIFF
--- a/prisma/migrations/curation-channels/001_curation_channels.sql
+++ b/prisma/migrations/curation-channels/001_curation_channels.sql
@@ -1,0 +1,43 @@
+-- Channel-based curation: the channels a subscription follows, 2026-07-27.
+--
+-- Design: docs/design/curation-channel-subscription-2026-07-27.md
+--
+-- One subscription follows N channels, so this is a separate table rather than
+-- an array column: unsubscribing a single channel, counting toward a quota and
+-- cleaning up legacy duplicates all stay ordinary queries.
+--
+-- last_seen_at is the incremental cursor. The weekly build asks each channel for
+-- uploads newer than it, which is what "only what went up this week" means.
+--
+-- Verified against the live API before writing this (channels.list?forHandle):
+--   @nomadcoders -> UCUpJs89fSBXNolQGOYKn0YQ, uploads UUUpJs89fSBXNolQGOYKn0YQ
+-- channel_id stores the UC… id; the uploads playlist comes back from the same
+-- call and is stored too, so the build never has to guess it from a convention.
+--
+-- Rollback: DROP TABLE public.curation_channels;
+
+CREATE TABLE IF NOT EXISTS public.curation_channels (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  subscription_id uuid NOT NULL REFERENCES public.curation_subscriptions(id) ON DELETE CASCADE,
+  channel_id      varchar(30)  NOT NULL,
+  uploads_playlist_id varchar(34),
+  channel_title   text,
+  thumbnail_url   text,
+  -- 'picked' = chosen from the user's YouTube subscriptions
+  -- 'manual' = pasted URL or @handle (works without connecting YouTube)
+  added_via       varchar(8) NOT NULL DEFAULT 'picked',
+  last_seen_at    timestamptz,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_curation_channels_sub_channel
+  ON public.curation_channels (subscription_id, channel_id);
+CREATE INDEX IF NOT EXISTS idx_curation_channels_subscription_id
+  ON public.curation_channels (subscription_id);
+
+ALTER TABLE public.curation_channels ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON COLUMN public.curation_channels.uploads_playlist_id IS
+  'From channels.list contentDetails.relatedPlaylists.uploads — stored so the weekly build never derives it from the UC->UU convention.';
+
+NOTIFY pgrst, 'reload schema';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -658,9 +658,39 @@ model curation_subscriptions {
   created_at  DateTime         @default(now()) @db.Timestamptz(6)
   updated_at  DateTime         @default(now()) @updatedAt @db.Timestamptz(6)
   items       curation_items[]
+  channels    curation_channels[]
 
   @@index([user_id], map: "idx_curation_subscriptions_user_id")
   @@index([next_run_at], map: "idx_curation_subscriptions_next_run_at")
+  @@schema("public")
+}
+
+/// Channels a curation follows (2026-07-27). One subscription, N channels —
+/// a table rather than an array column so unsubscribing a single channel,
+/// counting toward quota and cleaning duplicates stay ordinary queries.
+/// Design: docs/design/curation-channel-subscription-2026-07-27.md
+/// Raw SQL DDL: prisma/migrations/curation-channels/001_curation_channels.sql
+model curation_channels {
+  id                  String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  subscription_id     String    @db.Uuid
+  /// YouTube channel id (UC...)
+  channel_id          String    @db.VarChar(30)
+  /// contentDetails.relatedPlaylists.uploads from the same channels.list call —
+  /// stored so the weekly build never derives it from the UC->UU convention.
+  uploads_playlist_id String?   @db.VarChar(34)
+  /// Snapshot for display, so a renamed channel does not blank the row.
+  channel_title       String?
+  thumbnail_url       String?
+  /// 'picked' = from the user's YouTube subscriptions · 'manual' = pasted URL/@handle
+  added_via           String    @default("picked") @db.VarChar(8)
+  /// Incremental cursor: uploads newer than this are "new this week".
+  last_seen_at        DateTime? @db.Timestamptz(6)
+  created_at          DateTime  @default(now()) @db.Timestamptz(6)
+
+  subscription curation_subscriptions @relation(fields: [subscription_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([subscription_id, channel_id], map: "uq_curation_channels_sub_channel")
+  @@index([subscription_id], map: "idx_curation_channels_subscription_id")
   @@schema("public")
 }
 


### PR DESCRIPTION
First step of channel-based curation — pick channels, receive only what they posted this week.
Design: `docs/design/curation-channel-subscription-2026-07-27.md` (a = both entry points, James-approved).

## Why a table, not an array column

One subscription follows N channels. Unsubscribing a single channel, counting toward quota, and cleaning up duplicates all stay ordinary queries. The subscriptions table already carries a duplicate-row problem (21 active rows for 5 topics on one account) — an array would compound it.

## One assumption removed

The design assumed the `UC…` → `UU…` uploads-playlist convention. Verified against the live API instead:

```
channels.list?forHandle=@nomadcoders&part=contentDetails,snippet
  channelId  UCUpJs89fSBXNolQGOYKn0YQ
  title      노마드 코더 Nomad Coders
  uploads    UUUpJs89fSBXNolQGOYKn0YQ
```

It does match the convention — but the same **1-unit** call already returns it, so `uploads_playlist_id` is stored and nothing depends on the convention. Resolution happens once at subscribe time; the weekly build then only calls `playlistItems.list`.

**~12-20 units/week for a 10-channel subscription**, against ~800 for a single add-cards click, because `search.list` is never involved.

`last_seen_at` is the incremental cursor that defines "new this week".

## Verification

DDL applied to prod and verified before merge (9 columns, 2 indexes, RLS on, 0 rows), per the prisma-db-push silent-fail rule. `tsc` 0.

**Schema only** — no route, no builder branch, no UI. Those are P2 / P3 / P4.
