### PR TITLE
fix(curation): move judge backfill under src so it reaches the image

### DIFF
--- a/src/scripts/backfill-topic-judge.ts
+++ b/src/scripts/backfill-topic-judge.ts
@@ -5,6 +5,9 @@
  * the ones used:
  *   docker exec -i insighta-api node dist/scripts/backfill-topic-judge.js [--limit N]
  *
+ * Lives under src/ because the image only carries src/ (Dockerfile COPY) and tsc
+ * only compiles rootDir=src — a sibling of scripts/ would never reach the container.
+ *
  * Ordered by the same key serving uses (fetched_at desc, norm_score desc), so a
  * partial run always covers the rows a user could actually be shown first. Safe
  * to re-run: it only selects `judge_state IS NULL`.
@@ -41,7 +44,8 @@ async function main(): Promise<void> {
 
     for (const row of rows) {
       const v = byKeyword.get(row.keyword);
-      const state = !v || v.degraded ? 'unknown' : !v.safe ? 'unsafe' : !v.learnable ? 'unfit' : 'ok';
+      const state =
+        !v || v.degraded ? 'unknown' : !v.safe ? 'unsafe' : !v.learnable ? 'unfit' : 'ok';
       counts[state as keyof typeof counts] += 1;
       await prisma.trend_signals.update({
         where: { id: row.id },


### PR DESCRIPTION
## Why

`scripts/backfill-topic-judge.ts` (shipped in #1363) can never run.

- `Dockerfile:20` copies **only** `src` into the builder — `scripts/` is not in the image.
- `tsconfig.json` has `rootDir: ./src` and `include: ["src/**/*"]` — nothing outside `src` is compiled.
- The script imports through `@/` aliases, which `tsc-alias` rewrites for emitted files only.

So the command recorded in the handoff and the release note:

```
docker exec -i insighta-api node dist/scripts/backfill-topic-judge.js
```

would have failed with `MODULE_NOT_FOUND`, leaving all 19,129 unjudged rows unjudged and the `unfit` filter inert.

## What

`git mv scripts/backfill-topic-judge.ts src/scripts/`. Content unchanged apart from a comment recording why it lives there.

## Verification

```
npx tsc --noEmit          exit 0
npm run build             dist/scripts/backfill-topic-judge.js emitted (2.4k)
head dist/scripts/*.js    require("../modules/curation/topic-judge")   <- alias resolved
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)