### PR TITLE
fix(beta): lock unfinished menus for launch

### DIFF
--- a/frontend/src/features/mandala-wizard/ui/WizardStepDomain.tsx
+++ b/frontend/src/features/mandala-wizard/ui/WizardStepDomain.tsx
@@ -159,10 +159,13 @@ export default function WizardStepDomain({
         {t('wizard.domain.separator')}
       </div>
       <div className="text-center">
+        {/* Beta-launch decision (2026-07-28): blank creation is a dead end
+            today — disabled until the flow is reworked. */}
         <button
           type="button"
-          onClick={onCreateBlank}
-          className="inline-flex items-center gap-1.5 rounded-[10px] border border-border bg-transparent px-5 py-2.5 text-[13px] font-semibold text-muted-foreground transition-all duration-[180ms] hover:border-foreground/10 hover:bg-foreground/[0.02] hover:text-foreground"
+          disabled
+          aria-disabled
+          className="inline-flex cursor-not-allowed items-center gap-1.5 rounded-[10px] border border-border bg-transparent px-5 py-2.5 text-[13px] font-semibold text-muted-foreground opacity-40"
         >
           {t('wizard.domain.createBlank')} &rarr;
         </button>

--- a/frontend/src/features/mandala-wizard/ui/WizardStepGoal.tsx
+++ b/frontend/src/features/mandala-wizard/ui/WizardStepGoal.tsx
@@ -474,15 +474,15 @@ export default function WizardStepGoal({
           )}
         </div>
         <div className="text-center">
+          {/* Beta-launch decision (2026-07-28): blank creation is a dead end
+              today — disabled until the flow is reworked. */}
           <button
             type="button"
-            onClick={onCreateBlank}
-            disabled={isCreatingBlank}
-            className="text-[13px] font-medium text-muted-foreground/70 underline-offset-4 transition-colors hover:text-foreground hover:underline disabled:cursor-not-allowed disabled:opacity-50"
+            disabled
+            aria-disabled
+            className="text-[13px] font-medium text-muted-foreground/70 underline-offset-4 transition-colors disabled:cursor-not-allowed disabled:opacity-40"
           >
-            {isCreatingBlank
-              ? t('wizard.domain.creating', 'Creating...')
-              : t('wizard.domain.createBlank', 'Start from scratch →')}
+            {t('wizard.domain.createBlank', 'Start from scratch →')}
           </button>
         </div>
         <div />

--- a/frontend/src/features/view-mode/ui/ViewSwitcher.tsx
+++ b/frontend/src/features/view-mode/ui/ViewSwitcher.tsx
@@ -14,12 +14,32 @@ interface ViewSwitcherProps {
   onChange: (mode: ViewMode) => void;
 }
 
+// `disabled` = not ready for beta (2026-07-28 launch decision): list,
+// list-detail and insights stay visible but unclickable until they ship.
 const VIEW_OPTIONS = [
-  { value: 'grid' as const, icon: LayoutGrid, labelKey: 'view.grid', isBeta: false },
-  { value: 'list' as const, icon: List, labelKey: 'view.list', isBeta: true },
-  { value: 'list-detail' as const, icon: Columns2, labelKey: 'view.listDetail', isBeta: true },
-  { value: 'graph' as const, icon: Network, labelKey: 'view.graph', isBeta: true },
-  { value: 'insights' as const, icon: BarChart3, labelKey: 'view.insights', isBeta: true },
+  {
+    value: 'grid' as const,
+    icon: LayoutGrid,
+    labelKey: 'view.grid',
+    isBeta: false,
+    disabled: false,
+  },
+  { value: 'list' as const, icon: List, labelKey: 'view.list', isBeta: true, disabled: true },
+  {
+    value: 'list-detail' as const,
+    icon: Columns2,
+    labelKey: 'view.listDetail',
+    isBeta: true,
+    disabled: true,
+  },
+  { value: 'graph' as const, icon: Network, labelKey: 'view.graph', isBeta: true, disabled: false },
+  {
+    value: 'insights' as const,
+    icon: BarChart3,
+    labelKey: 'view.insights',
+    isBeta: true,
+    disabled: true,
+  },
 ];
 
 export function ViewSwitcher({ value, onChange }: ViewSwitcherProps) {
@@ -50,12 +70,15 @@ export function ViewSwitcher({ value, onChange }: ViewSwitcherProps) {
         </TooltipContent>
       </Tooltip>
       <DropdownMenuContent align="end" className="w-44">
-        {VIEW_OPTIONS.map(({ value: v, icon: Icon, labelKey, isBeta }) => {
+        {VIEW_OPTIONS.map(({ value: v, icon: Icon, labelKey, isBeta, disabled }) => {
           const isActive = v === value;
           return (
             <DropdownMenuItem
               key={v}
-              onSelect={() => onChange(v)}
+              disabled={disabled}
+              onSelect={() => {
+                if (!disabled) onChange(v);
+              }}
               className="flex items-center gap-2 text-[13px] focus:text-foreground"
             >
               <Icon className="h-4 w-4 flex-shrink-0" />

--- a/frontend/src/widgets/sidebar-skill-panel/ui/SidebarSkillPanel.tsx
+++ b/frontend/src/widgets/sidebar-skill-panel/ui/SidebarSkillPanel.tsx
@@ -149,6 +149,17 @@ import {
 
 const USER_VISIBLE_SKILL_TYPES: ReadonlySet<string> = new Set(USER_VISIBLE_SKILL_TYPES_ARRAY);
 
+// Beta-launch lockdown (2026-07-28): newsletter…blog are not ready — rows stay
+// visible for discoverability but cannot be toggled. Remove ids as they ship.
+const BETA_LOCKED_SKILLS: ReadonlySet<string> = new Set([
+  'newsletter',
+  'report',
+  'alert',
+  'recommend',
+  'script',
+  'blog',
+]);
+
 /**
  * UI-only PRO skill entries (no backend SkillId yet). Shown below the
  * free-tier divider with a Lock icon + PRO badge. Click → upgrade toast.
@@ -430,17 +441,23 @@ export function SidebarSkillPanel({ mandalaId }: SidebarSkillPanelProps) {
             const Icon = SKILL_ICONS[skill.id] ?? Sparkles;
             const isEnabled = skillEnabledMap[skill.id] ?? false;
             const isToggling = togglingSkillId === skill.id;
+            const isBetaLocked = BETA_LOCKED_SKILLS.has(skill.id);
 
             return (
               <button
                 key={skill.id}
                 type="button"
-                onClick={() => handleToggleSkill(skill.id)}
-                disabled={isToggling}
+                onClick={() => {
+                  if (!isBetaLocked) handleToggleSkill(skill.id);
+                }}
+                disabled={isToggling || isBetaLocked}
+                aria-disabled={isBetaLocked}
                 className={cn(
                   'flex items-center gap-3 px-4 py-2.5 rounded-md select-none transition-colors duration-150',
-                  'hover:bg-sidebar-accent',
-                  isEnabled ? 'text-sidebar-foreground' : 'text-sidebar-foreground/65',
+                  isBetaLocked ? 'opacity-40 cursor-not-allowed' : 'hover:bg-sidebar-accent',
+                  isEnabled && !isBetaLocked
+                    ? 'text-sidebar-foreground'
+                    : 'text-sidebar-foreground/65',
                   isToggling && 'opacity-50 pointer-events-none'
                 )}
               >


### PR DESCRIPTION
Beta-launch decision (2026-07-28): unfinished entry points stay visible but disabled until they ship.

- View switcher: list / list-detail / insights disabled (grid + knowledge graph stay live)
- Sidebar skill panel: newsletter, report, alert, recommend, script, blog rows locked (PRO teaser rows unchanged)
- Mandala wizard: start-from-scratch disabled on both steps (currently a dead end; reopens after the flow rework)

Verified visually on the local real app (all three surfaces render disabled, active items unaffected). FE-only; tsc 0, vitest 518/518, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)