### PR TITLE
feat(curation): turn channel mode on

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -144,6 +144,10 @@ services:
       # On: daily scan, due = KST weekday matches + this KST week not built yet.
       # Rollback: delete this line (code path reverts to the Sunday scan).
       - CURATION_SCHED_KST_ENABLED=true
+      # Channel mode. The builder only takes it when a subscription has rows in
+      # curation_channels, so with none registered this is a no-op; it becomes
+      # live the moment someone adds a channel in the dial. Rollback = false.
+      - CURATION_CHANNEL_SOURCE_ENABLED=true
       # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
       # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
       # a cell with ≥3 pool candidates drops its live search.list query → quota


### PR DESCRIPTION
The table, the API, the collection leg and the dial editor all shipped today — #1365 / #1367 / #1368 / #1372 — but the flag was off. Adding a channel in the app stored a row and changed nothing about what arrived that week.

## Why this is safe to turn on now

Verified on prod: `curation_channels` is **empty (0 rows)**. The builder takes the channel path only when a subscription has rows there:

```js
const channelMode = followed.length > 0;
```

So flipping this changes nothing today. It becomes live the moment someone adds a channel in the dial.

**That gate is load-bearing.** Gating on `source` alone would have flipped every existing curation into channel mode — `selectCuration` has always sent `source:'youtube_subs'` — and each would have received an empty week. #1371 fixed that before this flag could do harm.

## Rollback

Set it to `false`. No revert needed.