### PR TITLE
fix(charts): the cache and logs volumes are not throwaway

### DIFF
--- a/charts/insighta/environments/dev.yaml
+++ b/charts/insighta/environments/dev.yaml
@@ -12,6 +12,10 @@
 # in the design as 8.4, and it blocks T0 outright.
 api:
   replicaCount: 1
+  # Single replica, so a ReadWriteOnce claim is valid and the YouTube
+  # response cache survives a restart instead of spending quota to rebuild.
+  persistence:
+    enabled: true
   image:
     repository: insighta-api
     tag: local

--- a/charts/insighta/environments/prod.yaml
+++ b/charts/insighta/environments/prod.yaml
@@ -42,6 +42,24 @@
 # than losing data.
 api:
   replicaCount: 2
+  # Off at 2 replicas, deliberately. A ReadWriteOnce claim cannot back two
+  # pods, and k3s local-path offers nothing else. The two directories are not
+  # equivalent, so the trade differs:
+  #
+  #   /app/cache  each pod warms its own copy of the YouTube response cache.
+  #               The cost is one warm-up per pod, not a continuous one --
+  #               acceptable. The shared-cache answer is redis, which is
+  #               deployed and holds nothing (6.1 risk 3); this is the first
+  #               concrete consumer it would have.
+  #   /app/logs   lost on reschedule, and nothing ships them off the pod.
+  #               This is the same gap the design records for journald
+  #               (6.1 risk 5) and it is NOT solved here. Log shipping is a
+  #               P2 item; until then a rescheduled pod loses its history.
+  #
+  # Do not turn this on while replicaCount is above 1 -- the second pod will
+  # sit Pending on a volume it cannot attach.
+  persistence:
+    enabled: false
 frontend:
   replicaCount: 2
 redis:

--- a/charts/insighta/environments/staging.yaml
+++ b/charts/insighta/environments/staging.yaml
@@ -2,6 +2,10 @@
 # breaks on promotion, not to survive a node loss.
 api:
   replicaCount: 1
+  # Single replica, so a ReadWriteOnce claim is valid and the YouTube
+  # response cache survives a restart instead of spending quota to rebuild.
+  persistence:
+    enabled: true
 frontend:
   replicaCount: 1
 redis:

