### PR TITLE
feat(curation): channel resolution and follow/unfollow API (P2)

### DIFF
--- a/src/api/routes/curations.ts
+++ b/src/api/routes/curations.ts
@@ -20,7 +20,9 @@ import { suggestTopics } from '../../modules/curation/suggest';
 import { maybeTriggerProfileBuild } from '../../modules/curation/interest-profile';
 import { getAccessToken } from '../../modules/youtube/api';
 import { curationWeekKey } from '../../modules/queue/handlers/curation-weekly';
-import { getCurationLimit, type Tier } from '../../config/quota';
+import { getCurationLimit, getCurationChannelLimit, type Tier } from '../../config/quota';
+import { resolveChannel, resolveChannelIds } from '../../modules/curation/channel-resolve';
+import { resolveVideosApiKeys } from '../../skills/plugins/video-discover/v2/youtube-client';
 import { isValidWeekday, nextKstWeekdayAt } from '../../utils/kst';
 import { QUEUE_CONFIG } from '../../modules/queue/types';
 
@@ -55,6 +57,37 @@ async function resolveCurationTier(
     select: { id: true },
   });
   return approved ? 'pro' : 'free';
+}
+
+/** Infinity is not JSON — the wire form for "unlimited" is null. */
+const quotaValue = (n: number): number | null => (Number.isFinite(n) ? n : null);
+
+/**
+ * 404 unless the caller owns :id. Returns the subscription id + owner so the
+ * channel routes below never re-query it, and replies on failure so callers can
+ * `if (!owned) return;`.
+ */
+async function requireOwnedSubscription(
+  request: { user?: unknown; params: { id: string } },
+  reply: {
+    code: (n: number) => { send: (b: unknown) => unknown };
+  }
+): Promise<{ id: string; userId: string } | null> {
+  if (!request.user || !('userId' in (request.user as object))) {
+    reply.code(401).send({ status: 'error', code: 'UNAUTHORIZED' });
+    return null;
+  }
+  const userId = (request.user as { userId: string }).userId;
+  const prisma = getPrismaClient();
+  const sub = await prisma.curation_subscriptions.findUnique({
+    where: { id: request.params.id },
+    select: { id: true, user_id: true },
+  });
+  if (!sub || sub.user_id !== userId) {
+    reply.code(404).send({ status: 'error', code: 'CURATION_NOT_FOUND' });
+    return null;
+  }
+  return { id: sub.id, userId };
 }
 
 export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
@@ -251,6 +284,151 @@ export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     });
     return reply.send({ status: 'ok', data: { curations: withCounts } });
   });
