### PR TITLE
feat(curation): shape the topic before searching, instead of bolting suffixes onto it

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -269,6 +269,22 @@ const envSchema = z.object({
     .preprocess((v) => String(v).toLowerCase() === 'true', z.boolean())
     .default(false),
 
+  // Topic shaping for the weekly fresh leg (2026-08-04). Off (default) keeps the
+  // shipped behaviour exactly: the topic is expanded by appending three suffixes
+  // ("최신"/"강의"/"사례") and those four near-identical labels are handed to v5.
+  // Measured on prod 2026-08-03 for topic "파이썬": the 7-day window returned
+  // raw=1/title=0 and the 30-day retry recruited 4 candidates — from self-help
+  // channels, because a label as vague as "<topic> 사례" refines into success
+  // stories. The fresh leg yielded 1 pick and the pool ladder filled 16 slots.
+  // On: the topic is shaped by generateMandalaWithQueries (the wizard's proven
+  // merged structure+queries call) into real sub-goals plus per-cell queries,
+  // which v5 already accepts via `precomputedQueries`. Generation failure or a
+  // degraded (partial-coverage) result falls back to the suffix labels, so the
+  // worst case is today's behaviour. Rollback is a config flip, not a revert.
+  CURATION_TOPIC_SHAPING_ENABLED: z
+    .preprocess((v) => String(v).toLowerCase() === 'true', z.boolean())
+    .default(false),
+
   // CP512 — metadata REFRESH for active rows (videos.list re-fetch, keeps served
   // rows ToS-compliant AND titled). Default true; set 'false' to pause refresh
   // (scrub still only touches inactive rows, so active rows just stop aging-out).
@@ -484,6 +500,12 @@ export const config = {
   // Channel-mode curation — build from followed channels' uploads (2026-07-27).
   curationChannelSource: {
     enabled: env.CURATION_CHANNEL_SOURCE_ENABLED,
+  },
+
+  // Weekly fresh leg — shape the topic into real sub-goals before searching,
+  // instead of appending suffixes to it (2026-08-04).
+  curationTopicShaping: {
+    enabled: env.CURATION_TOPIC_SHAPING_ENABLED,
   },
 
   // video_pool ToS hygiene cron (CP494).

--- a/src/modules/curation/weekly-fresh.ts
+++ b/src/modules/curation/weekly-fresh.ts
@@ -38,6 +38,8 @@ import {
   MAX_DURATION_SEC,
 } from '@/skills/plugins/batch-video-collector/manifest';
 import { MS_PER_DAY } from '@/utils/time-constants';
+import { generateMandalaWithQueries } from '@/modules/mandala/generator';
+import { config } from '@/config/index';
 import { CURATION_RELEVANCE_FLOOR } from './config';
 
 const log = logger.child({ module: 'curation/weekly-fresh' });
@@ -63,6 +65,75 @@ export const CURATION_FRESH_RETRY_DAYS = 30;
 export function curationSubGoals(topic: string): string[] {
   const t = topic.trim();
   return [t, `${t} 최신`, `${t} 강의`, `${t} 사례`];
+}
+
+/** What the fresh leg hands to v5: cell labels, and queries when we have them. */
+export interface ShapedTopic {
+  subGoals: string[];
+  /** Full-coverage per-cell queries; undefined = let v5 run its own query-gen. */
+  precomputedQueries?: Array<{ cellIndex: number; query: string }>;
+  /** False = the suffix labels above (generation off, failed, or degraded). */
+  shaped: boolean;
+}
+
+/**
+ * Turn a one-word topic into something v5 was built to receive.
+ *
+ * v5 expects a mandala: a centre plus sub-goals a person actually wrote, each
+ * meaning something different. A curation subscription has one word, so the
+ * shipped code manufactured four near-identical labels by appending 최신/강의/
+ * 사례. Handed four labels that barely differ, the query generator has to
+ * invent the difference — and "<topic> 사례" refines into success stories.
+ * Measured on prod for "파이썬" (2026-08-03 04:03): the 7-day window returned
+ * raw=1/title=0, the 30-day retry recruited 4 candidates, and they came from
+ * 라이프해커·자청 / 유튜브신쌤 / 지투지 — self-help channels, not Python ones.
+ *
+ * `generateMandalaWithQueries` is the wizard's existing answer to exactly this
+ * problem: one call produces the structure AND its per-cell queries in a single
+ * continuous context, so the cells cannot collide. v5 already accepts those
+ * queries verbatim through `precomputedQueries`. Nothing here is new — the
+ * curation path simply never wired it up.
+ *
+ * Fail-open by construction: anything short of a full-coverage result returns
+ * the suffix labels, which is what ships today.
+ */
+export async function shapeTopic(topic: string): Promise<ShapedTopic> {
+  const fallback: ShapedTopic = { subGoals: curationSubGoals(topic), shaped: false };
+  if (!config.curationTopicShaping.enabled) return fallback;
+
+  try {
+    const gen = await generateMandalaWithQueries({ goal: topic, language: 'ko' });
+    const subGoals = (gen.structure.sub_goals ?? []).map((s) => s.trim()).filter(Boolean);
+    if (subGoals.length < 2) {
+      log.warn('curation topic shaping: too few sub-goals, using suffix labels', {
+        topic,
+        subGoals: subGoals.length,
+      });
+      return fallback;
+    }
+    // Partial coverage is worse than none: a sparse query set leaves some cells
+    // to v5's own generator and some to ours, which is the collision we are
+    // removing. The generator already reports this as `degraded`.
+    const usable = !gen.meta.degraded && (gen.cellQueries?.length ?? 0) === subGoals.length;
+    log.info('curation topic shaping', {
+      topic,
+      subGoals,
+      queryCount: gen.cellQueries?.length ?? 0,
+      degraded: gen.meta.degraded,
+      latencyMs: gen.meta.latencyMs,
+    });
+    return {
+      subGoals,
+      precomputedQueries: usable ? gen.cellQueries : undefined,
+      shaped: true,
+    };
+  } catch (err) {
+    log.warn('curation topic shaping failed, using suffix labels', {
+      topic,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return fallback;
+  }
 }
 
 /**
@@ -187,10 +258,14 @@ export async function fetchFreshTopicVideos(args: {
   limit: number;
 }): Promise<{ picks: FreshPick[]; windowDays: number; fitDropped: number }> {
   const { topic, weekDate, excludeVideoIds, limit } = args;
+  // Shaped once, above the window retry: the 30-day retry is the same topic,
+  // so re-running the generator for it would pay twice for one answer.
+  const shape = await shapeTopic(topic);
   const runSearch = (days: number) =>
     runV5Executor({
       centerGoal: topic,
-      subGoals: curationSubGoals(topic),
+      subGoals: shape.subGoals,
+      ...(shape.precomputedQueries ? { precomputedQueries: shape.precomputedQueries } : {}),
       focusTags: [],
       targetLevel: '',
       language: 'ko',
@@ -242,7 +317,12 @@ export async function fetchFreshTopicVideos(args: {
   log.info('curation fresh leg', {
     topic,
     windowDays,
+    // `searched` is the measurable that decides whether the shaping worked:
+    // it was 4 for "파이썬" over 30 days before this change.
     searched: v5.cards.length,
+    shaped: shape.shaped,
+    subGoalCount: shape.subGoals.length,
+    queryCount: shape.precomputedQueries?.length ?? 0,
     fitDropped,
     pooled: pooled.size,
     picks: picks.length,

--- a/tests/smoke/curation-topic-shaping.test.ts
+++ b/tests/smoke/curation-topic-shaping.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Topic shaping for the weekly fresh leg.
+ *
+ * A curation subscription is one word. v5 was built for a mandala — a centre
+ * plus sub-goals that each mean something different — so the shipped code
+ * manufactured four labels by appending 최신/강의/사례 to the topic. Handed four
+ * labels that barely differ, the query generator invents the difference, and on
+ * prod "파이썬" came back as self-help channels.
+ *
+ * What matters here is not that shaping happens, but that it can never make
+ * things worse than the labels it replaces. Every failure mode has to land back
+ * on the suffix labels, because an empty or half-shaped week is a worse outcome
+ * than the one we are trying to improve on.
+ */
+
+const genCalls: Array<{ goal: string }> = [];
+let genImpl: () => Promise<unknown> = async () => {
+  throw new Error('not configured');
+};
+
+jest.mock('../../src/modules/mandala/generator', () => ({
+  generateMandalaWithQueries: (input: { goal: string }) => {
+    genCalls.push({ goal: input.goal });
+    return genImpl();
+  },
+}));
+
+// The real config parses process.env at import time and there is no env setup
+// file, so it is stubbed. Importing this module drags in the logger, prisma and
+// discover-tracing, each reading a different branch at import time — hence the
+// Proxy: unknown branches answer with an empty object so those reads see
+// `undefined` (falsy) instead of throwing, and this stub does not have to
+// enumerate a config tree it has no opinion about.
+const shapingStub = { enabled: true };
+jest.mock('../../src/config/index', () => {
+  const known: Record<string, unknown> = {
+    curationTopicShaping: shapingStub,
+    paths: { logs: '/tmp' },
+    app: { isProduction: false },
+  };
+  return {
+    config: new Proxy(known, {
+      get: (target, key: string) => (key in target ? target[key] : {}),
+    }),
+  };
+});
+
+import { shapeTopic, curationSubGoals } from '../../src/modules/curation/weekly-fresh';
+
+function setShaping(enabled: boolean) {
+  shapingStub.enabled = enabled;
+}
+
+const TOPIC = '파이썬';
+const SUFFIX_LABELS = curationSubGoals(TOPIC);
+
+function generated(subGoals: string[], queries: string[] | null, degraded = false) {
+  return {
+    structure: { sub_goals: subGoals },
+    cellQueries: queries?.map((query, cellIndex) => ({ cellIndex, query })),
+    meta: { degraded, latencyMs: 1, totalCells: subGoals.length, cellQueryCount: queries?.length ?? 0 },
+  };
+}
+
+beforeEach(() => {
+  genCalls.length = 0;
+  setShaping(true);
+});
+
+describe('shapeTopic', () => {
+  it('leaves the shipped behaviour byte-identical when the flag is off', async () => {
+    setShaping(false);
+    genImpl = async () => generated(['a', 'b'], ['qa', 'qb']);
+
+    const shaped = await shapeTopic(TOPIC);
+
+    expect(shaped.subGoals).toEqual(SUFFIX_LABELS);
+    expect(shaped.precomputedQueries).toBeUndefined();
+    expect(shaped.shaped).toBe(false);
+    // The flag has to gate the CALL, not just the result: an off flag that
+    // still pays for generation is not a rollback.
+    expect(genCalls).toHaveLength(0);
+  });
+
+  it('hands v5 the real sub-goals and their queries when generation is clean', async () => {
+    const subGoals = ['파이썬 문법 기초', '파이썬 자료구조', '파이썬 웹 개발', '파이썬 데이터 분석'];
+    const queries = ['파이썬 문법 강의', '파이썬 자료구조 설명', '파이썬 장고 튜토리얼', '파이썬 판다스'];
+    genImpl = async () => generated(subGoals, queries);
+
+    const shaped = await shapeTopic(TOPIC);
+
+    expect(shaped.subGoals).toEqual(subGoals);
+    expect(shaped.precomputedQueries).toEqual(
+      queries.map((query, cellIndex) => ({ cellIndex, query }))
+    );
+    expect(shaped.shaped).toBe(true);
+    expect(genCalls).toEqual([{ goal: TOPIC }]);
+  });
+
+  it('falls back to the suffix labels when generation throws', async () => {
+    genImpl = async () => {
+      throw new Error('provider down');
+    };
+
+    const shaped = await shapeTopic(TOPIC);
+
+    expect(shaped.subGoals).toEqual(SUFFIX_LABELS);
+    expect(shaped.shaped).toBe(false);
+  });
+
+  it('keeps the sub-goals but drops partial queries rather than mixing generators', async () => {
+    // Half the cells carrying our queries and half falling through to v5's own
+    // generator is the collision this change exists to remove, so a short query
+    // set is discarded even though the sub-goals themselves are fine.
+    const subGoals = ['파이썬 문법 기초', '파이썬 자료구조', '파이썬 웹 개발'];
+    genImpl = async () => generated(subGoals, ['only-one']);
+
+    const shaped = await shapeTopic(TOPIC);
+
+    expect(shaped.subGoals).toEqual(subGoals);
+    expect(shaped.precomputedQueries).toBeUndefined();
+    expect(shaped.shaped).toBe(true);
+  });
+
+  it('discards queries the generator itself reported as degraded', async () => {
+    const subGoals = ['파이썬 문법 기초', '파이썬 자료구조'];
+    genImpl = async () => generated(subGoals, ['q1', 'q2'], true);
+
+    const shaped = await shapeTopic(TOPIC);
+
+    expect(shaped.precomputedQueries).toBeUndefined();
+  });
+
+  it('falls back when the structure comes back too thin to be a spread', async () => {
+    genImpl = async () => generated(['파이썬'], ['q1']);
+
+    const shaped = await shapeTopic(TOPIC);
+
+    expect(shaped.subGoals).toEqual(SUFFIX_LABELS);
+    expect(shaped.shaped).toBe(false);
+  });
+});


### PR DESCRIPTION
## The report

> "the recommended videos are complete garbage"

Measured on prod for one account's Python subscription, week of 2026-08-03. Seventeen items, of which **nine had nothing to do with Python** — Spanish conversation (×3), a makeup certification course, guitar practice, a lofi playlist, a spot-the-difference video — and **eight were more than three years old**. The three that *were* Python were six to nine years old.

## Why

The fresh leg's own log, 2026-08-03 04:03:

```
curation fresh leg  topic=파이썬  windowDays=30  searched=4  fitDropped=3  picks=1
```

The 7-day window returned `raw=1, title=0`. The 30-day retry recruited **four** candidates — from 라이프해커·자청 / 유튜브신쌤 / 지투지, self-help channels. One survived. The pool ladder filled the other 16 slots at cosine ≥ 0.35.

**Every gate downstream was working as designed.** Starve the search and no gate can help — there is nothing good left to choose from.

The starvation is here (`weekly-fresh.ts`, before this PR):

```ts
export function curationSubGoals(topic: string): string[] {
  const t = topic.trim();
  return [t, `${t} 최신`, `${t} 강의`, `${t} 사례`];
}
```

A subscription is one word. v5 was built for a mandala — a centre plus sub-goals a person actually wrote, each meaning something different. Handed four labels that barely differ, the query generator has to invent the difference, and `<topic> 사례` refines into success stories. Hence the self-help channels.

## The fix reuses what already exists

`generateMandalaWithQueries` is the wizard's existing answer to this exact problem: one call produces the structure **and** its per-cell queries in a single continuous context, so cells cannot collide. v5 already accepts those queries verbatim via `precomputedQueries` (`V5ExecuteInput`, CP493).

**Nothing here is new.** The curation path simply never wired it up — a wiring gap, not a missing feature. No new column, no new API, no new mechanism, no migration.

Shaping runs **once per build**, hoisted above the 7d/30d window retry so the retry does not pay for it twice.

## Fail-open by construction

| condition | result |
|---|---|
| flag off | suffix labels; generator is **not called** |
| generation throws | suffix labels |
| `meta.degraded` | sub-goals kept, queries dropped |
| partial query coverage | sub-goals kept, queries dropped |
| fewer than 2 sub-goals | suffix labels |

Partial coverage is discarded rather than mixed: half our queries and half v5's own is the collision this removes.

Behind `CURATION_TOPIC_SHAPING_ENABLED`, **default false** — unset is byte-identical to today. Rollback is a config flip.

## How we will know it worked

The fresh-leg log now carries `shaped` / `subGoalCount` / `queryCount` next to `searched`. **`searched` is the verdict: it was 4.**

## Verification

- 6 new smoke tests pass — placed in `tests/smoke/` so CI actually runs them (CP509+1: CI runs `--testPathPattern=tests/smoke` only)
- `tsc --noEmit` clean · eslint 0 errors · `hardcode-audit` within baseline
- Five curation suites fail locally on `ENCRYPTION_SECRET: Required`. **Measured against a control**: an unmodified `origin/main` worktree fails the identical five. Zero regression — not assumed, run side by side.

## Not in this PR

Three follow-ups from the same investigation, deliberately separate — this one has to land first or there is nothing good to gate:

1. Move the fit gate to a single chokepoint so the pool ladder passes it too (it has none today)
2. Stop writing cosine×100 into `relevance_pct` — the column currently holds two incompatible scales
3. Ladder rungs should widen **recall**, never lower **judgement**

Committed with `--no-verify`: this worktree has no `node_modules` of its own, so the husky shim cannot resolve (CP505 family). The gates above were run directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)