### PR TITLE
fix(curation): weekly novelty - history exclusion + freshness ladder + over-fetch

### DIFF
--- a/src/modules/curation/config.ts
+++ b/src/modules/curation/config.ts
@@ -8,6 +8,8 @@
  * modules — import from here.
  */
 
+import { MS_PER_DAY } from '@/utils/time-constants';
+
 /** Interest-signal weights (§4). Saved playlist videos = explicit intent → outrank subs. */
 export const INTEREST_WEIGHTS = Object.freeze({
   /** subscribed channel = passive interest */
@@ -61,6 +63,21 @@ export const CURATION_RELEVANCE_FLOOR = 40;
 
 /** recency window (days) for the discovery leg's publishedAfter — the rising bias (§4-B5). */
 export const CURATION_PUBLISHED_AFTER_DAYS = 365;
+
+/**
+ * Weekly-novelty freshness ladder (2026-08-03 defect fix): the topic-mode pick
+ * prefers this week's uploads and widens only when the pool is thin. The final
+ * `undefined` rung drops the time filter entirely — history exclusion alone
+ * then guarantees novelty. Ladder anchors on the week's Monday (weekStart).
+ */
+export const CURATION_FRESHNESS_LADDER_DAYS: readonly number[] = Object.freeze([7, 14, 30]);
+
+export function curationFreshnessCutoffs(weekStart: Date): Array<Date | undefined> {
+  return [
+    ...CURATION_FRESHNESS_LADDER_DAYS.map((d) => new Date(weekStart.getTime() - d * MS_PER_DAY)),
+    undefined,
+  ];
+}
 
 /** cooldown before re-attempting a failed interest-profile build — avoids the
  * suggest poll re-firing a doomed build every few seconds (P1). */

--- a/src/modules/queue/handlers/curation-build.ts
+++ b/src/modules/queue/handlers/curation-build.ts
@@ -29,6 +29,7 @@ import { MS_PER_DAY } from '@/utils/time-constants';
 import { config } from '../../../config';
 import { nextKstWeekdayAt } from '@/utils/kst';
 import { collectChannelUploads } from '@/modules/curation/channel-uploads';
+import { curationFreshnessCutoffs } from '@/modules/curation/config';
 import { resolveVideosApiKeys } from '@/skills/plugins/video-discover/v2/youtube-client';
 
 /**
@@ -65,6 +66,13 @@ async function deepEnrichCuration(
   weekDate: Date,
   prisma: ReturnType<typeof getPrismaClient>
 ): Promise<void> {
+  // History exclusion rides the live search too (weekly-novelty fix): a video
+  // served in ANY prior week must not come back through the enrichment door.
+  const everServed = await prisma.curation_items.findMany({
+    where: { subscription_id: subscriptionId },
+    select: { video_id: true },
+    distinct: ['video_id'],
+  });
   const v5 = await runV5Executor({
     centerGoal: topic,
     subGoals: [],
@@ -72,7 +80,7 @@ async function deepEnrichCuration(
     targetLevel: '',
     language: 'ko',
     includeEnCards: false,
-    excludeVideoIds: new Set<string>(),
+    excludeVideoIds: new Set(everServed.map((r) => r.video_id)),
     env: process.env,
   });
   const existing = await prisma.curation_items.findMany({
@@ -173,21 +181,50 @@ export async function registerCurationBuildWorker(): Promise<void> {
       // on video_pool_embeddings → top-N. NO live search / candidate embed / LLM picker;
       // runV5Executor's full pipeline (LLM×2 + search.list fanout + bulk embed) stalled
       // the build 20s+. ~1-2s. Thin-pool niche topics → async v5 enrichment = follow-up.
+      //
+      // Weekly novelty (2026-08-03 defect fix — measured 55~95% week-over-week
+      // repeats): the pick now carries the two constraints the weekly contract
+      // implies. 1) HISTORY EXCLUSION — anything this subscription has ever
+      // served in a PRIOR week stays out for good. 2) FRESHNESS LADDER —
+      // prefer this week's uploads, widen (7d→14d→30d→any) only while the
+      // rung cannot fill CURATION_MIN_VIDEOS.
       const [centerEmbedding] = await embedBatch([sub.topic]);
       if (!centerEmbedding) {
         log.warn('curation build: topic embed failed', { subscriptionId, topic: sub.topic });
         return;
       }
-      const matches = await matchFromVideoPoolByCenterGoal({
-        centerEmbedding,
-        subGoals: [],
-        language: 'ko',
-        limit: QUEUE_CONFIG.CURATION_TARGET_VIDEOS,
+      const servedBefore = await prisma.curation_items.findMany({
+        where: { subscription_id: subscriptionId, week_of: { not: new Date(weekOf) } },
+        select: { video_id: true },
+        distinct: ['video_id'],
       });
-      picked = matches.map((m) => ({
-        videoId: m.videoId,
-        relevancePct: Math.max(1, Math.min(100, Math.round((m.score ?? 0) * 100))),
-      }));
+      const served = new Set(servedBefore.map((r) => r.video_id));
+      picked = [];
+      let rungUsed: number | null = null;
+      for (const cutoff of curationFreshnessCutoffs(new Date(weekOf))) {
+        const matches = await matchFromVideoPoolByCenterGoal({
+          centerEmbedding,
+          subGoals: [],
+          language: 'ko',
+          limit: QUEUE_CONFIG.CURATION_TARGET_VIDEOS,
+          excludeVideoIds: served,
+          publishedAfter: cutoff,
+        });
+        picked = matches.map((m) => ({
+          videoId: m.videoId,
+          relevancePct: Math.max(1, Math.min(100, Math.round((m.score ?? 0) * 100))),
+        }));
+        rungUsed = cutoff
+          ? Math.round((new Date(weekOf).getTime() - cutoff.getTime()) / MS_PER_DAY)
+          : null;
+        if (picked.length >= QUEUE_CONFIG.CURATION_MIN_VIDEOS) break;
+      }
+      log.info('curation build (topic mode)', {
+        subscriptionId,
+        excludedHistory: served.size,
+        freshnessRungDays: rungUsed,
+        picked: picked.length,
+      });
     }
 
     // build-4 — rich-summary is REUSE-ONLY for P0. video_rich_summaries is a

--- a/src/skills/plugins/video-discover/v3/cache-matcher.ts
+++ b/src/skills/plugins/video-discover/v3/cache-matcher.ts
@@ -212,6 +212,14 @@ export interface MatchByCenterGoalOpts {
   threshold?: number;
   /** Same default + override semantics as `matchFromVideoPool`. */
   sources?: ReadonlyArray<string>;
+  /**
+   * Video ids to keep OUT of the result (curation weekly-novelty, 2026-08-03:
+   * a subscription's already-served history). Plain CTE predicate — the CP467
+   * planner poison was the cosine-expression WHERE, not column filters.
+   */
+  excludeVideoIds?: ReadonlySet<string>;
+  /** Only admit videos published at/after this instant (weekly freshness). */
+  publishedAfter?: Date;
 }
 
 interface CenterMatchRow {
@@ -250,6 +258,17 @@ export async function matchFromVideoPoolByCenterGoal(
   const limit = opts.limit ?? 64;
   const threshold = opts.threshold ?? DEFAULT_RELEVANCE_THRESHOLD;
   const sources = opts.sources ?? ['v2_promoted'];
+  // Over-fetch so the post-fetch threshold gate cannot leave the caller short:
+  // LIMIT-then-filter used to return e.g. 17/20 with no refill (curation
+  // device report 2026-08-03). Bounded ×2 keeps the ANN top-k path cheap.
+  const fetchLimit = limit * 2;
+  const excludeIds = opts.excludeVideoIds ? Array.from(opts.excludeVideoIds) : [];
+  const publishedFilter = opts.publishedAfter
+    ? Prisma.sql`AND published_at >= ${opts.publishedAfter}`
+    : Prisma.empty;
+  const excludeFilter = excludeIds.length
+    ? Prisma.sql`AND NOT (video_id = ANY(${excludeIds}::text[]))`
+    : Prisma.empty;
   const db = getPrismaClient();
   const t0 = Date.now();
 
@@ -276,6 +295,8 @@ export async function matchFromVideoPoolByCenterGoal(
         AND language = ${opts.language}
         AND quality_tier IN ('gold', 'silver')
         AND source = ANY(${sources}::text[])
+        ${publishedFilter}
+        ${excludeFilter}
     )
     SELECT
       e.video_id,
@@ -293,12 +314,13 @@ export async function matchFromVideoPoolByCenterGoal(
     JOIN public.video_pool_embeddings vpe
       ON vpe.video_id = e.video_id
     ORDER BY vpe.embedding <=> ${vectorLiteral}::vector ASC
-    LIMIT ${limit}
+    LIMIT ${fetchLimit}
   `);
 
   // Post-fetch threshold gate — preserves semantic floor without
-  // poisoning the SQL planner.
-  const aboveThreshold = rows.filter((r) => r.score >= threshold);
+  // poisoning the SQL planner. Over-fetched ×2 above, so threshold drops
+  // are refilled up to `limit` before the final slice.
+  const aboveThreshold = rows.filter((r) => r.score >= threshold).slice(0, limit);
 
   const subTokens = opts.subGoals.map((sg) => tokenizeLower(sg ?? ''));
   const matches: CachedMatch[] = aboveThreshold.map((r) => {

--- a/tests/unit/modules/curation-config.test.ts
+++ b/tests/unit/modules/curation-config.test.ts
@@ -1,0 +1,29 @@
+import {
+  CURATION_FRESHNESS_LADDER_DAYS,
+  curationFreshnessCutoffs,
+} from '../../../src/modules/curation/config';
+import { MS_PER_DAY } from '../../../src/utils/time-constants';
+
+describe('curationFreshnessCutoffs (weekly-novelty ladder, 2026-08-03)', () => {
+  const weekStart = new Date('2026-08-03T00:00:00Z');
+
+  it('yields one cutoff per ladder rung plus a final unbounded rung', () => {
+    const cutoffs = curationFreshnessCutoffs(weekStart);
+    expect(cutoffs).toHaveLength(CURATION_FRESHNESS_LADDER_DAYS.length + 1);
+    expect(cutoffs[cutoffs.length - 1]).toBeUndefined();
+  });
+
+  it('anchors each rung N days before the week start', () => {
+    const cutoffs = curationFreshnessCutoffs(weekStart);
+    CURATION_FRESHNESS_LADDER_DAYS.forEach((days, i) => {
+      expect(cutoffs[i]!.getTime()).toBe(weekStart.getTime() - days * MS_PER_DAY);
+    });
+  });
+
+  it('widens monotonically — every rung reaches further back than the last', () => {
+    const cutoffs = curationFreshnessCutoffs(weekStart);
+    for (let i = 1; i < CURATION_FRESHNESS_LADDER_DAYS.length; i++) {
+      expect(cutoffs[i]!.getTime()).toBeLessThan(cutoffs[i - 1]!.getTime());
+    }
+  });
+});


### PR DESCRIPTION
## What

James report (2026-08-03): curation serves the SAME videos week after week. Prod measured before the fix: **55-95% week-over-week overlap** (median 14-15 of 20; worst subscription 9/9 = 100% repeat).

## Root cause (3-fold, all measured)

1. **No time axis in selection**: topic mode = constant topic embedding -> pool-cosine KNN -> top-20. No publishedAfter, no served-history exclusion — "weekly" existed only in the week_of snapshot key. The original design got freshness as a by-product of v5 live search; the speed-driven swap to pool-KNN dropped it silently (orphaned CURATION_PUBLISHED_AFTER_DAYS is the evidence).
2. **Fetch-then-filter shortfall**: SQL LIMIT 20 -> JS cosine>=0.5 cut -> e.g. 17/20 with no refill (measured, sub 97662dc4); 17 >= MIN 15 so deep-enrich never fired either.
3. **Supply gap** (NOT fixed in this PR — layer B follow-up): pool has 0 embedded videos published within 7d, ~89 new rows/week across all topics.

## Changes (layer A of A->C->B)

- matchFromVideoPoolByCenterGoal: optional excludeVideoIds + publishedAfter as plain CTE predicates (CP467 planner poison was the cosine-expression WHERE, not column filters); existing callers unaffected
- Over-fetch x2 -> threshold filter -> slice(limit): threshold drops are refilled
- Topic-mode build: exclude the subscription's ENTIRE served history + freshness ladder 7d->14d->30d->unbounded (widens only under CURATION_MIN_VIDEOS); rung + exclusion count logged
- deep-enrich v5 now receives the full served history as excludeVideoIds
- curationFreshnessCutoffs helper + 3 unit tests

Channel mode untouched — its 7d lookback already embodies the weekly contract; a quiet week stays the honest answer.

## Verification
- tsc 0 / cache-matcher 3/3 / curation suites green / hardcode-audit 281 = baseline
- Full-unit delta vs origin/main = only the 3 new tests (queue-handlers kstEnabled mock gap fails identically on baseline)
- Post-deploy: rebuild one live subscription, re-measure overlap (expect ~0); freshness rung expected to fall through to unbounded until layer B lands (supply), which still guarantees novelty via history exclusion

## Follow-ups
- Layer C: same-user same-topic duplicate subscriptions (measured: 12x 파이썬... 1 user 19 dup rows) — deactivation + partial unique index
- Layer B: weekly per-topic supply (search.list publishedAfter=7d -> pool upsert -> embed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)