### PR TITLE
docs(labs): runnable read-only labs, and the datastore runbook

### DIFF
--- a/docs/labs/README.md
+++ b/docs/labs/README.md
@@ -1,0 +1,75 @@
+# 인프라 실습
+
+`docs/guides/infra-for-beginners` 가이드와 짝을 이루는 실행 가능한 실습이다.
+가이드가 설명이라면 이쪽은 손으로 확인하는 부분이다.
+
+## 순서
+
+| 랩 | 주제 | 성격 | 소요 |
+|---|---|---|---|
+| `lab01-server-and-ssh.sh` | 서버 한 대에 들어가 보기 | 읽기 전용 | 2분 |
+| `lab02-containers-and-images.sh` | 컨테이너 · 이미지 · ECR | 읽기 전용 | 3분 |
+| `lab03-kubernetes-objects.sh` | 파드 · 디플로이먼트 · 서비스 · 인그레스 | 읽기 전용 | 5분 |
+| `lab04-helm.sh` | 차트와 값, 환경별 렌더 | 로컬 전용 | 5분 |
+| `lab05-terraform.sh` | 코드와 실제 인프라의 차이 계산 | plan 전용 | 6분 |
+| `lab06-ansible.sh` | 서버 내부 설정 맞추기 | `--check` 전용 | 4분 |
+| `lab07-argocd-gitops.sh` | 깃이 곧 클러스터의 상태 | 읽기 전용 | 4분 |
+| `lab08-deploy-and-rollback.sh` | 배포 경로와 롤백 3층 | 읽기 전용 | 5분 |
+| `lab09-incident-drill.sh` | 장애 진단 순서 | 읽기 전용 | 6분 |
+
+순서대로 하는 것을 전제로 쓰였다. 뒤쪽 랩은 앞쪽에서 나온 용어를 설명 없이 쓴다.
+
+## 실행
+
+```bash
+bash docs/labs/lab01-server-and-ssh.sh
+```
+
+한 번에 이어서 보고 싶으면:
+
+```bash
+for i in 01 02 03 04 05 06 07 08 09; do
+  bash docs/labs/lab${i}-*.sh 2>&1
+  printf '\n─── 계속하려면 Enter ───'; read -r _
+done
+```
+
+## 안전
+
+**어떤 랩도 인프라를 바꾸지 않는다.** 설계상 그렇다:
+
+- terraform 은 `plan` 까지만 — `apply` 는 어느 랩에도 없다
+- ansible 은 `--check` 만 안내 — 실제 실행은 하지 않는다
+- kubectl 은 `get` · `describe` · `logs` 만 사용
+- helm 은 `template` 만 사용 — `install` · `upgrade` 없음
+
+그래도 실행 전에 스크립트를 읽어 보기를 권한다. 남이 쓴 스크립트를 읽지
+않고 돌리는 습관은 이 문서가 가르치려는 것의 반대다.
+
+## 출력에 관한 주의
+
+랩 출력에는 실행 시점의 실제 값이 들어간다 — AWS 계정 번호, 사설 IP,
+현재 접속 IP 등. **출력을 그대로 공개된 곳에 붙여 넣지 않는다.**
+이 리포지토리는 공개돼 있다.
+
+## 필요한 도구
+
+| 도구 | 필요한 랩 | 설치 |
+|---|---|---|
+| `curl`, `python3` | 대부분 | macOS 기본 |
+| `helm` | 04 | `brew install helm` |
+| `terraform` | 05 | `brew install terraform` |
+| `ansible` | 06 (선택) | `brew install ansible` |
+| AWS 자격증명 | 01·05 | `aws configure` |
+
+없는 도구는 해당 랩이 안내 문구를 내고 건너뛴다.
+
+## 접속이 안 될 때
+
+랩 01 이 실패하면 나머지도 실패한다. 대부분 원인은 방화벽에 등록된 IP 와
+현재 IP 가 다른 것이다:
+
+```bash
+bash scripts/ops/ssh.sh --update-sg   # 지금 IP 를 허용 목록에 추가
+bash scripts/ops/ssh.sh k3s "hostname"
+```

--- a/docs/labs/_lib.sh
+++ b/docs/labs/_lib.sh
@@ -1,0 +1,101 @@
+# Shared helpers for the lab scripts.
+#
+# Sourced, never executed. Every lab uses the same three devices:
+#
+#   step  — a numbered heading, so you know where you are
+#   say   — plain prose explaining what is about to happen and why
+#   run   — prints the command, then runs it
+#
+# `run` is the important one. The point of these labs is not that a script
+# produces output; it is that you see the exact command that produced it and
+# can type it yourself afterwards. Anything a lab does, you could do by hand.
+#
+# The printed command is therefore quoted so it can be copied and pasted
+# verbatim. An earlier version printed the arguments bare, which turned
+#   ssh.sh k3s "hostname && uptime"
+# into
+#   ssh.sh k3s hostname && uptime
+# — a different command, and one that runs `uptime` on the wrong machine.
+
+set -uo pipefail
+
+# Colours are switched off when the output is not a terminal, so piping a lab
+# into a file or into `less` gives clean text.
+if [ -t 1 ]; then
+  B=$'\033[1m'; DIM=$'\033[2m'; CYAN=$'\033[36m'; GREEN=$'\033[32m'
+  YELLOW=$'\033[33m'; RED=$'\033[31m'; R=$'\033[0m'
+else
+  B=''; DIM=''; CYAN=''; GREEN=''; YELLOW=''; RED=''; R=''
+fi
+
+LAB_STEP=0
+LAB_RULE='──────────────────────────────────────────────────────────────────────'
+
+# No attempt is made to pad text to a right-hand border: Hangul occupies two
+# terminal columns per character but one byte-length unit, so any such padding
+# is wrong for exactly the text this project writes.
+lab_title() {
+  printf '\n%s%s%s\n' "$CYAN" "$LAB_RULE" "$R"
+  printf '%s%s%s\n' "$B" "$1" "$R"
+  [ $# -ge 2 ] && printf '%s%s%s\n' "$DIM" "$2" "$R"
+  printf '%s%s%s\n' "$CYAN" "$LAB_RULE" "$R"
+}
+
+step() {
+  LAB_STEP=$((LAB_STEP + 1))
+  printf '\n%s%s %d. %s%s\n' "$B" "──" "$LAB_STEP" "$1" "$R"
+}
+
+say() { printf '%s\n' "$*" | fold -s -w 76 | sed 's/^/   /'; }
+
+# Quote one argument for display so the printed line is copy-pasteable.
+_q() {
+  case "$1" in
+    '' ) printf "''" ;;
+    *[!a-zA-Z0-9/._=:@-]* ) printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")" ;;
+    * ) printf '%s' "$1" ;;
+  esac
+}
+
+run() {
+  local disp='' a
+  for a in "$@"; do disp="$disp $(_q "$a")"; done
+  printf '\n%s   $%s%s\n' "$GREEN" "$disp" "$R"
+  "$@" 2>&1 | sed 's/^/     /'
+  return "${PIPESTATUS[0]}"
+}
+
+# Same as run, but for a shell pipeline that must be passed as one string.
+runsh() {
+  printf '\n%s   $ %s%s\n' "$GREEN" "$1" "$R"
+  bash -c "$1" 2>&1 | sed 's/^/     /'
+}
+
+note() { printf '\n%s   NOTE  %s%s\n' "$YELLOW" "$*" "$R"; }
+warn() { printf '\n%s   CAUTION  %s%s\n' "$RED" "$*" "$R"; }
+
+done_msg() { printf '\n%s   ✓ %s%s\n\n' "$GREEN" "$1" "$R"; }
+
+# Resolve the repository root from this file's location, so a lab can be run
+# from any directory.
+LAB_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SSH="$LAB_REPO/scripts/ops/ssh.sh"
+
+# Every cluster read goes through this. It exists so no lab ever contains a
+# hostname or an IP address: `ssh.sh` looks the address up from AWS by tag at
+# the moment you run it. When an address changes, nothing here needs editing.
+k() { bash "$SSH" k3s "sudo k3s kubectl $*" 2>&1 | grep -viE '^\[ssh\]'; }
+
+# Display form of the same call, for labs that want to show `kubectl ...`
+# rather than the SSH wrapper that carries it.
+kshow() {
+  printf '\n%s   $ kubectl %s%s\n' "$GREEN" "$*" "$R"
+  k "$@" | sed 's/^/     /'
+}
+
+require_cluster() {
+  if ! bash "$SSH" k3s "sudo k3s kubectl version --output=json >/dev/null" >/dev/null 2>&1; then
+    warn "클러스터에 닿지 않습니다. 먼저 lab01 을 실행해 접속 경로를 확인하세요."
+    exit 1
+  fi
+}

