### PR TITLE
fix(deploy): the dial has no path to production, and has not since the cutover

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       mobile_only: ${{ steps.d.outputs.mobile_only }}
+      dial: ${{ steps.d.outputs.dial }}
       api: ${{ steps.d.outputs.api }}
       frontend: ${{ steps.d.outputs.frontend }}
       redis: ${{ steps.d.outputs.redis }}
@@ -53,6 +54,7 @@ jobs:
           # workflow_dispatch has no diff to inspect -- treat it as "everything".
           if [ "${{ github.event_name }}" != "push" ]; then
             echo "mobile_only=false" >> "$GITHUB_OUTPUT"
+            echo "dial=true"         >> "$GITHUB_OUTPUT"
             echo "api=true"          >> "$GITHUB_OUTPUT"
             echo "frontend=true"     >> "$GITHUB_OUTPUT"
             echo "redis=true"        >> "$GITHUB_OUTPUT"
@@ -67,6 +69,7 @@ jobs:
           if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
              || ! git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
             echo "mobile_only=false" >> "$GITHUB_OUTPUT"
+            echo "dial=true"         >> "$GITHUB_OUTPUT"
             echo "api=true"          >> "$GITHUB_OUTPUT"
             echo "frontend=true"     >> "$GITHUB_OUTPUT"
             echo "redis=true"        >> "$GITHUB_OUTPUT"
@@ -81,6 +84,7 @@ jobs:
           # skip -- fall through to the full pipeline.
           if [ -z "$FILES" ]; then
             echo "mobile_only=false" >> "$GITHUB_OUTPUT"
+            echo "dial=true"         >> "$GITHUB_OUTPUT"
             echo "api=true"          >> "$GITHUB_OUTPUT"
             echo "frontend=true"     >> "$GITHUB_OUTPUT"
             echo "redis=true"        >> "$GITHUB_OUTPUT"
@@ -93,6 +97,12 @@ jobs:
           else
             MOBILE_ONLY=true
           fi
+
+          # Whether the dial changed at all, which is not the same question as
+          # whether it changed alone. The syntax gate hung off mobile_only, so a
+          # commit touching the dial and anything else skipped the only check
+          # the dial has.
+          if echo "$FILES" | grep -q '^frontend/public/mobile/'; then DIAL=true; else DIAL=false; fi
 
           # Which image actually needs rebuilding. The API image is built from
           # the repo root, so anything outside frontend/ can affect it.
@@ -133,19 +143,23 @@ jobs:
 
           echo "redis=$RD"                >> "$GITHUB_OUTPUT"
           echo "mobile_only=$MOBILE_ONLY" >> "$GITHUB_OUTPUT"
+          echo "dial=$DIAL"               >> "$GITHUB_OUTPUT"
           echo "api=$API"                 >> "$GITHUB_OUTPUT"
           echo "frontend=$FE"             >> "$GITHUB_OUTPUT"
           echo "deployable=$DEPLOYABLE"   >> "$GITHUB_OUTPUT"
-          echo "mobile_only=$MOBILE_ONLY api=$API frontend=$FE deployable=$DEPLOYABLE"
+          echo "mobile_only=$MOBILE_ONLY dial=$DIAL api=$API frontend=$FE deployable=$DEPLOYABLE"
 
   # The dial's only gate. Nothing in ci.yml reads frontend/public/mobile:
   # tsc looks at src, vitest looks at src, and vite copies public/ verbatim.
   # So a syntax error in this file has always been shippable. It is not now.
+  #
+  # Gated on `dial`, not `mobile_only`: this ran only when the dial changed by
+  # itself, so a commit carrying a dial edit alongside anything else skipped it.
   mobile-gate:
     name: Dial syntax gate
     runs-on: ubuntu-latest
     needs: [scope]
-    if: needs.scope.outputs.mobile_only == 'true'
+    if: needs.scope.outputs.dial == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Parse every inline script and check the build stamp
@@ -167,6 +181,11 @@ jobs:
     needs: [scope]
     # The ref guard matters for workflow_dispatch, which can be started from any
     # branch; the push trigger is already main-only.
+    #
+    # mobile_only stays here. It was removed from build-and-push because the dial
+    # is inside the frontend image and that job is the only thing that ships it.
+    # Edge functions are a different artifact that a dial edit cannot affect, so
+    # skipping them is narrowing, not a missed deploy.
     if: github.ref == 'refs/heads/main' && needs.scope.outputs.mobile_only != 'true' && needs.scope.outputs.deployable == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -189,11 +208,21 @@ jobs:
               --no-verify-jwt
           done
 
