### PR TITLE
fix(ci): charts/ is not a deployable path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ prompt
 scripts
 terraform
 ansible
+charts
 frontend
 *.md
 *.pem

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,7 +109,7 @@ jobs:
           # deployable=true, which wastes a deploy; an allowlist would silently
           # skip it, and a deploy that should have happened and did not is the
           # failure this repository can least afford.
-          IRRELEVANT='^(terraform|ansible|docs|prompt|tests|scripts|\.github|\.claude)/|^[^/]*\.md$'
+          IRRELEVANT='^(terraform|ansible|charts|docs|prompt|tests|scripts|\.github|\.claude)/|^[^/]*\.md$'
           if echo "$FILES" | grep -Eqv "$IRRELEVANT"; then
             DEPLOYABLE=true
           else


### PR DESCRIPTION
Merging a change to `charts/insighta/environments/prod.yaml` rebuilt and redeployed all of production.

## Why

Nothing in `charts/` reaches the running system. The Dockerfile copies `package*.json`, `prisma`, `tsconfig.json` and `src`; the deploy job ships `docker-compose.prod.yml` and `docker/redis/`. But `charts` was never declared irrelevant, so the predicate fell through to `deployable=true`.

That fall-through is the intended default — an unknown top-level directory should deploy, because a deploy that should have happened and did not is the failure this repo can least afford. So this was a wasted deploy, not a missed one. It still should not happen for a directory we added ourselves.

## Fix

`charts` added to the predicate **and** to `.dockerignore`. The existing guard test requires both — the predicate's comment claims every excluded path is kept out of the image, and the test enforces it.

Negative control re-run: removing `charts` from `.dockerignore` fails the guard.

```
✓ every directory the predicate calls irrelevant is excluded from the image
✓ flags a directory that is in the predicate but not in .dockerignore

# with charts removed from .dockerignore
✕ every directory the predicate calls irrelevant is excluded from the image
✕ flags a directory that is in the predicate but not in .dockerignore
```

## Note for worktree users

`node_modules` used to be a tracked symlink shared across worktrees, untracked in #1486. Checking out a commit from after that change deletes it from the working tree. Recreate it locally — `.gitignore` now keeps it out of git:

```
ln -s /path/to/main/checkout/node_modules node_modules
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)