### PR TITLE
feat(images): pull from ECR with an instance profile, and build redis at all

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,7 @@ jobs:
       mobile_only: ${{ steps.d.outputs.mobile_only }}
       api: ${{ steps.d.outputs.api }}
       frontend: ${{ steps.d.outputs.frontend }}
+      redis: ${{ steps.d.outputs.redis }}
       deployable: ${{ steps.d.outputs.deployable }}
     steps:
       - uses: actions/checkout@v4
@@ -54,6 +55,7 @@ jobs:
             echo "mobile_only=false" >> "$GITHUB_OUTPUT"
             echo "api=true"          >> "$GITHUB_OUTPUT"
             echo "frontend=true"     >> "$GITHUB_OUTPUT"
+            echo "redis=true"        >> "$GITHUB_OUTPUT"
             echo "deployable=true"   >> "$GITHUB_OUTPUT"
             echo "manual run -> full pipeline"; exit 0
           fi
@@ -67,6 +69,7 @@ jobs:
             echo "mobile_only=false" >> "$GITHUB_OUTPUT"
             echo "api=true"          >> "$GITHUB_OUTPUT"
             echo "frontend=true"     >> "$GITHUB_OUTPUT"
+            echo "redis=true"        >> "$GITHUB_OUTPUT"
             echo "deployable=true"   >> "$GITHUB_OUTPUT"
             echo "no usable base ($BEFORE) -> full pipeline"; exit 0
           fi
@@ -80,6 +83,7 @@ jobs:
             echo "mobile_only=false" >> "$GITHUB_OUTPUT"
             echo "api=true"          >> "$GITHUB_OUTPUT"
             echo "frontend=true"     >> "$GITHUB_OUTPUT"
+            echo "redis=true"        >> "$GITHUB_OUTPUT"
             echo "deployable=true"   >> "$GITHUB_OUTPUT"
             echo "empty diff -> full pipeline"; exit 0
           fi
@@ -94,6 +98,10 @@ jobs:
           # the repo root, so anything outside frontend/ can affect it.
           if echo "$FILES" | grep -qv '^frontend/'; then API=true; else API=false; fi
           if echo "$FILES" | grep -q  '^frontend/';  then FE=true;  else FE=false;  fi
+          # The redis image is a Dockerfile plus three files. Rebuilding it on
+          # every backend commit is 20 wasted seconds; rebuilding it never is
+          # how the cluster ended up with no redis image at all.
+          if echo "$FILES" | grep -q  '^docker/redis/'; then RD=true; else RD=false; fi
 
           # Does anything here reach production at all?
           #
@@ -117,6 +125,7 @@ jobs:
             echo "every changed path is excluded from the image and the box -> nothing to deploy"
           fi
 
+          echo "redis=$RD"                >> "$GITHUB_OUTPUT"
           echo "mobile_only=$MOBILE_ONLY" >> "$GITHUB_OUTPUT"
           echo "api=$API"                 >> "$GITHUB_OUTPUT"
           echo "frontend=$FE"             >> "$GITHUB_OUTPUT"
@@ -195,6 +204,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # The cluster pulls from ECR with an instance profile, so nothing has to
+      # hold a registry credential. GHCR keeps receiving the same images for
+      # the compose host, which is unchanged.
+      #
+      # The registry host is derived at runtime rather than written down: it
+      # contains the AWS account id and this repository is public.
+      - name: Log in to ECR
+        id: ecr
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TF_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-west-2
+        run: |
+          ACCT=$(aws sts get-caller-identity --query Account --output text)
+          REG="${ACCT}.dkr.ecr.us-west-2.amazonaws.com"
+          aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "$REG"
+          echo "registry=$REG" >> "$GITHUB_OUTPUT"
+          echo "::add-mask::$ACCT"
+          echo "::add-mask::$REG"
+
       # Only the image whose source actually moved. A backend-only commit used
       # to rebuild the frontend image and vice versa; the other side's :latest
       # is already correct, so the rebuild was pure wall-clock.
@@ -207,6 +236,8 @@ jobs:
           tags: |
             ${{ env.API_IMAGE }}:latest
             ${{ env.API_IMAGE }}:${{ github.sha }}
+            ${{ steps.ecr.outputs.registry }}/insighta-api:latest
+            ${{ steps.ecr.outputs.registry }}/insighta-api:${{ github.sha }}
           build-args: |
             GIT_SHA=${{ github.sha }}
           cache-from: type=gha