--- a/charts/insighta/templates/api.yaml
+++ b/charts/insighta/templates/api.yaml
@@ -1,3 +1,12 @@
+{{- /*
+   A ReadWriteOnce claim cannot be attached by two pods. Left to a comment,
+   enabling persistence at two replicas leaves the second pod Pending on a
+   volume it will never get -- a failure that looks like a scheduling problem
+   and is not. Fail at render instead.
+*/ -}}
+{{- if and .Values.api.persistence.enabled (gt (int .Values.api.replicaCount) 1) }}
+{{- fail (printf "api.persistence.enabled=true with api.replicaCount=%d: the cache and logs claims are ReadWriteOnce and cannot back more than one pod. Either drop to one replica or turn persistence off and accept per-pod cache warm-up." (int .Values.api.replicaCount)) }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -87,16 +96,74 @@ spec:
             # mount it lands on the container's root filesystem.
             - name: state
               mountPath: /var/insighta
-      # compose used named volumes for these. They hold regenerable data, so
-      # emptyDir is correct here -- a PVC would imply the contents must
-      # survive rescheduling, and they do not.
+      # An earlier revision called these regenerable and used emptyDir for
+      # both. That was written without looking at what they hold. Measured on
+      # production 2026-08-14:
+      #
+      #   /app/cache  13 MB  base64-named JSON, one file per playlist --
+      #               persisted YouTube API responses. Starting cold means
+      #               re-fetching them, and a subscriptions call costs 100
+      #               quota units. This is why redis is empty: the app caches
+      #               to disk, not to redis.
+      #   /app/logs   34 MB  combined*.log and error*.log going back to May.
+      #               The only copy; nothing ships them anywhere.
+      #
+      # Neither is user data, but neither is free to discard either. Both get
+      # a volume by default; emptyDir stays available for ephemeral
+      # environments through persistence.enabled.
       volumes:
+{{- if .Values.api.persistence.enabled }}
+        - name: cache
+          persistentVolumeClaim:
+            claimName: {{ include "insighta.fullname" . }}-api-cache
+        - name: logs
+          persistentVolumeClaim:
+            claimName: {{ include "insighta.fullname" . }}-api-logs
+{{- else }}
         - name: cache
           emptyDir: {}
         - name: logs
           emptyDir: {}
+{{- end }}
+        # Rebuilt on demand by pool-health; losing it costs one stale-query
+        # fallback, not history.
         - name: state
           emptyDir: {}
+{{- if .Values.api.persistence.enabled }}
+---
+# ReadWriteOnce, so these are only correct while api.replicaCount is 1.
+# Raising replicas requires either ReadWriteMany or accepting that each pod
+# keeps its own cache -- which is a decision, not a default.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "insighta.fullname" . }}-api-cache
+  labels:
+    {{- include "insighta.labels" . | nindent 4 }}
+spec:
+  accessModes: ["ReadWriteOnce"]
+  {{- with .Values.api.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.api.persistence.cacheSize }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "insighta.fullname" . }}-api-logs
+  labels:
+    {{- include "insighta.labels" . | nindent 4 }}
+spec:
+  accessModes: ["ReadWriteOnce"]
+  {{- with .Values.api.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.api.persistence.logsSize }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/insighta/values.yaml
+++ b/charts/insighta/values.yaml
@@ -35,6 +35,17 @@ api:
       cpu: 1000m
   # Memory limits kill the process; CPU limits only throttle it. Keep the
   # memory ceiling generous relative to the request.
+  # /app/cache and /app/logs hold 13 MB and 34 MB on production. The cache is
+  # persisted YouTube API responses -- discarding it spends quota to rebuild
+  # -- and the logs are the only copy. Off means emptyDir, which is right for
+  # a throwaway environment and wrong for a lasting one.
+  #
+  # ReadWriteOnce: correct only while replicaCount is 1. See prod.yaml.
+  persistence:
+    enabled: true
+    cacheSize: 2Gi
+    logsSize: 2Gi
+    storageClass: ""
   livenessProbe:
     httpGet: { path: /health, port: 3000 }
     initialDelaySeconds: 40


### PR DESCRIPTION
The chart mapped `/app/cache` and `/app/logs` to `emptyDir`, with a comment calling them regenerable. **That comment was written without looking at what they hold.**

## Measured on production, 2026-08-14

```
/app/cache  13 MB   base64-named JSON, one file per playlist
                    = persisted YouTube API responses
/app/logs   34 MB   combined*.log, error*.log going back to May
                    = the only copy
```

A cold cache re-fetches from YouTube, and a subscriptions call costs **100 quota units**. This is also why redis is empty — **the app caches to disk, not to redis.**

Neither is user data. Neither is free to discard.

## The conflict this exposes

Giving both a claim immediately collides with prod running api at **2 replicas**: a `ReadWriteOnce` claim cannot be attached by two pods, and k3s local-path offers nothing else.

The two directories do not deserve the same answer, so prod turns persistence off and states the trade for each:

| | at 2 replicas | acceptable? |
|---|---|---|
| **cache** | each pod warms its own | **yes** — one warm-up per pod, not continuous. The shared-cache answer is redis, which is deployed and holds nothing; this would be its first concrete consumer |
| **logs** | lost on reschedule, nothing ships them | **no** — same gap the design records for journald, and it is **not solved here**. Log shipping is a P2 item |

dev and staging run one replica and keep the claims.

## A comment is not a guard

Enabling persistence above one replica leaves the second pod `Pending` on a volume it will never get — which reads as a scheduling problem and is not. The template now fails at render:

```
Error: api.persistence.enabled=true with api.replicaCount=2: the cache and
logs claims are ReadWriteOnce and cannot back more than one pod. Either drop
to one replica or turn persistence off and accept per-pod cache warm-up.
```

Verified both directions — the bad combination fails with the reason, one replica with persistence on still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)