### PR TITLE
feat(cutover): size the node like production, and make prod.yaml survivable

### DIFF
--- a/charts/insighta/environments/prod.yaml
+++ b/charts/insighta/environments/prod.yaml
@@ -1,72 +1,63 @@
-# prod
+# Production on Kubernetes.
 #
-# frontend runs 2 replicas. It is a static file server that proxies to the
-# api and holds no state, so a second copy is free and covers rolling
-# updates and node drains. Measured traffic is under one request per minute;
-# this is an availability figure, not a load one.
-#
-# api runs 2. It could not before.
-#
-# The api process used to carry per-process state that was the only copy, and
-# schedulers whose overlap guards were in-process variables. Both are now
-# addressed, each verified on a running cluster rather than by reading:
-#
-#   scheduler/auto-sync.ts       the queue owns scheduling. One tick claims
-#                                due rows with FOR UPDATE SKIP LOCKED and
-#                                enqueues one job each, so overlapping ticks
-#                                and parallel workers cannot take the same
-#                                playlist. Measured: two concurrent claims,
-#                                8 rows each, intersection 0.
-#   ontology/chat.ts             history moved to ontology_conversations.
-#                                Measured: a turn written by one client is
-#                                read by another that shares no memory.
-#   youtube/api.ts               invalidation published to
-#                                youtube_cache_epochs. Measured: an entry
-#                                stored before an invalidation reads as a
-#                                miss in a different process; one stored
-#                                after it stays valid.
-#
-# Verified with api at 2 replicas: "AutoSyncScheduler started" appeared 0
-# times in the api pods and once in the worker, and one tick claimed 17 due
-# playlists and enqueued exactly 17 jobs.
-#
-# Requires the worker deployment and all three flags under statelessness,
-# which the chart sets. It also requires both migrations to have been applied
-# -- they are in the apply-custom-sql allowlist and were confirmed present in
-# production on 2026-08-14.
-#
-# What is still per-process and not fixed here, because none of it blocks a
-# second replica: the enrichment already-running guard, the quota-alert
-# throttle, the chat provider poller, the channel blocklist cache and the
-# wizard dedup set. Each degrades — duplicate work or a stale read — rather
-# than losing data.
+# During the parallel run this deployment and the compose host are both live
+# and both hold connections to the same Supabase instance. Supabase allows 60
+# and the host was measured using 27 on 2026-08-14, so the cluster's budget is
+# what is left, not what the end state can afford.
+
+# Images come from ECR with the node's instance profile. The registry host is
+# not committed -- it contains the AWS account id and this repository is
+# public -- so it is supplied to the cluster, and a render without it fails
+# with a message that says so.
+requireImageRegistry: true
+
 api:
-  replicaCount: 2
-  # Off at 2 replicas, deliberately. A ReadWriteOnce claim cannot back two
-  # pods, and k3s local-path offers nothing else. The two directories are not
-  # equivalent, so the trade differs:
+  # One, not two, until the compose host is decommissioned.
   #
-  #   /app/cache  each pod warms its own copy of the YouTube response cache.
-  #               The cost is one warm-up per pod, not a continuous one --
-  #               acceptable. The shared-cache answer is redis, which is
-  #               deployed and holds nothing (6.1 risk 3); this is the first
-  #               concrete consumer it would have.
-  #   /app/logs   lost on reschedule, and nothing ships them off the pod.
-  #               This is the same gap the design records for journald
-  #               (6.1 risk 5) and it is NOT solved here. Log shipping is a
-  #               P2 item; until then a rescheduled pod loses its history.
+  #   PRISMA_POOL_LIMIT is 15 in production.
+  #   2 replicas          = 30 connections
+  #   + worker            ~ 10
+  #   + compose host      = 27  (measured 2026-08-14)
+  #                       -------
+  #                         67  against a limit of 60
   #
-  # Do not turn this on while replicaCount is above 1 -- the second pod will
-  # sit Pending on a volume it cannot attach.
+  # Raise this to 2 in the same change that removes the host, not before.
+  replicaCount: 1
+
+  # emptyDir, not a claim. Two consequences, both deliberate:
+  #
+  # /app/logs  -- module logs also go to stdout since the logger change, so
+  #               `kubectl logs` carries them and a reschedule loses nothing
+  #               that is not already elsewhere.
+  # /app/cache -- 13 MB of YouTube API responses, refetched after a reschedule
+  #               at the cost of quota. This is the constraint that keeps
+  #               replicaCount at 1 even after the budget allows 2: the claim
+  #               is ReadWriteOnce, so moving this cache to redis is what
+  #               actually unblocks horizontal scale.
   persistence:
     enabled: false
+
 frontend:
+  # Static files, no shared state, ~4 MiB resident. Nothing here consumes a
+  # database connection.
   replicaCount: 2
+
 redis:
   replicaCount: 1
   persistence:
     enabled: true
     size: 8Gi
