### PR TITLE
chore(gates): enforce the two rules that were violated while being hard rules

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# GitHub artifacts are English-only. UI strings are Korean and live in files;
+# they never belong in a commit message, so this has no legitimate exception and
+# is checked mechanically rather than remembered.
+#
+# It was a hard rule for months and was violated anyway -- caught only by reading
+# the message back afterwards and amending it. A rule nothing enforces is a rule
+# that fires whenever someone happens to look.
+#
+# NOT `grep -P`: husky re-execs this under `sh -e`, where grep is BSD grep and
+# -P does not exist. It exits 2, the `&&` short-circuits, and the hook passes
+# every message including Korean ones -- a guard that silently never fires.
+# Setting the locale makes the range work on BSD and GNU alike; both directions
+# were run under `sh -e` before this was committed.
+#
+# Override, for the rare case where a quoted Korean identifier genuinely belongs:
+#   INSIGHTA_ALLOW_KOREAN_COMMIT=1 git commit ...
+
+MSG_FILE="$1"
+[ -n "$INSIGHTA_ALLOW_KOREAN_COMMIT" ] && exit 0
+
+# Strip comment lines: git's own template is not part of the message.
+BODY=$(grep -v '^#' "$MSG_FILE" 2>/dev/null)
+
+if printf '%s\n' "$BODY" | LC_ALL=en_US.UTF-8 grep -q '[가-힣]'; then
+  echo ""
+  echo "  Commit message contains Korean. GitHub artifacts are English-only."
+  echo ""
+  printf '%s\n' "$BODY" | LC_ALL=en_US.UTF-8 grep -n '[가-힣]' | head -5 | sed 's/^/    /'
+  echo ""
+  echo "  Rewrite those lines in English. UI strings stay Korean in the FILES;"
+  echo "  it is the message that has to be English."
+  echo ""
+  exit 1
+fi

--- a/reports/hardcode-audit/baseline.json
+++ b/reports/hardcode-audit/baseline.json
@@ -3,5 +3,6 @@
   "process-env-direct-read": 33,
   "inline-env-parser": 0,
   "raw-ms-per-day-literal": 0,
-  "raw-ms-per-hour-literal": 0
+  "raw-ms-per-hour-literal": 0,
+  "css-color-literal": 293
 }

--- a/scripts/audit/hardcode-audit.ts
+++ b/scripts/audit/hardcode-audit.ts
@@ -12,6 +12,8 @@ interface RuleDef {
   allowedFileGlobs: string[];
   searchGlobs?: string[];
   multiline?: boolean;
+  /** Directory to search. Defaults to `src`; the CSS rule needs `frontend`. */
+  searchRoot?: string;
 }
 
 const REPO_ROOT = resolve(__dirname, '..', '..');
@@ -60,6 +62,21 @@ const RULES: RuleDef[] = [
     pattern: String.raw`\b60\s*\*\s*60\s*\*\s*1000\b`,
     allowedFileGlobs: ['src/utils/time-constants.ts'],
   },
