### PR TITLE
feat(twa): serve Digital Asset Links, and ship the Play build kit

### DIFF
--- a/docs/deployment/twa/README.md
+++ b/docs/deployment/twa/README.md
@@ -1,0 +1,129 @@
+# TWA — the Play Store wrapper around the mobile PWA
+
+The Android app on Play is a Trusted Web Activity: a thin native shell that
+opens `https://insighta.one/mobile/` full-screen. There is no second codebase.
+Shipping a dial change ships an app change; the only reason to rebuild the app
+is a change to what is in this folder.
+
+## What lives where
+
+| | |
+|---|---|
+| `twa-manifest.json` | the whole app definition — package id, name, colors, start URL, orientation |
+| `nginx-host.conf` | the one change production nginx needs, with why and how to verify |
+| `frontend/public/.well-known/assetlinks.json` | **the fingerprint. Single source of truth** — it ships with the frontend build, so rotating keys is a code change |
+| `~/.bubblewrap/insighta-twa/android.keystore` | signing key, mode 600, **never in git** |
+| `~/.bubblewrap/insighta-keystore.pass` | its password, mode 600 |
+| `~/insighta-twa-release/` | built AAB/APK, kept out of the repo |
+
+**Losing the keystore ends the app.** Play identifies an app by its signing
+key, so a lost key means no updates to `one.insighta.app` — ever, under any
+account. Back it up somewhere that survives this laptop.
+
+## Build
+
+```bash
+cd <scratch dir>
+cp <repo>/docs/deployment/twa/twa-manifest.json .
+cp ~/.bubblewrap/insighta-twa/android.keystore .
+
+export ANDROID_HOME=~/.bubblewrap/android_sdk
+export BUBBLEWRAP_KEYSTORE_PASSWORD=$(cat ~/.bubblewrap/insighta-keystore.pass)
+export BUBBLEWRAP_KEY_PASSWORD=$BUBBLEWRAP_KEYSTORE_PASSWORD
+
+bubblewrap update --skipVersionUpgrade   # generates the project + checksum
+bubblewrap build --skipPwaValidation     # → app-release-bundle.aab
+```
+
+`update` first is not optional. `build` prompts for a version name when
+`manifest-checksum.txt` is missing, and the prompt cannot be answered by piping
+— `yes ""` sends empty input, which the validator rejects, and it loops. Run
+`update` and `build` never asks.
+
+### Three things that were wrong on the first attempt
+
+Worth keeping, because each cost a debugging round and none of them announce
+themselves.
+
+**The SDK looked complete and was rejected.** `AndroidSdkTools.validatePath`
+wants `<sdk>/tools` or `<sdk>/bin` at the SDK root. A modern SDK has neither —
+its binaries are at `cmdline-tools/latest/bin`. Fix:
+
+```bash
+ln -sfn ~/.bubblewrap/android_sdk/cmdline-tools/latest ~/.bubblewrap/android_sdk/tools
+```
+
+That one link does double duty: it satisfies the check, and it puts
+`sdkmanager` where `installBuildTools` looks for it (`tools/bin/sdkmanager`).
+`sdkmanager` warns about a duplicate package location afterwards; harmless.
+
+**bubblewrap 1.25.0 wants build-tools 36.1.0, not whatever is installed.**
+The version is hardcoded, and `zipalign` and `apksigner` are invoked from that
+exact directory. Install ahead of time so the build does not stop to ask:
+
+```bash
+yes | ~/.bubblewrap/android_sdk/cmdline-tools/latest/bin/sdkmanager \
+  --sdk_root=~/.bubblewrap/android_sdk "build-tools;36.1.0" "platforms;android-36"
+```
+
+**`jdkPath` must be the `.jdk` bundle, not its `Contents/Home`.** On macOS
+bubblewrap appends `/Contents/Home/` itself, so a config pointing at
+`.../temurin-17.jdk/Contents/Home` produces `.../Contents/Home/Contents/Home/`
+and Gradle reports an invalid `JAVA_HOME` — with a path that looks almost
+right, which is why it reads as a JDK problem rather than a config one.
+
+```bash
+bubblewrap updateConfig --jdkPath /Library/Java/JavaVirtualMachines/temurin-17.jdk
+bubblewrap doctor        # must say both paths are valid
+```
+
+## Verify before uploading
+
+Fingerprint mismatch is the failure that costs the most, because nothing errors
+— the app installs, works, and simply keeps its URL bar. Check the two match:
+
+```bash
+$ANDROID_HOME/build-tools/36.1.0/apksigner verify --print-certs app-release-signed.apk \
+  | grep -i 'SHA-256'
+jq -r '.[0].target.sha256_cert_fingerprints[0]' \
+  <repo>/frontend/public/.well-known/assetlinks.json
+```
+
+One prints lowercase unseparated, the other colon-separated uppercase. Same
+bytes. Also confirm the package id, which must equal what Play has:
+
+```bash
+$ANDROID_HOME/build-tools/36.1.0/aapt2 dump badging app-release-signed.apk | head -1
+# package: name='one.insighta.app' versionCode='1' versionName='1.0.0'
+```
+
+Verified for the 1.0.0 build on 2026-08-11: fingerprint matches, `jarsigner
+-verify` reports `jar verified`, package and version as above.
+
+## Asset Links
+
+Chrome fetches `https://insighta.one/.well-known/assetlinks.json` over HTTPS to
+confirm the app and the site have the same publisher. Until it returns 200 the
+app shows a URL bar. It measured **403** before this work, because both nginx
+layers end with:
+
+```nginx
+location ~ /\. { deny all; }
+```
+
+which matches any URI containing `/.`. The ACME challenge escapes it only by
+living in the port-80 block. Both layers need an exact-match exception, since a
+regex location outranks a prefix one:
+
+- container — already in `frontend/nginx/nginx.conf.template` (this repo)
+- host — `nginx-host.conf`, applied by James
+
+Deploy the frontend first. If nginx is fixed while the file is missing, the
+proxy returns the SPA shell with a 200 and a status-code check passes on the
+wrong body. Assert the package name, not the status.
+
+## Releasing a new version
+
+Bump `appVersionCode` (must strictly increase — Play rejects a repeat) and
+`appVersionName` in `twa-manifest.json`, rebuild, upload. Content changes on
+`/mobile/` need no rebuild at all.

