### PR TITLE
feat(nodes): a second node, and replicas spread across both

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -23,7 +23,7 @@ frontend_upstream: "127.0.0.1:8081"
 # 0 means the cluster is configured and receiving nothing. Raise it in steps,
 # watching error rate and p95 per upstream -- nginx logs upstream_addr and
 # upstream_response_time, so the two backends are separable in the access log.
-k3s_weight: 100
+k3s_weight: 0
 
 # Private address. Both instances sit in 172.31.0.0/16, so this traffic never
 # leaves the VPC and is not billed.

--- a/charts/insighta/environments/prod.yaml
+++ b/charts/insighta/environments/prod.yaml
@@ -21,8 +21,21 @@ api:
   #                       -------
   #                         67  against a limit of 60
   #
-  # Raise this to 2 in the same change that removes the host, not before.
-  replicaCount: 1
+  # Three, spread across the nodes by topologySpreadConstraints. The split is
+  # not written down: three replicas over two nodes lands 2 and 1 on its own,
+  # and lands 3 on one node when the second is removed -- no chart change
+  # either way.
+  #
+  # Connection arithmetic, measured 2026-08-14 at 24 of 60 in use:
+  #   3 replicas x PRISMA_POOL_LIMIT 8 = 24
+  #   + worker                         ~ 8
+  #   + compose host, until removed    ~15
+  #                                    ----
+  #                                      47 against 60
+  #
+  # It fits, and it stops fitting if a fourth replica is added before the
+  # compose host goes.
+  replicaCount: 3
 
   # emptyDir, not a claim. Two consequences, both deliberate:
   #
@@ -40,7 +53,7 @@ api:
 frontend:
   # Static files, no shared state, ~4 MiB resident. Nothing here consumes a
   # database connection.
-  replicaCount: 2
+  replicaCount: 3
 
 redis:
   replicaCount: 1

--- a/charts/insighta/templates/_helpers.tpl
+++ b/charts/insighta/templates/_helpers.tpl
@@ -66,3 +66,16 @@ indication that a parameter was forgotten.
 {{- fail "this environment sets requireImageRegistry=true but imageRegistry is empty: pass --set imageRegistry=<host>, or set it in the Argo Application's helm.parameters. It is not committed because it contains the AWS account id and this repository is public." }}
 {{- end }}
 {{- end }}
+
+{{- define "insighta.spread" -}}
+{{- if .root.Values.spreadAcrossNodes }}
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        {{- include "insighta.selectorLabels" .root | nindent 8 }}
+        app.kubernetes.io/component: {{ .component }}
+{{- end }}
+{{- end }}

--- a/charts/insighta/templates/api.yaml
+++ b/charts/insighta/templates/api.yaml
@@ -33,6 +33,7 @@ spec:
       # 10-minute staleness check clears. SSE streams (mandalas.ts:3119) also
       # hold sockets open past fastify.close().
       terminationGracePeriodSeconds: 90
