### PR TITLE
fix(curation): store channel uploads in the pool so the week can render

### DIFF
--- a/src/modules/curation/channel-uploads.ts
+++ b/src/modules/curation/channel-uploads.ts
@@ -17,6 +17,11 @@
  */
 
 import { logger } from '@/utils/logger';
+import { getPrismaClient } from '@/modules/database/client';
+import {
+  QUALITY_GOLD_VIEW_COUNT,
+  QUALITY_SILVER_VIEW_COUNT,
+} from '@/skills/plugins/batch-video-collector/manifest';
 import {
   videosBatchFullMetadata,
   parseIsoDuration,
@@ -36,6 +41,23 @@ export const UPLOADS_PAGE_SIZE = 50;
  * every upload is equally on-topic; a varying percentage here would be theatre.
  */
 export const CHANNEL_MODE_RELEVANCE_PCT = 100;
+
+/** Provenance for pool rows that arrived because a user followed the channel. */
+const POOL_SOURCE = 'user_channel';
+
+/**
+ * Tier by view count, matching the collector's thresholds.
+ *
+ * Deliberately NOT classifyQuality(): that decides ADMISSIBILITY too, and would
+ * reject a video for being under the view floor. A channel the user chose to
+ * follow does not get its uploads turned away for being unpopular -- that is
+ * the whole point of following it. Tier stays for diagnostics only.
+ */
+function tierByViews(views: number): string {
+  if (views >= QUALITY_GOLD_VIEW_COUNT) return 'gold';
+  if (views >= QUALITY_SILVER_VIEW_COUNT) return 'silver';
+  return 'bronze';
+}
 
 export interface ChannelUpload {
   videoId: string;
@@ -90,6 +112,71 @@ export async function fetchChannelUploads(
     log.warn('playlistItems.list threw', { channelId, error: (err as Error).message });
     return [];
   }
+}
+
+/**
+ * Persist what videos.list just told us. Keyed by video_id and deliberately
+ * conservative on update: `source` is never overwritten, so a row that arrived
+ * through a more authoritative path keeps its provenance and only gets its
+ * freshness and (possibly scrubbed) display fields restored.
+ *
+ * Failures are logged, never thrown: a pool write must not cost the user their
+ * week.
+ */
+async function storeUploadsInPool(
+  meta: Array<{
+    id?: string;
+    snippet?: {
+      title?: string;
+      description?: string;
+      channelTitle?: string;
+      channelId?: string;
+      publishedAt?: string;
+      thumbnails?: Record<string, { url?: string } | undefined>;
+    };
+    contentDetails?: { duration?: string };
+    statistics?: { viewCount?: string; likeCount?: string };
+  }>
+): Promise<void> {
+  if (meta.length === 0) return;
+  const prisma = getPrismaClient();
+  let stored = 0;
+  for (const m of meta) {
+    if (!m.id || !m.snippet?.title) continue;
+    const views = Number(m.statistics?.viewCount ?? 0) || 0;
+    const likes = Number(m.statistics?.likeCount ?? 0) || 0;
+    const thumbs = m.snippet.thumbnails ?? {};
+    const shared = {
+      title: m.snippet.title,
+      description: m.snippet.description ?? null,
+      channel_name: m.snippet.channelTitle ?? null,
+      channel_id: m.snippet.channelId ?? null,
+      view_count: BigInt(views),
+      like_count: BigInt(likes),
+      duration_seconds: parseIsoDuration(m.contentDetails?.duration),
+      published_at: m.snippet.publishedAt ? new Date(m.snippet.publishedAt) : null,
+      thumbnail_url: thumbs['high']?.url ?? thumbs['medium']?.url ?? thumbs['default']?.url ?? null,
+      is_active: true,
+      refreshed_at: new Date(),
+    };
+    try {
+      await prisma.video_pool.upsert({
+        where: { video_id: m.id },
+        create: {
+          video_id: m.id,
+          language: 'ko',
+          quality_tier: tierByViews(views),
+          source: POOL_SOURCE,
+          ...shared,
+        },
+        update: shared, // source and language stay as first written
+      });
+      stored += 1;
+    } catch (err) {
+      log.warn('pool write failed', { videoId: m.id, error: (err as Error).message });
+    }
+  }
+  log.info('channel uploads stored in pool', { stored, of: meta.length });
 }
 
 export interface ChannelPick {
@@ -156,6 +243,14 @@ export async function collectChannelUploads(
   const durationById = new Map(
     meta.map((m) => [m.id, parseIsoDuration(m.contentDetails?.duration)])
   );
+
+  // The deck reads title, channel, duration and thumbnail from video_pool, and
+  // nothing else puts a channel upload there -- the discover path only ever
+  // stores what it found in the pool to begin with. Without this the week's
+  // cards render blank: the item exists, its metadata does not.
+  //
+  // We already hold that metadata; it was fetched for the Shorts filter above.
+  await storeUploadsInPool(meta);
 
   const eligible = measured
     ? all.filter((u) => !isShortsByDuration(durationById.get(u.videoId) ?? null))

--- a/tests/smoke/curation-channel-uploads.test.ts
+++ b/tests/smoke/curation-channel-uploads.test.ts
@@ -7,6 +7,18 @@
  * being topped up from somewhere else.
  */
 
+const poolUpserts: Array<{ where: unknown; create: Record<string, unknown> }> = [];
+jest.mock('@/modules/database/client', () => ({
+  getPrismaClient: () => ({
+    video_pool: {
+      upsert: async (arg: { where: unknown; create: Record<string, unknown> }) => {
+        poolUpserts.push(arg);
+        return arg.create;
+      },
+    },
+  }),
+}));
+
 import {
   fetchChannelUploads,
   collectChannelUploads,
@@ -99,6 +111,92 @@ describe('fetchChannelUploads', () => {
     const fetchImpl = jest.fn() as unknown as typeof fetch;
     expect(await fetchChannelUploads('UC1', 'UU1', MONDAY, [], fetchImpl)).toEqual([]);
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('collectChannelUploads — the week must be renderable', () => {
+  // The deck reads title/thumbnail/duration from video_pool. The first channel
+  // curation on prod produced an item whose video was in no pool row at all, so
+  // the card rendered black with "1 / 1" in the header. Storing what videos.list
+  // already returned is what makes the week visible.
+  it('writes the metadata it fetched into the pool', async () => {
+    poolUpserts.length = 0;
+    const fetchImpl = jest.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes('/playlistItems'))
+        return playlistReply([{ id: 'vid1', at: '2026-07-31T10:00:00Z' }]);
+      return {
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              id: 'vid1',
+              snippet: {
+                title: '테크피드 이번 주 요약',
+                channelTitle: 'T3chfeed',
+                channelId: 'UC1',
+                publishedAt: '2026-07-31T10:00:00Z',
+                thumbnails: { high: { url: 'https://i/hq.jpg' } },
+              },
+              contentDetails: { duration: LONG },
+              statistics: { viewCount: '150000' },
+            },
+          ],
+        }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const out = await collectChannelUploads({
+      channels: [{ channel_id: 'UC1', uploads_playlist_id: 'UU1' }],
+      since: MONDAY,
+      limit: 10,
+      apiKeys: KEY,
+      fetchImpl,
+    });
+
+    expect(out.map((p) => p.videoId)).toEqual(['vid1']);
+    expect(poolUpserts).toHaveLength(1);
+    expect(poolUpserts[0]!.create).toMatchObject({
+      video_id: 'vid1',
+      title: '테크피드 이번 주 요약',
+      channel_name: 'T3chfeed',
+      thumbnail_url: 'https://i/hq.jpg',
+      quality_tier: 'gold', // 150k views
+      source: 'user_channel',
+    });
+  });
+
+  it('does not turn away an unpopular upload from a followed channel', async () => {
+    poolUpserts.length = 0;
+    const fetchImpl = jest.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes('/playlistItems'))
+        return playlistReply([{ id: 'tiny', at: '2026-07-31T10:00:00Z' }]);
+      return {
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              id: 'tiny',
+              snippet: { title: '조회수 12회', thumbnails: {} },
+              contentDetails: { duration: LONG },
+              statistics: { viewCount: '12' },
+            },
+          ],
+        }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const out = await collectChannelUploads({
+      channels: [{ channel_id: 'UC1', uploads_playlist_id: 'UU1' }],
+      since: MONDAY,
+      limit: 10,
+      apiKeys: KEY,
+      fetchImpl,
+    });
+    // following a channel means taking what it posts, popular or not
+    expect(out.map((p) => p.videoId)).toEqual(['tiny']);
+    expect(poolUpserts[0]!.create).toMatchObject({ quality_tier: 'bronze' });
   });
 });
 