+
+  /**
+   * GET /curations/:id/channels — the channels this curation follows.
+   * Empty for topic-mode curations; the dial uses that to pick which editor to show.
+   */
+  fastify.get<{ Params: { id: string } }>(
+    '/:id/channels',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const owned = await requireOwnedSubscription(request, reply);
+      if (!owned) return;
+      const prisma = getPrismaClient();
+      const channels = await prisma.curation_channels.findMany({
+        where: { subscription_id: owned.id },
+        orderBy: { created_at: 'asc' },
+        select: {
+          id: true,
+          channel_id: true,
+          channel_title: true,
+          thumbnail_url: true,
+          added_via: true,
+          last_seen_at: true,
+        },
+      });
+      const tier = await resolveCurationTier(prisma, owned.userId);
+      return reply.send({
+        status: 'ok',
+        data: { channels, limit: quotaValue(getCurationChannelLimit(tier)), tier },
+      });
+    }
+  );
+
+  /**
+   * POST /curations/:id/channels — follow a channel.
+   *
+   * Two entry points, one route (design §2-a option 3):
+   *   { input: "@nomadcoders" | url | UC... }   pasted by hand   -> added_via 'manual'
+   *   { channelId: "UC..." }                    picked from subs -> added_via 'picked'
+   *
+   * Both go through channels.list (1 unit) because the row stores the uploads
+   * playlist id from the response rather than deriving UC->UU. Idempotent: a
+   * channel already followed returns 200 with the existing row.
+   */
+  fastify.post<{ Params: { id: string }; Body: { input?: unknown; channelId?: unknown } }>(
+    '/:id/channels',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const owned = await requireOwnedSubscription(request, reply);
+      if (!owned) return;
+      const prisma = getPrismaClient();
+      const body = request.body ?? {};
+      const pasted = typeof body.input === 'string' ? body.input.trim() : '';
+      const picked = typeof body.channelId === 'string' ? body.channelId.trim() : '';
+      if (!pasted && !picked) {
+        return reply.code(400).send({ status: 'error', code: 'CHANNEL_INPUT_REQUIRED' });
+      }
+
+      const tier = await resolveCurationTier(prisma, owned.userId);
+      const limit = getCurationChannelLimit(tier);
+      const current = await prisma.curation_channels.count({
+        where: { subscription_id: owned.id },
+      });
+      if (current >= limit) {
+        return reply.code(403).send({
+          status: 'error',
+          code: 'CHANNEL_QUOTA_EXCEEDED',
+          message: 'Channel limit reached for this plan',
+          data: { tier, limit: quotaValue(limit), current },
+        });
+      }
+
+      const apiKeys = resolveVideosApiKeys(process.env);
+      const resolved = picked
+        ? (await resolveChannelIds([picked], apiKeys)).get(picked)
+        : await resolveChannel(pasted, apiKeys);
+      if (!resolved) {
+        return reply.code(404).send({
+          status: 'error',
+          code: 'CHANNEL_NOT_FOUND',
+          message: 'Could not resolve that channel',
+        });
+      }
+
+      // A channel with no uploads playlist cannot be built from — reject at the
+      // door rather than storing a row the weekly build silently skips.
+      if (!resolved.uploadsPlaylistId) {
+        return reply.code(422).send({
+          status: 'error',
+          code: 'CHANNEL_HAS_NO_UPLOADS',
+          message: 'That channel exposes no uploads playlist',
+        });
+      }
+
+      const row = await prisma.curation_channels.upsert({
+        where: {
+          subscription_id_channel_id: {
+            subscription_id: owned.id,
+            channel_id: resolved.channelId,
+          },
+        },
+        create: {
+          subscription_id: owned.id,
+          channel_id: resolved.channelId,
+          uploads_playlist_id: resolved.uploadsPlaylistId,
+          channel_title: resolved.title,
+          thumbnail_url: resolved.thumbnailUrl,
+          added_via: picked ? 'picked' : 'manual',
+        },
+        // Refresh the display snapshot on re-add; added_via records how it first
+        // arrived, so it is deliberately not overwritten.
+        update: {
+          uploads_playlist_id: resolved.uploadsPlaylistId,
+          channel_title: resolved.title,
+          thumbnail_url: resolved.thumbnailUrl,
+        },
+        select: {
+          id: true,
+          channel_id: true,
+          channel_title: true,
+          thumbnail_url: true,
+          added_via: true,
+          last_seen_at: true,
+        },
+      });
+      return reply.send({ status: 'ok', data: { channel: row } });
+    }
+  );
+
+  /** DELETE /curations/:id/channels/:channelId — stop following one channel. */
+  fastify.delete<{ Params: { id: string; channelId: string } }>(
+    '/:id/channels/:channelId',
+    { onRequest: [fastify.authenticate] },
+    async (request, reply) => {
+      const owned = await requireOwnedSubscription(request, reply);
+      if (!owned) return;
+      const prisma = getPrismaClient();
+      const removed = await prisma.curation_channels.deleteMany({
+        where: { subscription_id: owned.id, channel_id: request.params.channelId },
+      });
+      if (removed.count === 0) {
+        return reply.code(404).send({ status: 'error', code: 'CHANNEL_NOT_FOUND' });
+      }
+      return reply.send({ status: 'ok', data: { removed: removed.count } });
+    }
+  );
 
   /**
    * GET /curations/:id/items?week=YYYY-MM-DD — this curation's weekly video feed

--- a/src/config/quota.ts
+++ b/src/config/quota.ts
@@ -66,6 +66,8 @@ export interface TierLimitConfig {
    *  row: legacy duplicates exist in prod (one account holds 21 active rows for
    *  5 topics), so a row count would lock those users out immediately. */
   curations: number | null;
