### PR TITLE
feat(mandala): GET /:id/videos — placed videos, relevance-first (dial video tab V0)

### DIFF
--- a/src/api/routes/mandalas.ts
+++ b/src/api/routes/mandalas.ts
@@ -35,6 +35,15 @@ import { config } from '../../config';
 import { MemoryCache } from '../../utils/memory-cache';
 import { cardPublisher, type CardPayload } from '../../modules/recommendations/publisher';
 import { lookupChunkAnchors } from '../../modules/recommendations/chunk-anchor';
+import { getArchivedVideoIds } from '../../modules/exclude/archived-videos';
+import {
+  VIDEO_LIST_DEFAULT_LIMIT,
+  VIDEO_LIST_MAX_LIMIT,
+  dedupeByVideoId,
+  makeVideoListComparator,
+  segCoverage,
+  type VideoListEntry,
+} from '../../modules/mandala/video-list';
 import { generateMandalaActions } from '../../modules/mandala/generator';
 import { logger } from '../../utils/logger';
 
@@ -2089,6 +2098,187 @@ export const mandalaRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       mode: RECOMMENDATION_DEFAULT_MODE,
       items,
       lastRefreshed,
+    });
+  });
+
+  /**
+   * GET /api/v1/mandalas/:id/videos — the user's PLACED videos for this
+   * mandala, relevance-first (dial video tab V0, 2026-07-30).
+   *
+   * This is deliberately NOT `/recommendations`: that endpoint serves the
+   * 7d-TTL candidate cache. The video tab plays what the user actually kept
+   * (uvs ∪ ulc, cell_index >= 0), minus videos archived in this mandala —
+   * the same population fill-book synthesises the note from, so what you
+   * watch here is what the book grows from.
+   *
+   * Server-side sort mirrors the dashboard relevance-sort comparator (NULL →
+   * recency proxy capped at 60; see modules/mandala/video-list.ts).
+   * Offset pagination is bounded per-mandala, which structurally avoids
+   * the get-all-video-states 1000-row PostgREST cap (#834).
+   */
+  fastify.get<{
+    Params: { id: string };
+    Querystring: { limit?: string; offset?: string };
+  }>('/:id/videos', { onRequest: [fastify.authenticate] }, async (request, reply) => {
+    const userId = getUserId(request, reply);
+    if (!userId) return;
+
+    const mandalaId = request.params.id;
+    const mandala = await getMandalaManager().getMandalaById(userId, mandalaId);
+    if (!mandala) {
+      return reply.code(404).send({ error: 'Mandala not found' });
+    }
+
+    const limitRaw = request.query.limit !== undefined ? Number(request.query.limit) : NaN;
+    const offsetRaw = request.query.offset !== undefined ? Number(request.query.offset) : NaN;
+    const limit = Number.isInteger(limitRaw)
+      ? Math.min(Math.max(limitRaw, 1), VIDEO_LIST_MAX_LIMIT)
+      : VIDEO_LIST_DEFAULT_LIMIT;
+    const offset = Number.isInteger(offsetRaw) && offsetRaw >= 0 ? offsetRaw : 0;
+
+    const prisma = getPrismaClient();
+    const [videoStates, localCards, archivedIds] = await Promise.all([
+      prisma.userVideoState.findMany({
+        where: { user_id: userId, mandala_id: mandalaId, cell_index: { gte: 0 } },
+        select: {
+          relevance_pct: true,
+          pinned_at: true,
+          createdAt: true,
+          video: {
+            select: {
+              youtube_video_id: true,
+              title: true,
+              thumbnail_url: true,
+              channel_title: true,
+              duration_seconds: true,
+              view_count: true,
+            },
+          },
+        },
+      }),
+      prisma.user_local_cards.findMany({
+        where: {
+          user_id: userId,
+          mandala_id: mandalaId,
+          cell_index: { gte: 0 },
+          video_id: { not: null },
+        },
+        select: {
+          video_id: true,
+          title: true,
+          metadata_title: true,
+          thumbnail: true,
+          relevance_pct: true,
+          pinned_at: true,
+          created_at: true,
+        },
+      }),
+      getArchivedVideoIds(prisma, userId, mandalaId),
+    ]);
+
+    const entries: VideoListEntry[] = [];
+    for (const r of videoStates) {
+      const vid = r.video?.youtube_video_id;
+      if (!vid || archivedIds.has(vid)) continue;
+      entries.push({
+        videoId: vid,
+        title: r.video?.title ?? vid,
+        channel: r.video?.channel_title ?? null,
+        thumbnail: r.video?.thumbnail_url ?? null,
+        durationSec: r.video?.duration_seconds ?? null,
+        views: r.video?.view_count != null ? Number(r.video.view_count) : null,
+        relevancePct: r.relevance_pct ?? null,
+        pinnedAt: r.pinned_at?.toISOString() ?? null,
+        createdAtMs: r.createdAt.getTime(),
+        source: 'uvs',
+      });
+    }
+    for (const r of localCards) {
+      if (!r.video_id || archivedIds.has(r.video_id)) continue;
+      entries.push({
+        videoId: r.video_id,
+        title: r.title ?? r.metadata_title ?? r.video_id,
+        channel: null,
+        thumbnail: r.thumbnail ?? null,
+        durationSec: null,
+        views: null,
+        relevancePct: r.relevance_pct ?? null,
+        pinnedAt: r.pinned_at?.toISOString() ?? null,
+        createdAtMs: r.created_at?.getTime() ?? 0,
+        source: 'ulc',
+      });
+    }
+
+    const deduped = dedupeByVideoId(entries).sort(makeVideoListComparator(Date.now()));
+    const total = deduped.length;
+    const page = deduped.slice(offset, offset + limit);
+
+    // ulc-sourced rows carry no youtube_videos metadata — bridge the page's
+    // gaps in one batch (page-scoped, never the whole population).
+    const gapIds = page.filter((e) => e.source === 'ulc').map((e) => e.videoId);
+    if (gapIds.length > 0) {
+      const metaRows = await prisma.youtube_videos.findMany({
+        where: { youtube_video_id: { in: gapIds } },
+        select: {
+          youtube_video_id: true,
+          title: true,
+          thumbnail_url: true,
+          channel_title: true,
+          duration_seconds: true,
+          view_count: true,
+        },
+      });
+      const metaByVid = new Map(metaRows.map((m) => [m.youtube_video_id, m]));
+      for (const e of page) {
+        const m = metaByVid.get(e.videoId);
+        if (!m) continue;
+        e.channel = e.channel ?? m.channel_title ?? null;
+        e.thumbnail = e.thumbnail ?? m.thumbnail_url ?? null;
+        e.durationSec = e.durationSec ?? m.duration_seconds ?? null;
+        e.views = e.views ?? (m.view_count != null ? Number(m.view_count) : null);
+      }
+    }
+
+    // v2 clip-boundary probe for the page only: hasSegments gates the mound,
+    // segCoverage gates core-only mode (mirrors the PC < 0.9 hide + #1078 truncation).
+    const pageIds = page.map((e) => e.videoId);
+    const segByVid = new Map<string, { hasSegments: boolean; coverage: number | null }>();
+    if (pageIds.length > 0) {
+      const v2Rows = await prisma.video_rich_summaries.findMany({
+        where: { video_id: { in: pageIds }, template_version: 'v2' },
+        select: { video_id: true, segments: true },
+      });
+      const durByVid = new Map(page.map((e) => [e.videoId, e.durationSec]));
+      for (const row of v2Rows) {
+        const segments = (row.segments ?? null) as {
+          sections?: Array<{ to_sec?: unknown }>;
+        } | null;
+        const sections = Array.isArray(segments?.sections) ? segments.sections : null;
+        const hasSegments = sections != null && sections.length > 0;
+        segByVid.set(row.video_id, {
+          hasSegments,
+          coverage: hasSegments ? segCoverage(sections, durByVid.get(row.video_id) ?? null) : null,
+        });
+      }
+    }
+
+    return reply.send({
+      mandalaId,
+      total,
+      limit,
+      offset,
+      items: page.map((e) => ({
+        videoId: e.videoId,
+        title: e.title,
+        channel: e.channel,
+        thumbnail: e.thumbnail,
+        durationSec: e.durationSec,
+        views: e.views,
+        relevancePct: e.relevancePct,
+        pinnedAt: e.pinnedAt,
+        hasSegments: segByVid.get(e.videoId)?.hasSegments ?? false,
+        segCoverage: segByVid.get(e.videoId)?.coverage ?? null,
+      })),
     });
   });
 

