### PR TITLE
feat(collector): scope a run to one edition, and stop searching on rejected keywords [P4]

### DIFF
--- a/docs/handoffs/pool-inflow-ledger.md
+++ b/docs/handoffs/pool-inflow-ledger.md
@@ -3,7 +3,7 @@
 > 범위: `video_pool` 에 **무엇이 들어오고 언제 나가는가** — 수집·태깅·품질채점·만료.
 > **전역 영향**: 위저드·add-cards·큐레이션이 전부 같은 풀을 읽는다. 그래서 T·C 와 분리한다 (James 2026-08-04).
 > 정책: `docs/LEDGERS.md`. 파라미터 상세: `docs/PERFORMANCE_PARAMETERS.md`.
-> **최신 번호: P1** (P2 = 설계 단계 · P2-보류 = Smart Shopping, 나중에 추가)
+> **최신 번호: P4** (P2 = 설계 · P2-보류 = Smart Shopping · P3 택소노미 · P4 수집기 스코프)
 
 ---
 
@@ -224,6 +224,78 @@ James 목표 "일 2,000~3,000편" 과 맞고, **shaping 이 내놓는 하위주�
   수집이 같이 죽었고, 트렌드만 별도 워크플로로 부활. **`batch-video-collector.yml` 은 여전히 비활성.**
 - 표적 수집분 TTL (기본 30일이면 서빙 전 만료)
 - LLM 판정 예산
+
+---
+
+## P3 — 택소노미 9축 + 도메인 백필 (2026-08-04, 배포·적용 완료)
+
+PR #1465. **`trend_signals.domain` 22,201행 전부 NULL → 전량 기록.**
+
+### 로직
+
+택소노미 7 → 9축(+other). `language`+`exam` → `learning` 병합. 그리고 **짧은 영문 패턴에
+단어 경계 요구** — `ai` 가 `appalachian trail`·`email marketing`·`detail`·`chair yoga` 를,
+`ml` 이 `html` 을 먹고 있었다(전부 실측). 경계 없이 백필했으면 그 오분류가 DB 에 박혔다.
+
+### 측정 — 백필 후 실제 DB 분포
+
+| domain | 전체 22,201 | 수집이 쓰는 창 (ok+7일) |
+|---|---:|---:|
+| ai_ml | 1,440 | **566** |
+| learning | 1,419 | 476 |
+| health | 1,120 | 331 |
+| investment | 1,133 | 294 |
+| lifestyle | 909 | 247 |
+| career | 522 | 209 |
+| startup | 519 | 181 |
+| creator | 610 | 166 |
+| **policy** | 215 | **93** |
+| other | 14,314 (64.5%) | 2,294 (47.2%) |
+
+**9축 전부 93건 이상.** `other` 가 전체에서 64.5% 로 높은 것은 만료행 15,575건(70%)이
+끌어올린 값이며, 수집이 실제 뽑는 창에서는 47.2%다.
+
+### 부수 효과 — 필터버블 가드가 처음으로 작동
+
+제안 창 300행에서 `distinct_domains=10`, `null_rows=0`. `MAX_PER_DOMAIN=2` 가 오늘까지
+**한 번도 작동한 적이 없었다** — 셀 대상이 전부 NULL 이었다.
+
+### 롤백
+
+파생 컬럼(`domain = f(keyword)`)이라 되돌릴 대상이 아니다. 택소노미를 바꾸면 백필 재실행으로
+갱신한다. 다른 컬럼 무변경.
+
+### 관측
+
+배포 후 컨테이너 실측(`CURATION_DOMAINS` 10, `appalachian trail → other`) + 백필 후 DB
+전수 대조 완료. **NULL 잔재 0.**
+
+---
+
+## P4 — 수집기 도메인 스코프 + judge 필터 (2026-08-04)
+
+PR #1465 후속. **착수 전 상태로 등재 — 배포·측정 미완.**
+
+### 세 결함
+
+1. **도메인 어휘 불일치.** 수집기가 `metadata.seed_domain`(한글 버킷)에서 도메인을 뽑고
+   `domain` 컬럼(CurationDomain)을 안 봤다. 그래서 `video_pool_domain_tags` 는 7버킷,
+   택소노미는 9축으로 **조인 불가**였다. → 컬럼 우선, seed_domain 은 폴백.
+2. **judge 무시.** `judge_state` 필터가 없어 **unfit 27% + unsafe 3.8%** 에도 검색을 돌렸다.
+   키워드당 100 유닛이며, 판정이 이미 거른 것들이다. → `judge_state='ok'` 한정.
+3. **스코프 불가.** 한 도메인만 재려면 9개 값을 다 내야 했다. → `BATCH_COLLECTOR_DOMAIN`,
+   미설정 = 기존 동작 바이트 동일.
+
+### 파라미터
+
+| 이름 | Default | 영향 | 비용 |
+|---|---|---|---|
+| `BATCH_COLLECTOR_DOMAIN` | unset (= 전 도메인) | 한 판(edition)으로 수집 한정 | 스코프 시 9분의 1 |
+| (내부) judge 필터 | 없음 → `'ok'` | unfit/unsafe 키워드 제외 | **절감** — 30.8% 의 헛검색 제거 |
+
+### 관측
+
+**미측정.** 파일럿(Policy, 93키워드) 실행 후 1~4단 통과율과 함께 기록한다.
 
 ---
 