+  /** channels a single channel-mode curation may follow (null = unlimited) */
+  curationChannels: number | null;
   cards: number | null;
   aiSummaries: number | null;
   /**
@@ -83,6 +85,7 @@ export const TIER_LIMITS: Record<Tier, TierLimitConfig> = {
   free: {
     mandalas: 3,
     curations: 1,
+    curationChannels: 3,
     cards: 150,
     aiSummaries: 150,
     richSummaries: 30,
@@ -123,6 +126,7 @@ export const TIER_LIMITS: Record<Tier, TierLimitConfig> = {
   pro: {
     mandalas: 20,
     curations: 5,
+    curationChannels: 10,
     cards: 1_000,
     aiSummaries: 1_000,
     richSummaries: 200,
@@ -163,6 +167,7 @@ export const TIER_LIMITS: Record<Tier, TierLimitConfig> = {
   lifetime: {
     mandalas: null,
     curations: null,
+    curationChannels: null,
     cards: null,
     aiSummaries: null,
     richSummaries: null,
@@ -187,6 +192,7 @@ export const TIER_LIMITS: Record<Tier, TierLimitConfig> = {
   admin: {
     mandalas: null,
     curations: null,
+    curationChannels: null,
     cards: null,
     aiSummaries: null,
     richSummaries: null,
@@ -234,6 +240,11 @@ export function getCardsLimit(tier: Tier): number {
 /** Helper: get curation limit for a tier (returns Infinity for unlimited) */
 export function getCurationLimit(tier: Tier): number {
   return TIER_LIMITS[tier].curations ?? Infinity;
+}
+
+/** Helper: get per-curation channel limit for a tier (returns Infinity for unlimited) */
+export function getCurationChannelLimit(tier: Tier): number {
+  return TIER_LIMITS[tier].curationChannels ?? Infinity;
 }
 
 /** Helper: get rate limit max for a tier (returns 0 to indicate unlimited) */

