### PR TITLE
feat(terraform): k3s validation node, off by default

### DIFF
--- a/terraform/modules/k3s-node/main.tf
+++ b/terraform/modules/k3s-node/main.tf
@@ -1,0 +1,93 @@
+# The k3s validation node.
+#
+# Separate from the production instance on purpose. Installing k3s alongside
+# the running application would put its iptables rules on the same host that
+# terminates TLS and proxies to the production containers, and no snapshot or
+# rollback script removes the possibility of interference. A second instance
+# removes it outright.
+#
+# What this buys is isolation, not availability -- one node is still one node.
+# Availability arrives at cutover, when a second node is added.
+#
+# It is also what makes the migration plan's "parallel, traffic 0" real: with
+# two machines the cutover is a DNS weight and the rollback is that weight
+# going back to zero. On a shared host neither is true.
+
+# The node's own group. Deliberately not the production one, which opens 80 and
+# 443 to the world for the public site -- this node serves nothing.
+#
+# 6443 is absent on purpose. The access-plane design settled on reaching the
+# API server through an SSH forward rather than exposing it, so the cluster's
+# control port has no inbound rule at all. `kubectl` runs over `ssh -L`.
+#
+# ingress carries the same ignore_changes concession as the production group:
+# port 22 is opened at connect time by scripts/ssh-connect.sh, and without this
+# an apply would revoke a rule someone is using.
+resource "aws_security_group" "this" {
+  name_prefix = "insighta-k3s-"
+  description = "k3s validation node -- SSH only, no inbound API"
+  vpc_id      = var.vpc_id
+
+  dynamic "ingress" {
+    for_each = length(var.ssh_cidrs) > 0 ? [1] : []
+    content {
+      description = "SSH"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = var.ssh_cidrs
+    }
+  }
+
+  egress {
+    description = "All outbound -- image pulls, Supabase, package installs"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(var.tags, { Name = "insighta-k3s-sg" })
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [ingress]
+  }
+}
+
+resource "aws_instance" "this" {
+  ami                    = var.ami_id
+  instance_type          = var.instance_type
+  key_name               = var.key_name
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = concat([aws_security_group.this.id], var.security_group_ids)
+
+  associate_public_ip_address = true
+
+  root_block_device {
+    volume_size           = var.root_volume_size
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+
+  tags = merge(var.tags, {
+    Name = var.name
+    Role = "k3s-validation"
+  })
+
+  # No user_data. k3s is installed by hand for the first node so the install
+  # is observed rather than assumed; the repeatable form is an Ansible
+  # playbook, which is where it belongs once the arguments are settled.
+  #
+  # No EIP either. This node serves no traffic and nothing points DNS at it,
+  # so a stable address buys nothing yet. It gets one at cutover.
+  lifecycle {
+    ignore_changes = [ami, user_data, user_data_base64]
+  }
+}

--- a/terraform/modules/k3s-node/outputs.tf
+++ b/terraform/modules/k3s-node/outputs.tf
@@ -1,0 +1,19 @@
+output "instance_id" {
+  description = "Instance id."
+  value       = aws_instance.this.id
+}
+
+output "private_ip" {
+  description = "Private address. Preferred for anything inside the VPC."
+  value       = aws_instance.this.private_ip
+}
+
+output "public_ip" {
+  description = "Public address. Changes on stop/start -- no EIP is attached."
+  value       = aws_instance.this.public_ip
+}
+
+output "security_group_id" {
+  description = "The node's own security group."
+  value       = aws_security_group.this.id
+}

--- a/terraform/modules/k3s-node/variables.tf
+++ b/terraform/modules/k3s-node/variables.tf
@@ -1,0 +1,69 @@
+variable "name" {
+  description = "Instance name tag."
+  type        = string
+}
+
+variable "ami_id" {
+  description = "AMI to launch. Pinned, like the production instance -- a newer default image would replace the node."
+  type        = string
+}
+
+variable "instance_type" {
+  description = <<-EOT
+    t3.small (2 vCPU / 2 GiB) is the measured fit for a validation cluster:
+
+      k3s server (control plane + datastore)   ~500-700 MB
+      system                                    ~200 MB
+      application pods (measured 191 MB + worker) ~250 MB
+      headroom                                  ~600-800 MB
+
+    It is not sized to serve traffic. Production runs t3.medium with 2,971 MB
+    available, roughly five times this node's headroom.
+  EOT
+  type        = string
+  default     = "t3.small"
+}
+
+variable "key_name" {
+  description = "Existing EC2 key pair for SSH."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet to launch in. Same subnet as production so latency to Supabase matches."
+  type        = string
+}
+
+variable "security_group_ids" {
+  description = "Extra security groups beyond the node's own. Usually empty."
+  type        = list(string)
+  default     = []
+}
+
+variable "root_volume_size" {
+  description = "Root volume in GB. k3s plus container images take roughly 3 GB; 20 leaves room for images accumulating between prunes."
+  type        = number
+  default     = 20
+}
+
+variable "tags" {
+  description = "Tags applied to the instance and its volume."
+  type        = map(string)
+  default     = {}
+}
+
+variable "vpc_id" {
+  description = "VPC to create the node's security group in."
+  type        = string
+}
+
+variable "ssh_cidrs" {
+  description = <<-EOT
+    Standing port-22 sources. Empty by default and expected to stay empty:
+    access is opened at connect time by the same script that reaches the
+    production host, and left in the code it would be one more entry nobody
+    revokes.
+  EOT
+  type        = list(string)
+  default     = []
+}

--- a/terraform/projects/insighta/environments/prod/main.tf
+++ b/terraform/projects/insighta/environments/prod/main.tf
@@ -40,6 +40,29 @@ module "compute" {
   tags               = local.common_tags
 }
 
+# The k3s validation node (P2). Separate instance, no traffic, no DNS.
+#
+# Sized for validation rather than service: t3.small leaves roughly 600-800 MB
+# after k3s and the application pods, against production's 2,971 MB. It exists
+# so the cluster can be built and broken without the machine that serves the
+# site being involved.
+#
+# enable_k3s_node = false by default. Nothing is created until it is set, so
+# this module costs nothing until someone decides to spend.
+module "k3s_node" {
+  source = "../../../../modules/k3s-node"
+  count  = var.enable_k3s_node ? 1 : 0
+
+  name          = "insighta-k3s-1"
+  ami_id        = var.ami_id
+  instance_type = var.k3s_instance_type
+  key_name      = var.key_name
+  subnet_id     = local.subnet_id
+  vpc_id        = module.networking.vpc_id
+
+  tags = merge(local.common_tags, { Phase = "P2" })
+}
+
 module "backup" {
   source = "../../../../modules/backup"
 

--- a/terraform/projects/insighta/environments/prod/variables.tf
+++ b/terraform/projects/insighta/environments/prod/variables.tf
@@ -53,3 +53,19 @@ variable "backup_bucket_name" {
   type        = string
   default     = "insighta-backups"
 }
+
+variable "enable_k3s_node" {
+  description = <<-EOT
+    Create the k3s validation node. Default false: this is the only variable in
+    this stack whose flip costs money, so it is off until someone turns it on
+    rather than on until someone notices.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "k3s_instance_type" {
+  description = "Validation node size. See modules/k3s-node for the memory arithmetic behind t3.small."
+  type        = string
+  default     = "t3.small"
+}


### PR DESCRIPTION
P2 needs a cluster. This adds the instance as code without creating it.

## Why a separate instance

Installing k3s beside the running application puts its iptables rules on the host that terminates TLS and proxies to the production containers. A snapshot and a rollback script reduce that risk; they do not remove it. A second instance does.

It also makes the plan's **"parallel, traffic 0"** real — with two machines the cutover is a DNS weight and the rollback is that weight returning to zero. On a shared host neither is true.

What this buys is **isolation, not availability**. One node is still one node.

## Why t3.small

```
k3s server (control plane + datastore)        ~500-700 MB
system                                         ~200 MB
application pods (measured 191 MB + worker)    ~250 MB
────────────────────────────────────────────────────────
headroom                                       ~600-800 MB
```

Enough to validate, not to serve. Production runs t3.medium with **2,971 MB** available — about five times this headroom.

## Exposure

Its own security group, not production's — production opens 80 and 443 to the world for the public site; this node serves nothing.

**Port 6443 has no inbound rule at all.** The access-plane design settled on reaching the API server through an SSH forward rather than exposing it, so `kubectl` runs over `ssh -L`. Port 22 follows the existing pattern: opened at connect time, `ignore_changes` on ingress so an apply cannot revoke a rule someone is using.

No EIP (nothing points at it until cutover) and no `user_data` (the first install is done by hand so it is observed, then written as a playbook).

## Costs nothing until turned on

```
enable_k3s_node = false   exit 0, "No changes"
enable_k3s_node = true    2 to add, 0 to change, 0 to destroy
```

Planned against real state both ways. `false` is the default — it is the only variable in this stack whose flip costs money.

🤖 Generated with [Claude Code](https://claude.com/claude-code)