--- a/docs/deployment/twa/nginx-host.conf
+++ b/docs/deployment/twa/nginx-host.conf
@@ -1,0 +1,75 @@
+# Host nginx — Digital Asset Links exception
+#
+# Apply to: /etc/nginx/sites-available/insighta  (the :443 server block)
+# Applied by: James. This repo does not touch production.
+#
+# ---------------------------------------------------------------------------
+# Why this is needed
+# ---------------------------------------------------------------------------
+# The :443 block ends with:
+#
+#     location ~ /\. {
+#         deny all;
+#     }
+#
+# That regex matches any URI containing "/.", so it also catches
+# /.well-known/assetlinks.json. Measured 2026-08-11:
+#
+#     $ curl -o /dev/null -w '%{http_code}' https://insighta.one/.well-known/assetlinks.json
+#     403
+#
+# The ACME challenge is unaffected because it lives in the :80 block, which has
+# no such rule -- which is why this has never surfaced before.
+#
+# nginx location precedence is: exact (=), then ^~ prefix, then regex in file
+# order, then longest prefix. So a `location /.well-known/` would still lose to
+# the deny regex; an exact match wins outright. That is the whole trick here.
+#
+# Chrome fetches this file over HTTPS when the app is installed and re-checks
+# periodically. Until it returns 200 with the right JSON, the TWA shows a URL
+# bar at the top of the app -- the app still works, it just does not look
+# native. Nothing else breaks.
+#
+# ---------------------------------------------------------------------------
+# The change: add this block anywhere inside the :443 server block
+# ---------------------------------------------------------------------------
+
+    # Digital Asset Links (Play TWA). Must outrank the "/\." deny rule below,
+    # hence the exact match. Proxies to the frontend container, which serves
+    # the file from the build output -- so the fingerprint is versioned in git
+    # rather than hand-placed on this host.
+    location = /.well-known/assetlinks.json {
+        proxy_pass http://127.0.0.1:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+# ---------------------------------------------------------------------------
+# Apply and verify
+# ---------------------------------------------------------------------------
+#
+#   sudo nginx -t                      # must print "syntax is ok" and "test is successful"
+#   sudo systemctl reload nginx        # reload, not restart -- no dropped connections
+#
+#   curl -sI https://insighta.one/.well-known/assetlinks.json
+#     expect: HTTP/2 200
+#             content-type: application/json
+#
+#   curl -s https://insighta.one/.well-known/assetlinks.json | jq -e '.[0].target.package_name'
+#     expect: "one.insighta.app"
+#
+# Google's own checker (same one Chrome uses):
+#   https://digitalassetlinks.googleapis.com/v1/statements:list\
+#     ?source.web.site=https://insighta.one\
+#     &relation=delegate_permission/common.handle_all_urls
+#
+# Order matters: the frontend deploy that ships the file must land BEFORE this
+# nginx change is verified, or the proxy will return the SPA's index.html with
+# a 200 and the check above will pass on the wrong body. Check the package_name
+# assertion, not just the status code.
+#
+# Rollback: delete this block, `nginx -t`, reload. The app keeps working and
+# regains the URL bar.

--- a/docs/deployment/twa/twa-manifest.json
+++ b/docs/deployment/twa/twa-manifest.json
@@ -1,0 +1,43 @@
+{
+  "packageId": "one.insighta.app",
+  "host": "insighta.one",
+  "name": "Insighta",
+  "launcherName": "Insighta",
+  "display": "standalone",
+  "themeColor": "#F5F2EC",
+  "themeColorDark": "#000000",
+  "navigationColor": "#000000",
+  "navigationColorDark": "#000000",
+  "navigationDividerColor": "#000000",
+  "navigationDividerColorDark": "#000000",
+  "backgroundColor": "#F5F2EC",
+  "enableNotifications": true,
+  "startUrl": "/mobile/",
+  "iconUrl": "https://insighta.one/mobile/icon-512.png",
+  "maskableIconUrl": "https://insighta.one/mobile/icon-512.png",
+  "splashScreenFadeOutDuration": 300,
+  "signingKey": {
+    "path": "./android.keystore",
+    "alias": "android"
+  },
+  "appVersionName": "1.0.0",
+  "appVersionCode": 1,
+  "shortcuts": [],
+  "generatorApp": "bubblewrap-cli",
+  "webManifestUrl": "https://insighta.one/mobile/manifest.webmanifest",
+  "fallbackType": "customtabs",
+  "features": {},
+  "alphaDependencies": {
+    "enabled": false
+  },
+  "enableSiteSettingsShortcut": true,
+  "isChromeOSOnly": false,
+  "isMetaQuest": false,
+  "fullScopeUrl": "https://insighta.one/mobile/",
+  "minSdkVersion": 21,
+  "orientation": "portrait",
+  "fingerprints": [],
+  "additionalTrustedOrigins": [],
+  "retainedBundles": [],
+  "appVersion": "1.0.0"
+}

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -16,6 +16,16 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
+    # nginx's bundled mime.types has no entry for .webmanifest, so the PWA
+    # manifest was served as application/octet-stream (measured in prod
+    # 2026-08-11). The response also carries X-Content-Type-Options: nosniff,
+    # so browsers cannot correct for it. Chrome is lenient enough to install
+    # the PWA anyway, but the TWA install flow and the manifest checks that
+    # read it are entitled to the right type, and being explicit costs a line.
+    types {
+        application/manifest+json  webmanifest;
+    }
+
     # Logging format
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '

--- a/frontend/nginx/nginx.conf.template
+++ b/frontend/nginx/nginx.conf.template
@@ -55,6 +55,26 @@ server {
         access_log off;
     }
 
+    # Digital Asset Links — proves the Play app and this domain are the same
+    # publisher, which is what removes the URL bar from the TWA. Chrome fetches
+    # it over HTTPS at install time and re-checks periodically.
+    #
+    # This needs an exact-match block because the deny rule at the bottom of
+    # this file matches any URI containing "/." and would 403 it. Regex
+    # locations outrank prefix ones, so a `location /.well-known/` would lose;
+    # `location =` outranks both. The host nginx has the identical deny rule
+    # and needs the same exception -- see docs/deployment/twa/nginx-host.conf.
+    # The ACME challenge never hit this because it is served from the :80 block.
+    #
+    # The file itself ships in the frontend build (frontend/public/.well-known/),
+    # so rotating the signing key is a normal code change rather than an edit
+    # on the server.
+    location = /.well-known/assetlinks.json {
+        default_type application/json;
+        add_header Cache-Control "public, max-age=300" always;
+        access_log off;
+    }
+
     # Static file caching - Vite uses content hashes in filenames
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;

--- a/frontend/public/.well-known/assetlinks.json
+++ b/frontend/public/.well-known/assetlinks.json
@@ -1,0 +1,8 @@
+[{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "one.insighta.app",
+    "sha256_cert_fingerprints": ["70:F9:53:D9:BD:4E:3C:9A:66:21:99:07:99:3C:C2:4D:22:20:8A:8D:4A:B6:E2:6E:95:46:B0:5E:CF:27:C5:F0"]
+  }
+}]