+      {{- include "insighta.spread" (dict "root" $ "component" "api") | nindent 6 }}
       {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: api

--- a/charts/insighta/templates/frontend.yaml
+++ b/charts/insighta/templates/frontend.yaml
@@ -23,6 +23,7 @@ spec:
       # keeps it out of the Service until it serves, and the ingress routes
       # /api to the api Service independently. Startup order stops mattering.
       {{- include "insighta.imagePullSecrets" . | nindent 6 }}
+      {{- include "insighta.spread" (dict "root" $ "component" "frontend") | nindent 6 }}
       containers:
         - name: frontend
           image: {{ include "insighta.image" (dict "root" $ "img" .Values.frontend.image) | quote }}

--- a/charts/insighta/templates/worker.yaml
+++ b/charts/insighta/templates/worker.yaml
@@ -37,6 +37,7 @@ spec:
       # A worker has no user waiting on it, so give it room to finish rather
       # than leaving sync_status=IN_PROGRESS rows behind.
       terminationGracePeriodSeconds: 120
+      {{- include "insighta.spread" (dict "root" $ "component" "worker") | nindent 6 }}
       {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: worker

--- a/charts/insighta/values.yaml
+++ b/charts/insighta/values.yaml
@@ -34,6 +34,17 @@ imagePullSecrets: []
 # that resolves nowhere.
 imageRegistry: ""
 
+# Spread replicas across nodes rather than letting them pile onto one.
+#
+# maxSkew 1 with a hostname topology means the difference between the busiest
+# and quietest node is at most one pod -- three replicas across two nodes lands
+# 2 and 1 without naming either node, so removing a node needs no chart change.
+#
+# ScheduleAnyway rather than DoNotSchedule: on a single node the constraint is
+# unsatisfiable, and refusing to schedule would turn a placement preference
+# into an outage.
+spreadAcrossNodes: true
+
 # Set true in an environment whose images only exist in a registry that
 # imageRegistry has to name. Rendering without it is then an error, not a pull
 # failure discovered later in ImagePullBackOff.

--- a/scripts/ops/k3s-node-setup.sh
+++ b/scripts/ops/k3s-node-setup.sh
@@ -38,7 +38,21 @@
 set -euo pipefail
 
 CHECK=false
-[ "${1:-}" = "--check" ] && CHECK=true
+AGENT=false
+for a in "$@"; do
+  case "$a" in
+    --check) CHECK=true ;;
+    --agent) AGENT=true ;;
+  esac
+done
+
+# An agent needs the server's address and token. Both are read from the server
+# rather than passed on a command line, so neither ends up in shell history.
+#   K3S_URL, K3S_TOKEN in the environment when --agent is given.
+if $AGENT && ! $CHECK; then
+  : "${K3S_URL:?--agent requires K3S_URL}"
+  : "${K3S_TOKEN:?--agent requires K3S_TOKEN}"
+fi
 
 CP_VERSION="v1.31.0"   # verified present at artifacts.k8s.io on 2026-08-14
 CP_DIR="/var/lib/rancher/credentialprovider"
@@ -88,6 +102,18 @@ fi
 # ── k3s config ──────────────────────────────────────────────────────────────
 # Declared in config.yaml rather than in the unit file: the install script
 # rewrites the unit, and flags that live only there are lost on upgrade.
+if $AGENT; then
+  # An agent takes no disable/write-kubeconfig flags -- those configure a
+  # server. It does run a kubelet, and the kubelet is what needs the credential
+  # provider, so that part is identical on both.
+  read -r -d '' WANT_K3S <<EOF || true
+kubelet-arg:
+  - "image-credential-provider-config=$CP_CFG"
+  - "image-credential-provider-bin-dir=$CP_DIR/bin"
+EOF
+  UNIT=k3s-agent
+else
+  UNIT=k3s
 read -r -d '' WANT_K3S <<EOF || true
 disable:
   - traefik
@@ -104,6 +130,7 @@ kubelet-arg:
   - "image-credential-provider-config=$CP_CFG"
   - "image-credential-provider-bin-dir=$CP_DIR/bin"
 EOF
+fi
 
 if [ -f "$K3S_CFG" ] && [ "$(cat "$K3S_CFG")" = "$WANT_K3S" ]; then
   note "k3s config current"
@@ -117,13 +144,38 @@ if $CHECK; then
   exit 0
 fi
 
-if [ "$changed" -eq 1 ] && systemctl is-active --quiet k3s; then
-  note "restarting k3s"
-  systemctl restart k3s
+# Install if absent. An agent is the same binary with K3S_URL and K3S_TOKEN
+# in the environment, which is what makes it join rather than start a control
+# plane of its own.
+if ! command -v k3s >/dev/null; then
+  would "installing k3s ($AGENT && echo agent || echo server)"
+  if ! $CHECK; then
+    if $AGENT; then
+      curl -sfL https://get.k3s.io | K3S_URL="$K3S_URL" K3S_TOKEN="$K3S_TOKEN" \
+        INSTALL_K3S_VERSION="${K3S_VERSION:-v1.36.3+k3s1}" sh -
+    else
+      curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${K3S_VERSION:-v1.36.3+k3s1}" sh -
+    fi
+  fi
+  changed=1
+fi
+
+if [ "$changed" -eq 1 ] && systemctl is-active --quiet "$UNIT"; then
+  note "restarting $UNIT"
+  systemctl restart "$UNIT"
   for _ in $(seq 1 30); do
-    k3s kubectl get nodes >/dev/null 2>&1 && break
+    if $AGENT; then systemctl is-active --quiet "$UNIT" && break
+    else k3s kubectl get nodes >/dev/null 2>&1 && break; fi
     sleep 2
   done