+  # No mobile_only guard here, and that is the whole repair. It skipped this job
+  # because `fast-mobile` shipped the dial by rsync instead; that job addressed
+  # the host released on 2026-08-19 and was removed with it. The guard outlived
+  # its destination, so a dial-only commit ran the syntax gate, skipped every
+  # build and deploy job, and reported green having shipped nothing. Measured
+  # 2026-08-19: main carried build 99 since 2026-08-13 and production served 97.
+  #
+  # The per-image conditions below already do the narrowing this guard was
+  # standing in for: a dial-only commit sets frontend=true, api=false,
+  # redis=false, so it builds one image and not three.
   build-and-push:
     name: Build & Push Docker Images
     runs-on: ubuntu-latest
     needs: [scope]
-    if: needs.scope.outputs.mobile_only != 'true' && needs.scope.outputs.deployable == 'true'
+    if: needs.scope.outputs.deployable == 'true'
     permissions:
       contents: read
       packages: write
@@ -294,6 +323,9 @@ jobs:
     name: Database Schema Sync
     runs-on: ubuntu-latest
     needs: [scope]
+    # mobile_only stays here, and deliberately. This runs `prisma db push`
+    # against the production database. A dial edit cannot change the schema, so
+    # running it would be a write to production with no reason to be there.
     if: needs.scope.outputs.mobile_only != 'true' && needs.scope.outputs.deployable == 'true'
     steps:
       - uses: actions/checkout@v4

--- a/tests/smoke/deploy-dial-path.test.ts
+++ b/tests/smoke/deploy-dial-path.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The dial has a path to production (regression, 2026-08-19).
+ *
+ * Measured that day: main had carried dial build 99 since 2026-08-13 and
+ * production served 97. The pods were healthy and running the current image;
+ * the image contained 97, because nothing had built one.
+ *
+ * A dial-only commit sets mobile_only=true. Three jobs were written as
+ * `mobile_only != 'true'`, which was correct while `fast-mobile` shipped the
+ * dial by rsync instead of by image. That job addressed the host released on
+ * 2026-08-19 and was removed with it, and the guard outlived its destination:
+ * the syntax gate ran, every build and deploy job skipped, and the run was
+ * green having shipped nothing.
+ *
+ * The failure has no symptom. There is no red check, no error, and the site
+ * keeps serving — just an older dial than the repository says. That is what
+ * makes it worth pinning rather than remembering.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+
+const DEPLOY = path.join(__dirname, '../../.github/workflows/deploy.yml');
+
+type Job = { if?: string; needs?: string | string[] };
+const wf = yaml.load(fs.readFileSync(DEPLOY, 'utf-8')) as {
+  jobs: Record<string, Job>;
+};
+const jobs = wf.jobs;
+const cond = (name: string) => jobs[name]?.if ?? '';
+
+describe('a dial-only commit reaches production', () => {
+  it('the job that builds the image does not skip on mobile_only', () => {
+    // build-and-push is the only thing that puts frontend/public/mobile into a
+    // deployable artifact. Narrowing belongs in its per-image step conditions,
+    // which already read scope.outputs.frontend.
+    expect(jobs['build-and-push']).toBeDefined();
+    expect(cond('build-and-push')).not.toMatch(/mobile_only/);
+  });
+
+  it('the job that pins the tag is reachable from a dial-only commit', () => {
+    // publish-tags needs build-and-push. If that is skipped this is skipped
+    // too, and the chart keeps pointing at whatever it pointed at before.
+    const needs = ([] as string[]).concat(jobs['publish-tags']?.needs ?? []);
+    expect(needs).toContain('build-and-push');
+    expect(cond('publish-tags')).not.toMatch(/mobile_only/);
+  });
+
+  it('the syntax gate runs whenever the dial changed, not only when it changed alone', () => {
+    // Gating on mobile_only meant a commit touching the dial and one other file
+    // skipped the only check the dial has: ci.yml does not read this directory
+    // at all, since tsc and vitest look at src and vite copies public/ verbatim.
+    expect(cond('mobile-gate')).toMatch(/needs\.scope\.outputs\.dial\b/);
+    expect(cond('mobile-gate')).not.toMatch(/mobile_only/);
+  });
+
+  it('scope publishes the dial signal the gate reads', () => {
+    const outputs = (jobs['scope'] as unknown as { outputs?: Record<string, string> }).outputs;
+    expect(outputs).toBeDefined();
+    expect(Object.keys(outputs!)).toContain('dial');
+  });
+
+  it('mobile_only survives only where skipping is narrowing, not a missed deploy', () => {
+    // These two are different artifacts a dial edit cannot affect. migrate in
+    // particular runs `prisma db push` against production, so running it for a
+    // dial edit would be a write with no reason to be there.
+    expect(cond('migrate')).toMatch(/mobile_only != 'true'/);
+    expect(cond('deploy-edge-functions')).toMatch(/mobile_only != 'true'/);
+  });
+});