### PR DESCRIPTION
Continues the TWA handoff from the career session. **AAB is built and verified; Play upload is James's.**

## The blocker, measured

```
$ curl -o /dev/null -w '%{http_code}' https://insighta.one/.well-known/assetlinks.json
403
```

Both nginx layers end with:

```nginx
location ~ /\. { deny all; }
```

That regex matches any URI containing `/.`, so it swallows the whole `.well-known` tree. **The ACME challenge escapes it only because it lives in the `:80` block** — which is why years of certificate renewals never surfaced this.

A prefix location would not help: regex locations outrank prefix ones. An exact match outranks both.

| layer | where | who applies |
|---|---|---|
| container | `frontend/nginx/nginx.conf.template` | **this PR** |
| host | `docs/deployment/twa/nginx-host.conf` | **James** (prod not touched here) |

**Deploy order matters and is written down.** Ship the file first — fixing nginx while the file is missing makes the proxy answer with the SPA shell and a `200`, so a status-code check passes on the wrong body. Assert the package name.

## Verified, not asserted

Ran a real nginx against the changed config:

| request | result |
|---|---|
| `/.well-known/assetlinks.json` | **200 `application/json`**, correct body |
| `/.hidden` | **403** — deny rule intact for everything else |
| `nginx -t` | syntax ok |

