### PR TITLE
fix(curation): finance education is a subject, not a solicitation; require channels

### DIFF
--- a/src/modules/curation/topic-judge.ts
+++ b/src/modules/curation/topic-judge.ts
@@ -48,10 +48,17 @@ Users subscribe to a topic and receive a weekly set of educational videos about 
 For each keyword decide two independent things:
 
 "safe": false when the keyword is sexual or suggestive, promotes gambling or
-speculation as entertainment, solicits investment (stock picks, guaranteed
-returns), instructs illegal or self-harming activity, or promotes hatred toward
-a group. Reporting, documentary, prevention and first-hand accounts of these
-subjects are SAFE — naming a social problem is not promoting it.
+speculation as entertainment, solicits investment (a specific pick to buy, a
+guaranteed return, a get-rich scheme), instructs illegal or self-harming
+activity, or promotes hatred toward a group. Reporting, documentary, prevention
+and first-hand accounts of these subjects are SAFE — naming a social problem is
+not promoting it.
+
+Studying a field is not soliciting it. Investing, personal finance, real estate,
+markets, economics and accounting are ordinary subjects people learn, and are
+SAFE — including named methods and instruments (value investing, dividend ETFs,
+index funds, REITs). Mark them unsafe only when the keyword itself is a pitch:
+a particular ticker to buy now, a promised return, "10x", "월 1000만원".
 
 "learnable": false when no weekly educational series could reasonably be built
 from it. Personal names, place names, song or film titles, individual channel or

--- a/src/modules/queue/handlers/curation-build.ts
+++ b/src/modules/queue/handlers/curation-build.ts
@@ -31,9 +31,6 @@ import { nextKstWeekdayAt } from '@/utils/kst';
 import { collectChannelUploads } from '@/modules/curation/channel-uploads';
 import { resolveVideosApiKeys } from '@/skills/plugins/video-discover/v2/youtube-client';
 
-/** curation_subscriptions.source value that means "build from followed channels". */
-const CHANNEL_SOURCE = 'youtube_subs';
-
 const log = logger.child({ module: 'queue/curation-build' });
 
 export interface CurationBuildPayload {
@@ -122,8 +119,20 @@ export async function registerCurationBuildWorker(): Promise<void> {
     // build-1/2/3 — how the week's videos are chosen. This is the ONLY thing the
     // source branch changes; the snapshot write, watched_at preservation and
     // cadence advance below are shared verbatim.
-    const channelMode =
-      config.curationChannelSource.enabled && sub.source === CHANNEL_SOURCE && !job.data.deep;
+    // `source` alone is NOT the signal: selectCuration has always created every
+    // curation with source='youtube_subs' (mobile/index.html), so gating on it
+    // would flip every existing topic curation into channel mode the moment the
+    // flag went on -- and each would get an empty week, because none of them
+    // follow any channels. Followed channels are the honest signal: they only
+    // exist when the user added them.
+    const followed =
+      config.curationChannelSource.enabled && !job.data.deep
+        ? await prisma.curation_channels.findMany({
+            where: { subscription_id: subscriptionId },
+            select: { channel_id: true, uploads_playlist_id: true },
+          })
+        : [];
+    const channelMode = followed.length > 0;
 
     let picked: Array<{ videoId: string; relevancePct: number }>;
 
@@ -131,10 +140,7 @@ export async function registerCurationBuildWorker(): Promise<void> {
       // Channel mode — the user named the channels, so there is nothing to
       // discover and nothing to score. Uploads since this week's Monday (KST),
       // interleaved so one prolific channel cannot fill the week.
-      const channels = await prisma.curation_channels.findMany({
-        where: { subscription_id: subscriptionId },
-        select: { channel_id: true, uploads_playlist_id: true },
-      });
+      const channels = followed;
       picked = await collectChannelUploads({
         channels,
         since: new Date(weekOf),

--- a/tests/smoke/topic-judge-prompt.test.ts
+++ b/tests/smoke/topic-judge-prompt.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Guard on the judging prompt's finance carve-out.
+ *
+ * The first 300-row backfill on prod marked an entire legitimate domain unsafe:
+ * `가치투자101`, `배당 etf 미국`, `부동산 투자 기초` all came back
+ * "investment solicitation". Studying how investing works is not soliciting it,
+ * and losing personal finance as a curation subject is a large hole.
+ *
+ * The fix is a paragraph of prompt, which nothing else would notice going
+ * missing. This reads the source the same way api-url-contract.test.ts does —
+ * it cannot check what the model concludes, only that the instruction is still
+ * there to be followed.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC = path.resolve(__dirname, '../../src/modules/curation/topic-judge.ts');
+
+describe('topic-judge prompt', () => {
+  const prompt = fs.readFileSync(SRC, 'utf-8');
+
+  it('says studying a field is not soliciting it', () => {
+    expect(prompt).toContain('Studying a field is not soliciting it');
+  });
+
+  it.each(['Investing', 'personal finance', 'real estate', 'dividend ETFs'])(
+    'names %s as an ordinary subject',
+    (term) => {
+      expect(prompt).toContain(term);
+    }
+  );
+
+  it('still restricts unsafe finance to an actual pitch', () => {
+    // the narrow definition is what keeps the carve-out from swallowing the rule
+    expect(prompt).toMatch(/a particular ticker to buy now|guaranteed return|get-rich scheme/);
+  });
+
+  it('keeps the reporting/documentary carve-out for the other categories', () => {
+    expect(prompt.replace(/\s+/g, ' ')).toContain(
+      'naming a social problem is\nnot promoting it'.replace(/\s+/g, ' ')
+    );
+  });
+});


### PR DESCRIPTION
Two defects found by running things, not reading them.

## 1. Judging rejected a whole legitimate domain

The first 300-row backfill on prod came back `ok 244 / unsafe 11 / unfit 45 / unknown 0`. Four of the eleven "unsafe" were ordinary finance education:

| keyword | reason given |
|---|---|
| 가치투자101 | investment solicitation |
| 배당 etf 추천 | solicits investment advice |
| 배당 etf 포트폴리오 | investment solicitation |
| 부동산 투자 기초 | investment speculation |

Studying how investing works is not soliciting it. Losing personal finance, real estate and markets as curation subjects is a large hole — and it is the opposite of the instruction that produced this feature: block what is unethical, not what is unfamiliar.

The prompt now says so, and keeps unsafe narrow: **a specific ticker to buy now, a promised return, a get-rich pitch.** The deterministic blocklist was already correct (pump-and-dump markers only) and is untouched — this was purely the model's reading of the prompt.

The 300 judged rows get reset to `NULL` and re-judged before the remaining 18,829 run.

**This is why the backfill ran 300 first.** At full size it would have written 19,129 verdicts and quietly removed a domain.

## 2. Channel mode would have emptied every existing curation

The gate was `sub.source === 'youtube_subs'`. But `selectCuration` in the dial has **always** created every curation with that source:

```js
api('/curations',{method:'POST',body:JSON.stringify({topic:topic,source:'youtube_subs'})})
```

So flipping `CURATION_CHANNEL_SOURCE_ENABLED` on would have put every existing topic curation into channel mode — and each would have received an **empty week**, because none of them follow any channels.

Followed channels are the honest signal: rows only exist when a user added them. `channelMode = flag && followed.length > 0`. The flag is now safe to turn on with users mid-flight.

## Tests

7 — a guard on the prompt's carve-out paragraph, which nothing else would notice going missing. It reads the source the same way `api-url-contract.test.ts` does; it cannot check what the model concludes, only that the instruction is still there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)