### PR TITLE
feat(curation): nine domains, and short patterns stop claiming words they sit inside [P3]

### DIFF
--- a/src/modules/curation/domain-taxonomy.ts
+++ b/src/modules/curation/domain-taxonomy.ts
@@ -13,21 +13,52 @@
 export type CurationDomain =
   | 'ai_ml'
   | 'career'
-  | 'investment'
   | 'startup'
-  | 'language'
-  | 'exam'
+  | 'investment'
+  | 'health'
+  | 'learning'
+  | 'policy'
+  | 'creator'
+  | 'lifestyle'
   | 'other';
 
+/**
+ * The nine weekly editions (James 2026-08-04), in their canonical order, plus
+ * the 'other' fallback. `language` and `exam` merged into `learning`: both were
+ * "someone studying", and splitting them left each too thin to fill an edition.
+ *
+ * Smart Shopping is deliberately absent — measured supply was 30 fresh keywords
+ * of 1,879, and the cause is structural. See P2-보류 in
+ * docs/handoffs/pool-inflow-ledger.md for the conditions to add it.
+ */
 export const CURATION_DOMAINS: readonly CurationDomain[] = Object.freeze([
   'ai_ml',
   'career',
-  'investment',
   'startup',
-  'language',
-  'exam',
+  'investment',
+  'health',
+  'learning',
+  'policy',
+  'creator',
+  'lifestyle',
   'other',
 ]);
+
+/**
+ * Short ASCII patterns match on a word boundary; everything else is a plain
+ * substring. Without this, 'ai' claims appalachian trail, email marketing,
+ * detail and chair yoga, and 'ml' claims html — measured against the live
+ * keyword set, so the tagging backfill would have written that in.
+ * Korean patterns need no boundary: the language does not glue them into
+ * unrelated words the way English does.
+ */
+const SHORT_ASCII = /^[a-z]{1,3}$/;
+function patternHits(haystack: string, pattern: string): boolean {
+  if (SHORT_ASCII.test(pattern)) {
+    return new RegExp(`(^|[^a-z])${pattern}([^a-z]|$)`).test(haystack);
+  }
+  return haystack.includes(pattern);
+}
 
 /** Ordered rules — first matching domain wins. Patterns are lowercase substrings (ko + en). */
 const DOMAIN_RULES: ReadonlyArray<{ domain: CurationDomain; patterns: readonly string[] }> =