### PR DESCRIPTION
The dial cannot reach production, and has not been able to since the cutover.

## What was measured

```
main (origin)        {"build": "2026-08-13-99"}    PR #1484, 2026-08-13
production (curl)    {"build": "2026-08-04-97"}
inside the pod       {"build": "2026-08-04-97"}
```

The frontend pods are healthy and running the image the chart names
(`sha256:3ed77d9d`, pushed 2026-08-14). The image contains 97. Nothing built one
that contains 99.

## Why

A dial-only commit sets `mobile_only=true`, and three jobs read
`mobile_only != 'true'`. That was correct while `fast-mobile` shipped the dial by
rsync rather than by image build. `fast-mobile` addressed the host released on
2026-08-19 and was removed with it in #1519; the guard outlived its destination.

What a dial-only commit does today: the syntax gate runs, `build-and-push`
skips, `publish-tags` skips because it needs `build-and-push`, and the run is
green. Nothing shipped.

There is no symptom. No red check, no error, the site keeps serving — an older
dial than the repository says.

## The change

The guard is removed from `build-and-push` only. Its per-image step conditions
already do the narrowing it was standing in for: a dial-only commit sets
`frontend=true`, `api=false`, `redis=false`, so one image is built, not three.
`publish-tags` follows because it needs that job.

It stays on `migrate` and `deploy-edge-functions`. Those are different artifacts
a dial edit cannot affect, and `migrate` runs `prisma db push` against the
production database — running it for a dial edit would be a write to production
with no reason to be there.

## A second hole, closed here

`mobile-gate` also hung off `mobile_only`, so a commit touching the dial **and
anything else** skipped it. It is the only check the dial has: `ci.yml` does not
read `frontend/public/mobile` at all — `tsc` and `vitest` look at `src`, and
vite copies `public/` verbatim. `scope` now publishes `dial` (the dial changed at
all, alone or not) and the gate reads that.

## Verification

The detection block was extracted from this workflow with a YAML parser and run
against real git repositories rather than retyped, so what ran is the shipped
logic and not a copy of it:

| changed | mobile_only | dial | frontend | deployable |
|---|---|---|---|---|
| dial only | true | true | true | true |
| dial + api | false | true | true | true |
| api only | false | false | false | true |
| charts only | false | false | false | **false** |
| docs only | false | false | false | **false** |

`charts` staying `deployable=false` is what keeps `publish-tags` from looping.

`tests/smoke/deploy-dial-path.test.ts` pins the invariant — 5/5. Negative
control: restoring both guards fails 2 of the 5; reverting that passes 5 again.

## What this does not do

This ships the dial inside the frontend image, so a 473KB text edit rebuilds the
SPA and redeploys it. That is the correct default and not the end state — the
dial is a separately versioned, zero-shared-code artifact that wants its own tag
and its own rollback. The design for that is in
`docs/ops/dial-separate-artifact.md`, and it is a separate PR.

## After merge, this does not ship build 99 by itself

Stated wrongly in the first revision of this description, and corrected after
running the case rather than reasoning about it:

```
THIS PR (.github + tests)   dial=false  frontend=false  deployable=false
```

Both paths this PR touches are in the `IRRELEVANT` exclusion, so merging it
deploys nothing — as intended by that list, and it means the repair takes effect
for the *next* dial commit rather than for the dial sitting unshipped now.

Shipping build 99 needs one deployable run. `workflow_dispatch` is the existing
mechanism: `scope` treats a manual run as "everything", which rebuilds the
frontend image from main, and `publish-tags` then writes the first commit sha
into the chart. Production syncs manually, so the dial reaches the site on that
sync and `https://insighta.one/mobile/version.json` should then read
`2026-08-13-99`.

That run also executes `migrate`, which is `prisma db push` against the
production database. It is the same job every ordinary deploy runs and there is
no pending schema change, but it is a write to production and the decision to
start it is not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
