### PR TITLE
fix(curation): retire duplicate subscriptions + family-history exclusion (layer C)

### DIFF
--- a/prisma/migrations/curation/003_dedupe_subscriptions_unique.sql
+++ b/prisma/migrations/curation/003_dedupe_subscriptions_unique.sql
@@ -1,0 +1,32 @@
+-- Weekly-novelty defect follow-up (2026-08-03): legacy same-user same-topic
+-- duplicate subscriptions multiplied weekly builds (measured: one user held
+-- 19 duplicate active rows across 3 topics). POST /curations has deduped at
+-- the app layer since then, but the legacy rows remain and a concurrent-create
+-- race window persists.
+--
+-- 1) Deactivate duplicates, keeping per (user, normalised topic) the row with
+--    the richest curation_items history (ties -> oldest). Reversible: is_active
+--    flip only, no deletes; items of deactivated rows are retained (they feed
+--    the family served-history exclusion in the weekly build).
+-- 2) Partial unique index as the DB-level backstop for the create race.
+--
+-- Idempotent: the UPDATE is a no-op once clean; CREATE UNIQUE INDEX guarded
+-- by IF NOT EXISTS.
+
+UPDATE curation_subscriptions s
+SET is_active = false
+WHERE s.is_active
+  AND s.id NOT IN (
+    SELECT DISTINCT ON (user_id, lower(btrim(topic))) id
+    FROM curation_subscriptions s2
+    WHERE s2.is_active
+    ORDER BY
+      user_id,
+      lower(btrim(topic)),
+      (SELECT count(*) FROM curation_items i WHERE i.subscription_id = s2.id) DESC,
+      s2.created_at ASC
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_curation_subs_user_topic_active
+  ON curation_subscriptions (user_id, lower(btrim(topic)))
+  WHERE is_active;

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -197,6 +197,10 @@ APPLY_FILES=(
   # IF NOT EXISTS + NOTIFY pgrst — fully idempotent.
   "prisma/migrations/curation/001_create_curation_tables.sql"
   "prisma/migrations/curation/002_curation_personalization.sql"
+  # 2026-08-03 weekly-novelty follow-up: deactivate legacy same-user same-topic
+  # duplicate subscriptions + partial unique backstop. UPDATE no-ops once clean;
+  # index guarded by IF NOT EXISTS — idempotent.
+  "prisma/migrations/curation/003_dedupe_subscriptions_unique.sql"
   # curation-watched (2026-07-21): watched_at derived-only column for lineup row
   # meta (M/N listened / weekly complete). ADD COLUMN IF NOT EXISTS = idempotent.
   "prisma/migrations/curation-watched/001_watched_at.sql"

--- a/src/api/routes/curations.ts
+++ b/src/api/routes/curations.ts
@@ -229,18 +229,40 @@ export const curationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         data: { tier, limit, current: distinctTopics },
       });
     }
-    const sub = await prisma.curation_subscriptions.create({
-      data: {
-        user_id: userId,
-        topic,
-        cadence: 'weekly',
-        source,
-        mandala_id: mandalaId,
-        is_active: true,
-        // recurring weekly refresh starts a week out; the FIRST build runs now.
-        next_run_at: new Date(now.getTime() + 7 * MS_PER_DAY),
-      },
-    });
+    let sub;
+    try {
+      sub = await prisma.curation_subscriptions.create({
+        data: {
+          user_id: userId,
+          topic,
+          cadence: 'weekly',
+          source,
+          mandala_id: mandalaId,
+          is_active: true,
+          // recurring weekly refresh starts a week out; the FIRST build runs now.
+          next_run_at: new Date(now.getTime() + 7 * MS_PER_DAY),
+        },
+      });
+    } catch (e: unknown) {
+      // uq_curation_subs_user_topic_active backstop: a concurrent create for the
+      // same normalised topic won the race — return the winner, same as the
+      // app-level dedup above would have.
+      if ((e as { code?: string }).code === 'P2002') {
+        const winner = (
+          await prisma.curation_subscriptions.findMany({
+            where: { user_id: userId, is_active: true },
+            select: { id: true, topic: true, source: true },
+          })
+        ).find((s) => norm(s.topic) === norm(topic));
+        if (winner) {
+          return reply.send({
+            status: 'ok',
+            data: { id: winner.id, topic: winner.topic, source: winner.source, buildJobId: null },
+          });
+        }
+      }
+      throw e;
+    }
 
     // The channel row must exist BEFORE the first build is enqueued: the builder
     // decides between channel and topic mode by whether any channels are