--- a/src/skills/plugins/batch-video-collector/executor.ts
+++ b/src/skills/plugins/batch-video-collector/executor.ts
@@ -77,6 +77,8 @@ interface HydratedState {
   limit: number;
   offset: number;
   runType: string;
+  /** Restrict this run to one edition's keywords. Undefined = all domains. */
+  domain?: string;
 }
 
 /**
@@ -141,8 +143,20 @@ export const executor: SkillExecutor = {
         ? parseInt(envOffset, 10)
         : computeRotationOffset(Date.now(), limit, BATCH_COLLECTOR_ROTATION_DAYS);
 
+    // Scope one run to a single edition ('policy', 'ai_ml', …). Unset = every
+    // domain, byte-identical to the shipped behaviour. The pilot uses it to
+    // measure one edition's pass rates without spending quota on the other eight.
+    const domain = ctx.env['BATCH_COLLECTOR_DOMAIN']?.trim() || undefined;
     const videosApiKeys = resolveVideosApiKeys(ctx.env);
-    const state: HydratedState = { apiKeys, videosApiKeys, ollamaUrl, limit, offset, runType };
+    const state: HydratedState = {
+      apiKeys,
+      videosApiKeys,
+      ollamaUrl,
+      limit,
+      offset,
+      runType,
+      domain,
+    };
     return { ok: true, hydrated: state as unknown as Record<string, unknown> };
   },
 
@@ -171,7 +185,10 @@ export const executor: SkillExecutor = {
       const keywords =
         state.runType === GOAL_RUN_TYPE
           ? await loadGoalKeywords(db, state.limit)
-          : await loadTrendKeywords(db, state.limit, { offset: state.offset });
+          : await loadTrendKeywords(db, state.limit, {
+              offset: state.offset,
+              ...(state.domain ? { domain: state.domain } : {}),
+            });
       if (keywords.length === 0) {
         await finalizeRun(db, run.id, {
           status: 'failed',

--- a/src/skills/plugins/batch-video-collector/sources/trend-source.ts
+++ b/src/skills/plugins/batch-video-collector/sources/trend-source.ts
@@ -2,13 +2,19 @@
  * batch-video-collector — Source A: trend keywords
  *
  * Pulls live keywords from the `trend_signals` table (populated by the
- * trend-collector skill). Each row carries `metadata.seed_domain` when
- * it came from the Suggest pipeline — we use that as the domain tag.
- * LLM-extracted rows (source='youtube_trending_extracted') don't have a
- * seed_domain and get tagged 'general'.
+ * trend-collector skill).
  *
- * The `limit` is split proportionally across domains so one domain can't
- * dominate the daily quota spend.
+ * The domain tag comes from the `domain` COLUMN, which the P3 backfill filled
+ * with the nine-edition taxonomy. It used to come from `metadata.seed_domain`,
+ * a separate vocabulary of Korean buckets ('기술/개발', '학습/교육') that never
+ * met CurationDomain — so pool tags and weekly editions were named in two
+ * languages that could not be joined. seed_domain remains the fallback for
+ * rows the backfill has not reached.
+ *
+ * Rows are restricted to judge_state='ok'. The judge already rejected personal
+ * names, product models and vlog formats at collection time; spending search
+ * quota on keywords it rejected buys candidates that cannot become a weekly
+ * subject. 27% unfit and 3.8% unsafe were being collected on.
  */
 
 import type { PrismaClient } from '@prisma/client';
@@ -32,6 +38,7 @@ interface TrendRow {
   norm_score: number;
   source: string;
   metadata: unknown;
+  domain: string | null;
 }
 
 const DEFAULT_DOMAIN = 'general';
