### PR TITLE
docs: point two absolute rules at files that exist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,14 @@
 
 ## 세션 시작 필수 로드 (매 세션 첫 번째 액션)
 
-아래 4개 파일을 읽기 전에는 어떤 작업도 시작하지 않는다:
+아래 3개 파일을 읽기 전에는 어떤 작업도 시작하지 않는다:
 - `.claude/agents/DELEGATION.md`
 - `memory/work-efficiency.md`
-- `memory/feedback-speed-agents.md`
 - `memory/troubleshooting.md`
+
+> `feedback-speed-agents.md` (memory 디렉토리) 는 **존재한 적이 없다** (2026-08-11 확인). 이 목록이
+> 없는 파일을 요구해 왔으므로, 매 세션 이 규칙은 조용히 미충족 상태였다. 다루려던 내용은
+> `work-efficiency.md` 와 `DELEGATION.md` 에 이미 있다.
 
 ## 팀 에이전트 강제 규칙
 
@@ -25,9 +28,15 @@
 
 ## UI 작업 전 필수 확인
 
-- **UI/프론트엔드 코드 수정 전에 반드시 `memory/ux-issues.md`를 읽고 기존 이슈 및 regression 체크리스트를 확인한 후 작업한다. 예외 없음.**
-- 카드/D&D/선택 관련 수정 시 ux-issues.md의 Regression Pattern Warning 체크리스트 6항목 확인
-- UI 수정 후 체크리스트 기반 영향 범위 자체 검증
+- **UI/프론트엔드 코드 수정 전에 반드시 `memory/troubleshooting.md` 의 LEVEL-2+ 시각/UI 패턴을 확인한 후 작업한다. 예외 없음.**
+- `scripts/cc-facts.sh` 가 매 `/init` 에 그 목록을 출력한다 — 별도로 찾을 필요 없다.
+- 카드/D&D/선택 관련 수정 시 `/check` 의 `[6ab]`(측정 셋업 assert) · `[6ac]`(실앱 재현 + 렌더레이어 전수) 항목 적용
+- UI 수정 후 영향 범위 자체 검증
+
+> 이 규칙은 2026-08-11 까지 `ux-issues.md` (memory 디렉토리) 를 가리켰고, **그 파일은 존재하지 않았다.**
+> "예외 없음" 이라고 쓰인 절대규칙이 매 UI 세션마다 조용히 통과했다는 뜻이다. 지금 주력
+> 개발 표면이 다이얼 PWA — 전부 UI 다. 실제로 UI 회귀 이력을 담고 있는 곳으로 재지정한다.
+> 빈 파일을 만들어 링크만 살리는 선택지는 버렸다: 지표는 초록이 되고 규칙은 여전히 비어 있게 된다.
 
 ## Hard Rules
 

--- a/README.md
+++ b/README.md
@@ -119,9 +119,11 @@ API reference: `http://localhost:3000/api-reference`
 ## Docs
 
 - [Vision](./docs/VISION.md) — product philosophy, persona model, trust graph
-- [Architecture](./docs/architecture/) — system topology
-- [SSOT](./docs/SSOT.md) — decision tracking
 - [README rewrite rationale](./docs/handoffs/readme-rewrite-cp490.md) — editing rules SSOT for this README
+
+Architecture notes and the SSOT decision log are kept out of this repo on
+purpose: they name production topology, which R3 above excludes. They are not
+missing, and they are not public.
 
 ## License
 


### PR DESCRIPTION
`CLAUDE.md` required reading `memory/ux-issues.md` before any UI change and marked it *no exceptions*. That file has never existed. The rule therefore passed silently on every UI session — and the dial PWA, the current main development surface, is entirely UI.

The session-boot list had the same defect: it demanded `memory/feedback-speed-agents.md`, also never present, as one of four files to read "before starting any work".

`README.md` linked `docs/SSOT.md` and `docs/architecture/`. Both are gitignored by the policy stated in README's own header comment (production topology stays out of the public repo), so the links resolved on the author's machine and broke for anyone who cloned.

## What changed

- UI rule now points at `troubleshooting.md`'s LEVEL-2+ visual entries, where the regression history actually lives. `scripts/cc-facts.sh` prints that list at boot, so it costs nothing to consult.
- Boot list drops the file that never existed; its subject is covered by `work-efficiency.md` and `DELEGATION.md`.
- README says the two documents are withheld on purpose rather than linking into nothing.

## Why not just create the files

Empty placeholders would turn both links green while leaving the rules empty — strictly worse than a red link, because it removes the signal and keeps the gap. This project has hit that exact shape before: back-filling both ledgers to make the contiguity check pass disabled the check itself.

## Verification

`scripts/audit/harness-audit.sh` measures dangling references as H3. It counted 8; skill *outputs* (absent until first run) are excluded as a different condition, leaving 4 real ones, of which this PR closes 2. The remaining 2 stay red on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)