## AAB

| | |
|---|---|
| package | `one.insighta.app` |
| version | 1.0.0 (code 1) |
| `jarsigner -verify` | **jar verified** |
| APK signer SHA-256 | `70f953d9…cf27c5f0` |
| assetlinks fingerprint | `70:F9:53:D9:…:C5:F0` — **same bytes** |

That last row is the one worth checking: a mismatch throws no error. The app installs, works, and simply keeps its URL bar forever.

Artifacts at `~/insighta-twa-release/`, not in git.

## Manifest content type

`manifest.webmanifest` was served as `application/octet-stream` with `nosniff` beside it, so browsers had no way to correct it. Added `application/manifest+json`.

nginx's `types` directive can replace the inherited map rather than extend it, so I tested instead of reasoning: css, js and png keep their types; only webmanifest changes.

## Three build blockers (README)

None announce themselves; each cost a round.

1. **SDK looked complete and was rejected** — `validatePath` wants `<sdk>/tools` or `<sdk>/bin`, which modern SDKs have at `cmdline-tools/latest/bin`. One symlink fixes it *and* puts `sdkmanager` where `installBuildTools` looks.
2. **build-tools 36.1.0 is pinned** in bubblewrap 1.25.0 — 34.0.0 was installed.
3. **`jdkPath` must be the `.jdk` bundle** — macOS appends `Contents/Home` itself, so a config already pointing there yields `.../Contents/Home/Contents/Home/` and Gradle reports an invalid JAVA_HOME, which reads like a JDK problem rather than a config one.

Also: `bubblewrap build` prompts for a version name when `manifest-checksum.txt` is absent, and the prompt cannot be piped — empty input is rejected and it loops. `bubblewrap update --skipVersionUpgrade` first, then `build` never asks.

## Two handoff corrections

- **`/privacy` is not missing.** The handoff recorded it as "SPA catch-all 200, no substance". `PrivacyPage.tsx` is 267 lines across 12 sections, routed at `/privacy`, live and returning 200. `curl` on any SPA route returns the shell — that was a measurement artifact, not a missing page. **Nothing to build.** Whether the existing text satisfies Play's data-safety declaration is a content review, not an engineering task.
- **`deploy/` is gitignored** (`.gitignore:210`), so the handoff's suggested location could not be tracked. Landed under `docs/deployment/twa/` instead, which is.

## Not included

Play upload, and the host nginx edit. Both James.

🤖 Generated with [Claude Code](https://claude.com/claude-code)