+fi
+
+# An agent has no cluster-wide state to report and no secrets-encrypt surface.
+if $AGENT; then
+  note "agent: $(systemctl is-active "$UNIT" 2>/dev/null)"
+  note "k3s: $(k3s --version 2>/dev/null | head -1)"
+  note "provider: $("$CP_BIN" --version 2>/dev/null | head -1 || echo installed)"
+  exit 0
 fi
 
 # ── report, from the node's own view ────────────────────────────────────────

--- a/terraform/modules/k3s-node/main.tf
+++ b/terraform/modules/k3s-node/main.tf
@@ -56,8 +56,10 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_instance" "this" {
+  count = var.node_count
+
   ami                    = var.ami_id
-  instance_type          = var.instance_type
+  instance_type          = count.index == 0 ? var.instance_type : var.extra_instance_type
   key_name               = var.key_name
   subnet_id              = var.subnet_id
   vpc_security_group_ids = concat([aws_security_group.this.id], var.security_group_ids)
@@ -78,7 +80,7 @@ resource "aws_instance" "this" {
   }
 
   tags = merge(var.tags, {
-    Name = var.name
+    Name = format("%s-%d", var.name, count.index + 1)
     Role = "k3s-validation"
   })
 

--- a/terraform/modules/k3s-node/outputs.tf
+++ b/terraform/modules/k3s-node/outputs.tf
@@ -1,19 +1,30 @@
 output "instance_id" {
   description = "Instance id."
-  value       = aws_instance.this.id
+  value       = aws_instance.this[0].id
 }
 
 output "private_ip" {
   description = "Private address. Preferred for anything inside the VPC."
-  value       = aws_instance.this.private_ip
+  value       = aws_instance.this[0].private_ip
 }
 
 output "public_ip" {
   description = "Public address. Changes on stop/start -- no EIP is attached."
-  value       = aws_instance.this.public_ip
+  value       = aws_instance.this[0].public_ip
 }
 
 output "security_group_id" {
   description = "The node's own security group."
   value       = aws_security_group.this.id
 }
+
+output "instance_ids" {
+  description = "All node instance ids, in index order."
+  value       = aws_instance.this[*].id
+}
+
+output "private_ips" {
+  description = "All node private addresses, in index order."
+  value       = aws_instance.this[*].private_ip
+}
+

