### PR TITLE
fix(queue): the api enqueues, so the api has to start pg-boss

### DIFF
--- a/src/api/background.ts
+++ b/src/api/background.ts
@@ -54,18 +54,29 @@ const CRONS: Array<{ name: string; start: () => void; stop: () => void }> = [
 export async function startBackgroundWork(log: BackgroundLogger): Promise<void> {
   log.info(`Process role: ${describeProcessRole()}`);
 
-  if (runsQueueWorkers()) {
-    try {
-      await initJobQueue();
-      log.info('JobQueue initialized (pg-boss + enrich-video + batch-scan)');
-    } catch (err) {
-      log.warn({ err }, 'JobQueue init failed (non-fatal)');
-    }
-  } else {
-    // pg-boss needs session-mode connections, the scarce kind on Supabase.
-    // Leaving them to the worker deployment keeps the web tier's connection
-    // cost to the Prisma pool alone.
-    log.info('JobQueue skipped (RUN_QUEUE_WORKERS=false)');
+  // Started in every process, with or without handlers.
+  //
+  // This used to be skipped entirely when RUN_QUEUE_WORKERS was false, to keep
+  // session-mode connections on the worker deployment. That reasoning was
+  // sound and the conclusion was wrong: the api serves the endpoints that
+  // *enqueue*, and pg-boss `send()` throws unless the client is started. From
+  // the web/worker split until 2026-08-19 every internal trigger endpoint
+  // returned 500 with "JobQueue not started", which took out
+  // batch-video-collector and pool-maintenance nightly and had no symptom
+  // beyond two red workflows among several red for other reasons.
+  //
+  // The connection cost is answered by sizing rather than by absence: a
+  // producer opens QUEUE_CONFIG.PRODUCER_POOL_MAX, not pg-boss's default of
+  // 10, and runs neither the supervisor nor the scheduler.
+  try {
+    await initJobQueue({ registerWorkers: runsQueueWorkers() });
+    log.info(
+      runsQueueWorkers()
+        ? 'JobQueue initialized (pg-boss + handlers)'
+        : 'JobQueue initialized (producer only -- enqueue works, handlers run on the worker)'
+    );
+  } catch (err) {
+    log.warn({ err }, 'JobQueue init failed (non-fatal)');
   }
 
   if (!runsSchedulers()) {
@@ -90,12 +101,13 @@ export async function startBackgroundWork(log: BackgroundLogger): Promise<void> 
 }
 
 export async function stopBackgroundWork(log: BackgroundLogger): Promise<void> {
-  if (runsQueueWorkers()) {
-    try {
-      await getJobQueue().stop();
-    } catch {
-      /* ignore */
-    }
+  // Unconditional, to match startBackgroundWork: a producer holds a pool too,
+  // and leaving it open on shutdown holds session-mode connections until the
+  // server times them out.
+  try {
+    await getJobQueue().stop();
+  } catch {
+    /* ignore */
   }
 
   if (!runsSchedulers()) return;

--- a/src/modules/queue/index.ts
+++ b/src/modules/queue/index.ts
@@ -56,11 +56,21 @@ import { logger } from '../../utils/logger';
  * Starts pg-boss, registers workers, sets up schedules.
  * Call during server startup, after database connection is established.
  */
-export async function initJobQueue(): Promise<void> {
+export async function initJobQueue(opts: { registerWorkers?: boolean } = {}): Promise<void> {
   const queue = getJobQueue();
+  const registerWorkers = opts.registerWorkers !== false;
 
-  // Start pg-boss (creates schema on first run)
-  await queue.start();
+  // Start pg-boss (creates schema on first run). This happens in every
+  // process, including ones that register no handlers: `send()` throws
+  // without it. Skipping it on the api pods is what made every internal
+  // trigger endpoint return 500 after the web/worker split -- measured
+  // 2026-08-19, "JobQueue not started. Call start() first."
+  await queue.start({ producerOnly: !registerWorkers });
+
+  if (!registerWorkers) {
+    logger.info('Job queue started as producer (enqueue only, no handlers)');
+    return;
+  }
 
   // Register workers
   await registerEnrichVideoWorker();

--- a/src/modules/queue/manager.ts
+++ b/src/modules/queue/manager.ts
@@ -54,16 +54,29 @@ export class JobQueueManager {
   /**
    * Initialize and start pg-boss.
    * Creates pgboss schema + tables on first run.
+   *
+   * `producerOnly` is for a process that enqueues but runs no handlers. It
+   * still needs pg-boss started -- `send()` throws without it, which is how
+   * the api pods came to return 500 on every internal trigger endpoint after
+   * the web/worker split -- but it does not need the supervisor, the
+   * scheduler, or a pool sized for concurrent work. Those belong to whichever
+   * process owns the queue, and running them in several places is duplicated
+   * maintenance against one database.
    */
-  async start(): Promise<void> {
+  async start(opts: { producerOnly?: boolean } = {}): Promise<void> {
     if (this.started) return;
 
     const connectionString = this.getConnectionString();
+    const producerOnly = opts.producerOnly === true;
 
     this.boss = new PgBoss({
       connectionString,
       schema: 'pgboss',
-      monitorStateIntervalSeconds: 30,
+      max: producerOnly ? QUEUE_CONFIG.PRODUCER_POOL_MAX : QUEUE_CONFIG.WORKER_POOL_MAX,
+      // Option names verified against pg-boss 9.0.3 types.d.ts rather than
+      // recalled: `max`, `noSupervisor`, `noScheduling`.
+      ...(producerOnly ? { noSupervisor: true, noScheduling: true } : {}),
+      ...(producerOnly ? {} : { monitorStateIntervalSeconds: 30 }),
       archiveCompletedAfterSeconds: QUEUE_CONFIG.ARCHIVE_COMPLETED_AFTER_DAYS * 86400,
       archiveFailedAfterSeconds: QUEUE_CONFIG.ARCHIVE_FAILED_AFTER_DAYS * 86400,
       deleteAfterDays: 30,
@@ -81,7 +94,11 @@ export class JobQueueManager {
     try {
       await this.boss.start();
       this.started = true;
-      logger.info('JobQueue started (pg-boss)', { schema: 'pgboss' });
+      logger.info('JobQueue started (pg-boss)', {
+        schema: 'pgboss',
+        role: producerOnly ? 'producer' : 'worker',
+        max: producerOnly ? QUEUE_CONFIG.PRODUCER_POOL_MAX : QUEUE_CONFIG.WORKER_POOL_MAX,
+      });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       logger.error('JobQueue start failed', { error: msg });

--- a/src/modules/queue/types.ts
+++ b/src/modules/queue/types.ts
@@ -485,6 +485,20 @@ export const NOTE_CV_ENRICH_OPTIONS = {
 // ============================================================================
 
 export const QUEUE_CONFIG = {
+  /**
+   * pg-boss connection ceilings, stated rather than defaulted.
+   *
+   * pg-boss opens its own pg.Pool, separate from Prisma's, and its default is
+   * 10. Three api replicas starting it unbounded would be 30 session-mode
+   * connections against a Supabase limit of 60, on top of Prisma's.
+   *
+   * A process that only enqueues needs almost nothing: a send is one short
+   * statement. A process that runs the workers needs room for concurrent
+   * handlers.
+   */
+  PRODUCER_POOL_MAX: 2,
+  WORKER_POOL_MAX: 8,
+
   /** Batch scan schedule: every 30 minutes (cron) */
   BATCH_SCAN_CRON: '*/30 * * * *',
   /** Observability Phase 2-A key-count alarm: daily at 08:07 (off-hour). */

--- a/tests/smoke/queue-producer-role.test.ts
+++ b/tests/smoke/queue-producer-role.test.ts
@@ -1,0 +1,71 @@
+/**
+ * A process that enqueues starts pg-boss, even when it runs no handlers
+ * (regression, 2026-08-19).
+ *
+ * The web/worker split set RUN_QUEUE_WORKERS=false on the api pods so the
+ * node-cron schedulers and pg-boss consumers would run in exactly one place.
+ * That part was right. What went with it was `initJobQueue()` itself, and the
+ * api is what serves the endpoints that enqueue -- pg-boss `send()` throws
+ * unless the client has been started.
+ *
+ * Measured in production on 2026-08-19:
+ *
+ *   POST /api/v1/internal/skills/batch-video-collector/run   -> 500 in 0.3s
+ *   POST /api/v1/internal/pool-maintenance/run               -> 500
+ *   api log: "enqueue failed: JobQueue not started. Call start() first."
+ *
+ * Both scheduled workflows had been failing nightly. The 500 arrives in a
+ * third of a second, so it looked nothing like the ingress timeout that was
+ * taking down the collectors beside them, and it was hidden among those.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { QUEUE_CONFIG } from '../../src/modules/queue/types';
+
+describe('queue producer role', () => {
+  it('a producer pool is bounded well below the worker pool', () => {
+    // pg-boss defaults to 10 and opens its own pool, separate from Prisma's.
+    // Three api replicas at the default would be 30 session-mode connections
+    // against a Supabase limit of 60.
+    expect(QUEUE_CONFIG.PRODUCER_POOL_MAX).toBeGreaterThan(0);
+    expect(QUEUE_CONFIG.PRODUCER_POOL_MAX).toBeLessThan(QUEUE_CONFIG.WORKER_POOL_MAX);
+    expect(QUEUE_CONFIG.PRODUCER_POOL_MAX).toBeLessThan(10);
+  });
+
+  it('the whole fleet fits in the connection budget', () => {
+    // Stated in charts/insighta/environments/prod.yaml. Written as a sum so a
+    // later change to any term has to face the total.
+    const API_REPLICAS = 3;
+    const PRISMA_POOL_LIMIT = 8;
+    const SUPABASE_LIMIT = 60;
+
+    const prisma = API_REPLICAS * PRISMA_POOL_LIMIT + PRISMA_POOL_LIMIT; // api + worker
+    const pgboss = API_REPLICAS * QUEUE_CONFIG.PRODUCER_POOL_MAX + QUEUE_CONFIG.WORKER_POOL_MAX;
+
+    expect(prisma + pgboss).toBeLessThan(SUPABASE_LIMIT);
+  });
+
+  it('startBackgroundWork does not gate the queue on the worker flag', () => {
+    // Read as source rather than imported: importing the queue module pulls in
+    // the runtime config, which needs a populated environment. What is being
+    // pinned is the wiring, and the wiring is visible in the text.
+    const bg = fs.readFileSync(path.join(__dirname, '../../src/api/background.ts'), 'utf-8');
+    // The defect was `if (runsQueueWorkers()) { await initJobQueue(); }`.
+    expect(bg).toMatch(/initJobQueue\(\{\s*registerWorkers:\s*runsQueueWorkers\(\)\s*\}\)/);
+    expect(bg).not.toMatch(/if\s*\(runsQueueWorkers\(\)\)\s*\{[^}]*initJobQueue\(\)/s);
+  });
+
+  it('start() distinguishes the two roles', () => {
+    const mgr = fs.readFileSync(
+      path.join(__dirname, '../../src/modules/queue/manager.ts'),
+      'utf-8'
+    );
+    // Option names are from pg-boss 9.0.3 types.d.ts. A producer runs neither
+    // the supervisor nor the scheduler: those maintain one shared database and
+    // do not need doing once per api replica.
+    expect(mgr).toMatch(/producerOnly/);
+    expect(mgr).toMatch(/noSupervisor:\s*true/);
+    expect(mgr).toMatch(/noScheduling:\s*true/);
+    expect(mgr).toMatch(/max:\s*producerOnly\s*\?/);
+  });
+});


### PR DESCRIPTION
Two scheduled workflows have been failing nightly since the web/worker split, for a reason unrelated to the ingress timeout that was taking down the collectors beside them.

Measured in production today:

```
POST /api/v1/internal/skills/batch-video-collector/run   500 in 0.3s
POST /api/v1/internal/pool-maintenance/run               500
api log: "enqueue failed: JobQueue not started. Call start() first."
```

A 500 in a third of a second looks nothing like a timeout, which is why it sat unnoticed among workflows that were red for the timeout.

## Cause

`RUN_QUEUE_WORKERS=false` on the api pods was right in intent — node-cron schedulers are guarded by per-process variables, so three replicas fire every schedule three times, and pg-boss consumers hold session-mode connections, the scarce kind on Supabase.

What went with the flag was `initJobQueue()` itself. **The api is what serves the endpoints that enqueue**, and pg-boss `send()` throws unless the client is started.

Producer and consumer were one flag. They are now one flag and one parameter: every process starts pg-boss, only a worker registers handlers.

## The connection cost, answered by sizing rather than absence

pg-boss opens its own pool, separate from Prisma's, and defaults to 10 — three api replicas at that default would be 30 session-mode connections against a limit of 60.

```
3 api x prisma 8    24
worker prisma        8
3 api x producer 2   6
worker pg-boss       8
                   ---
                    46   against 60
```

A producer runs neither the supervisor nor the scheduler; those maintain one shared database and do not need doing once per replica. Option names (`max`, `noSupervisor`, `noScheduling`) were read from pg-boss 9.0.3's `types.d.ts`, not recalled.

## Verification

`tests/smoke/queue-producer-role.test.ts` — 4/4, pinning the budget arithmetic and the wiring. Negative control: restoring `if (runsQueueWorkers()) await initJobQueue()` fails the wiring case; reverting passes.

`tsc --noEmit` clean. The full smoke suite fails 15 identical suites here and on `origin/main` — they need a populated environment locally and pass in CI. Compared against a clean `origin/main` worktree: **this branch adds zero failures**.

## This does not verify itself

The endpoints keep returning 500 until an api image carrying this change is running. Confirming it means watching the next scheduled run — or one manual trigger — actually enqueue.

Related: **B-2** in `docs/ops/k8s-migration-issue-checklist.md`. `trend-collector` succeeded at 07:59Z today, so the ingress timeout fix worked; these two were a second, unrelated cause hidden behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)