### PR DESCRIPTION
The first channel curation on prod produced a **black card**. The header read `1 / 1`, so the item existed — what did not exist was anything to draw.

## Why

The deck reads title, channel, duration and thumbnail from `video_pool`. The discover path never noticed that dependency, because its candidates come **out of** the pool. The channel path takes ids straight from `playlistItems` and wrote only those ids, so every metadata field served as `null`.

Verified on prod before touching anything:

```
curation_items   _B3MdSlLrOo   week_of 2026-07-27   relevance 100
in video_pool    0 of 2
```

## Fix

The metadata was **already in hand** — `videos.list` is called a few lines above for the Shorts filter, and the result was discarded. It is now upserted, keyed by `video_id`, with `source` left alone on update so a row that arrived through a more authoritative path keeps its provenance.

Tier is computed here rather than through `classifyQuality`, which decides **admissibility** as well and would reject a video for falling under the view floor. A channel the user chose to follow does not get its uploads turned away for being unpopular — that is the point of following it. Thresholds are imported from the collector's manifest, not restated.

A pool write that fails is logged, never thrown: it must not cost the user their week.

## Tests

15, two new:
- the metadata reaches the pool with the right shape (`title` / `channel_name` / `thumbnail_url` / `quality_tier: gold` / `source: user_channel`)
- a 12-view upload from a followed channel still arrives, tiered `bronze`