### PR TITLE
fix(ci): a workflow cannot push to main, so both stop trying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -380,6 +380,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -404,21 +405,84 @@ jobs:
           done
           grep -E '^  (api|frontend|redis)Tag:' "$F"
 
-      # Nothing to do when the tags already match, which happens on a re-run.
-      - name: Commit
+      # This pushed straight to main until 2026-08-19 and was refused on its
+      # first execution (run 32218303510):
+      #
+      #   remote: error: GH006: Protected branch update failed for refs/heads/main.
+      #   remote: - 8 of 8 required status checks are expected.
+      #
+      # main requires 8 checks with strict on, and a commit pushed by CI carries
+      # none, so it can never satisfy them. That is a property of the mechanism,
+      # not of the configuration -- there is no setting on this job that makes a
+      # direct push work.
+      #
+      # What it does instead: push a branch, which protection does not cover, and
+      # open a pull request from it. Merging that PR is one click, and it is the
+      # same change this job used to attempt.
+      #
+      # Why the merge is not automatic. GitHub does not trigger workflows from
+      # events created with GITHUB_TOKEN, so ci.yml would never run on a PR this
+      # job opens, the 8 required checks would never report, and auto-merge would
+      # wait forever. Closing that gap needs a token that is not GITHUB_TOKEN --
+      # a credential decision, recorded in docs/ops/k8s-migration-issue-checklist.md
+      # under A-5 rather than made here.
+      #
+      # enforce_admins is false on this branch, so an admin can merge the PR even
+      # with the checks unreported. That is the intended path until A-5 is settled.
+      - name: Open a pull request with the tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet -- charts/insighta/environments/prod.yaml; then
-            echo "tags already at ${{ github.sha }}"
+          F=charts/insighta/environments/prod.yaml
+          SHA=${{ github.sha }}
+
+          # A re-run, or a deploy whose images were already pinned, has nothing
+          # to propose. Not an error.
+          if git diff --quiet -- "$F"; then
+            echo "tags already at $SHA"
+            echo "### Image tags already at \`$SHA\`" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          git add charts/insighta/environments/prod.yaml
-          git commit -m "chore(images): point prod at ${{ github.sha }}" \
-                     -m "Written by deploy.yml after pushing to ECR. The scope job
-          treats a values-only change as non-deployable, so this does not loop."
-          git push origin main
+
+          BRANCH="images/${SHA:0:12}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add "$F"
+          git commit -m "chore(images): point prod at $SHA"
+
+          # Branch names outside main are not protected, so this succeeds where
+          # the push to main did not.
+          git push --force-with-lease origin "$BRANCH"
+
+          # An existing PR for this sha means a re-run; reuse it rather than
+          # failing on the duplicate.
+          URL=$(gh pr list --head "$BRANCH" --json url --jq '.[0].url // empty')
+          if [ -z "$URL" ]; then
+            URL=$(gh pr create --base main --head "$BRANCH" \
+              --title "chore(images): point prod at ${SHA:0:12}" \
+              --body "Opened by deploy.yml after pushing these images to ECR.
+
+          Merging this is what tells the cluster which images to run: ArgoCD reads
+          \`charts/insighta/environments/prod.yaml\` from this repository, and until this
+          lands it still names the previous ones.
+
+          Production syncs manually, so merging does not deploy on its own.
+
+          Not merged automatically: GitHub does not run workflows on events created
+          with GITHUB_TOKEN, so the required checks will not report here. See A-5 in
+          \`docs/ops/k8s-migration-issue-checklist.md\`.")
+          fi
+
+          echo "::notice title=Image tags need one merge::$URL"
+          {
+            echo "### Image tags are waiting on a merge"
+            echo
+            echo "\`$SHA\`"
+            echo
+            echo "$URL"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # `fast-mobile` and `deploy` lived here until 2026-08-19. Both ended in an SSH
   # session to secrets.EC2_HOST, copying files onto the host that served the site

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -37,6 +37,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   rollback:
@@ -92,7 +93,22 @@ jobs:
             echo "  $repo:$T present"
           done
 
-      - name: Write the tag and push
+      # Pushed straight to main until 2026-08-19. It never ran that way: the
+      # same push in deploy.yml's publish-tags was refused by branch protection
+      # on its first execution, and this workflow writes by identical means, so
+      # the proof arrived without an incident to arrive during.
+      #
+      #   remote: error: GH006: Protected branch update failed for refs/heads/main.
+      #   remote: - 8 of 8 required status checks are expected.
+      #
+      # A rollback that opens a pull request is slower than one that pushes, and
+      # a rollback is wanted when something is already wrong. That cost is stated
+      # rather than hidden: enforce_admins is false on this branch, so an admin
+      # merges without waiting for checks. What is not acceptable is the previous
+      # state, in which this workflow would have failed at the push mid-incident.
+      - name: Write the tag and open a pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           F=charts/insighta/environments/prod.yaml
@@ -105,17 +121,38 @@ jobs:
 
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BRANCH="rollback/$T"
+          git checkout -b "$BRANCH"
           git add "$F"
           git commit -m "revert(images): roll prod back to $T" \
                      -m "From ${{ steps.target.outputs.current }}. Reason: ${{ inputs.reason }}
           Triggered by ${{ github.actor }}. redisTag is left alone: the redis image
           is a cache built from three files and is not part of an application
           rollback."
-          git push origin main
+          git push --force-with-lease origin "$BRANCH"
+
+          URL=$(gh pr list --head "$BRANCH" --json url --jq '.[0].url // empty')
+          if [ -z "$URL" ]; then
+            URL=$(gh pr create --base main --head "$BRANCH" \
+              --title "revert(images): roll prod back to $T" \
+              --body "Rollback requested by ${{ github.actor }}. Reason: ${{ inputs.reason }}
+
+          From ${{ steps.target.outputs.current }} to $T. Both images were confirmed present
+          in ECR before this was opened.
+
+          Merge, then sync. Merging alone changes nothing, because production syncs manually.
+          Required checks will not report here: GitHub does not run workflows on events
+          created with GITHUB_TOKEN. enforce_admins is false, so an admin can merge without
+          them, and during an incident that is the intended path.")
+          fi
+          echo "::notice title=Rollback is waiting on a merge::$URL"
+          echo "ROLLBACK_PR=$URL" >> "$GITHUB_ENV"
 
       - name: What happens next
         run: |
-          echo "The chart now names ${{ steps.target.outputs.target }}."
+          echo "A pull request naming ${{ steps.target.outputs.target }} is open:"
+          echo "  $ROLLBACK_PR"
+          echo "Merge it. Nothing below takes effect until it is on main."
           echo
           echo "prod syncs manually, so this does not take effect until someone syncs:"
           echo "  bash scripts/ops/argocd-ui.sh"

--- a/docs/ops/k8s-migration-issue-checklist.md
+++ b/docs/ops/k8s-migration-issue-checklist.md
@@ -13,6 +13,7 @@ compose 단일 호스트에서 k3s 로 옮기면 **구조적으로 예상 가능
 | A-2 | 다이얼 배포 경로 소실 | **결함 — PR #1520 대기** |
 | A-3 | 이미지 태그 `latest` | **미완 — 첫 SHA 미기록** |
 | A-4 | 롤백 워크플로 | **미검증** |
+| A-5 | CI 가 보호 브랜치에 쓸 수 없다 | **결함 — 부분 수리** |
 | B-1 | 3 replica × in-process 스케줄러 중복 | **해결** |
 | B-2 | 데이터 파이프라인 4종 | **결함 — 수리 미검증** |
 | B-3 | DB 백업 | **정상** |
@@ -23,6 +24,7 @@ compose 단일 호스트에서 k3s 로 옮기면 **구조적으로 예상 가능
 | C-4 | graceful shutdown | **정상**(frontend 경미) |
 | C-5 | 리소스 한계 · OOM | **정상** |
 | C-6 | TLS 갱신 | **정상** |
+| C-7 | 프로드 Argo Application 이 git 에 없다 | **결함** |
 | D-1 | 시크릿 etcd 평문 | **미해결(기지)** |
 | D-2 | api 볼륨 emptyDir | **허용 — 근거 불일치** |
 | D-3 | SSE × 3 replica | **정상** |
@@ -75,6 +77,43 @@ prod (curl)     {"build": "2026-08-04-97"}
 
 `rollback.yml` 은 차트 태그를 커밋하는 방식으로 재작성됐으나 `workflow_dispatch` 라 실행된 적이 없다.
 파싱과 참조 키 존재만 확인했다. A-3 가 해소되기 전에는 실행해도 "되돌아갈 태그 없음" 으로 종료한다.
+
+### A-5. CI 가 보호 브랜치에 쓸 수 없다 — 결함, 부분 수리
+
+`publish-tags` 최초 실행(run `32218303510`)이 거부됐다.
+
+```
+remote: error: GH006: Protected branch update failed for refs/heads/main.
+remote: - 8 of 8 required status checks are expected.
+remote: ! [remote rejected] main -> main (protected branch hook declined)
+```
+
+보호 설정 실측:
+
+```
+required_checks  8개   strict: true
+enforce_admins   false
+restrictions     없음   required_pull_request_reviews  없음
+```
+
+CI 가 push 한 커밋은 체크를 하나도 달고 있지 않으므로 **구조적으로** 필수 체크를 만족할 수 없다.
+job 설정으로 해결되지 않는다. `rollback.yml` 이 동일한 방식이라 같은 결함을 공유했고,
+재작성 후 실행된 적이 없어 **장애 중에 발견될 예정이었다.**
+
+**막힌 지점.** 완전 자동화의 선택지가 셋인데 전부 이 세션 밖의 결정을 요구한다.
+
+| 안 | 필요한 것 | 비용 |
+|---|---|---|
+| CI 가 main 에 직접 push | 관리자 권한 PAT (`enforce_admins: false` 이므로 우회 가능) | 공개 리포 main 에 push 가능한 상시 크레덴셜 |
+| 봇 PR + auto-merge | PAT (GITHUB_TOKEN 이 만든 이벤트는 워크플로를 **트리거하지 않아** 필수 체크가 영원히 미보고) + `allow_auto_merge` 활성화 | 크레덴셜 + 배포 완료가 CI 속도에 종속 |
+| Argo 가 별도 브랜치를 추적 | 프로드 Application 의 `targetRevision` 변경 | 그 Application 이 git 에 없다 — C-7 |
+
+**지금 한 것.** 브랜치 push 는 보호 대상이 아니므로, 두 워크플로가 브랜치를 밀고 PR 을 연다.
+`enforce_admins: false` 라 관리자는 체크 미보고 상태로도 머지할 수 있다 — 클릭 한 번.
+배포가 마지막 단계에서 실패하지 않고, 무엇을 해야 하는지가 run summary 와 `::notice` 에 남는다.
+
+**푸는 조건**: 위 표에서 하나를 고르는 것. 크레덴셜 생성은 James 권한이라 여기서 정하지 않는다.
+회귀 = `tests/smoke/workflow-git-writes.test.ts` (워크플로가 main 에 push 하지 않음을 고정).
 
 ---
 
@@ -201,6 +240,29 @@ insighta-tls  notAfter 2026-11-16T07:57:13Z  renewalTime 2026-10-17T07:57:13Z
 ```
 
 cert-manager 가 10-17 에 갱신한다. compose 시절 호스트 nginx + certbot 경로는 호스트와 함께 사라졌다.
+
+### C-7. 프로드 Argo Application 이 git 에 없다 — 결함
+
+```
+$ grep -n "name: insighta-" charts/bootstrap/applications.yaml
+14:  name: insighta-dev
+34:  name: insighta-staging
+57:  name: insighta-validation
+```
+
+프로드가 없다. 클러스터의 `insighta-prod` 는 `kubectl.kubernetes.io/last-applied-configuration` 를
+갖고 `ownerReferences` 가 비어 있다 — **손으로 apply 됐고 root-app 이 관리하지 않는다.**
+
+파일 상단 주석은 아직 *"There is no prod Application yet... It is added at P4, with the cutover"* 라고
+적혀 있다. P4 는 2026-08-14 에 끝났고 Application 은 만들어졌으나 리포에 돌아오지 않았다.
+
+결과 셋:
+- **클러스터 재구축 시 이 Application 을 기억으로 복원해야 한다.** 무엇을 배포할지 결정하는 객체가
+  재구축 절차의 대상 밖에 있다.
+- Argo 설정 변경(예: A-5 의 세 번째 안)이 GitOps 가 아니라 클러스터 수작업이 된다.
+- 그 spec 이 `imageRegistry` 로 AWS 계정 id 를 담고 있다. 공개 리포라 그대로는 커밋할 수 없다 —
+  이것이 애초에 커밋되지 않은 이유로 보이며, `requireImageRegistry` 와 같은 방식
+  (값은 Argo 의 helm parameter 로, 파일에는 부재)으로 풀 수 있다.
 
 ---
 

--- a/tests/smoke/workflow-git-writes.test.ts
+++ b/tests/smoke/workflow-git-writes.test.ts
@@ -1,0 +1,60 @@
+/**
+ * No workflow writes to main by pushing to it (regression, 2026-08-19).
+ *
+ * publish-tags ran for the first time on 2026-08-19 and was refused:
+ *
+ *   remote: error: GH006: Protected branch update failed for refs/heads/main.
+ *   remote: - 8 of 8 required status checks are expected.
+ *
+ * main requires 8 status checks with strict on. A commit CI pushes carries
+ * none, so it can never satisfy them, and no setting on the job changes that.
+ * rollback.yml wrote by identical means and had not been run since it was
+ * rewritten, so the same defect was sitting in the workflow that exists to be
+ * used during an incident.
+ *
+ * Both now push a branch and open a pull request. This pins that: a workflow
+ * may push branches, and may not push main.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const DIR = path.join(__dirname, '../../.github/workflows');
+const files = fs.readdirSync(DIR).filter((f) => f.endsWith('.yml'));
+
+/** Lines that run a command, with comments and blank lines removed. */
+function commandLines(text: string): string[] {
+  return text
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !l.startsWith('#'));
+}
+
+describe('workflows do not push to a protected branch', () => {
+  it.each(files)('%s does not push main', (file) => {
+    const lines = commandLines(fs.readFileSync(path.join(DIR, file), 'utf-8'));
+    // `git push origin main`, `git push origin HEAD:main`, and the refs/heads
+    // spelling of either. A push to a branch name that merely contains "main"
+    // (mainline/, main-backup) is not matched.
+    const pushesMain = lines.filter((l) =>
+      /git\s+push\b[^|;&]*\b(origin\s+)?(HEAD:)?(refs\/heads\/)?main\s*$/.test(l)
+    );
+    expect(pushesMain).toEqual([]);
+  });
+
+  it('the two jobs that write image tags open a pull request instead', () => {
+    // Naming them explicitly: a rename that drops the mechanism should fail
+    // here rather than pass because the file no longer matches a pattern.
+    const deploy = fs.readFileSync(path.join(DIR, 'deploy.yml'), 'utf-8');
+    const rollback = fs.readFileSync(path.join(DIR, 'rollback.yml'), 'utf-8');
+    for (const [name, text] of [
+      ['deploy.yml', deploy],
+      ['rollback.yml', rollback],
+    ] as const) {
+      expect(text).toMatch(/gh pr create/);
+      // Opening a PR needs this permission; without it the call 403s at the
+      // point the tag would have been written.
+      expect(text).toMatch(/pull-requests:\s*write/);
+      expect(name).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
`publish-tags` ran for the first time on 2026-08-19 and was refused:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 8 of 8 required status checks are expected.
remote: ! [remote rejected] main -> main (protected branch hook declined)
```

`main` requires 8 checks with `strict: true`. A commit CI pushes carries none, so it can never satisfy them. No setting on the job changes that — the mechanism is wrong.

`rollback.yml` writes by identical means and has not run since it was rewritten. Same defect, sitting in the workflow whose whole purpose is to work during an incident.

## The change

Both push a branch — protection covers `main`, not branch creation — and open a pull request from it. Merging is one click and is the same change the push attempted.

## Why the merge is not automatic

A limit, not a preference. GitHub does not trigger workflows from events created with `GITHUB_TOKEN`, so `ci.yml` never runs on a PR these jobs open, the required checks never report, and auto-merge would wait forever.

`enforce_admins` is false, so an admin merges without the checks. During a rollback that is the intended path, and the generated PR body says so.

## What blocks full automation

Three options, each needing a decision outside this PR. Written up as **A-5** in `docs/ops/k8s-migration-issue-checklist.md`:

| option | needs | cost |
|---|---|---|
| CI pushes main directly | admin PAT | a standing credential that can push to a public repo's main |
| bot PR + auto-merge | PAT + `allow_auto_merge` | credential, and deploy completion tied to CI duration |
| ArgoCD tracks another branch | change prod `targetRevision` | that Application is not in git — see C-7 |

## C-7, found while looking

**The production ArgoCD Application is not in this repository.** `applications.yaml` carries dev, staging and validation. The live `insighta-prod` object has `last-applied-configuration` and no `ownerReferences` — applied by hand, not managed by the root app. The comment at the top of that file still says a prod Application will be added at P4; P4 completed on 2026-08-14 and it never came back to git.

Rebuilding the cluster would mean restoring from memory the object that decides what runs.

## Verification

`tests/smoke/workflow-git-writes.test.ts` — 16/16 across all fifteen workflows. Negative control: restoring the push to main fails exactly the `deploy.yml` case; reverting passes again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)