### PR TITLE
fix(deploy): the chart named images that were never built

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -397,12 +397,38 @@ jobs:
           F=charts/insighta/environments/prod.yaml
           SHA=${{ github.sha }}
 
-          for key in apiTag frontendTag redisTag; do
-            before=$(grep -E "^  $key:" "$F")
+          # Only the images this run actually built. build-and-push is
+          # selective -- each image has its own `if` on scope.outputs -- while
+          # this loop used to write all three tags unconditionally. So a commit
+          # touching src/ produced one api image and a chart claiming all three
+          # were at that sha.
+          #
+          # Measured 2026-08-20 after #1525, which touched src/ and tests/:
+          #
+          #   insighta-api:ee911588        present
+          #   insighta-frontend:ee911588   ABSENT
+          #   insighta-redis:ee911588      ABSENT
+          #
+          # A sync against that chart gives ImagePullBackOff on three frontend
+          # pods and redis. Nothing reports it until someone syncs, and then it
+          # is an outage caused by a deploy that reported success.
+          #
+          # A tag left alone keeps naming the last image that was actually
+          # built for it, which is exactly what should still be running.
+          wrote=0
+          for pair in "apiTag:${{ needs.scope.outputs.api }}" \
+                      "frontendTag:${{ needs.scope.outputs.frontend }}" \
+                      "redisTag:${{ needs.scope.outputs.redis }}"; do
+            key=${pair%%:*}
+            built=${pair#*:}
+            if [ "$built" != "true" ]; then
+              echo "$key left at $(grep -E "^  $key:" "$F" | awk '{print $2}') -- no image was built for it this run"
+              continue
+            fi
             sed -i -E "s|^  $key:.*|  $key: $SHA|" "$F"
-            after=$(grep -E "^  $key:" "$F")
-            [ "$before" != "$after" ] || { echo "$key unchanged -- refusing"; exit 1; }
+            wrote=$((wrote + 1))
           done
+          [ "$wrote" -gt 0 ] || { echo "no image was built this run; nothing to pin"; }
           grep -E '^  (api|frontend|redis)Tag:' "$F"
 
       # This pushed straight to main until 2026-08-19 and was refused on its

--- a/charts/insighta/environments/prod.yaml
+++ b/charts/insighta/environments/prod.yaml
@@ -34,8 +34,8 @@ requireImageRegistry: true
 # and would fail the same way -- it has not been run since it was rewritten.
 images:
   apiTag: ee9115880fe2386664344af9b45dbc3975df6bcf
-  frontendTag: ee9115880fe2386664344af9b45dbc3975df6bcf
-  redisTag: ee9115880fe2386664344af9b45dbc3975df6bcf
+  frontendTag: 057d82c1b9d5f9e46cd4d182dced5c594910514d
+  redisTag: 057d82c1b9d5f9e46cd4d182dced5c594910514d
 
 api:
   # One, not two, until the compose host is decommissioned.

--- a/tests/smoke/publish-tags-matches-builds.test.ts
+++ b/tests/smoke/publish-tags-matches-builds.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The chart only names images that were built (regression, 2026-08-20).
+ *
+ * build-and-push is selective: each image has its own condition on
+ * scope.outputs, so a commit touching src/ builds the api image and nothing
+ * else. publish-tags wrote all three tags to github.sha regardless.
+ *
+ * Measured after #1525, which touched src/ and tests/:
+ *
+ *   insighta-api:ee911588        present in ECR
+ *   insighta-frontend:ee911588   ABSENT
+ *   insighta-redis:ee911588      ABSENT
+ *
+ * charts/insighta/environments/prod.yaml claimed all three. A sync against it
+ * would have given ImagePullBackOff on three frontend pods and redis -- an
+ * outage produced by a deploy that reported success, with nothing between the
+ * two to say so.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+
+const ROOT = path.join(__dirname, '../..');
+const DEPLOY = path.join(ROOT, '.github/workflows/deploy.yml');
+const PROD = path.join(ROOT, 'charts/insighta/environments/prod.yaml');
+
+const deploy = fs.readFileSync(DEPLOY, 'utf-8');
+const wf = yaml.load(deploy) as {
+  jobs: Record<string, { steps?: Array<{ if?: string; name?: string }> }>;
+};
+
+describe('publish-tags writes only what build-and-push built', () => {
+  it('each image build is conditional on its own scope output', () => {
+    // The premise. If these ever become unconditional the whole hazard goes
+    // away, and this test should be deleted rather than worked around.
+    const steps = wf.jobs['build-and-push']?.steps ?? [];
+    const conds = steps
+      .filter((s) => (s.name ?? '').startsWith('Build & push'))
+      .map((s) => s.if ?? '');
+    expect(conds).toHaveLength(3);
+    expect(conds.join(' ')).toMatch(/scope\.outputs\.api/);
+    expect(conds.join(' ')).toMatch(/scope\.outputs\.frontend/);
+    expect(conds.join(' ')).toMatch(/scope\.outputs\.redis/);
+  });
+
+  it('the tag loop reads the same three outputs', () => {
+    // The defect was `for key in apiTag frontendTag redisTag` with no reference
+    // to what was built. Pinning the pairing, not the syntax.
+    const loop = deploy.slice(deploy.indexOf('publish-tags:'));
+    for (const out of ['api', 'frontend', 'redis']) {
+      expect(loop).toMatch(new RegExp(`needs\\.scope\\.outputs\\.${out}\\b`));
+    }
+  });
+
+  it('no tag is advanced unconditionally', () => {
+    const loop = deploy.slice(deploy.indexOf('publish-tags:'));
+    expect(loop).not.toMatch(/for key in apiTag frontendTag redisTag/);
+  });
+
+  it('prod.yaml pins a concrete sha for every image', () => {
+    // `latest` is what pinning replaced: two revisions naming one string, and
+    // IfNotPresent letting nodes diverge under it.
+    const prod = yaml.load(fs.readFileSync(PROD, 'utf-8')) as {
+      images?: Record<string, string>;
+    };
+    const images = prod.images ?? {};
+    for (const key of ['apiTag', 'frontendTag', 'redisTag']) {
+      expect(images[key]).toBeDefined();
+      expect(images[key]).not.toBe('latest');
+      expect(images[key]).toMatch(/^[0-9a-f]{40}$/);
+    }
+  });
+});


### PR DESCRIPTION
**`main` is currently in a state where an ArgoCD sync takes production down.** Caught by running the pre-sync check, not by a failure.

## What is wrong

`build-and-push` is selective — each image has its own condition on `scope.outputs`. `publish-tags` wrote all three tags to `github.sha` regardless.

#1525 touched `src/` and `tests/`, so it built one image. The chart claims all three are at that sha. Measured in ECR:

```
insighta-api:ee911588        present
insighta-frontend:ee911588   ABSENT
insighta-redis:ee911588      ABSENT
```

Syncing that gives `ImagePullBackOff` on three frontend pods and redis — an outage produced by a deploy that **reported success**, with nothing between the two to say so. Same shape as the rest of this week's defects: no signal until someone acts on it.

## The change

The loop writes a tag only when this run built that image. A tag left alone keeps naming the last image actually built for it, which is what should still be running.

`prod.yaml` is corrected in the same commit, because leaving it is leaving a loaded sync:

| | before | after | in ECR |
|---|---|---|---|
| apiTag | ee911588 | ee911588 | ✅ |
| frontendTag | ee911588 | 057d82c1 | ✅ |
| redisTag | ee911588 | 057d82c1 | ✅ |

All three verified present after the edit.

## Verification

`tests/smoke/publish-tags-matches-builds.test.ts` — 4/4. Pins the pairing between the build conditions and the tag loop, and requires `prod.yaml` to name a concrete sha rather than `latest`. Negative control: restoring the unconditional loop fails two of four; reverting passes four.

## Merge before syncing

The ArgoCD sync is on hold until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)