### PR TITLE
fix(audit): report an unsearchable rule instead of killing the audit

### DIFF
--- a/scripts/audit/hardcode-audit.ts
+++ b/scripts/audit/hardcode-audit.ts
@@ -84,24 +84,44 @@ interface RuleResult {
   description: string;
   violationCount: number;
   violations: Array<{ file: string; line: number; text: string }>;
+  /** Set when the rule could not be evaluated. Never the same as zero. */
+  skipped?: string;
 }
 
-function runRg(pattern: string, searchGlobs: string[], searchRoot = 'src'): string {
+/**
+ * rg exits 1 for "searched fine, matched nothing" and 2 for "could not
+ * search" — a missing searchRoot being the case that matters here, because a
+ * rule pointed at a directory that is not in the checkout audits nothing.
+ * Told apart so the caller can treat the two differently: one is a clean zero,
+ * the other is a rule that did not run.
+ */
+export type RgOutcome =
+  | { kind: 'output'; stdout: string }
+  | { kind: 'missing-path'; message: string };
+
+export function classifyRgError(err: unknown): RgOutcome | null {
+  const e = err as { stdout?: Buffer | string; stderr?: Buffer | string; status?: number | null };
+  const stdout = typeof e.stdout === 'string' ? e.stdout : '';
+  if (e.status === 1) return { kind: 'output', stdout };
+  const stderr = typeof e.stderr === 'string' ? e.stderr : String(e.stderr ?? '');
+  if (e.status === 2 && /No such file or directory/i.test(stderr)) {
+    return { kind: 'missing-path', message: stderr.trim() };
+  }
+  return null; // not ours to interpret — let it throw
+}
+
+function runRg(pattern: string, searchGlobs: string[], searchRoot = 'src'): RgOutcome {
   const globArgs = searchGlobs.map((g) => `--glob '${g}'`).join(' ');
   try {
-    const out = execSync(
-      `rg --json --line-number -e '${pattern}' ${globArgs} ${searchRoot}`,
-      {
-        cwd: REPO_ROOT,
-        encoding: 'utf8',
-        maxBuffer: 32 * 1024 * 1024,
-      }
-    );
-    return out;
+    const out = execSync(`rg --json --line-number -e '${pattern}' ${globArgs} ${searchRoot}`, {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    return { kind: 'output', stdout: out };
   } catch (err) {
-    // rg exits 1 when zero matches.
-    const execErr = err as { stdout?: Buffer | string; status?: number | null };
-    if (execErr.status === 1) return typeof execErr.stdout === 'string' ? execErr.stdout : '';
+    const outcome = classifyRgError(err);
+    if (outcome) return outcome;
     throw err;
   }
 }
@@ -123,14 +143,21 @@ function matchesAnyGlob(file: string, globs: string[]): boolean {
 }
 
 function auditRule(rule: RuleDef): RuleResult {
-  const searchGlobs = rule.searchGlobs ?? [
-    '!**/__tests__/**',
-    '!**/*.test.ts',
-    '!**/*.spec.ts',
-  ];
-  const raw = runRg(rule.pattern, searchGlobs, rule.searchRoot);
+  const searchGlobs = rule.searchGlobs ?? ['!**/__tests__/**', '!**/*.test.ts', '!**/*.spec.ts'];
+  const outcome = runRg(rule.pattern, searchGlobs, rule.searchRoot);
+  if (outcome.kind === 'missing-path') {
+    // Zero violations here would be a lie: nothing was searched. Carry the
+    // reason so the rule is reported as unevaluated rather than clean.
+    return {
+      id: rule.id,
+      description: rule.description,
+      violationCount: 0,
+      violations: [],
+      skipped: `searchRoot '${rule.searchRoot ?? 'src'}' not in this checkout — ${outcome.message}`,
+    };
+  }
   const violations: RuleResult['violations'] = [];
-  for (const line of raw.split('\n')) {
+  for (const line of outcome.stdout.split('\n')) {
     if (!line.trim()) continue;
     try {
       const event = JSON.parse(line);
@@ -139,7 +166,10 @@ function auditRule(rule: RuleDef): RuleResult {
       if (matchesAnyGlob(filePath, rule.allowedFileGlobs)) continue;
       const text = (event.data.lines.text as string).trim();
       // Skip hour-literal hits that are part of the day literal (counted separately).
-      if (rule.id === 'raw-ms-per-hour-literal' && /\b24\s*\*\s*60\s*\*\s*60\s*\*\s*1000\b/.test(text)) {
+      if (
+        rule.id === 'raw-ms-per-hour-literal' &&
+        /\b24\s*\*\s*60\s*\*\s*60\s*\*\s*1000\b/.test(text)
+      ) {
         continue;
       }
       // Defining a token is how a colour is allowed to enter the system; the
@@ -153,8 +183,9 @@ function auditRule(rule: RuleDef): RuleResult {
         // toward writing the channels out by hand. Strip those calls and judge
         // whatever literal is left on the line.
         const stripped = text.replace(/\b(?:rgba?|hsla?)\(\s*var\([^)]*\)[^)]*\)/gi, '');
-        if (/\brgba?\(|\bhsla?\(/.test(stripped)) { /* a colour function is always a value */ }
-        else {
+        if (/\brgba?\(|\bhsla?\(/.test(stripped)) {
+          /* a colour function is always a value */
+        } else {
           // A #hex is only a COLOUR where a value can go, which means after a
           // colon. An id selector can spell one by accident -- #cdFeed is six
           // hex digits -- and counting those taught nothing except to rename
@@ -162,7 +193,10 @@ function auditRule(rule: RuleDef): RuleResult {
           const hex = /#[0-9a-fA-F]{3,8}\b/g;
           let isValue = false;
           for (let m = hex.exec(stripped); m; m = hex.exec(stripped)) {
-            if (stripped.lastIndexOf(':', m.index) !== -1) { isValue = true; break; }
+            if (stripped.lastIndexOf(':', m.index) !== -1) {
+              isValue = true;
+              break;
+            }
           }
           if (!isValue) continue;
         }
@@ -219,10 +253,7 @@ function main(): void {
   };
 
   mkdirSync(REPORT_DIR, { recursive: true });
-  const stampedPath = resolve(
-    REPORT_DIR,
-    `report-${report.generatedAt.replace(/[:]/g, '-')}.json`
-  );
+  const stampedPath = resolve(REPORT_DIR, `report-${report.generatedAt.replace(/[:]/g, '-')}.json`);
   writeFileSync(stampedPath, JSON.stringify(report, null, 2));
   const latestPath = resolve(REPORT_DIR, 'latest.json');
   writeFileSync(latestPath, JSON.stringify(report, null, 2));
@@ -231,21 +262,33 @@ function main(): void {
   console.log(`[hardcode-audit] report: ${stampedPath}`);
   for (const r of results) {
     // eslint-disable-next-line no-console
-    console.log(`  ${r.id}: ${r.violationCount} violation(s) — ${r.description}`);
+    if (r.skipped) console.log(`  ${r.id}: SKIPPED — ${r.description}`);
+    else console.log(`  ${r.id}: ${r.violationCount} violation(s) — ${r.description}`);
   }
   // eslint-disable-next-line no-console
   console.log(`[hardcode-audit] total: ${totalViolations}`);
 
   const baseline = loadBaseline();
   let failed = false;
+
+  // A rule that could not run is not a rule that passed. Reported before the
+  // baseline comparison so it cannot be read as a clean result, and it fails
+  // the run: the fix is to point the rule at a path this checkout has, or to
+  // retire the rule in the same change that removed the path.
+  const skipped = results.filter((r) => r.skipped);
+  for (const r of skipped) {
+    // eslint-disable-next-line no-console
+    console.error(`[hardcode-audit] NOT EVALUATED: ${r.id} — ${r.skipped}`);
+    failed = true;
+  }
+
   if (baseline) {
     for (const r of results) {
+      if (r.skipped) continue;
       const allowed = baseline[r.id] ?? 0;
       if (r.violationCount > allowed) {
         // eslint-disable-next-line no-console
-        console.error(
-          `[hardcode-audit] FAIL: ${r.id} — ${r.violationCount} > baseline ${allowed}`
-        );
+        console.error(`[hardcode-audit] FAIL: ${r.id} — ${r.violationCount} > baseline ${allowed}`);
         for (const v of r.violations.slice(0, 10)) {
           // eslint-disable-next-line no-console
           console.error(`    ${v.file}:${v.line}  ${v.text}`);
@@ -258,8 +301,14 @@ function main(): void {
     console.warn(
       `[hardcode-audit] no baseline at ${BASELINE_PATH} — current counts will be used to seed one`
     );
+    // Seeding a skipped rule at 0 would lock it there — the baseline may only
+    // move down, so a directory that was simply absent on seeding day would
+    // become a permanent zero nobody could explain.
     const seeded: Record<string, number> = {};
-    for (const r of results) seeded[r.id] = r.violationCount;
+    for (const r of results) {
+      if (r.skipped) continue;
+      seeded[r.id] = r.violationCount;
+    }
     mkdirSync(dirname(BASELINE_PATH), { recursive: true });
     writeFileSync(BASELINE_PATH, JSON.stringify(seeded, null, 2));
     // eslint-disable-next-line no-console
@@ -269,4 +318,7 @@ function main(): void {
   process.exit(failed ? 1 : 0);
 }
 
-main();
+// Only when run as a command. Importing the module — which the regression
+// test does, to reach classifyRgError — must not run the audit and call
+// process.exit.
+if (require.main === module) main();

--- a/tests/smoke/hardcode-audit-missing-searchroot.test.ts
+++ b/tests/smoke/hardcode-audit-missing-searchroot.test.ts
@@ -1,0 +1,60 @@
+/**
+ * A rule pointed at a directory the checkout does not have used to kill the
+ * whole audit. `css-color-literal` searches `frontend/public/mobile`, which is
+ * on main but not on older branches, and rg answers exit 2 there. runRg only
+ * forgave exit 1, so the process died with a stack trace and the other five
+ * rules never ran — an audit that reports nothing at all rather than a verdict.
+ *
+ * The repair has to keep two cases apart. Exit 1 is "searched, matched
+ * nothing" and is a clean zero. Exit 2 with a missing path is "did not
+ * search", which must never be recorded as zero: a rule counted at zero sits
+ * under its baseline and reads as passing, and the baseline may only move
+ * down, so a zero seeded from an absent directory would lock the rule shut.
+ * These pin the classification the rest of that behaviour hangs on.
+ */
+export {};
+
+import { classifyRgError } from '../../scripts/audit/hardcode-audit';
+
+const rgMissingPathStderr = 'rg: frontend/public/mobile: No such file or directory (os error 2)\n';
+
+describe('classifyRgError', () => {
+  it('treats exit 1 as a completed search with no matches', () => {
+    const outcome = classifyRgError({ status: 1, stdout: '', stderr: '' });
+    expect(outcome).toEqual({ kind: 'output', stdout: '' });
+  });
+
+  it('keeps stdout that rg produced before exiting 1', () => {
+    const outcome = classifyRgError({ status: 1, stdout: '{"type":"summary"}\n', stderr: '' });
+    expect(outcome).toEqual({ kind: 'output', stdout: '{"type":"summary"}\n' });
+  });
+
+  it('reports a missing searchRoot rather than swallowing it as zero', () => {
+    const outcome = classifyRgError({ status: 2, stdout: '', stderr: rgMissingPathStderr });
+    expect(outcome).toEqual({
+      kind: 'missing-path',
+      message: rgMissingPathStderr.trim(),
+    });
+  });
+
+  it('reads a Buffer stderr, which is what execSync hands back unencoded', () => {
+    const outcome = classifyRgError({
+      status: 2,
+      stdout: '',
+      stderr: Buffer.from(rgMissingPathStderr),
+    });
+    expect(outcome?.kind).toBe('missing-path');
+  });
+
+  it('declines any other failure so it keeps throwing', () => {
+    // A bad regex is also exit 2, and it is not a missing path — surfacing it
+    // as an unevaluated rule would hide a broken pattern behind a warning.
+    expect(
+      classifyRgError({ status: 2, stdout: '', stderr: 'rg: regex parse error\n' })
+    ).toBeNull();
+    expect(
+      classifyRgError({ status: 127, stdout: '', stderr: 'rg: command not found\n' })
+    ).toBeNull();
+    expect(classifyRgError(new Error('spawn ENOENT'))).toBeNull();
+  });
+});


### PR DESCRIPTION
## What broke

`hardcode-audit` has six rules. Five search `src`; `css-color-literal` searches `frontend/public/mobile`. On a checkout that lacks that directory, rg exits **2**, and `runRg` forgave only exit **1** — so the process died with a stack trace and **the other five rules never ran**.

```
rg: frontend/public/mobile: No such file or directory (os error 2)
    at runRg (scripts/audit/hardcode-audit.ts:92:17)
Node.js v24.10.0
```

The failure reads as a broken tool. It is a wrong checkout — but an audit that cannot answer at all is worse than one that answers partially, and nothing in the output said which rule or which path.

## What changed

The two rg exit codes now mean different things:

| rg exit | meaning | treated as |
|---|---|---|
| 1 | searched, matched nothing | **clean zero** |
| 2 + `No such file or directory` | did not search | **unevaluated** |
| anything else | unknown | rethrown |

**Unevaluated is deliberately not zero.** A rule counted at zero sits under its baseline and reads as passing; and because the baseline may only move down, a zero seeded from an absent directory would lock that rule shut with no trace of why. So a skipped rule is excluded from the baseline comparison **and** from seeding, printed as `NOT EVALUATED`, and it **fails the run**. The fix for a skip is to repoint the rule or retire it in the same change that removed the path — not to let coverage disappear quietly.

`main()` moved behind a `require.main` guard so importing the module for the test does not run the audit and call `process.exit`.

## Verification

Both directions, on this worktree:

```
# normal
[hardcode-audit] total: 281          exit 0     (baseline: 33 + 248)

# frontend/public/mobile moved aside
  css-color-literal: SKIPPED
[hardcode-audit] total: 33
[hardcode-audit] NOT EVALUATED: css-color-literal — searchRoot
  'frontend/public/mobile' not in this checkout — rg: ... (os error 2)
                                     exit 1
```

Directory restored, `git status` clean. The five remaining rules still ran in the skipped case — that is the part the crash used to take out.

- `tsc --noEmit` — 0
- `tests/smoke/hardcode-audit-missing-searchroot.test.ts` — 5 passed
- `eslint` — 0 errors (also cleared the 12 pre-existing prettier errors in the touched file; the 5 remaining warnings are pre-existing `any` in the JSON walk)

## Test

`classifyRgError` is exported and pinned on five cases, including the real stderr string captured from the crash and a `Buffer` stderr (what `execSync` hands back unencoded). A bad regex is *also* exit 2 and must keep throwing — surfacing it as an unevaluated rule would hide a broken pattern behind a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)