### PR TITLE
fix(db): a waiting DDL blocks readers, so bound the wait instead of the statement

### DIFF
--- a/prisma/migrations/ontology/011_drop_edge_triggers.sql
+++ b/prisma/migrations/ontology/011_drop_edge_triggers.sql
@@ -23,8 +23,31 @@
 -- §4.1 for the full rationale and rollback plan.
 -- ============================================================================
 
-DROP TRIGGER IF EXISTS trg_goal_edge ON public.user_mandala_levels;
-DROP TRIGGER IF EXISTS trg_topic_edges ON public.user_mandala_levels;
+-- `DROP TRIGGER IF EXISTS` still takes ACCESS EXCLUSIVE on the table even when
+-- there is no trigger to drop, and this file re-runs on every deploy long after
+-- the drop happened. On 2026-08-20 that no-op waited three minutes on
+-- user_mandala_levels and failed the deploy; on the deploys where it succeeded
+-- it was holding new readers behind it for however long it waited.
+--
+-- Asking pg_trigger first costs one catalog read and takes no lock at all, so
+-- the steady state -- both triggers already gone, which is every run since
+-- CP416 -- stops touching the table.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_goal_edge' AND NOT tgisinternal
+  ) THEN
+    EXECUTE 'DROP TRIGGER trg_goal_edge ON public.user_mandala_levels';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_topic_edges' AND NOT tgisinternal
+  ) THEN
+    EXECUTE 'DROP TRIGGER trg_topic_edges ON public.user_mandala_levels';
+  END IF;
+END $$;
 
 -- Sanity: confirm drop
 DO $$

--- a/scripts/apply-custom-sql.sh
+++ b/scripts/apply-custom-sql.sh
@@ -210,7 +210,49 @@ APPLY_FILES=(
 )
 
 SKIP_FILES=" ${SKIP_SQL_FILES:-} "
-export PGOPTIONS="-c statement_timeout=180000"
+
+# Every file here re-runs on every deploy, and most of them contain ALTER TABLE
+# or DROP TRIGGER, which take ACCESS EXCLUSIVE. That lock is not just slow to
+# get on a busy table -- while it is *queued*, PostgreSQL holds every new reader
+# behind it. So a statement that waits also stops the table being read.
+#
+# With statement_timeout alone that wait could last three minutes. On
+# 2026-08-20 it did: 011_drop_edge_triggers.sql, whose triggers were dropped at
+# CP416 and which is now a pure no-op, sat three minutes on
+# user_mandala_levels (20,483 rows) and failed the deploy. The deploys where it
+# succeeded are the ones worth worrying about -- the table was stalled and
+# nothing recorded it.
+#
+# lock_timeout bounds the waiting rather than the statement. A DDL that cannot
+# have the table promptly gives it up instead of forming a queue behind itself.
+LOCK_TIMEOUT_MS="${SQL_LOCK_TIMEOUT_MS:-5000}"
+LOCK_RETRIES="${SQL_LOCK_RETRIES:-3}"
+LOCK_RETRY_SLEEP="${SQL_LOCK_RETRY_SLEEP:-10}"
+export PGOPTIONS="-c statement_timeout=180000 -c lock_timeout=${LOCK_TIMEOUT_MS}"
+
+# Retry is for contention only. A file that fails for any other reason fails the
+# deploy on the first try, because re-running a statement that raised a real
+# error just raises it again more slowly.
+apply_one() {
+  local f="$1" attempt=1 out rc
+  while :; do
+    out=$(psql "$DIRECT_URL" -v ON_ERROR_STOP=1 -f "$f" 2>&1)
+    rc=$?
+    printf '%s\n' "$out"
+    [ $rc -eq 0 ] && return 0
+    if ! printf '%s' "$out" | grep -q "canceling statement due to lock timeout"; then
+      return $rc
+    fi
+    if [ "$attempt" -ge "$LOCK_RETRIES" ]; then
+      echo "::error::$f could not take its lock in $LOCK_RETRIES attempts."
+      echo "::error::Something is holding the table. This is contention, not a broken migration."
+      return $rc
+    fi
+    echo "::warning::$f lost a lock race (attempt $attempt/$LOCK_RETRIES); retrying in ${LOCK_RETRY_SLEEP}s"
+    attempt=$((attempt + 1))
+    sleep "$LOCK_RETRY_SLEEP"
+  done
+}
 
 for f in "${APPLY_FILES[@]}"; do
   if [[ "$SKIP_FILES" == *" $f "* ]]; then
@@ -222,8 +264,10 @@ for f in "${APPLY_FILES[@]}"; do
     exit 1
   fi
   echo "::group::Applying $f"
-  psql "$DIRECT_URL" -v ON_ERROR_STOP=1 -f "$f"
+  apply_one "$f"
+  rc=$?
   echo "::endgroup::"
+  [ $rc -eq 0 ] || exit $rc
 done
 
 echo "Custom SQL migrations applied (${#APPLY_FILES[@]} files in allowlist)."


### PR DESCRIPTION
Today's deploy (`32328728415`) failed here:

```
psql:prisma/migrations/ontology/011_drop_edge_triggers.sql:26:
ERROR: canceling statement due to statement timeout
```

Line 26 is `DROP TRIGGER IF EXISTS trg_goal_edge ON public.user_mandala_levels`. **The triggers were dropped at CP416 and are gone** — confirmed against production, `pg_trigger` returns nothing. The statement does nothing, and took three minutes to do it.

## Why a no-op costs three minutes

`IF EXISTS` does not avoid the lock. The statement requests ACCESS EXCLUSIVE whether or not there is a trigger to drop — and a **queued** ACCESS EXCLUSIVE request holds every new reader behind it. So this no-op can stop `user_mandala_levels` (20,483 rows) being read for as long as it waits.

The failure is the visible case. **The deploys where it succeeded are the ones worth worrying about**: same wait, no record.

The runner sets `statement_timeout=180000` and no `lock_timeout`, and re-applies **all 53 files** in its allowlist every deploy, most of them `ALTER TABLE` or `DROP TRIGGER`. The exposure is per-deploy and repository-wide, not one migration.

## Two changes

`lock_timeout=5s` bounds the *waiting* rather than the statement, so a DDL that cannot have the table gives it up instead of forming a queue behind itself. Contention is retried 3× at 10s — and **only** contention: any other error fails on the first attempt, because re-running a statement that raised a real error raises it again more slowly.

`011` asks `pg_trigger` before dropping. A catalog read takes no lock, so the steady state — both triggers already gone, every run since CP416 — stops touching the table.

## Verified against a real postgres, not reasoned about

| | |
|---|---|
| no `lock_timeout` | waits the full `statement_timeout`, errors `canceling statement due to statement timeout` ← today's message |
| `lock_timeout=2s` | gives up in 2s, errors `canceling statement due to lock timeout` ← what the retry matches |
| retry loop | two lock-timeout failures, then succeeded when the holder released — **rc=0 after 13s** |
| real error | rc=3 in 0s, **zero** retry warnings |
| guarded `011` | **rc=0 in 0s** against a table held in ACCESS EXCLUSIVE |

🤖 Generated with [Claude Code](https://claude.com/claude-code)