### PR TITLE
feat(curation): build the week from followed channels (P3)

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -260,6 +260,15 @@ const envSchema = z.object({
     .preprocess((v) => String(v).toLowerCase() === 'true', z.boolean())
     .default(false),
 
+  // Channel-mode curation (2026-07-27). Off (default) keeps the shipped behaviour
+  // exactly: a subscription with source='youtube_subs' still builds through the
+  // discover path, so the column can be set before the leg exists. On: such a
+  // subscription is built from its followed channels' uploads instead.
+  // Rollback is a config flip, not a revert.
+  CURATION_CHANNEL_SOURCE_ENABLED: z
+    .preprocess((v) => String(v).toLowerCase() === 'true', z.boolean())
+    .default(false),
+
   // CP512 — metadata REFRESH for active rows (videos.list re-fetch, keeps served
   // rows ToS-compliant AND titled). Default true; set 'false' to pause refresh
   // (scrub still only touches inactive rows, so active rows just stop aging-out).
@@ -470,6 +479,11 @@ export const config = {
   // Weekly curation schedule — KST calendar instead of UTC wall-clock (2026-07-27).
   curationSchedule: {
     kstEnabled: env.CURATION_SCHED_KST_ENABLED,
+  },
+
+  // Channel-mode curation — build from followed channels' uploads (2026-07-27).
+  curationChannelSource: {
+    enabled: env.CURATION_CHANNEL_SOURCE_ENABLED,
   },
 
   // video_pool ToS hygiene cron (CP494).

--- a/src/modules/curation/channel-uploads.ts
+++ b/src/modules/curation/channel-uploads.ts
@@ -1,0 +1,191 @@
+/**
+ * Channel-mode collection leg (P3).
+ * Design: docs/design/curation-channel-subscription-2026-07-27.md §4.
+ *
+ * Reads what the followed channels uploaded this week. Two differences from the
+ * discover path, both deliberate:
+ *
+ *   - Server API key, not the user's OAuth token. The uploads playlist is public
+ *     and this runs unattended on a weekly cron; a build that dies because an
+ *     access token expired overnight is a build that silently stops arriving.
+ *   - No relevance scoring. The user picked the channel — that IS the relevance.
+ *     CURATION_RELEVANCE_FLOOR is not applied here (§4 "품질"), and the stored
+ *     relevance_pct is a constant so the feed's existing sort stays total.
+ *
+ * Cost: 1 unit per channel (playlistItems.list, 50 newest uploads) + 1 unit per
+ * 50 videos (videos.list for duration). Ten channels ≈ 12-20 units a week.
+ */
+
+import { logger } from '@/utils/logger';
+import {
+  videosBatchFullMetadata,
+  parseIsoDuration,
+  isShortsByDuration,
+} from '@/skills/plugins/video-discover/v2/youtube-client';
+
+const log = logger.child({ module: 'channel-uploads' });
+
+const API = 'https://www.googleapis.com/youtube/v3';
+
+/** playlistItems.list page size — the newest 50 uploads cover a week for any
+ *  realistic channel, so the leg never pages (1 unit per channel, flat). */
+export const UPLOADS_PAGE_SIZE = 50;
+
+/**
+ * Displayed relevance for channel-mode items. The user chose the channel, so
+ * every upload is equally on-topic; a varying percentage here would be theatre.
+ */
+export const CHANNEL_MODE_RELEVANCE_PCT = 100;
+
+export interface ChannelUpload {
+  videoId: string;
+  channelId: string;
+  publishedAt: Date;
+  title: string;
+}
+
+interface PlaylistItemsResponse {
+  items?: Array<{
+    snippet?: { title?: string; resourceId?: { videoId?: string } };
+    contentDetails?: { videoId?: string; videoPublishedAt?: string };
+  }>;
+}
+
+/**
+ * Newest uploads for one channel, filtered to those published at or after
+ * `since`. Returns [] (never throws) on an API failure: one unreachable channel
+ * must not empty the whole week.
+ */
+export async function fetchChannelUploads(
+  channelId: string,
+  uploadsPlaylistId: string,
+  since: Date,
+  apiKeys: string[],
+  fetchImpl: typeof fetch = fetch
+): Promise<ChannelUpload[]> {
+  const key = apiKeys[0];
+  if (!key) return [];
+  const url =
+    `${API}/playlistItems?part=snippet,contentDetails` +
+    `&playlistId=${encodeURIComponent(uploadsPlaylistId)}` +
+    `&maxResults=${UPLOADS_PAGE_SIZE}&key=${key}`;
+  try {
+    const res = await fetchImpl(url);
+    if (!res.ok) {
+      log.warn('playlistItems.list failed', { status: res.status, channelId });
+      return [];
+    }
+    const json = (await res.json()) as PlaylistItemsResponse;
+    const out: ChannelUpload[] = [];
+    for (const item of json.items ?? []) {
+      const videoId = item.contentDetails?.videoId ?? item.snippet?.resourceId?.videoId;
+      const publishedRaw = item.contentDetails?.videoPublishedAt;
+      if (!videoId || !publishedRaw) continue;
+      const publishedAt = new Date(publishedRaw);
+      if (Number.isNaN(publishedAt.getTime()) || publishedAt < since) continue;
+      out.push({ videoId, channelId, publishedAt, title: item.snippet?.title ?? '' });
+    }
+    return out;
+  } catch (err) {
+    log.warn('playlistItems.list threw', { channelId, error: (err as Error).message });
+    return [];
+  }
+}
+
+export interface ChannelPick {
+  videoId: string;
+  relevancePct: number;
+}
+
+export interface CollectChannelUploadsArgs {
+  channels: Array<{ channel_id: string; uploads_playlist_id: string | null }>;
+  since: Date;
+  limit: number;
+  apiKeys: string[];
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Collect this week's uploads across every followed channel, drop Shorts, and
+ * order newest-first.
+ *
+ * Interleaved round-robin by channel so one prolific uploader cannot fill the
+ * whole week: take each channel's newest, then each channel's second-newest, and
+ * so on. Within a round, newer wins.
+ *
+ * An empty result is a legitimate outcome (§2-d): a week where nothing was
+ * uploaded shows an honest empty week, not filler from somewhere else.
+ */
+export async function collectChannelUploads(
+  args: CollectChannelUploadsArgs
+): Promise<ChannelPick[]> {
+  const { channels, since, limit, apiKeys, fetchImpl = fetch } = args;
+  const usable = channels.filter((c) => c.uploads_playlist_id);
+  if (usable.length === 0 || limit <= 0) return [];
+
+  const perChannel = await Promise.all(
+    usable.map((c) =>
+      fetchChannelUploads(c.channel_id, c.uploads_playlist_id as string, since, apiKeys, fetchImpl)
+    )
+  );
+
+  const all = perChannel.flat();
+  if (all.length === 0) return [];
+
+  // Shorts are excluded the same way the rest of the product excludes them —
+  // by measured duration, not by title heuristics.
+  //
+  // Two kinds of "no duration" that must not be conflated:
+  //   the call failed        -> nothing was measured, keep everything. An API
+  //                             blip must not silently empty someone's week.
+  //   the call returned but
+  //   this video has none    -> treat as Shorts, per isShortsByDuration: videos.list
+  //                             omits contentDetails.duration for Shorts specifically.
+  let measured = true;
+  const meta = await videosBatchFullMetadata({
+    videoIds: [...new Set(all.map((u) => u.videoId))],
+    apiKey: apiKeys,
+    fetchFn: fetchImpl,
+  }).catch((err: unknown) => {
+    log.warn('videos.list failed, shorts filter unavailable this run', {
+      error: (err as Error).message,
+    });
+    measured = false;
+    return [];
+  });
+  const durationById = new Map(
+    meta.map((m) => [m.id, parseIsoDuration(m.contentDetails?.duration)])
+  );
+
+  const eligible = measured
+    ? all.filter((u) => !isShortsByDuration(durationById.get(u.videoId) ?? null))
+    : all;
+
+  const byChannel = new Map<string, ChannelUpload[]>();
+  for (const u of eligible) {
+    const list = byChannel.get(u.channelId) ?? [];
+    list.push(u);
+    byChannel.set(u.channelId, list);
+  }
+  for (const list of byChannel.values()) {
+    list.sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
+  }
+
+  const picked: ChannelPick[] = [];
+  const seen = new Set<string>();
+  const lists = [...byChannel.values()];
+  const deepest = Math.max(...lists.map((l) => l.length));
+  for (let round = 0; round < deepest && picked.length < limit; round++) {
+    const thisRound = lists
+      .map((l) => l[round])
+      .filter((u): u is ChannelUpload => Boolean(u))
+      .sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
+    for (const u of thisRound) {
+      if (picked.length >= limit) break;
+      if (seen.has(u.videoId)) continue;
+      seen.add(u.videoId);
+      picked.push({ videoId: u.videoId, relevancePct: CHANNEL_MODE_RELEVANCE_PCT });
+    }
+  }
+  return picked;
+}

--- a/src/modules/queue/handlers/curation-build.ts
+++ b/src/modules/queue/handlers/curation-build.ts
@@ -28,6 +28,11 @@ import { runV5Executor } from '@/skills/plugins/video-discover/v5/executor';
 import { MS_PER_DAY } from '@/utils/time-constants';
 import { config } from '../../../config';
 import { nextKstWeekdayAt } from '@/utils/kst';
+import { collectChannelUploads } from '@/modules/curation/channel-uploads';
+import { resolveVideosApiKeys } from '@/skills/plugins/video-discover/v2/youtube-client';
+
+/** curation_subscriptions.source value that means "build from followed channels". */
+const CHANNEL_SOURCE = 'youtube_subs';
 
 const log = logger.child({ module: 'queue/curation-build' });
 
@@ -114,26 +119,55 @@ export async function registerCurationBuildWorker(): Promise<void> {
       return;
     }
 
-    // build-1/2/3 — INSTANT pool-cosine KNN (reuses add-cards Layer1,
-    // matchFromVideoPoolByCenterGoal). Embed the topic ONCE (~0.5s) → pgvector cosine
-    // on video_pool_embeddings → top-N. NO live search / candidate embed / LLM picker;
-    // runV5Executor's full pipeline (LLM×2 + search.list fanout + bulk embed) stalled
-    // the build 20s+. ~1-2s. Thin-pool niche topics → async v5 enrichment = follow-up.
-    const [centerEmbedding] = await embedBatch([sub.topic]);
-    if (!centerEmbedding) {
-      log.warn('curation build: topic embed failed', { subscriptionId, topic: sub.topic });
-      return;
+    // build-1/2/3 — how the week's videos are chosen. This is the ONLY thing the
+    // source branch changes; the snapshot write, watched_at preservation and
+    // cadence advance below are shared verbatim.
+    const channelMode =
+      config.curationChannelSource.enabled && sub.source === CHANNEL_SOURCE && !job.data.deep;
+
+    let picked: Array<{ videoId: string; relevancePct: number }>;
+
+    if (channelMode) {
+      // Channel mode — the user named the channels, so there is nothing to
+      // discover and nothing to score. Uploads since this week's Monday (KST),
+      // interleaved so one prolific channel cannot fill the week.
+      const channels = await prisma.curation_channels.findMany({
+        where: { subscription_id: subscriptionId },
+        select: { channel_id: true, uploads_playlist_id: true },
+      });
+      picked = await collectChannelUploads({
+        channels,
+        since: new Date(weekOf),
+        limit: QUEUE_CONFIG.CURATION_TARGET_VIDEOS,
+        apiKeys: resolveVideosApiKeys(process.env),
+      });
+      log.info('curation build (channel mode)', {
+        subscriptionId,
+        channels: channels.length,
+        picked: picked.length,
+      });
+    } else {
+      // Topic mode — INSTANT pool-cosine KNN (reuses add-cards Layer1,
+      // matchFromVideoPoolByCenterGoal). Embed the topic ONCE (~0.5s) → pgvector cosine
+      // on video_pool_embeddings → top-N. NO live search / candidate embed / LLM picker;
+      // runV5Executor's full pipeline (LLM×2 + search.list fanout + bulk embed) stalled
+      // the build 20s+. ~1-2s. Thin-pool niche topics → async v5 enrichment = follow-up.
+      const [centerEmbedding] = await embedBatch([sub.topic]);
+      if (!centerEmbedding) {
+        log.warn('curation build: topic embed failed', { subscriptionId, topic: sub.topic });
+        return;
+      }
+      const matches = await matchFromVideoPoolByCenterGoal({
+        centerEmbedding,
+        subGoals: [],
+        language: 'ko',
+        limit: QUEUE_CONFIG.CURATION_TARGET_VIDEOS,
+      });
+      picked = matches.map((m) => ({
+        videoId: m.videoId,
+        relevancePct: Math.max(1, Math.min(100, Math.round((m.score ?? 0) * 100))),
+      }));
     }
-    const matches = await matchFromVideoPoolByCenterGoal({
-      centerEmbedding,
-      subGoals: [],
-      language: 'ko',
-      limit: QUEUE_CONFIG.CURATION_TARGET_VIDEOS,
-    });
-    const picked: Array<{ videoId: string; relevancePct: number }> = matches.map((m) => ({
-      videoId: m.videoId,
-      relevancePct: Math.max(1, Math.min(100, Math.round((m.score ?? 0) * 100))),
-    }));
 
     // build-4 — rich-summary is REUSE-ONLY for P0. video_rich_summaries is a
     // video-keyed GLOBAL table (leaks across goals), so the build never writes it
@@ -177,7 +211,11 @@ export async function registerCurationBuildWorker(): Promise<void> {
     // Thin pool (niche topic) → enqueue a background live-search enrichment (serve-first:
     // the fast pool result is already served; v5 appends more behind). Separate singleton
     // key so it doesn't collide with the weekly/immediate fast build.
-    if (picked.length < QUEUE_CONFIG.CURATION_MIN_VIDEOS) {
+    //
+    // NEVER in channel mode: a quiet week there is the honest answer (§2-d), and
+    // topping it up with discovered videos would put channels in the feed that
+    // the user did not follow — the exact thing this mode exists to prevent.
+    if (!channelMode && picked.length < QUEUE_CONFIG.CURATION_MIN_VIDEOS) {
       await enqueueCurationBuild(
         { subscriptionId, weekOf, deep: true },
         { singletonKey: `${subscriptionId}:deep` }
@@ -208,9 +246,11 @@ export async function registerCurationBuildWorker(): Promise<void> {
       subscriptionId,
       weekOf,
       topic: sub.topic,
-      poolMatches: matches.length,
+      mode: channelMode ? 'channel' : 'topic',
       picked: picked.length,
-      belowMin: picked.length < QUEUE_CONFIG.CURATION_MIN_VIDEOS,
+      // Only meaningful in topic mode; channel mode has no pool and an empty
+      // week is a valid outcome there, not a shortfall.
+      belowMin: !channelMode && picked.length < QUEUE_CONFIG.CURATION_MIN_VIDEOS,
     });
   });
 }

--- a/tests/smoke/curation-channel-uploads.test.ts
+++ b/tests/smoke/curation-channel-uploads.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Channel-mode collection leg.
+ *
+ * The properties that matter are the ones a user would notice: a week only
+ * contains things published that week, one busy channel cannot crowd out the
+ * others, Shorts stay out, and a quiet week stays honestly empty instead of
+ * being topped up from somewhere else.
+ */
+
+import {
+  fetchChannelUploads,
+  collectChannelUploads,
+  CHANNEL_MODE_RELEVANCE_PCT,
+} from '../../src/modules/curation/channel-uploads';
+
+const KEY = ['test-key'];
+const MONDAY = new Date('2026-07-27T00:00:00+09:00');
+
+function playlistReply(items: Array<{ id: string; at: string; title?: string }>) {
+  return {
+    ok: true,
+    json: async () => ({
+      items: items.map((i) => ({
+        snippet: { title: i.title ?? i.id, resourceId: { videoId: i.id } },
+        contentDetails: { videoId: i.id, videoPublishedAt: i.at },
+      })),
+    }),
+  } as unknown as Response;
+}
+
+/** videos.list reply — duration drives the Shorts filter. */
+function videosReply(rows: Array<{ id: string; duration: string }>) {
+  return {
+    ok: true,
+    json: async () => ({
+      items: rows.map((r) => ({
+        id: r.id,
+        snippet: { title: r.id },
+        contentDetails: { duration: r.duration },
+      })),
+    }),
+  } as unknown as Response;
+}
+
+const LONG = 'PT12M30S';
+const SHORT = 'PT45S';
+
+/** Routes a call to the playlist or videos stub based on its URL. */
+function router(
+  uploads: Record<string, Array<{ id: string; at: string }>>,
+  durations: Record<string, string>
+) {
+  return jest.fn(async (url: unknown) => {
+    const u = String(url);
+    if (u.includes('/playlistItems')) {
+      const pl = decodeURIComponent(u.match(/playlistId=([^&]+)/)?.[1] ?? '');
+      return playlistReply(uploads[pl] ?? []);
+    }
+    // searchParams encodes the comma, so decode before splitting
+    const ids = decodeURIComponent(u.match(/[?&]id=([^&]+)/)?.[1] ?? '')
+      .split(',')
+      .filter(Boolean);
+    return videosReply(ids.map((id) => ({ id, duration: durations[id] ?? LONG })));
+  }) as unknown as typeof fetch;
+}
+
+describe('fetchChannelUploads', () => {
+  it('keeps only uploads published at or after the week start', async () => {
+    const fetchImpl = jest.fn(async () =>
+      playlistReply([
+        { id: 'new1', at: '2026-07-27T09:00:00Z' },
+        { id: 'lastweek', at: '2026-07-24T09:00:00Z' },
+      ])
+    ) as unknown as typeof fetch;
+
+    const out = await fetchChannelUploads('UC1', 'UU1', MONDAY, KEY, fetchImpl);
+    expect(out.map((u) => u.videoId)).toEqual(['new1']);
+  });
+
+  it('returns [] instead of throwing when the channel call fails', async () => {
+    const fetchImpl = jest.fn(
+      async () => ({ ok: false, status: 404 }) as unknown as Response
+    ) as unknown as typeof fetch;
+    expect(await fetchChannelUploads('UC1', 'UU1', MONDAY, KEY, fetchImpl)).toEqual([]);
+  });
+
+  it('skips rows with no publish date rather than guessing one', async () => {
+    const fetchImpl = jest.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => ({ items: [{ contentDetails: { videoId: 'x' } }] }),
+        }) as unknown as Response
+    ) as unknown as typeof fetch;
+    expect(await fetchChannelUploads('UC1', 'UU1', MONDAY, KEY, fetchImpl)).toEqual([]);
+  });
+
+  it('spends nothing when no API key is configured', async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    expect(await fetchChannelUploads('UC1', 'UU1', MONDAY, [], fetchImpl)).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('collectChannelUploads', () => {
+  const twoChannels = [
+    { channel_id: 'UC1', uploads_playlist_id: 'UU1' },
+    { channel_id: 'UC2', uploads_playlist_id: 'UU2' },
+  ];
+
+  it('interleaves so one prolific channel cannot fill the week', async () => {
+    const fetchImpl = router(
+      {
+        UU1: [
+          { id: 'a1', at: '2026-07-31T10:00:00Z' },
+          { id: 'a2', at: '2026-07-30T10:00:00Z' },
+          { id: 'a3', at: '2026-07-29T10:00:00Z' },
+        ],
+        UU2: [{ id: 'b1', at: '2026-07-28T10:00:00Z' }],
+      },
+      {}
+    );
+
+    const out = await collectChannelUploads({
+      channels: twoChannels,
+      since: MONDAY,
+      limit: 3,
+      apiKeys: KEY,
+      fetchImpl,
+    });
+    // round 1 takes the newest from each channel before round 2 revisits UC1
+    expect(out.map((p) => p.videoId)).toEqual(['a1', 'b1', 'a2']);
+  });
+
+  it('drops Shorts by measured duration', async () => {
+    const fetchImpl = router(
+      {
+        UU1: [
+          { id: 'short', at: '2026-07-31T10:00:00Z' },
+          { id: 'long', at: '2026-07-30T10:00:00Z' },
+        ],
+      },
+      { short: SHORT, long: LONG }
+    );
+
+    const out = await collectChannelUploads({
+      channels: [twoChannels[0]!],
+      since: MONDAY,
+      limit: 10,
+      apiKeys: KEY,
+      fetchImpl,
+    });
+    expect(out.map((p) => p.videoId)).toEqual(['long']);
+  });
+
+  it('keeps everything when videos.list itself fails (no measurement, no drop)', async () => {
+    const fetchImpl = jest.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes('/playlistItems'))
+        return playlistReply([{ id: 'unknown', at: '2026-07-31T10:00:00Z' }]);
+      return { ok: false, status: 500 } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const out = await collectChannelUploads({
+      channels: [twoChannels[0]!],
+      since: MONDAY,
+      limit: 10,
+      apiKeys: KEY,
+      fetchImpl,
+    });
+    expect(out.map((p) => p.videoId)).toEqual(['unknown']);
+  });
+
+  it('drops a video whose duration is absent from a successful reply', async () => {
+    // videos.list omits contentDetails.duration for Shorts specifically, so an
+    // absent duration in an OK reply is treated as a Short (codebase convention).
+    const fetchImpl = jest.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes('/playlistItems'))
+        return playlistReply([{ id: 'nodur', at: '2026-07-31T10:00:00Z' }]);
+      return {
+        ok: true,
+        json: async () => ({ items: [{ id: 'nodur', snippet: { title: 'nodur' } }] }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const out = await collectChannelUploads({
+      channels: [twoChannels[0]!],
+      since: MONDAY,
+      limit: 10,
+      apiKeys: KEY,
+      fetchImpl,
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('reports an empty week honestly rather than reaching further back', async () => {
+    const fetchImpl = router({ UU1: [{ id: 'old', at: '2026-07-20T10:00:00Z' }] }, {});
+    const out = await collectChannelUploads({
+      channels: [twoChannels[0]!],
+      since: MONDAY,
+      limit: 10,
+      apiKeys: KEY,
+      fetchImpl,
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('survives one channel failing without losing the other', async () => {
+    const fetchImpl = jest.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes('playlistId=UU1')) return { ok: false, status: 403 } as unknown as Response;
+      if (u.includes('/playlistItems'))
+        return playlistReply([{ id: 'b1', at: '2026-07-28T10:00:00Z' }]);
+      return videosReply([{ id: 'b1', duration: LONG }]);
+    }) as unknown as typeof fetch;
+
+    const out = await collectChannelUploads({
+      channels: twoChannels,
+      since: MONDAY,
+      limit: 10,
+      apiKeys: KEY,
+      fetchImpl,
+    });
+    expect(out.map((p) => p.videoId)).toEqual(['b1']);
+  });
+
+  it('ignores channels with no uploads playlist and spends nothing on them', async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    const out = await collectChannelUploads({
+      channels: [{ channel_id: 'UC1', uploads_playlist_id: null }],
+      since: MONDAY,
+      limit: 10,
+      apiKeys: KEY,
+      fetchImpl,
+    });
+    expect(out).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates a video that two followed channels both surface', async () => {
+    const fetchImpl = router(
+      {
+        UU1: [{ id: 'same', at: '2026-07-31T10:00:00Z' }],
+        UU2: [{ id: 'same', at: '2026-07-31T10:00:00Z' }],
+      },
+      {}
+    );
+    const out = await collectChannelUploads({
+      channels: twoChannels,
+      since: MONDAY,
+      limit: 10,
+      apiKeys: KEY,
+      fetchImpl,
+    });
+    expect(out).toHaveLength(1);
+  });
+
+  it('stores a constant relevance — the user picked the channel', async () => {
+    const fetchImpl = router({ UU1: [{ id: 'a1', at: '2026-07-31T10:00:00Z' }] }, {});
+    const out = await collectChannelUploads({
+      channels: [twoChannels[0]!],
+      since: MONDAY,
+      limit: 10,
+      apiKeys: KEY,
+      fetchImpl,
+    });
+    expect(out[0]!.relevancePct).toBe(CHANNEL_MODE_RELEVANCE_PCT);
+  });
+});


### PR DESCRIPTION
Design: `docs/design/curation-channel-subscription-2026-07-27.md` — P3. Follows #1365 (table) and #1367 (resolve + CRUD).

## What

The builder now branches on **how the week's videos are chosen**. Everything downstream — the `week_of` snapshot, `watched_at` preservation across a same-week rebuild, the cadence advance — is the existing code, shared verbatim.

```
source === 'youtube_subs' && flag on  ->  collectChannelUploads()
otherwise                             ->  pool-cosine KNN   (unchanged)
```

Channel mode reads each followed channel's uploads playlist and keeps what was published on or after this week's Monday. No discovery, no embedding, no relevance floor: the user named the channel, which is the thing relevance was trying to approximate. The stored `relevance_pct` is a constant rather than a number that would look meaningful and not be.

## Decisions worth reviewing

**Round-robin picking.** Everyone's newest, then everyone's second-newest. A channel that uploads daily cannot crowd out one that uploads weekly.

**No deep enrichment in channel mode.** A quiet week is the honest answer (design §2-d). Topping it up would put channels in the feed that the user did not follow — the exact thing this mode exists to prevent.

**Two kinds of missing duration, kept apart.**

| situation | behaviour | why |
|---|---|---|
| `videos.list` call fails | keep everything | nothing was measured; an API blip must not empty someone's week |
| call succeeds, this video has no duration | treat as a Short | `videos.list` omits it for Shorts specifically — the existing `isShortsByDuration` convention |

**Server API key, not the user's OAuth token.** The uploads playlist is public and this runs unattended on a weekly cron; a build that dies because a token expired overnight is a build that silently stops arriving.

## Cost

1 unit per channel + 1 per 50 videos → roughly **12–20 units a week for ten channels**, against ~100 units per `search.list` on the discover path.

## Rollout

`CURATION_CHANNEL_SOURCE_ENABLED` defaults **false**. A `youtube_subs` subscription still builds through discover until it is turned on, so the column can be set before the leg is live, and rollback is a config flip rather than a revert. **No user-visible change from merging this PR.**

## Not in this PR

P4 — the dial editor, which is the only device-gated piece.

## Tests

13 in `tests/smoke/curation-channel-uploads.test.ts`: week-boundary filtering, round-robin interleave, Shorts by duration, both missing-duration cases, one channel failing without losing the others, cross-channel dedup, honest empty week, and the no-key / no-playlist short-circuits that must not spend a call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)