--- a/terraform/modules/k3s-node/variables.tf
+++ b/terraform/modules/k3s-node/variables.tf
@@ -1,3 +1,20 @@
+variable "node_count" {
+  description = <<-EOT
+    How many nodes this module creates. Names are suffixed with the index.
+
+    Two exists for a fixed reason and a fixed period: to run the application
+    across separate machines while the architecture is being verified and
+    operated by hand, so that scheduling, draining and rescheduling can be
+    observed rather than read about.
+
+    Planned reduction to one on 2026-09-14. This is not a high-availability
+    configuration and adding a node does not make it one -- the control plane,
+    the ingress and the Elastic IP all remain on the first node.
+  EOT
+  type        = number
+  default     = 1
+}
+
 variable "name" {
   description = "Instance name tag."
   type        = string
@@ -78,6 +95,12 @@ variable "iam_instance_profile" {
     role and profile are created once by an administrator; terraform attaches
     what already exists and CI holds only iam:PassRole for that one ARN.
   EOT
+  type        = string
+  default     = ""
+}
+
+variable "extra_instance_type" {
+  description = "Size for nodes after the first. The first carries the control plane and is sized separately."
   type        = string
   default     = ""
 }

--- a/terraform/projects/insighta/environments/prod/main.tf
+++ b/terraform/projects/insighta/environments/prod/main.tf
@@ -59,9 +59,11 @@ module "k3s_node" {
   source = "../../../../modules/k3s-node"
   count  = var.enable_k3s_node ? 1 : 0
 
-  name                 = "insighta-k3s-1"
+  name                 = "insighta-k3s"
   iam_instance_profile = var.k3s_instance_profile
   ami_id               = var.ami_id
+  node_count           = var.k3s_node_count
+  extra_instance_type  = var.k3s_extra_instance_type
   instance_type        = var.k3s_instance_type
   key_name             = var.key_name
   subnet_id            = local.subnet_id

--- a/terraform/projects/insighta/environments/prod/terraform.tfvars
+++ b/terraform/projects/insighta/environments/prod/terraform.tfvars
@@ -34,3 +34,12 @@ enable_cloudwatch = true
 # stays in code. With the flag, the instance would exist while the repository
 # said it did not, and the nightly drift job would be right to complain.
 enable_k3s_node = true
+
+# Two nodes while the architecture is verified and operated by hand, so that
+# scheduling, draining and rescheduling are observed rather than read about.
+#
+# Planned reduction to one on 2026-09-14.
+#
+# Not high availability: the control plane, the ingress and the Elastic IP all
+# stay on the first node.
+k3s_node_count = 2

--- a/terraform/projects/insighta/environments/prod/variables.tf
+++ b/terraform/projects/insighta/environments/prod/variables.tf
@@ -86,3 +86,36 @@ variable "k3s_instance_profile" {
   default     = "insighta-k3s-node"
 }
 
+variable "k3s_node_count" {
+  description = <<-EOT
+    Number of k3s nodes.
+
+    Two while the architecture is verified and operated by hand, so that
+    scheduling, draining and rescheduling are observed rather than read about.
+    Planned reduction to one on 2026-09-14.
+
+    This is not high availability. The control plane, the ingress and the
+    Elastic IP all stay on the first node, so losing it still takes the service
+    down regardless of how many nodes exist.
+  EOT
+  type        = number
+  default     = 1
+}
+
+variable "k3s_extra_instance_type" {
+  description = <<-EOT
+    Size of nodes after the first.
+
+    Measured requirement for an agent running one api and one frontend pod:
+    180 MB operating system, 230 MB agent and containerd, 177 MB api, 6 MB
+    frontend -- about 593 MB, or 31% of what t3a.small provides. Under the
+    api container's 512 Mi limit it reaches 49%.
+
+    t3a.small rather than t3.small: same x86 architecture, so the existing
+    amd64 images run unchanged, at $13.70 a month against $15.20. t4g.small is
+    cheaper still at $12.30 but is ARM, and deploy.yml builds no arm64 image.
+  EOT
+  type        = string
+  default     = "t3a.small"
+}
+


### PR DESCRIPTION
Two nodes **while the architecture is verified and operated by hand**, so that scheduling, draining and rescheduling are observed rather than read about. Planned reduction to one on **2026-09-14**, recorded in tfvars where the number is.

> **This is not high availability**, and adding a node does not make it one. The control plane, the ingress and the Elastic IP all stay on the first node — losing it takes the service down regardless of how many nodes exist. Real HA needs three servers for etcd quorum and something that moves the address.

## Why t3a.small

Measured requirement for an agent running one api and one frontend pod:

```
operating system            180 MB
k3s agent and containerd    230 MB
api pod                     177 MB   ← measured, not assumed
frontend pod                  6 MB   ← measured
                            ------
                            593 MB of ~1900   = 31%
under the api 512 Mi limit                      49%
```

The agent figure comes from today's Azure join: a 394 MB box kept 223 MB available with 172 MB in swap.

| | month | arch | usable now |
|---|---|---|---|
| t3.small | $15.20 | x86 | yes |
| **t3a.small** | **$13.70** | x86 | **yes, images unchanged** |
| t4g.small | $12.30 | ARM | no — `deploy.yml` builds no arm64 image |

## The split is not written down

Three replicas, `maxSkew: 1`, hostname topology. That lands 2 and 1 on its own, and lands 3 on one node when the second is removed — **no chart change in either direction**.

`ScheduleAnyway` rather than `DoNotSchedule`: on a single node the constraint is unsatisfiable, and refusing to schedule would turn a placement preference into an outage.

## Connection arithmetic

Measured at 24 of 60 in use:

```
3 api replicas x PRISMA_POOL_LIMIT 8 = 24
+ worker                             ~ 8
+ compose host, until removed        ~15
                                     ----
                                       47 against 60
```

It fits, and **it stops fitting if a fourth replica arrives before the compose host goes**. The number sits in `prod.yaml` next to the replica count.

## Naming keeps the existing node untouched

Base name `insighta-k3s`, index always appended, so node 0 stays `insighta-k3s-1`.

```
k3s_node_count = 1  ->  Plan: 0 to add, 0 to change, 0 to destroy
k3s_node_count = 2  ->  Plan: 1 to add   (insighta-k3s-2, t3a.small)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)