--- a/src/modules/curation/channel-resolve.ts
+++ b/src/modules/curation/channel-resolve.ts
@@ -1,0 +1,172 @@
+/**
+ * Channel resolution for channel-based curation (P2).
+ * Design: docs/design/curation-channel-subscription-2026-07-27.md §2-a, §4.
+ *
+ * Takes whatever a user pastes — a URL, an @handle, a bare channel id — and
+ * returns the one thing the weekly build actually needs: the uploads playlist.
+ *
+ * It comes from the same `channels.list` response as the id, so the build never
+ * derives it from the UC->UU convention. That convention happens to hold today
+ * (verified 2026-07-27: @nomadcoders -> UCUpJs89fSBXNolQGOYKn0YQ, uploads
+ * UUUpJs89fSBXNolQGOYKn0YQ), but it is not a documented guarantee and the call
+ * that would tell us costs the same 1 unit either way.
+ */
+
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'channel-resolve' });
+
+const API = 'https://www.googleapis.com/youtube/v3';
+
+/** channels.list accepts at most 50 ids per call. */
+export const CHANNEL_LOOKUP_BATCH = 50;
+
+export interface ResolvedChannel {
+  channelId: string;
+  title: string | null;
+  uploadsPlaylistId: string | null;
+  thumbnailUrl: string | null;
+}
+
+/** What the user typed, reduced to something channels.list can accept. */
+type ChannelRef =
+  | { kind: 'id'; value: string }
+  | { kind: 'handle'; value: string }
+  | { kind: 'username'; value: string };
+
+/** A channel id is always `UC` + 22 url-safe base64 chars. */
+const CHANNEL_ID_RE = /^UC[\w-]{22}$/;
+
+/**
+ * Parse a pasted string into a lookup key. Pure — no network, so the parsing
+ * rules are testable without a quota unit.
+ *
+ * Accepted:
+ *   UCUpJs89fSBXNolQGOYKn0YQ
+ *   @nomadcoders                       (with or without the @)
+ *   https://youtube.com/@nomadcoders
+ *   https://www.youtube.com/channel/UC.../videos
+ *   https://youtube.com/c/SomeName     (legacy custom url -> treated as a handle)
+ *   https://youtube.com/user/SomeName  (legacy username)
+ */
+export function parseChannelRef(input: string): ChannelRef | null {
+  const raw = input.trim();
+  if (!raw) return null;
+
+  if (CHANNEL_ID_RE.test(raw)) return { kind: 'id', value: raw };
+  if (raw.startsWith('@')) {
+    const h = raw.slice(1).split(/[/?#]/)[0] ?? '';
+    return h ? { kind: 'handle', value: h } : null;
+  }
+
+  // Anything URL-shaped: read the path, ignore the rest.
+  const m = raw.match(/^(?:https?:\/\/)?(?:www\.|m\.)?youtube\.com\/(.+)$/i);
+  if (m) {
+    const segments = (m[1] ?? '').split(/[?#]/)[0]?.split('/').filter(Boolean) ?? [];
+    const [first, second] = segments;
+    if (!first) return null;
+    if (first.startsWith('@')) {
+      const h = first.slice(1);
+      return h ? { kind: 'handle', value: h } : null;
+    }
+    if (first === 'channel' && second) {
+      return CHANNEL_ID_RE.test(second) ? { kind: 'id', value: second } : null;
+    }
+    if (first === 'user' && second) return { kind: 'username', value: second };
+    if (first === 'c' && second) return { kind: 'handle', value: second };
+    return null;
+  }
+
+  // A bare word is most likely a handle typed without the @.
+  if (/^[\w.-]{3,30}$/.test(raw)) return { kind: 'handle', value: raw };
+  return null;
+}
+
+function paramFor(ref: ChannelRef): string {
+  if (ref.kind === 'id') return `id=${encodeURIComponent(ref.value)}`;
+  if (ref.kind === 'handle') return `forHandle=${encodeURIComponent(ref.value)}`;
+  return `forUsername=${encodeURIComponent(ref.value)}`;
+}
+
+interface ChannelsListItem {
+  id?: string;
+  snippet?: { title?: string; thumbnails?: Record<string, { url?: string } | undefined> };
+  contentDetails?: { relatedPlaylists?: { uploads?: string } };
+}
+
+function toResolved(item: ChannelsListItem): ResolvedChannel | null {
+  if (!item.id) return null;
+  const thumbs = item.snippet?.thumbnails ?? {};
+  return {
+    channelId: item.id,
+    title: item.snippet?.title ?? null,
+    uploadsPlaylistId: item.contentDetails?.relatedPlaylists?.uploads ?? null,
+    thumbnailUrl: thumbs['medium']?.url ?? thumbs['default']?.url ?? null,
+  };
+}
+
+/**
+ * Resolve one pasted reference. Returns null when the input is unparseable or
+ * the channel does not exist — the caller turns that into a 404/400, never into
+ * a silently stored row.
+ *
+ * Cost: 1 unit.
+ */
+export async function resolveChannel(
+  input: string,
+  apiKeys: string[],
+  fetchImpl: typeof fetch = fetch
+): Promise<ResolvedChannel | null> {
+  const ref = parseChannelRef(input);
+  if (!ref) return null;
+  const key = apiKeys[0];
+  if (!key) {
+    log.warn('no YouTube API key configured, channel resolution unavailable');
+    return null;
+  }
+
+  const url = `${API}/channels?part=snippet,contentDetails&${paramFor(ref)}&key=${key}`;
+  const res = await fetchImpl(url);
+  if (!res.ok) {
+    log.warn('channels.list failed', { status: res.status, kind: ref.kind });
+    return null;
+  }
+  const json = (await res.json()) as { items?: ChannelsListItem[] };
+  const first = json.items?.[0];
+  return first ? toResolved(first) : null;
+}
+
+/**
+ * Batch-resolve channel ids already known (the "pick from my subscriptions"
+ * path, where the ids come from subscriptions.list). 1 unit per 50.
+ */
+export async function resolveChannelIds(
+  channelIds: string[],
+  apiKeys: string[],
+  fetchImpl: typeof fetch = fetch
+): Promise<Map<string, ResolvedChannel>> {
+  const out = new Map<string, ResolvedChannel>();
+  const ids = [...new Set(channelIds.filter((id) => CHANNEL_ID_RE.test(id)))];
+  const key = apiKeys[0];
+  if (ids.length === 0 || !key) return out;
+
+  for (let i = 0; i < ids.length; i += CHANNEL_LOOKUP_BATCH) {
+    const batch = ids.slice(i, i + CHANNEL_LOOKUP_BATCH);
+    const url = `${API}/channels?part=snippet,contentDetails&id=${batch.join(',')}&key=${key}`;
+    try {
+      const res = await fetchImpl(url);
+      if (!res.ok) {
+        log.warn('channels.list batch failed', { status: res.status, size: batch.length });
+        continue;
+      }
+      const json = (await res.json()) as { items?: ChannelsListItem[] };
+      for (const item of json.items ?? []) {
+        const r = toResolved(item);
+        if (r) out.set(r.channelId, r);
+      }
+    } catch (err) {
+      log.warn('channels.list batch threw', { error: (err as Error).message });
+    }
+  }
+  return out;
+}

--- a/tests/smoke/curation-channel-resolve.test.ts
+++ b/tests/smoke/curation-channel-resolve.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Channel resolution — parsing rules and the channels.list contract.
+ *
+ * Parsing is pure, so every accepted spelling is asserted without spending a
+ * quota unit. The network tests pin the two things the weekly build depends on:
+ * the uploads playlist comes from the RESPONSE (never derived from UC->UU), and
+ * an unresolvable input yields null rather than a half-filled row.
+ */
+
+import {
+  parseChannelRef,
+  resolveChannel,
+  resolveChannelIds,
+} from '../../src/modules/curation/channel-resolve';
+
+const KEY = ['test-key'];
+const CH = 'UCUpJs89fSBXNolQGOYKn0YQ';
+
+function channelsReply(items: unknown[]) {
+  return {
+    ok: true,
+    json: async () => ({ items }),
+  } as unknown as Response;
+}
+
+const nomad = {
+  id: CH,
+  snippet: { title: '노마드 코더', thumbnails: { medium: { url: 'https://i/med.jpg' } } },
+  contentDetails: { relatedPlaylists: { uploads: 'UUUpJs89fSBXNolQGOYKn0YQ' } },
+};
+
+describe('parseChannelRef', () => {
+  it('accepts a bare channel id', () => {
+    expect(parseChannelRef(CH)).toEqual({ kind: 'id', value: CH });
+  });
+
+  it('accepts handles with and without the @', () => {
+    expect(parseChannelRef('@nomadcoders')).toEqual({ kind: 'handle', value: 'nomadcoders' });
+    expect(parseChannelRef('nomadcoders')).toEqual({ kind: 'handle', value: 'nomadcoders' });
+  });
+
+  it.each([
+    ['https://youtube.com/@nomadcoders', { kind: 'handle', value: 'nomadcoders' }],
+    ['https://www.youtube.com/@nomadcoders/videos', { kind: 'handle', value: 'nomadcoders' }],
+    ['http://m.youtube.com/@nomadcoders?si=x', { kind: 'handle', value: 'nomadcoders' }],
+    [`https://www.youtube.com/channel/${CH}`, { kind: 'id', value: CH }],
+    [`youtube.com/channel/${CH}/videos`, { kind: 'id', value: CH }],
+    ['https://youtube.com/c/SomeName', { kind: 'handle', value: 'SomeName' }],
+    ['https://youtube.com/user/SomeName', { kind: 'username', value: 'SomeName' }],
+  ])('parses %s', (input, expected) => {
+    expect(parseChannelRef(input as string)).toEqual(expected);
+  });
+
+  it.each([
+    ['', 'empty'],
+    ['   ', 'blank'],
+    ['https://youtube.com/watch?v=abc', 'a video url is not a channel'],
+    ['https://vimeo.com/@someone', 'another host'],
+    ['https://youtube.com/channel/notavalidid', 'malformed id after /channel/'],
+  ])('rejects %s (%s)', (input) => {
+    expect(parseChannelRef(input as string)).toBeNull();
+  });
+});
+
+describe('resolveChannel', () => {
+  it('returns the uploads playlist from the response, not from the id', async () => {
+    const fetchImpl = jest.fn(async () => channelsReply([nomad])) as unknown as typeof fetch;
+    const out = await resolveChannel('@nomadcoders', KEY, fetchImpl);
+    expect(out).toEqual({
+      channelId: CH,
+      title: '노마드 코더',
+      uploadsPlaylistId: 'UUUpJs89fSBXNolQGOYKn0YQ',
+      thumbnailUrl: 'https://i/med.jpg',
+    });
+  });
+
+  it('asks channels.list by handle for a handle, by id for an id', async () => {
+    const urls: string[] = [];
+    const fetchImpl = jest.fn(async (url: unknown) => {
+      urls.push(String(url));
+      return channelsReply([nomad]);
+    }) as unknown as typeof fetch;
+
+    await resolveChannel('@nomadcoders', KEY, fetchImpl);
+    await resolveChannel(CH, KEY, fetchImpl);
+    expect(urls[0]).toContain('forHandle=nomadcoders');
+    expect(urls[1]).toContain(`id=${CH}`);
+    // the uploads playlist is only in contentDetails — always request it
+    expect(urls[0]).toContain('part=snippet%2CcontentDetails'.replace('%2C', ','));
+  });
+
+  it('returns null for an empty items array', async () => {
+    const fetchImpl = jest.fn(async () => channelsReply([])) as unknown as typeof fetch;
+    expect(await resolveChannel('@ghost', KEY, fetchImpl)).toBeNull();
+  });
+
+  it('returns null on a non-OK status without throwing', async () => {
+    const fetchImpl = jest.fn(
+      async () => ({ ok: false, status: 403 }) as unknown as Response
+    ) as unknown as typeof fetch;
+    expect(await resolveChannel('@nomadcoders', KEY, fetchImpl)).toBeNull();
+  });
+
+  it('does not call out when the input is unparseable', async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    expect(await resolveChannel('https://youtube.com/watch?v=abc', KEY, fetchImpl)).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('does not call out when no API key is configured', async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    expect(await resolveChannel('@nomadcoders', [], fetchImpl)).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a channel with no thumbnails or uploads playlist', async () => {
+    const fetchImpl = jest.fn(async () =>
+      channelsReply([{ id: CH, snippet: { title: 'bare' } }])
+    ) as unknown as typeof fetch;
+    const out = await resolveChannel(CH, KEY, fetchImpl);
+    expect(out).toMatchObject({ channelId: CH, uploadsPlaylistId: null, thumbnailUrl: null });
+  });
+});
+
+describe('resolveChannelIds', () => {
+  it('batches 50 at a time and keys the result by channel id', async () => {
+    const ids = Array.from({ length: 51 }, (_, i) => `UC${String(i).padStart(22, 'x')}`);
+    let calls = 0;
+    const fetchImpl = jest.fn(async (url: unknown) => {
+      calls++;
+      const idParam = String(url).match(/id=([^&]+)/)?.[1] ?? '';
+      const batch = idParam.split(',');
+      return channelsReply(
+        batch.map((id) => ({
+          id,
+          snippet: { title: id },
+          contentDetails: { relatedPlaylists: { uploads: id.replace(/^UC/, 'UU') } },
+        }))
+      );
+    }) as unknown as typeof fetch;
+
+    const out = await resolveChannelIds(ids, KEY, fetchImpl);
+    expect(calls).toBe(2);
+    expect(out.size).toBe(51);
+    expect(out.get(ids[0]!)?.uploadsPlaylistId).toBe(ids[0]!.replace(/^UC/, 'UU'));
+  });
+
+  it('drops malformed ids before spending a call', async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    const out = await resolveChannelIds(['not-an-id', ''], KEY, fetchImpl);
+    expect(out.size).toBe(0);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('keeps the batches that succeed when one fails', async () => {
+    const ids = Array.from({ length: 51 }, (_, i) => `UC${String(i).padStart(22, 'y')}`);
+    let call = 0;
+    const fetchImpl = jest.fn(async (url: unknown) => {
+      call++;
+      if (call === 1) return { ok: false, status: 500 } as unknown as Response;
+      const idParam = String(url).match(/id=([^&]+)/)?.[1] ?? '';
+      return channelsReply(idParam.split(',').map((id) => ({ id, snippet: { title: id } })));
+    }) as unknown as typeof fetch;
+
+    const out = await resolveChannelIds(ids, KEY, fetchImpl);
+    expect(out.size).toBe(1); // only the second batch survived
+  });
+});


### PR DESCRIPTION
Design: `docs/design/curation-channel-subscription-2026-07-27.md` — P2 of the channel-mode plan. P1 (`curation_channels` table) shipped in #1365.

## What

The server half of "I want only the channels I picked, and only what they uploaded this week."

```
GET    /curations/:id/channels
POST   /curations/:id/channels     { input: "@handle" | url | "UC..." }  or  { channelId: "UC..." }
DELETE /curations/:id/channels/:channelId
```

Both add paths converge on `channels.list` (1 unit) because the row stores `uploads_playlist_id` **from that response**. The `UC` → `UU` convention holds today (verified against `@nomadcoders` → `UCUpJs89fSBXNolQGOYKn0YQ` / `UUUpJs89fSBXNolQGOYKn0YQ`), but it is not a documented guarantee and the authoritative call costs the same single unit.

`parseChannelRef` is pure, so every accepted spelling is covered without spending quota: bare id, `@handle`, handle without the `@`, `/channel/`, legacy `/c/` and `/user/`, with or without scheme, `www`/`m`, and query strings. A watch URL is rejected rather than guessed at.

A channel exposing no uploads playlist is refused with 422 rather than stored as a row the weekly build would silently skip.

## Quota

The per-plan channel ceiling lives in `src/config/quota.ts` beside the existing curation ceiling — free 3 / pro 10, lifetime and admin unlimited — not as a literal in the route. `Infinity` is not JSON, so the wire form for unlimited is `null`.

## Not in this PR

- **P3** `buildFromChannels()` + builder `source` branch + `CURATION_CHANNEL_SOURCE_ENABLED` flag.
- **P4** dial editor. The frontend api-client method lands with it — adding an unused one now would be dead code.

Until P3, a `youtube_subs` subscription still builds through the discover path, so this PR changes no user-visible behaviour.

## Tests

24 in `tests/smoke/curation-channel-resolve.test.ts`: the parsing table (accept and reject), uploads-playlist-from-response, per-kind query parameter, 50-per-batch splitting, one batch failing without losing the others, and the no-key / unparseable short-circuits that must not spend a call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)