### PR TITLE
fix(deploy): a .gitignore edit was a deployable change

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,7 +117,12 @@ jobs:
           # deployable=true, which wastes a deploy; an allowlist would silently
           # skip it, and a deploy that should have happened and did not is the
           # failure this repository can least afford.
-          IRRELEVANT='^(terraform|ansible|charts|docs|prompt|tests|scripts|\.github|\.claude)/|^[^/]*\.md$'
+          # Top-level metadata files are named individually rather than by a
+          # pattern. A rule like "any dotfile" would swallow .dockerignore,
+          # which decides what goes into the image and is the opposite of
+          # irrelevant. Verified 2026-08-14 by listing /app inside the running
+          # image: none of these are present.
+          IRRELEVANT='^(terraform|ansible|charts|docs|prompt|tests|scripts|\.github|\.claude)/|^[^/]*\.md$|^(\.gitignore|\.gitattributes|\.editorconfig|LICENSE)$'
           if echo "$FILES" | grep -Eqv "$IRRELEVANT"; then
             DEPLOYABLE=true
           else

--- a/tests/smoke/deploy-predicate-dockerignore.test.ts
+++ b/tests/smoke/deploy-predicate-dockerignore.test.ts
@@ -54,3 +54,60 @@ describe('deploy predicate vs .dockerignore', () => {
     expect(pretend.filter((d) => !ignored.has(d))).toEqual(['not-in-dockerignore']);
   });
 });
+
+/**
+ * The directory list above is only half the predicate. The other half decides
+ * top-level files, and it read `^[^/]*\.md$` alone -- so a .gitignore edit was
+ * a deployable change.
+ *
+ * That is not theoretical: PR #1497 changed .gitignore, scripts/ and tests/,
+ * and rebuilt and redeployed production at 06:01:47Z on 2026-08-14. Nothing in
+ * it could reach the running application.
+ *
+ * The fix names files individually rather than matching dotfiles as a class,
+ * because .dockerignore is a dotfile and decides what the image contains --
+ * the opposite of irrelevant. These cases pin both directions.
+ */
+describe('deploy predicate: which paths trigger a deploy', () => {
+  function predicate(): RegExp {
+    const wf = readFileSync(join(ROOT, '.github/workflows/deploy.yml'), 'utf8');
+    const line = wf.split('\n').find((l) => l.includes('IRRELEVANT='));
+    if (!line) throw new Error('IRRELEVANT= not found in deploy.yml');
+    const body = line.split("'")[1];
+    if (!body) throw new Error(`could not extract the pattern from: ${line.trim()}`);
+    return new RegExp(body);
+  }
+
+  // true  = a change to this path must rebuild and redeploy
+  // false = it provably cannot alter what runs, so it must not
+  const CASES: Array<[string, boolean]> = [
+    ['src/api/server.ts', true],
+    ['frontend/src/App.tsx', true],
+    ['package.json', true],
+    ['docker/redis/Dockerfile', true],
+    // Decides what goes into the image. A dotfile, and the opposite of irrelevant.
+    ['.dockerignore', true],
+
+    ['.gitignore', false],
+    ['.gitattributes', false],
+    ['.editorconfig', false],
+    ['LICENSE', false],
+    ['README.md', false],
+    ['scripts/ops/ssh.sh', false],
+    ['tests/smoke/x.test.ts', false],
+    ['charts/insighta/values.yaml', false],
+    ['terraform/main.tf', false],
+    ['.github/workflows/ci.yml', false],
+  ];
+
+  it.each(CASES)('%s -> deploys=%s', (path, shouldDeploy) => {
+    expect(!predicate().test(path)).toBe(shouldDeploy);
+  });
+
+  // Negative control: a path nobody classified must fall through to deploying.
+  // An allowlist would silently skip it, and a deploy that should have happened
+  // and did not is the failure this repository can least afford.
+  it('an unknown top-level directory still deploys', () => {
+    expect(predicate().test('some-new-thing/file.ts')).toBe(false);
+  });
+});


### PR DESCRIPTION
The predicate decides top-level files with `^[^/]*\.md$` and nothing else, so **every top-level file that is not markdown counted as production-affecting**.

## It happened

PR #1497 changed `.gitignore`, `scripts/` and `tests/`. It rebuilt the images and redeployed production:

```
insighta-api    started 2026-08-14T06:01:47Z  restarts=0
insighta-redis  started 2026-08-14T06:01:47Z  restarts=0
insighta-frontend  started 2026-08-13T04:26:20Z   (untouched)
```

api and redis recreated in the same second, frontend left alone — the signature of compose recreating services whose definition moved. Nothing in that PR could reach the running application.

The deploy succeeded and production stayed healthy, but it should not have run.

## The fix names files individually

Not "any dotfile". `.dockerignore` is a dotfile and decides what the image contains, which is the opposite of irrelevant — a class rule would have swallowed it and turned a real deploy trigger into a skipped one.

Verified by listing `/app` inside the running image: none of the added names are present.

## Test

The existing test only checked that predicate directories appear in `.dockerignore`. It now pins per-path behaviour in both directions:

| must deploy | must not |
|---|---|
| `src/api/server.ts` | `.gitignore` |
| `frontend/src/App.tsx` | `.gitattributes` |
| `package.json` | `.editorconfig` |
| `docker/redis/Dockerfile` | `LICENSE` |
| **`.dockerignore`** | `README.md`, `scripts/`, `tests/`, `charts/`, `terraform/`, `.github/` |

Plus a control: an unclassified top-level directory still deploys. An allowlist would silently skip it, and a deploy that should have happened and did not is the failure this repository can least afford.

```
Tests: 19 passed, 19 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)