### PR TITLE
chore(images): point prod at ee911588

### DIFF
--- a/charts/insighta/environments/prod.yaml
+++ b/charts/insighta/environments/prod.yaml
@@ -33,9 +33,9 @@ requireImageRegistry: true
 # this commit edits it. Same for rollback.yml, which pushes by the same means
 # and would fail the same way -- it has not been run since it was rewritten.
 images:
-  apiTag: 057d82c1b9d5f9e46cd4d182dced5c594910514d
-  frontendTag: 057d82c1b9d5f9e46cd4d182dced5c594910514d
-  redisTag: 057d82c1b9d5f9e46cd4d182dced5c594910514d
+  apiTag: ee9115880fe2386664344af9b45dbc3975df6bcf
+  frontendTag: ee9115880fe2386664344af9b45dbc3975df6bcf
+  redisTag: ee9115880fe2386664344af9b45dbc3975df6bcf
 
 api:
   # One, not two, until the compose host is decommissioned.


### PR DESCRIPTION
Opened by hand from the branch `publish-tags` pushed on run `32328728415`.

The job pushed the branch successfully and then failed at PR creation:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to
create or approve pull requests (createPullRequest)
```

Repo setting, measured: `can_approve_pull_request_reviews: false`. The branch push is the part that needed branch protection not to apply, and that worked — this is the last gap, and it is one repository setting rather than a mechanism problem.

## What this carries

`ee911588` = `fix(queue): the api enqueues, so the api has to start pg-boss` (#1525). Pinning it is what puts that fix in front of the two internal endpoints that have been returning 500 since the web/worker split.

Production syncs manually, so merging does not deploy on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)