--- a/src/modules/mandala/video-list.ts
+++ b/src/modules/mandala/video-list.ts
@@ -1,0 +1,93 @@
+/**
+ * Video-mode list helpers (V0 of the dial video tab redesign, 2026-07-30).
+ *
+ * Pure functions only — the route in `src/api/routes/mandalas.ts` composes
+ * them. Kept separate so the sort/merge/coverage rules are unit-testable
+ * without Fastify or Prisma.
+ *
+ * The sort is a server-side mirror of the FE dashboard comparator
+ * (`frontend/src/widgets/card-list-view/ui/CardListView.tsx`
+ * `relevanceSortValue`): a real 0-100 A-stage score wins outright; an
+ * unscored (NULL) card falls back to a recency proxy capped BELOW the
+ * recommended(70)/core(80) tiers so fresh-but-unscored cards interleave mid-tier
+ * instead of sinking — same constants, same 90d linear fade.
+ */
+
+export const NULL_RECENCY_CAP = 60;
+export const NULL_RECENCY_WINDOW_MS = 90 * 24 * 60 * 60 * 1000; // 90d linear fade to 0
+
+export const VIDEO_LIST_DEFAULT_LIMIT = 50;
+export const VIDEO_LIST_MAX_LIMIT = 200;
+
+export interface VideoListEntry {
+  videoId: string; // 11-char YouTube id
+  title: string;
+  channel: string | null;
+  thumbnail: string | null;
+  durationSec: number | null;
+  views: number | null;
+  relevancePct: number | null;
+  pinnedAt: string | null; // ISO
+  createdAtMs: number; // placement row creation — recency proxy input
+  source: 'uvs' | 'ulc';
+}
+
+export const videoListSortValue = (
+  relevancePct: number | null,
+  createdAtMs: number,
+  nowMs: number
+): number => {
+  if (relevancePct != null) return relevancePct;
+  const frac = Math.max(0, 1 - (nowMs - createdAtMs) / NULL_RECENCY_WINDOW_MS);
+  return frac * NULL_RECENCY_CAP;
+};
+
+/** DESC by sort value; stable videoId tiebreak so pages don't reshuffle. */
+export const makeVideoListComparator =
+  (nowMs: number) =>
+  (a: VideoListEntry, b: VideoListEntry): number => {
+    const d =
+      videoListSortValue(b.relevancePct, b.createdAtMs, nowMs) -
+      videoListSortValue(a.relevancePct, a.createdAtMs, nowMs);
+    return d !== 0 ? d : a.videoId.localeCompare(b.videoId);
+  };
+
+/**
+ * Same video can be placed in both uvs and ulc. Keep one row per videoId:
+ * a scored row beats an unscored one (the score is what we sort by);
+ * on equal scoredness uvs wins (primary placement table, CP498).
+ */
+export const dedupeByVideoId = (entries: VideoListEntry[]): VideoListEntry[] => {
+  const byId = new Map<string, VideoListEntry>();
+  for (const e of entries) {
+    const prev = byId.get(e.videoId);
+    if (!prev) {
+      byId.set(e.videoId, e);
+      continue;
+    }
+    const prevScored = prev.relevancePct != null;
+    const curScored = e.relevancePct != null;
+    if (curScored && !prevScored) byId.set(e.videoId, e);
+    else if (curScored === prevScored && prev.source === 'ulc' && e.source === 'uvs')
+      byId.set(e.videoId, e);
+  }
+  return Array.from(byId.values());
+};
+
+/**
+ * Coverage of the v2 section timeline over the actual video duration.
+ * Mirrors the PC gate (PlayerChrome hides the relevance strip < 0.9) and
+ * the #1078 long-video truncation caveat: the mound and core-only mode must
+ * not pretend the whole video was analysed when only the head was.
+ * Returns null when it cannot be computed (no sections / no duration).
+ */
+export const segCoverage = (
+  sections: Array<{ to_sec?: unknown }> | null | undefined,
+  durationSec: number | null
+): number | null => {
+  if (!sections || sections.length === 0 || !durationSec || durationSec <= 0) return null;
+  const last = sections[sections.length - 1];
+  const to = typeof last?.to_sec === 'number' ? last.to_sec : null;
+  if (to == null || to <= 0) return null;
+  return Math.min(1, to / durationSec);
+};

