### PR TITLE
fix(curation): judge every pick at one chokepoint, and drop what cannot be judged [C3]

### DIFF
--- a/src/modules/curation/config.ts
+++ b/src/modules/curation/config.ts
@@ -69,8 +69,14 @@ export const CURATION_PUBLISHED_AFTER_DAYS = 365;
  * incident): the topic-mode pick walks these rungs ACCUMULATING candidates,
  * freshest-first, until the week is full. Principle order is codified —
  * this week's uploads > fresh > never-served > less-aligned never-served >
- * long-ago-served re-entry — and NO rung combination may end at an empty
- * week ("덜 정렬된 카드 > 카드 0장", the converged serving principle).
+ * long-ago-served re-entry.
+ *
+ * RETIRED 2026-08-04: "NO rung combination may end at an empty week
+ * (덜 정렬된 카드 > 카드 0장)". Read as "any card beats none", it walked the
+ * ladder down to cosine 0.35 and put Spanish lessons under "파이썬". The owner's
+ * rule now: garbage does not enter, even at the cost of a thin or empty week.
+ * The rungs still widen WHERE we look; they no longer lower HOW GOOD it must
+ * be — curation-build.ts judges the assembled week at one chokepoint.
  *
  * exclusionWeeks: how far back the served-history exclusion reaches.
  * null = everything ever served stays out; 4 = only the last four weeks

--- a/src/modules/curation/pool-titles.ts
+++ b/src/modules/curation/pool-titles.ts
@@ -1,0 +1,29 @@
+/**
+ * Titles for a set of pool video ids.
+ *
+ * The deck renders a curation item by joining `video_pool`, so this is the
+ * title the user will actually read. Anything judged or logged about an item
+ * has to come from here rather than from whatever the search leg happened to
+ * carry, or we judge one string and show another.
+ *
+ * A missing entry means the pool row is gone: that item cannot render at all
+ * (the empty cards incident), so callers drop it rather than substituting.
+ */
+import type { PrismaClient } from '@prisma/client';
+
+export async function getPoolTitles(
+  prisma: PrismaClient,
+  videoIds: readonly string[]
+): Promise<Map<string, string>> {
+  if (!videoIds.length) return new Map();
+  const rows = await prisma.video_pool.findMany({
+    where: { video_id: { in: [...videoIds] } },
+    select: { video_id: true, title: true },
+  });
+  const out = new Map<string, string>();
+  for (const r of rows) {
+    const t = r.title?.trim();
+    if (t) out.set(r.video_id, t);
+  }
+  return out;
+}

--- a/src/modules/curation/weekly-fresh.ts
+++ b/src/modules/curation/weekly-fresh.ts
@@ -6,8 +6,10 @@
  *
  * Responsibilities, in serving-contract order:
  *   1. v5 live search, publishedAfter = 7d (one 30d retry when empty)
- *   2. fit gate — computeCardRelevance(centerGoal=topic) with the (previously
- *      orphaned) CURATION_RELEVANCE_FLOOR, fail-open on LLM errors
+ *   2. fit gate — computeCardRelevance(centerGoal=topic) against
+ *      CURATION_RELEVANCE_FLOOR, fail-CLOSED (2026-08-04). The build-level
+ *      gate in curation-build.ts judges every leg's picks again at the
+ *      chokepoint; this one only saves work by dropping early.
  *   3. pool upsert AWAITED — the deck renders items via a video_pool join
  *      (backfill-curation-pool.ts: absent row = renders as nothing), so this
  *      is a RENDERING precondition, not an optimization. Admission mirrors
