### PR TITLE
fix(ci): stop keeping a second copy of the runbook's path list

### DIFF
--- a/.github/workflows/notify-runbook.yml
+++ b/.github/workflows/notify-runbook.yml
@@ -5,22 +5,21 @@ name: Notify Runbook
 # means a change here can invalidate a chapter there with nothing over there
 # noticing, so this tells it.
 #
-# Paths are the ones runbook chapters actually cite. Adding a cite over there
-# without adding the path here is the way this silently stops working, so the
-# lists are kept identical on purpose — the mirror's daily schedule is the
-# backstop for exactly that mistake.
+# Every push to main, with no path filter — deliberately.
+#
+# The first version listed the eight paths the chapters cite, which made this
+# file a second copy of a list that already exists over there, in each chapter's
+# cites header. Two declarations of the same thing drift: someone adds a cite,
+# forgets this list, and the notification silently stops covering it. Where the
+# relevant paths are is knowledge the mirror already has and this repository
+# does not, so the filtering belongs there.
+#
+# The cost of dropping the filter is a dispatch on pushes that turn out to be
+# irrelevant. The mirror's check takes about a minute and decides that for
+# itself, which is cheap next to a stale runbook nobody was told about.
 on:
   push:
     branches: [main]
-    paths:
-      - 'terraform/**'
-      - '.github/workflows/deploy.yml'
-      - '.github/workflows/terraform.yml'
-      - '.github/workflows/backup.yml'
-      - 'scripts/audit/hardcode-audit.ts'
-      - 'Dockerfile'
-      - '.dockerignore'
-      - 'docker-compose.prod.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## The defect

#1480 shipped with a path filter listing the eight paths runbook chapters cite — and I wrote the consequence down as a *known limitation*:

> 메인 리포의 감시 경로 8개와 미러의 `cites` 선언이 따로 관리돼 어긋날 수 있습니다. 그래서 정기검사를 백스톱으로 남겼습니다.

**That is the exact pattern this repo spent the day removing.** A declaration kept in two places, drifting apart, with a periodic check papering over it. The runbook's own design chapter says it plainly:

> **desired state 는 한 곳에만 둔다. 선언이 두 벌 있으면 반드시 갈라진다.**

Someone adds a `cites:` entry over there, forgets this list, and the notification silently stops covering it. A daily job that catches the mistake a day later is not a fix; it is a tolerance.

## The fix

**Delete the filter.** Every push to `main` dispatches. Which paths matter is knowledge the mirror already has and this repo does not — the `cites:` headers — so the filtering belongs there.

```diff
  on:
    push:
      branches: [main]
-     paths:
-       - 'terraform/**'
-       - '.github/workflows/deploy.yml'
-       ... 6 more
```

**Cost:** a dispatch on pushes that turn out to be irrelevant. The mirror's check takes about a minute and decides for itself — cheap next to a stale runbook nobody was told about.

**No new failure mode:** the mirror already handles being woken for nothing.

## Also

The mirror's `schedule` comment is corrected in a companion commit there. It no longer compensates for two lists disagreeing — there is one list. It covers the dispatch not arriving at all: token missing, revoked, or the call failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)