### PR TITLE
fix(graph): cap synthetic card nodes at the total node cap

### DIFF
--- a/src/modules/ontology/graph.ts
+++ b/src/modules/ontology/graph.ts
@@ -320,8 +320,12 @@ export async function getMandalaSubgraph(
     });
   }
 
-  // 2) cards → synthetic nodes where needed + cell placement edges
+  // 2) cards → synthetic nodes where needed + cell placement edges.
+  // Synthetic nodes respect the SAME total node cap — without this, a
+  // card-heavy account ballooned to ~9k nodes and froze the tab's layout
+  // thread (prod-measured on beta day). Overflow flips `truncated`.
   const presentNodeIds = new Set(nodes.map((n) => n.id));
+  let syntheticOverflow = false;
   for (const card of cardRows) {
     const matchedId =
       (card.state_id ? nodeIdByStateId.get(card.state_id) : undefined) ??
@@ -334,6 +338,10 @@ export async function getMandalaSubgraph(
     } else {
       videoNodeId = `derived-video-${card.ytid}`;
       if (!presentNodeIds.has(videoNodeId)) {
+        if (presentNodeIds.size >= SUBGRAPH_NODE_CAP) {
+          syntheticOverflow = true;
+          continue;
+        }
         presentNodeIds.add(videoNodeId);
         nodes.push({
           id: videoNodeId,
@@ -373,5 +381,5 @@ export async function getMandalaSubgraph(
     });
   }
 
-  return { nodes, edges, truncated };
+  return { nodes, edges, truncated: truncated || syntheticOverflow };
 }

--- a/tests/smoke/ontology-subgraph.test.ts
+++ b/tests/smoke/ontology-subgraph.test.ts
@@ -124,6 +124,31 @@ describe('getMandalaSubgraph (user-wide)', () => {
     expect(result.edges[0]?.id).toBe('e-real');
   });
 
+  it('caps synthetic card nodes at the total node cap and flags truncation', async () => {
+    // 4,100 placed cards with no ontology nodes at all — synthetic creation
+    // must stop at the 4,000 cap instead of ballooning the payload (prod
+    // beta-day incident: ~9k nodes froze the layout thread).
+    const manyCards = Array.from({ length: 4100 }, (_, i) => ({
+      ytid: `yt${i}`,
+      state_id: null,
+      title: `V${i}`,
+      mandala_id: MANDALA,
+      cell_pos: null,
+    }));
+    mockPrisma([
+      [], // roots
+      [], // sectors
+      manyCards,
+      [], // card-node match
+      [], // edges
+      [], // nodes
+    ]);
+
+    const result = await getMandalaSubgraph(null, USER, 4);
+    expect(result.nodes).toHaveLength(4000);
+    expect(result.truncated).toBe(true);
+  });
+
   it('drops edges whose endpoints fall outside the kept node set', async () => {
     mockPrisma([
       [{ id: ROOT, mandala_id: MANDALA }],


### PR DESCRIPTION
Synthetic card projections bypassed the 4,000-node subgraph cap, so a card-heavy account returned ~9k nodes and froze the browser layout thread (measured on prod right after the user-wide graph shipped). Synthetic creation now stops at the cap and flips `truncated`; a regression test pins the node count at 4,000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)