@@ -249,7 +251,7 @@ export interface FreshPick {
 /**
  * The whole fresh leg: search → fit gate → pool (awaited) → embed (best
  * effort). Returns ONLY render-safe picks (pool row confirmed) with an honest
- * relevance (Haiku fit score; fail-open keeps the card at the floor value).
+ * relevance (Haiku fit score; an unjudged card is dropped, not floored).
  */
 export async function fetchFreshTopicVideos(args: {
   topic: string;
@@ -283,9 +285,12 @@ export async function fetchFreshTopicVideos(args: {
   }
   if (!v5.cards.length) return { picks: [], windowDays, fitDropped: 0 };
 
-  // Fit gate (design §6): score each fresh candidate against the topic; drop
-  // below the floor. Fail-open — an LLM outage must not empty the week, so an
-  // errored score keeps the card AT the floor (honest minimum, logged).
+  // Fit gate: score each fresh candidate against the topic; drop below the
+  // floor. fail-CLOSED — an unjudged video is one we do not know about, and
+  // garbage does not enter even at the cost of a thin week (owner, 2026-08-04).
+  // This used to keep an errored card AT the floor so an LLM outage could not
+  // empty the week; emptying the week is now the acceptable outcome, and a
+  // silent pass is not.
   const scored: Array<{ card: V5Card; relevancePct: number }> = [];
   let fitDropped = 0;
   for (const card of v5.cards.slice(0, limit * 2)) {
@@ -302,7 +307,7 @@ export async function fetchFreshTopicVideos(args: {
       }
       scored.push({ card, relevancePct: r.relevancePct });
     } else {
-      scored.push({ card, relevancePct: CURATION_RELEVANCE_FLOOR });
+      fitDropped += 1;
     }
     if (scored.length >= limit) break;
   }

--- a/src/modules/queue/handlers/curation-build.ts
+++ b/src/modules/queue/handlers/curation-build.ts
@@ -28,6 +28,9 @@ import { MS_PER_DAY } from '@/utils/time-constants';
 import { config } from '../../../config';
 import { nextKstWeekdayAt } from '@/utils/kst';
 import { collectChannelUploads } from '@/modules/curation/channel-uploads';
+import { computeCardRelevance } from '@/modules/relevance/compute-card-relevance';
+import { CURATION_RELEVANCE_FLOOR } from '@/modules/curation/config';
+import { getPoolTitles } from '@/modules/curation/pool-titles';
 import { curationPickPlan } from '@/modules/curation/config';
 import { fetchFreshTopicVideos } from '@/modules/curation/weekly-fresh';
 import { resolveVideosApiKeys } from '@/skills/plugins/video-discover/v2/youtube-client';
@@ -294,6 +297,23 @@ export async function registerCurationBuildWorker(): Promise<void> {
         }
       }
       picked = Array.from(acc.values());
+
+      // One judge, at the one place every leg arrives.
+      //
+      // The fit gate used to live inside the fresh leg only, so anything the
+      // pool ladder contributed entered with no topic judgement at all —
+      // measured 2026-08-04 on a "파이썬" subscription: 16 of 17 items came
+      // from the ladder at cosine >= 0.35, and nine of them were unrelated
+      // (Spanish lessons, a makeup exam course, guitar practice, a lofi
+      // playlist). Duplicating the gate per leg is what let it be missed; the
+      // guarantee moves to the chokepoint instead.
+      //
+      // fail-CLOSED. An unjudged video is one we do not know about, and the
+      // rule is that garbage does not enter even at the cost of a thin week.
+      // The fresh leg's own fail-open (keep at floor on judge error) is the
+      // opposite of that and is retired by this.
+      picked = await gateByFit(prisma, sub.topic, picked);
+
       // The weekly contract, finally measurable: how much of the week is new.
       const histSet = new Set(history.map((h) => h.videoId));
       const repeats = picked.filter((p) => histSet.has(p.videoId)).length;
@@ -410,3 +430,71 @@ export async function registerCurationBuildWorker(): Promise<void> {
     });
   });
 }
+
+/**
+ * Drop every pick the topic judge does not pass. Runs on the assembled week,
+ * whichever leg produced each item.
+ *
+ * Titles come from video_pool because that is the same row the deck renders
+ * from — judging a title the user will never see would be judging the wrong
+ * thing. A pick with no pool row cannot render anyway, so it is dropped here
+ * rather than surviving as a ghost card.
+ */
+async function gateByFit(
+  prisma: ReturnType<typeof getPrismaClient>,
+  topic: string,
+  picks: Array<{ videoId: string; relevancePct: number }>
+): Promise<Array<{ videoId: string; relevancePct: number }>> {
+  if (!picks.length) return picks;
+
+  const titles = await getPoolTitles(
+    prisma,
+    picks.map((p) => p.videoId)
+  );
+
+  const kept: Array<{ videoId: string; relevancePct: number }> = [];
+  let noTitle = 0;
+  let judgeFailed = 0;
+  let belowFloor = 0;
+
+  for (const pick of picks) {
+    const title = titles.get(pick.videoId);
+    if (!title) {
+      noTitle += 1;
+      continue;
+    }
+    const r = await computeCardRelevance({
+      videoId: pick.videoId,
+      title,
+      centerGoal: topic,
+      language: 'ko',
+    });
+    if (!r.ok) {
+      judgeFailed += 1;
+      continue;
+    }
+    if (r.relevancePct < CURATION_RELEVANCE_FLOOR) {
+      belowFloor += 1;
+      continue;
+    }
+    // One scale from here on. The ladder used to store cosine x 100 in the same
+    // column the fresh leg filled with a judge score, so the ordering mixed two
+    // units that do not compare.
+    kept.push({ videoId: pick.videoId, relevancePct: r.relevancePct });
+  }
+
+  log.info('curation fit gate', {
+    topic,
+    inPicks: picks.length,
+    kept: kept.length,
+    noTitle,
+    judgeFailed,
+    belowFloor,
+    floor: CURATION_RELEVANCE_FLOOR,
+  });
+  return kept.sort((a, b) => b.relevancePct - a.relevancePct);
+}
+
+/** Test seam — the gate is internal to the build, but it is the one piece
+ *  whose behaviour a reviewer needs pinned independently of a live queue. */
+export const __testing = { gateByFit };

