### PR TITLE
fix(curation): empty-week floor - accumulating pick ladder + snapshot preservation (layer D)

### DIFF
--- a/src/modules/curation/config.ts
+++ b/src/modules/curation/config.ts
@@ -65,18 +65,51 @@ export const CURATION_RELEVANCE_FLOOR = 40;
 export const CURATION_PUBLISHED_AFTER_DAYS = 365;
 
 /**
- * Weekly-novelty freshness ladder (2026-08-03 defect fix): the topic-mode pick
- * prefers this week's uploads and widens only when the pool is thin. The final
- * `undefined` rung drops the time filter entirely — history exclusion alone
- * then guarantees novelty. Ladder anchors on the week's Monday (weekStart).
+ * Weekly pick ladder (2026-08-03, revised same day after the empty-week
+ * incident): the topic-mode pick walks these rungs ACCUMULATING candidates,
+ * freshest-first, until the week is full. Principle order is codified —
+ * this week's uploads > fresh > never-served > less-aligned never-served >
+ * long-ago-served re-entry — and NO rung combination may end at an empty
+ * week ("덜 정렬된 카드 > 카드 0장", the converged serving principle).
+ *
+ * exclusionWeeks: how far back the served-history exclusion reaches.
+ * null = everything ever served stays out; 4 = only the last four weeks
+ * stay out (a month-old good video returning beats an empty week).
  */
-export const CURATION_FRESHNESS_LADDER_DAYS: readonly number[] = Object.freeze([7, 14, 30]);
+export interface CurationPickRung {
+  freshDays: number | null;
+  threshold: number;
+  exclusionWeeks: number | null;
+}
 