--- a/src/modules/queue/handlers/curation-build.ts
+++ b/src/modules/queue/handlers/curation-build.ts
@@ -60,19 +60,44 @@ export interface CurationBuildPayload {
  * already served; this runs the (slow but async) live v5 search and APPENDS new videos
  * to the week — never blocks the user. Serve-first pattern.
  */
+/**
+ * Everything this user has been served for this topic, across the WHOLE
+ * subscription family (legacy duplicate rows were deactivated 2026-08-03, but
+ * their items are history too — a repeat through a deactivated twin is still
+ * a repeat to the user). `excludeWeekOf` keeps the current week rebuildable.
+ */
+async function servedHistory(
+  prisma: ReturnType<typeof getPrismaClient>,
+  sub: { id: string; user_id: string; topic: string },
+  excludeWeekOf?: Date
+): Promise<Set<string>> {
+  const norm = (s: string) => s.trim().toLowerCase();
+  const siblings = await prisma.curation_subscriptions.findMany({
+    where: { user_id: sub.user_id },
+    select: { id: true, topic: true },
+  });
+  const familyIds = siblings.filter((s) => norm(s.topic) === norm(sub.topic)).map((s) => s.id);
+  const rows = await prisma.curation_items.findMany({
+    where: {
+      subscription_id: { in: familyIds.length ? familyIds : [sub.id] },
+      ...(excludeWeekOf ? { week_of: { not: excludeWeekOf } } : {}),
+    },
+    select: { video_id: true },
+    distinct: ['video_id'],
+  });
+  return new Set(rows.map((r) => r.video_id));
+}
+
 async function deepEnrichCuration(
   subscriptionId: string,
   topic: string,
   weekDate: Date,
-  prisma: ReturnType<typeof getPrismaClient>
+  prisma: ReturnType<typeof getPrismaClient>,
+  sub: { id: string; user_id: string; topic: string }
 ): Promise<void> {
   // History exclusion rides the live search too (weekly-novelty fix): a video
   // served in ANY prior week must not come back through the enrichment door.
-  const everServed = await prisma.curation_items.findMany({
-    where: { subscription_id: subscriptionId },
-    select: { video_id: true },
-    distinct: ['video_id'],
-  });
+  const everServed = await servedHistory(prisma, sub);
   const v5 = await runV5Executor({
     centerGoal: topic,
     subGoals: [],
@@ -80,7 +105,7 @@ async function deepEnrichCuration(
     targetLevel: '',
     language: 'ko',
     includeEnCards: false,
-    excludeVideoIds: new Set(everServed.map((r) => r.video_id)),
+    excludeVideoIds: everServed,
     env: process.env,
   });
   const existing = await prisma.curation_items.findMany({
@@ -133,7 +158,7 @@ export async function registerCurationBuildWorker(): Promise<void> {
     // Background enrichment pass (thin-pool topics) — append live-search results, don't
     // touch cadence or replace the week. The fast pool result is already live.
     if (job.data.deep) {
-      await deepEnrichCuration(subscriptionId, sub.topic, new Date(weekOf), prisma);
+      await deepEnrichCuration(subscriptionId, sub.topic, new Date(weekOf), prisma, sub);
       return;
     }
 
@@ -193,12 +218,7 @@ export async function registerCurationBuildWorker(): Promise<void> {
         log.warn('curation build: topic embed failed', { subscriptionId, topic: sub.topic });
         return;
       }
-      const servedBefore = await prisma.curation_items.findMany({
-        where: { subscription_id: subscriptionId, week_of: { not: new Date(weekOf) } },
-        select: { video_id: true },
-        distinct: ['video_id'],
-      });
-      const served = new Set(servedBefore.map((r) => r.video_id));
+      const served = await servedHistory(prisma, sub, new Date(weekOf));
       picked = [];
       let rungUsed: number | null = null;
       for (const cutoff of curationFreshnessCutoffs(new Date(weekOf))) {


### PR DESCRIPTION
## What

Layer C of the weekly-novelty repair (A merged as #1443; B = supply follow-up).

Measured on prod: one user held **19 duplicate ACTIVE subscription rows** (12x one topic) — legacy from before the app-level dedup in POST /curations. Each duplicate multiplied the weekly build and made topic-count quota unreadable.

## Changes
- **Migration 003** (allowlisted, idempotent — verified on local dev DB including a re-run): deactivate duplicates keeping per (user, normalised topic) the row with the richest item history (ties -> oldest). is_active flip only — reversible, items retained. Partial unique index `uq_curation_subs_user_topic_active` as the DB backstop for the concurrent-create race the app check cannot close
- **POST /curations** catches P2002 from that index and returns the race winner (same contract as the app-level dedup path)
- **Family-history exclusion**: the weekly build and deep-enrich now exclude everything served across ALL of the user's same-topic subscription rows (active or not) — a repeat through a deactivated twin is still a repeat to the user
- Migration file force-added per the single-file manual-DDL convention (prisma/migrations is gitignored)

## Verification
- tsc 0; curation/queue suites — no new failures vs baseline (queue-handlers kstEnabled mock gap pre-exists on main)
- Local DDL: applied, index present, idempotent re-run clean
- Prod apply rides the deploy allowlist runner; post-deploy check: the same-user same-topic dup query returns 0 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)