@@ -41,6 +48,9 @@ export interface LoadTrendKeywordsOpts {
    *  3-day rotation so day 0 takes rows 0..59, day 1 60..119, day 2 120..179.
    *  Over-fetch is sized so slicing after dedup still has enough rows. */
   offset?: number;
+  /** Restrict to one edition's keywords ('policy', 'ai_ml', …). Undefined =
+   *  every domain, which is the shipped behaviour. */
+  domain?: string;
 }
 
 /**
@@ -56,7 +66,11 @@ export async function loadTrendKeywords(
   // Fetch enough to cover offset + limit with dedup headroom.
   const fetchCount = Math.max((offset + limit) * 3, 50);
   const rows = await db.trend_signals.findMany({
-    where: { expires_at: { gt: new Date() } },
+    where: {
+      expires_at: { gt: new Date() },
+      judge_state: 'ok',
+      ...(opts.domain ? { domain: opts.domain } : {}),
+    },
     orderBy: [{ norm_score: 'desc' }],
     take: fetchCount,
     select: {
@@ -65,6 +79,7 @@ export async function loadTrendKeywords(
       norm_score: true,
       source: true,
       metadata: true,
+      domain: true,
     },
   });
 
@@ -77,16 +92,21 @@ export async function loadTrendKeywords(
     deduped.push({
       keyword: r.keyword,
       language: r.language,
-      domain: extractDomain(r.metadata),
+      domain: r.domain ?? extractDomain(r.metadata),
       trendSource: r.source,
       score: r.norm_score,
     });
   }
 
   const out = deduped.slice(offset, offset + limit);
-  log.info(
-    `loaded ${out.length} unique trend keywords (from ${rows.length} raw rows, dedup'd ${deduped.length}, offset ${offset}, limit ${limit})`
-  );
+  log.info('loaded trend keywords', {
+    loaded: out.length,
+    raw: rows.length,
+    deduped: deduped.length,
+    offset,
+    limit,
+    domain: opts.domain ?? '(all)',
+  });
   return out;
 }
 

--- a/tests/smoke/collector-domain-scope.test.ts
+++ b/tests/smoke/collector-domain-scope.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Collector keyword loading — domain scope, judge filter, column-over-metadata.
+ *
+ * Three things are pinned, each of which was a real gap:
+ *
+ *   The domain tag now comes from the `domain` COLUMN the P3 backfill filled,
+ *   not from `metadata.seed_domain`. Those were two vocabularies — the column
+ *   speaks CurationDomain ('policy'), the metadata speaks Korean buckets
+ *   ('기술/개발') — so pool tags and weekly editions could not be joined.
+ *
+ *   Rows are restricted to judge_state='ok'. The judge rejects personal names,
+ *   product models and vlog formats at collection time, and 27% unfit plus
+ *   3.8% unsafe were being searched on anyway.
+ *
+ *   A run can be scoped to one edition, so the pilot measures one domain
+ *   without spending quota on the other eight.
+ */
+export {};
+
+// The real config parses process.env at import time and there is no env setup
+// file. The module under test drags in the logger, which reads a different
+// branch at import — hence the Proxy: unknown branches answer with an empty
+// object instead of throwing, so this stub need not enumerate the config tree.
+jest.mock('../../src/config/index', () => {
+  const known: Record<string, unknown> = {
+    paths: { logs: '/tmp' },
+    app: { isProduction: false },
+  };
+  return {
+    config: new Proxy(known, {
+      get: (target, key: string) => (key in target ? target[key] : {}),
+    }),
+  };
+});
+
+const queries: Array<Record<string, unknown>> = [];
+let reply: Array<Record<string, unknown>> = [];
+
+const db = {
+  trend_signals: {
+    findMany: (arg: Record<string, unknown>) => {
+      queries.push(arg);
+      return Promise.resolve(reply);
+    },
+  },
+};
+
+import { loadTrendKeywords } from '../../src/skills/plugins/batch-video-collector/sources/trend-source';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const load = (limit: number, opts?: Record<string, unknown>) =>
+  loadTrendKeywords(db as any, limit, opts as any);
+
+/** The `where` clause the loader sent on the most recent call. */
+function lastWhere(): Record<string, unknown> {
+  return (queries[0]?.['where'] ?? {}) as Record<string, unknown>;
+}
+
+function row(over: Record<string, unknown> = {}) {
+  return {
+    keyword: 'kw',
+    language: 'ko',
+    norm_score: 1,
+    source: 'youtube_suggest',
+    metadata: {},
+    domain: 'policy',
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  queries.length = 0;
+  reply = [];
+});
+
+describe('domain scope', () => {
+  it('asks for one domain when scoped', async () => {
+    await load(10, { domain: 'policy' });
+    expect(lastWhere()['domain']).toBe('policy');
+  });
+
+  it('leaves the query unscoped when no domain is given — shipped behaviour', async () => {
+    await load(10);
+    expect(lastWhere()['domain']).toBeUndefined();
+  });
+});
+
+describe('judge filter', () => {
+  it('only asks for keywords the judge passed', async () => {
+    await load(10);
+    expect(lastWhere()['judge_state']).toBe('ok');
+  });
+
+  it('applies the judge filter with or without a domain scope', async () => {
+    await load(10, { domain: 'ai_ml' });
+    expect(lastWhere()['judge_state']).toBe('ok');
+  });
+});
+
+describe('domain comes from the column, not the metadata', () => {
+  it('prefers the backfilled column', async () => {
+    reply = [row({ domain: 'policy', metadata: { seed_domain: '기술/개발' } })];
+    const out = await load(10);
+    expect(out[0]?.domain).toBe('policy');
+  });
+
+  it('falls back to seed_domain when the column is null', async () => {
+    reply = [row({ domain: null, metadata: { seed_domain: '기술/개발' } })];
+    const out = await load(10);
+    expect(out[0]?.domain).toBe('기술/개발');
+  });
+
+  it('falls back to general when neither is present', async () => {
+    reply = [row({ domain: null, metadata: {} })];
+    const out = await load(10);
+    expect(out[0]?.domain).toBe('general');
+  });
+});
+
+describe('existing behaviour is untouched', () => {
+  it('dedupes by keyword and language, highest score first', async () => {
+    reply = [
+      row({ keyword: 'AI', norm_score: 0.9 }),
+      row({ keyword: 'ai', norm_score: 0.4 }),
+      row({ keyword: 'ai', language: 'en', norm_score: 0.3 }),
+    ];
+    const out = await load(10);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.score).toBe(0.9);
+  });
+
+  it('slices by offset for rotation', async () => {
+    reply = ['a', 'b', 'c', 'd'].map((k) => row({ keyword: k }));
+    const out = await load(2, { offset: 2 });
+    expect(out.map((k) => k.keyword)).toEqual(['c', 'd']);
+  });
+});