--- a/src/modules/mandala/video-list.ts
+++ b/src/modules/mandala/video-list.ts
@@ -13,8 +13,10 @@
  * instead of sinking — same constants, same 90d linear fade.
  */
 
+import { MS_PER_DAY } from '@/utils/time-constants';
+
 export const NULL_RECENCY_CAP = 60;
-export const NULL_RECENCY_WINDOW_MS = 90 * 24 * 60 * 60 * 1000; // 90d linear fade to 0
+export const NULL_RECENCY_WINDOW_MS = 90 * MS_PER_DAY; // 90d linear fade to 0
 
 export const VIDEO_LIST_DEFAULT_LIMIT = 50;
 export const VIDEO_LIST_MAX_LIMIT = 200;

--- a/tests/unit/modules/video-list.test.ts
+++ b/tests/unit/modules/video-list.test.ts
@@ -1,0 +1,107 @@
+/**
+ * V0 dial video tab (2026-07-30) — pure helpers behind
+ * GET /api/v1/mandalas/:id/videos. Sort must mirror the FE dashboard
+ * relevance-sort comparator (NULL → recency proxy ≤ 60, 90d fade); dedupe must
+ * prefer scored rows and uvs; segCoverage feeds the core-only eligibility gate.
+ */
+
+import {
+  NULL_RECENCY_CAP,
+  NULL_RECENCY_WINDOW_MS,
+  videoListSortValue,
+  makeVideoListComparator,
+  dedupeByVideoId,
+  segCoverage,
+  type VideoListEntry,
+} from '@/modules/mandala/video-list';
+
+const NOW = 1_800_000_000_000;
+
+const entry = (over: Partial<VideoListEntry>): VideoListEntry => ({
+  videoId: 'vid00000000',
+  title: 't',
+  channel: null,
+  thumbnail: null,
+  durationSec: null,
+  views: null,
+  relevancePct: null,
+  pinnedAt: null,
+  createdAtMs: NOW,
+  source: 'uvs',
+  ...over,
+});
+
+describe('videoListSortValue', () => {
+  it('returns the real score when present, even 0', () => {
+    expect(videoListSortValue(87, NOW, NOW)).toBe(87);
+    expect(videoListSortValue(0, NOW, NOW)).toBe(0);
+  });
+
+  it('caps a brand-new unscored row at NULL_RECENCY_CAP (below the recommended tier 70)', () => {
+    expect(videoListSortValue(null, NOW, NOW)).toBe(NULL_RECENCY_CAP);
+  });
+
+  it('fades linearly to 0 over the 90d window', () => {
+    const half = videoListSortValue(null, NOW - NULL_RECENCY_WINDOW_MS / 2, NOW);
+    expect(half).toBeCloseTo(NULL_RECENCY_CAP / 2, 5);
+    expect(videoListSortValue(null, NOW - NULL_RECENCY_WINDOW_MS * 2, NOW)).toBe(0);
+  });
+});
+
+describe('makeVideoListComparator', () => {
+  it('sorts scored above fresh-unscored when the score beats the cap', () => {
+    const scored = entry({ videoId: 'scored00000', relevancePct: 71 });
+    const fresh = entry({ videoId: 'fresh000000', relevancePct: null, createdAtMs: NOW });
+    const out = [fresh, scored].sort(makeVideoListComparator(NOW));
+    expect(out[0]!.videoId).toBe('scored00000');
+  });
+
+  it('interleaves a fresh unscored row above a low-scored one (no bottom-dumping)', () => {
+    const low = entry({ videoId: 'low00000000', relevancePct: 30 });
+    const fresh = entry({ videoId: 'fresh000000', relevancePct: null, createdAtMs: NOW });
+    const out = [low, fresh].sort(makeVideoListComparator(NOW));
+    expect(out[0]!.videoId).toBe('fresh000000');
+  });
+
+  it('breaks ties by videoId so pagination is stable across refetches', () => {
+    const a = entry({ videoId: 'aaaaaaaaaaa', relevancePct: 50 });
+    const b = entry({ videoId: 'bbbbbbbbbbb', relevancePct: 50 });
+    expect([b, a].sort(makeVideoListComparator(NOW))[0]!.videoId).toBe('aaaaaaaaaaa');
+  });
+});
+
+describe('dedupeByVideoId', () => {
+  it('keeps the scored row over the unscored duplicate regardless of order', () => {
+    const unscored = entry({ source: 'uvs', relevancePct: null });
+    const scored = entry({ source: 'ulc', relevancePct: 88 });
+    expect(dedupeByVideoId([unscored, scored])[0]!.relevancePct).toBe(88);
+    expect(dedupeByVideoId([scored, unscored])[0]!.relevancePct).toBe(88);
+  });
+
+  it('prefers uvs on equal scoredness (primary placement table)', () => {
+    const ulc = entry({ source: 'ulc', relevancePct: 90, title: 'ulc' });
+    const uvs = entry({ source: 'uvs', relevancePct: 90, title: 'uvs' });
+    expect(dedupeByVideoId([ulc, uvs])[0]!.title).toBe('uvs');
+    expect(dedupeByVideoId([uvs, ulc])[0]!.title).toBe('uvs');
+  });
+
+  it('leaves distinct videos untouched', () => {
+    const a = entry({ videoId: 'aaaaaaaaaaa' });
+    const b = entry({ videoId: 'bbbbbbbbbbb' });
+    expect(dedupeByVideoId([a, b])).toHaveLength(2);
+  });
+});
+
+describe('segCoverage', () => {
+  it('computes last-section end over duration, clamped to 1', () => {
+    expect(segCoverage([{ to_sec: 540 }], 600)).toBeCloseTo(0.9, 5);
+    expect(segCoverage([{ to_sec: 700 }], 600)).toBe(1);
+  });
+
+  it('is null when sections or duration are unusable (#1078 honesty: no fake full coverage)', () => {
+    expect(segCoverage(null, 600)).toBeNull();
+    expect(segCoverage([], 600)).toBeNull();
+    expect(segCoverage([{ to_sec: 540 }], null)).toBeNull();
+    expect(segCoverage([{ to_sec: 'x' }], 600)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

V0 of the adopted dial video-mode design (James-approved 2026-07-30). The video tab must play the user's **kept** videos in **relevance order** — but no endpoint serves that list: the current tab replays the 7d recommendation cache, and the web client composes placed cards client-side from two Edge Functions (exposed to the PostgREST 1000-row cap, #834).

## What

`GET /api/v1/mandalas/:id/videos?limit&offset` (authed, ownership-checked):

- Population = `user_video_states` ∪ `user_local_cards` (`cell_index >= 0`, this mandala) − mandala-archived videos — the same population `fill-book` synthesises the note from.
- Dedupe by videoId: scored row beats unscored; uvs beats ulc on ties (CP498 primary-table rule).
- Server-side sort mirrors the dashboard relevance comparator (`CardListView.relevanceSortValue`): NULL relevance → recency proxy capped at 60 with a 90d linear fade — no bottom-dumping of unscored cards.
- Offset pagination (default 50, max 200) — per-mandala scope structurally sidesteps #834.
- Per item: `videoId, title, channel, thumbnail, durationSec, views, relevancePct, pinnedAt, hasSegments, segCoverage`. The last two let the client gate the relevance mound and core-only playback (mirrors the PC `PlayerChrome` coverage<0.9 hide and the #1078 truncation caveat) without N+1 rich-summary fetches. ulc metadata gaps are bridged from `youtube_videos` page-scoped.

## Tests

- `tests/unit/modules/video-list.test.ts` — 11 cases: sort mirror (score wins, cap 60, 90d fade), stable tiebreak, dedupe preferences, coverage math + null-honesty.
- `tsc --noEmit` clean; backend only (no frontend/src changes).

## Write path

Read-only endpoint — no writes, no schema change, no flags.

Next: V1 switches the dial video tab from the note player to the curation deck engine consuming this endpoint (with curation-deck + note-player regression gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)