@@ -221,12 +252,31 @@ jobs:
           tags: |
             ${{ env.FRONTEND_IMAGE }}:latest
             ${{ env.FRONTEND_IMAGE }}:${{ github.sha }}
+            ${{ steps.ecr.outputs.registry }}/insighta-frontend:latest
+            ${{ steps.ecr.outputs.registry }}/insighta-frontend:${{ github.sha }}
           build-args: |
             VITE_API_URL=/api
             VITE_SUPABASE_URL=${{ secrets.SUPABASE_URL }}
             VITE_SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_ANON_KEY }}
             VITE_POSTHOG_KEY=${{ secrets.VITE_POSTHOG_KEY }}
             VITE_CHATBOT_PROVIDER=qwen-lora
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # This image existed in no registry until 2026-08-14: deploy.yml pushed
+      # api and frontend, and the box built redis itself through compose. A
+      # cluster cannot build, so a cutover had no redis to pull.
+      - name: Build & push Redis image
+        if: needs.scope.outputs.redis == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/redis
+          push: true
+          tags: |
+            ghcr.io/jk42jj/insighta-redis:latest
+            ghcr.io/jk42jj/insighta-redis:${{ github.sha }}
+            ${{ steps.ecr.outputs.registry }}/insighta-redis:latest
+            ${{ steps.ecr.outputs.registry }}/insighta-redis:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/charts/insighta/environments/validation.yaml
+++ b/charts/insighta/environments/validation.yaml
@@ -8,8 +8,21 @@
 # Created out of band:
 #   kubectl -n <ns> create secret docker-registry ghcr \
 #     --docker-server=ghcr.io --docker-username=<user> --docker-password=<PAT>
-imagePullSecrets:
-  - ghcr
+# Images live in ECR and the node pulls them with an instance profile, so no
+# pull secret exists in this namespace at all. Left empty deliberately.
+imagePullSecrets: []
+
+# The registry host is not committed: it embeds the AWS account id and this
+# repository is public. Supplied to the cluster instead, alongside the
+# insighta-env secret:
+#
+#   kubectl -n argocd patch application insighta-validation --type merge -p \
+#     '{"spec":{"source":{"helm":{"parameters":[
+#       {"name":"imageRegistry","value":"<acct>.dkr.ecr.us-west-2.amazonaws.com"}]}}}}'
+#
+# requireImageRegistry makes a forgotten parameter a render failure that names
+# itself, rather than four pods in ImagePullBackOff.
+requireImageRegistry: true
 
 api:
   replicaCount: 1

--- a/charts/insighta/templates/_helpers.tpl
+++ b/charts/insighta/templates/_helpers.tpl
@@ -41,3 +41,28 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Full image reference. Prefixes .Values.imageRegistry when set, so the same
+chart serves a cluster pulling from a private registry whose host cannot be
+committed and one pulling from the repository as written.
+*/}}
+{{- define "insighta.image" -}}
+{{- $reg := .root.Values.imageRegistry | default "" -}}
+{{- if $reg -}}
+{{ $reg }}/{{ base .img.repository }}:{{ .img.tag }}
+{{- else -}}
+{{ .img.repository }}:{{ .img.tag }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Fails the render when an environment declares it needs a registry and none was
+supplied. A missing registry otherwise surfaces as ImagePullBackOff with no
+indication that a parameter was forgotten.
+*/}}
+{{- define "insighta.checkRegistry" -}}
+{{- if and .Values.requireImageRegistry (not .Values.imageRegistry) }}
+{{- fail "this environment sets requireImageRegistry=true but imageRegistry is empty: pass --set imageRegistry=<host>, or set it in the Argo Application's helm.parameters. It is not committed because it contains the AWS account id and this repository is public." }}
+{{- end }}
+{{- end }}