@@ -43,23 +74,54 @@ const DOMAIN_RULES: ReadonlyArray<{ domain: CurationDomain; patterns: readonly s
         'llm',
         'gpt',
         'claude',
-        'codex',
         'gemini',
-        'kimi',
-        'qwen',
-        'llama',
-        'transformer',
         '생성형',
         '프롬프트',
-        'prompt',
-        'agent',
         '에이전트',
-        'rag',
-        'diffusion',
-        'stable',
-        'openai',
-        'anthropic',
-        '모델',
+        '자율주행',
+        '양자',
+        '알고리즘',
+        '데이터',
+        '개발',
+        '코딩',
+        '프로그래',
+        '파이썬',
+        'python',
+        '자바',
+        'javascript',
+        '리액트',
+        'kubernetes',
+        'devops',
+        'sql',
+        '클라우드',
+        '서버',
+        '아키텍처',
+        '임베디드',
+        '로봇',
+        'iot',
+        '블록체인',
+        '리눅스',
+        '컴파일러',
+        'saas',
+        'api',
+        // English technical terms the Korean patterns above do not reach. Without
+        // these "reinforcement learning" lands in `learning`, which is the study
+        // domain — the word is shared, the subject is not.
+        'reinforcement',
+        'neural',
+        'transformer',
+        'computer vision',
+        'nlp',
+        'kubernetes',
+        'webassembly',
+        'microservice',
+        'serverless',
+        'compiler',
+        '마이크로서비스',
+        '서버리스',
+        '분산 시스템',
+        '메시지 큐',
+        '데이터베이스',
       ],
     },
     {
@@ -72,16 +134,40 @@ const DOMAIN_RULES: ReadonlyArray<{ domain: CurationDomain; patterns: readonly s
         '커리어',
         '직무',
         '취준',
-        'career',
-        'interview',
-        'resume',
-        'job',
         '연봉',
-        '개발자',
-        '부트캠프',
-        'bootcamp',
-        '전환',
+        '인턴',
+        '채용',
         '포트폴리오',
+        '부트캠프',
+        '자격증',
+        '고시',
+        '공무원',
+        '전문성',
+        'career',
+        'resume',
+        'interview',
+      ],
+    },
+    {
+      domain: 'startup',
+      patterns: [
+        '창업',
+        '스타트업',
+        '사업',
+        '공모',
+        '소자본',
+        '부업',
+        '수익화',
+        '수익 창출',
+        '경영',
+        '생산성',
+        '이커머스',
+        'ecommerce',
+        'startup',
+        '구독서비스',
+        '세일즈',
+        'esg',
+        '지속가능경영',
       ],
     },
     {
@@ -93,40 +179,60 @@ const DOMAIN_RULES: ReadonlyArray<{ domain: CurationDomain; patterns: readonly s
         '부동산',
         '경제',
         '금융',
-        'etf',
         '코인',
         '비트코인',
-        'crypto',
-        'stock',
-        'invest',
-        'finance',
+        'etf',
         '배당',
         '연금',
         '자산',
+        '펀드',
+        '옵션',
+        '커버드콜',
+        '스테이킹',
+        '가상화폐',
+        '세금',
+        '재무',
+        '재정',
+        '부채',
+        '임대',
+        '경매',
+        'stock',
+        'invest',
+        'finance',
       ],
     },
     {
-      domain: 'startup',
+      domain: 'health',
       patterns: [
-        '창업',
-        '스타트업',
-        '사업',
-        '공모',
-        '소자본',
-        '온라인창업',
-        '부업',
-        'startup',
-        '마케팅',
-        'marketing',
-        '브랜딩',
-        '이커머스',
-        'ecommerce',
-        '수익화',
-        'saas',
+        '건강',
+        '운동',
+        '수면',
+        '근력',
+        '다이어트',
+        '식단',
+        '요가',
+        '명상',
+        '마라톤',
+        '주짓수',
+        '체력',
+        '심장',
+        '스킨케어',
+        '장수',
+        '트레이닝',
+        '스포츠',
+        '격투기',
+        '재활',
+        '마음챙김',
+        '헬스',
+        '영양',
+        'fitness',
+        'health',
+        'yoga',
+        'workout',
       ],
     },
     {
-      domain: 'language',
+      domain: 'learning',
       patterns: [
         '영어',
         '토익',
@@ -135,28 +241,113 @@ const DOMAIN_RULES: ReadonlyArray<{ domain: CurationDomain; patterns: readonly s
         '회화',
         '일본어',
         '중국어',
+        '어학',
+        '스피킹',
         'english',
         'toeic',
         'ielts',
         'language',
-        '어학',
-        '스피킹',
-      ],
-    },
-    {
-      domain: 'exam',
-      patterns: [
         '수능',
         '내신',
-        '공무원',
-        '자격증',
-        '기사',
-        '고시',
         '입시',
-        'exam',
         '수험',
         '모의고사',
         '검정',
+        'exam',
+        '공부',
+        '학습',
+        '강의',
+        '논문',
+        '학위',
+        '교육',
+        '속독',
+        '자기계발',
+        '습관',
+        '집중력',
+        '시간관리',
+        '마인드맵',
+        '글쓰기',
+        'study',
+        'learning',
+        'edtech',
+      ],
+    },
+    {
+      domain: 'policy',
+      patterns: [
+        '정책',
+        '지원사업',
+        '복지',
+        '제도',
+        '정부',
+        '노인',
+        '장애',
+        '돌봄',
+        '자원봉사',
+        '지역사회',
+        '청년',
+        '공공',
+        '사회복지',
+        '연금제도',
+        'policy',
+        'welfare',
+        'disability',
+        'accessibility',
+        'inclusion',
+      ],
+    },
+    {
+      domain: 'creator',
+      patterns: [
+        '마케팅',
+        '콘텐츠',
+        '브랜딩',
+        'sns',
+        '유튜브',
+        '뉴스레터',
+        '크리에이터',
+        '일러스트',
+        '디자인',
+        '캘리그라피',
+        '영상편집',
+        '사진',
+        '출판',
+        '저작',
+        'marketing',
+        'branding',
+        'content',
+        'design',
+        'youtube',
+      ],
+    },
+    {
+      domain: 'lifestyle',
+      patterns: [
+        '여행',
+        '라이프',
+        '트렌드',
+        '미니멀',
+        '노마드',
+        '디톡스',
+        '공예',
+        '취미',
+        '정원',
+        '제로웨이스트',
+        '하이킹',
+        '등산',
+        '자전거',
+        '캠핑',
+        '보드게임',
+        '반려',
+        '요리',
+        '인테리어',
+        '명상음악',
+        '순례',
+        '철도',
+        '워케이션',
+        'travel',
+        'hobby',
+        'lifestyle',
       ],
     },
   ]);