--- a/docs/labs/lab01-server-and-ssh.sh
+++ b/docs/labs/lab01-server-and-ssh.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Lab 01 — 서버 한 대에 들어가 보기
+#
+# 목표: SSH 가 무엇이고, 우리가 왜 `ssh` 를 직접 치지 않고 스크립트를 쓰는지,
+#       그리고 그 서버 위에서 실제로 무엇이 돌고 있는지 눈으로 확인한다.
+#
+# 안전: 전부 읽기 전용. 서버 상태를 바꾸는 명령은 하나도 없다.
+
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+lab_title "Lab 01 — 서버 한 대에 들어가 보기" \
+  "읽기 전용. 약 2분."
+
+step "SSH 란 무엇인가"
+say "내 노트북에서 저 멀리 AWS 에 있는 리눅스 서버의 명령줄을 쓰는 방법이다."
+say "비밀번호 대신 '키 파일' 로 신원을 증명한다. 키는 두 조각이다 —"
+say "공개키는 서버에 미리 넣어 두고, 개인키는 내 노트북에만 있다."
+say ""
+say "우리 개인키 위치:"
+run ls -l "${INSIGHTA_SSH_KEY:-$HOME/.ssh/insighta/prx01-tubearchive.pem}"
+note "권한이 600 이어야 한다. 다른 사용자가 읽을 수 있으면 ssh 가 거부한다."
+
+step "왜 ssh 를 직접 치지 않는가"
+say "서버 주소는 바뀐다. 인스턴스를 재생성하면 IP 가 달라지고, 방화벽은"
+say "내 집 IP 만 허용하는데 통신사가 IP 를 바꾸면 갑자기 접속이 막힌다."
+say ""
+say "그래서 주소를 외우거나 파일에 적어 두지 않는다. scripts/ops/ssh.sh 가"
+say "실행 시점에 AWS 에 '이름표가 insighta-k3s-1 인 서버 주소가 뭐야' 라고"
+say "물어보고, 필요하면 방화벽에 지금 내 IP 를 넣은 뒤 접속한다."
+say ""
+say "이 스크립트가 아는 대상들 — 이름 하나가 서버 하나다:"
+runsh "grep -oE '^ +[a-z0-9|]+\) echo \"insighta' '$SSH' | sed 's/) echo .*//; s/^ */    - /'"
+
+step "실제로 들어가서 확인하기"
+say "지금부터 나오는 출력은 전부 AWS 안의 서버가 대답한 것이다."
+run bash "$SSH" k3s "hostname && uptime"
+
+step "이 서버는 무엇을 돌리고 있나"
+say "리눅스에서 '항상 떠 있어야 하는 프로그램' 은 systemd 라는 관리자가 맡는다."
+say "우리 서버에서 가장 중요한 서비스는 k3s — 쿠버네티스 본체다."
+run bash "$SSH" k3s "systemctl is-active k3s && systemctl show k3s -p ActiveEnterTimestamp --value"
+
+step "자원은 얼마나 쓰고 있나"
+say "t3.medium 은 vCPU 2, 메모리 4GB 다. 여유가 있는지 본다."
+run bash "$SSH" k3s "free -h | head -2 && echo && df -h / | tail -1 && echo && nproc"
+
+step "두 번째 서버도 같은 방식으로"
+say "우리는 서버가 두 대다. 두 번째는 k3s2 라는 이름으로 부른다."
+run bash "$SSH" k3s2 "hostname && free -h | head -2"
+
+note "여기서 배운 것: 서버 주소는 코드에 적지 않는다. 이름으로 부르고,"
+note "주소는 실행 시점에 AWS 에 물어본다. 이것이 이 프로젝트의 기본 규칙이다."
+
+done_msg "Lab 01 완료 — 다음: lab02-containers.sh"

--- a/docs/labs/lab02-containers-and-images.sh
+++ b/docs/labs/lab02-containers-and-images.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Lab 02 — 컨테이너와 이미지
+#
+# 목표: '이미지' 와 '컨테이너' 의 차이, 이미지가 어디에 보관되는지,
+#       그리고 우리 클러스터가 비밀번호 없이 그 보관소에서 이미지를
+#       가져오는 구조를 확인한다.
+#
+# 안전: 전부 읽기 전용.
+
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+require_cluster
+
+lab_title "Lab 02 — 컨테이너와 이미지" "읽기 전용. 약 3분."
+
+step "이미지와 컨테이너는 다른 것이다"
+say "이미지 = 프로그램과 그것이 필요로 하는 모든 파일을 한 덩어리로 굳힌 것."
+say "         레시피가 아니라 '완성된 냉동식품' 에 가깝다. 변하지 않는다."
+say ""
+say "컨테이너 = 그 이미지를 실제로 실행한 것. 같은 이미지로 3개를 띄우면"
+say "           컨테이너는 3개, 이미지는 여전히 1개다."
+say ""
+say "우리 api 는 지금 3개가 떠 있지만 이미지는 하나다:"
+kshow get pods -n insighta-prod -l app.kubernetes.io/component=api \
+  -o custom-columns=POD:.metadata.name,IMAGE:.spec.containers[0].image --no-headers
+
+step "이미지는 어디에 보관되나 — ECR"
+say "이미지를 저장해 두는 창고를 '레지스트리' 라고 한다. 공개 창고가"
+say "Docker Hub 이고, 우리는 AWS 의 비공개 창고인 ECR 을 쓴다."
+say ""
+say "이미지 주소를 뜯어 보면 창고 위치가 그대로 적혀 있다:"
+runsh "bash '$SSH' k3s \"sudo k3s kubectl get deploy insighta-api -n insighta-prod -o jsonpath='{.spec.template.spec.containers[0].image}'\" 2>/dev/null | grep -v '^\[ssh\]' | awk -F/ '{print \"     레지스트리 : \" \$1; print \"     리포지토리 : \" \$2}' | sed 's/^/  /'"
+note "앞부분이 AWS 계정 소유의 ECR 주소, 뒷부분이 리포지토리 이름과 태그다."
+
+step "비밀번호 없이 어떻게 가져오나"
+say "보통은 클러스터에 '풀 시크릿' 이라는 비밀번호를 넣어 둔다. 우리는 넣지"
+say "않았다. 확인해 보자 — 결과가 비어 있어야 정상이다:"
+kshow get secret -n insighta-prod --field-selector type=kubernetes.io/dockerconfigjson
+say ""
+say "대신 서버 자체에 '이 EC2 는 ECR 을 읽어도 된다' 는 권한(인스턴스 프로파일)이"
+say "붙어 있고, kubelet 이 그 권한을 이미지 받을 때마다 임시 토큰으로 바꿔 준다."
+say "그 번역기가 아래 파일이다:"
+run bash "$SSH" k3s "ls -l /var/lib/rancher/credentialprovider/ 2>/dev/null; cat /var/lib/rancher/credentialprovider/config.yaml 2>/dev/null | head -20"
+note "비밀번호가 어디에도 저장되지 않는다는 것이 요점이다. 토큰은 12시간마다"
+note "새로 발급되고, 서버를 폐기하면 권한도 같이 사라진다."
+
+step "지금 서버에 내려받아 둔 이미지 목록"
+say "k3s 는 containerd 라는 실행기를 쓴다. 그 창고를 직접 들여다본다:"
+run bash "$SSH" k3s "sudo k3s ctr images ls -q | grep -v sha256 | grep insighta | head -10"
+
+step "태그 — 우리 구성의 알려진 약점"
+say "태그는 이미지에 붙이는 이름표다. 우리가 지금 쓰는 태그를 확인해 보자:"
+runsh "grep -n 'tag:' '$LAB_REPO/charts/insighta/values.yaml' | sed 's/^/     values.yaml:/'"
+say ""
+say "latest 는 '지금 최신' 이라는 뜻이므로, 어제의 latest 와 오늘의 latest 가"
+say "다른 이미지를 가리킨다. 이름은 같은데 내용물이 바뀐다."
+say ""
+say "그 결과가 아래에 그대로 보인다. 배포 이력은 리비전 2개인데,"
+say "두 리비전이 가리키는 이미지 문자열이 동일하다:"
+kshow -n insighta-prod get rs -l app.kubernetes.io/component=api \
+  -o custom-columns='REPLICASET:.metadata.name,REPLICAS:.spec.replicas,IMAGE:.spec.template.spec.containers[0].image' --no-headers
+warn "따라서 kubectl rollout undo 는 '이전 코드' 로 돌아가지 못한다."
+warn "파드만 새로 만들 뿐, 같은 latest 를 다시 받아온다."
+say ""
+say "여기에 pullPolicy 가 겹친다:"
+kshow -n insighta-prod get deploy insighta-api -o jsonpath='{.spec.template.spec.containers[0].imagePullPolicy}'
+say ""
+say "IfNotPresent 는 '이미 받아 둔 게 있으면 다시 받지 않는다' 는 뜻이다."
+say "서버 두 대가 서로 다른 시점에 latest 를 받아 두었다면, 같은 태그인데"
+say "서로 다른 코드가 도는 상태가 된다."
+say ""
+say "지금 실제로 그런 상태인지 digest(내용물의 지문)로 확인한다:"
+runsh "bash '$SSH' k3s \"sudo k3s kubectl -n insighta-prod get pods -o json\" 2>/dev/null | grep -v '^\[ssh\]' | python3 -c \"
+import json,sys
+d=json.load(sys.stdin); seen={}
+for p in d['items']:
+    for cs in p['status'].get('containerStatuses',[]) or []:
+        seen.setdefault(cs['name'],set()).add(cs.get('imageID','').split('@')[-1][:19])
+for c,g in sorted(seen.items()):
+    print('  %-10s digest %d개  %s' % (c,len(g),'일치' if len(g)==1 else '불일치 — 노드마다 다른 코드'))
+\""
+note "지금은 일치한다. 하지만 그것은 운이 좋은 것이지 구조가 막아 준 것이"
+note "아니다. 올바른 해법은 태그를 커밋 해시나 digest 로 고정하는 것이다."
+note "그러면 리비전마다 이미지 문자열이 달라지고, rollout undo 가 진짜"
+note "이전 코드로 되돌아간다."
+
+done_msg "Lab 02 완료 — 다음: lab03-kubernetes-objects.sh"

