### PR TITLE
fix(argocd): bootstrap pointed at a deleted branch

### DIFF
--- a/charts/bootstrap/applications.yaml
+++ b/charts/bootstrap/applications.yaml
@@ -17,7 +17,7 @@ spec:
   project: insighta-dev
   source:
     repoURL: https://github.com/JK42JJ/insighta
-    targetRevision: feat/p2-helm-chart-t0
+    targetRevision: main
     path: charts/insighta
     helm:
       releaseName: insighta
@@ -37,7 +37,7 @@ spec:
   project: insighta-staging
   source:
     repoURL: https://github.com/JK42JJ/insighta
-    targetRevision: feat/p2-helm-chart-t0
+    targetRevision: main
     path: charts/insighta
     helm:
       releaseName: insighta
@@ -46,4 +46,27 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: insighta-staging
+  syncPolicy: {}
+---
+# The AWS validation node. Deployed by hand first, then handed to Argo so the
+# handover itself is the thing being tested: whether a release created by the
+# helm CLI can be adopted without recreating it.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: insighta-validation
+  namespace: argocd
+spec:
+  project: insighta-validation
+  source:
+    repoURL: https://github.com/JK42JJ/insighta
+    targetRevision: main
+    path: charts/insighta
+    helm:
+      releaseName: insighta
+      valueFiles:
+        - environments/validation.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: insighta
   syncPolicy: {}

--- a/charts/bootstrap/projects.yaml
+++ b/charts/bootstrap/projects.yaml
@@ -63,3 +63,20 @@ spec:
       duration: 24h
       applications: ["*"]
       manualSync: true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: insighta-validation
+  namespace: argocd
+spec:
+  description: AWS validation node -- no traffic, no DNS, nothing depends on it
+  sourceRepos:
+    - https://github.com/JK42JJ/insighta
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: insighta
+  clusterResourceWhitelist: []
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"

--- a/charts/bootstrap/root-app.yaml
+++ b/charts/bootstrap/root-app.yaml
@@ -13,7 +13,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/JK42JJ/insighta
-    targetRevision: feat/p2-helm-chart-t0
+    targetRevision: main
     path: charts/bootstrap
   destination:
     server: https://kubernetes.default.svc

--- a/scripts/ci/check-charts.sh
+++ b/scripts/ci/check-charts.sh
@@ -106,6 +106,51 @@ for env in $ENVS; do
   [ "$FAIL" -eq 1 ] && say "$env: $count objects"
 done
 
+# The Argo bootstrap points at a branch and a values file. Both can rot without
+# any render failing: on 2026-08-14 all four manifests still referenced
+# feat/p2-helm-chart-t0, which had been merged and deleted, so every
+# Application would have failed to sync with nothing in the chart to explain
+# why.
+echo "bootstrap:"
+for f in charts/bootstrap/*.yaml; do
+  [ -f "$f" ] || continue
+
+  while read -r ref; do
+    [ -z "$ref" ] && continue
+    case "$ref" in
+      # A 40-char hex string is a commit and cannot be checked this way.
+      [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) continue ;;
+    esac
+    # Only the remote answers this. A local refs/remotes entry is not
+    # evidence: a branch deleted on origin stays in the local repository until
+    # someone prunes, and an earlier version of this check consulted it as a
+    # fallback -- which made the check incapable of failing. Verified by
+    # reintroducing the dead branch: the check passed.
+    #
+    # ls-remote exits 0 when found and 2 when the ref does not exist. Any
+    # other status means the remote could not be reached, which is reported
+    # rather than treated as a pass.
+    set +e
+    git ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1
+    rc=$?
+    set -e
+    case "$rc" in
+      0) ok  "$(basename "$f"): targetRevision $ref exists" ;;
+      2) bad "$(basename "$f"): targetRevision '$ref' is not a branch on origin" ;;
+      *) say "$(basename "$f"): could not reach origin (git ls-remote exit $rc) -- targetRevision unchecked" ;;
+    esac
+  done < <(grep -h 'targetRevision:' "$f" | awk '{print $2}' | sort -u)
+
+  while read -r vf; do
+    [ -z "$vf" ] && continue
+    if [ -f "$CHART/$vf" ]; then
+      ok "$(basename "$f"): $vf exists"
+    else
+      bad "$(basename "$f"): valueFile $vf does not exist"
+    fi
+  done < <(sed -n '/valueFiles:/,/^ *[a-z]/p' "$f" | grep -oE '^ *- [a-zA-Z0-9._/-]+\.yaml' | awk '{print $2}' | sort -u)
+done
+
 if command -v kubeconform >/dev/null; then
   echo "kubeconform:"
   for env in $ENVS; do


### PR DESCRIPTION
All four Application and AppProject manifests carried:

```yaml
targetRevision: feat/p2-helm-chart-t0
```

That branch was merged and deleted. **Every Application would have failed to sync**, and nothing in the chart or the cluster would have explained why — the manifests render, validate and apply cleanly. Now `main`.

Adds `insighta-validation`, the Application for the AWS node, and its project. The node was deployed with the helm CLI first, so this also tests whether Argo adopts an existing release rather than requiring a clean namespace.

## New checks

`check-charts.sh` gains two: every `targetRevision` must be a branch that exists on origin, and every referenced `valueFile` must exist.

**The first version of the branch check could not fail.** It asked `git ls-remote` and fell back to `git rev-parse origin/<ref>`, which succeeds against a stale local tracking ref — a branch deleted on origin stays in the local repository until someone prunes.

```
git ls-remote --exit-code --heads origin feat/p2-helm-chart-t0   exit 2   (correct)
git rev-parse --verify origin/feat/p2-helm-chart-t0              exit 0   (stale)
check result                                                     passed
```

The fallback is gone. `ls-remote`'s exit status decides, and an unreachable remote is reported rather than counted as a pass.

| reintroduced | result |
|---|---|
| `targetRevision: feat/p2-helm-chart-t0` | FAIL — not a branch on origin |
| `valueFiles: environments/nope.yaml` | FAIL — valueFile does not exist |
| both restored | OK |

### On the negative control itself

The first two attempts at the branch control used `sed -i '' '0,/re/s//.../'`. BSD sed ignores the `0,/re/` address form without an error, so the file was never modified and the check "passed" against unchanged input twice. The reproduction was redone with a method that asserts its own edit landed before drawing any conclusion.

## Cluster state

ArgoCD v3.5.1 core install is running on the validation node — controller, repo-server, redis, applicationset. Core rather than the full install because the node has 1910 MB total and the app pods already hold about half; the API server and dex would not fit.

```
argocd-application-controller-0        1/1  Running
argocd-applicationset-controller-...   1/1  Running
argocd-redis-...                       1/1  Running
argocd-repo-server-...                 1/1  Running
node: cpu 14%, mem 1488Mi / 1910Mi
```

Application pods unaffected (4/4 Running), production 200 throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)