--- a/charts/insighta/templates/api.yaml
+++ b/charts/insighta/templates/api.yaml
@@ -1,3 +1,4 @@
+{{- include "insighta.checkRegistry" . }}
 {{- /*
    A ReadWriteOnce claim cannot be attached by two pods. Left to a comment,
    enabling persistence at two replicas leaves the second pod Pending on a
@@ -35,7 +36,7 @@ spec:
       {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: api
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          image: {{ include "insighta.image" (dict "root" $ "img" .Values.api.image) | quote }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           args: {{ toYaml .Values.api.command | nindent 12 }}
           ports:

--- a/charts/insighta/templates/frontend.yaml
+++ b/charts/insighta/templates/frontend.yaml
@@ -1,3 +1,4 @@
+{{- include "insighta.checkRegistry" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,7 +25,7 @@ spec:
       {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: frontend
-          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          image: {{ include "insighta.image" (dict "root" $ "img" .Values.frontend.image) | quote }}
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/insighta/templates/redis.yaml
+++ b/charts/insighta/templates/redis.yaml
@@ -1,3 +1,4 @@
+{{- include "insighta.checkRegistry" . }}
 {{- if .Values.redis.enabled }}
 # StatefulSet, not Deployment. docker/redis/redis.conf enables AOF
 # (appendonly yes, appendfsync everysec) with RDB snapshots as a secondary
@@ -26,7 +27,7 @@ spec:
       {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: redis
-          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          image: {{ include "insighta.image" (dict "root" $ "img" .Values.redis.image) | quote }}
           imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
           # Overrides maxmemory from redis.conf so it stays below the
           # container limit; the image's entrypoint forwards these.

--- a/charts/insighta/templates/schema-sync-job.yaml
+++ b/charts/insighta/templates/schema-sync-job.yaml
@@ -1,3 +1,4 @@
+{{- include "insighta.checkRegistry" . }}
 {{- if .Values.schemaSync.enabled }}
 # Applies the Prisma schema before the app rolls out.
 #
@@ -64,7 +65,7 @@ spec:
 {{- end }}
       containers:
         - name: schema-sync
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          image: {{ include "insighta.image" (dict "root" $ "img" .Values.api.image) | quote }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           command: ["npx", "prisma@{{ .Values.schemaSync.cliVersion }}", "db", "push", "--skip-generate", "--accept-data-loss"]
           envFrom:

--- a/charts/insighta/templates/worker.yaml
+++ b/charts/insighta/templates/worker.yaml
@@ -40,7 +40,7 @@ spec:
       {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: worker
-          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          image: {{ include "insighta.image" (dict "root" $ "img" .Values.api.image) | quote }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           args: ["worker"]
           ports:

--- a/charts/insighta/values.yaml
+++ b/charts/insighta/values.yaml
@@ -24,6 +24,21 @@ envSecretName: insighta-env
 # this every pod sits in ImagePullBackOff with no other symptom.
 imagePullSecrets: []
 
+# Registry host to prefix onto every image repository, or "" to use each
+# repository exactly as written.
+#
+# The AWS registry host embeds the account id and this repository is public, so
+# it is supplied per-cluster rather than committed -- the same way the
+# insighta-env secret is. An environment that requires it says so and fails
+# loudly when it is missing, rather than silently rendering an image reference
+# that resolves nowhere.
+imageRegistry: ""
+
+# Set true in an environment whose images only exist in a registry that
+# imageRegistry has to name. Rendering without it is then an error, not a pull
+# failure discovered later in ImagePullBackOff.
+requireImageRegistry: false
+
 api:
   replicaCount: 1
   image:
@@ -134,8 +149,10 @@ redis:
   # This is a single point of failure and is recorded as one in the design.
   replicaCount: 1
   image:
-    repository: insighta-redis
-    tag: local
+    # Pushed by deploy.yml since 2026-08-14. Before that it existed in no
+    # registry and the default here named an image only the compose host had.
+    repository: ghcr.io/jk42jj/insighta-redis
+    tag: latest
     pullPolicy: IfNotPresent
   port: 6379
   # docker/redis/redis.conf ships maxmemory 2gb with maxmemory-policy

--- a/scripts/ci/check-charts.sh
+++ b/scripts/ci/check-charts.sh
@@ -48,7 +48,21 @@ for env in $ENVS; do
   vals="$CHART/environments/$env.yaml"
   [ -f "$vals" ] || { bad "$env: $vals missing"; continue; }
 
-  if ! out=$(helm template insighta "$CHART" -f "$vals" --namespace insighta 2>&1); then
+  # An environment whose images only exist in a registry whose host is not
+  # committed declares requireImageRegistry. Supply a placeholder so the render
+  # can be checked, and assert first that omitting it is an error -- a
+  # requirement nothing enforces is a comment.
+  extra=()
+  if grep -q '^requireImageRegistry: true' "$vals"; then
+    if helm template insighta "$CHART" -f "$vals" --namespace insighta >/dev/null 2>&1; then
+      bad "$env: declares requireImageRegistry but renders without one"
+    else
+      ok "$env: refuses to render without imageRegistry"
+    fi
+    extra=(--set "imageRegistry=registry.invalid")
+  fi
+
+  if ! out=$(helm template insighta "$CHART" -f "$vals" --namespace insighta ${extra[@]+"${extra[@]}"} 2>&1); then
     bad "$env: render failed"
     printf '%s\n' "$out" | sed 's/^/        /' | head -20
     continue
@@ -86,7 +100,8 @@ for env in $ENVS; do
 
   # Private registry pulls need a secret. Without one every pod sits in
   # ImagePullBackOff and nothing else in the render looks wrong.
-  wantsecret=$(grep -c '^imagePullSecrets:' "$vals" || true)
+  # An empty list is a declaration that none are wanted, not a request for them.
+  wantsecret=$(grep -cE '^imagePullSecrets:[[:space:]]*$' "$vals" || true)
   gotsecret=$(printf '%s\n' "$out" | grep -c 'imagePullSecrets:' || true)
   podspecs=$(printf '%s\n' "$out" | grep -c '^      containers:' || true)
   if [ "$wantsecret" -gt 0 ] && [ "$gotsecret" -ne "$podspecs" ]; then
@@ -154,7 +169,9 @@ done
 if command -v kubeconform >/dev/null; then
   echo "kubeconform:"
   for env in $ENVS; do
-    if helm template insighta "$CHART" -f "$CHART/environments/$env.yaml" --namespace insighta \
+    reg=()
+    grep -q '^requireImageRegistry: true' "$CHART/environments/$env.yaml" && reg=(--set "imageRegistry=registry.invalid")
+    if helm template insighta "$CHART" -f "$CHART/environments/$env.yaml" --namespace insighta ${reg[@]+"${reg[@]}"} \
        | kubeconform -strict -summary -ignore-missing-schemas 2>&1 | sed "s/^/    $env /"; then :; else
       bad "$env: kubeconform"
     fi

--- a/terraform/modules/k3s-node/main.tf
+++ b/terraform/modules/k3s-node/main.tf
@@ -61,6 +61,7 @@ resource "aws_instance" "this" {
   key_name               = var.key_name
   subnet_id              = var.subnet_id
   vpc_security_group_ids = concat([aws_security_group.this.id], var.security_group_ids)
+  iam_instance_profile   = var.iam_instance_profile != "" ? var.iam_instance_profile : null
 
   associate_public_ip_address = true
 

--- a/terraform/modules/k3s-node/variables.tf
+++ b/terraform/modules/k3s-node/variables.tf
@@ -67,3 +67,18 @@ variable "ssh_cidrs" {
   type        = list(string)
   default     = []
 }
+
+variable "iam_instance_profile" {
+  description = <<-EOT
+    Name of an existing instance profile to attach, or "" for none.
+
+    Deliberately a name rather than a managed resource. Creating the role here
+    would require CI's terraform principal to hold iam:CreateRole, which is the
+    standard path from "CI can deploy" to "CI can mint an administrator". The
+    role and profile are created once by an administrator; terraform attaches
+    what already exists and CI holds only iam:PassRole for that one ARN.
+  EOT
+  type        = string
+  default     = ""
+}
+

--- a/terraform/projects/insighta/environments/prod/main.tf
+++ b/terraform/projects/insighta/environments/prod/main.tf
@@ -53,12 +53,13 @@ module "k3s_node" {
   source = "../../../../modules/k3s-node"
   count  = var.enable_k3s_node ? 1 : 0
 
-  name          = "insighta-k3s-1"
-  ami_id        = var.ami_id
-  instance_type = var.k3s_instance_type
-  key_name      = var.key_name
-  subnet_id     = local.subnet_id
-  vpc_id        = module.networking.vpc_id
+  name                 = "insighta-k3s-1"
+  iam_instance_profile = var.k3s_instance_profile
+  ami_id               = var.ami_id
+  instance_type        = var.k3s_instance_type
+  key_name             = var.key_name
+  subnet_id            = local.subnet_id
+  vpc_id               = module.networking.vpc_id
 
   tags = merge(local.common_tags, { Phase = "P2" })
 }
@@ -87,4 +88,55 @@ locals {
     ManagedBy   = "terraform"
     Project     = "insighta"
   }
+}
+
+# ── Container images ────────────────────────────────────────────────────────
+#
+# The cluster could not pull ghcr.io/jk42jj/* because those packages are
+# private and no long-lived credential for them exists: the token stored on the
+# production box is a CI GITHUB_TOKEN and was measured expired (401) on
+# 2026-08-14. Handing a personal access token to a cluster replaces that with a
+# secret that has to be rotated and cannot be revoked without breaking pulls.
+#
+# ECR removes the credential instead of managing it. The node carries an
+# instance profile with ECR read; the kubelet authenticates with it and there
+# is no pull secret in any namespace. GHCR keeps receiving the same images, so
+# the compose host is untouched.
+#
+# Storage is bounded to the last 5 tags per repository -- roughly 2 GB, about
+# $0.20 a month at us-west-2 rates.
+resource "aws_ecr_repository" "images" {
+  for_each = toset(["insighta-api", "insighta-frontend", "insighta-redis"])
+
+  name                 = each.key
+  image_tag_mutability = "MUTABLE" # :latest is expected to move
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_ecr_lifecycle_policy" "images" {
+  for_each   = aws_ecr_repository.images
+  repository = each.value.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep the last 5 images; older tags are reachable by digest in the deploy log if ever needed."
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = 5
+      }
+      action = { type = "expire" }
+    }]
+  })
+}
+
+output "ecr_registry" {
+  description = "Registry host for the image repositories."
+  value       = split("/", values(aws_ecr_repository.images)[0].repository_url)[0]
 }

--- a/terraform/projects/insighta/environments/prod/variables.tf
+++ b/terraform/projects/insighta/environments/prod/variables.tf
@@ -69,3 +69,10 @@ variable "k3s_instance_type" {
   type        = string
   default     = "t3.small"
 }
+
+variable "k3s_instance_profile" {
+  description = "Existing instance profile for the k3s node. Empty disables the attachment."
+  type        = string
+  default     = "insighta-k3s-node"
+}
+


### PR DESCRIPTION
Two things blocked a cutover, both found by running the chart on a real cluster rather than on k3d.

## 1. No credential existed for pulling `ghcr.io/jk42jj/*`

Those packages are private. The `gh` CLI token has no `read:packages`, and the credential stored on the production box is a CI `GITHUB_TOKEN` measured **expired** on 2026-08-14 (401; `docker pull` fails). Production works because `deploy.yml` logs in fresh on every run — which a cluster cannot do.

Handing a PAT to the cluster replaces a missing secret with one that expires and cannot be revoked without breaking pulls. **ECR removes the credential instead**: the node carries an instance profile with ECR read, the kubelet authenticates with it, and no namespace holds a pull secret. GHCR keeps receiving the same images, so the compose host is unchanged.

## 2. The redis image existed in no registry

`deploy.yml` pushed api and frontend; the box built redis itself through compose. A cluster cannot build, so a cutover had nothing to pull. Now built and pushed like the other two, gated on `docker/redis/` changing so a backend commit does not rebuild it.

## IAM is arranged so CI cannot escalate

The role and instance profile are created **once by an administrator**; terraform references the profile by name, and CI holds `iam:PassRole` for that one ARN and **no `iam:CreateRole`**.

| simulated | decision |
|---|---|
| `ecr:PutImage` on `insighta-api` | allowed |
| `ecr:CreateRepository` | allowed |
| `ecr:PutImage` on another repository | **implicitDeny** |
| `iam:CreateRole` | **implicitDeny** |
| `iam:AttachRolePolicy` | **implicitDeny** |
| `iam:CreateUser` | **implicitDeny** |

## The registry host is not committed

It embeds the AWS account id and this repository is public, so it is supplied per-cluster like the `insighta-env` secret.

`values.yaml` gains `imageRegistry`; `requireImageRegistry` makes an environment that needs one **fail its render with a message that names the problem**, rather than four pods in `ImagePullBackOff`.

```
Error: this environment sets requireImageRegistry=true but imageRegistry is empty:
pass --set imageRegistry=<host>, or set it in the Argo Application's helm.parameters.
It is not committed because it contains the AWS account id and this repository is public.
```

`check-charts.sh` asserts both directions — such an environment must refuse to render without a registry, and must render with one.

## Terraform, planned against real state

```
Plan: 6 to add, 1 to change, 0 to destroy
  aws_ecr_repository.images        x3   (scan on push, keep last 5 tags, ~$0.20/mo)
  aws_ecr_lifecycle_policy.images  x3
  module.k3s_node[0].aws_instance  updated in-place, not replaced
```

## Two things this also fixes

- `worker.yaml` was left out of the image-reference change on the first pass and would have kept a hardcoded reference. Caught by rendering and reading the output.
- redis's default repository still named `insighta-redis:local` — an image only the compose host ever had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)