### PR TITLE
fix(ops): reach the second node, and print the install mode rather than the test

### DIFF
--- a/scripts/ops/ssh.sh
+++ b/scripts/ops/ssh.sh
@@ -37,13 +37,14 @@ die() { printf '[ssh] %s\n' "$*" >&2; exit 1; }
 target_spec() {
   case "$1" in
     prod) echo "insighta-prod:ubuntu:insighta-ec2-ts" ;;
-    k3s)  echo "insighta-k3s-1:ubuntu:" ;;
-    *)    die "unknown target '$1' (prod|k3s)" ;;
+    k3s|k3s1) echo "insighta-k3s-1:ubuntu:" ;;
+    k3s2) echo "insighta-k3s-2:ubuntu:" ;;
+    *)    die "unknown target '$1' (prod|k3s|k3s2)" ;;
   esac
 }
 
 TARGET="${1:-}"
-[ -n "$TARGET" ] || die "usage: $0 <prod|k3s> [--update-sg|--print-host|command...]"
+[ -n "$TARGET" ] || die "usage: $0 <prod|k3s|k3s2> [--update-sg|--print-host|command...]"
 shift || true
 
 IFS=: read -r NAME_TAG SSH_USER TS_ALIAS <<<"$(target_spec "$TARGET")"


### PR DESCRIPTION
`scripts/ops/ssh.sh` gains `k3s2`.

Without it the second node is reachable only by typing its address — the habit that put a stale IP in `~/.ssh/config` and sent an ansible run at the wrong machine earlier today.

```bash
scripts/ops/ssh.sh k3s2 "sudo systemctl status k3s-agent"
```

`k3s-node-setup.sh` printed the literal string:

```
installing k3s (true && echo agent || echo server)
```

because the test sat inside double quotes with no command substitution. The install itself was correct; only the line describing it was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)