### PR TITLE
fix(pipeline): remove jobs addressing a deleted host, and pin images by commit

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -111,166 +111,24 @@ jobs:
   # 04-29. That is the dataset the documented re-enable path would want back, so
   # the thing worth capturing is the volume, not the current keys — snapshotting
   # DBSIZE would faithfully archive nothing.
-  redis:
-    name: Redis Volume Backup
-    runs-on: ubuntu-latest
-    env:
-      SG_ID: sg-079aa1ca6855e587b
-      VOLUME: tubearchive_redis_data
-
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TF_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Open SSH for runner IP
-        run: |
-          RUNNER_IP=$(curl -s ifconfig.me)
-          echo "RUNNER_IP=$RUNNER_IP" >> "$GITHUB_ENV"
-          aws ec2 authorize-security-group-ingress \
-            --group-id "$SG_ID" \
-            --protocol tcp --port 22 \
-            --cidr "$RUNNER_IP/32" \
-            --tag-specifications "ResourceType=security-group-rule,Tags=[{Key=Purpose,Value=github-actions-backup}]"
-
-      # Same reason as deploy.yml: the rule is not usable the moment the API
-      # returns, and this job goes straight to SSH with nothing in between.
-      - name: Wait for SSH to become reachable
-        run: |
-          for i in $(seq 1 30); do
-            if timeout 3 bash -c "cat < /dev/null > /dev/tcp/${{ secrets.EC2_HOST }}/22" 2>/dev/null; then
-              echo "port 22 reachable after ${i} attempt(s)"; exit 0
-            fi
-            sleep 2
-          done
-          echo "::error::port 22 never became reachable from $RUNNER_IP after 60s"
-          exit 1
-
-      - name: Snapshot the volume on the host
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            set -euo pipefail
-
-            # Fold the incr file into a fresh base so the archive is one
-            # consistent point rather than a base plus whatever arrived while
-            # tar was reading. BGREWRITEAOF is async; wait for it to finish.
-            docker exec insighta-redis redis-cli BGREWRITEAOF
-            for i in $(seq 1 60); do
-              INPROG=$(docker exec insighta-redis redis-cli INFO persistence \
-                | tr -d '\r' | awk -F: '/^aof_rewrite_in_progress:/{print $2}')
-              [ "$INPROG" = "0" ] && break
-              sleep 1
-            done
-            if [ "$INPROG" != "0" ]; then
-              echo "::error::AOF rewrite still running after 60s — archive would be torn"
-              exit 1
-            fi
-
-            # Record what is being captured, so a restore can be checked
-            # against it rather than against an assumption.
-            docker exec insighta-redis redis-cli DBSIZE | tr -d '\r' > /tmp/redis-dbsize.txt
-            docker exec insighta-redis tar czf - -C /data . > /tmp/redis-backup.tgz
-            ls -l /tmp/redis-backup.tgz
-
-      - name: Fetch the archive
-        uses: appleboy/scp-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          source: "/tmp/redis-backup.tgz,/tmp/redis-dbsize.txt"
-          target: "./incoming"
-          strip_components: 1
-
-      # A backup nobody has restored is a file, not a backup. Load the archive
-      # into a throwaway Redis and make it answer before anything is uploaded.
-      - name: Restore test
-        run: |
-          set -euo pipefail
-          ARCHIVE=./incoming/redis-backup.tgz
-          EXPECTED=$(tr -dc '0-9' < ./incoming/redis-dbsize.txt)
-          echo "source DBSIZE: ${EXPECTED}"
-
-          mkdir -p restore && tar xzf "$ARCHIVE" -C restore
-          ls -l restore restore/appendonlydir || true
-
-          docker run -d --name redis-restore \
-            -v "$PWD/restore:/data" \
-            redis:7-alpine redis-server --appendonly yes --dir /data
-          for i in $(seq 1 30); do
-            docker exec redis-restore redis-cli PING 2>/dev/null | grep -q PONG && break
-            sleep 1
-          done
-
-          GOT=$(docker exec redis-restore redis-cli DBSIZE | tr -dc '0-9')
-          echo "restored DBSIZE: ${GOT}"
-          docker logs redis-restore 2>&1 | tail -20
-
-          if [ "$GOT" != "$EXPECTED" ]; then
-            echo "::error::restore mismatch — source ${EXPECTED} keys, restored ${GOT}"
-            exit 1
-          fi
-          echo "restore verified: ${GOT} keys"
-          echo "restored_keys=${GOT}" >> "$GITHUB_ENV"
-
-      - name: Upload to S3
-        run: |
-          set -euo pipefail
-          YEAR=$(date +%Y); MONTH=$(date +%m)
-          FILENAME="redis-$(date +%Y%m%d-%H%M%S).tgz"
-          S3_PATH="s3://${BACKUP_BUCKET}/redis/${YEAR}/${MONTH}/${FILENAME}"
-          aws s3 cp ./incoming/redis-backup.tgz "$S3_PATH"
-          SIZE=$(stat -c%s ./incoming/redis-backup.tgz)
-          echo "backup_path=${S3_PATH}" >> "$GITHUB_ENV"
-          echo "backup_size=${SIZE}" >> "$GITHUB_ENV"
-
-      - name: Cleanup old backups (30+ days)
-        run: |
-          CUTOFF=$(date -d '30 days ago' +%Y-%m-%d)
-          aws s3 ls "s3://${BACKUP_BUCKET}/redis/" --recursive \
-            | while read -r d _ _ key; do
-                if [[ "$d" < "$CUTOFF" ]]; then
-                  aws s3 rm "s3://${BACKUP_BUCKET}/$key"
-                fi
-              done
-
-      - name: Remove the archive from the host
-        if: always()
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: rm -f /tmp/redis-backup.tgz /tmp/redis-dbsize.txt
-
-      - name: Close SSH
-        if: always()
-        run: |
-          if [ -n "${RUNNER_IP:-}" ]; then
-            aws ec2 revoke-security-group-ingress \
-              --group-id "$SG_ID" \
-              --protocol tcp --port 22 \
-              --cidr "$RUNNER_IP/32" 2>/dev/null || true
-          fi
-
-      - name: Summary
-        run: |
-          echo "### Redis Backup Complete" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Path**: \`${{ env.backup_path }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Size**: ${{ env.backup_size }} bytes" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Restore verified**: ${{ env.restored_keys }} keys loaded into a scratch Redis" >> "$GITHUB_STEP_SUMMARY"
+  # A `redis` job backed up the redis volume until 2026-08-19. It ran `docker exec`
+  # against a container on secrets.EC2_HOST, which was released that day, and it
+  # had been failing since the cutover on 2026-08-14 -- which is why this workflow
+  # reported failure daily while the database backup above kept succeeding.
+  #
+  # It is not being rewritten against the cluster pod, because there is nothing in
+  # it to back up. Measured 2026-08-19: DBSIZE 0, used_memory 1.06M, /data 16K.
+  # Redis here is a cache, declared as such in charts/insighta/environments/
+  # prod.yaml, and it is backed by an 8Gi PVC that survives pod restarts.
+  #
+  # If redis is ever given data that cannot be recomputed, this decision needs
+  # revisiting, and the backup belongs in the chart as a CronJob rather than in a
+  # workflow reaching in from outside.
 
   notify-failure:
     name: Notify on Failure
     runs-on: ubuntu-latest
-    needs: [backup, redis]
+    needs: [backup]
     if: failure()
     steps:
       - name: Create failure issue

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,12 +105,13 @@ jobs:
 
           # Does anything here reach production at all?
           #
-          # Every path below is excluded from the API image by .dockerignore,
-          # is not copied to the box by the deploy job (which ships only
-          # docker-compose.prod.yml and docker/redis/), and cannot arrive
-          # through a bind mount — compose declares named volumes only
-          # (cache_data, logs_data, redis_data). So a change confined to them
-          # provably cannot alter what runs.
+          # Every path below is excluded from the API image by .dockerignore, so
+          # a change confined to them cannot alter what the image contains.
+          #
+          # charts/ is in this list and has to stay there. publish-tags writes the
+          # commit sha into charts/insighta/environments/prod.yaml and pushes to
+          # main, and that push has to come back here as deployable=false or it
+          # starts a loop. Checked against that exact path on 2026-08-19.
           #
           # Written as an exclusion rather than an allowlist on purpose. A new
           # top-level directory nobody thought about falls through to
@@ -289,122 +290,6 @@ jobs:
   # nginx root: no npm install, no vite build, no image, no container restart.
   # There is no drift risk because it only ever copies what is in git -- the next
   # full deploy rebuilds the image from those same files.
-  fast-mobile:
-    name: Fast dial deploy
-    runs-on: ubuntu-latest
-    needs: [scope, mobile-gate]
-    if: needs.scope.outputs.mobile_only == 'true'
-    environment: production
-    env:
-      SG_ID: sg-079aa1ca6855e587b
-    steps:
-      # Skipping the image build is only safe if the image on the box is already
-      # current. If the previous deploy failed -- Docker Hub timed out on
-      # 718bd88f -- the backend change it carried is still unshipped, and this
-      # job would sail past it and report green, leaving the failure to be found
-      # by hand. Refuse instead, and say what to do about it.
-      - name: Refuse to skip the build over a failed deploy
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # -R explicitly: this step runs before checkout, so there is no git
-          # repo for gh to infer the remote from and it exits 1 -- which the
-          # guard then reported as "the previous deploy failed". The guard was
-          # blocking every fast dial deploy on its own lookup error.
-          PREV=$(gh run list -R "${{ github.repository }}" \
-                   --workflow deploy.yml --branch main --limit 20 \
-                   --json databaseId,conclusion,headSha \
-                   --jq "[.[] | select(.databaseId != ${{ github.run_id }}) | select(.conclusion != null and .conclusion != \"cancelled\" and .conclusion != \"skipped\")][0]") \
-            || { echo "::warning::could not read deploy history; proceeding without the staleness check"; PREV=""; }
-          CONC=$(echo "$PREV" | jq -r '.conclusion // "none"')
-          SHA=$(echo "$PREV"  | jq -r '.headSha  // "none"')
-          echo "previous completed deploy: $CONC ($SHA)"
-          if [ "$CONC" != "success" ] && [ "$CONC" != "none" ]; then
-            echo "::error::the last deploy ($SHA) ended in '$CONC', so the image on the box may be stale. Re-run that deploy first, then re-run this one."
-            exit 1
-          fi
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TF_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
-      - uses: actions/checkout@v4
-
-      - name: Open SSH for runner IP
-        run: |
-          RUNNER_IP=$(curl -s ifconfig.me)
-          echo "RUNNER_IP=$RUNNER_IP" >> "$GITHUB_ENV"
-          aws ec2 authorize-security-group-ingress \
-            --group-id "$SG_ID" \
-            --protocol tcp --port 22 \
-            --cidr "$RUNNER_IP/32" \
-            --tag-specifications "ResourceType=security-group-rule,Tags=[{Key=Purpose,Value=github-actions-deploy}]"
-
-      # A new ingress rule is not usable the instant the API returns. The full
-      # deploy job never noticed because several steps run between opening the
-      # rule and its first scp; this job goes straight there and timed out on
-      # its first live run. Wait for the port to actually answer rather than
-      # sleeping a guessed number of seconds.
-      - name: Wait for SSH to become reachable
-        run: |
-          for i in $(seq 1 30); do
-            if timeout 3 bash -c "cat < /dev/null > /dev/tcp/${{ secrets.EC2_HOST }}/22" 2>/dev/null; then
-              echo "port 22 reachable after ${i} attempt(s)"; exit 0
-            fi
-            sleep 2
-          done
-          echo "::error::port 22 never became reachable from $RUNNER_IP after 60s"
-          exit 1
-
-      - name: Copy dial files to EC2
-        uses: appleboy/scp-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          source: "frontend/public/mobile/*"
-          target: "/tmp/dial/"
-          strip_components: 3
-          overwrite: true
-
-      - name: Install into the running nginx and verify
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            set -e
-            docker cp /tmp/dial/. insighta-frontend:/usr/share/nginx/html/mobile/
-            rm -rf /tmp/dial
-            # nginx serves from disk per request, so no reload is needed. Prove
-            # the file the browser will receive is the one we just shipped.
-            docker exec insighta-frontend cat /usr/share/nginx/html/mobile/version.json
-
-      - name: Verify over HTTPS
-        run: |
-          WANT=$(node -p "require('./frontend/public/mobile/version.json').build")
-          for i in $(seq 1 10); do
-            GOT=$(curl -sf "https://${{ secrets.DOMAIN }}/mobile/version.json" | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).build" 2>/dev/null || true)
-            [ "$GOT" = "$WANT" ] && { echo "live build = $GOT"; exit 0; }
-            sleep 3
-          done
-          echo "::error::dial still serving '$GOT', expected '$WANT'"
-          exit 1
-
-      - name: Close SSH for runner IP
-        if: always()
-        run: |
-          if [ -n "$RUNNER_IP" ]; then
-            aws ec2 revoke-security-group-ingress \
-              --group-id "$SG_ID" \
-              --protocol tcp --port 22 \
-              --cidr "$RUNNER_IP/32" 2>/dev/null || true
-          fi
-
   migrate:
     name: Database Schema Sync
     runs-on: ubuntu-latest
@@ -456,471 +341,62 @@ jobs:
           DATABASE_URL: ${{ secrets.DIRECT_URL }}
           DIRECT_URL: ${{ secrets.DIRECT_URL }}
 
-  deploy:
-    name: Deploy to EC2
+  publish-tags:
+    name: Point the chart at this commit
+    needs: [scope, build-and-push]
+    if: github.ref == 'refs/heads/main' && needs.scope.outputs.deployable == 'true'
     runs-on: ubuntu-latest
-    needs: [scope, migrate, build-and-push]
-    if: needs.scope.outputs.mobile_only != 'true' && needs.scope.outputs.deployable == 'true'
-    environment: production
-    env:
-      SG_ID: sg-079aa1ca6855e587b
+    permissions:
+      contents: write
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.TF_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.TF_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
-
       - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Open SSH for runner IP
+      # The cluster learns which image to run by reading this repository, so the
+      # tag has to arrive here rather than being pushed at the cluster. ArgoCD is
+      # not reachable from a runner on purpose -- it holds cluster-admin and has
+      # no public address -- so a write-back to git is the path that exists.
+      - name: Write the commit sha into the prod values
         run: |
-          RUNNER_IP=$(curl -s ifconfig.me)
-          echo "RUNNER_IP=$RUNNER_IP" >> "$GITHUB_ENV"
-          aws ec2 authorize-security-group-ingress \
-            --group-id "$SG_ID" \
-            --protocol tcp --port 22 \
-            --cidr "$RUNNER_IP/32" \
-            --tag-specifications "ResourceType=security-group-rule,Tags=[{Key=Purpose,Value=github-actions-deploy}]"
-          echo "Opened SSH for $RUNNER_IP"
+          set -euo pipefail
+          F=charts/insighta/environments/prod.yaml
+          SHA=${{ github.sha }}
 
-      - name: Copy docker-compose.prod.yml to EC2
-        uses: appleboy/scp-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          source: "docker-compose.prod.yml"
-          target: "/opt/tubearchive/"
-          overwrite: true
+          for key in apiTag frontendTag redisTag; do
+            before=$(grep -E "^  $key:" "$F")
+            sed -i -E "s|^  $key:.*|  $key: $SHA|" "$F"
+            after=$(grep -E "^  $key:" "$F")
+            [ "$before" != "$after" ] || { echo "$key unchanged -- refusing"; exit 1; }
+          done
+          grep -E '^  (api|frontend|redis)Tag:' "$F"
 
-      # CP395 — Redis container is built locally on EC2 from source files in
-      # docker/redis/. Ship the directory alongside the compose file so the
-      # `build:` directive in docker-compose.prod.yml can resolve.
-      - name: Copy docker/redis/ to EC2
-        uses: appleboy/scp-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          source: "docker/redis/*"
-          target: "/opt/tubearchive/docker/redis/"
-          overwrite: true
-          strip_components: 2
-
-      - name: Ensure LLM keys in .env
-        uses: appleboy/ssh-action@v1
-        env:
-          OR_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OR_MODEL: ${{ secrets.OPENROUTER_MODEL }}
-          COHERE_KEY: ${{ secrets.COHERE_API_KEY }}
-          # Naver Open API — book research/factcheck Korean evidence leg
-          # (2026-07-14 provider swap; Google CSE closed to new customers).
-          NAVER_ID: ${{ secrets.NAVER_CLIENT_ID }}
-          NAVER_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
-          ELEVEN_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
-          NARRATION_PREPRODUCE_ENABLED: ${{ vars.NARRATION_PREPRODUCE_ENABLED }}
-          YT_SEARCH_KEY: ${{ secrets.YOUTUBE_API_KEY_SEARCH }}
-          YT_SEARCH_KEY_2: ${{ secrets.YOUTUBE_API_KEY_SEARCH_2 }}
-          YT_SEARCH_KEY_3: ${{ secrets.YOUTUBE_API_KEY_SEARCH_3 }}
-          YT_SEARCH_KEY_4: ${{ secrets.YOUTUBE_API_KEY_SEARCH_4 }}
-          YT_SEARCH_KEY_5: ${{ secrets.YOUTUBE_API_KEY_SEARCH_5 }}
-          YT_SEARCH_KEY_6: ${{ secrets.YOUTUBE_API_KEY_SEARCH_6 }}
-          YT_SEARCH_KEY_7: ${{ secrets.YOUTUBE_API_KEY_SEARCH_7 }}
-          YT_SEARCH_KEY_8: ${{ secrets.YOUTUBE_API_KEY_SEARCH_8 }}
-          YT_VIDEOS_KEY: ${{ secrets.YOUTUBE_API_KEY_VIDEOS }}
-          YT_VIDEOS_KEY_2: ${{ secrets.YOUTUBE_API_KEY_VIDEOS_2 }}
-          DB_URL: ${{ secrets.DATABASE_URL }}
-          DB_DIRECT: ${{ secrets.DIRECT_URL }}
-          REDIS_ADMIN_PW: ${{ secrets.REDIS_ADMIN_PASSWORD }}
-          REDIS_COLLECTOR_PW: ${{ secrets.REDIS_COLLECTOR_PASSWORD }}
-          REDIS_INSIGHTA_PW: ${{ secrets.REDIS_INSIGHTA_PASSWORD }}
-          REDIS_INSIGHTA_UPSERT_PW: ${{ secrets.REDIS_INSIGHTA_UPSERT_PASSWORD }}
-          TAILSCALE_IP: ${{ vars.INSIGHTA_TAILSCALE_IP }}
-          # CP475+1 — migrated from secrets.QWEN_LORA_API_URL because the URL is
-          # not a credential (CP392 Hard Rule "non-secret config is not a Secret").
-          # Post-merge cleanup: `gh secret delete QWEN_LORA_API_URL`.
-          QWEN_LORA_API_URL: ${{ vars.QWEN_LORA_API_URL }}
-          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
-          # CP474 — selects which provider the CopilotKit chatbot route uses.
-          # Values: 'gemini' | 'openrouter' | 'local' | 'qwen-runpod'.
-          # Default 'openrouter' per src/config/index.ts when unset; set the
-          # GitHub Variable CHATBOT_PROVIDER=qwen-runpod to activate the
-          # RunPod/vLLM path (also activates the Bug 1 chat.completions fix
-          # via QwenRunpodAdapter + the persona/SFT prompt middleware).
-          CHATBOT_PROVIDER: ${{ vars.CHATBOT_PROVIDER }}
-          # CP477+14 — background-poller failover (qwen-runpod → openrouter)
-          # toggle. Non-secret per CP392 (boolean flag, not a credential).
-          # Default empty ⇒ src/config/index.ts coerces to `false` ⇒ poller
-          # is a no-op and main HEAD behaviour is preserved exactly. Set
-          # GitHub Variable CHATBOT_FAILOVER_ENABLED=true to activate. To
-          # roll back, set back to false (or unset) + redeploy — no code
-          # revert required.
-          CHATBOT_FAILOVER_ENABLED: ${{ vars.CHATBOT_FAILOVER_ENABLED }}
-          LS_API_KEY: ${{ secrets.LEMONSQUEEZY_LIVE_API_KEY }}
-          LS_WEBHOOK_SECRET: ${{ secrets.LEMONSQUEEZY_LIVE_WEBHOOK_SECRET }}
-          LS_STORE_ID: ${{ vars.LEMONSQUEEZY_LIVE_STORE_ID }}
-          LS_VARIANT_MONTHLY: ${{ vars.LEMONSQUEEZY_LIVE_VARIANT_ID_PRO_MONTHLY }}
-          LS_VARIANT_YEARLY: ${{ vars.LEMONSQUEEZY_LIVE_VARIANT_ID_PRO_YEARLY }}
-          LS_VARIANT_LIFETIME: ${{ vars.LEMONSQUEEZY_LIVE_VARIANT_ID_PRO_LIFETIME }}
-          # CP500++ CONFIG-SSOT (2026-06-16) — runtime toggle env vars removed
-          # from this env: block (their .env-write blocks in the script were also
-          # deleted). Toggle activation SSOT now lives in docker-compose.prod.yml
-          # `environment:`. Only secrets remain here + in the script's .env writes.
-          # Guard: scripts/ci/check-config-ssot.sh. Design: docs/handoffs/
-          # crosscutting-audit-phase2-design.md (PR-1).
-          # Mac Mini transcript proxy. EC2 outbound to YouTube is blocked
-          # for caption fetch; the Mac Mini (KR ISP IP, Tailscale 4242)
-          # successfully fetches and forwards via x-transcript-token auth.
-          # When unset, caption-extractor falls back to direct
-          # youtube-transcript on EC2 (known to fail) — set both to enable.
-          MAC_MINI_TRANSCRIPT_URL: ${{ secrets.MAC_MINI_TRANSCRIPT_URL }}
-          MAC_MINI_TRANSCRIPT_TOKEN: ${{ secrets.MAC_MINI_TRANSCRIPT_TOKEN }}
-          # Azure App Service transcript proxy (2026-07-09) — always-on cloud
-          # host running the same Webshare-backed service, off EC2 (ToS). Tried
-          # BEFORE Mac Mini (fixes the Mac Mini SPOF). Non-secret URL = literal
-          # (reuses MAC_MINI_TRANSCRIPT_TOKEN for x-transcript-token auth).
-          AZURE_TRANSCRIPT_URL: https://insighta-transcript-proxy-dqaxe5f7hqgddmdz.eastus2-01.azurewebsites.net
-          # ⑤ snapshot get-or-extract — pod slidegen-service. URL = Variable
-          # (CP392, not a credential), TOKEN = Secret. Both unset ⇒ extract
-          # disabled (numerize-client returns []); serve-from-cache still works.
-          SNAPSHOT_SERVICE_URL: ${{ vars.SNAPSHOT_SERVICE_URL }}
-          SNAPSHOT_SERVICE_TOKEN: ${{ secrets.SNAPSHOT_SERVICE_TOKEN }}
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          # CP500++ CONFIG-SSOT — toggle keys removed from this forward list
-          # (now compose-SSOT); only secrets + non-conflicting config remain.
-          envs: OR_KEY,OR_MODEL,COHERE_KEY,YT_SEARCH_KEY,YT_SEARCH_KEY_2,YT_SEARCH_KEY_3,YT_SEARCH_KEY_4,YT_SEARCH_KEY_5,YT_SEARCH_KEY_6,YT_SEARCH_KEY_7,YT_SEARCH_KEY_8,YT_VIDEOS_KEY,YT_VIDEOS_KEY_2,DB_URL,DB_DIRECT,REDIS_ADMIN_PW,REDIS_COLLECTOR_PW,REDIS_INSIGHTA_PW,REDIS_INSIGHTA_UPSERT_PW,TAILSCALE_IP,QWEN_LORA_API_URL,RUNPOD_API_KEY,CHATBOT_PROVIDER,CHATBOT_FAILOVER_ENABLED,LS_API_KEY,LS_WEBHOOK_SECRET,LS_STORE_ID,LS_VARIANT_MONTHLY,LS_VARIANT_YEARLY,LS_VARIANT_LIFETIME,MAC_MINI_TRANSCRIPT_URL,MAC_MINI_TRANSCRIPT_TOKEN,AZURE_TRANSCRIPT_URL,SNAPSHOT_SERVICE_URL,SNAPSHOT_SERVICE_TOKEN,ELEVEN_KEY,NARRATION_PREPRODUCE_ENABLED,NAVER_ID,NAVER_SECRET
-          script: |
-            set -e
-            cd /opt/tubearchive
-            # Add OPENROUTER keys if missing, update if present
-            grep -q '^OPENROUTER_API_KEY=' .env 2>/dev/null && sed -i "s|^OPENROUTER_API_KEY=.*|OPENROUTER_API_KEY=${OR_KEY}|" .env || echo "OPENROUTER_API_KEY=${OR_KEY}" >> .env
-            grep -q '^OPENROUTER_MODEL=' .env 2>/dev/null && sed -i "s|^OPENROUTER_MODEL=.*|OPENROUTER_MODEL=${OR_MODEL}|" .env || echo "OPENROUTER_MODEL=${OR_MODEL}" >> .env
-            # 2026-07-13 — ElevenLabs narration pre-produce key (flag-gated by
-            # NARRATION_PREPRODUCE_ENABLED; see src/modules/narration/). Guarded
-            # like CHATBOT_FAILOVER_ENABLED so an unset secret never blanks .env.
-            if [ -n "${ELEVEN_KEY}" ]; then
-              grep -q '^ELEVENLABS_API_KEY=' .env 2>/dev/null && sed -i "s|^ELEVENLABS_API_KEY=.*|ELEVENLABS_API_KEY=${ELEVEN_KEY}|" .env || echo "ELEVENLABS_API_KEY=${ELEVEN_KEY}" >> .env
-            fi
-            # Narration flag — GitHub Variable NARRATION_PREPRODUCE_ENABLED=true
-            # to activate; unset leaves .env untouched (config default false).
-            if [ -n "${NARRATION_PREPRODUCE_ENABLED}" ]; then
-              grep -q '^NARRATION_PREPRODUCE_ENABLED=' .env 2>/dev/null && sed -i "s|^NARRATION_PREPRODUCE_ENABLED=.*|NARRATION_PREPRODUCE_ENABLED=${NARRATION_PREPRODUCE_ENABLED}|" .env || echo "NARRATION_PREPRODUCE_ENABLED=${NARRATION_PREPRODUCE_ENABLED}" >> .env
-            fi
-            # 2026-05-12 — Cohere Rerank API key (hybrid-retrieval spec, Issue #610).
-            # Used by src/modules/rerank/cohere-client.ts. Same idempotent pattern.
-            # Flag V3_ENABLE_HYBRID_RERANK stays in docker-compose.prod.yml as
-            # tuning knob (CP392 non-secret rule).
-            if [ -n "${COHERE_KEY}" ]; then
-              grep -q '^COHERE_API_KEY=' .env 2>/dev/null && sed -i "s|^COHERE_API_KEY=.*|COHERE_API_KEY=${COHERE_KEY}|" .env || echo "COHERE_API_KEY=${COHERE_KEY}" >> .env
-            fi
-            # Naver Open API (book research/factcheck Korean evidence).
-            # Absent = skip — graceful naverEnabled=false, fill-book logs the
-            # degradation loudly (silent-0 class, 2026-07-14). The global leg
-            # rides OPENROUTER_API_KEY (already synced above).
-            if [ -n "${NAVER_ID}" ]; then
-              grep -q '^NAVER_CLIENT_ID=' .env 2>/dev/null && sed -i "s|^NAVER_CLIENT_ID=.*|NAVER_CLIENT_ID=${NAVER_ID}|" .env || echo "NAVER_CLIENT_ID=${NAVER_ID}" >> .env
-            fi
-            if [ -n "${NAVER_SECRET}" ]; then
-              grep -q '^NAVER_CLIENT_SECRET=' .env 2>/dev/null && sed -i "s|^NAVER_CLIENT_SECRET=.*|NAVER_CLIENT_SECRET=${NAVER_SECRET}|" .env || echo "NAVER_CLIENT_SECRET=${NAVER_SECRET}" >> .env
-            fi
-            # CP500++ CONFIG-SSOT (2026-06-16) — runtime TOGGLES removed from the
-            # .env-write path. Toggle activation SSOT = docker-compose.prod.yml
-            # `environment:` (compose literal wins over env_file per Docker
-            # precedence; the old dual-write let compose silently override .env =
-            # the §10-C silent-DEAD bug, e.g. YOUTUBE_METADATA_BACKFILL_ENABLED
-            # was compose=false while .env=... → process=false). deploy.yml now
-            # writes ONLY secrets to .env. To flip a toggle: edit the compose
-            # `environment:` literal + redeploy; verify with
-            # `docker exec insighta-api printenv | grep KEY`. CI guard prevents
-            # re-introducing a dual definition: scripts/ci/check-config-ssot.sh.
-            # Design: docs/handoffs/crosscutting-audit-phase2-design.md (PR-1).
-            # 2026-04-18 — sync DB URLs from GitHub Secrets so password
-            # rotations propagate to prod .env without manual SSH. Was
-            # blocking deploy after Supabase password rotation (container
-            # healthcheck failed because .env had stale password).
-            if [ -n "${DB_URL}" ]; then
-              grep -q '^DATABASE_URL=' .env 2>/dev/null && sed -i "s|^DATABASE_URL=.*|DATABASE_URL=${DB_URL}|" .env || echo "DATABASE_URL=${DB_URL}" >> .env
-            fi
-            if [ -n "${DB_DIRECT}" ]; then
-              grep -q '^DIRECT_URL=' .env 2>/dev/null && sed -i "s|^DIRECT_URL=.*|DIRECT_URL=${DB_DIRECT}|" .env || echo "DIRECT_URL=${DB_DIRECT}" >> .env
-            fi
-            # CP475+ — Mac Mini transcript proxy (Tailscale). When unset,
-            # caption-extractor falls back to direct youtube-transcript on
-            # EC2 (known to fail with false "disabled" errors due to
-            # YouTube IP blocking us-west-2 outbound). Idempotent set.
-            if [ -n "${MAC_MINI_TRANSCRIPT_URL}" ]; then
-              grep -q '^MAC_MINI_TRANSCRIPT_URL=' .env 2>/dev/null && sed -i "s|^MAC_MINI_TRANSCRIPT_URL=.*|MAC_MINI_TRANSCRIPT_URL=${MAC_MINI_TRANSCRIPT_URL}|" .env || echo "MAC_MINI_TRANSCRIPT_URL=${MAC_MINI_TRANSCRIPT_URL}" >> .env
-            fi
-            if [ -n "${MAC_MINI_TRANSCRIPT_TOKEN}" ]; then
-              grep -q '^MAC_MINI_TRANSCRIPT_TOKEN=' .env 2>/dev/null && sed -i "s|^MAC_MINI_TRANSCRIPT_TOKEN=.*|MAC_MINI_TRANSCRIPT_TOKEN=${MAC_MINI_TRANSCRIPT_TOKEN}|" .env || echo "MAC_MINI_TRANSCRIPT_TOKEN=${MAC_MINI_TRANSCRIPT_TOKEN}" >> .env
-            fi
-            if [ -n "${AZURE_TRANSCRIPT_URL}" ]; then
-              grep -q '^AZURE_TRANSCRIPT_URL=' .env 2>/dev/null && sed -i "s|^AZURE_TRANSCRIPT_URL=.*|AZURE_TRANSCRIPT_URL=${AZURE_TRANSCRIPT_URL}|" .env || echo "AZURE_TRANSCRIPT_URL=${AZURE_TRANSCRIPT_URL}" >> .env
-            fi
-            # ⑤ snapshot get-or-extract — pod slidegen-service URL + token. New
-            # keys (not in docker-compose.prod.yml `environment:` literals) so the
-            # .env (env_file) value flows through — no compose-override (CP500++).
-            # Idempotent set; unset ⇒ skipped (extract stays disabled, safe).
-            if [ -n "${SNAPSHOT_SERVICE_URL}" ]; then
-              grep -q '^SNAPSHOT_SERVICE_URL=' .env 2>/dev/null && sed -i "s|^SNAPSHOT_SERVICE_URL=.*|SNAPSHOT_SERVICE_URL=${SNAPSHOT_SERVICE_URL}|" .env || echo "SNAPSHOT_SERVICE_URL=${SNAPSHOT_SERVICE_URL}" >> .env
-            fi
-            if [ -n "${SNAPSHOT_SERVICE_TOKEN}" ]; then
-              grep -q '^SNAPSHOT_SERVICE_TOKEN=' .env 2>/dev/null && sed -i "s|^SNAPSHOT_SERVICE_TOKEN=.*|SNAPSHOT_SERVICE_TOKEN=${SNAPSHOT_SERVICE_TOKEN}|" .env || echo "SNAPSHOT_SERVICE_TOKEN=${SNAPSHOT_SERVICE_TOKEN}" >> .env
-            fi
-            # CP360 — primary YouTube API key for video-discover search.list.
-            # Mirrors the OPENROUTER pattern: idempotent add-or-update.
-            if [ -n "${YT_SEARCH_KEY}" ]; then
-              grep -q '^YOUTUBE_API_KEY_SEARCH=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_SEARCH=.*|YOUTUBE_API_KEY_SEARCH=${YT_SEARCH_KEY}|" .env || echo "YOUTUBE_API_KEY_SEARCH=${YT_SEARCH_KEY}" >> .env
-            fi
-            # 2026-04-17 — quota failover keys (resolveSearchApiKeys in
-            # src/skills/plugins/video-discover/v2/youtube-client.ts rotates on 403).
-            if [ -n "${YT_SEARCH_KEY_2}" ]; then
-              grep -q '^YOUTUBE_API_KEY_SEARCH_2=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_SEARCH_2=.*|YOUTUBE_API_KEY_SEARCH_2=${YT_SEARCH_KEY_2}|" .env || echo "YOUTUBE_API_KEY_SEARCH_2=${YT_SEARCH_KEY_2}" >> .env
-            fi
-            if [ -n "${YT_SEARCH_KEY_3}" ]; then
-              grep -q '^YOUTUBE_API_KEY_SEARCH_3=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_SEARCH_3=.*|YOUTUBE_API_KEY_SEARCH_3=${YT_SEARCH_KEY_3}|" .env || echo "YOUTUBE_API_KEY_SEARCH_3=${YT_SEARCH_KEY_3}" >> .env
-            fi
-            if [ -n "${YT_SEARCH_KEY_4}" ]; then
-              grep -q '^YOUTUBE_API_KEY_SEARCH_4=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_SEARCH_4=.*|YOUTUBE_API_KEY_SEARCH_4=${YT_SEARCH_KEY_4}|" .env || echo "YOUTUBE_API_KEY_SEARCH_4=${YT_SEARCH_KEY_4}" >> .env
-            fi
-            if [ -n "${YT_SEARCH_KEY_5}" ]; then
-              grep -q '^YOUTUBE_API_KEY_SEARCH_5=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_SEARCH_5=.*|YOUTUBE_API_KEY_SEARCH_5=${YT_SEARCH_KEY_5}|" .env || echo "YOUTUBE_API_KEY_SEARCH_5=${YT_SEARCH_KEY_5}" >> .env
-            fi
-            if [ -n "${YT_SEARCH_KEY_6}" ]; then
-              grep -q '^YOUTUBE_API_KEY_SEARCH_6=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_SEARCH_6=.*|YOUTUBE_API_KEY_SEARCH_6=${YT_SEARCH_KEY_6}|" .env || echo "YOUTUBE_API_KEY_SEARCH_6=${YT_SEARCH_KEY_6}" >> .env
-            fi
-            if [ -n "${YT_SEARCH_KEY_7}" ]; then
-              grep -q '^YOUTUBE_API_KEY_SEARCH_7=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_SEARCH_7=.*|YOUTUBE_API_KEY_SEARCH_7=${YT_SEARCH_KEY_7}|" .env || echo "YOUTUBE_API_KEY_SEARCH_7=${YT_SEARCH_KEY_7}" >> .env
-            fi
-            if [ -n "${YT_SEARCH_KEY_8}" ]; then
-              grep -q '^YOUTUBE_API_KEY_SEARCH_8=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_SEARCH_8=.*|YOUTUBE_API_KEY_SEARCH_8=${YT_SEARCH_KEY_8}|" .env || echo "YOUTUBE_API_KEY_SEARCH_8=${YT_SEARCH_KEY_8}" >> .env
-            fi
-            # CP492 — dedicated VIDEOS pool (videos.list / batch-video-collector via
-            # resolveVideosApiKeys). Separate Google projects so bulk videos.list does
-            # not burn the user-facing search.list projects' daily Queries quota.
-            if [ -n "${YT_VIDEOS_KEY}" ]; then
-              grep -q '^YOUTUBE_API_KEY_VIDEOS=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_VIDEOS=.*|YOUTUBE_API_KEY_VIDEOS=${YT_VIDEOS_KEY}|" .env || echo "YOUTUBE_API_KEY_VIDEOS=${YT_VIDEOS_KEY}" >> .env
-            fi
-            if [ -n "${YT_VIDEOS_KEY_2}" ]; then
-              grep -q '^YOUTUBE_API_KEY_VIDEOS_2=' .env 2>/dev/null && sed -i "s|^YOUTUBE_API_KEY_VIDEOS_2=.*|YOUTUBE_API_KEY_VIDEOS_2=${YT_VIDEOS_KEY_2}|" .env || echo "YOUTUBE_API_KEY_VIDEOS_2=${YT_VIDEOS_KEY_2}" >> .env
-            fi
-            # CP395 — Redis (video dictionary) ACL passwords + Tailscale IP.
-            # Passwords consumed by docker/redis/entrypoint.sh via envsubst
-            # into redis.acl at container start. TAILSCALE_IP used by
-            # docker-compose.prod.yml to bind 6379 on Tailscale interface
-            # only (no public SG change).
-            if [ -n "${REDIS_ADMIN_PW}" ]; then
-              grep -q '^REDIS_ADMIN_PASSWORD=' .env 2>/dev/null && sed -i "s|^REDIS_ADMIN_PASSWORD=.*|REDIS_ADMIN_PASSWORD=${REDIS_ADMIN_PW}|" .env || echo "REDIS_ADMIN_PASSWORD=${REDIS_ADMIN_PW}" >> .env
-            fi
-            if [ -n "${REDIS_COLLECTOR_PW}" ]; then
-              grep -q '^REDIS_COLLECTOR_PASSWORD=' .env 2>/dev/null && sed -i "s|^REDIS_COLLECTOR_PASSWORD=.*|REDIS_COLLECTOR_PASSWORD=${REDIS_COLLECTOR_PW}|" .env || echo "REDIS_COLLECTOR_PASSWORD=${REDIS_COLLECTOR_PW}" >> .env
-            fi
-            if [ -n "${REDIS_INSIGHTA_PW}" ]; then
-              grep -q '^REDIS_INSIGHTA_PASSWORD=' .env 2>/dev/null && sed -i "s|^REDIS_INSIGHTA_PASSWORD=.*|REDIS_INSIGHTA_PASSWORD=${REDIS_INSIGHTA_PW}|" .env || echo "REDIS_INSIGHTA_PASSWORD=${REDIS_INSIGHTA_PW}" >> .env
-            fi
-            if [ -n "${REDIS_INSIGHTA_UPSERT_PW}" ]; then
-              grep -q '^REDIS_INSIGHTA_UPSERT_PASSWORD=' .env 2>/dev/null && sed -i "s|^REDIS_INSIGHTA_UPSERT_PASSWORD=.*|REDIS_INSIGHTA_UPSERT_PASSWORD=${REDIS_INSIGHTA_UPSERT_PW}|" .env || echo "REDIS_INSIGHTA_UPSERT_PASSWORD=${REDIS_INSIGHTA_UPSERT_PW}" >> .env
-            fi
-            if [ -n "${TAILSCALE_IP}" ]; then
-              grep -q '^INSIGHTA_TAILSCALE_IP=' .env 2>/dev/null && sed -i "s|^INSIGHTA_TAILSCALE_IP=.*|INSIGHTA_TAILSCALE_IP=${TAILSCALE_IP}|" .env || echo "INSIGHTA_TAILSCALE_IP=${TAILSCALE_IP}" >> .env
-            fi
-            # CP449 — qwen-lora chatbot serving (chat-qwen.ts route).
-            # QWEN_LORA_API_URL points at Ollama OR RunPod runsync;
-            # chat-qwen.ts auto-detects via 'runpod.ai' substring.
-            # RUNPOD_API_KEY only used when URL is RunPod.
-            if [ -n "${QWEN_LORA_API_URL}" ]; then
-              grep -q '^QWEN_LORA_API_URL=' .env 2>/dev/null && sed -i "s|^QWEN_LORA_API_URL=.*|QWEN_LORA_API_URL=${QWEN_LORA_API_URL}|" .env || echo "QWEN_LORA_API_URL=${QWEN_LORA_API_URL}" >> .env
-            fi
-            if [ -n "${RUNPOD_API_KEY}" ]; then
-              grep -q '^RUNPOD_API_KEY=' .env 2>/dev/null && sed -i "s|^RUNPOD_API_KEY=.*|RUNPOD_API_KEY=${RUNPOD_API_KEY}|" .env || echo "RUNPOD_API_KEY=${RUNPOD_API_KEY}" >> .env
-            fi
-            # CP474 — chatbot provider selector. Empty/unset ⇒ BE default
-            # 'openrouter' (src/config/index.ts:109). Set 'qwen-runpod' to
-            # activate the RunPod/vLLM path + Bug 1 chat.completions fix.
-            if [ -n "${CHATBOT_PROVIDER}" ]; then
-              grep -q '^CHATBOT_PROVIDER=' .env 2>/dev/null && sed -i "s|^CHATBOT_PROVIDER=.*|CHATBOT_PROVIDER=${CHATBOT_PROVIDER}|" .env || echo "CHATBOT_PROVIDER=${CHATBOT_PROVIDER}" >> .env
-            fi
-            # CP477+14 — chatbot failover toggle. Same idempotent pattern as
-            # RICH_SUMMARY_ENABLED / YOUTUBE_METADATA_BACKFILL_ENABLED. When
-            # the GitHub Variable is unset/empty the conditional skips, so
-            # the src/config/index.ts default ('false' → no failover) stays
-            # in effect. Activate via
-            # `gh variable set CHATBOT_FAILOVER_ENABLED --body true` then
-            # redeploy. Rollback by setting back to false (or unset) +
-            # redeploy — no code revert needed.
-            if [ -n "${CHATBOT_FAILOVER_ENABLED}" ]; then
-              grep -q '^CHATBOT_FAILOVER_ENABLED=' .env 2>/dev/null && sed -i "s|^CHATBOT_FAILOVER_ENABLED=.*|CHATBOT_FAILOVER_ENABLED=${CHATBOT_FAILOVER_ENABLED}|" .env || echo "CHATBOT_FAILOVER_ENABLED=${CHATBOT_FAILOVER_ENABLED}" >> .env
-            fi
-            # CP456 — Lemon Squeezy billing. billingConfig.enabled requires
-            # API_KEY + WEBHOOK_SECRET + STORE_ID + VARIANT_MONTHLY +
-            # VARIANT_YEARLY all set (src/modules/billing/config.ts). Unset
-            # before this step => /api/v1/billing/* returns 503. API_KEY +
-            # WEBHOOK_SECRET are GH Secrets; STORE_ID + VARIANT_* are GH
-            # Variables (CP392 — visible in LS dashboard URL, non-secret).
-            if [ -n "${LS_API_KEY}" ]; then
-              grep -q '^LEMONSQUEEZY_API_KEY=' .env 2>/dev/null && sed -i "s|^LEMONSQUEEZY_API_KEY=.*|LEMONSQUEEZY_API_KEY=${LS_API_KEY}|" .env || echo "LEMONSQUEEZY_API_KEY=${LS_API_KEY}" >> .env
-            fi
-            if [ -n "${LS_WEBHOOK_SECRET}" ]; then
-              grep -q '^LEMONSQUEEZY_WEBHOOK_SECRET=' .env 2>/dev/null && sed -i "s|^LEMONSQUEEZY_WEBHOOK_SECRET=.*|LEMONSQUEEZY_WEBHOOK_SECRET=${LS_WEBHOOK_SECRET}|" .env || echo "LEMONSQUEEZY_WEBHOOK_SECRET=${LS_WEBHOOK_SECRET}" >> .env
-            fi
-            if [ -n "${LS_STORE_ID}" ]; then
-              grep -q '^LEMONSQUEEZY_STORE_ID=' .env 2>/dev/null && sed -i "s|^LEMONSQUEEZY_STORE_ID=.*|LEMONSQUEEZY_STORE_ID=${LS_STORE_ID}|" .env || echo "LEMONSQUEEZY_STORE_ID=${LS_STORE_ID}" >> .env
-            fi
-            if [ -n "${LS_VARIANT_MONTHLY}" ]; then
-              grep -q '^LEMONSQUEEZY_VARIANT_ID_PRO_MONTHLY=' .env 2>/dev/null && sed -i "s|^LEMONSQUEEZY_VARIANT_ID_PRO_MONTHLY=.*|LEMONSQUEEZY_VARIANT_ID_PRO_MONTHLY=${LS_VARIANT_MONTHLY}|" .env || echo "LEMONSQUEEZY_VARIANT_ID_PRO_MONTHLY=${LS_VARIANT_MONTHLY}" >> .env
-            fi
-            if [ -n "${LS_VARIANT_YEARLY}" ]; then
-              grep -q '^LEMONSQUEEZY_VARIANT_ID_PRO_YEARLY=' .env 2>/dev/null && sed -i "s|^LEMONSQUEEZY_VARIANT_ID_PRO_YEARLY=.*|LEMONSQUEEZY_VARIANT_ID_PRO_YEARLY=${LS_VARIANT_YEARLY}|" .env || echo "LEMONSQUEEZY_VARIANT_ID_PRO_YEARLY=${LS_VARIANT_YEARLY}" >> .env
-            fi
-            if [ -n "${LS_VARIANT_LIFETIME}" ]; then
-              grep -q '^LEMONSQUEEZY_VARIANT_ID_PRO_LIFETIME=' .env 2>/dev/null && sed -i "s|^LEMONSQUEEZY_VARIANT_ID_PRO_LIFETIME=.*|LEMONSQUEEZY_VARIANT_ID_PRO_LIFETIME=${LS_VARIANT_LIFETIME}|" .env || echo "LEMONSQUEEZY_VARIANT_ID_PRO_LIFETIME=${LS_VARIANT_LIFETIME}" >> .env
-            fi
-            chmod 600 .env
-
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            set -e
-
-            cd /opt/tubearchive
-
-            # Pull latest images (prebuilt services only — api, frontend ship
-            # from GHCR). redis is built locally on EC2 from ./docker/redis/
-            # per CP395; attempting to pull it fails because the tag does not
-            # exist in any registry.
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            docker compose -f docker-compose.prod.yml pull api frontend
-            docker compose -f docker-compose.prod.yml build redis
-
-            # Save current image digests for rollback
-            docker compose -f docker-compose.prod.yml images -q > /tmp/previous-images.txt 2>/dev/null || true
-
-            # Deploy with zero-downtime
-            docker compose -f docker-compose.prod.yml up -d --remove-orphans
-
-            # Wait for health check
-            echo "Waiting for services to be healthy..."
-            sleep 5
-
-            RETRIES=6
-            for i in $(seq 1 $RETRIES); do
-              if curl -sf http://localhost:3000/health > /dev/null 2>&1; then
-                echo "Health check passed on attempt $i!"
-                break
-              fi
-              if [ $i -eq $RETRIES ]; then
-                echo "Health check failed after $RETRIES attempts. Rolling back..."
-                docker compose -f docker-compose.prod.yml down
-                docker compose -f docker-compose.prod.yml up -d
-                exit 1
-              fi
-              echo "Attempt $i/$RETRIES - waiting..."
-              sleep 5
-            done
-
-            # CP395 — post-deploy Redis smoke test. Catches silent auth
-            # failures (e.g. CRLF-contaminated passwords, ACL render errors)
-            # that leave the container healthy but unusable.
-            echo "Redis ACL smoke test..."
-            REDIS_SMOKE_ADMIN_PW=$(grep '^REDIS_ADMIN_PASSWORD=' .env | cut -d= -f2- | tr -d '\r\n')
-            REDIS_SMOKE_COLL_PW=$(grep '^REDIS_COLLECTOR_PASSWORD=' .env | cut -d= -f2- | tr -d '\r\n')
-            REDIS_SMOKE_READ_PW=$(grep '^REDIS_INSIGHTA_PASSWORD=' .env | cut -d= -f2- | tr -d '\r\n')
-            REDIS_SMOKE_UPS_PW=$(grep '^REDIS_INSIGHTA_UPSERT_PASSWORD=' .env | cut -d= -f2- | tr -d '\r\n')
-            for attempt in 1 2 3 4 5; do
-              if docker exec insighta-redis redis-cli --user admin -a "$REDIS_SMOKE_ADMIN_PW" --no-auth-warning ping 2>/dev/null | grep -q PONG; then
-                break
-              fi
-              if [ "$attempt" = "5" ]; then
-                echo "Redis admin auth failed after 5 attempts"
-                docker logs --tail 30 insighta-redis
-                exit 1
-              fi
-              sleep 2
-            done
-            ACL_COUNT=$(docker exec insighta-redis redis-cli --user admin -a "$REDIS_SMOKE_ADMIN_PW" --no-auth-warning ACL LIST | wc -l)
-            if [ "$ACL_COUNT" != "5" ]; then
-              echo "Redis ACL LIST returned $ACL_COUNT rows, expected 5 (default off + 4 on)"
-              exit 1
-            fi
-            for U_PW in "collector:$REDIS_SMOKE_COLL_PW" "insighta:$REDIS_SMOKE_READ_PW" "insighta-upsert:$REDIS_SMOKE_UPS_PW"; do
-              USR="${U_PW%%:*}"; PW="${U_PW#*:}"
-              if ! docker exec insighta-redis redis-cli --user "$USR" -a "$PW" --no-auth-warning ping 2>/dev/null | grep -q PONG; then
-                echo "Redis user '$USR' auth failed"
-                exit 1
-              fi
-            done
-            # Tailscale bind check — 6379 must listen on Tailscale IP only.
-            REDIS_SMOKE_TSIP=$(grep '^INSIGHTA_TAILSCALE_IP=' .env | cut -d= -f2- | tr -d '\r\n')
-            BIND_OK=$(ss -tlnp 2>/dev/null | grep ":6379 " | grep -c "$REDIS_SMOKE_TSIP" || true)
-            if [ "$BIND_OK" = "0" ]; then
-              echo "Redis port 6379 not bound to Tailscale IP ($REDIS_SMOKE_TSIP) — check compose port mapping"
-              ss -tlnp | grep ":6379 " || echo "(no 6379 listener)"
-              exit 1
-            fi
-            # CP411 follow-up (20d) — verify end-to-end consumer path: the
-            # insighta ACL user must be able to SMEMBERS the whitelist key.
-            # Catches regressions in `docker/redis/redis.acl.template` keys
-            # pattern or command grant list. Empty set is a valid PASS.
-            if ! docker exec insighta-redis redis-cli --user insighta -a "$REDIS_SMOKE_READ_PW" --no-auth-warning SMEMBERS whitelist:channels > /dev/null 2>&1; then
-              echo "Redis insighta user cannot SMEMBERS whitelist:channels — check ACL keys pattern"
-              exit 1
-            fi
-            echo "Redis smoke test OK — 4 users authenticate, bound to Tailscale iface, insighta→whitelist SMEMBERS OK."
-
-            # Cleanup old images
-            docker image prune -f
-
-      - name: Verify deployment
+      # Nothing to do when the tags already match, which happens on a re-run.
+      - name: Commit
         run: |
-          sleep 5
-          curl -sf https://${{ secrets.DOMAIN }}/health || echo "External health check pending (DNS may not be configured yet)"
-
-      # Every deploy leaves its SHA-tagged image on the box and nothing removed
-      # them: measured 2026-08-13, images held 4.92 GB with 1.767 GB reclaimable
-      # after five weeks, on a 20 GB disk already at 66%. No systemd timer, no
-      # crontab. A one-off cleanup would put us back here in a month, so the
-      # collection happens where the images are created.
-      #
-      # Deliberately not `prune -a`. That keeps only what is running and would
-      # delete every local rollback target. rollback.yml pulls from GHCR, which
-      # would make that safe — except GHCR's own retention has not been
-      # confirmed (the token lacks read:packages), and rollback is not something
-      # to stake on an unverified assumption. 30 days keeps a month of targets
-      # locally; revisit once GHCR retention is known.
-      #
-      # Runs only after Verify, so a deploy that failed leaves everything alone.
-      - name: Reclaim old images
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            BEFORE=$(df --output=used -BM / | tail -1 | tr -dc '0-9')
-            # Images in use by a running container are never touched by prune.
-            docker image prune -af --filter 'until=720h' || true
-            docker builder prune -f --filter 'until=720h' || true
-            AFTER=$(df --output=used -BM / | tail -1 | tr -dc '0-9')
-            echo "disk used: ${BEFORE}M -> ${AFTER}M (freed $((BEFORE - AFTER))M)"
-            df -h / | tail -1
-            docker system df
-
-      - name: Close SSH for runner IP
-        if: always()
-        run: |
-          if [ -n "$RUNNER_IP" ]; then
-            aws ec2 revoke-security-group-ingress \
-              --group-id "$SG_ID" \
-              --protocol tcp --port 22 \
-              --cidr "$RUNNER_IP/32" 2>/dev/null || true
-            echo "Closed SSH for $RUNNER_IP"
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- charts/insighta/environments/prod.yaml; then
+            echo "tags already at ${{ github.sha }}"
+            exit 0
           fi
+          git add charts/insighta/environments/prod.yaml
+          git commit -m "chore(images): point prod at ${{ github.sha }}" \
+                     -m "Written by deploy.yml after pushing to ECR. The scope job
+          treats a values-only change as non-deployable, so this does not loop."
+          git push origin main
+
+  # `fast-mobile` and `deploy` lived here until 2026-08-19. Both ended in an SSH
+  # session to secrets.EC2_HOST, copying files onto the host that served the site
+  # before the cluster cutover on 2026-08-14. That instance was released on
+  # 2026-08-19, so both jobs addressed a machine that no longer exists.
+  #
+  # They were not failing yet only because every merge since had touched docs or
+  # terraform, which `scope` marks non-deployable. The first real code change
+  # would have been the first failure.
+  #
+  # Nothing replaces them here. Images still reach ECR from `build-and-push`, and
+  # what carries them into the cluster is ArgoCD reading this repository. The
+  # image tag it reads is set in charts/insighta/environments/prod.yaml.

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,66 +1,128 @@
+# Roll production back to a previous image, by writing that image's tag into the
+# chart and letting the cluster reconcile.
+#
+# The previous version of this workflow opened an SSH session to the host that
+# served the site before the cutover on 2026-08-14 and ran `docker compose` on
+# it. That host was released on 2026-08-19. It had last run in April, and failed.
+#
+# There is no SSH here, and nothing is pushed at the cluster. ArgoCD holds
+# cluster-admin and has no public address, so a runner cannot reach it by design.
+# What the cluster reads is this repository, so a rollback is a commit: the tag
+# in charts/insighta/environments/prod.yaml changes, and the next sync moves the
+# pods. The same path deploy.yml uses going forward, run backwards.
+#
+# This became possible on 2026-08-19. Before that the chart pinned `latest`, so
+# every revision named the same image and there was no earlier tag to return to.
+
 name: Rollback
 
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Image tag to rollback to (commit SHA or "previous")'
+      sha:
+        description: 'Commit sha to roll back to, or "previous" for the tag before the current one'
         required: true
         default: previous
         type: string
+      reason:
+        description: 'Why (shown in the commit and the run name)'
+        required: true
+        type: string
 
-env:
-  API_IMAGE: ghcr.io/jk42jj/insighta-api
-  FRONTEND_IMAGE: ghcr.io/jk42jj/insighta-frontend
+run-name: 'Rollback to ${{ inputs.sha }} — ${{ inputs.reason }}'
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  contents: write
 
 jobs:
   rollback:
-    name: Rollback Deployment
+    name: Point the chart at an earlier commit
     runs-on: ubuntu-latest
-    environment: production
     steps:
-      - name: Rollback via SSH
-        uses: appleboy/ssh-action@v1
+      - uses: actions/checkout@v4
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            set -e
-            cd /opt/tubearchive
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-            VERSION="${{ github.event.inputs.version }}"
+      # "previous" means the tag before the one in the file now, which is read
+      # from the history of the file itself rather than from the commit log of
+      # the repository: those differ whenever a deploy was skipped.
+      - name: Resolve the target tag
+        id: target
+        run: |
+          set -euo pipefail
+          F=charts/insighta/environments/prod.yaml
+          CURRENT=$(grep -E '^  apiTag:' "$F" | awk '{print $2}')
+          echo "current: $CURRENT"
 
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          if [ "${{ inputs.sha }}" = "previous" ]; then
+            TARGET=$(git log -p --follow -- "$F" \
+              | grep -E '^\+  apiTag:' \
+              | awk '{print $3}' \
+              | grep -v "^$CURRENT$" \
+              | head -1)
+            [ -n "$TARGET" ] || { echo "no earlier tag recorded in $F"; exit 1; }
+          else
+            TARGET="${{ inputs.sha }}"
+          fi
 
-            if [ "$VERSION" = "previous" ]; then
-              echo "Rolling back to previous deployment..."
-              docker compose -f docker-compose.prod.yml down
-              docker compose -f docker-compose.prod.yml up -d
-            else
-              echo "Rolling back to version: $VERSION"
-              export API_IMAGE_TAG="${{ env.API_IMAGE }}:${VERSION}"
-              export FRONTEND_IMAGE_TAG="${{ env.FRONTEND_IMAGE }}:${VERSION}"
+          [ "$TARGET" != "$CURRENT" ] || { echo "target equals current; nothing to do"; exit 1; }
+          echo "target: $TARGET"
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "target=$TARGET"   >> "$GITHUB_OUTPUT"
 
-              # Update image tags in env
-              sed -i "s|API_IMAGE=.*|API_IMAGE=${API_IMAGE_TAG}|" .env.production
-              sed -i "s|FRONTEND_IMAGE=.*|FRONTEND_IMAGE=${FRONTEND_IMAGE_TAG}|" .env.production
+      # A tag that was never pushed produces pods stuck on ImagePullBackOff, and
+      # the rollback is then a second outage on top of the first.
+      - name: Confirm the images exist in ECR
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TF_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-west-2
+        run: |
+          set -euo pipefail
+          T=${{ steps.target.outputs.target }}
+          for repo in insighta-api insighta-frontend; do
+            aws ecr describe-images --repository-name "$repo" --image-ids "imageTag=$T" >/dev/null \
+              || { echo "$repo:$T is not in ECR — refusing"; exit 1; }
+            echo "  $repo:$T present"
+          done
 
-              docker compose -f docker-compose.prod.yml pull
-              docker compose -f docker-compose.prod.yml up -d --remove-orphans
-            fi
+      - name: Write the tag and push
+        run: |
+          set -euo pipefail
+          F=charts/insighta/environments/prod.yaml
+          T=${{ steps.target.outputs.target }}
 
-            # Verify rollback
-            sleep 10
-            RETRIES=6
-            for i in $(seq 1 $RETRIES); do
-              if curl -sf http://localhost:3000/health > /dev/null 2>&1; then
-                echo "Rollback successful! Health check passed."
-                exit 0
-              fi
-              echo "Waiting for health check... ($i/$RETRIES)"
-              sleep 10
-            done
+          for key in apiTag frontendTag; do
+            sed -i -E "s|^  $key:.*|  $key: $T|" "$F"
+          done
+          grep -E '^  (api|frontend)Tag:' "$F"
 
-            echo "WARNING: Health check failed after rollback"
-            exit 1
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$F"
+          git commit -m "revert(images): roll prod back to $T" \
+                     -m "From ${{ steps.target.outputs.current }}. Reason: ${{ inputs.reason }}
+          Triggered by ${{ github.actor }}. redisTag is left alone: the redis image
+          is a cache built from three files and is not part of an application
+          rollback."
+          git push origin main
+
+      - name: What happens next
+        run: |
+          echo "The chart now names ${{ steps.target.outputs.target }}."
+          echo
+          echo "prod syncs manually, so this does not take effect until someone syncs:"
+          echo "  bash scripts/ops/argocd-ui.sh"
+          echo
+          echo "Or from a shell on the node:"
+          echo "  kubectl -n argocd patch app insighta-prod --type merge \\"
+          echo "    -p '{\"operation\":{\"sync\":{\"revision\":\"HEAD\"}}}'"
+          echo
+          echo "Then confirm the pods actually changed image, not just restarted:"
+          echo "  kubectl -n insighta-prod get pods -o jsonpath='{.items[*].status.containerStatuses[*].imageID}'"

--- a/charts/insighta/environments/prod.yaml
+++ b/charts/insighta/environments/prod.yaml
@@ -11,6 +11,21 @@
 # with a message that says so.
 requireImageRegistry: true
 
+# Image tags, written by .github/workflows/deploy.yml after it pushes to ECR.
+#
+# These were `latest` in values.yaml until 2026-08-19, and `latest` cost two
+# things. Rollback: both deployment revisions pointed at the same string, so
+# `kubectl rollout undo` replaced pods with the same image and reported success
+# while changing nothing. Consistency: with pullPolicy IfNotPresent, two nodes
+# that pulled `latest` on different days run different code under one tag.
+#
+# A commit sha makes each deploy a distinct image string, which restores both.
+# The values are managed by CI -- edit them by merging, not by hand.
+images:
+  apiTag: latest
+  frontendTag: latest
+  redisTag: latest
+
 api:
   # One, not two, until the compose host is decommissioned.
   #

--- a/charts/insighta/templates/_helpers.tpl
+++ b/charts/insighta/templates/_helpers.tpl
@@ -50,9 +50,9 @@ committed and one pulling from the repository as written.
 {{- define "insighta.image" -}}
 {{- $reg := .root.Values.imageRegistry | default "" -}}
 {{- if $reg -}}
-{{ $reg }}/{{ base .img.repository }}:{{ .img.tag }}
+{{ $reg }}/{{ base .img.repository }}:{{ .tag | default .img.tag }}
 {{- else -}}
-{{ .img.repository }}:{{ .img.tag }}
+{{ .img.repository }}:{{ .tag | default .img.tag }}
 {{- end -}}
 {{- end }}
 

--- a/charts/insighta/templates/api.yaml
+++ b/charts/insighta/templates/api.yaml
@@ -37,7 +37,7 @@ spec:
       {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: api
-          image: {{ include "insighta.image" (dict "root" $ "img" .Values.api.image) | quote }}
+          image: {{ include "insighta.image" (dict "root" $ "img" .Values.api.image "tag" (get ($.Values.images | default dict) "apiTag")) | quote }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           args: {{ toYaml .Values.api.command | nindent 12 }}
           ports:

--- a/charts/insighta/templates/frontend.yaml
+++ b/charts/insighta/templates/frontend.yaml
@@ -26,7 +26,7 @@ spec:
       {{- include "insighta.spread" (dict "root" $ "component" "frontend") | nindent 6 }}
       containers:
         - name: frontend
-          image: {{ include "insighta.image" (dict "root" $ "img" .Values.frontend.image) | quote }}
+          image: {{ include "insighta.image" (dict "root" $ "img" .Values.frontend.image "tag" (get ($.Values.images | default dict) "frontendTag")) | quote }}
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/insighta/templates/redis.yaml
+++ b/charts/insighta/templates/redis.yaml
@@ -27,7 +27,7 @@ spec:
       {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: redis
-          image: {{ include "insighta.image" (dict "root" $ "img" .Values.redis.image) | quote }}
+          image: {{ include "insighta.image" (dict "root" $ "img" .Values.redis.image "tag" (get ($.Values.images | default dict) "redisTag")) | quote }}
           imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
           # Overrides maxmemory from redis.conf so it stays below the
           # container limit; the image's entrypoint forwards these.

--- a/charts/insighta/templates/schema-sync-job.yaml
+++ b/charts/insighta/templates/schema-sync-job.yaml
@@ -65,7 +65,7 @@ spec:
 {{- end }}
       containers:
         - name: schema-sync
-          image: {{ include "insighta.image" (dict "root" $ "img" .Values.api.image) | quote }}
+          image: {{ include "insighta.image" (dict "root" $ "img" .Values.api.image "tag" (get ($.Values.images | default dict) "apiTag")) | quote }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           command: ["npx", "prisma@{{ .Values.schemaSync.cliVersion }}", "db", "push", "--skip-generate", "--accept-data-loss"]
           envFrom:

--- a/charts/insighta/templates/worker.yaml
+++ b/charts/insighta/templates/worker.yaml
@@ -41,7 +41,7 @@ spec:
       {{- include "insighta.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: worker
-          image: {{ include "insighta.image" (dict "root" $ "img" .Values.api.image) | quote }}
+          image: {{ include "insighta.image" (dict "root" $ "img" .Values.api.image "tag" (get ($.Values.images | default dict) "apiTag")) | quote }}
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           args: ["worker"]
           ports:

--- a/charts/insighta/values.yaml
+++ b/charts/insighta/values.yaml
@@ -54,6 +54,7 @@ api:
   replicaCount: 1
   image:
     repository: ghcr.io/jk42jj/insighta-api
+    # environments/*.yaml override this via images.apiTag; see prod.yaml
     tag: latest
     pullPolicy: IfNotPresent
   command: ["api"]
@@ -137,6 +138,7 @@ frontend:
   replicaCount: 1
   image:
     repository: ghcr.io/jk42jj/insighta-frontend
+    # environments/*.yaml override this via images.frontendTag; see prod.yaml
     tag: latest
     pullPolicy: IfNotPresent
   port: 8081
@@ -173,6 +175,7 @@ redis:
     # Pushed by deploy.yml since 2026-08-14. Before that it existed in no
     # registry and the default here named an image only the compose host had.
     repository: ghcr.io/jk42jj/insighta-redis
+    # environments/*.yaml override this via images.redisTag; see prod.yaml
     tag: latest
     pullPolicy: IfNotPresent
   port: 6379

--- a/scripts/ci/check-config-ssot.sh
+++ b/scripts/ci/check-config-ssot.sh
@@ -36,8 +36,16 @@ compose_keys="$(printf '%s\n' "$compose_api_block" \
   | sed -E 's/^[[:space:]]+-[[:space:]]+//; s/=.*$//')"
 
 # --- deploy.yml keys written to .env (lines touching .env, anchored `^KEY=`) ---
-deploy_env_keys="$(grep -E '\.env' "$DEPLOY" \
-  | grep -oE '\^[A-Za-z_][A-Za-z0-9_]*=' \
+# `|| true` on both greps: zero matches is now the expected state, not an error.
+# The .env-writing step lived in the `deploy` job, which addressed the host that
+# served the site before the cutover and was removed on 2026-08-19 along with
+# that host. With nothing writing .env from CI there is no second definition
+# left to conflict with, which is the condition this guard exists to reach.
+#
+# Without these, `set -e` turns an empty grep into a failed build and the guard
+# reports a violation precisely when the violation has been eliminated.
+deploy_env_keys="$( { grep -E '\.env' "$DEPLOY" || true; } \
+  | { grep -oE '\^[A-Za-z_][A-Za-z0-9_]*=' || true; } \
   | sed -E 's/^\^//; s/=$//' \
   | sort -u)"
 

--- a/tests/smoke/deploy-env-contract.test.ts
+++ b/tests/smoke/deploy-env-contract.test.ts
@@ -1,22 +1,31 @@
 /**
- * Deploy env-injection contract (regression, 2026-07-14 CSE silent-0).
+ * Env-injection contract (regression, 2026-07-14 CSE silent-0).
  *
- * Failure class: a config module reads an env var, but deploy.yml never
- * writes it to the EC2 .env — the feature silently degrades for months
- * (GOOGLE_CSE_* was name-registered at CP458, code shipped at CP504, yet
- * research yielded 0 findings and factcheck ran without web evidence
- * because the credentials were never injected anywhere; 2026-07-14 the
- * evidence source moved to Naver + the OpenRouter web plugin).
+ * Failure class: a config module reads an env var that nothing puts into the
+ * running container, so the feature degrades silently for months. GOOGLE_CSE_*
+ * was name-registered at CP458 and the code shipped at CP504, yet research
+ * returned 0 findings and factcheck ran without web evidence, because the
+ * credentials were never injected anywhere. On 2026-07-14 the evidence source
+ * moved to Naver plus the OpenRouter web plugin.
  *
- * This test pins the contract: every env var listed here MUST have a
- * sync line in deploy.yml's .env-write block.
+ * The mechanism this pins changed on 2026-08-19. It used to be deploy.yml
+ * writing a .env file onto an EC2 host over SSH; that host was released and the
+ * job with it. Values now reach the container from the `insighta-env` secret in
+ * the cluster, pulled in with envFrom.
+ *
+ * The contract is the same and the failure it prevents is the same: a variable
+ * the code reads must have exactly one declared path into the container, and
+ * that path must be visible in this repository rather than assumed.
  */
 import * as fs from 'fs';
 import * as path from 'path';
 
-const DEPLOY_YML = path.join(__dirname, '../../.github/workflows/deploy.yml');
+const ROOT = path.join(__dirname, '../..');
+const API_TEMPLATE = path.join(ROOT, 'charts/insighta/templates/api.yaml');
+const WORKER_TEMPLATE = path.join(ROOT, 'charts/insighta/templates/worker.yaml');
+const DEPLOY_YML = path.join(ROOT, '.github/workflows/deploy.yml');
 
-// Env vars whose ONLY production injection path is the deploy.yml .env sync.
+/** Vars whose only production injection path is the cluster secret. */
 const ENV_SYNCED_VARS = [
   'OPENROUTER_API_KEY',
   'COHERE_API_KEY',
@@ -24,32 +33,46 @@ const ENV_SYNCED_VARS = [
   'NAVER_CLIENT_SECRET',
 ];
 
-// appleboy/ssh-action forwards ONLY variables named in `envs:` to the remote
-// shell — a sync line whose shell var is missing there silently writes nothing
-// (exactly how NAVER_* was dropped on 2026-07-14 despite a green deploy).
-// Shell-name mapping for vars whose step-env name differs from the .env name.
-const ENVS_LIST_SHELL_NAMES: Record<string, string> = {
-  OPENROUTER_API_KEY: 'OR_KEY',
-  COHERE_API_KEY: 'COHERE_KEY',
-  NAVER_CLIENT_ID: 'NAVER_ID',
-  NAVER_CLIENT_SECRET: 'NAVER_SECRET',
-};
+/** The secret those values live in, created outside git and holding 144 keys. */
+const SECRET_NAME = 'insighta-env';
 
-describe('deploy.yml env-injection contract', () => {
-  const yml = fs.readFileSync(DEPLOY_YML, 'utf-8');
-  const envsLine = yml
-    .split('\n')
-    .filter((l) => l.trim().startsWith('envs:'))
-    .join(',');
+describe('env-injection contract', () => {
+  const api = fs.readFileSync(API_TEMPLATE, 'utf-8');
+  const worker = fs.readFileSync(WORKER_TEMPLATE, 'utf-8');
 
-  it.each(ENV_SYNCED_VARS)('%s shell var is forwarded via the envs: list', (name) => {
-    const shellName = ENVS_LIST_SHELL_NAMES[name] ?? name;
-    expect(envsLine).toMatch(new RegExp(`[ ,]${shellName}(,|$)`));
+  it.each([
+    ['api', api],
+    ['worker', worker],
+  ])('%s pulls its whole environment from one secret', (_name, tpl) => {
+    // envFrom is what makes every key in the secret present in the container.
+    // Naming variables individually is the arrangement that let GOOGLE_CSE_*
+    // go missing, so the assertion is on the bulk form.
+    expect(tpl).toMatch(/envFrom:/);
+    expect(tpl).toMatch(/secretRef:/);
+    expect(tpl).toMatch(/\.Values\.envSecretName/);
   });
 
-  it.each(ENV_SYNCED_VARS)('%s has a .env sync line', (name) => {
-    // The idempotent sync pattern: grep -q '^NAME=' .env ... || echo "NAME=..." >> .env
-    expect(yml).toMatch(new RegExp(`\\^${name}=`));
-    expect(yml).toContain(`${name}=`);
+  it('the secret that name resolves to is the one holding the keys', () => {
+    // The template references a value; this pins what the value is, so a rename
+    // in the chart cannot quietly point the deployment at an empty secret.
+    const values = fs.readFileSync(path.join(ROOT, 'charts/insighta/values.yaml'), 'utf-8');
+    expect(values).toMatch(new RegExp(`envSecretName:\\s*${SECRET_NAME}`));
+  });
+
+  it.each(ENV_SYNCED_VARS)('%s is not injected by any second path', (name) => {
+    // Two paths mean one can drift or be removed while the other hides it.
+    // The deploy workflow used to write these into a .env file; that job is
+    // gone, and this asserts it does not come back by accident.
+    const yml = fs.readFileSync(DEPLOY_YML, 'utf-8');
+    const writesEnvFile = new RegExp(`\\^${name}=.*>>.*\\.env`, 'm');
+    expect(yml).not.toMatch(writesEnvFile);
+  });
+
+  it('the workflow no longer addresses the released host', () => {
+    // The host that served the site before the cutover was released on
+    // 2026-08-19. A reference to it here would be a job that cannot succeed.
+    const yml = fs.readFileSync(DEPLOY_YML, 'utf-8');
+    const uses = yml.split('\n').filter((l) => l.includes('EC2_HOST') && !l.trim().startsWith('#'));
+    expect(uses).toEqual([]);
   });
 });


### PR DESCRIPTION
Three defects, all downstream of the cutover on 2026-08-14 and the release of
the original host on 2026-08-19.

## Dead deploy paths

`deploy.yml` ended in an SSH session to `secrets.EC2_HOST`, copying a compose
file onto a machine that no longer exists. `fast-mobile` did the same for the
dial assets. Neither had failed yet: every merge since had touched docs or
terraform, which `scope` marks non-deployable. The first real code change would
have been the first failure.

`backup.yml` had a `redis` job running `docker exec` against the same host. It
has been red daily since 2026-08-14 while the database backup beside it kept
succeeding, which is why this workflow reported failure every morning with the
backups arriving normally.

## The redis backup is removed rather than rewritten

Measured today: `DBSIZE 0`, `used_memory 1.06M`, `/data 16K`. Redis here is a
cache, declared as one in `prod.yaml`, sitting on an 8Gi PVC that survives
restarts. There is nothing to back up.

If it is ever given data that cannot be recomputed, the backup belongs in the
chart as a CronJob rather than in a workflow reaching in from outside. The
comment left in `backup.yml` says so.

## Image tags by commit

`latest` cost two things.

**Rollback.** Both deployment revisions pointed at the same string, so
`rollout undo` replaced pods with the same image, reported success, and changed
nothing.

**Consistency.** With `pullPolicy: IfNotPresent`, two nodes that pulled `latest`
on different days run different code under one tag.

`prod.yaml` now carries `images.apiTag`, `images.frontendTag` and
`images.redisTag`; the image helper prefers them and falls back to the chart
default, so dev and staging are untouched. A new `publish-tags` job writes the
commit sha there after the push to ECR.

The write-back goes through git rather than at the cluster because ArgoCD holds
cluster-admin and has no public address — a runner cannot reach it. `charts/` is
already in the `scope` exclusion so the resulting push returns
`deployable=false`. That was checked against the exact path rather than assumed:

```
charts/insighta/environments/prod.yaml     deployable=false
src/api/server.ts                          deployable=true
```

The comment on that exclusion now records why the entry has to stay.

## Verification

```
helm render, all environments                    ok
--set images.apiTag=abc1234 → insighta-api:abc1234   ok
dev unchanged (insighta-api:local)               ok
scripts/ci/check-charts.sh                       ok
scripts/ci/check-timeouts.sh                     7 passed, 0 failed
tsc --noEmit                                     0 errors
no job needs a job that no longer exists         ok
```

## The two guards that were asserting against the old host

Both CI failures on this branch were the guards, not the change.

`check-config-ssot.sh` searched `deploy.yml` for `.env`-writing lines. Under
`set -e` an empty grep is a failed build, so the guard reported a violation at
the point the violation was eliminated: with the `deploy` job removed, nothing
writes `.env` from CI, which is the state the guard exists to reach. `|| true`
on both greps.

`deploy-env-contract.test.ts` pinned a mechanism that no longer exists. It
asserted four keys appear in an `appleboy/ssh-action` `envs:` list and in a
`.env` sync line. Values reach the container from the `insighta-env` secret via
`envFrom`, so the test now asserts the bulk form. Naming variables individually
is the arrangement that let `GOOGLE_CSE_*` go missing for months, which is the
failure this file was written for. Two assertions are added: that
`envSecretName` resolves to the secret holding the keys, so a chart rename
cannot point the deployment at an empty secret, and that no second injection
path reappears in `deploy.yml`.

## rollback.yml is rewritten, not left standing

The earlier revision of this PR left it in place. It is replaced here.

It opened an SSH session to the released host and ran `docker compose`. The
replacement performs a rollback as a commit: the tag in
`charts/insighta/environments/prod.yaml` changes and the cluster reconciles —
the deploy path in this PR, run backwards. It goes through git for the same
reason `publish-tags` does: ArgoCD holds cluster-admin and has no public
address, so a runner cannot reach it.

It refuses a tag that is not in ECR. A missing image produces
`ImagePullBackOff`, which makes the rollback a second outage on top of the
first. `redisTag` is not moved: that image is a cache built from three files and
is not part of an application rollback.

**Precondition, and what clears it.** `prod.yaml` currently reads `latest` for
every tag, so no earlier tag is recorded and the workflow exits 1 rather than
proceeding. `publish-tags` writes the first commit sha on the next deployable
merge to `main`; rollback is usable from the deploy after that one. This is not
a limitation of the workflow — it is the absence of history that pinning tags
creates, and it clears on its own with the first deploy.

**Not exercised.** `workflow_dispatch` cannot be run without pushing to `main`,
so this was verified by parsing and by confirming every key it reads and edits
exists: `apiTag`, `frontendTag`, `envSecretName`, `TF_AWS_ACCESS_KEY_ID`,
`TF_AWS_SECRET_ACCESS_KEY`.

## Also unblocked by this

`Deploy to EC2` has failed on `main` since `#1518` merged (run `32209484706`,
2026-08-19 02:42) — the job this PR removes. Every merge to `main` fails that
workflow until this lands. Production is unaffected: ArgoCD reconciles from the
repository on a separate path, and both domains return 200.

## Verification, second round

```
scripts/ci/check-config-ssot.sh          exit 0
jest deploy-env-contract                 8 passed, 8 total
rollback.yml yaml parse                  jobs=[rollback] inputs=[sha, reason]
prod.yaml apiTag/frontendTag/redisTag    present
values.yaml envSecretName: insighta-env  present
gh secret list TF_AWS_*                  both present
re-run after prettier reformat           8 passed, 8 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
