### PR TITLE
fix(ops): print the install mode, not the test that chooses it

### DIFF
--- a/scripts/ops/k3s-node-setup.sh
+++ b/scripts/ops/k3s-node-setup.sh
@@ -148,7 +148,7 @@ fi
 # in the environment, which is what makes it join rather than start a control
 # plane of its own.
 if ! command -v k3s >/dev/null; then
-  would "installing k3s ($AGENT && echo agent || echo server)"
+  would "installing k3s ($($AGENT && echo agent || echo server))"
   if ! $CHECK; then
     if $AGENT; then
       curl -sfL https://get.k3s.io | K3S_URL="$K3S_URL" K3S_TOKEN="$K3S_TOKEN" \


### PR DESCRIPTION
`k3s-node-setup.sh` printed the literal string:

```
installing k3s (true && echo agent || echo server)
```

because the test sat inside double quotes with no command substitution. The install itself was correct; only the line describing it was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)