### PR TITLE
fix(ci): stale-pr-triage failed when it found something

### DIFF
--- a/.github/workflows/stale-pr-triage.yml
+++ b/.github/workflows/stale-pr-triage.yml
@@ -81,4 +81,14 @@ jobs:
             fi
           done
 
-          [ "$flagged" -eq 0 ] && echo "No stale PRs. 🎉" >> "$GITHUB_STEP_SUMMARY"
+          # An `[ cond ] && cmd` as the final line under `set -e` exits with the
+          # test's status. With even one stale PR the test is false, so the job
+          # reported failure for having found something — it passed only when
+          # there was nothing to report. Written as an if so the exit status is
+          # the script's, not the last test's.
+          if [ "$flagged" -eq 0 ]; then
+            echo "No stale PRs. 🎉" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**$flagged PR(s) awaiting a decision.** This job reports; it never closes." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
The nightly triage job has been reporting **failure** — including [this morning's run](https://github.com/JK42JJ/insighta/actions/runs/31760021089), which produced a correct 14-PR report and then exited 1.

## Cause

The last line of the script:

```bash
[ "$flagged" -eq 0 ] && echo "No stale PRs." >> "$GITHUB_STEP_SUMMARY"
```

under `set -euo pipefail`. With one or more stale PRs the test is false, and as the **final command** its status becomes the script's. So the job failed precisely when it had work to report, and went green only when there was nothing.

## Why it matters beyond the red X

A red triage job reads as *"the tooling is broken"*, not *"these PRs need a decision"*. The report it produced was correct every night and easy to dismiss.

## Verified both ways

```
flagged=3, old form -> exit 1
flagged=3, new form -> exit 0
flagged=0, new form -> exit 0
```

The summary now also states the count and repeats that this job never closes anything — which is its documented behaviour, and worth saying in the output rather than only in a comment at the top of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)