+  {
+    // A colour written straight into a declaration is one the theme cannot
+    // reach. Defining a token is how a colour enters the system, so lines that
+    // declare a custom property (`--cd-chip-bg: rgba(...)`) are exempt and
+    // everything else is counted. Baseline-gated like the rest: the existing
+    // literals are recorded, and the count may only go down.
+    id: 'css-color-literal',
+    description: 'Colour literal in a CSS declaration (define a token and reference it)',
+    // rg has no look-around, so the token-definition exemption is applied in
+    // code below rather than in the pattern.
+    pattern: String.raw`#[0-9a-fA-F]{3,8}\b|\brgba?\(|\bhsla?\(`,
+    allowedFileGlobs: [],
+    searchRoot: 'frontend/public/mobile',
+    searchGlobs: ['**/*.html', '**/*.css'],
+  },
 ];
 
 interface RuleResult {
@@ -69,11 +86,11 @@ interface RuleResult {
   violations: Array<{ file: string; line: number; text: string }>;
 }
 
-function runRg(pattern: string, searchGlobs: string[]): string {
+function runRg(pattern: string, searchGlobs: string[], searchRoot = 'src'): string {
   const globArgs = searchGlobs.map((g) => `--glob '${g}'`).join(' ');
   try {
     const out = execSync(
-      `rg --json --line-number -e '${pattern}' ${globArgs} src`,
+      `rg --json --line-number -e '${pattern}' ${globArgs} ${searchRoot}`,
       {
         cwd: REPO_ROOT,
         encoding: 'utf8',
@@ -111,7 +128,7 @@ function auditRule(rule: RuleDef): RuleResult {
     '!**/*.test.ts',
     '!**/*.spec.ts',
   ];
-  const raw = runRg(rule.pattern, searchGlobs);
+  const raw = runRg(rule.pattern, searchGlobs, rule.searchRoot);
   const violations: RuleResult['violations'] = [];
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue;
@@ -125,6 +142,10 @@ function auditRule(rule: RuleDef): RuleResult {
       if (rule.id === 'raw-ms-per-hour-literal' && /\b24\s*\*\s*60\s*\*\s*60\s*\*\s*1000\b/.test(text)) {
         continue;
       }
+      // Defining a token is how a colour is allowed to enter the system; the
+      // rule is about colours written straight into a declaration, where the
+      // theme cannot reach them.
+      if (rule.id === 'css-color-literal' && /--[a-z0-9-]+\s*:/i.test(text)) continue;
       violations.push({
         file: filePath,
         line: event.data.line_number as number,


### PR DESCRIPTION
Both of these were **already hard rules**, and both were broken this session. The fix is not another line of prose — it is a check that runs whether or not anyone remembers it.

### 1. `.husky/commit-msg` — Korean in a commit message is blocked

GitHub artifacts are English-only. UI strings are Korean and live in files, never in a commit message, so there is no legitimate exception. Escape hatch: `INSIGHTA_ALLOW_KOREAN_COMMIT=1`.

**Not `grep -P`.** husky re-execs the hook under `sh -e`, where `grep` is BSD grep: `-P` does not exist, the command exits 2, the `&&` short-circuits, and **every message passes** — a guard that silently never fires. The first draft did exactly that and looked correct, because a passing message passes either way.

Five cases run under the real hook before committing:

| case | want | got |
|---|---|---|
| Korean subject | block | ✅ exit 1 |
| Korean body | block | ✅ exit 1 |
| English only | pass | ✅ exit 0 |
| Korean only in a `#` comment | pass | ✅ exit 0 |
| override env var | pass | ✅ exit 0 |

### 2. `hardcode-audit` — sixth rule: CSS colour literals

A colour written straight into a declaration is one the theme cannot reach. Defining a token is how a colour enters the system, so lines declaring a custom property are exempt — that exemption lives in code because `rg` has no look-around.

Baseline seeded at the **293** that already exist and, like every other rule here, may only go down. Verified that token definitions (`--cd-chip-bg: rgba(...)`) are **0** of those 293.

Adding it needed a per-rule `searchRoot`: the audit only ever looked at `src`, so the entire dial was outside anything it could see.

### Why this shape

The same session produced a guard of mine that **blocked every fast dial deploy** by reporting its own lookup failure as *"the last deploy failed"* (#1393). Same shape as the `grep -P` bug above, opposite symptom: one refuses everything, one permits everything, and neither was ever observed firing.

New LEVEL-2 memory entry: **a guard must be fired in the failing direction, in its real execution environment, before it is merged.** CI green means the guard did not fire — not that it works.

Note: `.husky/` and `scripts/audit/` are gitignored, but `pre-commit`/`pre-push` and `hardcode-audit.ts` are already tracked by force-add. `commit-msg` follows the same convention.