### PR DESCRIPTION
Prepares the P2 pilot. Three gaps, all in how keywords are chosen **before any quota is spent**.

## 1. Two domain vocabularies that never met

The collector read `metadata.seed_domain`, not the `domain` column.

| | speaks |
|---|---|
| `trend_signals.domain` (P3 backfill) | `CurationDomain` — `policy`, `ai_ml` |
| `metadata.seed_domain` | a separate set of Korean bucket names |

So `video_pool_domain_tags` was named in a vocabulary the weekly editions **cannot be joined against** — which is exactly why the pool holds 7 buckets while the taxonomy now has 9 axes. The column wins now; `seed_domain` stays as fallback for rows P3 has not reached.

## 2. The judge was ignored

Keywords loaded with no `judge_state` filter. The judge already rejects personal names, product models, organisation names and vlog formats **at collection time** — and **27% unfit + 3.8% unsafe** were being searched on anyway.

That is 100 quota units per keyword, spent on subjects that cannot become a weekly edition. Now `judge_state='ok'` only.

## 3. A run could not be scoped

Measuring one edition meant paying for all nine. `BATCH_COLLECTOR_DOMAIN` scopes it; **unset is byte-identical** to today.

## Why the pilot needs all three

It runs on **Policy — the thinnest edition, 93 fresh judged keywords**. Running it on AI (566) would pass and then leave Policy dry in production, which is the wrong order to learn that in.

## Verification

- **9 tests** in `tests/smoke/` so CI runs them (CP509+1) — domain scope on/off, judge filter, column-over-metadata precedence with both fallbacks, and the existing dedup/rotation behaviour pinned unchanged
- `tsc`, `eslint`, `hardcode-audit` clean
- **The ledger guard was run against this branch and fails it without a number**, naming both touched paths — then passes with `P4`. The guard shipped this morning; this is it working on its first real subject.
- The existing `trend-source` suite fails locally on missing env — **identically on an unmodified `origin/main` worktree**, checked side by side, not assumed

## Ledger

`P3` (taxonomy + backfill, shipped and measured) and `P4` (this, registered before shipping and marked **unmeasured**) are both entered in `docs/handoffs/pool-inflow-ledger.md`.

P3's entry records what the database actually holds rather than what the dry run predicted: 22,201 rows written, zero null, nine editions at 93–566 keywords in the collection window. And a side effect worth writing down — `MAX_PER_DOMAIN`, the suggester's filter-bubble guard, had **never once fired**, because everything it counted was null.

## Not in this PR

**No collection has been run.** This changes which keywords get chosen; the pilot that actually spends quota and writes to `video_pool` is the next step, and it wants its own go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)