### PR TITLE
infra(compute): release the original production host, after moving the address off it

### DIFF
--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -44,12 +44,7 @@ resource "aws_instance" "this" {
 
 # A stable address so DNS and the SSH allowlist do not move when the instance
 # is stopped or replaced.
-resource "aws_eip" "this" {
-  domain = "vpc"
-  tags   = merge(var.tags, { Name = "${var.name}-eip" })
-}
-
-resource "aws_eip_association" "this" {
-  instance_id   = var.eip_instance_id != "" ? var.eip_instance_id : aws_instance.this.id
-  allocation_id = aws_eip.this.id
-}
+# The Elastic IP used to live here. It was moved to the root module on
+# 2026-08-19: the address outlived this instance at the cutover, and a resource
+# whose lifecycle is tied to a host it no longer belongs to plans to delete
+# something nobody meant to delete. See aws_eip.service in the prod environment.

--- a/terraform/modules/compute/outputs.tf
+++ b/terraform/modules/compute/outputs.tf
@@ -3,10 +3,6 @@ output "instance_id" {
   value       = aws_instance.this.id
 }
 
-output "public_ip" {
-  description = "Elastic IP attached to the instance."
-  value       = aws_eip.this.public_ip
-}
 
 output "private_ip" {
   description = "Private address inside the VPC."

--- a/terraform/projects/insighta/environments/prod/main.tf
+++ b/terraform/projects/insighta/environments/prod/main.tf
@@ -27,6 +27,7 @@ module "iam" {
 }
 
 module "compute" {
+  count  = var.enable_prod_instance ? 1 : 0
   source = "../../../../modules/compute"
 
   name          = "insighta-prod"
@@ -162,14 +163,48 @@ output "ecr_registry" {
 # trust.
 #
 # Roughly $3.60/month, and it is released when the host is decommissioned.
+# The service address, and the reason the original host can be removed without
+# taking the site with it.
+#
+# It was declared inside module.compute, which was accurate while that instance
+# answered for the domain. It stopped being accurate at the cutover on
+# 2026-08-14: the association moved to the cluster node while the resource stayed
+# where it was. Removing the module in that state plans to release the address,
+# and a released Elastic IP is not returned on request -- DNS would resolve to an
+# address belonging to someone else.
+#
+# Moved here so ownership matches reality. The moved blocks below make this a
+# state operation: nothing is created, nothing is destroyed, and a plan run
+# immediately afterwards reports no changes. If it reports anything else, the
+# move is wrong and applying it would change the address.
+resource "aws_eip" "service" {
+  domain = "vpc"
+  tags   = merge(local.common_tags, { Name = "insighta-prod-eip" })
+}
+
+resource "aws_eip_association" "service" {
+  instance_id   = var.enable_k3s_node ? module.k3s_node[0].instance_id : one(module.compute[*].instance_id)
+  allocation_id = aws_eip.service.id
+}
+
+moved {
+  from = module.compute.aws_eip.this
+  to   = aws_eip.service
+}
+
+moved {
+  from = module.compute.aws_eip_association.this
+  to   = aws_eip_association.service
+}
+
 resource "aws_eip" "prod_standby" {
-  count  = var.enable_k3s_node ? 1 : 0
+  count  = var.enable_k3s_node && var.enable_prod_instance ? 1 : 0
   domain = "vpc"
   tags   = merge(local.common_tags, { Name = "insighta-prod-standby-eip" })
 }
 
 resource "aws_eip_association" "prod_standby" {
-  count         = var.enable_k3s_node ? 1 : 0
-  instance_id   = module.compute.instance_id
+  count         = var.enable_k3s_node && var.enable_prod_instance ? 1 : 0
+  instance_id   = module.compute[0].instance_id
   allocation_id = aws_eip.prod_standby[0].id
 }

--- a/terraform/projects/insighta/environments/prod/outputs.tf
+++ b/terraform/projects/insighta/environments/prod/outputs.tf
@@ -3,7 +3,7 @@
 # "No changes" an unambiguous statement rather than one with a footnote.
 output "instance_id" {
   description = "Production EC2 instance."
-  value       = module.compute.instance_id
+  value       = one(module.compute[*].instance_id)
 }
 
 output "instance_profile" {
@@ -13,7 +13,7 @@ output "instance_profile" {
 
 output "public_ip" {
   description = "Elastic IP. This is the address in DNS and in the SSH allowlists."
-  value       = module.compute.public_ip
+  value       = aws_eip.service.public_ip
 }
 
 output "security_group_id" {

--- a/terraform/projects/insighta/environments/prod/terraform.tfvars
+++ b/terraform/projects/insighta/environments/prod/terraform.tfvars
@@ -49,3 +49,17 @@ enable_k3s_node = true
 # the datastore is SQLite, which admits only one server. Redundancy needs three
 # servers on etcd, which is a cost decision rather than a configuration change.
 k3s_node_count = 1
+
+# The original production host, kept as a rollback target after the cluster
+# cutover on 2026-08-14 and released on 2026-08-19.
+#
+# Five days of the cluster serving every request, a backup verified in three
+# places, and the only traffic still reaching this host was vulnerability
+# scanning: 155 requests in the last day, all of them for paths like
+# /wp-links-opml.php.
+#
+# What goes with it is the two-second rollback that reassociated an address.
+# What remains is reverting in git and letting the pipeline rebuild, which is
+# minutes rather than seconds. That trade is the reason this is a variable and
+# not a deletion.
+enable_prod_instance = false

--- a/terraform/projects/insighta/environments/prod/variables.tf
+++ b/terraform/projects/insighta/environments/prod/variables.tf
@@ -54,6 +54,21 @@ variable "backup_bucket_name" {
   default     = "insighta-backups"
 }
 
+variable "enable_prod_instance" {
+  description = <<-EOT
+    Create the original production EC2 instance. Default true so adding the
+    variable does not change anyone else's plan; production sets it to false,
+    having moved to the cluster on 2026-08-14 and kept this host as a rollback
+    target until 2026-08-19.
+
+    The service Elastic IP is not affected. It was moved out of module.compute
+    on the same day precisely so that this flag could be flipped without the
+    address going with the instance.
+  EOT
+  type        = bool
+  default     = true
+}
+
 variable "enable_k3s_node" {
   description = <<-EOT
     Create the k3s validation node. Default false: this is the only variable in


### PR DESCRIPTION
Removes the EC2 instance that served the site before the cluster cutover, and
the standby Elastic IP with it. Already applied; this records it in code, and
`terraform plan` reports no changes.

## Why now

The cluster has served every request since 2026-08-14. Over the five days since,
the only traffic reaching the original host was vulnerability scanning — 155
requests in the last day, for paths like `/wp-links-opml.php` and `/admin.php`.
It was running three healthy containers that nothing consulted.

A backup was taken first and verified in three places: locally, on the Mac Mini,
and in S3 under `ec2-decommission/`. The first attempt omitted the TLS
certificates, the ubuntu home directory and the environment key list; those were
added and the archive repacked. The key list carries names only, checked.

## The part that made this not routine

The plan said this, below the summary:

```
# module.compute.aws_eip.this will be destroyed
    allocation_id = "eipalloc-00f7d9e8a3637a5ad"
```

That allocation is `44.231.152.49`, which is what `insighta.one` resolves to.
The address was declared inside `module.compute` — accurate while that instance
answered for the domain, and no longer accurate after the cutover, when the
association moved to the cluster node and the resource stayed behind. Removing
the module in that state releases the service address, and a released Elastic IP
is not returned on request.

`Plan: 0 to add, 0 to change, 3 to destroy` would not have told anyone this.

## Order of operations

**Move the address out of the module.** Two `moved` blocks relocate
`aws_eip.this` and `aws_eip_association.this` to the root as `aws_eip.service`
and `aws_eip_association.service`. Plan: `0 to add, 0 to change, 0 to destroy`,
with only the two moves listed. Applied, then verified: same allocation, same
association, same DNS answer, site still 200.

**Then remove the host.** `enable_prod_instance` defaults to true so adding the
variable does not change anyone else's plan; production sets it to false. The
resulting plan destroyed three resources and no others:

- `module.compute.aws_instance.this` — the t3.medium
- `aws_eip.prod_standby[0]` — the standby address
- `aws_eip_association.prod_standby[0]`

Sixty health checks during the apply all returned 200.

## After

| | |
|---|---|
| EC2 | `insighta-k3s-1` (t3.medium), one instance |
| Elastic IP | `44.231.152.49`, attached to it |
| Pods | 20 Running, 0 otherwise |
| Endpoints | apex and www both 200, five security headers |
| Drift | none |

About $34 a month. With the second cluster node released earlier the same day,
roughly $48 in total.

## What is given up

The rollback that reassociated an address in two seconds. What remains is
reverting in git and letting the pipeline rebuild, which takes minutes. That
trade is why this is a variable rather than a deletion — the instance can be
recreated from the same code, though it would come back empty and need the
backup restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)