--- a/tests/smoke/curation-fit-gate.test.ts
+++ b/tests/smoke/curation-fit-gate.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The build-level fit gate.
+ *
+ * Reported on 2026-08-04, on a subscription whose topic was "파이썬": guitar
+ * chord practice, a makeup certification course, Spanish conversation, a
+ * general-trivia audiobook. Sixteen of seventeen items came from the pool
+ * ladder, which had no topic judgement of any kind — the gate lived inside the
+ * fresh leg, so anything arriving by another route skipped it.
+ *
+ * What is pinned here is that the judge now sees every pick regardless of which
+ * leg produced it, that an unjudged pick is dropped rather than admitted, and
+ * that what survives is ordered by one scale instead of two.
+ */
+export {};
+
+jest.mock('../../src/config/index', () => {
+  const known: Record<string, unknown> = {
+    paths: { logs: '/tmp' },
+    app: { isProduction: false },
+  };
+  return {
+    config: new Proxy(known, {
+      get: (target, key: string) => (key in target ? target[key] : {}),
+    }),
+  };
+});
+
+const scores = new Map<string, { ok: boolean; relevancePct: number }>();
+jest.mock('../../src/modules/relevance/compute-card-relevance', () => ({
+  computeCardRelevance: (a: { videoId: string }) =>
+    Promise.resolve(scores.get(a.videoId) ?? { ok: true, relevancePct: 100 }),
+}));
+
+const titles = new Map<string, string>();
+jest.mock('../../src/modules/curation/pool-titles', () => ({
+  getPoolTitles: () => Promise.resolve(titles),
+}));
+
+import { __testing } from '../../src/modules/queue/handlers/curation-build';
+import { CURATION_RELEVANCE_FLOOR } from '../../src/modules/curation/config';
+
+const gate = __testing.gateByFit;
+const prisma = {} as never;
+const pick = (videoId: string, relevancePct = 46) => ({ videoId, relevancePct });
+
+beforeEach(() => {
+  scores.clear();
+  titles.clear();
+});
+
+describe('every leg is judged, not just the fresh one', () => {
+  it('drops a pick the judge scores below the floor', async () => {
+    titles.set('guitar', '기타코드 체인지가 어렵다면 이렇게 연습해 보세요');
+    scores.set('guitar', { ok: true, relevancePct: CURATION_RELEVANCE_FLOOR - 1 });
+
+    const out = await gate(prisma, '파이썬', [pick('guitar')]);
+
+    expect(out).toEqual([]);
+  });
+
+  it('keeps a pick at or above the floor', async () => {
+    titles.set('py', '파이썬 함수 def 문법 총정리');
+    scores.set('py', { ok: true, relevancePct: CURATION_RELEVANCE_FLOOR });
+
+    const out = await gate(prisma, '파이썬', [pick('py')]);
+
+    expect(out.map((p) => p.videoId)).toEqual(['py']);
+  });
+
+  it('judges a pool pick even though it arrived with a cosine score', async () => {
+    // The ladder wrote cosine x 100 into relevancePct; a high one must not
+    // buy admission on its own.
+    titles.set('spanish', '여행 스페인어회화 01강 - 기내에서');
+    scores.set('spanish', { ok: true, relevancePct: 12 });
+
+    const out = await gate(prisma, '파이썬', [pick('spanish', 99)]);
+
+    expect(out).toEqual([]);
+  });
+});
+
+describe('fail-closed', () => {
+  it('drops a pick the judge could not score', async () => {
+    titles.set('unknown', '무언가');
+    scores.set('unknown', { ok: false, relevancePct: 0 });
+
+    const out = await gate(prisma, '파이썬', [pick('unknown')]);
+
+    expect(out).toEqual([]);
+  });
+
+  it('drops a pick with no pool row, which could not render anyway', async () => {
+    const out = await gate(prisma, '파이썬', [pick('ghost')]);
+
+    expect(out).toEqual([]);
+  });
+
+  it('returns an empty week rather than admitting anything unjudged', async () => {
+    for (const id of ['a', 'b', 'c']) {
+      titles.set(id, id);
+      scores.set(id, { ok: false, relevancePct: 0 });
+    }
+
+    const out = await gate(prisma, '파이썬', ['a', 'b', 'c'].map((i) => pick(i)));
+
+    expect(out).toEqual([]);
+  });
+});
+
+describe('one scale', () => {
+  it('stores the judge score, not whatever the leg carried in', async () => {
+    titles.set('py', '파이썬 자료구조');
+    scores.set('py', { ok: true, relevancePct: 87 });
+
+    const out = await gate(prisma, '파이썬', [pick('py', 35)]);
+
+    expect(out[0]?.relevancePct).toBe(87);
+  });
+
+  it('orders the week by that one scale', async () => {
+    for (const [id, s] of [
+      ['low', 55],
+      ['high', 95],
+      ['mid', 70],
+    ] as Array<[string, number]>) {
+      titles.set(id, id);
+      scores.set(id, { ok: true, relevancePct: s });
+    }
+
+    const out = await gate(prisma, '파이썬', ['low', 'high', 'mid'].map((i) => pick(i)));
+
+    expect(out.map((p) => p.videoId)).toEqual(['high', 'mid', 'low']);
+  });
+});
+
+describe('nothing to do', () => {
+  it('passes an empty pick list straight through', async () => {
+    expect(await gate(prisma, '파이썬', [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
> "python 편성에 기타코드, 바이브코드, 클로드, 메이크업, 영화리뷰분석, 잡학지식, NLP 감정분석, GPT-5.6, 스페인어… 개 쓰레기"

Reported twice today. Sixteen of seventeen items came from the pool ladder, and **the ladder had no topic judgement of any kind.** The gate lived inside the fresh leg, so anything arriving by another route skipped it.

## One judge, at the one place every leg arrives

Duplicating a guard per leg is what let it be missed — the third time this shape has appeared in this repo. So the guarantee moves to the chokepoint: `curation-build` judges the assembled week **after every leg has contributed**, and there is no route into a week that avoids it.

## Fail-closed

Both at the chokepoint and in the fresh leg. An unjudged video is one we do not know about, and the rule is that garbage does not enter even at the cost of a thin week.

The fresh leg used to do the opposite:

```ts
} else {
  scored.push({ card, relevancePct: CURATION_RELEVANCE_FLOOR });  // judge failed → admitted
}
```

Its comment said *"an LLM outage must not empty the week"*. **Emptying the week is now the acceptable outcome; a silent pass is not.**

## Titles come from what the deck renders

`video_pool` — the same row the deck joins. Judging a title the user will never see would be judging the wrong thing. A pick with no pool row is dropped rather than surviving as a ghost card.

## One scale

The ladder wrote `cosine × 100` into the same column the fresh leg filled with a judge score. A **46** meaning "cosine 0.46" outranked a **45** meaning "the judge gave it 45" — the ordering compared two units that do not compare. Everything kept now carries the judge's number, and the week is sorted by it.

## The retired principle is marked, not deleted

`config.ts:72` said *"NO rung combination may end at an empty week (덜 정렬된 카드 > 카드 0장)"*. Read as "any card beats none", that is what walked the ladder down to cosine 0.35 and put Spanish lessons under "python".

It is now marked **RETIRED** in place, with what it caused — so the next reader does not restore it on the same reasoning that produced it. The rungs still widen **where** we look; they no longer lower **how good it must be**.

## Expect the week to get much shorter

Of the 17 items measured this morning, 13 scored below the floor on the ladder's own numbers. **That is the decision, not a regression.**

## Verification

9 tests in `tests/smoke/` so CI runs them: below-floor dropped, at-floor kept, a pool pick judged despite carrying a high cosine, judge-failure dropped, missing pool row dropped, an all-unjudged week returning empty, the judge's score stored over the leg's, and ordering by that one scale.

`tsc`, `eslint`, `hardcode-audit` clean.

**Not yet measured against the reporter's actual screen.** That is the only verification that counts here, and it comes after merge + rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)