### PR TITLE
feat(ops): direct SSH as the path, Tailscale as the fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,6 +228,11 @@ scripts/*
 # CP500++ — CI guards (tracked so GitHub Actions can run them).
 !scripts/ci/
 !scripts/ci/**
+# Operational entry points. scripts/ssh-connect.sh predates this and is still
+# ignored, which is why its Tailscale-first ordering and its IP-detection fix
+# have never been reviewable.
+!scripts/ops/
+!scripts/ops/**
 prompt/
 
 # Dev tool configs

--- a/scripts/ops/ssh.sh
+++ b/scripts/ops/ssh.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# SSH to a project host. Direct SSH is the path; Tailscale is the fallback.
+#
+#   scripts/ops/ssh.sh prod                     interactive
+#   scripts/ops/ssh.sh prod "docker ps"         command
+#   scripts/ops/ssh.sh k3s  "sudo k3s kubectl get nodes"
+#   scripts/ops/ssh.sh k3s --update-sg          authorize this machine, do not connect
+#   scripts/ops/ssh.sh k3s --print-host         resolve and print, do not connect
+#
+# Port 22 on both hosts is allow-listed by source address, so a connection from
+# a new location times out until the security group is told about it. This
+# script does that first, every time, then connects.
+#
+# Determining "this machine's address" is the part that goes wrong. Ask without
+# forcing a protocol and a dual-stack connection can report a different address
+# than the one an SSH session will actually leave from:
+#
+#     curl -4 ifconfig.me            211.234.196.34     <- what SSH uses
+#     curl    checkip.amazonaws.com  211.234.196.243    <- what gets authorized
+#
+# Measured 2026-08-14, and the reason a node with correct security group rules,
+# route table, NACL and instance status refused connections for an hour. Every
+# lookup here forces IPv4 and the result is cross-checked against a second
+# source before anything is authorized.
+#
+# Hosts are resolved from AWS by Name tag rather than written down, so a
+# stop/start that changes the public address does not turn this into a file
+# that lies.
+
+set -euo pipefail
+
+log() { printf '[ssh] %s\n' "$*" >&2; }
+die() { printf '[ssh] %s\n' "$*" >&2; exit 1; }
+
+# name-tag : ssh-user : tailscale-alias (empty = no fallback available)
+target_spec() {
+  case "$1" in
+    prod) echo "insighta-prod:ubuntu:insighta-ec2-ts" ;;
+    k3s)  echo "insighta-k3s-1:ubuntu:" ;;
+    *)    die "unknown target '$1' (prod|k3s)" ;;
+  esac
+}
+
+TARGET="${1:-}"
+[ -n "$TARGET" ] || die "usage: $0 <prod|k3s> [--update-sg|--print-host|command...]"
+shift || true
+
+IFS=: read -r NAME_TAG SSH_USER TS_ALIAS <<<"$(target_spec "$TARGET")"
+
+KEY="${INSIGHTA_SSH_KEY:-$HOME/.ssh/insighta/prx01-tubearchive.pem}"
+[ -f "$KEY" ] || die "key not found: $KEY"
+
+# ── this machine's IPv4, agreed by two independent sources ──────────────────
+my_ipv4() {
+  local a b
+  a=$(curl -4 -s --max-time 6 ifconfig.me 2>/dev/null || true)
+  b=$(curl -4 -s --max-time 6 https://api.ipify.org 2>/dev/null || true)
+  [ -n "$a" ] || a=$(curl -4 -s --max-time 6 https://checkip.amazonaws.com 2>/dev/null | tr -d '\n' || true)
+  [ -n "$a" ] || die "could not determine this machine's IPv4 address"
+
+  # Disagreement means one of them saw a different egress path. Authorizing a
+  # guess is what produced the hour-long timeout this script exists to prevent.
+  if [ -n "$b" ] && [ "$a" != "$b" ]; then
+    die "IPv4 lookups disagree ($a vs $b) -- refusing to authorize a guess"
+  fi
+  case "$a" in
+    *:*)          die "got an IPv6 address ($a); this script requires IPv4" ;;
+    *.*.*.*)      printf '%s' "$a" ;;
+    *)            die "unrecognised address: $a" ;;
+  esac
+}
+
+# ── host and security group, resolved from AWS ──────────────────────────────
+resolve() {
+  aws ec2 describe-instances \
+    --filters "Name=tag:Name,Values=$NAME_TAG" "Name=instance-state-name,Values=running" \
+    --query 'Reservations[0].Instances[0].{ip:PublicIpAddress,sg:SecurityGroups[0].GroupId}' \
+    --output text 2>/dev/null
+}
+
+authorize() {
+  local sg="$1" ip="$2"
+  if aws ec2 describe-security-group-rules --filters "Name=group-id,Values=$sg" \
+       --query "SecurityGroupRules[?FromPort==\`22\`].CidrIpv4" --output text 2>/dev/null \
+     | tr '\t' '\n' | grep -qx "$ip/32"; then
+    log "security group already allows $ip"
+    return 0
+  fi
+  if aws ec2 authorize-security-group-ingress --group-id "$sg" \
+       --protocol tcp --port 22 --cidr "$ip/32" >/dev/null 2>&1; then
+    log "authorized $ip on $sg"
+    # A new rule is not instant from the caller's point of view.
+    sleep 2
+  else
+    log "WARN: could not authorize $ip (no AWS credentials, or rule exists)"
+  fi
+}
+
+read -r HOST_IP SG_ID <<<"$(resolve)"
+[ -n "${HOST_IP:-}" ] && [ "$HOST_IP" != "None" ] || die "$NAME_TAG: no running instance with a public address"
+
+if [ "${1:-}" = "--print-host" ]; then
+  printf '%s\n' "$HOST_IP"
+  exit 0
+fi
+
+MY_IP=$(my_ipv4)
+authorize "$SG_ID" "$MY_IP"
+
+if [ "${1:-}" = "--update-sg" ]; then
+  log "security group updated; not connecting"
+  exit 0
+fi
+
+SSH_OPTS=(-o ConnectTimeout=15 -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -i "$KEY")
+
+# ── path 1: direct ──────────────────────────────────────────────────────────
+if [ "$#" -gt 0 ]; then
+  ssh "${SSH_OPTS[@]}" "$SSH_USER@$HOST_IP" "$@" && exit 0
+else
+  ssh "${SSH_OPTS[@]}" "$SSH_USER@$HOST_IP" && exit 0
+fi
+rc=$?
+log "direct SSH to $HOST_IP failed (exit $rc)"
+
+# ── path 2: Tailscale, only if this host has a peer ─────────────────────────
+[ -n "$TS_ALIAS" ] || die "$TARGET has no Tailscale fallback; direct SSH is the only path"
+
+log "falling back to Tailscale ($TS_ALIAS)"
+if [ "$#" -gt 0 ]; then
+  exec ssh -o ConnectTimeout=15 "$TS_ALIAS" "$@"
+else
+  exec ssh -o ConnectTimeout=15 "$TS_ALIAS"
+fi

--- a/tests/smoke/ops-ssh-ipv4.test.ts
+++ b/tests/smoke/ops-ssh-ipv4.test.ts
@@ -1,0 +1,129 @@
+/**
+ * scripts/ops/ssh.sh authorizes this machine's address on a security group and
+ * then connects. If it authorizes the wrong address the connection times out,
+ * and every layer anyone would think to check -- security group, route table,
+ * NACL, instance status -- looks correct, because each of them is.
+ *
+ * That is not hypothetical. Measured 2026-08-14 on the k3s node:
+ *
+ *   curl -4 ifconfig.me            211.234.196.34     the address SSH leaves from
+ *   curl    checkip.amazonaws.com  211.234.196.243    the address that got authorized
+ *
+ * One hour of diagnosis, ending at a rule for an address this machine does not
+ * use. These tests pin the two properties that prevent it: every lookup forces
+ * IPv4, and a disagreement between sources stops the script rather than
+ * choosing one.
+ *
+ * The address-detection function is extracted from the script and run against a
+ * stubbed curl, so this tests the behaviour rather than the text.
+ */
+
+import { execFileSync } from 'child_process';
+import { mkdtempSync, writeFileSync, chmodSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const SCRIPT = join(__dirname, '..', '..', 'scripts', 'ops', 'ssh.sh');
+
+/**
+ * Runs my_ipv4() from the script with `curl` replaced by a stub that prints
+ * `responses` in order, one per invocation.
+ */
+function runWithStubbedCurl(responses: string[]): { ok: boolean; out: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'ssh-ipv4-'));
+  try {
+    writeFileSync(
+      join(dir, 'curl'),
+      `#!/usr/bin/env bash
+n=$(cat "${dir}/n" 2>/dev/null || echo 0)
+echo $((n + 1)) > "${dir}/n"
+# Record the flags so a test can assert -4 was passed.
+echo "$@" >> "${dir}/calls"
+case "$n" in
+${responses.map((r, i) => `  ${i}) printf '%s' '${r}' ;;`).join('\n')}
+  *) exit 1 ;;
+esac
+`,
+      { mode: 0o755 }
+    );
+    chmodSync(join(dir, 'curl'), 0o755);
+
+    const script = readFileSync(SCRIPT, 'utf8');
+    const start = script.indexOf('my_ipv4() {');
+    const end = script.indexOf('\n}\n', start);
+    if (start < 0 || end < 0) throw new Error('my_ipv4 not found in ssh.sh');
+    const fn = script.slice(start, end + 3);
+
+    const harness = join(dir, 'run.sh');
+    writeFileSync(
+      harness,
+      `set -euo pipefail
+die() { printf '%s\\n' "$*" >&2; exit 1; }
+${fn}
+my_ipv4
+`
+    );
+
+    try {
+      const out = execFileSync('bash', [harness], {
+        env: { ...process.env, PATH: `${dir}:${process.env['PATH']}` },
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      return { ok: true, out };
+    } catch (e) {
+      const err = e as { stdout?: string; stderr?: string };
+      return { ok: false, out: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('scripts/ops/ssh.sh address detection', () => {
+  it('returns the address when both sources agree', () => {
+    const r = runWithStubbedCurl(['203.0.113.7', '203.0.113.7']);
+    expect(r.ok).toBe(true);
+    expect(r.out.trim()).toBe('203.0.113.7');
+  });
+
+  it('refuses when the two sources disagree', () => {
+    // The exact shape of the bug: one lookup sees .34, another sees .243.
+    const r = runWithStubbedCurl(['211.234.196.34', '211.234.196.243']);
+    expect(r.ok).toBe(false);
+    expect(r.out).toMatch(/disagree/i);
+  });
+
+  it('refuses an IPv6 answer rather than authorizing it as a v4 CIDR', () => {
+    const v6 = '2001:2d8:f193:150c::1';
+    const r = runWithStubbedCurl([v6, v6]);
+    expect(r.ok).toBe(false);
+    expect(r.out).toMatch(/IPv4/);
+  });
+
+  it('forces IPv4 on every address lookup', () => {
+    // A lookup without -4 is how the wrong address was obtained. Assert on the
+    // script text as well as the behaviour: a future edit that drops the flag
+    // would still pass the stubbed-agreement test above, because the stub
+    // cannot know which protocol a real curl would have chosen.
+    const script = readFileSync(SCRIPT, 'utf8');
+    const fn = script.slice(
+      script.indexOf('my_ipv4() {'),
+      script.indexOf('\n}\n', script.indexOf('my_ipv4() {'))
+    );
+    const lookups = fn.match(/curl[^\n]*/g) ?? [];
+    expect(lookups.length).toBeGreaterThanOrEqual(2);
+    for (const call of lookups) {
+      expect(call).toMatch(/curl\s+-4\b/);
+    }
+  });
+
+  // Negative control: the assertion above has to be able to fail, or it would
+  // pass against a script that never forces IPv4 at all.
+  it('the -4 assertion can fail', () => {
+    const withFlag = 'curl -4 -s --max-time 6 ifconfig.me';
+    const without = 'curl -s --max-time 6 ifconfig.me';
+    expect(withFlag).toMatch(/curl\s+-4\b/);
+    expect(without).not.toMatch(/curl\s+-4\b/);
+  });
+});


### PR DESCRIPTION
Adds `scripts/ops/ssh.sh`, a tracked entry point for both hosts.

```bash
scripts/ops/ssh.sh prod "docker ps"
scripts/ops/ssh.sh k3s  "sudo k3s kubectl get nodes"
scripts/ops/ssh.sh k3s  --update-sg
```

It authorizes this machine on the target's security group, connects **directly**, and falls back to Tailscale only if the direct attempt fails and the host has a peer.

`scripts/ssh-connect.sh` tries Tailscale first, which inverts the two. It is also gitignored, so neither its ordering nor its fixes have ever been reviewable. This file is tracked.

## The address bug

The k3s node had no entry point at all, and connecting to it by hand cost an hour to a wrong address:

```
curl -4 ifconfig.me            211.234.196.34     what SSH leaves from
curl    checkip.amazonaws.com  211.234.196.243    what got authorized
```

The security group, route table, NACL and instance status all checked out — because each of them was correct. The rule was for an address this machine does not use.

Every lookup here forces IPv4, and **two sources must agree** before anything is authorized. A disagreement stops the script rather than picking one.

Hosts are resolved from AWS by `Name` tag rather than written into the file, so a stop/start that changes the public address does not turn this into a file that lies.

## Test

`tests/smoke/ops-ssh-ipv4.test.ts` extracts the address function and runs it against a stubbed `curl`.

| case | expected |
|---|---|
| both sources agree | returns the address |
| sources disagree (`.34` vs `.243`) | fails, "disagree" |
| IPv6 answer | fails, "IPv4" |
| every lookup uses `-4` | asserted on the script |
| the `-4` assertion can fail | negative control |

```
Tests: 5 passed, 5 total
```

The `-4` check is asserted against the script text as well as behaviour: a future edit dropping the flag would still pass the stubbed-agreement test, because a stub cannot know which protocol a real `curl` would have chosen.

## Verified

```
scripts/ops/ssh.sh k3s   ->  ip-172-31-11-236 Ready          (no Tailscale)
scripts/ops/ssh.sh prod  ->  insighta-api Up 4 hours (healthy)
```

`.gitignore` gains `!scripts/ops/`, next to the existing `!scripts/ci/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)