### PR TITLE
fix(ingress): declare the class, or the controller refuses the object

### DIFF
--- a/charts/insighta/environments/prod.yaml
+++ b/charts/insighta/environments/prod.yaml
@@ -75,6 +75,18 @@ postgresDev:
 ingress:
   enabled: true
 
+  # Required, and it was missing. The main Ingress carries this class only
+  # because it was patched onto the live object by hand on 2026-08-14; the
+  # chart never declared it. A second Ingress rendered from the same chart
+  # therefore came out with no class at all and the controller refused it:
+  #
+  #   W ignoring ingress insighta-api-ratelimit ... does not contain a
+  #     valid IngressClass
+  #
+  # Which mattered more than a missing rate limit: /api had just been moved to
+  # that Ingress, so the path lost its rule and fell through to the frontend.
+  className: nginx
+
   # Both names, because DNS sends both here: www is a CNAME to the apex, which
   # resolves to this cluster. The host nginx served both (server_name on the
   # :80 and :443 blocks) and its certificate covered both.

--- a/charts/insighta/environments/staging.yaml
+++ b/charts/insighta/environments/staging.yaml
@@ -16,6 +16,9 @@ redis:
 
 ingress:
   enabled: true
+  # Without a class the controller refuses the object outright -- it does not
+  # fall back to a default. prod hit exactly that on 2026-08-18.
+  className: nginx
   host: staging.insighta.one
   tls:
     enabled: true

--- a/scripts/ci/check-charts.sh
+++ b/scripts/ci/check-charts.sh
@@ -140,6 +140,34 @@ done
 # keeps the older object's rule and ignores the newer one. An annotation on the
 # ignored object is configured and inert -- it renders, it validates, and it
 # does nothing. Caught 2026-08-18 on a rate-limit Ingress that duplicated /api.
+# An Ingress with no ingressClassName is refused by the controller, not
+# defaulted. It renders, it validates, and it is ignored:
+#
+#   W ignoring ingress <name> ... does not contain a valid IngressClass
+#
+# Caught 2026-08-18 when a second Ingress inherited no class and took /api with
+# it, leaving the path with no rule at all.
+echo "ingress class:"
+for env in $ENVS; do
+  reg=""
+  grep -q '^requireImageRegistry: true' "$CHART/environments/$env.yaml" && reg="--set imageRegistry=registry.invalid"
+  # shellcheck disable=SC2086
+  noclass=$(helm template insighta "$CHART" -f "$CHART/environments/$env.yaml" --namespace insighta $reg 2>/dev/null \
+    | python3 -c "
+import sys, yaml
+out = []
+for d in yaml.safe_load_all(sys.stdin):
+    if d and d.get('kind') == 'Ingress' and not d['spec'].get('ingressClassName'):
+        out.append(d['metadata']['name'])
+print(' '.join(out))
+")
+  if [ -n "$noclass" ]; then
+    bad "$env: Ingress without ingressClassName: $noclass"
+  else
+    ok "$env: every Ingress declares a class"
+  fi
+done
+
 echo "ingress paths:"
 for env in $ENVS; do
   helm template insighta "$CHART" -f "$CHART/environments/$env.yaml" --namespace insighta \


### PR DESCRIPTION
The chart never set `ingressClassName`. The live main Ingress carries `nginx` only because it was **patched onto the object by hand** on 2026-08-14, so a second Ingress rendered from the same chart came out with no class and was refused:

```
W ignoring ingress insighta-api-ratelimit in insighta-prod ...
  ingress does not contain a valid IngressClass
```

## Why this mattered more than a missing rate limit

`/api` had just moved to that Ingress, so **the path lost its rule entirely**:

```
generated config, host insighta.one:
  location "/"                 → frontend
  location "/api-reference/"   → api
  location "/documentation/"   → api
  location "/health/"          → api
  location "/oauth/callback/"  → api
  (no location /api)
```

Requests to `/api/...` now fall through to `/` → the frontend service, and reach the API only because the frontend container proxies them onward. It answers, but by accident.

`staging` had the same gap and was never deployed, so it never surfaced.

## Control

`check-charts.sh` rejects an Ingress with no class. Verified by removing it:

```
FAIL  prod: Ingress without ingressClassName: insighta insighta-api-ratelimit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)