-export function curationFreshnessCutoffs(weekStart: Date): Array<Date | undefined> {
-  return [
-    ...CURATION_FRESHNESS_LADDER_DAYS.map((d) => new Date(weekStart.getTime() - d * MS_PER_DAY)),
-    undefined,
-  ];
+export const CURATION_PICK_RUNGS: readonly CurationPickRung[] = Object.freeze([
+  { freshDays: 7, threshold: 0.5, exclusionWeeks: null },
+  { freshDays: 14, threshold: 0.5, exclusionWeeks: null },
+  { freshDays: 30, threshold: 0.5, exclusionWeeks: null },
+  { freshDays: null, threshold: 0.5, exclusionWeeks: null },
+  { freshDays: null, threshold: 0.35, exclusionWeeks: null },
+  { freshDays: null, threshold: 0.35, exclusionWeeks: 4 },
+  { freshDays: null, threshold: 0.2, exclusionWeeks: 4 },
+]);
+
+/** Concrete per-week plan: rungs resolved to dates against the week's Monday. */
+export interface CurationPickStep {
+  publishedAfter?: Date;
+  threshold: number;
+  /** Exclude only items served at/after this week_of; undefined = exclude all. */
+  exclusionAfter?: Date;
+}
+
+export function curationPickPlan(weekStart: Date): CurationPickStep[] {
+  return CURATION_PICK_RUNGS.map((r) => ({
+    ...(r.freshDays != null
+      ? { publishedAfter: new Date(weekStart.getTime() - r.freshDays * MS_PER_DAY) }
+      : {}),
+    threshold: r.threshold,
+    ...(r.exclusionWeeks != null
+      ? { exclusionAfter: new Date(weekStart.getTime() - r.exclusionWeeks * 7 * MS_PER_DAY) }
+      : {}),
+  }));
 }
 
 /** cooldown before re-attempting a failed interest-profile build — avoids the

--- a/src/modules/queue/handlers/curation-build.ts
+++ b/src/modules/queue/handlers/curation-build.ts
@@ -34,7 +34,7 @@ import { MS_PER_DAY } from '@/utils/time-constants';
 import { config } from '../../../config';
 import { nextKstWeekdayAt } from '@/utils/kst';
 import { collectChannelUploads } from '@/modules/curation/channel-uploads';
-import { curationFreshnessCutoffs } from '@/modules/curation/config';
+import { curationPickPlan } from '@/modules/curation/config';
 import { resolveVideosApiKeys } from '@/skills/plugins/video-discover/v2/youtube-client';
 
 /**
@@ -49,6 +49,10 @@ import { resolveVideosApiKeys } from '@/skills/plugins/video-discover/v2/youtube
  * Seven days is what a weekly delivery means, so seven days is what it asks for.
  */
 const CHANNEL_LOOKBACK_DAYS = 7;
+
+/** Deep-pass widened retry window when the 7-day live search comes back empty
+ *  (niche topics; empty-week floor, 2026-08-03). One retry only — quota. */
+const CURATION_DEEP_RETRY_DAYS = 30;
 
 const log = logger.child({ module: 'queue/curation-build' });
 
@@ -75,7 +79,7 @@ async function servedHistory(
   prisma: ReturnType<typeof getPrismaClient>,
   sub: { id: string; user_id: string; topic: string },
   excludeWeekOf?: Date
-): Promise<Set<string>> {
+): Promise<Array<{ videoId: string; weekOf: Date }>> {
   const norm = (s: string) => s.trim().toLowerCase();
   const siblings = await prisma.curation_subscriptions.findMany({
     where: { user_id: sub.user_id },
@@ -87,10 +91,13 @@ async function servedHistory(
       subscription_id: { in: familyIds.length ? familyIds : [sub.id] },
       ...(excludeWeekOf ? { week_of: { not: excludeWeekOf } } : {}),
     },
-    select: { video_id: true },
+    // MOST RECENT week per video: the rung horizon asks "was this served
+    // recently", so keep the newest sighting of each video_id.
+    select: { video_id: true, week_of: true },
+    orderBy: [{ video_id: 'asc' }, { week_of: 'desc' }],
     distinct: ['video_id'],
   });
-  return new Set(rows.map((r) => r.video_id));
+  return rows.map((r) => ({ videoId: r.video_id, weekOf: r.week_of }));
 }
 
 async function deepEnrichCuration(
@@ -102,23 +109,28 @@ async function deepEnrichCuration(
 ): Promise<void> {
   // History exclusion rides the live search too (weekly-novelty fix): a video
   // served in ANY prior week must not come back through the enrichment door.
-  const everServed = await servedHistory(prisma, sub);
+  const everServed = new Set((await servedHistory(prisma, sub)).map((h) => h.videoId));
   // Layer B (weekly supply, 2026-08-03): the live search asks for THIS WEEK'S
   // uploads — publishedAfter = the trailing week before weekDate (the same
   // seven-days-is-a-week rule channel mode uses). v5 internally upserts its
   // picks into video_pool (reusePickedToPool), so each weekly deep run also
-  // feeds next week's pool rungs.
-  const v5 = await runV5Executor({
-    centerGoal: topic,
-    subGoals: [],
-    focusTags: [],
-    targetLevel: '',
-    language: 'ko',
-    includeEnCards: false,
-    excludeVideoIds: everServed,
-    publishedAfter: new Date(weekDate.getTime() - CHANNEL_LOOKBACK_DAYS * MS_PER_DAY).toISOString(),
-    env: process.env,
-  });
+  // feeds next week's pool rungs. Niche topics can yield zero in a 7-day
+  // window — one widened retry (30d) before accepting a quiet enrichment
+  // (empty-week floor, revised 2026-08-03).
+  const runSearch = (days: number) =>
+    runV5Executor({
+      centerGoal: topic,
+      subGoals: [],
+      focusTags: [],
+      targetLevel: '',
+      language: 'ko',
+      includeEnCards: false,
+      excludeVideoIds: everServed,
+      publishedAfter: new Date(weekDate.getTime() - days * MS_PER_DAY).toISOString(),
+      env: process.env,
+    });
+  let v5 = await runSearch(CHANNEL_LOOKBACK_DAYS);
+  if (!v5.cards.length) v5 = await runSearch(CURATION_DEEP_RETRY_DAYS);
   const existing = await prisma.curation_items.findMany({
     where: { subscription_id: subscriptionId, week_of: weekDate },
     select: { video_id: true },
@@ -289,42 +301,55 @@ export async function registerCurationBuildWorker(): Promise<void> {
       // runV5Executor's full pipeline (LLM×2 + search.list fanout + bulk embed) stalled
       // the build 20s+. ~1-2s. Thin-pool niche topics → async v5 enrichment = follow-up.
       //
-      // Weekly novelty (2026-08-03 defect fix — measured 55~95% week-over-week
-      // repeats): the pick now carries the two constraints the weekly contract
-      // implies. 1) HISTORY EXCLUSION — anything this subscription has ever
-      // served in a PRIOR week stays out for good. 2) FRESHNESS LADDER —
-      // prefer this week's uploads, widen (7d→14d→30d→any) only while the
-      // rung cannot fill CURATION_MIN_VIDEOS.
+      // Weekly novelty + empty-week floor (2026-08-03, revised after the
+      // empty-week incident): the pick walks CURATION_PICK_RUNGS and
+      // ACCUMULATES, freshest-first, until the week is full — this week's
+      // uploads > fresh > never-served > less-aligned never-served >
+      // long-ago-served re-entry. The last rungs shrink the exclusion horizon
+      // (a month-old good video returning beats a thin week), so a niche
+      // topic can no longer drain itself to zero.
       const [centerEmbedding] = await embedBatch([sub.topic]);
       if (!centerEmbedding) {
         log.warn('curation build: topic embed failed', { subscriptionId, topic: sub.topic });
         return;
       }
-      const served = await servedHistory(prisma, sub, new Date(weekOf));
-      picked = [];
-      let rungUsed: number | null = null;
-      for (const cutoff of curationFreshnessCutoffs(new Date(weekOf))) {
+      const history = await servedHistory(prisma, sub, new Date(weekOf));
+      const plan = curationPickPlan(new Date(weekOf));
+      const acc = new Map<string, { videoId: string; relevancePct: number }>();
+      const rungStats: Array<{ rung: number; added: number }> = [];
+      for (let r = 0; r < plan.length; r++) {
+        if (acc.size >= QUEUE_CONFIG.CURATION_TARGET_VIDEOS) break;
+        const step = plan[r]!;
+        const excluded = new Set(acc.keys());
+        for (const h of history) {
+          if (!step.exclusionAfter || h.weekOf >= step.exclusionAfter) excluded.add(h.videoId);
+        }
         const matches = await matchFromVideoPoolByCenterGoal({
           centerEmbedding,
           subGoals: [],
           language: 'ko',
           limit: QUEUE_CONFIG.CURATION_TARGET_VIDEOS,
-          excludeVideoIds: served,
-          publishedAfter: cutoff,
+          threshold: step.threshold,
+          excludeVideoIds: excluded,
+          publishedAfter: step.publishedAfter,
         });
-        picked = matches.map((m) => ({
-          videoId: m.videoId,
-          relevancePct: Math.max(1, Math.min(100, Math.round((m.score ?? 0) * 100))),
-        }));
-        rungUsed = cutoff
-          ? Math.round((new Date(weekOf).getTime() - cutoff.getTime()) / MS_PER_DAY)
-          : null;
-        if (picked.length >= QUEUE_CONFIG.CURATION_MIN_VIDEOS) break;
+        let added = 0;
+        for (const m of matches) {
+          if (acc.size >= QUEUE_CONFIG.CURATION_TARGET_VIDEOS) break;
+          if (acc.has(m.videoId)) continue;
+          acc.set(m.videoId, {
+            videoId: m.videoId,
+            relevancePct: Math.max(1, Math.min(100, Math.round((m.score ?? 0) * 100))),
+          });
+          added += 1;
+        }
+        if (added) rungStats.push({ rung: r, added });
       }
+      picked = Array.from(acc.values());
       log.info('curation build (topic mode)', {
         subscriptionId,
-        excludedHistory: served.size,
-        freshnessRungDays: rungUsed,
+        historySize: history.length,
+        rungStats,
         picked: picked.length,
       });
     }
@@ -340,33 +365,45 @@ export async function registerCurationBuildWorker(): Promise<void> {
     // caveat: delete-recreate must not turn "in progress" back into "new") — a
     // NEW week's rows are born NULL, which is the intended weekly reset.
     const weekDate = new Date(weekOf);
-    const prevWatched = new Map(
-      (
-        await prisma.curation_items.findMany({
-          where: { subscription_id: subscriptionId, week_of: weekDate, watched_at: { not: null } },
-          select: { video_id: true, watched_at: true },
-        })
-      ).map((r) => [r.video_id, r.watched_at])
-    );
-    await prisma.$transaction([
-      prisma.curation_items.deleteMany({
-        where: { subscription_id: subscriptionId, week_of: weekDate },
-      }),
-      ...(picked.length
-        ? [
-            prisma.curation_items.createMany({
-              data: picked.map((p, i) => ({
-                subscription_id: subscriptionId,
-                video_id: p.videoId,
-                relevance_pct: p.relevancePct,
-                position: i,
-                week_of: weekDate,
-                watched_at: prevWatched.get(p.videoId) ?? null,
-              })),
-            }),
-          ]
-        : []),
-    ]);
+    // Empty-week floor (2026-08-03 incident): the snapshot is REPLACED only
+    // when there is a replacement. picked=0 used to delete the week and write
+    // nothing — an empty feed. Now the previous snapshot is preserved and the
+    // deep pass still runs behind.
+    if (!picked.length) {
+      log.warn('curation build: nothing pickable — preserving existing week', {
+        subscriptionId,
+        topic: sub.topic,
+        mode: channelMode ? 'channel' : 'topic',
+      });
+    } else {
+      const prevWatched = new Map(
+        (
+          await prisma.curation_items.findMany({
+            where: {
+              subscription_id: subscriptionId,
+              week_of: weekDate,
+              watched_at: { not: null },
+            },
+            select: { video_id: true, watched_at: true },
+          })
+        ).map((r) => [r.video_id, r.watched_at])
+      );
+      await prisma.$transaction([
+        prisma.curation_items.deleteMany({
+          where: { subscription_id: subscriptionId, week_of: weekDate },
+        }),
+        prisma.curation_items.createMany({
+          data: picked.map((p, i) => ({
+            subscription_id: subscriptionId,
+            video_id: p.videoId,
+            relevance_pct: p.relevancePct,
+            position: i,
+            week_of: weekDate,
+            watched_at: prevWatched.get(p.videoId) ?? null,
+          })),
+        }),
+      ]);
+    }
 
     // Topic mode ALWAYS enqueues the deep pass now (weekly supply, 2026-08-03):
     // it is no longer just a thin-pool fallback — it is where this week's

--- a/tests/unit/modules/curation-config.test.ts
+++ b/tests/unit/modules/curation-config.test.ts
@@ -1,29 +1,39 @@
-import {
-  CURATION_FRESHNESS_LADDER_DAYS,
-  curationFreshnessCutoffs,
-} from '../../../src/modules/curation/config';
+import { CURATION_PICK_RUNGS, curationPickPlan } from '../../../src/modules/curation/config';
 import { MS_PER_DAY } from '../../../src/utils/time-constants';
 
-describe('curationFreshnessCutoffs (weekly-novelty ladder, 2026-08-03)', () => {
+describe('curationPickPlan (weekly pick ladder + empty-week floor, 2026-08-03)', () => {
   const weekStart = new Date('2026-08-03T00:00:00Z');
+  const plan = curationPickPlan(weekStart);
 
-  it('yields one cutoff per ladder rung plus a final unbounded rung', () => {
-    const cutoffs = curationFreshnessCutoffs(weekStart);
-    expect(cutoffs).toHaveLength(CURATION_FRESHNESS_LADDER_DAYS.length + 1);
-    expect(cutoffs[cutoffs.length - 1]).toBeUndefined();
+  it('yields one step per rung', () => {
+    expect(plan).toHaveLength(CURATION_PICK_RUNGS.length);
   });
 
-  it('anchors each rung N days before the week start', () => {
-    const cutoffs = curationFreshnessCutoffs(weekStart);
-    CURATION_FRESHNESS_LADDER_DAYS.forEach((days, i) => {
-      expect(cutoffs[i]!.getTime()).toBe(weekStart.getTime() - days * MS_PER_DAY);
+  it('resolves freshness cutoffs N days before the week start, unbounded rungs omit it', () => {
+    CURATION_PICK_RUNGS.forEach((rung, i) => {
+      if (rung.freshDays != null) {
+        expect(plan[i]!.publishedAfter!.getTime()).toBe(
+          weekStart.getTime() - rung.freshDays * MS_PER_DAY
+        );
+      } else {
+        expect(plan[i]!.publishedAfter).toBeUndefined();
+      }
     });
   });
 
-  it('widens monotonically — every rung reaches further back than the last', () => {
-    const cutoffs = curationFreshnessCutoffs(weekStart);
-    for (let i = 1; i < CURATION_FRESHNESS_LADDER_DAYS.length; i++) {
-      expect(cutoffs[i]!.getTime()).toBeLessThan(cutoffs[i - 1]!.getTime());
+  it('loosens monotonically — thresholds never rise, exclusion horizons never widen', () => {
+    for (let i = 1; i < plan.length; i++) {
+      expect(plan[i]!.threshold).toBeLessThanOrEqual(plan[i - 1]!.threshold);
+      const prev = plan[i - 1]!.exclusionAfter?.getTime() ?? -Infinity;
+      const cur = plan[i]!.exclusionAfter?.getTime() ?? -Infinity;
+      expect(cur).toBeGreaterThanOrEqual(prev);
     }
+  });
+
+  it('final rungs shrink the exclusion horizon so a niche topic cannot drain to zero', () => {
+    const last = plan[plan.length - 1]!;
+    expect(last.exclusionAfter).toBeDefined();
+    expect(last.exclusionAfter!.getTime()).toBe(weekStart.getTime() - 4 * 7 * MS_PER_DAY);
+    expect(last.threshold).toBeLessThan(0.5);
   });
 });


### PR DESCRIPTION
## What

Layer D — the empty-week floor. Post-deploy verification of layers A-C caught a same-day incident: a niche topic drained to picked=0 (few pool videos above cosine 0.5, all already served), and the snapshot step deleted the week before noticing there was no replacement — one live subscription served an EMPTY feed. The converged serving principle (fewer-aligned cards beat zero cards) had not been carried into the new selection path.

## Changes
- **CURATION_PICK_RUNGS (7 rungs, accumulating)**: the pick walks freshest-first until TARGET — this week's uploads > fresh > never-served > less-aligned never-served (threshold 0.5 -> .35 -> .2) > long-ago-served re-entry (exclusion horizon shrinks from all-time to the last 4 weeks). A month-old good video returning beats a thin week
- **Snapshot preservation**: picked=0 no longer deletes the week — the previous snapshot survives; the deep pass still runs behind
- **Deep mini-ladder**: a 7-day live search returning nothing retries once at 30 days (niche topics; one retry, quota-bounded)
- servedHistory now carries (videoId, most-recent weekOf) so rung horizons ask "served recently?" not "served ever?"
- rungStats logged per build — the weekly contract is finally measurable

## Verification
- tsc 0; curation/queue/cache-matcher suites — no new failures vs baseline
- 4 rewritten unit tests for curationPickPlan (monotonic loosening, horizon shrink, cutoff anchoring)
- Post-deploy: re-enqueue the incident subscription (currently empty), expect a full week, overlap-vs-history ~0, rungStats in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)