### PR TITLE
feat(terraform): create the k3s validation node

### DIFF
--- a/terraform/projects/insighta/environments/prod/terraform.tfvars
+++ b/terraform/projects/insighta/environments/prod/terraform.tfvars
@@ -25,3 +25,12 @@ ssh_cidrs = []
 # Phase 2 features
 enable_ssm        = false
 enable_cloudwatch = true
+
+# P2 — the k3s validation node. Turning this on is the first line in this file
+# that costs money: one t3.small, roughly $15/month, running until P2 and P3
+# are done and it is destroyed.
+#
+# It is declared here rather than passed as a command flag so the desired state
+# stays in code. With the flag, the instance would exist while the repository
+# said it did not, and the nightly drift job would be right to complain.
+enable_k3s_node = true


### PR DESCRIPTION
Turns on the module from #1493. **This is the first spend.**

One t3.small, roughly **$15/month**, running until P2 and P3 are done and it is destroyed.

## Plan against real state

```
Plan: 2 to add, 0 to change, 0 to destroy
  module.k3s_node[0].aws_instance.this
  module.k3s_node[0].aws_security_group.this
```

The 14 production resources are untouched.

## Why in tfvars rather than a command flag

The desired state stays in code. Passed as `-var`, the instance would exist while the repository said it did not — and the nightly drift job would be right to complain.

## Rollback

Set it back to `false`. The node is destroyed, nothing else is affected. It holds nothing worth keeping: the cluster is a validation target and everything on it is reproducible from the chart.

## After this merges

```
1  k3s install  --disable traefik --disable servicelb
                (the host runs nothing on 80/443, but the defaults would
                 claim them and that is a habit worth not forming)
2  chart deploy, traffic 0
3  ArgoCD
4  confirm production is unaffected
```

Uninstall is `/usr/local/bin/k3s-uninstall.sh`, which the installer places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)