### PR TITLE
fix(ci): the deploy guard was failing on its own lookup, not on a bad deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -225,9 +225,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          PREV=$(gh run list --workflow deploy.yml --branch main --limit 20 \
+          # -R explicitly: this step runs before checkout, so there is no git
+          # repo for gh to infer the remote from and it exits 1 -- which the
+          # guard then reported as "the previous deploy failed". The guard was
+          # blocking every fast dial deploy on its own lookup error.
+          PREV=$(gh run list -R "${{ github.repository }}" \
+                   --workflow deploy.yml --branch main --limit 20 \
                    --json databaseId,conclusion,headSha \
-                   --jq "[.[] | select(.databaseId != ${{ github.run_id }}) | select(.conclusion != null and .conclusion != \"cancelled\" and .conclusion != \"skipped\")][0]")
+                   --jq "[.[] | select(.databaseId != ${{ github.run_id }}) | select(.conclusion != null and .conclusion != \"cancelled\" and .conclusion != \"skipped\")][0]") \
+            || { echo "::warning::could not read deploy history; proceeding without the staleness check"; PREV=""; }
           CONC=$(echo "$PREV" | jq -r '.conclusion // "none"')
           SHA=$(echo "$PREV"  | jq -r '.headSha  // "none"')
           echo "previous completed deploy: $CONC ($SHA)"


### PR DESCRIPTION
Build `2026-07-28-38` merged to main and never reached the box — the live dial stayed on `37`.

### Cause

The fast dial path's staleness guard runs **before checkout**, so `gh` had no git repo to infer the remote from:

```
failed to determine base repo: fatal: not a git repository
##[error]Process completed with exit code 1
```

The step runs under `bash -e`, so that lookup error killed the step, and the failure surfaced as *"the last deploy ended in failure, so the image may be stale"* — about a deploy that was fine. Every fast dial deploy was blocked by it.

### Fix

- `gh run list -R ${{ github.repository }}` — works without a checkout.
- If the lookup fails anyway: warn and continue. The guard exists to catch a **known** bad previous deploy; blocking a good one over its own inability to check is strictly worse than not checking.

### Note

The next run will see run `30339853682` (this bug) as the last completed deploy. This PR touches a workflow, so it takes the full path rather than the fast one, and its success becomes the new baseline — and it carries build 38 to the box in the frontend image.