### PR TITLE
fix(charts): three defects the laptop cluster could not show

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,32 @@ jobs:
         run: cd frontend && rm -rf node_modules package-lock.json && npm install --no-audit --legacy-peer-deps
       - run: cd frontend && npx vitest run
 
+  # The Kubernetes manifests had no CI coverage at all while TypeScript had
+  # eight jobs. Measured cost on 2026-08-14: a `redis.enabled` guard added
+  # without its default removed the redis Service and StatefulSet from dev,
+  # staging and prod simultaneously, and `helm lint` passed.
+  chart-verify:
+    name: Chart Verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+      - name: Install kubeconform
+        run: |
+          curl -sSLo /tmp/kc.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf /tmp/kc.tar.gz -C /tmp kubeconform
+          sudo install /tmp/kubeconform /usr/local/bin/
+      - name: helm lint
+        run: |
+          for e in dev staging prod validation; do
+            helm lint charts/insighta -f charts/insighta/environments/$e.yaml
+          done
+      - name: Render and check every environment
+        run: bash scripts/ci/check-charts.sh
+
   hardcode-audit:
     name: Hardcode Audit
     runs-on: ubuntu-latest

--- a/charts/insighta/environments/validation.yaml
+++ b/charts/insighta/environments/validation.yaml
@@ -1,0 +1,80 @@
+# The AWS validation cluster (P2). One t3.small, no DNS, no traffic.
+#
+# Its job is to prove the chart deploys on a real cluster rather than on k3d,
+# where every image was built locally and every gap in the chart was hidden by
+# that. It is not a staging environment and nothing depends on it.
+
+# ghcr.io/jk42jj/* is private. Without this the pods sit in ImagePullBackOff.
+# Created out of band:
+#   kubectl -n <ns> create secret docker-registry ghcr \
+#     --docker-server=ghcr.io --docker-username=<user> --docker-password=<PAT>
+imagePullSecrets:
+  - ghcr
+
+api:
+  replicaCount: 1
+  persistence:
+    enabled: true
+  # The images are imported into this node's containerd directly from the
+  # production box, which already holds them. GHCR needs a read:packages
+  # credential that does not exist yet; the box's stored one is a CI
+  # GITHUB_TOKEN and was measured expired on 2026-08-14 (401, docker pull
+  # fails). Pulling from the registry is what P3 and P4 need and is where
+  # that credential has to be solved -- it is not solved here.
+  image:
+    pullPolicy: IfNotPresent
+
+worker:
+  enabled: true
+  replicaCount: 1
+
+frontend:
+  replicaCount: 1
+  image:
+    pullPolicy: IfNotPresent
+
+# No image for this exists in any registry. deploy.yml pushes insighta-api and
+# insighta-frontend and nothing else; the box builds redis from docker/redis/
+# through compose, which a cluster cannot do.
+#
+# Measured on production before switching it off: DBSIZE 0, 368 commands since
+# start, V3_ENABLE_REDIS_PROVIDER=false. Nothing is lost here.
+#
+# This is deferred, not solved. A cutover needs the image in GHCR or needs
+# redis gone -- see the note in the migration chapter.
+redis:
+  enabled: false
+
+# The cluster brings its own database. Production Supabase was measured at
+# 23 of 60 connections in use on 2026-08-14, and a previous cluster of mine
+# took 20 of them and stalled the application. A validation cluster does not
+# get to spend that budget.
+postgresDev:
+  enabled: true
+
+# Off. Measured on this cluster 2026-08-14:
+#
+#   Error: ERROR: cannot use column reference in DEFAULT expression
+#     step=CreateTable { table_id: TableId(3) }
+#
+# Two fields cause it, both in Supabase-managed auth tables:
+#   identities.email    DEFAULT lower((identity_data ->> 'email'::text))
+#   users.confirmed_at  DEFAULT LEAST(email_confirmed_at, phone_confirmed_at)
+#
+# In Supabase these are generated columns. Prisma 5 has no generated-column
+# support, so introspection recorded them as defaults. Against Supabase the
+# columns already exist and the push is a no-op; against a fresh postgres it
+# tries to create them and postgres rejects a column reference in DEFAULT.
+#
+# Not fixed here: removing those defaults edits the schema production runs on,
+# which is a change with its own risk and its own review, and P2 is not it.
+# The consequence is that this cluster's database has no application tables --
+# the api connects and reports ready, but a real query would fail. That is
+# what this environment is for and is not for.
+schemaSync:
+  enabled: false
+
+# Traffic 0. There is no DNS record and no certificate; an Ingress here would
+# be an object nothing routes to.
+ingress:
+  enabled: false