@@ -165,7 +356,7 @@ const DOMAIN_RULES: ReadonlyArray<{ domain: CurationDomain; patterns: readonly s
 export function mapKeywordToDomain(keyword: string): CurationDomain {
   const kw = keyword.toLowerCase();
   for (const rule of DOMAIN_RULES) {
-    if (rule.patterns.some((p) => kw.includes(p))) return rule.domain;
+    if (rule.patterns.some((p) => patternHits(kw, p))) return rule.domain;
   }
   return 'other';
 }
@@ -187,7 +378,7 @@ export function extractTaxonomyKeywords(
     for (const p of rule.patterns) {
       // Require ≥2 chars so single-letter noise (ml/ai are intentional) is bounded,
       // and dedupe so a repeated pattern in one title counts once.
-      if (p.length >= 2 && lower.includes(p) && !seen.has(p)) {
+      if (p.length >= 2 && patternHits(lower, p) && !seen.has(p)) {
         seen.add(p);
         out.push({ kw: p, domain: rule.domain });
       }

--- a/src/scripts/backfill-trend-domain.ts
+++ b/src/scripts/backfill-trend-domain.ts
@@ -1,0 +1,86 @@
+/**
+ * Backfill `trend_signals.domain` from the nine-domain taxonomy (P3).
+ *
+ * The column has been NULL on every row since the table was created, which left
+ * MAX_PER_DOMAIN — the filter-bubble guard in the suggester — with nothing to
+ * count, and makes domain-keyed collection impossible to write at all.
+ *
+ * Derived, not authored: `domain` is a function of `keyword`, so re-running is
+ * safe and a taxonomy change is re-applied by running it again. Nothing else on
+ * the row is touched.
+ *
+ *   npx tsx src/scripts/backfill-trend-domain.ts            # dry run, prints the plan
+ *   npx tsx src/scripts/backfill-trend-domain.ts --apply    # writes
+ *   npx tsx src/scripts/backfill-trend-domain.ts --apply --only-null
+ */
+import { getPrismaClient } from '@/modules/database';
+import { mapKeywordToDomain, CURATION_DOMAINS } from '@/modules/curation/domain-taxonomy';
+import { logger } from '@/utils/logger';
+
+const log = logger.child({ module: 'scripts/backfill-trend-domain' });
+
+/** Rows per UPDATE batch — small enough that a long run stays interruptible. */
+const BATCH = 500;
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes('--apply');
+  const onlyNull = process.argv.includes('--only-null');
+  const prisma = getPrismaClient();
+
+  const rows = await prisma.trend_signals.findMany({
+    where: onlyNull ? { domain: null } : {},
+    select: { id: true, keyword: true, domain: true },
+  });
+
+  const planned = rows
+    .map((r) => ({ id: r.id, from: r.domain, to: mapKeywordToDomain(r.keyword) }))
+    .filter((r) => r.from !== r.to);
+
+  const tally: Record<string, number> = Object.fromEntries(CURATION_DOMAINS.map((d) => [d, 0]));
+  for (const r of planned) tally[r.to] = (tally[r.to] ?? 0) + 1;
+
+  console.log(`scanned ${rows.length} rows, ${planned.length} would change\n`);
+  for (const d of CURATION_DOMAINS) {
+    const n = tally[d] ?? 0;
+    const pct = planned.length ? ((100 * n) / planned.length).toFixed(1) : '0.0';
+    console.log(`  ${d.padEnd(11)} ${String(n).padStart(6)}  ${pct.padStart(5)}%`);
+  }
+
+  if (!apply) {
+    console.log('\ndry run — pass --apply to write');
+    await prisma.$disconnect();
+    return;
+  }
+
+  // Grouped by target domain so each batch is one UPDATE ... WHERE id IN (...),
+  // rather than a statement per row.
+  const byDomain = new Map<string, string[]>();
+  for (const r of planned) {
+    const list = byDomain.get(r.to) ?? [];
+    list.push(r.id);
+    byDomain.set(r.to, list);
+  }
+
+  let written = 0;
+  for (const [domain, ids] of byDomain) {
+    for (let i = 0; i < ids.length; i += BATCH) {
+      const slice = ids.slice(i, i + BATCH);
+      const res = await prisma.trend_signals.updateMany({
+        where: { id: { in: slice } },
+        data: { domain },
+      });
+      written += res.count;
+    }
+    log.info('backfill-trend-domain: domain written', { domain, rows: ids.length });
+  }
+
+  console.log(`\nwrote ${written} rows`);
+  await prisma.$disconnect();
+}
+
+main().catch((err: unknown) => {
+  log.error('backfill-trend-domain failed', {
+    error: err instanceof Error ? err.message : String(err),
+  });
+  process.exit(1);
+});

--- a/tests/smoke/curation-domain-taxonomy-9.test.ts
+++ b/tests/smoke/curation-domain-taxonomy-9.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Nine-domain taxonomy (P3).
+ *
+ * Two things are being pinned. That every weekly edition has a domain to sit
+ * in, and that short ASCII patterns stop claiming words they merely appear
+ * inside — 'ai' was taking appalachian trail, email marketing, detail and
+ * chair yoga, all four measured against the live keyword set, so a tagging
+ * backfill would have written that into the database.
+ */
+export {};
+
+import {
+  mapKeywordToDomain,
+  extractTaxonomyKeywords,
+  CURATION_DOMAINS,
+  type CurationDomain,
+} from '../../src/modules/curation/domain-taxonomy';
+
+describe('the nine editions each have a domain', () => {
+  it('carries nine domains plus the fallback, in canonical order', () => {
+    expect(CURATION_DOMAINS).toEqual([
+      'ai_ml',
+      'career',
+      'startup',
+      'investment',
+      'health',
+      'learning',
+      'policy',
+      'creator',
+      'lifestyle',
+      'other',
+    ]);
+  });
+
+  const cases: Array<[string, CurationDomain]> = [
+    ['Claude 모델', 'ai_ml'],
+    ['머신러닝', 'ai_ml'],
+    ['면접 준비', 'career'],
+    ['창업 아이템', 'startup'],
+    ['ETF 투자', 'investment'],
+    ['근력운동 루틴', 'health'],
+    ['토익 단어', 'learning'],
+    ['노인 복지주택', 'policy'],
+    ['뉴스레터 마케팅', 'creator'],
+    ['디지털 노마드', 'lifestyle'],
+    ['바이올린 연주', 'other'],
+  ];
+  it.each(cases)('%s → %s', (keyword, domain) => {
+    expect(mapKeywordToDomain(keyword)).toBe(domain);
+  });
+});
+
+describe('short ASCII patterns need a word boundary', () => {
+  // Every one of these was ai_ml before the boundary rule, measured on the
+  // live trend_signals keyword set.
+  it.each([
+    ['appalachian trail', 'other'],
+    ['detail', 'other'],
+    ['html', 'other'],
+  ])('%s no longer counts as AI', (keyword, domain) => {
+    expect(mapKeywordToDomain(keyword)).toBe(domain);
+  });
+
+  it('still matches the same tokens when they stand alone', () => {
+    expect(mapKeywordToDomain('ai 학습')).toBe('ai_ml');
+    expect(mapKeywordToDomain('ml 파이프라인')).toBe('ai_ml');
+  });
+
+  it('sends the boundary-freed keywords to where they belong, not just away', () => {
+    expect(mapKeywordToDomain('email marketing')).toBe('creator');
+    expect(mapKeywordToDomain('chair yoga')).toBe('health');
+  });
+
+  it('keeps Korean patterns as plain substrings', () => {
+    // No boundary rule applies, so a keyword containing the pattern still hits.
+    expect(mapKeywordToDomain('주식 투자 입문')).toBe('investment');
+  });
+});
+
+describe('learning absorbed language and exam', () => {
+  it('puts both study kinds in one edition', () => {
+    expect(mapKeywordToDomain('영어회화')).toBe('learning');
+    expect(mapKeywordToDomain('수능 국어')).toBe('learning');
+  });
+
+  it('does not lose a technical term to the shared word "learning"', () => {
+    // 'reinforcement learning' is AI, not studying — the noun is shared.
+    expect(mapKeywordToDomain('reinforcement learning')).toBe('ai_ml');
+  });
+});
+
+describe('extractTaxonomyKeywords', () => {
+  it('reports each matched pattern with its domain', () => {
+    const out = extractTaxonomyKeywords('머신러닝으로 ETF 투자 분석하기');
+    expect(out.find((k) => k.kw === '머신러닝')?.domain).toBe('ai_ml');
+    expect(out.find((k) => k.kw === 'etf')?.domain).toBe('investment');
+  });
+
+  it('does not extract a short pattern from inside a longer word', () => {
+    const out = extractTaxonomyKeywords('appalachian trail hiking');
+    expect(out.find((k) => k.kw === 'ai')).toBeUndefined();
+  });
+
+  it('returns nothing for a title with no known interest area', () => {
+    expect(extractTaxonomyKeywords('바이올린 연주회 후기')).toEqual([]);
+  });
+});


### PR DESCRIPTION
First implementation step of P2 (`docs/handoffs/pool-inflow-ledger.md`). Registered as **P3**.

## Nine buckets for nine editions

The taxonomy had **seven** against nine weekly editions, so Health, Policy, Creator and Lifestyle all collapsed into `other` — **504 of 1,879 fresh keywords (27%)** with no shelf to sit on.

`language` and `exam` merge into `learning`: both were "someone studying", and split they were each too thin to fill an edition.

## The bigger fix: `ai` was claiming words it merely sits inside

Short ASCII patterns now require a word boundary. Measured against the **live** keyword set, not imagined:

| keyword | before | after |
|---|---|---|
| `appalachian trail` | **ai_ml** | other |
| `email marketing` | **ai_ml** | creator |
| `detail` | **ai_ml** | other |
| `chair yoga` | **ai_ml** | health |
| `html` | **ai_ml** (`ml`) | other |

The tagging backfill would have written every one of those into the database as AI. Korean patterns stay plain substrings — the language does not glue them into unrelated words the way English does.

## Distribution after the change (1,879 live keywords)

| domain | n | | domain | n |
|---|---:|---|---|---:|
| ai_ml | 317 | | startup | 97 |
| learning | 231 | | creator | 76 |
| health | 196 | | career | 59 |
| investment | 165 | | **policy** | **49** |
| lifestyle | 107 | | other | 582 |

**Every edition has at least 49 keywords**, so even the thinnest has something to collect on — which is why the P2 pilot runs on Policy.

`ai_ml` falling from the 423 a looser rule set claimed is **the false positives leaving**, not supply disappearing. `other` at 31% is the cost of precision, and under the no-garbage rule that is the right side to err on.

## Backfill script

`trend_signals.domain` has been **NULL on all 22,201 rows** since the table was created, which left `MAX_PER_DOMAIN` — the suggester's filter-bubble guard — with nothing to count, and makes domain-keyed collection impossible to write at all.

Derived-only: `domain` is a function of `keyword`, so re-running is safe and a taxonomy change is re-applied by running it again. **Dry-runs by default**, prints the distribution before writing, touches no other column.

## Verification

- **23 tests**, in `tests/smoke/` so CI actually runs them (CP509+1)
- `tsc --noEmit` clean · `eslint` clean · `hardcode-audit` within baseline
- The five curation suites that fail locally fail **identically on an unmodified `origin/main`** — no env, no DB. Measured against that control, not assumed.

Note on my own process: the first eslint run reported 35 errors and I misread `exit=0` — that was `echo`'s exit, not eslint's. Fixed and re-verified with the exit code actually captured.

## Not in this PR

The backfill has **not been run against prod**. It is a data write on live rows and wants an explicit go — dry run first, then apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)