+
+# CI owns the schema. deploy.yml's migrate job runs `prisma db push` against
+# Supabase on every deployable change, independently of where the application
+# runs. A second pusher inside the chart would race it against the database
+# production reads.
+schemaSync:
+  enabled: false
+
+# Supabase, not an in-cluster database.
+postgresDev:
+  enabled: false
 
 ingress:
   enabled: true

--- a/scripts/ci/check-charts.sh
+++ b/scripts/ci/check-charts.sh
@@ -33,12 +33,17 @@ command -v helm >/dev/null || { echo "helm not found"; exit 127; }
 # Expectations, one line per environment:
 #   <env>|<kind/name that must exist, comma separated>|<must NOT exist>
 #
+# prod must NOT render the schema-sync Job. deploy.yml's migrate job runs
+# `prisma db push` against Supabase on every deployable change, independently of
+# where the application runs; a second pusher inside the chart would race it
+# against the database production reads.
+#
 # These are not a restatement of the templates. Each entry is a decision that
 # was made for a reason and would be a defect to lose silently.
 read -r -d '' EXPECT <<'EOF' || true
 dev|Service/insighta-redis,StatefulSet/insighta-redis,Deployment/insighta-api,Deployment/insighta-worker|Job/insighta-schema-sync
 staging|Service/insighta-redis,StatefulSet/insighta-redis,Deployment/insighta-api,Job/insighta-schema-sync|
-prod|Service/insighta-redis,StatefulSet/insighta-redis,Deployment/insighta-api,Deployment/insighta-worker,Job/insighta-schema-sync|StatefulSet/insighta-postgres
+prod|Service/insighta-redis,StatefulSet/insighta-redis,Deployment/insighta-api,Deployment/insighta-worker,Ingress/insighta|StatefulSet/insighta-postgres,Job/insighta-schema-sync
 validation|Deployment/insighta-api,Deployment/insighta-worker,StatefulSet/insighta-postgres|StatefulSet/insighta-redis,Ingress/insighta,Job/insighta-schema-sync
 EOF
 

--- a/terraform/projects/insighta/environments/prod/variables.tf
+++ b/terraform/projects/insighta/environments/prod/variables.tf
@@ -65,9 +65,19 @@ variable "enable_k3s_node" {
 }
 
 variable "k3s_instance_type" {
-  description = "Validation node size. See modules/k3s-node for the memory arithmetic behind t3.small."
+  description = <<-EOT
+    Instance type for the k3s node.
+
+    t3.small carried the validation cluster at 73% of 1910 MB with k3s, ArgoCD
+    core, four application pods and a development database. That leaves no room
+    for traffic, a second replica, or a spike.
+
+    Production runs t3.medium and uses 585 MB of 3836 MB, with the three
+    containers totalling 182 MiB. Matching it removes node size as a variable
+    when comparing the two during the parallel run.
+  EOT
   type        = string
-  default     = "t3.small"
+  default     = "t3.medium"
 }
 
 variable "k3s_instance_profile" {


### PR DESCRIPTION
Two preparations for P4. **Neither moves traffic.**

## Node: t3.small → t3.medium, in place

t3.small carried the validation cluster at **73% of 1910 MB** with k3s, ArgoCD core, four pods and a development database — no room for traffic, a second replica, or a spike.

Production runs t3.medium at 585 MB of 3836 MB, its three containers totalling 182 MiB. Matching it removes node size as a variable when comparing the two during the parallel run.

```
Plan: 0 to add, 1 to change, 0 to destroy
  ~ instance_type = "t3.small" -> "t3.medium"
```

## prod.yaml, rewritten around the constraint that actually binds

During the parallel run this deployment **and** the compose host hold connections to the same Supabase instance.

```
PRISMA_POOL_LIMIT is 15 in production.
2 api replicas      = 30
+ worker            ~ 10
+ compose host      = 27   measured 2026-08-14
                    -----
                      67   against a limit of 60
```

`api.replicaCount` drops from 2 to 1, to be raised **in the same change that removes the host**. The file says so where the number is.

### schemaSync off for prod

`deploy.yml`'s migrate job runs `prisma db push` against Supabase on every deployable change, independently of where the application runs. A second pusher inside the chart would race it against the database production reads.

`check-charts.sh` now asserts prod renders no schema-sync Job. Verified by re-enabling it:

```
FAIL  prod: present but must not be: Job/insighta-schema-sync
```

### The comment that matters most

`/app/cache` is 13 MB of YouTube responses on a **ReadWriteOnce** claim. That — not the connection budget — is what keeps `replicaCount` at 1 even after the budget allows 2. Moving that cache to redis is what actually unblocks horizontal scale, and the file records it next to the number it explains.

## Still missing before traffic moves

- cert-manager and `insighta-tls` — nothing issues a certificate for the cluster yet
- the real `insighta-env` secret — the cluster holds five dummy keys
- `portfolio.insighta.one` — served from `/var/www/portfolio` on the host, not from any container

🤖 Generated with [Claude Code](https://claude.com/claude-code)