### PR TITLE
feat(ci): tell the private mirror when paths its runbook describes change

### DIFF
--- a/.github/workflows/notify-runbook.yml
+++ b/.github/workflows/notify-runbook.yml
@@ -1,0 +1,61 @@
+name: Notify Runbook
+
+# The runbook lives in the private mirror because it carries account and
+# resource identifiers this repository is public and cannot hold. That split
+# means a change here can invalidate a chapter there with nothing over there
+# noticing, so this tells it.
+#
+# Paths are the ones runbook chapters actually cite. Adding a cite over there
+# without adding the path here is the way this silently stops working, so the
+# lists are kept identical on purpose — the mirror's daily schedule is the
+# backstop for exactly that mistake.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/deploy.yml'
+      - '.github/workflows/terraform.yml'
+      - '.github/workflows/backup.yml'
+      - 'scripts/audit/hardcode-audit.ts'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'docker-compose.prod.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Tell the mirror to re-check
+    runs-on: ubuntu-latest
+    steps:
+      # RUNBOOK_DISPATCH_TOKEN is a fine-grained PAT with Contents: read and
+      # Actions: write on JK42JJ/insighta-private and nothing else. Without it
+      # this job is skipped rather than failed: a missing token should not turn
+      # every push to main red, and the mirror still catches drift on its daily
+      # run — a day later instead of a minute later.
+      - name: Dispatch
+        env:
+          TOKEN: ${{ secrets.RUNBOOK_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "${TOKEN:-}" ]; then
+            echo "::warning::RUNBOOK_DISPATCH_TOKEN is not set; the mirror picks this up on its daily schedule instead of now"
+            exit 0
+          fi
+          CODE=$(curl -sS -o /tmp/resp.txt -w '%{http_code}' \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/JK42JJ/insighta-private/dispatches \
+            -d "{\"event_type\":\"app-main-push\",\"client_payload\":{\"sha\":\"${{ github.sha }}\"}}")
+          echo "dispatch -> HTTP $CODE"
+          # 204 is the documented success for this endpoint; anything else is a
+          # real failure and should be visible rather than swallowed.
+          if [ "$CODE" != "204" ]; then
+            cat /tmp/resp.txt
+            echo "::error::dispatch failed with HTTP $CODE"
+            exit 1
+          fi


### PR DESCRIPTION
## Why

The infrastructure runbook lives in the **private mirror**, because it carries the account id, instance and security-group identifiers, and the elastic IP — none of which belong in a public repository.

That split has a cost: **a change here can invalidate a chapter there, and nothing over there notices.**

## What this does

Fires a `repository_dispatch` to `JK42JJ/insighta-private` on pushes to `main` touching the paths those chapters cite:

```
terraform/**                        .github/workflows/deploy.yml
.github/workflows/terraform.yml     .github/workflows/backup.yml
scripts/audit/hardcode-audit.ts     Dockerfile
.dockerignore                       docker-compose.prod.yml
```

The mirror then re-checks each chapter against the code it describes and opens an issue if one is behind. **Numbers in the runbook are deliberately never regenerated** — it records a specific day, and rewriting its figures would make the page look maintained while its sentences quietly stopped being true.

## Degradation

**Skips when `RUNBOOK_DISPATCH_TOKEN` is absent**, with a warning. A missing secret should not turn every push to `main` red, and the mirror runs the same check daily — so the cost of no token is a day's delay, not a gap. Any other HTTP status is a real failure and surfaces.

## Requires

A fine-grained PAT as `RUNBOOK_DISPATCH_TOKEN` — **Contents: read** and **Actions: write** on `JK42JJ/insighta-private`, nothing else. Until it exists this job no-ops.

## Known limitation

The path list here and the `cites:` headers in the mirror are maintained separately and can drift apart. The daily schedule over there is the backstop for exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)