### PR TITLE
chore(curation): turn topic shaping on

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -148,6 +148,18 @@ services:
       # curation_channels, so with none registered this is a no-op; it becomes
       # live the moment someone adds a channel in the dial. Rollback = false.
       - CURATION_CHANNEL_SOURCE_ENABLED=true
+      # Topic shaping for the weekly fresh leg (#1459). Off, a subscription's one
+      # word was expanded by appending three suffixes, and v5 -- which expects a
+      # mandala, i.e. sub-goals that each mean something different -- had to
+      # invent the difference between four near-identical labels. Measured on
+      # 2026-08-03 for "파이썬": the 7-day window returned raw=1/title=0, the
+      # 30-day retry recruited 4 candidates, all from self-help channels, and the
+      # pool ladder filled the other 16 slots at cosine >= 0.35. On: the topic is
+      # shaped by generateMandalaWithQueries into real sub-goals + per-cell
+      # queries, which v5 already accepts via precomputedQueries.
+      # Verdict metric: `searched` in the `curation fresh leg` log. It was 4.
+      # Rollback: delete this line (the code falls back to the suffix labels).
+      - CURATION_TOPIC_SHAPING_ENABLED=true
       # CP494 canary — pool-first backfill gate. Fill cells from the quota-FREE +
       # embedding-FREE video_pool (tsvector, v2_promoted ~1.1k) BEFORE live search;
       # a cell with ≥3 pool candidates drops its live search.list query → quota


### PR DESCRIPTION
Release for #1459, which merged with its flag off — prod behaviour is still the old path.

## What is being turned on

Off, a subscription's one word is expanded by appending three suffixes, and v5 — which expects a mandala, i.e. sub-goals that each mean something different — has to invent the difference between four near-identical labels.

Measured on prod, 2026-08-03 04:03, one account's Python subscription:

```
curation fresh leg  topic=파이썬  windowDays=30  searched=4  fitDropped=3  picks=1
```

Four candidates over thirty days, all from self-help channels. The pool ladder filled the remaining 16 slots at cosine ≥ 0.35 — which is how Spanish lessons, a makeup certification course and a lofi playlist ended up under "Python".

On, the topic is shaped by `generateMandalaWithQueries` into real sub-goals plus per-cell queries, which v5 already accepts via `precomputedQueries`.

## Why compose and not deploy.yml

Compose `environment:` literals override `env_file`, so a key written to `.env` that is *also* literal here would never take effect (CP500++, where a toggle sat dead for months this way). Its two curation siblings are set the same way, three lines up. `deploy.yml` has no `CURATION_` entries at all.

## Verdict metric

`searched`, in the same log line. **It was 4.** If it stays around 4 after this, the shaping is not the lever and the flag comes back off.

## Blast radius

All beta users' weekly builds, not a canary — the flag is global. Worth stating plainly: this is a release, not a deploy.

Failure modes stay fail-open by construction (generation throws / degraded / too few sub-goals → the suffix labels, i.e. today). Rollback is deleting this line.

## After merge

Rebuild one Python subscription immediately rather than waiting a week, per the owner's call — this week's items there are the garbage above, so there is nothing to lose by replacing them.

YAML parse verified; the three curation keys read back as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)