--- a/docs/labs/lab03-kubernetes-objects.sh
+++ b/docs/labs/lab03-kubernetes-objects.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Lab 03 — 쿠버네티스의 다섯 가지 물건
+#
+# 목표: 파드 · 디플로이먼트 · 서비스 · 인그레스 · 네임스페이스가
+#       각각 무엇을 담당하는지, 요청 하나가 이들을 어떤 순서로 통과하는지
+#       실제 클러스터에서 확인한다.
+#
+# 안전: 전부 읽기 전용.
+
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+require_cluster
+
+lab_title "Lab 03 — 쿠버네티스의 다섯 가지 물건" "읽기 전용. 약 5분."
+
+step "네임스페이스 — 서랍 칸막이"
+say "한 클러스터 안에 여러 시스템이 산다. 서로 이름이 겹치지 않도록"
+say "칸을 나눈 것이 네임스페이스다. 우리 칸은 네 개다:"
+kshow get ns -o custom-columns=NAME:.metadata.name,AGE:.metadata.creationTimestamp --no-headers
+say ""
+say "  insighta-prod  우리 서비스"
+say "  ingress-nginx  바깥에서 들어오는 요청을 받는 문지기"
+say "  cert-manager   HTTPS 인증서를 자동으로 발급/갱신"
+say "  argocd         깃 저장소와 클러스터를 맞춰 주는 배포기"
+
+step "파드 — 실제로 도는 것"
+say "파드는 컨테이너를 감싼 가장 작은 실행 단위다. 죽으면 되살아나지 않고,"
+say "'새 파드' 가 대신 만들어진다. 그래서 이름 뒤에 임의 문자열이 붙는다."
+kshow get pods -n insighta-prod -o custom-columns='POD:.metadata.name,NODE:.spec.nodeName,READY:.status.containerStatuses[0].ready,RESTARTS:.status.containerStatuses[0].restartCount' --no-headers
+note "NODE 열을 보라. 같은 종류의 파드가 서버 두 대에 나뉘어 있다."
+note "한 대가 죽어도 서비스가 이어지도록 일부러 흩어 놓은 것이다."
+
+step "디플로이먼트 — 몇 개를 유지할지 정하는 규칙"
+say "파드를 직접 만들지 않는다. '이 이미지로 3개 유지해' 라고 선언하면"
+say "쿠버네티스가 알아서 3개를 맞춘다. 하나가 죽으면 즉시 새로 만든다."
+kshow get deploy -n insighta-prod -o custom-columns='DEPLOY:.metadata.name,DESIRED:.spec.replicas,READY:.status.readyReplicas,IMAGE:.spec.template.spec.containers[0].image' --no-headers
+say ""
+say "'흩어 놓기' 규칙도 여기 선언돼 있다 — maxSkew 1 은 '서버 간 개수 차이가"
+say "1 을 넘지 않게' 라는 뜻이다:"
+kshow get deploy insighta-api -n insighta-prod -o jsonpath='{.spec.template.spec.topologySpreadConstraints}'
+
+step "서비스 — 변하는 주소에 고정 이름 붙이기"
+say "파드는 죽고 새로 생기며 IP 가 매번 바뀐다. 그래서 파드를 직접 부르지"
+say "않고, 서비스라는 고정된 이름을 부른다. 서비스가 살아 있는 파드에게"
+say "알아서 나눠 준다."
+kshow get svc -n insighta-prod -o custom-columns='SERVICE:.metadata.name,TYPE:.spec.type,CLUSTER-IP:.spec.clusterIP,PORT:.spec.ports[0].port' --no-headers
+say ""
+say "지금 이 서비스가 실제로 누구에게 보내고 있는지 (엔드포인트):"
+kshow get endpoints insighta-api -n insighta-prod -o jsonpath='{.subsets[*].addresses[*].ip}'
+
+step "인그레스 — 어떤 주소를 어디로 보낼지"
+say "바깥에서 온 요청의 도메인과 경로를 보고 어느 서비스로 넘길지 정한다."
+kshow get ingress -n insighta-prod -o custom-columns='INGRESS:.metadata.name,CLASS:.spec.ingressClassName,HOSTS:.spec.rules[*].host' --no-headers
+say ""
+say "경로별 규칙을 펼쳐 보면:"
+runsh "bash '$SSH' k3s \"sudo k3s kubectl get ingress -n insighta-prod -o json\" 2>/dev/null | grep -v '^\[ssh\]' | python3 -c \"
+import json,sys
+d=json.load(sys.stdin)
+for it in d['items']:
+    print('  '+it['metadata']['name']+'  (class='+str(it['spec'].get('ingressClassName'))+')')
+    for r in it['spec']['rules']:
+        for p in r['http']['paths']:
+            print('     '+r['host']+p['path']+'  ->  '+p['backend']['service']['name']+':'+str(p['backend']['service']['port']['number']))
+\""
+warn "class 가 비어 있는 인그레스는 컨트롤러가 통째로 무시한다. 규칙이"
+warn "존재하는데 동작하지 않는 가장 흔한 원인이다."
+
+step "요청 하나가 지나가는 길"
+say "  브라우저"
+say "    → DNS 가 insighta.one 을 우리 고정 IP 로 알려 준다"
+say "    → 그 IP 가 붙은 서버의 ingress-nginx 파드가 받는다"
+say "    → 인그레스 규칙에서 도메인+경로로 목적지 서비스를 고른다"
+say "    → 서비스가 살아 있는 파드 하나를 골라 넘긴다"
+say "    → 파드 안의 컨테이너가 응답한다"
+say ""
+say "실제로 끝까지 통하는지 확인:"
+runsh "curl -s -o /dev/null -w '     insighta.one     -> HTTP %{http_code}  (%{time_total}s)\n' https://insighta.one/health"
+runsh "curl -s -o /dev/null -w '     www.insighta.one -> HTTP %{http_code}  (%{time_total}s)\n' https://www.insighta.one/health"
+
+done_msg "Lab 03 완료 — 다음: lab04-helm.sh"

