### PR TITLE
fix(logger): write module logs to stdout in production, not only to files

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -64,13 +64,30 @@ if (!isServerless) {
   );
 }
 
-// Console transport for development or serverless
-if (!config.app.isProduction || isServerless) {
-  transports.push(
-    new winston.transports.Console({
-      format: isServerless ? logFormat : consoleFormat,
-    })
-  );
+// Console transport.
+//
+// This used to be development-and-serverless only, which meant production
+// wrote these logs to files and nowhere else. Fastify's own logger goes to
+// stdout, so `docker logs` and `kubectl logs` carried request lines and none
+// of the module-level logs written through here -- different loggers,
+// different content, and only one of them observable from outside the
+// container.
+//
+// That is survivable while the log directory is a named volume, because the
+// files outlive a restart. It stops being survivable in a cluster: the
+// directory is per-pod and a reschedule takes the only copy with it.
+//
+// Writing to stdout as well makes the files a convenience rather than the
+// record. Nothing is removed -- file transports stay -- so behaviour on the
+// current host is unchanged apart from the same lines now also appearing in
+// `docker logs`, where the daemon already rotates them at 10 MB x 3.
+if (isServerless) {
+  transports.push(new winston.transports.Console({ format: logFormat }));
+} else if (config.app.isProduction) {
+  // Structured, so a collector can parse it. Not the human-readable format.
+  transports.push(new winston.transports.Console({ format: logFormat }));
+} else {
+  transports.push(new winston.transports.Console({ format: consoleFormat }));
 }
 
 export const logger = winston.createLogger({

--- a/tests/smoke/logger-transports.test.ts
+++ b/tests/smoke/logger-transports.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The application runs two loggers with different content:
+ *
+ *   fastify (pino)  -> stdout   HTTP request and response lines
+ *   winston         -> files    module-level logs and errors
+ *
+ * In production winston had no Console transport, so its lines existed only
+ * in /app/logs. `docker logs` and `kubectl logs` carried the request lines
+ * and none of these. That is survivable while the log directory is a named
+ * volume — the files outlive a restart — and stops being survivable in a
+ * cluster, where the directory is per-pod and a reschedule takes the only
+ * copy with it.
+ *
+ * These tests pin the transport set so the production case cannot silently
+ * lose its console again.
+ */
+
+describe('winston transports by environment', () => {
+  const ORIGINAL = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL };
+    jest.resetModules();
+  });
+
+  function transportsFor(env: Record<string, string>): string[] {
+    jest.resetModules();
+    // Importing the logger pulls in the config module, whose schema requires
+    // a secret of at least 64 characters. Supplying a filler keeps the test
+    // about transports rather than about configuration loading.
+    process.env = { ...ORIGINAL, ENCRYPTION_SECRET: 'x'.repeat(64), ...env };
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { logger } = require('../../src/utils/logger');
+    return logger.transports.map((t: { constructor: { name: string } }) => t.constructor.name);
+  }
+
+  it('writes to the console in production, not only to files', () => {
+    const names = transportsFor({ NODE_ENV: 'production' });
+    expect(names).toContain('Console');
+  });
+
+  it('keeps the file transports in production', () => {
+    const names = transportsFor({ NODE_ENV: 'production' });
+    // Removing these would change behaviour on the current host, where the
+    // files are what anyone reading logs actually opens.
+    expect(names.filter((n) => n === 'File').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('writes to the console in development too', () => {
+    const names = transportsFor({ NODE_ENV: 'development' });
+    expect(names).toContain('Console');
+  });
+
+  // Negative control: the assertion above has to be capable of failing, or it
+  // would keep passing against a logger with no console at all.
+  it('can tell a transport list apart from one missing Console', () => {
+    const withConsole = ['File', 'File', 'Console'];
+    const without = ['File', 'File'];
+    expect(withConsole).toContain('Console');
+    expect(without).not.toContain('Console');
+  });
+});


### PR DESCRIPTION
Two loggers, different content:

| logger | destination | carries |
|---|---|---|
| fastify (pino) | **stdout** | HTTP request / response lines |
| winston | **files only, in production** | module logs and errors |

So `docker logs` showed the request lines and **none of the rest**. The winston content existed in `/app/logs` and nowhere else.

This is a live path, not a dead one — `error2.log` was written to at 00:00 today.

## Why it matters now

Survivable today: the log directory is a named volume, so the files outlive a restart or a redeploy.

**Not survivable in a cluster**: the directory is per-pod, and a reschedule takes the only copy with it.

Deferring to a log collector would not have fixed it either — **a collector reads stdout, and these lines were not there to read.** That was the gap in calling this a P2 item.

## The change

```
before   if (!isProduction || isServerless)  -> Console
after    always Console; structured format in production, readable in dev
```

Nothing is removed. File transports stay, so the current host behaves as before apart from the same lines now also appearing in `docker logs` — where the daemon already rotates at 10 MB × 3.

## Verification

```
✓ writes to the console in production, not only to files
✓ keeps the file transports in production
✓ writes to the console in development too
✓ can tell a transport list apart from one missing Console

# with the production console removed
✕ writes to the console in production, not only to files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)