### PR TITLE
fix(grid): strict mandala filter - never flash the whole local store

### DIFF
--- a/frontend/src/pages/index/model/useCardOrchestrator.ts
+++ b/frontend/src/pages/index/model/useCardOrchestrator.ts
@@ -262,8 +262,11 @@ export function useCardOrchestrator(
           c.cellIndex >= 0 &&
           c.levelId &&
           c.levelId !== 'scratchpad' &&
-          // Only show cards belonging to the current mandala
-          (!mandalaId || c.mandalaId === mandalaId)
+          // STRICT mandala match. `!mandalaId ||` used to pass EVERYTHING
+          // through while the mandala id was still resolving — the grid
+          // flashed the user's entire local store (1,018 cross-mandala cards
+          // on prod, beta-day incident 2026-07-28). No id → no cards.
+          c.mandalaId === mandalaId
       ),
     [persistedLocalCards, mandalaId]
   );
@@ -289,8 +292,8 @@ export function useCardOrchestrator(
           c.cellIndex >= 0 &&
           c.levelId &&
           c.levelId !== 'scratchpad' &&
-          // Only show cards belonging to the current mandala
-          (!mandalaId || c.mandalaId === mandalaId)
+          // STRICT mandala match (see mandalaLocalCards above).
+          c.mandalaId === mandalaId
       ),
     [syncedCards, mandalaId]
   );


### PR DESCRIPTION
While the mandala id was still resolving (mandala list not yet loaded), the card classification filters passed everything through (`!mandalaId ||` fallback), so the grid flashed the user's ENTIRE local card store — 1,018 cross-mandala cards on a prod account (beta-day incident), which also fired a tens-of-kB `v2-summaries` request that 503'd. Data was never corrupted (DB verified: the mandala really has 62 cards; zero card writes in the window) — this was a read-path race, latent before today and exposed by slow mandala-list loads after repeated hard reloads.

Cards now require an exact mandala match; while the id resolves the grid stays empty (skeleton) instead of leaking the store. Pattern swept repo-wide (the two other `!mandalaId` hits are early-return guards, safe direction).

Verification: vitest 518/518 (includes D&D change guard + orchestrator suites), build clean, real-app check across mandala switches (correct cards only, no flash, 0 console errors). Playwright dnd-smoke not run (auth setup unavailable locally) — orchestrator change is filter-only, no DnD handler/context touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)