--- a/docs/labs/lab04-helm.sh
+++ b/docs/labs/lab04-helm.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Lab 04 — Helm: 같은 설계로 환경을 네 벌 만들기
+#
+# 목표: 차트(템플릿) + 값(환경별 차이) 이 어떻게 합쳐져 실제 YAML 이 되는지
+#       직접 렌더해서 눈으로 본다. 클러스터에는 아무것도 보내지 않는다.
+#
+# 안전: 전부 로컬. helm template 은 렌더만 하고 아무 데도 접속하지 않는다.
+
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+lab_title "Lab 04 — Helm: 같은 설계로 환경을 네 벌 만들기" \
+  "로컬 전용. 클러스터 변경 없음. 약 5분."
+
+CHART="$LAB_REPO/charts/insighta"
+
+if ! command -v helm >/dev/null 2>&1; then
+  warn "helm 이 설치돼 있지 않습니다.  brew install helm  후 다시 실행하세요."
+  exit 1
+fi
+
+step "문제: 환경마다 조금씩 다른 같은 것"
+say "개발·스테이징·검증·운영은 구조가 같다. 다른 것은 몇 가지 숫자와"
+say "이름뿐이다 — 파드를 몇 개 띄울지, 도메인이 무엇인지, DB 를 클러스터"
+say "안에 둘지 밖에 둘지."
+say ""
+say "이걸 YAML 네 벌로 복사해 두면 한 곳만 고치고 세 곳을 잊게 된다."
+say "Helm 은 '틀 한 벌 + 환경별 값 네 벌' 로 이 문제를 없앤다."
+
+step "틀 — templates/"
+runsh "ls -1 '$CHART/templates' | sed 's/^/     /'"
+say ""
+say "값 — environments/"
+runsh "ls -1 '$CHART/environments' | sed 's/^/     /'"
+
+step "환경별로 무엇이 다른가"
+say "운영 환경의 값 파일을 열어 보자. 이 파일이 곧 '운영은 이렇게 다르다'"
+say "라는 선언이다:"
+runsh "grep -vE '^\s*#|^\s*$' '$CHART/environments/prod.yaml' | head -40 | sed 's/^/     /'"
+
+step "먼저: 운영 렌더는 일부러 거부된다"
+say "운영 값으로 그냥 렌더하면 실패한다. 실패가 정상이다 — 왜 그런지 읽어 보자:"
+runsh "helm template insighta '$CHART' -f '$CHART/environments/prod.yaml' 2>&1 | head -4 | fold -s -w 70 | sed 's/^/     /'"
+say ""
+say "이 리포지토리는 공개돼 있다. 이미지 창고 주소에는 AWS 계정 번호가"
+say "들어 있으므로 파일에 적어 둘 수 없다. 그래서 차트는 '주소를 넣지"
+say "않았으면 아예 만들지 않겠다' 고 거부한다."
+note "값이 비면 조용히 빈 문자열로 렌더되는 것이 기본 동작이다. 그러면"
+note "이미지 주소가 없는 배포가 나가서 운영이 멈춘다. 이 거부는 그것을"
+note "막기 위해 일부러 넣은 것이다."
+say ""
+say "렌더만 해 볼 때는 아무 값이나 넣으면 된다. CI 도 같은 방법을 쓴다:"
+say "  --set imageRegistry=registry.invalid"
+
+REG="--set imageRegistry=registry.invalid"
+
+step "렌더 — 틀과 값이 합쳐지면"
+say "helm template 은 결과 YAML 을 만들어 화면에 보여 줄 뿐, 클러스터에"
+say "보내지 않는다. 배포 전에 '무엇이 나갈지' 확인하는 가장 안전한 방법이다."
+say ""
+say "운영 환경으로 렌더했을 때 만들어지는 물건들:"
+runsh "helm template insighta '$CHART' -f '$CHART/environments/prod.yaml' $REG | grep -E '^kind:|^  name:' | paste - - | sed 's/kind: //; s/name: //' | sort -u | sed 's/^/     /'"
+
+step "같은 틀, 다른 값 — 개발 환경과 비교"
+say "개발 환경에는 운영에 없는 것이 있다. 무엇인지 차이만 뽑아 본다:"
+runsh "
+prod=\$(helm template insighta '$CHART' -f '$CHART/environments/prod.yaml' $REG | grep -E '^  name:' | sort -u)
+dev=\$(helm template insighta '$CHART' -f '$CHART/environments/dev.yaml' | grep -E '^  name:' | sort -u)
+echo '     개발에만 있는 것:'
+comm -13 <(echo \"\$prod\") <(echo \"\$dev\") | sed 's/  name: /       + /'
+echo '     운영에만 있는 것:'
+comm -23 <(echo \"\$prod\") <(echo \"\$dev\") | sed 's/  name: /       + /'
+"
+say ""
+say "이 세 줄이 어디서 나왔는지 값 파일에서 확인하자:"
+runsh "
+echo '     dev.yaml   api.persistence.enabled = '\$(awk '/^api:/{a=1} a&&/persistence:/{p=1} p&&/enabled:/{print \$2; exit}' '$CHART/environments/dev.yaml')
+echo '     prod.yaml  api.persistence.enabled = '\$(awk '/^api:/{a=1} a&&/persistence:/{p=1} p&&/enabled:/{print \$2; exit}' '$CHART/environments/prod.yaml')
+echo '     prod.yaml  ingress.apiRateLimit     = '\$(grep -A2 'apiRateLimit:' '$CHART/environments/prod.yaml' | grep rps | tr -d ' ')
+"
+note "값 한 줄이 물건 하나를 만들고 없앤다. dev 의 persistence.enabled=true 가"
+note "디스크 두 개를 만들었고, prod 의 apiRateLimit 가 인그레스를 하나 더"
+note "만들었다. 템플릿은 양쪽 모두 같은 파일이다."
+
+step "레플리카 수 비교"
+say "같은 디플로이먼트 템플릿이 환경마다 다른 개수를 만든다:"
+runsh "
+for env in dev staging prod; do
+  reg=''
+  grep -q '^requireImageRegistry: true' '$CHART/environments/'\$env'.yaml' && reg='--set imageRegistry=registry.invalid'
+  n=\$(helm template insighta '$CHART' -f '$CHART/environments/'\$env'.yaml' \$reg 2>&1 | awk '/^kind: Deployment/{d=1} d&&/^  name: insighta-api\$/{f=1} f&&/replicas:/{print \$2; exit}')
+  printf '     %-9s api replicas = %s\n' \"\$env\" \"\${n:-렌더실패}\"
+done
+"
+
+step "렌더가 깨지면 배포도 깨진다 — CI 가 먼저 잡는다"
+say "값 이름을 잘못 쓰거나 템플릿 문법을 틀리면 렌더 자체가 실패한다."
+say "그것을 사람이 아니라 CI 가 잡도록 검사를 붙여 두었다:"
+runsh "grep -E '^\s*(#|echo \"|check_)' '$LAB_REPO/scripts/ci/check-charts.sh' | grep -iE 'check|verify|ensure' | head -12 | sed 's/^/     /'"
+say ""
+say "직접 돌려 보자. 네 환경을 모두 렌더하고 규칙을 검사한다:"
+runsh "bash '$LAB_REPO/scripts/ci/check-charts.sh' 2>&1 | tail -20 | sed 's/^/     /'"
+
+done_msg "Lab 04 완료 — 다음: lab05-terraform.sh"

--- a/docs/labs/lab05-terraform.sh
+++ b/docs/labs/lab05-terraform.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Lab 05 — Terraform: 서버를 손이 아니라 코드로 만든다
+#
+# 목표: '지금 AWS 에 있는 것' 과 '코드가 있어야 한다고 말하는 것' 을
+#       terraform 이 어떻게 비교하는지 본다.
+#
+# 안전: plan 까지만. apply 는 이 스크립트에 없다.
+#       plan 은 아무것도 바꾸지 않는다 — 차이만 계산해서 보여 준다.
+
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+lab_title "Lab 05 — Terraform: 서버를 코드로 만든다" \
+  "plan 전용. 인프라 변경 없음. 약 6분."
+
+TF="$LAB_REPO/terraform/projects/insighta/environments/prod"
+
+if ! command -v terraform >/dev/null 2>&1; then
+  warn "terraform 이 없습니다.  brew install terraform  후 다시 실행하세요."
+  exit 1
+fi
+
+step "왜 콘솔에서 클릭하지 않는가"
+say "AWS 웹 콘솔에서 서버를 만들면 3분이면 된다. 문제는 그 다음이다 —"
+say "여섯 달 뒤에 '이 서버가 왜 이 설정이지?' 를 아무도 답할 수 없고,"
+say "똑같은 것을 하나 더 만들라고 하면 기억에 의존해야 한다."
+say ""
+say "Terraform 은 '있어야 할 상태' 를 파일로 적어 둔다. 그 파일이 곧"
+say "설명이자 복제 수단이자 변경 이력이다."
+
+step "우리 코드의 구조"
+say "modules/ 는 재사용 부품, projects/ 는 그 부품을 조립한 실제 환경이다."
+runsh "ls -1 '$LAB_REPO/terraform/modules' | sed 's/^/     modules\/     /'"
+runsh "ls -1 '$LAB_REPO/terraform/projects/insighta/environments' | sed 's/^/     environments\/ /'"
+
+step "부품 하나 열어 보기 — k3s 노드"
+say "서버 한 대를 만드는 데 필요한 것이 전부 이 안에 있다."
+say "무엇을 입력받는지(변수)부터 본다:"
+runsh "grep -E '^variable' '$LAB_REPO/terraform/modules/k3s-node/variables.tf' | sed 's/variable \"/     - /; s/\" {//'"
+say ""
+say "그리고 무엇을 만드는지(리소스):"
+runsh "grep -E '^resource' '$LAB_REPO/terraform/modules/k3s-node/main.tf' | sed 's/resource \"/     - /; s/\" \"/  ->  /; s/\" {//'"
+note "node_count 라는 변수가 보인다. 이 숫자 하나가 서버 대수를 정한다."
+note "지금은 2, 검증 기간이 끝나면 1 로 줄인다. 코드는 그대로다."
+
+step "지금 상태 확인 — init"
+say "terraform 은 '지금 AWS 가 이렇더라' 를 상태 파일에 적어 둔다."
+say "그 파일은 S3 에 있고, init 은 거기에 연결하는 단계다."
+run terraform -chdir="$TF" init -input=false -no-color
+
+step "차이 계산 — plan"
+say "plan 은 세 가지를 비교한다: 코드 · 상태파일 · 실제 AWS."
+say "그리고 '무엇을 바꿔야 셋이 같아지는가' 를 출력한다. 바꾸지는 않는다."
+say ""
+say "No changes 가 나오면 코드와 현실이 일치한다는 뜻이다:"
+run terraform -chdir="$TF" plan -input=false -no-color -lock=false
+warn "만약 변경 항목이 나온다면 그것은 '코드에 없는 손질' 이 AWS 에"
+warn "가해졌다는 신호다. 콘솔에서 손으로 바꾼 것이 대표적이다."
+
+step "무엇이 관리되고 있나"
+say "상태 파일에 등록된 것들 — 이 목록에 없는 것은 terraform 이 모른다:"
+runsh "terraform -chdir='$TF' state list 2>/dev/null | sed 's/^/     /'"
+
+step "apply 는 왜 여기 없는가"
+say "plan 은 읽기다. apply 는 쓰기이고, 서버를 지우고 다시 만들 수도 있다."
+say "이 실습에서는 다루지 않는다. 실제로 인프라를 바꿀 때의 순서는:"
+say ""
+say "  1. 코드를 고친다"
+say "  2. plan 을 돌려 출력 전체를 읽는다"
+say "  3. destroy / replace 가 있으면 멈추고 왜인지 먼저 이해한다"
+say "  4. 되돌릴 방법을 정한 뒤에 apply 한다"
+warn "3번을 건너뛰면 running 중인 서버가 사라진다. plan 출력에서"
+warn "  '# ... must be replaced'  라는 줄을 항상 찾아본다."
+
+done_msg "Lab 05 완료 — 다음: lab06-ansible.sh"

--- a/docs/labs/lab06-ansible.sh
+++ b/docs/labs/lab06-ansible.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Lab 06 — Ansible: 서버 '안' 을 코드로 맞춘다
+#
+# 목표: terraform 이 서버를 만든 뒤, 그 안의 설정을 누가 맞추는지 본다.
+#       --check 모드로 '무엇이 달라질지' 만 확인한다.
+#
+# 안전: --check --diff 만 사용. 서버를 바꾸지 않는다.
+
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+
+lab_title "Lab 06 — Ansible: 서버 안을 코드로 맞춘다" \
+  "--check 전용. 서버 변경 없음. 약 4분."
+
+ANS="$LAB_REPO/ansible"
+
+step "terraform 과 무엇이 다른가"
+say "  terraform  서버라는 '상자' 를 만든다 — 몇 대, 어떤 크기, 어떤 네트워크"
+say "  ansible    그 상자 '안' 을 맞춘다 — 패키지 설치, 설정 파일, 서비스 기동"
+say ""
+say "둘은 경쟁 도구가 아니라 순서다. 상자가 있어야 안을 채운다."
+
+step "우리 ansible 의 구조"
+say "역할(role) 하나가 '무엇을 어떻게 설정하는가' 한 묶음이다."
+runsh "find '$ANS' -maxdepth 2 -type d -not -name '.*' | sed \"s|$ANS|     ansible|\""
+
+step "nginx 역할이 하는 일"
+say "작업 목록을 보면 사람이 손으로 할 일이 그대로 적혀 있다:"
+runsh "grep -E '^- name:|^  - name:' '$ANS/roles/nginx/tasks/main.yml' 2>/dev/null | sed 's/.*name: /     - /'"
+
+step "설정 파일은 템플릿이다"
+say "고정된 파일이 아니라 변수를 끼워 넣는 틀이다. 그래서 서버가 여러 대여도"
+say "같은 템플릿을 쓴다. 틀 안의 변수 자리를 찾아보자:"
+runsh "grep -oE '\{\{ *[a-z_]+ *\}\}' '$ANS/roles/nginx/templates/insighta.conf.j2' 2>/dev/null | sort -u | sed 's/^/     /' | head -12"
+
+step "누구에게 적용하나 — 인벤토리"
+say "인벤토리는 '어떤 서버가 어떤 그룹에 속하는가' 의 목록이다."
+runsh "find '$ANS/inventory' -type f | sed \"s|$ANS|     ansible|\""
+
+if ! command -v ansible-playbook >/dev/null 2>&1; then
+  note "ansible 이 설치돼 있지 않아 실제 실행은 건너뜁니다."
+  note "설치:  brew install ansible"
+  done_msg "Lab 06 완료(부분) — 다음: lab07-argocd.sh"
+  exit 0
+fi
+
+step "무엇이 달라질지만 본다 — --check --diff"
+say "--check 는 '적용한 셈 치고' 돌린다. 바꾸지 않고 차이만 보고한다."
+say "--diff 는 파일 내용이 어떻게 달라지는지 줄 단위로 보여 준다."
+runsh "ls '$ANS/playbooks/' 2>/dev/null | sed 's/^/     playbook: /'"
+note "실제 실행 명령 형태:"
+note "  ansible-playbook -i ansible/inventory <playbook>.yml --check --diff"
+warn "--check 없이 돌리면 즉시 서버가 바뀐다. 처음에는 항상 --check 부터."
+
+step "changed 가 0 이어야 정상"
+say "ansible 은 '이미 그 상태면 아무것도 하지 않는다'(멱등). 그래서 두 번"
+say "돌려도 결과가 같다. --check 에서 changed 가 나오면 둘 중 하나다:"
+say ""
+say "  · 코드를 고쳤는데 아직 서버에 반영하지 않았다  (정상)"
+say "  · 누가 서버에서 손으로 고쳤다                  (조사 대상)"
+
+done_msg "Lab 06 완료 — 다음: lab07-argocd.sh"

--- a/docs/labs/lab07-argocd-gitops.sh
+++ b/docs/labs/lab07-argocd-gitops.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Lab 07 — ArgoCD: 깃에 적힌 것이 곧 클러스터의 상태
+#
+# 목표: 사람이 kubectl apply 를 치는 대신, 깃 저장소를 계속 읽어서
+#       클러스터를 그에 맞추는 방식(GitOps)이 무엇인지 확인한다.
+#
+# 안전: 전부 읽기 전용. sync 를 유발하지 않는다.
+
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+require_cluster
+
+lab_title "Lab 07 — ArgoCD: 깃이 곧 클러스터의 상태" "읽기 전용. 약 4분."
+
+step "손으로 배포할 때의 문제"
+say "kubectl apply 로 배포하면 '지금 클러스터에 무엇이 떠 있는가' 를"
+say "아무도 정확히 모른다. 누가 언제 무엇을 apply 했는지 기록이 없고,"
+say "깃의 내용과 실제가 어긋나도 알 방법이 없다."
+say ""
+say "ArgoCD 는 반대로 한다 — 깃을 계속 읽고, 클러스터가 깃과 다르면"
+say "'어긋났다(OutOfSync)' 고 알리거나 자동으로 맞춘다."
+
+step "무엇을 지켜보고 있나"
+kshow get applications -n argocd -o custom-columns='APP:.metadata.name,SYNC:.status.sync.status,HEALTH:.status.health.status,REVISION:.status.sync.revision' --no-headers
+
+step "어느 저장소의 어느 경로를 보고 있나"
+runsh "bash '$SSH' k3s \"sudo k3s kubectl get applications -n argocd -o json\" 2>/dev/null | grep -v '^\[ssh\]' | python3 -c \"
+import json,sys
+d=json.load(sys.stdin)
+for a in d['items']:
+    s=a['spec']['source']
+    print('  '+a['metadata']['name'])
+    print('     repo     '+s.get('repoURL',''))
+    print('     path     '+s.get('path',''))
+    print('     revision '+s.get('targetRevision',''))
+    dst=a['spec']['destination']
+    print('     -> ns    '+dst.get('namespace',''))
+\""
+note "targetRevision 이 브랜치 이름이면 그 브랜치에 머지되는 순간 배포된다."
+note "고정된 태그면 사람이 값을 올려야 배포된다. 어느 쪽인지가 곧"
+note "'자동 배포인가 수동 배포인가' 의 답이다."
+
+step "Synced 와 Healthy 는 다른 말이다"
+say "  Synced   = 깃에 적힌 것과 클러스터의 선언이 같다"
+say "  Healthy  = 그 선언대로 실제로 잘 돌고 있다"
+say ""
+say "Synced 이면서 Degraded 일 수 있다 — 깃대로 배포했는데 그 코드가"
+say "죽는 경우다. 반대로 OutOfSync 이면서 Healthy 일 수도 있다."
+kshow get applications -n argocd -o custom-columns='APP:.metadata.name,SYNC:.status.sync.status,HEALTH:.status.health.status' --no-headers
+
+step "자동으로 맞출 것인가, 알리기만 할 것인가"
+runsh "bash '$SSH' k3s \"sudo k3s kubectl get applications -n argocd -o json\" 2>/dev/null | grep -v '^\[ssh\]' | python3 -c \"
+import json,sys
+d=json.load(sys.stdin)
+for a in d['items']:
+    sp=a['spec'].get('syncPolicy') or {}
+    auto=sp.get('automated')
+    print('  %-22s %s' % (a['metadata']['name'], 'automated: '+json.dumps(auto) if auto else 'manual (사람이 Sync 를 눌러야 함)'))
+\""
+
+step "화면으로 보기"
+say "ArgoCD 에는 웹 화면이 있다. 인터넷에 열어 두지 않았으므로 SSH 두 번을"
+say "거쳐서 들어간다. 이 스크립트가 그것을 대신한다:"
+say ""
+say "     bash scripts/ops/argocd-ui.sh              화면 열기"
+say "     bash scripts/ops/argocd-ui.sh --password   비밀번호만 출력"
+say "     bash scripts/ops/argocd-ui.sh --stop       터널 닫기"
+warn "ArgoCD 는 클러스터 전체 권한을 가진다. 공개 주소를 붙이면 비밀번호"
+warn "하나가 뚫리는 순간 클러스터 전체가 넘어간다. 그래서 SSH 안에 둔다."
+
+step "현재 배포된 리비전 = 깃의 어느 지점인가"
+runsh "bash '$SSH' k3s \"sudo k3s kubectl get applications -n argocd -o jsonpath='{range .items[*]}{.metadata.name}{\\\" \\\"}{.status.sync.revision}{\\\"\\\\n\\\"}{end}'\" 2>/dev/null | grep -v '^\[ssh\]' | sed 's/^/     /'"
+note "이 해시를 git log 에서 찾으면 '지금 운영에 뭐가 떠 있는가' 가"
+note "정확히 한 커밋으로 특정된다. 이것이 GitOps 의 핵심 이득이다."
+
+done_msg "Lab 07 완료 — 다음: lab08-deploy-and-rollback.sh"

--- a/docs/labs/lab08-deploy-and-rollback.sh
+++ b/docs/labs/lab08-deploy-and-rollback.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Lab 08 — 배포와 롤백
+#
+# 목표: 코드 한 줄이 운영까지 가는 경로 전체를 따라가 보고,
+#       되돌리는 방법이 몇 층으로 준비돼 있는지 각각의 한계까지 확인한다.
+#
+# 안전: 전부 읽기 전용. 실제 배포도 롤백도 하지 않는다.
+
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+require_cluster
+
+lab_title "Lab 08 — 배포와 롤백" "읽기 전용. 약 5분."
+
+step "코드가 운영까지 가는 길"
+say "  1. 브랜치에서 코드를 고치고 PR 을 연다"
+say "  2. CI 가 검사한다 — 타입 · 테스트 · 차트 렌더"
+say "  3. main 에 머지된다"
+say "  4. 워크플로가 이미지를 만들어 ECR 에 올린다"
+say "  5. 클러스터가 그 이미지로 파드를 교체한다"
+say ""
+say "실제 워크플로 목록:"
+runsh "ls -1 '$LAB_REPO/.github/workflows/' | sed 's/^/     /'"
+
+step "무엇이 배포를 유발하나"
+say "'머지하면 배포된다' 를 추측하지 말고 트리거 선언을 직접 읽는다:"
+runsh "
+for f in '$LAB_REPO'/.github/workflows/deploy*.yml; do
+  [ -f \"\$f\" ] || continue
+  echo \"     \$(basename \$f)\"
+  awk '/^on:/{o=1;next} o&&/^[a-z]/{exit} o' \"\$f\" | sed 's/^/       /'
+done
+"
+
+step "지금 운영에 떠 있는 것"
+kshow get deploy -n insighta-prod -o custom-columns='DEPLOY:.metadata.name,READY:.status.readyReplicas,UPDATED:.status.updatedReplicas,IMAGE:.spec.template.spec.containers[0].image' --no-headers
+
+step "교체는 한 번에 일어나지 않는다"
+say "파드를 전부 죽이고 새로 만들면 그 사이 서비스가 끊긴다. 그래서"
+say "몇 개씩 바꾼다. 그 규칙이 아래에 있다:"
+kshow get deploy insighta-api -n insighta-prod -o jsonpath='{.spec.strategy}'
+say ""
+say "maxUnavailable = 교체 중 없어도 되는 최대 개수"
+say "maxSurge       = 교체 중 잠깐 더 띄워도 되는 최대 개수"
+
+step "새 파드가 준비됐는지 무엇으로 판단하나"
+say "컨테이너가 떴다고 요청을 받을 준비가 된 것은 아니다. readinessProbe 가"
+say "통과해야 서비스가 트래픽을 보낸다. 이것이 무중단 배포의 핵심이다:"
+kshow get deploy insighta-api -n insighta-prod -o jsonpath='{.spec.template.spec.containers[0].readinessProbe}'
+
+step "되돌리는 방법 — 1층: 쿠버네티스 리비전"
+kshow -n insighta-prod rollout history deploy/insighta-api
+say ""
+say "명령은  kubectl rollout undo deploy/insighta-api  이다."
+say "다만 우리 구성에서는 이것만으로 코드가 돌아가지 않는다. 확인:"
+kshow -n insighta-prod get rs -l app.kubernetes.io/component=api \
+  -o custom-columns='REPLICASET:.metadata.name,IMAGE:.spec.template.spec.containers[0].image' --no-headers
+warn "두 리비전이 같은 이미지 문자열(:latest)을 가리킨다. undo 는 파드를"
+warn "새로 만들 뿐 이전 코드로 돌아가지 않는다. Lab 02 에서 본 그 문제다."
+
+step "되돌리는 방법 — 2층: 깃 되돌리기"
+say "코드를 되돌리는 커밋을 만들어 머지하면 파이프라인이 다시 돌아 이전"
+say "상태의 이미지를 만든다. 느리지만 확실하고, 이력이 남는다."
+say ""
+say "     git revert <bad-commit>  →  PR  →  머지  →  자동 배포"
+note "지금 구성에서 실제로 코드를 되돌리는 유일하게 신뢰할 수 있는 경로다."
+
+step "되돌리는 방법 — 3층: 진입점 되돌리기"
+say "배포가 아니라 인프라 자체가 문제일 때 쓴다. 고정 IP(EIP)를 예전"
+say "서버에 다시 붙이면 트래픽이 통째로 그쪽으로 간다. 약 2초 걸린다."
+say ""
+say "지금 고정 IP 가 어디에 붙어 있는지:"
+runsh "terraform -chdir='$LAB_REPO/terraform/projects/insighta/environments/prod' state list 2>/dev/null | grep -i eip | sed 's/^/     /'"
+warn "이 방법은 예전 서버가 살아 있을 때만 쓸 수 있다. 지금은 EC2 #1 이"
+warn "대기 상태로 남아 있어서 가능하지만, 철거하면 이 층은 사라진다."
+
+step "배포 전에 스스로 물어볼 것"
+say "  · 되돌릴 좌표가 있는가            — 어느 커밋/이미지로 돌아가나"
+say "  · 되돌리는 데 몇 분 걸리는가      — 측정한 값인가 추측인가"
+say "  · 데이터도 되돌아가는가           — DB 변경은 대개 되돌아가지 않는다"
+say "  · 무엇을 보고 실패를 알아채나     — 어떤 지표, 몇 분 안에"
+
+done_msg "Lab 08 완료 — 다음: lab09-incident-drill.sh"

--- a/docs/labs/lab09-incident-drill.sh
+++ b/docs/labs/lab09-incident-drill.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Lab 09 — 장애가 났을 때 어디를 먼저 보나
+#
+# 목표: 증상에서 원인으로 가는 순서를 손에 익힌다. 실제 이 클러스터에서
+#       겪은 사고들을 소재로, 그때 무엇을 봤어야 했는지 따라간다.
+#
+# 안전: 전부 읽기 전용 진단 명령.
+
+source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
+require_cluster
+
+lab_title "Lab 09 — 장애가 났을 때 어디를 먼저 보나" "읽기 전용. 약 6분."
+
+step "원칙: 증상에서 시작해 한 층씩 내려간다"
+say "  바깥 → 안 순서로 좁힌다."
+say ""
+say "  1. 밖에서 접속되나        curl"
+say "  2. 문지기가 받았나        ingress 로그"
+say "  3. 규칙이 있나            ingress 객체"
+say "  4. 서비스가 파드를 아나   endpoints"
+say "  5. 파드가 살아 있나       get pods / describe"
+say "  6. 앱이 뭐라고 하나       파드 로그"
+say ""
+warn "이 순서를 건너뛰고 '캐시겠지' '환경 차이겠지' 로 추측하면 반드시"
+warn "엉뚱한 곳을 고치게 된다. 매 단계는 확인이지 짐작이 아니다."
+
+step "1층 — 밖에서 접속되나"
+runsh "
+for u in https://insighta.one/health https://www.insighta.one/health https://insighta.one/; do
+  curl -s -o /dev/null -w \"     %{http_code}  %{time_total}s  \$u\n\" --max-time 15 \$u
+done
+"
+
+step "2층 — 문지기가 실제로 받았나"
+say "ingress 컨트롤러의 로그에 방금 그 요청이 남아 있어야 한다."
+say "host= 필드가 있어서 어느 도메인으로 들어왔는지 구분된다:"
+runsh "bash '$SSH' k3s \"sudo k3s kubectl -n ingress-nginx logs deploy/ingress-nginx-controller --tail=6 --since=3m\" 2>/dev/null | grep -v '^\[ssh\]' | sed 's/^/     /' | cut -c1-150"
+note "로그가 비어 있다면 요청이 아예 도착하지 않은 것이다 — DNS 나"
+note "고정 IP 연결을 의심한다. 로그는 있는데 5xx 면 안쪽 문제다."
+
+step "3층 — 규칙이 존재하고, 유효한가"
+say "인그레스가 있어도 class 가 없으면 컨트롤러가 통째로 무시한다."
+say "그런 경우 규칙은 보이는데 동작하지 않는다:"
+kshow get ingress -A -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,CLASS:.spec.ingressClassName,HOSTS:.spec.rules[*].host' --no-headers
+say ""
+say "컨트롤러가 무시한 것이 있는지 직접 확인:"
+runsh "bash '$SSH' k3s \"sudo k3s kubectl -n ingress-nginx logs deploy/ingress-nginx-controller --tail=400\" 2>/dev/null | grep -iE 'ignoring ingress|does not contain a valid IngressClass' | tail -5 | sed 's/^/     /' || echo '     (무시된 인그레스 없음)'"
+
+step "4층 — 서비스가 살아 있는 파드를 알고 있나"
+say "엔드포인트가 비어 있으면 서비스는 보낼 곳이 없다. 503 의 흔한 원인이다."
+runsh "bash '$SSH' k3s \"sudo k3s kubectl -n insighta-prod get endpoints -o custom-columns=SVC:.metadata.name,ADDRS:.subsets[*].addresses[*].ip --no-headers\" 2>/dev/null | grep -v '^\[ssh\]' | sed 's/^/     /'"
+
+step "5층 — 파드 상태와 최근 사건"
+kshow get pods -n insighta-prod -o custom-columns='POD:.metadata.name,PHASE:.status.phase,READY:.status.containerStatuses[0].ready,RESTARTS:.status.containerStatuses[0].restartCount,AGE:.metadata.creationTimestamp' --no-headers
+say ""
+say "재시작이 쌓이고 있으면 이유가 이벤트에 남는다:"
+runsh "bash '$SSH' k3s \"sudo k3s kubectl -n insighta-prod get events --sort-by=.lastTimestamp\" 2>/dev/null | grep -v '^\[ssh\]' | tail -8 | cut -c1-140 | sed 's/^/     /'"
+
+step "6층 — 앱이 뭐라고 하나"
+say "여기까지 와서야 애플리케이션 로그를 본다. 먼저 보면 대개 길을 잃는다."
+runsh "bash '$SSH' k3s \"sudo k3s kubectl -n insighta-prod logs deploy/insighta-api --tail=8 --since=10m\" 2>/dev/null | grep -v '^\[ssh\]' | cut -c1-150 | sed 's/^/     /'"
+
+step "노드 자체는 괜찮은가"
+say "메모리가 부족하면 쿠버네티스가 파드를 죽인다. 그러면 앱 로그에는"
+say "아무 잘못도 안 나온다 — 원인이 앱 밖에 있기 때문이다."
+kshow top nodes
+runsh "bash '$SSH' k3s \"sudo k3s kubectl get nodes -o custom-columns='NODE:.metadata.name,MEMPRESSURE:.status.conditions[?(@.type==\\\"MemoryPressure\\\")].status,DISKPRESSURE:.status.conditions[?(@.type==\\\"DiskPressure\\\")].status,READY:.status.conditions[?(@.type==\\\"Ready\\\")].status' --no-headers\" 2>/dev/null | grep -v '^\[ssh\]' | sed 's/^/     /'"
+
+step "인증서 만료 — 조용히 다가오는 장애"
+say "HTTPS 인증서는 90일마다 갱신된다. 자동 갱신이 멈춰 있으면 아무 경고"
+say "없이 어느 날 전부 접속 불가가 된다."
+kshow get certificate -A -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,READY:.status.conditions[0].status,EXPIRY:.status.notAfter' --no-headers
+
+step "이 클러스터에서 실제로 겪은 것들"
+say "  · 504 — 요청이 60초에 잘렸다. 작업 자체는 140~181초 걸린다."
+say "         ingress 기본 타임아웃이 60초, 예전 서버는 180초였다."
+say "  · www 접속 불가 — 인그레스에 호스트가 하나만 있었다."
+say "  · 보안 헤더 5개 → 1개 — 예전 nginx 가 서버 단위로 넣던 것이"
+say "         컨트롤러로 옮기면서 빠졌다."
+say "  · rate limit 소실 — 예전에는 /api 에만 걸려 있었다."
+say "  · 인그레스가 무시됨 — class 를 선언하지 않아서."
+note "공통점: 전부 '옮기면서 빠진 것' 이지 '새로 생긴 버그' 가 아니다."
+note "인프라를 옮길 때는 기능 목록이 아니라 설정 항목을 대조해야 한다."
+
+done_msg "Lab 09 완료 — 전체 과정 끝. 가이드 문서로 돌아가세요."

--- a/docs/ops/datastore-sqlite-to-etcd.md
+++ b/docs/ops/datastore-sqlite-to-etcd.md
@@ -1,0 +1,305 @@
+# k3s 데이터스토어 전환: SQLite → 내장 etcd
+
+작성 2026-08-19 · 상태 **계획(미실행)** · 대상 `insighta-k3s-1`, `insighta-k3s-2`
+
+이 문서는 왜 바꾸는지, 어떻게 바꾸는지, 바꾼 뒤 형상이 어떻게 되는지를 기록한다.
+절차는 아직 실행하지 않았다. 실행 시 각 단계의 실제 출력을 §6 에 append 한다.
+
+---
+
+## 1. 왜 바꾸는가
+
+### 1-1. 현재 상태 (2026-08-19 실측)
+
+```
+$ sudo ls -la /var/lib/rancher/k3s/server/db/
+-rw-r--r-- 1 root root 11472896 Aug 19 00:03 state.db
+-rw-r--r-- 1 root root    32768 Aug 19 00:04 state.db-shm
+-rw-r--r-- 1 root root  8689112 Aug 19 00:04 state.db-wal
+
+$ sudo systemctl cat k3s | grep -A6 ExecStart
+ExecStart=/usr/local/bin/k3s \
+    server \
+	'--disable' 'traefik' \
+	'--disable' 'servicelb' \
+	'--write-kubeconfig-mode' '644'
+
+$ sudo systemctl cat k3s | grep -cE 'cluster-init|datastore-endpoint'
+0
+```
+
+`state.db` 가 존재하고 `--cluster-init` · `--datastore-endpoint` 가 모두 없다.
+**SQLite 단일 서버 모드**로 확정된다.
+
+### 1-2. 이 상태에서 불가능한 것
+
+k3s 바이너리가 지원하는 데이터스토어 옵션을 직접 확인하면 다음과 같다.
+
+```
+$ k3s server --help | grep -E 'cluster-init|datastore-endpoint'
+--cluster-init              (cluster) Initialize a new cluster using embedded Etcd
+--datastore-endpoint value  (db) Specify etcd, NATS, MySQL, Postgres, or SQLite
+```
+
+서버 노드를 2대 이상 두려면 둘 중 하나가 필요하다. SQLite 는 다중 서버를 지원하지
+않는다. 따라서 현재 구성에서는 **제어평면 이중화가 원천적으로 불가능**하다.
+
+### 1-3. 인스턴스 크기를 올리면 해결되는가
+
+해결되지 않는다. 인스턴스를 t3.small 에서 t3.medium 으로 올리는 것은 수직 확장이며
+처리 용량만 늘어난다. 기계는 여전히 한 대이고, 그 한 대가 정지하면 서비스도 정지한다.
+가용성과 용량은 다른 축이다.
+
+### 1-4. 현재 단일 장애점
+
+| 구성요소 | 위치 | 정지 시 영향 |
+|---|---|---|
+| k3s 서버 (제어평면) | 노드1 | 배포·스케줄링 중단 |
+| SQLite 데이터스토어 | 노드1 | 클러스터 상태 소실 위험 |
+| ingress-nginx | 노드1 | **외부 요청 전부 실패** |
+| Elastic IP | 노드1 | 진입 경로 소멸 |
+| cert-manager | 노드1 | 인증서 갱신 중단 (90일 내 전면 장애) |
+
+노드2 가 정상이어도 노드1 이 정지하면 서비스가 중단된다.
+
+---
+
+## 2. 목표 형상
+
+```
+                        Elastic IP
+                             │
+              ┌──────────────┼──────────────┐
+              │              │              │
+         ┌────▼────┐    ┌────▼────┐    ┌────▼────┐
+         │ 서버 1  │    │ 서버 2  │    │ 서버 3  │
+         │ etcd    │◄──►│ etcd    │◄──►│ etcd    │
+         │ ingress │    │ ingress │    │ ingress │
+         └─────────┘    └─────────┘    └─────────┘
+              쿼럼 2/3 — 1대 정지를 견딘다
+```
+
+### 2-1. 왜 3대인가 (2대가 아니라)
+
+etcd 는 쓰기를 과반 합의로 결정한다.
+
+| 서버 수 | 쿼럼 | 견딜 수 있는 정지 | 판정 |
+|---:|---:|---:|---|
+| 1 | 1 | 0대 | 현재 상태 |
+| **2** | **2** | **0대** | **1대보다 나쁨** |
+| 3 | 2 | 1대 | 최소 HA |
+| 5 | 3 | 2대 | 과잉 |
+
+2대 구성은 둘 중 어느 하나만 정지해도 쿼럼(2)을 잃어 쓰기가 멈춘다. 1대일 때는
+그 1대가 죽어야 멈추므로, **2대는 가용성이 오히려 내려간다.** 짝수 대 구성을
+하지 않는 이유가 이것이다.
+
+### 2-2. 비용
+
+| 구성 | 인스턴스 | 월 비용(개략) |
+|---|---|---|
+| 현재 | t3.medium 1 + t3a.small 1 | 기준 |
+| 목표 | t3.medium 3 | 기준 + 약 2배 |
+
+비용 결정은 James 권한이다. 이 문서는 기술 조건만 정리한다.
+
+---
+
+## 3. 전환 방식 결정
+
+### 3-1. 제자리 전환은 하지 않는다
+
+기존 SQLite 클러스터에 `--cluster-init` 을 추가하는 방식은 채택하지 않는다.
+데이터스토어 종류가 다르므로 기동 시 불일치가 발생하며, 실패 시 되돌릴 지점이
+없다. **본 세션에서 이 동작을 검증하지 않았으므로 추정으로 절차에 넣지 않는다.**
+
+### 3-2. 채택 방식: 신규 클러스터 + GitOps 복원 + EIP 이동
+
+커트오버 때 검증된 방식을 그대로 쓴다.
+
+1. 새 서버 3대에 etcd 모드로 클러스터를 구성한다
+2. ArgoCD 를 설치하고 같은 git 저장소를 가리킨다 — 워크로드가 자동 복원된다
+3. 시크릿을 주입한다 (현재 수동, §5-2 참조)
+4. 검증 후 Elastic IP 를 새 클러스터로 재연결한다 (약 2초)
+5. 문제 발생 시 EIP 를 원위치 — 기존 클러스터는 그대로 살아 있다
+
+**이 방식의 이점**: 기존 클러스터를 건드리지 않으므로 롤백이 EIP 재연결 한 번이다.
+GitOps 를 도입해 둔 것이 여기서 값을 한다 — 워크로드 정의가 git 에 있으므로
+클러스터를 새로 만들어도 같은 상태가 재현된다.
+
+---
+
+## 4. 절차
+
+각 단계는 **판정 기준**을 통과해야 다음으로 넘어간다.
+
+### 4-1. 리허설 (폐기용 노드)
+
+prod 에 적용하기 전에 폐기 가능한 인스턴스에서 1회 완주한다. 리허설 없이 prod 에
+적용하지 않는다.
+
+```bash
+# 1. 폐기용 t3.small 3대 기동 (terraform 별도 워크스페이스)
+# 2. 아래 4-2 전 과정을 그대로 수행
+# 3. 서버 1대를 강제 정지시켜 쿼럼 유지 확인   ← 리허설의 핵심
+# 4. 소요 시간 측정 → prod 작업 창 산정 근거
+```
+
+**판정**: 서버 1대 정지 상태에서 `kubectl get nodes` 가 응답하고 파드가 계속
+Running 이면 통과.
+
+### 4-2. 신규 클러스터 구성
+
+```bash
+# 서버 1 — 클러스터 초기화
+curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.36.3+k3s1 sh -s - server \
+  --cluster-init \
+  --disable traefik --disable servicelb \
+  --write-kubeconfig-mode 644 \
+  --secrets-encryption \
+  --etcd-snapshot-schedule-cron '0 */6 * * *' \
+  --etcd-snapshot-retention 20
+
+# 판정: 아래가 etcd 를 보고해야 한다
+sudo k3s kubectl get --raw /readyz?verbose | grep etcd
+sudo ls /var/lib/rancher/k3s/server/db/etcd/    # 디렉터리 존재
+sudo test -f /var/lib/rancher/k3s/server/db/state.db && echo "SQLite 잔존 — 중단"
+
+# 서버 2, 3 — 조인
+TOKEN=$(ssh server1 sudo cat /var/lib/rancher/k3s/server/node-token)
+curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.36.3+k3s1 \
+  K3S_TOKEN="$TOKEN" sh -s - server \
+  --server https://<서버1 사설주소>:6443 \
+  --disable traefik --disable servicelb \
+  --write-kubeconfig-mode 644
+
+# 판정: 3대가 모두 control-plane,etcd 역할로 Ready
+sudo k3s kubectl get nodes -o wide
+sudo k3s kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.labels}{"\n"}{end}' | grep -c etcd   # 3 이어야 함
+```
+
+### 4-3. 시크릿 암호화 활성화 (현재 미적용 상태 해소)
+
+현재 클러스터는 설정 파일에 `secrets-encryption: true` 가 있으나 실제 상태는
+`Disabled` 다. 신규 구성에서는 기동 인자로 넣고 **반드시 상태를 확인**한다.
+
+```bash
+sudo k3s secrets-encrypt status
+# 판정: Encryption Status: Enabled
+
+# 음성 대조 — 실제로 암호화되는지 원본에서 확인
+sudo grep -c 'k8s:enc:' /var/lib/rancher/k3s/server/db/etcd/member/snap/db
+# 판정: 0 이 아니어야 한다. 0 이면 설정만 되고 적용은 안 된 것
+```
+
+**이 음성 대조를 생략하지 않는다.** 현재 클러스터가 정확히 "설정은 켜져 있는데
+실제로는 꺼져 있는" 상태이고, 상태 확인을 하지 않아서 여태 몰랐다.
+
+### 4-4. 부트스트랩 + 워크로드 복원
+
+```bash
+# ingress-nginx / cert-manager / ArgoCD
+sudo k3s kubectl apply -f charts/bootstrap/
+sudo k3s kubectl apply -f charts/bootstrap/ingress-nginx-config.yaml
+
+# 판정
+sudo k3s kubectl -n ingress-nginx get pods
+sudo k3s kubectl -n argocd get applications
+```
+
+### 4-5. 시크릿 주입
+
+```bash
+# 144키. 현재 수동. 상세는 §5-2
+sudo k3s kubectl -n insighta-prod create secret generic insighta-env --from-env-file=<파일>
+
+# 판정: 키 개수 일치
+sudo k3s kubectl -n insighta-prod get secret insighta-env -o json | python3 -c \
+  "import json,sys; print(len(json.load(sys.stdin)['data']))"   # 144
+```
+
+### 4-6. 검증 후 EIP 이동
+
+```bash
+# 클러스터 내부에서 먼저 확인 (외부 트래픽 없이)
+sudo k3s kubectl -n insighta-prod get pods          # 전부 Running
+sudo k3s kubectl -n insighta-prod exec deploy/insighta-api -- curl -s localhost:3000/health
+
+# EIP 재연결 (terraform)
+terraform -chdir=terraform/projects/insighta/environments/prod plan   # 항목 확인 필수
+terraform -chdir=terraform/projects/insighta/environments/prod apply
+
+# 판정 (외부에서)
+curl -s -o /dev/null -w '%{http_code}\n' https://insighta.one/health      # 200
+curl -s -o /dev/null -w '%{http_code}\n' https://www.insighta.one/health  # 200
+curl -sI https://insighta.one | grep -ciE 'strict-transport|x-content-type|x-frame|x-xss|referrer-policy'  # 5
+```
+
+### 4-7. 롤백
+
+EIP 를 기존 클러스터로 되돌린다. 기존 클러스터는 이 절차 동안 계속 살아 있다.
+
+```bash
+# terraform 에서 eip_instance_id 를 기존 노드로 되돌리고 apply
+# 소요: 약 2초. DNS 무관.
+```
+
+---
+
+## 5. 함께 처리할 항목
+
+전환은 클러스터를 새로 만드는 작업이므로, 현재 미해결 항목 중 이 시점에 같이
+해소해야 유리한 것들이 있다.
+
+### 5-1. ingress DaemonSet 화
+
+서버가 3대가 되어도 ingress 가 1대에만 있으면 진입점은 여전히 단일 장애점이다.
+Deployment 를 DaemonSet 으로 바꾸면 3대 모두가 진입점이 된다. 추가 비용 0.
+
+### 5-2. 시크릿 144키 수동 주입 해소
+
+현재 재구축 시간의 대부분이 이 단계다. 144키 중 실제 비밀은 API 키·DB 접속 문자열
+정도이고 나머지는 기능 플래그와 임계값이다.
+
+접두어별 분포 (2026-08-19 실측):
+```
+V3 14 · YOUTUBE 14 · V5 10 · REDIS 7 · LEMONSQUEEZY 6 · OPENROUTER 5
+BOOK 4 · DISCOVER 4 · MANDALA 4 · SUPABASE 4 · BATCH 3 · CURATION 3
+```
+
+두 갈래로 나누는 것이 정답이다.
+- **설정값** (`BOOK_GATE_MODE`, `BATCH_COLLECTOR_LIMIT`, `CURATION_SCHED_KST_ENABLED` 등)
+  → ConfigMap 또는 차트 values 로 이동. git 에서 관리 가능해진다.
+- **진짜 비밀** (API 키, DB 접속 문자열) → External Secrets Operator 로 외부 보관소에서 주입
+
+### 5-3. 이미지 태그 고정
+
+`latest` 를 커밋 SHA 로 바꾸는 작업. 새 클러스터에서 시작하면 기존 캐시가 없으므로
+전환과 함께 적용하기 좋다. 상세는 별도 항목.
+
+---
+
+## 6. 실행 기록
+
+절차를 실행할 때 각 단계의 실제 명령과 출력을 아래에 append 한다.
+계획과 실제가 달랐던 지점을 반드시 남긴다.
+
+```
+(미실행)
+```
+
+---
+
+## 7. 최종 형상 (전환 완료 후 이 절을 채운다)
+
+전환이 끝나면 아래를 실측값으로 채운다.
+
+| 항목 | 전환 전 | 전환 후 |
+|---|---|---|
+| 데이터스토어 | SQLite (`state.db` 11MB) | |
+| 서버 노드 | 1 | |
+| 견딜 수 있는 서버 정지 | 0대 | |
+| 시크릿 암호화 | Disabled | |
+| 진입점 | 노드1 단독 | |
+| etcd 스냅샷 | 없음 | |
+| 재구축 수동 단계 | 시크릿 144키 | |


### PR DESCRIPTION
Adds the lab scripts that the beginner infrastructure guide refers to, plus the
runbook for moving the cluster datastore off SQLite.

## Why

The guide tells the reader to run `bash docs/labs/lab01-server-and-ssh.sh`, but
those files existed only in a local worktree. Following the instruction produced
`No such file or directory`. This commit makes the instruction true.

## What the labs do

Nine scripts under `docs/labs/`, one per chapter of the guide. Each prints the
command before running it, so the reader can retype anything by hand afterwards.

Every executed command is read-only. This was verified by extracting each call
that reaches the `run` / `runsh` / `k` / `kshow` helpers:

```
curl -s · helm template · k3s ctr · k3s kubectl · terraform -chdir
```

`terraform` stops at `plan`. `ansible-playbook` is documented with `--check`
only and never executed. `kubectl apply` appears in prose but is not run.

Hosts are resolved through `scripts/ops/ssh.sh` rather than written down, so no
address or account identifier is committed. Runtime output does contain them,
and `docs/labs/README.md` says so.

All nine were run end to end against production before this commit.

## Runbook

`docs/ops/datastore-sqlite-to-etcd.md` records a measurement made while writing
the guide: the cluster runs on SQLite, not etcd. The server has neither
`--cluster-init` nor `--datastore-endpoint`, so a second server node is not
possible and control-plane redundancy cannot be added to this cluster as it
stands.

The runbook covers why the move is needed, why three servers rather than two
(two loses quorum on any single failure, which is worse than one), the procedure
with a pass criterion per step, and rollback. Sections 6 and 7 are left empty on
purpose and get filled with the real output when the procedure runs.

It also records that `secrets-encryption: true` is present in the config while
`k3s secrets-encrypt status` reports `Disabled`, and adds a negative control so
the next attempt cannot repeat that.

## Verification

A checker was run over the guide and its references: secret exposure, path
existence on `main`, config values against the files, and values against the
live cluster. 33 pass. The two failures were the missing `docs/labs`, which this
commit resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