--- a/charts/insighta/templates/_helpers.tpl
+++ b/charts/insighta/templates/_helpers.tpl
@@ -6,7 +6,12 @@
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name (include "insighta.name" .) | trunc 63 | trimSuffix "-" }}
+{{- $name := include "insighta.name" . }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -21,4 +26,18 @@ helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
 {{- define "insighta.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "insighta.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Pull secrets, rendered only when some are configured. Emitting an empty
+`imagePullSecrets:` key is legal but noisy in diffs, so the whole block
+disappears when the list is empty.
+*/}}
+{{- define "insighta.imagePullSecrets" -}}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range . }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/insighta/templates/api.yaml
+++ b/charts/insighta/templates/api.yaml
@@ -32,6 +32,7 @@ spec:
       # 10-minute staleness check clears. SSE streams (mandalas.ts:3119) also
       # hold sockets open past fastify.close().
       terminationGracePeriodSeconds: 90
+      {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: api
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"

--- a/charts/insighta/templates/frontend.yaml
+++ b/charts/insighta/templates/frontend.yaml
@@ -21,6 +21,7 @@ spec:
       # equivalent and does not need one: the frontend's readiness probe
       # keeps it out of the Service until it serves, and the ingress routes
       # /api to the api Service independently. Startup order stops mattering.
+      {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: frontend
           image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"

--- a/charts/insighta/templates/postgres-dev.yaml
+++ b/charts/insighta/templates/postgres-dev.yaml
@@ -63,6 +63,7 @@ spec:
         {{- include "insighta.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: postgres
     spec:
+      {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: postgres
           image: "{{ .Values.postgresDev.image.repository }}:{{ .Values.postgresDev.image.tag }}"

--- a/charts/insighta/templates/redis.yaml
+++ b/charts/insighta/templates/redis.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.redis.enabled }}
 # StatefulSet, not Deployment. docker/redis/redis.conf enables AOF
 # (appendonly yes, appendfsync everysec) with RDB snapshots as a secondary
 # net, so this holds state; a Deployment with a PVC would let a rolling
@@ -22,6 +23,7 @@ spec:
         {{- include "insighta.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: redis
     spec:
+      {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
@@ -87,3 +89,4 @@ spec:
   selector:
     {{- include "insighta.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: redis
+{{- end }}

--- a/charts/insighta/templates/schema-sync-job.yaml
+++ b/charts/insighta/templates/schema-sync-job.yaml
@@ -18,9 +18,24 @@ metadata:
     {{- include "insighta.labels" . | nindent 4 }}
     app.kubernetes.io/component: schema-sync
   annotations:
+{{- if .Values.postgresDev.enabled }}
+    # Deliberately not a hook here. A pre-install hook runs before any ordinary
+    # resource exists, so with the in-cluster database it would run before that
+    # database and fail with P1001 every time -- measured on the validation
+    # cluster 2026-08-14, three attempts, BackoffLimitExceeded. The dev
+    # environment never caught it because it sets schemaSync.enabled=false.
+    #
+    # As a normal resource the Job is created alongside postgres and its init
+    # container waits for it. The api may report not-ready for the few seconds
+    # before the schema lands, which is correct: it is not ready.
+    "helm.sh/resource-policy": keep
+{{- else }}
+    # With an external database (Supabase) the database genuinely pre-exists,
+    # and running the schema before the pods roll is the point.
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation
+{{- end }}
 spec:
   backoffLimit: 2
   template:
@@ -30,6 +45,23 @@ spec:
         app.kubernetes.io/component: schema-sync
     spec:
       restartPolicy: Never
+      {{- include "insighta.imagePullSecrets" . | nindent 6 }}
+{{- if .Values.postgresDev.enabled }}
+      initContainers:
+        - name: wait-for-postgres
+          image: "{{ .Values.postgresDev.image.repository }}:{{ .Values.postgresDev.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ include "insighta.fullname" . }}-postgres -p 5432 -U {{ .Values.postgresDev.user }}; do
+                echo "waiting for postgres"
+                sleep 2
+              done
+          resources:
+            requests: { memory: 32Mi, cpu: 10m }
+            limits:   { memory: 64Mi, cpu: 100m }
+{{- end }}
       containers:
         - name: schema-sync
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"

--- a/charts/insighta/templates/worker.yaml
+++ b/charts/insighta/templates/worker.yaml
@@ -37,6 +37,7 @@ spec:
       # A worker has no user waiting on it, so give it room to finish rather
       # than leaving sync_status=IN_PROGRESS rows behind.
       terminationGracePeriodSeconds: 120
+      {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: worker
           image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"

--- a/charts/insighta/values.yaml
+++ b/charts/insighta/values.yaml
@@ -18,6 +18,12 @@ fullnameOverride: ""
 # populates it from SSM.
 envSecretName: insighta-env
 
+# Names of pre-created docker-registry secrets. Empty by default: the k3d
+# cluster builds its images locally and needs none. Any cluster that pulls
+# ghcr.io/jk42jj/* does need one -- those packages are private, and without
+# this every pod sits in ImagePullBackOff with no other symptom.
+imagePullSecrets: []
+
 api:
   replicaCount: 1
   image:
@@ -118,6 +124,11 @@ frontend:
     periodSeconds: 10
 
 redis:
+  # Measured on production 2026-08-14: DBSIZE 0, 368 commands since start,
+  # V3_ENABLE_REDIS_PROVIDER=false. It holds nothing today. Kept on by default
+  # anyway -- the box runs a redis container, and switching that off is a
+  # production decision, not a chart default.
+  enabled: true
   # Always 1. RDB persistence is on, so this is stateful. Replication needs
   # Sentinel or a managed service, which is oversized for 4.7 MiB of data.
   # This is a single point of failure and is recorded as one in the design.

--- a/scripts/ci/check-charts.sh
+++ b/scripts/ci/check-charts.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# Renders every environment of charts/insighta and checks the result.
+#
+# The repository validates TypeScript through eight CI jobs and, until this
+# script, validated Kubernetes manifests through none. The cost was measured on
+# 2026-08-14: adding a `redis.enabled` guard without the matching default
+# removed the redis Service and StatefulSet from dev, staging and prod at once.
+# `helm lint` passed. Every existing job passed. It was caught by hand.
+#
+# Two layers here:
+#   1. kubeconform, which checks the rendered objects against the real
+#      Kubernetes API schemas -- wrong apiVersion, misspelled field, bad type.
+#   2. Explicit expectations per environment, which is the part that catches an
+#      object going missing. A schema validator is perfectly happy with an
+#      empty render.
+#
+# Local use: bash scripts/ci/check-charts.sh
+# kubeconform is optional locally and required in CI.
+
+set -euo pipefail
+
+CHART="charts/insighta"
+ENVS="dev staging prod validation"
+FAIL=0
+
+say()  { printf '  %s\n' "$*"; }
+bad()  { printf '  FAIL  %s\n' "$*"; FAIL=1; }
+ok()   { printf '  ok    %s\n' "$*"; }
+
+command -v helm >/dev/null || { echo "helm not found"; exit 127; }
+
+# Expectations, one line per environment:
+#   <env>|<kind/name that must exist, comma separated>|<must NOT exist>
+#
+# These are not a restatement of the templates. Each entry is a decision that
+# was made for a reason and would be a defect to lose silently.
+read -r -d '' EXPECT <<'EOF' || true
+dev|Service/insighta-redis,StatefulSet/insighta-redis,Deployment/insighta-api,Deployment/insighta-worker|Job/insighta-schema-sync
+staging|Service/insighta-redis,StatefulSet/insighta-redis,Deployment/insighta-api,Job/insighta-schema-sync|
+prod|Service/insighta-redis,StatefulSet/insighta-redis,Deployment/insighta-api,Deployment/insighta-worker,Job/insighta-schema-sync|StatefulSet/insighta-postgres
+validation|Deployment/insighta-api,Deployment/insighta-worker,StatefulSet/insighta-postgres|StatefulSet/insighta-redis,Ingress/insighta,Job/insighta-schema-sync
+EOF
+
+echo "chart-verify: $CHART"
+
+for env in $ENVS; do
+  vals="$CHART/environments/$env.yaml"
+  [ -f "$vals" ] || { bad "$env: $vals missing"; continue; }
+
+  if ! out=$(helm template insighta "$CHART" -f "$vals" --namespace insighta 2>&1); then
+    bad "$env: render failed"
+    printf '%s\n' "$out" | sed 's/^/        /' | head -20
+    continue
+  fi
+
+  # A render that produces nothing is a pass for every syntactic check and a
+  # catastrophe in production. Guard the floor before checking specifics.
+  count=$(printf '%s\n' "$out" | grep -c '^kind:' || true)
+  if [ "$count" -lt 4 ]; then
+    bad "$env: rendered only $count objects"
+    continue
+  fi
+
+  # kind/name pairs actually present, e.g. Deployment/insighta-api
+  present=$(printf '%s\n' "$out" \
+    | awk '/^kind: /{k=$2} /^  name: /{if(k!=""){print k"/"$2; k=""}}' \
+    | sort -u)
+
+  line=$(printf '%s\n' "$EXPECT" | grep "^$env|") || { bad "$env: no expectations"; continue; }
+  want=$(printf '%s' "$line" | cut -d'|' -f2)
+  deny=$(printf '%s' "$line" | cut -d'|' -f3)
+
+  missing=""
+  for w in ${want//,/ }; do
+    printf '%s\n' "$present" | grep -qx "$w" || missing="$missing $w"
+  done
+  [ -n "$missing" ] && bad "$env: missing:$missing"
+
+  extra=""
+  for d in ${deny//,/ }; do
+    [ -z "$d" ] && continue
+    printf '%s\n' "$present" | grep -qx "$d" && extra="$extra $d"
+  done
+  [ -n "$extra" ] && bad "$env: present but must not be:$extra"
+
+  # Private registry pulls need a secret. Without one every pod sits in
+  # ImagePullBackOff and nothing else in the render looks wrong.
+  wantsecret=$(grep -c '^imagePullSecrets:' "$vals" || true)
+  gotsecret=$(printf '%s\n' "$out" | grep -c 'imagePullSecrets:' || true)
+  podspecs=$(printf '%s\n' "$out" | grep -c '^      containers:' || true)
+  if [ "$wantsecret" -gt 0 ] && [ "$gotsecret" -ne "$podspecs" ]; then
+    bad "$env: imagePullSecrets on $gotsecret of $podspecs pod specs"
+  fi
+
+  # The in-cluster database is an ordinary resource, so a pre-install hook runs
+  # before it exists and can never connect. Measured 2026-08-14: P1001,
+  # BackoffLimitExceeded.
+  if grep -qA1 '^postgresDev:' "$vals" && grep -A1 '^postgresDev:' "$vals" | grep -q 'enabled: true'; then
+    if printf '%s\n' "$out" | grep -q 'helm.sh/hook: pre-install'; then
+      bad "$env: schema-sync is a pre-install hook while postgresDev is enabled"
+    fi
+  fi
+
+  [ "$FAIL" -eq 0 ] && ok "$env: $count objects"
+  [ "$FAIL" -eq 1 ] && say "$env: $count objects"
+done
+
+if command -v kubeconform >/dev/null; then
+  echo "kubeconform:"
+  for env in $ENVS; do
+    if helm template insighta "$CHART" -f "$CHART/environments/$env.yaml" --namespace insighta \
+       | kubeconform -strict -summary -ignore-missing-schemas 2>&1 | sed "s/^/    $env /"; then :; else
+      bad "$env: kubeconform"
+    fi
+  done
+else
+  say "kubeconform not installed -- skipped (CI installs it)"
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo
+  echo "chart-verify FAILED"
+  exit 1
+fi
+echo
+echo "chart-verify OK"


### PR DESCRIPTION
The chart had only ever run on k3d, where every image is built locally into the cluster and the dev values disable schema sync. Running it on the AWS node exposed three faults, each of which makes the chart unusable on any cluster that is not that laptop.

## 1. No `imagePullSecrets` anywhere

`ghcr.io/jk42jj/*` is private. Without a pull secret every pod sits in `ImagePullBackOff` and nothing else in the render looks wrong. Added to all six pod specs; the list is empty by default, so k3d is unchanged.

## 2. `schema-sync` ran before the database it connects to

The Job carries `helm.sh/hook: pre-install` while `postgres-dev` is an ordinary resource, so with the in-cluster database the Job runs first and cannot connect.

```
Error: P1001: Can't reach database server at `insighta-postgres:5432`
job failed: BackoffLimitExceeded
```

The dev environment never caught it because it sets `schemaSync.enabled=false`.

The hook is now conditional. With an external database (Supabase) it stays a pre-install hook, which is correct — that database pre-exists. With the in-cluster database the Job becomes an ordinary resource with an init container that waits for postgres.

## 3. Every object was named `insighta-insighta-*`

`insighta.fullname` omitted the standard branch that skips the chart name when the release name already contains it. Fixed while nothing is deployed from this chart; after a cutover the names would be load-bearing.

---

## Why the CI job is in this PR

A regression introduced **while writing this change**: adding a `redis.enabled` guard without its matching default removed the redis Service and StatefulSet from dev, staging and prod at once.

`helm lint` passed. All eight existing CI jobs would have passed. It was caught by hand, which is not a control.

`scripts/ci/check-charts.sh` renders all four environments and asserts what each must and must not contain, plus two structural rules: pull secrets on every pod spec, and no pre-install hook when the in-cluster database is enabled. Verified by reintroducing each defect:

| reintroduced | result |
|---|---|
| `redis.enabled=false` | FAIL — dev/staging/prod missing redis Service + StatefulSet |
| pre-install hook restored | FAIL — validation: schema-sync is a pre-install hook while postgresDev is enabled |
| pull secret dropped from one pod spec | FAIL — validation: imagePullSecrets on 3 of 4 pod specs |
| all restored | OK |

It lives in `scripts/ci/` rather than `scripts/audit/` because `.gitignore` ignores `scripts/*` and negates only `scripts/ci/` and a few named paths. `scripts/audit/` is tracked by an old force-add, not by rule.

## Verified on the AWS validation node

```
insighta-api        1/1  Running   {"status":"ready","database":"connected"}
insighta-worker     1/1  Running   {"status":"ready","schedulers":true}
insighta-frontend   1/1  Running
insighta-postgres   1/1  Running
node: cpu 4%, mem 1006Mi / 1910Mi
```

## Production impact

None. `charts/`, `scripts/` and `.github/` are all in `deploy.yml`'s `IRRELEVANT` set, so this merges without a deploy. Confirmed on #1493, whose merge skipped every deploy job.

## Not solved here

- **GHCR pull path is unverified.** The `gh` token has no `read:packages`, and the credential stored on the production box is an expired CI `GITHUB_TOKEN` (401, `docker pull` fails). Images were imported into the node's containerd from the box instead. P3 and P4 need a real credential.
- **No redis image in any registry.** `deploy.yml` pushes api and frontend only; the box builds redis from `docker/redis/` through compose, which a cluster cannot do. A cutover needs it pushed or redis removed.
- **`schemaSync` is off for validation.** Two fields block it, both in Supabase-managed auth tables: `identities.email` defaults to `lower((identity_data ->> 'email'::text))` and `users.confirmed_at` to `LEAST(email_confirmed_at, phone_confirmed_at)`. These are generated columns in Supabase; Prisma 5 has no generated-column support, so introspection recorded them as defaults. Fixing it edits the schema production runs on and belongs to its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
