### PR TITLE
fix(terraform): describe the moved Elastic IP before an apply moves it back

### DIFF
--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -50,6 +50,6 @@ resource "aws_eip" "this" {
 }
 
 resource "aws_eip_association" "this" {
-  instance_id   = aws_instance.this.id
+  instance_id   = var.eip_instance_id != "" ? var.eip_instance_id : aws_instance.this.id
   allocation_id = aws_eip.this.id
 }

--- a/terraform/modules/compute/variables.tf
+++ b/terraform/modules/compute/variables.tf
@@ -52,3 +52,19 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "eip_instance_id" {
+  description = <<-EOT
+    Instance the Elastic IP points at, or "" for this module's own instance.
+
+    The address is the service's public identity -- DNS resolves insighta.one
+    to it -- and it is deliberately separable from the instance that answers.
+    Moving it is how the edge moved to the cluster on 2026-08-14 without a DNS
+    change: two seconds of reassociation, no TTL, no client caches.
+
+    Terraform has to describe that, or the next apply moves it back.
+  EOT
+  type        = string
+  default     = ""
+}
+

--- a/terraform/projects/insighta/environments/prod/main.tf
+++ b/terraform/projects/insighta/environments/prod/main.tf
@@ -29,9 +29,15 @@ module "iam" {
 module "compute" {
   source = "../../../../modules/compute"
 
-  name               = "insighta-prod"
-  ami_id             = var.ami_id
-  instance_type      = var.instance_type
+  name          = "insighta-prod"
+  ami_id        = var.ami_id
+  instance_type = var.instance_type
+
+  # The service address now answers from the cluster. Declared here rather than
+  # left as drift: terraform.yml applies on every push to main, and a plan that
+  # still believed the address belonged to this instance would move it back --
+  # silently, as a side effect of an unrelated merge.
+  eip_instance_id    = var.enable_k3s_node ? module.k3s_node[0].instance_id : ""
   key_name           = var.key_name
   subnet_id          = local.subnet_id
   security_group_ids = [module.security.security_group_id]
@@ -139,4 +145,29 @@ resource "aws_ecr_lifecycle_policy" "images" {
 output "ecr_registry" {
   description = "Registry host for the image repositories."
   value       = split("/", values(aws_ecr_repository.images)[0].repository_url)[0]
+}
+
+# ── Standby address for the former edge ─────────────────────────────────────
+#
+# insighta-prod carried the service address until 2026-08-14. When that address
+# moved to the cluster, the host was left with no public IP at all -- and this
+# subnet routes through an internet gateway, not a NAT, so no public IP means
+# no outbound internet.
+#
+# That matters because the host is the rollback target. Its containers talk to
+# Supabase; without egress they fail their health checks, and a rollback to a
+# stack that has been failing for two weeks is not a rollback anyone should
+# trust.
+#
+# Roughly $3.60/month, and it is released when the host is decommissioned.
+resource "aws_eip" "prod_standby" {
+  count  = var.enable_k3s_node ? 1 : 0
+  domain = "vpc"
+  tags   = merge(local.common_tags, { Name = "insighta-prod-standby-eip" })
+}
+
+resource "aws_eip_association" "prod_standby" {
+  count         = var.enable_k3s_node ? 1 : 0
+  instance_id   = module.compute.instance_id
+  allocation_id = aws_eip.prod_standby[0].id
 }


### PR DESCRIPTION
The service address was reassociated to the cluster **with the CLI**. Terraform still believed it belonged to the compute instance — and `terraform.yml` applies on every push to `main`.

```
Note: Objects have changed outside of Terraform
  # module.compute.aws_eip_association.this will be created
Plan: 1 to add
```

**The next merge, on any subject, would have moved the address back** to a host that no longer runs the application. Silently, as a side effect of something unrelated.

## The address is separable from the instance

The compute module now takes `eip_instance_id`. That separation is the mechanism the cutover used — two seconds of reassociation, no DNS change, no TTL, no client caches — and terraform has to be able to express it or it will keep undoing it.

The existing association was **imported**, not recreated: creating it would have meant a second reassociation of a live address.

## Standby address

`insighta-prod` was left with no public IP when the service address moved, and this subnet routes through an **internet gateway rather than a NAT** — so no public IP means no egress at all.

That host is the rollback target and its containers talk to Supabase. Without egress they fail health checks, and a rollback to a stack that has been failing for two weeks is not a rollback anyone should trust.

About **$3.60/month**, released when the host is decommissioned.

## Result

```
terraform plan -> No changes
```

(before the standby tags, which the next apply adds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)