### PR TITLE
chore(images): pin prod to 057d82c1, by hand, because CI cannot write it

### DIFF
--- a/charts/insighta/environments/prod.yaml
+++ b/charts/insighta/environments/prod.yaml
@@ -21,10 +21,21 @@ requireImageRegistry: true
 #
 # A commit sha makes each deploy a distinct image string, which restores both.
 # The values are managed by CI -- edit them by merging, not by hand.
+#
+# This first set was written by hand, because publish-tags could not write it.
+# Its first execution (run 32218303510) pushed straight to main and was refused:
+#
+#   remote: error: GH006: Protected branch update failed for refs/heads/main.
+#   remote: - 8 of 8 required status checks are expected.
+#
+# A direct push from CI cannot satisfy required status checks, so that job has
+# to open a pull request instead. Until it does, this file is edited the way
+# this commit edits it. Same for rollback.yml, which pushes by the same means
+# and would fail the same way -- it has not been run since it was rewritten.
 images:
-  apiTag: latest
-  frontendTag: latest
-  redisTag: latest
+  apiTag: 057d82c1b9d5f9e46cd4d182dced5c594910514d
+  frontendTag: 057d82c1b9d5f9e46cd4d182dced5c594910514d
+  redisTag: 057d82c1b9d5f9e46cd4d182dced5c594910514d
 
 api:
   # One, not two, until the compose host is decommissioned.


### PR DESCRIPTION
Does by hand what `publish-tags` was going to do, and records why it had to.

## What happened

`publish-tags` ran for the first time today (run `32218303510`) and was refused:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 8 of 8 required status checks are expected.
remote: ! [remote rejected] main -> main (protected branch hook declined)
```

`main` requires 8 checks with `strict: true`. A commit CI pushes directly carries none, so it can never satisfy them. `enforce_admins` is false — an admin could push — but `GITHUB_TOKEN` acts as `github-actions[bot]`, which is not one. The mechanism is wrong, not the configuration.

`rollback.yml` writes the tag and pushes the same way. It has not run since it was rewritten, so this is the proof that would otherwise have arrived mid-outage.

## Why by hand

Everything else in that deploy succeeded — the images are built and pushed. Only the write-back failed. Pinning by hand costs one PR and stops the dial waiting; repairing the job is a separate change and does not need to block this.

## Checked before pinning

A tag that was never pushed produces `ImagePullBackOff`, which makes a deploy an outage:

```
insighta-api        PRESENT
insighta-frontend   PRESENT
insighta-redis      PRESENT
```

`helm template` renders all three at the pinned tag.

## Effect

- Production has served dial build 97 since 2026-08-04 while main carried 99 from 2026-08-13. The image tagged `057d82c1` contains 99. **It reaches the site on the next manual ArgoCD sync, not on this merge.**
- Ends the `latest` window: two revisions naming one string, with `IfNotPresent` letting nodes diverge under it.
- `charts/` is `deployable=false`, so this merge starts no deploy and cannot loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)